### PR TITLE
Inline more methods in SelectorFilter

### DIFF
--- a/Source/WebCore/css/SelectorFilter.cpp
+++ b/Source/WebCore/css/SelectorFilter.cpp
@@ -33,6 +33,7 @@
 #include "CommonAtomStrings.h"
 #include "ElementInlines.h"
 #include "HTMLNames.h"
+#include "SelectorFilterInlines.h"
 #include "ShadowRoot.h"
 #include "StyledElement.h"
 
@@ -180,83 +181,6 @@ void SelectorFilter::collectSimpleSelectorHash(CollectedSelectorHashes& collecte
     default:
         break;
     }
-}
-
-void SelectorFilter::collectSelectorHashes(CollectedSelectorHashes& collectedHashes, const CSSSelector& rightmostSelector, IncludeRightmost includeRightmost)
-{
-    auto [selector, relation, skipOverSubselectors] = [&] {
-        if (includeRightmost == IncludeRightmost::No)
-            return std::tuple { rightmostSelector.tagHistory(), rightmostSelector.relation(), true };
-
-        return std::tuple { &rightmostSelector, CSSSelector::Relation::Subselector, false };
-    }();
-
-    for (; selector; selector = selector->tagHistory()) {
-        // Only collect identifiers that match ancestors.
-        switch (relation) {
-        case CSSSelector::Relation::Subselector:
-            if (!skipOverSubselectors)
-                collectSimpleSelectorHash(collectedHashes, *selector);
-            break;
-        case CSSSelector::Relation::DirectAdjacent:
-        case CSSSelector::Relation::IndirectAdjacent:
-        case CSSSelector::Relation::ShadowDescendant:
-        case CSSSelector::Relation::ShadowPartDescendant:
-        case CSSSelector::Relation::ShadowSlotted:
-            skipOverSubselectors = true;
-            break;
-        case CSSSelector::Relation::DescendantSpace:
-        case CSSSelector::Relation::Child:
-            skipOverSubselectors = false;
-            collectSimpleSelectorHash(collectedHashes, *selector);
-            break;
-        }
-        relation = selector->relation();
-    }
-}
-
-auto SelectorFilter::chooseSelectorHashesForFilter(const CollectedSelectorHashes& collectedSelectorHashes) -> Hashes
-{
-    Hashes resultHashes;
-    unsigned index = 0;
-
-    auto addIfNew = [&] (unsigned hash) {
-        for (unsigned i = 0; i < index; ++i) {
-            if (resultHashes[i] == hash)
-                return;
-        }
-        resultHashes[index++] = hash;
-    };
-
-    auto copyHashes = [&] (auto& hashes) {
-        for (auto& hash : hashes) {
-            addIfNew(hash);
-            if (index == resultHashes.size())
-                return true;
-        }
-        return false;
-    };
-
-    // There is a limited number of slots. Prefer more specific selector types.
-    if (copyHashes(collectedSelectorHashes.ids))
-        return resultHashes;
-    if (copyHashes(collectedSelectorHashes.attributes))
-        return resultHashes;
-    if (copyHashes(collectedSelectorHashes.classes))
-        return resultHashes;
-    if (copyHashes(collectedSelectorHashes.tags))
-        return resultHashes;
-
-    // Null-terminate if not full.
-    resultHashes[index] = 0;
-    return resultHashes;
-}
-
-SelectorFilter::Hashes SelectorFilter::collectHashes(const CSSSelector& selector)
-{
-    CollectedSelectorHashes collectedHashes;
-    collectSelectorHashes(collectedHashes, selector, IncludeRightmost::No);
-    return chooseSelectorHashesForFilter(collectedHashes);
 }
 
 SelectorFilter::CollectedSelectorHashes SelectorFilter::collectHashesForTesting(const CSSSelector& selector)

--- a/Source/WebCore/css/SelectorFilter.h
+++ b/Source/WebCore/css/SelectorFilter.h
@@ -48,8 +48,8 @@ public:
     void parentStackReserveInitialCapacity(size_t initialCapacity) { m_parentStack.reserveInitialCapacity(initialCapacity); }
 
     using Hashes = std::array<unsigned, 4>;
-    bool fastRejectSelector(const Hashes&) const;
-    static Hashes collectHashes(const CSSSelector&);
+    inline bool fastRejectSelector(const Hashes&) const;
+    inline static Hashes collectHashes(const CSSSelector&);
 
     static void collectElementIdentifierHashes(const Element&, Vector<unsigned, 4>&);
 
