### PR TITLE
REGRESSION (278112@main): [ MacOS iOS ] TestWebKitAPI.Color.P3ConversionToSRGB is a consistent failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/ColorTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ColorTests.cpp
@@ -372,8 +372,8 @@ TEST(Color, P3ConversionToSRGB)
     Color p3Color { DisplayP3<float> { 1.0, 0.5, 0.25, 0.75 } };
     auto sRGBAColor = p3Color.toColorTypeLossy<SRGBA<float>>().resolved();
     EXPECT_FLOAT_EQ(sRGBAColor.red, 1.0f);
-    EXPECT_FLOAT_EQ(sRGBAColor.green, 0.50120097f);
-    EXPECT_FLOAT_EQ(sRGBAColor.blue, 0.2616162f);
+    EXPECT_FLOAT_EQ(sRGBAColor.green, 0.46253288f);
+    EXPECT_FLOAT_EQ(sRGBAColor.blue, 0.14912745f);
     EXPECT_FLOAT_EQ(sRGBAColor.alpha, 0.75f);
 }
 


### PR DESCRIPTION
#### a5997b3faeb5b7b4e4fcbb77779309e509dd6c92
<pre>
REGRESSION (278112@main): [ MacOS iOS ] TestWebKitAPI.Color.P3ConversionToSRGB is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=273497">https://bugs.webkit.org/show_bug.cgi?id=273497</a>

Reviewed by Tim Nguyen.

Update results to account for change in gamut mapping from CSS gamut mapping to clipping.

* Tools/TestWebKitAPI/Tests/WebCore/ColorTests.cpp:
(TestWebKitAPI::TEST(Color, P3ConversionToSRGB)):

Canonical link: <a href="https://commits.webkit.org/278226@main">https://commits.webkit.org/278226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c752180119613a706ede41b20a73aac1351a26a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53125 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/559 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/127 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40700 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26739 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42910 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21824 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24173 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/123 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8252 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46211 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/169 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54706 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24976 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/123 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48085 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26233 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47125 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10946 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27095 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25963 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->