### PR TITLE
JSC EWS should run `testing` builds

### DIFF
--- a/Source/JavaScriptCore/API/JSAPIWrapperObject.mm
+++ b/Source/JavaScriptCore/API/JSAPIWrapperObject.mm
@@ -118,7 +118,7 @@ void JSAPIWrapperObject::finishCreation(VM& vm)
     Base::finishCreation(vm);
     WeakSet::allocate(this, jsAPIWrapperObjectHandleOwner(), 0); // Balanced in JSAPIWrapperObjectHandleOwner::finalize.
 }
-    
+
 void JSAPIWrapperObject::setWrappedObject(void* wrappedObject)
 {
     ASSERT(!m_wrappedObject);

--- a/Tools/CISupport/build-webkit-org/loadConfig.py
+++ b/Tools/CISupport/build-webkit-org/loadConfig.py
@@ -40,7 +40,7 @@ main_filter = ChangeFilter(branch=["main", None])
 
 BUILDER_NAME_LENGTH_LIMIT = 70
 STEP_NAME_LENGTH_LIMIT = 50
-
+VALID_CONFIGURATIONS = ['debug', 'production', 'release', 'release-and-assert']
 
 def pickLatestBuild(builder, requests):
     return max(requests, key=operator.attrgetter("submittedAt"))
@@ -170,7 +170,7 @@ def checkValidBuilder(config, builder):
     if len(builder['name']) > BUILDER_NAME_LENGTH_LIMIT:
         raise Exception(f"Builder name {builder['name']} is longer than maximum allowed by Buildbot ({BUILDER_NAME_LENGTH_LIMIT} characters).")
 
-    if 'configuration' in builder and builder['configuration'] not in ['debug', 'production', 'release']:
+    if 'configuration' in builder and builder['configuration'] not in VALID_CONFIGURATIONS:
         raise Exception(f"Invalid configuration: {builder.get('configuration')} for builder: {builder.get('name')}")
 
     if not builder.get('factory'):

--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -401,13 +401,13 @@
     {
       "name": "JSC-Tests-EWS", "shortname": "jsc", "icon": "buildAndTest",
       "factory": "JSCBuildAndTestsFactory", "platform": "mac-ventura",
-      "configuration": "release", "runTests": "true",
+      "configuration": "release-and-assert", "runTests": "true",
       "workernames": ["ews127", "ews128", "ews251", "ews252"]
     },
     {
       "name": "JSC-Tests-arm64-EWS", "shortname": "jsc-arm64", "icon": "buildAndTest",
       "factory": "JSCBuildAndTestsFactory", "platform": "mac-ventura",
-      "configuration": "release", "runTests": "true",
+      "configuration": "release-and-assert", "runTests": "true",
       "workernames": ["ews136", "ews137"]
     },
     {

--- a/Tools/CISupport/ews-build/loadConfig.py
+++ b/Tools/CISupport/ews-build/loadConfig.py
@@ -47,7 +47,7 @@ custom_suffix = get_custom_suffix()
 
 BUILDER_NAME_LENGTH_LIMIT = 70
 STEP_NAME_LENGTH_LIMIT = 50
-
+VALID_CONFIGURATIONS = ['debug', 'production', 'release', 'release-and-assert']
 
 def loadBuilderConfig(c, is_test_mode_enabled=False, setup_main_schedulers=True, setup_force_schedulers=True, master_prefix_path=os.path.dirname(os.path.abspath(__file__))):
     with open(os.path.join(master_prefix_path, 'config.json')) as config_json:
@@ -184,7 +184,7 @@ def checkValidBuilder(config, builder):
     if len(builder['name']) > BUILDER_NAME_LENGTH_LIMIT:
         raise Exception('Builder name {} is longer than maximum allowed by Buildbot ({} characters).'.format(builder['name'], BUILDER_NAME_LENGTH_LIMIT))
 
-    if 'configuration' in builder and builder['configuration'] not in ['debug', 'production', 'release']:
+    if 'configuration' in builder and builder['configuration'] not in VALID_CONFIGURATIONS:
         raise Exception('Invalid configuration: {} for builder: {}'.format(builder.get('configuration'), builder.get('name')))
 
     if not builder.get('factory'):

--- a/Tools/Scripts/webkitperl/BuildSubproject.pm
+++ b/Tools/Scripts/webkitperl/BuildSubproject.pm
@@ -260,7 +260,7 @@ sub buildUpToProject
             push @extraCommands, $arg;
         }
 
-        my $command = "make SCHEME=\"$schemeName\" " . (lc configuration()) . " GCC_PREPROCESSOR_ADDITIONS=\"@compilerFlags\" @extraCommands";
+        my $command = "make SCHEME=\"$schemeName\" " . "release+assert" . " GCC_PREPROCESSOR_ADDITIONS=\"@compilerFlags\" @extraCommands";
 
         print "\n";
         print "building ", $projectName, "\n";


### PR DESCRIPTION
#### 5fb4057cb9fbd3718205918f0b2bebb1387443ee
<pre>
JSC EWS should run `testing` builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=273551">https://bugs.webkit.org/show_bug.cgi?id=273551</a>
<a href="https://rdar.apple.com/127363472">rdar://127363472</a>

Reviewed by NOBODY (OOPS!).

build-jsc&apos;s Release+Assert builds are just regular Release builds but with
ASSERT_ENABLED=1. It&apos;s not uncommon for JSC asserts to catch real issues
so seeing them in EWS would be better than not.

* Source/JavaScriptCore/API/JSAPIWrapperObject.mm: Remove whitespace so this PR seems relevant for JSC EWS.
* Tools/CISupport/build-webkit-org/loadConfig.py:
(checkValidBuilder):
* Tools/CISupport/ews-build/config.json:
* Tools/CISupport/ews-build/loadConfig.py:
(checkValidBuilder):
* Tools/CISupport/ews-build/steps_unittest.py:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fb4057cb9fbd3718205918f0b2bebb1387443ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93320 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39117 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90414 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16065 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68152 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25871 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79918 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48520 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6090 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34328 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38225 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81162 "Found unexpected failure with change (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76471 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35213 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95163 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/88691 "Found 691 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_sort.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort3.js.default, ChakraCore.yaml/ChakraCore/test/Array/nativeFloatArray_sort.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug232281.js.default, ChakraCore.yaml/ChakraCore/test/Regex/blue_102584_1.js.default, ChakraCore.yaml/ChakraCore/test/Regex/regex_replacefn.js.default, ChakraCore.yaml/ChakraCore/test/Strings/replace.js.default, ChakraCore.yaml/ChakraCore/test/Strings/string_replace.js.default ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15538 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11385 "Found 2 new test failures: http/tests/webrtc/filtering-ice-candidate-same-origin-frame.html media/video-replaces-poster.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77023 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/87948 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15794 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76274 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20660 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19080 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8575 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15554 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20861 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109632 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15295 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26361 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18744 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17077 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->