### PR TITLE
[GTK] Don't notify cursor when cursorRect is default-initialized

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/InputMethodFilter.cpp
+++ b/Source/WebKit/UIProcess/API/glib/InputMethodFilter.cpp
@@ -215,6 +215,10 @@ void InputMethodFilter::notifyCursorRect(const IntRect& cursorRect)
     if (!isEnabled() || !m_context)
         return;
 
+    // Don't notify cursor area when cursorRect is default-initialized (location and size are all 0).
+    if (!cursorRect.x() && !cursorRect.y() && !cursorRect.width() && !cursorRect.height())
+        return;
+
     // Don't move the window unless the cursor actually moves more than 10
     // pixels. This prevents us from making the window flash during minor
     // cursor adjustments.


### PR DESCRIPTION
#### f69bdc37c4623ebe9e47c6c1179d21820dbcebb3
<pre>
[GTK] Don&apos;t notify cursor when cursorRect is default-initialized
<a href="https://bugs.webkit.org/show_bug.cgi?id=218148">https://bugs.webkit.org/show_bug.cgi?id=218148</a>

Reviewed by Michael Catanzaro.

For input methods in preedit mode, editor state update functions could
get an IntRect that is default-initialized (with x, y, width and height
all 0), which makes the input method popup at the top left corner
instead of its expected position.

* Source/WebKit/UIProcess/API/glib/InputMethodFilter.cpp:
(WebKit::InputMethodFilter::notifyCursorRect): Modified to check if
cursorRect is default-initialized.

Canonical link: <a href="https://commits.webkit.org/278261@main">https://commits.webkit.org/278261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e16b47fc8ad966a144838e31030b5b68a079409

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49892 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53135 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/569 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35240 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/137 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40711 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26749 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42928 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21836 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24183 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8262 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46240 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/192 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54716 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24986 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/145 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48095 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26243 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43114 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47181 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10970 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27105 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25973 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->