### PR TITLE
[GStreamer] Memory leak fixes in GStreamerElementHarness tests

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
@@ -36,18 +36,18 @@ using namespace WebCore;
 
 namespace TestWebKitAPI {
 
-void GStreamerTest::SetUp()
+void GStreamerTest::SetUpTestSuite()
 {
-    if (!gst_is_initialized())
-        gst_init(nullptr, nullptr);
+    ASSERT(!gst_is_initialized());
+    gst_init(nullptr, nullptr);
+    ASSERT(gst_is_initialized());
 }
 
-void GStreamerTest::TearDown()
+void GStreamerTest::TearDownTestSuite()
 {
-    // It might be tempting to call gst_deinit() here. However, that
-    // will tear down the whole process from the GStreamer POV, and the
-    // seemingly symmetrical call to gst_init() will fail to
-    // initialize GStreamer correctly.
+    ASSERT(gst_is_initialized());
+    gst_deinit();
+    ASSERT(!gst_is_initialized());
 }
 
 TEST_F(GStreamerTest, gstStructureJSONSerializing)

--- a/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.h
+++ b/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.h
@@ -32,8 +32,8 @@ namespace TestWebKitAPI {
 
 class GStreamerTest : public testing::Test {
 public:
-    void SetUp() override;
-    void TearDown() override;
+    static void SetUpTestSuite();
+    static void TearDownTestSuite();
 };
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### bafd8951d49e3ff6979d57ceb9a9c118dadbd649
<pre>
[GStreamer] Memory leak fixes in GStreamerElementHarness tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=273544">https://bugs.webkit.org/show_bug.cgi?id=273544</a>

Reviewed by Xabier Rodriguez-Calvar.

Fix memory leaks detected by the GStreamer leak tracer.

* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp:
(TestWebKitAPI::GStreamerTest::SetUpTestSuite):
(TestWebKitAPI::GStreamerTest::TearDownTestSuite):
(TestWebKitAPI::GStreamerTest::SetUp): Deleted.
(TestWebKitAPI::GStreamerTest::TearDown): Deleted.
* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.h:
* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/278264@main">https://commits.webkit.org/278264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b634126f352d373796ed7cef50ed5a85ec40ccb8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2127 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53102 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/536 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40682 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21806 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24152 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/113 "Found 1 new test failure: http/tests/media/hls/track-webvtt-multitracks.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8229 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46158 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/147 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Exiting early after 60 failures. 17708 tests run. 60 failures; Uploaded test results; Exiting early after 60 failures. 15947 tests run. 60 failures; Running compile-webkit-without-change") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54683 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24953 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/100 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48069 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26210 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43076 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47105 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10965 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27071 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25938 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->