### PR TITLE
messageerror event doesn't fire on ServiceWorkerGlobalScope

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-serviceworker-failure.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-serviceworker-failure.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL SharedArrayBuffer cannot cross agent clusters, service worker edition assert_unreached: Got an unexpected message from the service worker: worker onmessage was reached when in state "we are expecting a messageerror due to the window sending us a SAB" and data null Reached unreachable code
+PASS SharedArrayBuffer cannot cross agent clusters, service worker edition
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/ServiceWorkerGlobalScope/error-message-event-worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/ServiceWorkerGlobalScope/error-message-event-worker.js
@@ -1,0 +1,2 @@
+self.onmessageerror = e => { e.source.postMessage("received error event"); };
+self.onmessage = e => { e.source.postMessage("received message event"); };

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/ServiceWorkerGlobalScope/error-message-event.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/ServiceWorkerGlobalScope/error-message-event.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Verify error event is received
+

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/ServiceWorkerGlobalScope/error-message-event.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/ServiceWorkerGlobalScope/error-message-event.https.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Service Worker GlobalScope onerror event</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+ <script src="/common/get-host-info.sub.js"></script>
+</head>
+<body>
+<canvas id=canvas></canvas>
+<script>
+var registration;
+
+async function registerServiceWorker()
+{
+    const registration = await navigator.serviceWorker.register("error-message-event-worker.js", { scope : "." });
+    let activeWorker = registration.active;
+    if (activeWorker)
+        return registration;
+    activeWorker = registration.installing;
+    return new Promise(resolve => {
+        activeWorker.addEventListener('statechange', () => {
+            if (activeWorker.state === "activated")
+                resolve(registration);
+        });
+    });
+}
+
+promise_test(async (test) => {
+    registration = await registerServiceWorker();
+
+    const stream = canvas.captureStream();
+    const track = stream.getVideoTracks()[0];
+    // MediaStreamTrack is not defined in service worker contexts.
+    registration.active.postMessage({ track }, [track]);
+
+    const result = await new Promise(resolve => navigator.serviceWorker.onmessage = e => resolve(e.data));
+    assert_equals(result, "received error event");
+}, "Verify error event is received");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/module/window-serviceworker-failure.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/module/window-serviceworker-failure.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL WebAssembly.Module cannot cross agent clusters, service worker edition assert_unreached: Got an unexpected message from the service worker: worker onmessage was reached when in state "we are expecting a messageerror due to the window sending us a WebAssembly.Module" and data null Reached unreachable code
+PASS WebAssembly.Module cannot cross agent clusters, service worker edition
 

--- a/Source/WebCore/workers/service/ExtendableMessageEvent.idl
+++ b/Source/WebCore/workers/service/ExtendableMessageEvent.idl
@@ -26,11 +26,12 @@
 [
     EnabledBySetting=ServiceWorkersEnabled,
     Exposed=ServiceWorker,
+    JSCustomMarkFunction,
     JSGenerateToJSObject,
 ] interface ExtendableMessageEvent : ExtendableEvent {
     [Custom] constructor([AtomString] DOMString type, optional ExtendableMessageEventInit eventInitDict);
 
-    [CachedAttribute, CustomGetter] readonly attribute any data;
+    readonly attribute any data;
     readonly attribute USVString origin;
     readonly attribute DOMString lastEventId;
     [SameObject] readonly attribute (ServiceWorkerClient or ServiceWorker or MessagePort)? source;


### PR DESCRIPTION
#### fddda893fc92edb8d258d2b12b126db11c3ba264
<pre>
messageerror event doesn&apos;t fire on ServiceWorkerGlobalScope
<a href="https://bugs.webkit.org/show_bug.cgi?id=272967">https://bugs.webkit.org/show_bug.cgi?id=272967</a>
<a href="https://rdar.apple.com/127104436">rdar://127104436</a>

Reviewed by Chris Dumez.

Like for messages on worker, we now deserialize the data just before firing the event.
If deserialization fails, we use messageerror event, other wise we keep using message event.

We update ExtendableMessageEvent to use a JSValueInWrappedObject instead of a SerializedScriptValue.
This allows to store a JSValue, which also simplifies the custom binding.

We reuse the same principle for the JS constructor.
We continue using the custom constructor as we create the JS wrapper in ExtendableMessageEvent::create.

* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-serviceworker-failure.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/ServiceWorkerGlobalScope/error-message-event-worker.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/ServiceWorkerGlobalScope/error-message-event.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/ServiceWorkerGlobalScope/error-message-event.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/module/window-serviceworker-failure.https-expected.txt:
* Source/WebCore/bindings/js/JSExtendableMessageEventCustom.cpp:
(WebCore::constructJSExtendableMessageEvent):
(WebCore::JSExtendableMessageEvent::visitAdditionalChildren):
(WebCore::JSExtendableMessageEvent::data const): Deleted.
* Source/WebCore/workers/service/ExtendableMessageEvent.cpp:
(WebCore::createWrapperAndSetData):
(WebCore::ExtendableMessageEvent::create):
(WebCore::ExtendableMessageEvent::ExtendableMessageEvent):
* Source/WebCore/workers/service/ExtendableMessageEvent.h:
* Source/WebCore/workers/service/ExtendableMessageEvent.idl:
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
(WebCore::fireMessageEvent):

Canonical link: <a href="https://commits.webkit.org/278408@main">https://commits.webkit.org/278408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63f08cab853ed69e379467130f2694276ca45962

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53629 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1060 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/710 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41087 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43361 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22191 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24751 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/617 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8748 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46725 "Found 1 new API test failure: TestWebKitAPI.SleepDisabler.Load (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/680 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55217 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25468 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/606 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48495 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26729 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43540 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47533 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11061 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27591 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26461 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->