### PR TITLE
ExtendableMessageEvent.ports should return the same object

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/ServiceWorkerGlobalScope/message-event-ports-worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/ServiceWorkerGlobalScope/message-event-ports-worker.js
@@ -1,0 +1,3 @@
+self.onmessage = e => {
+    e.source.postMessage(e.ports === e.ports ? "same ports array" : "different ports array");
+};

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/ServiceWorkerGlobalScope/message-event-ports.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/ServiceWorkerGlobalScope/message-event-ports.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Verify MessageEvent.ports getter returns the same object
+

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/ServiceWorkerGlobalScope/message-event-ports.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/ServiceWorkerGlobalScope/message-event-ports.https.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Service Worker GlobalScope onerror event</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<canvas id=canvas></canvas>
+<script>
+var registration;
+
+async function registerServiceWorker()
+{
+    const registration = await navigator.serviceWorker.register("message-event-ports-worker.js", { scope : "." });
+    let activeWorker = registration.active;
+    if (activeWorker)
+        return registration;
+    activeWorker = registration.installing;
+    return new Promise(resolve => {
+        activeWorker.addEventListener('statechange', () => {
+            if (activeWorker.state === "activated")
+                resolve(registration);
+        });
+    });
+}
+
+promise_test(async (test) => {
+    registration = await registerServiceWorker();
+
+    registration.active.postMessage("test");
+    let result = await new Promise(resolve => navigator.serviceWorker.onmessage = e => resolve(e.data));
+    assert_equals(result, "same ports array", "empty array");
+
+    const channel = new MessageChannel();;
+    const port = channel.port1;
+    registration.active.postMessage({ port }, [port]);
+    result = await new Promise(resolve => navigator.serviceWorker.onmessage = e => resolve(e.data));
+    assert_equals(result, "same ports array", "not empty array");
+}, "Verify MessageEvent.ports getter returns the same object");
+</script>
+</body>
+</html>

--- a/Source/WebCore/bindings/js/JSExtendableMessageEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSExtendableMessageEventCustom.cpp
@@ -54,10 +54,19 @@ JSC::EncodedJSValue constructJSExtendableMessageEvent(JSC::JSGlobalObject* lexic
     return JSValue::encode(object.strongWrapper.get());
 }
 
+JSC::JSValue JSExtendableMessageEvent::ports(JSC::JSGlobalObject& lexicalGlobalObject) const
+{
+    auto throwScope = DECLARE_THROW_SCOPE(lexicalGlobalObject.vm());
+    return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, wrapped().cachedPorts(), [&](JSC::ThrowScope& throwScope) {
+        return toJS<IDLFrozenArray<IDLInterface<MessagePort>>>(lexicalGlobalObject, *globalObject(), throwScope, wrapped().ports());
+    });
+}
+
 template<typename Visitor>
 void JSExtendableMessageEvent::visitAdditionalChildren(Visitor& visitor)
 {
     wrapped().data().visit(visitor);
+    wrapped().cachedPorts().visit(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN(JSExtendableMessageEvent);

--- a/Source/WebCore/workers/service/ExtendableMessageEvent.h
+++ b/Source/WebCore/workers/service/ExtendableMessageEvent.h
@@ -68,6 +68,7 @@ public:
     ~ExtendableMessageEvent();
 
     JSValueInWrappedObject& data() { return m_data; }
+    JSValueInWrappedObject& cachedPorts() { return m_cachedPorts; }
 
     const String& origin() const { return m_origin; }
     const String& lastEventId() const { return m_lastEventId; }
@@ -83,6 +84,7 @@ private:
     String m_lastEventId;
     std::optional<ExtendableMessageEventSource> m_source;
     Vector<Ref<MessagePort>> m_ports;
+    JSValueInWrappedObject m_cachedPorts;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/ExtendableMessageEvent.idl
+++ b/Source/WebCore/workers/service/ExtendableMessageEvent.idl
@@ -35,7 +35,7 @@
     readonly attribute USVString origin;
     readonly attribute DOMString lastEventId;
     [SameObject] readonly attribute (ServiceWorkerClient or ServiceWorker or MessagePort)? source;
-    readonly attribute FrozenArray<MessagePort> ports;
+    [CustomGetter] readonly attribute FrozenArray<MessagePort> ports;
 };
 
 dictionary ExtendableMessageEventInit : ExtendableEventInit {


### PR DESCRIPTION
#### ac508ff120502d26793f9b60113f36baf69091db
<pre>
ExtendableMessageEvent.ports should return the same object
<a href="https://bugs.webkit.org/show_bug.cgi?id=273542">https://bugs.webkit.org/show_bug.cgi?id=273542</a>
<a href="https://rdar.apple.com/127350353">rdar://127350353</a>

Reviewed by Chris Dumez.

Reuse what was done for MessageEvent.ports in ExtendableMessageEvent.ports.
We use a JSValueInWrappedObject to store the JS ports object so that we always return the same JS object.

* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/ServiceWorkerGlobalScope/message-event-ports-worker.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/ServiceWorkerGlobalScope/message-event-ports.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/ServiceWorkerGlobalScope/message-event-ports.https.html: Added.
* Source/WebCore/bindings/js/JSExtendableMessageEventCustom.cpp:
(WebCore::JSExtendableMessageEvent::ports const):
(WebCore::JSExtendableMessageEvent::visitAdditionalChildren):
* Source/WebCore/workers/service/ExtendableMessageEvent.h:
* Source/WebCore/workers/service/ExtendableMessageEvent.idl:

Originally-landed-as: bb2720bcf112. <a href="https://bugs.webkit.org/show_bug.cgi?id=273542">https://bugs.webkit.org/show_bug.cgi?id=273542</a>
Canonical link: <a href="https://commits.webkit.org/278690@main">https://commits.webkit.org/278690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9425e0af77e5b9bfeecf36104b67a7b287bc7746

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54571 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2001 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53614 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41790 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53410 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28265 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22908 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25590 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1497 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47559 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1570 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56164 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26426 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1467 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49188 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27669 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44302 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48368 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11222 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28559 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27404 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->