### PR TITLE
Safari crashes at WebKit::WebExtensionContext::openInspectors.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -641,7 +641,7 @@ static inline NSArray *toAPI(const WebKit::WebExtensionContext::WindowVector& wi
 
 - (NSArray<id<_WKWebExtensionWindow>> *)openWindows
 {
-    return toAPI(_webExtensionContext->openWindows());
+    return toAPI(_webExtensionContext->openWindows(WebKit::WebExtensionContext::IgnoreExtensionAccess::Yes));
 }
 
 - (id<_WKWebExtensionWindow>)focusedWindow
@@ -666,7 +666,7 @@ static inline NSSet *toAPI(const WebKit::WebExtensionContext::TabVector& tabs)
 
 - (NSSet<id<_WKWebExtensionTab>> *)openTabs
 {
-    return toAPI(_webExtensionContext->openTabs());
+    return toAPI(_webExtensionContext->openTabs(WebKit::WebExtensionContext::IgnoreExtensionAccess::Yes));
 }
 
 static inline Ref<WebKit::WebExtensionWindow> toImpl(id<_WKWebExtensionWindow> window, WebKit::WebExtensionContext& context)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm
@@ -226,9 +226,6 @@ void WebExtensionContext::cookiesGetAllCookieStores(CompletionHandler<void(Expec
     stores.set(defaultSessionID, Vector<WebExtensionTabIdentifier> { });
 
     for (Ref tab : openTabs()) {
-        if (!tab->extensionHasAccess())
-            continue;
-
         for (WKWebView *webView in tab->webViews()) {
             auto sessionID = webView.configuration.websiteDataStore->_websiteDataStore.get()->sessionID();
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1987,26 +1987,25 @@ bool WebExtensionContext::isValidTab(const WebExtensionTab& tab)
     return tab.isValid() && tab.extensionContext() == this && m_tabMap.get(tab.identifier()) == &tab;
 }
 
-WebExtensionContext::WindowVector WebExtensionContext::openWindows() const
+WebExtensionContext::WindowVector WebExtensionContext::openWindows(IgnoreExtensionAccess ignoreExtensionAccess) const
 {
-    return WTF::map(m_windowOrderVector, [&](auto& identifier) -> Ref<WebExtensionWindow> {
+    return WTF::compactMap(m_windowOrderVector, [&](auto& identifier) -> std::optional<Ref<WebExtensionWindow>> {
         RefPtr window = m_windowMap.get(identifier);
         ASSERT(window && window->isOpen());
+
+        if (ignoreExtensionAccess == IgnoreExtensionAccess::No && !window->extensionHasAccess())
+            return std::nullopt;
         return *window;
     });
 }
 
-WebExtensionContext::TabVector WebExtensionContext::openTabs() const
+WebExtensionContext::TabVector WebExtensionContext::openTabs(IgnoreExtensionAccess ignoreExtensionAccess) const
 {
-    TabVector result;
-    result.reserveInitialCapacity(m_tabMap.size());
-
-    for (Ref tab : m_tabMap.values()) {
-        if (tab->isOpen())
-            result.append(WTFMove(tab));
-    }
-
-    return result;
+    return WTF::compactMap(m_tabMap, [&](auto& entry) -> std::optional<Ref<WebExtensionTab>> {
+        if (ignoreExtensionAccess == IgnoreExtensionAccess::No && !entry.value->extensionHasAccess())
+            return std::nullopt;
+        return entry.value;
+    });
 }
 
 RefPtr<WebExtensionWindow> WebExtensionContext::focusedWindow(IgnoreExtensionAccess ignoreExtensionAccess) const
@@ -3526,14 +3525,20 @@ URL WebExtensionContext::inspectorBackgroundPageURL() const
 
 WebExtensionContext::InspectorTabVector WebExtensionContext::openInspectors(Function<bool(WebExtensionTab&, WebInspectorUIProxy&)>&& predicate) const
 {
+    ASSERT(isLoaded());
+
+    if (!extension().hasInspectorBackgroundPage())
+        return { };
+
     InspectorTabVector result;
 
     for (Ref tab : openTabs()) {
-        if (!tab->extensionHasAccess())
-            continue;
-
         for (WKWebView *webView in tab->webViews()) {
-            Ref inspector = *webView._inspector->_inspector;
+            auto *webInspector = webView._inspector;
+            if (!webInspector)
+                continue;
+
+            Ref inspector = *webInspector->_inspector;
             if (inspector->isVisible() && (!predicate || predicate(tab, inspector)))
                 result.append({ inspector, tab.ptr() });
         }
@@ -3544,14 +3549,24 @@ WebExtensionContext::InspectorTabVector WebExtensionContext::openInspectors(Func
 
 WebExtensionContext::InspectorTabVector WebExtensionContext::loadedInspectors() const
 {
+    ASSERT(isLoaded());
+
+    if (!extension().hasInspectorBackgroundPage())
+        return { };
+
     InspectorTabVector result;
+
     for (auto entry : m_inspectorBackgroundPageMap)
         result.append({ entry.key, getTab(std::get<WebExtensionTabIdentifier>(entry.value)) });
+
     return result;
 }
 
 RefPtr<API::InspectorExtension> WebExtensionContext::inspectorExtension(WebPageProxyIdentifier webPageProxyIdentifier) const
 {
+    ASSERT(isLoaded());
+    ASSERT(extension().hasInspectorBackgroundPage());
+
     RefPtr<WebInspectorUIProxy> foundInspector;
 
     for (auto entry : m_inspectorBackgroundPageMap) {
@@ -3575,6 +3590,9 @@ RefPtr<API::InspectorExtension> WebExtensionContext::inspectorExtension(WebPageP
 
 RefPtr<WebInspectorUIProxy> WebExtensionContext::inspector(const API::InspectorExtension& inspectorExtension) const
 {
+    ASSERT(isLoaded());
+    ASSERT(extension().hasInspectorBackgroundPage());
+
     for (auto entry : m_inspectorExtensionMap) {
         if (entry.value.ptr() == &inspectorExtension)
             return &entry.key;
@@ -3585,10 +3603,10 @@ RefPtr<WebInspectorUIProxy> WebExtensionContext::inspector(const API::InspectorE
 
 HashSet<Ref<WebProcessProxy>> WebExtensionContext::processes(const API::InspectorExtension& inspectorExtension) const
 {
-    HashSet<Ref<WebProcessProxy>> result;
+    ASSERT(isLoaded());
+    ASSERT(extension().hasInspectorBackgroundPage());
 
-    if (!isLoaded())
-        return result;
+    HashSet<Ref<WebProcessProxy>> result;
 
     RefPtr inspectorProxy = inspector(inspectorExtension);
     if (!inspectorProxy)
@@ -3606,6 +3624,11 @@ HashSet<Ref<WebProcessProxy>> WebExtensionContext::processes(const API::Inspecto
 
 bool WebExtensionContext::isInspectorBackgroundPage(WKWebView *webView) const
 {
+    ASSERT(isLoaded());
+
+    if (!extension().hasInspectorBackgroundPage())
+        return false;
+
     for (auto entry : m_inspectorBackgroundPageMap) {
         if (webView == std::get<RetainPtr<WKWebView>>(entry.value))
             return true;
@@ -3616,13 +3639,7 @@ bool WebExtensionContext::isInspectorBackgroundPage(WKWebView *webView) const
 
 bool WebExtensionContext::isDevToolsMessageAllowed()
 {
-#if ENABLE(INSPECTOR_EXTENSIONS)
-    if (!isLoaded())
-        return false;
-    return extension().hasInspectorBackgroundPage();
-#else
-    return false;
-#endif
+    return isLoaded() && extension().hasInspectorBackgroundPage();
 }
 
 void WebExtensionContext::loadInspectorBackgroundPagesDuringLoad()

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -379,8 +379,8 @@ public:
 
     void openNewTab(const WebExtensionTabParameters&, CompletionHandler<void(RefPtr<WebExtensionTab>)>&&);
 
-    WindowVector openWindows() const;
-    TabVector openTabs() const;
+    WindowVector openWindows(IgnoreExtensionAccess = IgnoreExtensionAccess::No) const;
+    TabVector openTabs(IgnoreExtensionAccess = IgnoreExtensionAccess::No) const;
 
     RefPtr<WebExtensionWindow> focusedWindow(IgnoreExtensionAccess = IgnoreExtensionAccess::No) const;
     RefPtr<WebExtensionWindow> frontmostWindow(IgnoreExtensionAccess = IgnoreExtensionAccess::No) const;


### PR DESCRIPTION
#### 484a4fe7b14f08bae1bdccd3e68309bc1ec1ef38
<pre>
Safari crashes at WebKit::WebExtensionContext::openInspectors.
<a href="https://webkit.org/b/273560">https://webkit.org/b/273560</a>
<a href="https://rdar.apple.com/127189700">rdar://127189700</a>

Reviewed by Brian Weinstein.

Add a null check for _WKInspector befor tryign to get API::Inspector from it.

Also moved extensionHasAccess() check to openWindows() and openTabs(), so the
caller does not need to do it. A extensionHasAccess() check was missing in
the openInspectors() loop of openTabs().

Also skip extra work with early returns for !hasInspectorBackgroundPage().

Finally, adopt WTF::compactMap and WTF::map() more.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext openWindows]): Pass IgnoreExtensionAccess::Yes since API should see all.
(-[_WKWebExtensionContext openTabs]): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm:
(WebKit::WebExtensionContext::cookiesGetAllCookieStores):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::openWindows const):
(WebKit::WebExtensionContext::openTabs const):
(WebKit::WebExtensionContext::openInspectors const):
(WebKit::WebExtensionContext::loadedInspectors const):
(WebKit::WebExtensionContext::inspectorExtension const):
(WebKit::WebExtensionContext::inspector const):
(WebKit::WebExtensionContext::processes const):
(WebKit::WebExtensionContext::isInspectorBackgroundPage const):
(WebKit::WebExtensionContext::isDevToolsMessageAllowed): Removed #ifdef since this method
is already guarded by it.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:

Canonical link: <a href="https://commits.webkit.org/278239@main">https://commits.webkit.org/278239@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cef391d15b5b653d116a0c79c630dc776df2b42

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53143 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/577 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/145 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40714 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26759 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42938 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21839 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24193 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8270 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46254 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54724 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24994 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/147 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48108 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26251 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47155 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27113 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7202 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->