@@ -67,8 +67,8 @@ public:
 private:
     void initializeParentStack(Element& parent);
     enum class IncludeRightmost : bool { No, Yes };
-    static void collectSelectorHashes(CollectedSelectorHashes&, const CSSSelector& rightmostSelector, IncludeRightmost);
-    static Hashes chooseSelectorHashesForFilter(const CollectedSelectorHashes&);
+    inline static void collectSelectorHashes(CollectedSelectorHashes&, const CSSSelector& rightmostSelector, IncludeRightmost);
+    inline static Hashes chooseSelectorHashesForFilter(const CollectedSelectorHashes&);
 
     struct ParentStackFrame {
         ParentStackFrame() : element(0) { }
@@ -82,16 +82,5 @@ private:
     static const unsigned bloomFilterKeyBits = 12;
     CountingBloomFilter<bloomFilterKeyBits> m_ancestorIdentifierFilter;
 };
-
-inline bool SelectorFilter::fastRejectSelector(const Hashes& hashes) const
-{
-    for (auto& hash : hashes) {
-        if (!hash)
-            return false;
-        if (!m_ancestorIdentifierFilter.mayContain(hash))
-            return true;
-    }
-    return false;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/css/SelectorFilterInlines.h
+++ b/Source/WebCore/css/SelectorFilterInlines.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSSelectorList.h"
+#include "SelectorFilter.h"
+
+namespace WebCore {
+
+inline bool SelectorFilter::fastRejectSelector(const Hashes& hashes) const
+{
+    for (auto& hash : hashes) {
+        if (!hash)
+            return false;
+        if (!m_ancestorIdentifierFilter.mayContain(hash))
+            return true;
+    }
+    return false;
+}
+
+inline void SelectorFilter::collectSelectorHashes(CollectedSelectorHashes& collectedHashes, const CSSSelector& rightmostSelector, IncludeRightmost includeRightmost)
+{
+    auto [selector, relation, skipOverSubselectors] = [&] {
+        if (includeRightmost == IncludeRightmost::No)
+            return std::tuple { rightmostSelector.tagHistory(), rightmostSelector.relation(), true };
+
+        return std::tuple { &rightmostSelector, CSSSelector::Relation::Subselector, false };
+    }();
+
+    for (; selector; selector = selector->tagHistory()) {
+        // Only collect identifiers that match ancestors.
+        switch (relation) {
+        case CSSSelector::Relation::Subselector:
+            if (!skipOverSubselectors)
+                collectSimpleSelectorHash(collectedHashes, *selector);
+            break;
+        case CSSSelector::Relation::DirectAdjacent:
+        case CSSSelector::Relation::IndirectAdjacent:
+        case CSSSelector::Relation::ShadowDescendant:
+        case CSSSelector::Relation::ShadowPartDescendant:
+        case CSSSelector::Relation::ShadowSlotted:
+            skipOverSubselectors = true;
+            break;
+        case CSSSelector::Relation::DescendantSpace:
+        case CSSSelector::Relation::Child:
+            skipOverSubselectors = false;
+            collectSimpleSelectorHash(collectedHashes, *selector);
+            break;
+        }
+        relation = selector->relation();
+    }
+}
+
+inline auto SelectorFilter::chooseSelectorHashesForFilter(const CollectedSelectorHashes& collectedSelectorHashes) -> Hashes
+{
+    Hashes resultHashes;
+    unsigned index = 0;
+
+    auto addIfNew = [&] (unsigned hash) {
+        for (unsigned i = 0; i < index; ++i) {
+            if (resultHashes[i] == hash)
+                return;
+        }
+        resultHashes[index++] = hash;
+    };
+
+    auto copyHashes = [&] (auto& hashes) {
+        for (auto& hash : hashes) {
+            addIfNew(hash);
+            if (index == resultHashes.size())
+                return true;
+        }
+        return false;
+    };
+
+    // There is a limited number of slots. Prefer more specific selector types.
+    if (copyHashes(collectedSelectorHashes.ids))
+        return resultHashes;
+    if (copyHashes(collectedSelectorHashes.attributes))
+        return resultHashes;
+    if (copyHashes(collectedSelectorHashes.classes))
+        return resultHashes;
+    if (copyHashes(collectedSelectorHashes.tags))
+        return resultHashes;
+
+    // Null-terminate if not full.
+    resultHashes[index] = 0;
+    return resultHashes;
+}
+
+SelectorFilter::Hashes SelectorFilter::collectHashes(const CSSSelector& selector)
+{
+    CollectedSelectorHashes collectedHashes;
+    collectSelectorHashes(collectedHashes, selector, IncludeRightmost::No);
+    return chooseSelectorHashesForFilter(collectedHashes);
+}
+
+}

--- a/Source/WebCore/css/parser/CSSTokenizerInputStream.h
+++ b/Source/WebCore/css/parser/CSSTokenizerInputStream.h
@@ -53,7 +53,7 @@ public:
 
     // Gets the char at lookaheadOffset from the current stream position. Will
     // return NUL (kEndOfFileMarker) if the stream position is at the end.
-    UChar peek(unsigned lookaheadOffset) const
+    inline UChar peek(unsigned lookaheadOffset) const
     {
         if ((m_offset + lookaheadOffset) >= m_stringLength)
             return kEndOfFileMarker;

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -44,6 +44,7 @@
 #include "SVGElement.h"
 #include "SelectorCheckerTestFunctions.h"
 #include "SelectorCompiler.h"
+#include "SelectorFilterInlines.h"
 #include "SelectorMatchingState.h"
 #include "ShadowRoot.h"
 #include "StyleProperties.h"

--- a/Source/WebCore/style/HasSelectorFilter.cpp
+++ b/Source/WebCore/style/HasSelectorFilter.cpp
@@ -27,7 +27,7 @@
 
 #include "ElementChildIteratorInlines.h"
 #include "RuleFeature.h"
-#include "SelectorFilter.h"
+#include "SelectorFilterInlines.h"
 #include "StyleRule.h"
 #include "TypedElementDescendantIteratorInlines.h"
 

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -39,7 +39,7 @@
 #include "ScriptExecutionContext.h"
 #include "SecurityOrigin.h"
 #include "SelectorChecker.h"
-#include "SelectorFilter.h"
+#include "SelectorFilterInlines.h"
 #include "StyleResolver.h"
 #include "StyleRule.h"
 #include "StyleRuleImport.h"


### PR DESCRIPTION
#### c75f473fe9f2d771c738749c376e7738cb2b7235
<pre>
Inline more methods in SelectorFilter
<a href="https://bugs.webkit.org/show_bug.cgi?id=273558">https://bugs.webkit.org/show_bug.cgi?id=273558</a>
<a href="https://rdar.apple.com/127375992">rdar://127375992</a>

Reviewed by NOBODY (OOPS!).

Instrumenting page load time with Dtrace shows a large number of calls into SelectorFilter methods
during initial page load and rendering. Specifically, during about 1s of loading, there are
approximately 40k calls to both SelectorFilter::chooseSelectorHashesForFilter() and
SelectorFilter::collectHashes(). This makes these two methods the #22 and #23 most frequent
methods called in WebCore during a representative page load.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/SelectorFilter.cpp:
(WebCore::SelectorFilter::collectSelectorHashes): Deleted.
(WebCore::SelectorFilter::chooseSelectorHashesForFilter): Deleted.
(WebCore::SelectorFilter::collectHashes): Deleted.
* Source/WebCore/css/SelectorFilter.h:
(WebCore::SelectorFilter::fastRejectSelector const): Deleted.
* Source/WebCore/css/SelectorFilterInlines.h: Added.
(WebCore::SelectorFilter::fastRejectSelector const):
(WebCore::SelectorFilter::collectSelectorHashes):
(WebCore::SelectorFilter::chooseSelectorHashesForFilter):
(WebCore::SelectorFilter::collectHashes):
* Source/WebCore/css/parser/CSSTokenizerInputStream.h:
(WebCore::CSSTokenizerInputStream::peek const):
* Source/WebCore/style/ElementRuleCollector.cpp:
* Source/WebCore/style/HasSelectorFilter.cpp:
* Source/WebCore/style/RuleData.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c75f473fe9f2d771c738749c376e7738cb2b7235

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53139 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/573 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52197 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/141 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40715 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26755 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42932 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21845 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24199 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/153 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8266 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46245 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54720 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24990 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/149 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48102 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43121 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47142 "Found 5 new API test failures: /TestWebCore:Color.P3ConversionToSRGB, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/listbox, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/value/basic, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/selection/menulist (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27109 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25977 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->