### PR TITLE
[WebGPU] useResources: should not be called on empty resource list

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2101,6 +2101,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-273023.html [ Pass Failure ]
 [ Debug ] fast/webgpu/fuzz-126711484.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-126711484.html [ Pass Failure ]
+[ Debug ] fast/webgpu/fuzz-273505.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-273505.html [ Pass Failure Slow ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-273505-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-273505-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-273505.html
+++ b/LayoutTests/fast/webgpu/fuzz-273505.html
@@ -1,0 +1,29131 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter();
+let device0 = await adapter0.requestDevice({
+label: '\u{1f72f}\u09af\u{1f7eb}\u630d\ua242\u{1f647}\uf8e1\u270c',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+});
+let imageData0 = new ImageData(224, 204);
+let img0 = await imageWithData(205, 53, '#88ed8d73', '#e69d72a4');
+try {
+adapter0.label = '\u0003\ub500\u132e\uf8a2\u0a4a';
+} catch {}
+let texture0 = device0.createTexture({
+label: '\uef19\ud022\ub361\ueb18\u{1fbb7}',
+size: [1320, 96, 1],
+mipLevelCount: 9,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let textureView0 = texture0.createView({label: '\u4f00\u073e\uccc1\u7893', dimension: '2d-array', baseMipLevel: 6});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\u2a1a\ub342\u{1fc5c}\u06cb\u4748\u09d2\u200d',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 224, y: 8, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(1150), /* required buffer size: 1150 */
+{offset: 230, bytesPerRow: 396}, {width: 64, height: 24, depthOrArrayLayers: 1});
+} catch {}
+let imageBitmap0 = await createImageBitmap(img0);
+let commandEncoder0 = device0.createCommandEncoder({label: '\u0187\u075c\u0529\u27c3\u{1fec5}\u82f0\u784e\u{1f666}\ub2ac'});
+let textureView1 = texture0.createView({label: '\ue09a\u526d\ua2b3\u8890\u8365', dimension: '2d', mipLevelCount: 5, baseArrayLayer: 0});
+try {
+renderBundleEncoder0.setVertexBuffer(85, undefined, 2085082217, 642100254);
+} catch {}
+let bindGroupLayout0 = device0.createBindGroupLayout({
+label: '\u05ac\u109e\ub2e7\ucd4b\u291f\ub9f2\u3bc7\u8e17',
+entries: [{
+binding: 561,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}],
+});
+let commandEncoder1 = device0.createCommandEncoder();
+let querySet0 = device0.createQuerySet({
+label: '\ufcfb\u094f\uf163\u8d70\u5f08\u0b7b\ua583',
+type: 'occlusion',
+count: 2099,
+});
+let textureView2 = texture0.createView({aspect: 'all', baseMipLevel: 5, mipLevelCount: 2});
+let renderBundle0 = renderBundleEncoder0.finish();
+document.body.prepend(img0);
+let video0 = await videoWithData();
+let pipelineLayout0 = device0.createPipelineLayout({label: '\uc999\u055f\u4eb1\u6498\u{1f95c}\u3d64\u4b09', bindGroupLayouts: [bindGroupLayout0]});
+let commandBuffer0 = commandEncoder1.finish({
+label: '\u672c\ud0b7\u663c\u{1f612}',
+});
+let texture1 = device0.createTexture({
+size: {width: 64},
+dimension: '1d',
+format: 'rgba8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8sint', 'rgba8sint'],
+});
+let shaderModule0 = device0.createShaderModule({
+label: '\udd56\u0333\u04e2',
+code: `@group(0) @binding(561)
+var<storage, read_write> global0: array<u32>;
+
+@compute @workgroup_size(4, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec4<f32>,
+  @location(3) f1: vec3<f32>,
+  @builtin(frag_depth) f2: f32,
+  @location(0) f3: vec2<u32>,
+  @location(1) f4: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(sample_mask) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(4) a1: vec2<i32>, @location(6) a2: vec3<i32>, @location(5) a3: vec4<f32>, @location(14) a4: vec4<f32>, @builtin(instance_index) a5: u32, @location(12) a6: vec2<u32>, @location(8) a7: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let renderBundle1 = renderBundleEncoder0.finish({label: '\u{1f7d1}\uf502\u6533\uafa8\u922c\u0895\u2b67\u0b1c\u1b9e\u67a3\uc9b2'});
+let pipeline0 = await device0.createRenderPipelineAsync({
+label: '\u2883\u0bb0\u022d\u988a\u22a6\u079d\u3881',
+layout: pipelineLayout0,
+multisample: {
+count: 4,
+mask: 0xb3c55fc5,
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'bgra8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'keep',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 557,
+stencilWriteMask: 1586,
+depthBias: 31,
+depthBiasSlopeScale: 85,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 668,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 520,
+shaderLocation: 5,
+}, {
+format: 'float32',
+offset: 336,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 1544,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x2',
+offset: 1124,
+shaderLocation: 12,
+}, {
+format: 'sint32x4',
+offset: 212,
+shaderLocation: 4,
+}, {
+format: 'sint8x4',
+offset: 1056,
+shaderLocation: 6,
+}, {
+format: 'unorm16x4',
+offset: 680,
+shaderLocation: 8,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let canvas0 = document.createElement('canvas');
+let sampler0 = device0.createSampler({
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMaxClamp: 99.270,
+});
+let shaderModule1 = device0.createShaderModule({
+code: `@group(0) @binding(561)
+var<storage, read_write> function0: array<u32>;
+
+@compute @workgroup_size(1, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec3<i32>,
+  @builtin(frag_depth) f1: f32,
+  @location(2) f2: vec4<i32>,
+  @location(3) f3: vec4<f32>,
+  @builtin(sample_mask) f4: u32,
+  @location(0) f5: vec3<u32>,
+  @location(4) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(0) a0: vec4<f32>, @builtin(instance_index) a1: u32, @location(15) a2: vec2<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroupLayout1 = device0.createBindGroupLayout({
+entries: [{
+binding: 257,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+}, {
+binding: 43,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+}],
+});
+let commandEncoder2 = device0.createCommandEncoder({});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(1000), /* required buffer size: 1000 */
+{offset: 1000}, {width: 15, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise0 = device0.createRenderPipelineAsync({
+label: '\u0b11\u05a6\u{1f6de}\u06b5\ucaf1\u567a',
+layout: pipelineLayout0,
+multisample: {
+mask: 0xef01c96b,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.GREEN}, {format: 'rg8sint', writeMask: GPUColorWrite.GREEN}, undefined, {
+  format: 'rg32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'src-alpha', dstFactor: 'dst'},
+alpha: {operation: 'add', srcFactor: 'one', dstFactor: 'src-alpha'},
+},
+  writeMask: GPUColorWrite.BLUE
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'invert',
+depthFailOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2545,
+stencilWriteMask: 1132,
+depthBiasClamp: 86,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 1960,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 112,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1760,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1524,
+attributes: [{
+format: 'sint16x4',
+offset: 428,
+shaderLocation: 15,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'none',
+unclippedDepth: true,
+},
+});
+let img1 = await imageWithData(142, 183, '#b4fe5da4', '#1a694126');
+let buffer0 = device0.createBuffer({
+  label: '\ue726\uba9c\u0d18\ubdbd\ubeaf\u2f07\u5b4d\u0cbd\ub75e\u59b5',
+  size: 37235,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX
+});
+let texture2 = device0.createTexture({
+label: '\ua1c2\ud2d2\u44a1\u0048\u333f\uc844\u7075\u{1fdc7}\u{1fe48}',
+size: [1320, 96, 1],
+mipLevelCount: 7,
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x6-unorm-srgb', 'astc-8x6-unorm-srgb'],
+});
+let pipeline1 = await device0.createRenderPipelineAsync({
+label: '\u{1fa9d}\u7ce1',
+layout: 'auto',
+multisample: {
+mask: 0x8f273e41,
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rg8sint'}, undefined, {format: 'rg32float'}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'src'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'zero'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+depthBias: 16,
+depthBiasSlopeScale: 83,
+depthBiasClamp: 87,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 528,
+attributes: [{
+format: 'unorm8x4',
+offset: 260,
+shaderLocation: 14,
+}, {
+format: 'uint8x2',
+offset: 350,
+shaderLocation: 12,
+}, {
+format: 'float32x3',
+offset: 276,
+shaderLocation: 8,
+}, {
+format: 'float32x3',
+offset: 484,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 1684,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x4',
+offset: 1088,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 1392,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1408,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1816,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 1696,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let commandEncoder3 = device0.createCommandEncoder({label: '\ua9b9\u0397\ue09d\u0229\u{1f818}\u31fd\ua4e9\u02b0'});
+let texture3 = device0.createTexture({
+label: '\ue0d2\u7826\u2857\u{1fd61}\ufcc1\u66db\u0375\u2ca4',
+size: {width: 438, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+sampleCount: 1,
+dimension: '2d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  label: '\u5179\u6bd4\u0b5a',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+let sampler1 = device0.createSampler({
+label: '\u94dc\ucf23\u9187\u{1f9c7}\uf71b\u05b6\u2fb3\u28cc\u0b67',
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 68.277,
+lodMaxClamp: 82.874,
+});
+try {
+renderBundleEncoder1.setIndexBuffer(buffer0, 'uint16', 8562, 5073);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(4, buffer0, 1432, 26980);
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+let pipeline2 = device0.createComputePipeline({
+label: '\u261e\u{1f6cd}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+let bindGroupLayout2 = device0.createBindGroupLayout({
+label: '\u05fa\u{1fad7}\u077d\u{1fc25}',
+entries: [{
+binding: 788,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+}, {
+binding: 803,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+}],
+});
+let querySet1 = device0.createQuerySet({
+label: '\ue520\u46a5\u569c\u0b86\uc683\u056f\u{1fee1}\u6200\u{1faf2}',
+type: 'occlusion',
+count: 2461,
+});
+pseudoSubmit(device0, commandEncoder0);
+let texture4 = device0.createTexture({
+label: '\u0f3f\u{1fb9c}',
+size: {width: 438},
+dimension: '1d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+commandEncoder2.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 56, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 5, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer1 = device0.createBuffer({
+  label: '\u0fbd\u{1fffe}\ud603\u{1f6fa}\u077a\u33ea\u0513',
+  size: 59133,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE
+});
+try {
+renderBundleEncoder1.setVertexBuffer(5, buffer0);
+} catch {}
+try {
+commandEncoder2.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 250, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 448 widthInBlocks: 112 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 33380 */
+offset: 32932,
+buffer: buffer1,
+}, {width: 112, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 7, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 336, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 35, height: 1, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let imageData1 = new ImageData(8, 140);
+let querySet2 = device0.createQuerySet({
+label: '\u6d8c\u7a8d\u0c6e\u89d0\u0223\u{1fad4}\u5f0a\u074c\u3461\u01f8\u{1fdb3}',
+type: 'occlusion',
+count: 992,
+});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  label: '\u1525\uc306\uc408\ue853\u0af4',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder3.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 1,
+  origin: { x: 0, y: 32, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 1296 widthInBlocks: 81 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 52368 */
+offset: 51072,
+bytesPerRow: 1536,
+buffer: buffer1,
+}, {width: 648, height: 8, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 1,
+  origin: { x: 464, y: 32, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 3,
+  origin: { x: 32, y: 16, z: 1 },
+  aspect: 'all',
+}, {width: 136, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(222, 788);
+let buffer2 = device0.createBuffer({
+  label: '\u0948\ufd84\u0d91\u{1febf}\u095f\ud13b\uf129\u{1f746}',
+  size: 1403,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let querySet3 = device0.createQuerySet({
+label: '\uc393\u09dd',
+type: 'occlusion',
+count: 350,
+});
+let texture5 = gpuCanvasContext0.getCurrentTexture();
+try {
+commandEncoder2.copyBufferToBuffer(buffer2, 240, buffer1, 12800, 20);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.clearBuffer(buffer1, 7696, 41192);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({
+label: '\ub79c\uceb9\u04f0\u{1f77e}\ua603\u0345',
+entries: [],
+});
+let commandEncoder4 = device0.createCommandEncoder();
+let computePassEncoder0 = commandEncoder4.beginComputePass({label: '\u{1f839}\ue733\u0cc4\u0e48\ufc1b\u08fb'});
+let sampler2 = device0.createSampler({
+label: '\u8556\u0b25',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 99.146,
+lodMaxClamp: 99.754,
+maxAnisotropy: 4,
+});
+try {
+computePassEncoder0.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder1.setIndexBuffer(buffer0, 'uint32', 18308, 12598);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(5, buffer0, 17108);
+} catch {}
+try {
+  await buffer2.mapAsync(GPUMapMode.WRITE, 1024, 136);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 22700, new Int16Array(16815), 2035, 13044);
+} catch {}
+offscreenCanvas0.height = 125;
+let bindGroupLayout4 = device0.createBindGroupLayout({
+entries: [],
+});
+let texture6 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderBundleEncoder2.setVertexBuffer(3, buffer0, 35684, 1035);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 4204, new Int16Array(3267), 2321, 504);
+} catch {}
+let pipeline3 = device0.createComputePipeline({
+label: '\u0841\u2904\u0739\u04d9\ue8c4\u187d\ud781',
+layout: 'auto',
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+});
+let pipeline4 = device0.createRenderPipeline({
+label: '\ua8da\u{1fb7d}\u344b\u{1fd66}\u095c\u{1f874}\u{1f79c}\u1ea1\u0286\uea3d',
+layout: pipelineLayout0,
+multisample: {
+mask: 0x7702147,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.BLUE}, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 1287,
+stencilWriteMask: 3725,
+depthBias: 91,
+depthBiasClamp: 70,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1588,
+attributes: [{
+format: 'sint32x4',
+offset: 176,
+shaderLocation: 15,
+}, {
+format: 'float32',
+offset: 1308,
+shaderLocation: 0,
+}],
+}
+]
+},
+});
+let texture7 = device0.createTexture({
+label: '\u5e59\ub6b1\uc7fc\ucd77\u51e0\u0926\u3a2a\ud0c9\u0cc3',
+size: {width: 64, height: 90, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-8x5-unorm', 'astc-8x5-unorm'],
+});
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder({label: '\u{1fee5}\u{1f695}\u070f'});
+let renderBundle2 = renderBundleEncoder0.finish({label: '\u{1fbe2}\u0677\u03e1\u{1ff4e}\u03da\u032b\u0885\u{1f880}\udfca\uc0a1\u0729'});
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(17, undefined, 1883029151);
+} catch {}
+try {
+commandEncoder5.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 7,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 32304 */
+offset: 32304,
+rowsPerImage: 125,
+buffer: buffer1,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder5.clearBuffer(buffer1, 45760, 1040);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 24916, new DataView(new ArrayBuffer(29352)), 11279, 15724);
+} catch {}
+canvas0.height = 625;
+let computePassEncoder1 = commandEncoder4.beginComputePass({});
+let renderBundle3 = renderBundleEncoder2.finish({});
+try {
+renderBundleEncoder1.setVertexBuffer(2, buffer0, 10496, 4888);
+} catch {}
+try {
+commandEncoder5.copyBufferToTexture({
+/* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 9764 */
+offset: 9764,
+buffer: buffer0,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 30, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder2.insertDebugMarker('\u0e03');
+} catch {}
+let pipeline5 = await device0.createComputePipelineAsync({
+label: '\u973b\u{1f691}\ub081\ub8c2\u5a37\u0374\u{1f651}\u{1ff01}\u6542\u99fc\u0574',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+offscreenCanvas0.getContext('bitmaprenderer');
+} catch {}
+let textureView3 = texture0.createView({
+  label: '\u{1f628}\u0f14\u008b\u0b9c\ubccb\u29ac\u0e89\u{1f9c0}',
+  dimension: '2d-array',
+  aspect: 'all',
+  format: 'astc-8x8-unorm',
+  baseMipLevel: 8
+});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\u{1ff55}\u7120\u5d3d\u0081\uf019',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+try {
+computePassEncoder1.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(buffer2, 240, buffer1, 22276, 168);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 39616, new Int16Array(46263), 4521, 2216);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let canvas1 = document.createElement('canvas');
+let offscreenCanvas1 = new OffscreenCanvas(254, 633);
+let pipelineLayout1 = device0.createPipelineLayout({label: '\u{1fc2f}\u{1f681}\ua573', bindGroupLayouts: []});
+let commandEncoder6 = device0.createCommandEncoder({});
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 163, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 15, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 237, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['etc2-rgb8unorm', 'astc-5x5-unorm'],
+colorSpace: 'srgb',
+});
+} catch {}
+let texture8 = device0.createTexture({
+label: '\u{1f8f3}\u0df6\u9227',
+size: {width: 128, height: 180, depthOrArrayLayers: 1029},
+mipLevelCount: 10,
+dimension: '3d',
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rg16sint'],
+});
+let sampler3 = device0.createSampler({
+label: '\u{1f7a7}\u{1fd76}\u5cbd\ubc96\u{1fd7e}\u7983\ued3e',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+lodMinClamp: 28.012,
+lodMaxClamp: 47.400,
+compare: 'equal',
+});
+try {
+renderBundleEncoder3.setVertexBuffer(35, undefined);
+} catch {}
+try {
+commandEncoder6.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 5680 */
+offset: 5680,
+buffer: buffer0,
+}, {
+  texture: texture2,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder6.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 195, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 21, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 45, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let canvas2 = document.createElement('canvas');
+let texture9 = device0.createTexture({
+label: '\u8a87\ua8ee\u70ef\ua88d\u0c84\u0dcc\u0a8e\u5e16',
+size: {width: 876, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'rgba16uint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16uint'],
+});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\u{1f83c}\u846d\u850d\u067d\u{1f9a7}\u{1f7f6}\u{1f7d3}',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder3.setVertexBuffer(0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 53160, new Float32Array(2245), 869, 1180);
+} catch {}
+let pipeline6 = await device0.createRenderPipelineAsync({
+layout: pipelineLayout0,
+multisample: {
+count: 4,
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint', writeMask: 0}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, undefined, {format: 'rg32float', writeMask: 0}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'dst'},
+alpha: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'one-minus-src-alpha'},
+},
+  writeMask: 0
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3950,
+depthBias: 62,
+depthBiasSlopeScale: 24,
+depthBiasClamp: 14,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 196,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 12,
+shaderLocation: 12,
+}, {
+format: 'snorm16x2',
+offset: 20,
+shaderLocation: 5,
+}, {
+format: 'sint32x4',
+offset: 12,
+shaderLocation: 6,
+}, {
+format: 'sint32x4',
+offset: 120,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 148,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x2',
+offset: 40,
+shaderLocation: 8,
+}, {
+format: 'snorm16x4',
+offset: 28,
+shaderLocation: 14,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let videoFrame0 = new VideoFrame(video0, {timestamp: 0});
+let bindGroup0 = device0.createBindGroup({
+label: '\u0173\u0553\ua4e7\u3ac3\u85a1',
+layout: bindGroupLayout4,
+entries: [],
+});
+let commandBuffer1 = commandEncoder6.finish({
+label: '\u0362\u05ee',
+});
+let texture10 = device0.createTexture({
+size: {width: 660, height: 48, depthOrArrayLayers: 1},
+mipLevelCount: 9,
+format: 'r32sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r32sint', 'r32sint', 'r32sint'],
+});
+try {
+renderBundleEncoder3.setVertexBuffer(29, undefined);
+} catch {}
+try {
+commandEncoder3.copyBufferToBuffer(buffer0, 32992, buffer1, 40644, 0);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 42, y: 1, z: 0 },
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(24)), /* required buffer size: 97 */
+{offset: 97}, {width: 339, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder2 = commandEncoder3.beginComputePass({label: '\u1169\ufb22'});
+try {
+renderBundleEncoder3.setPipeline(pipeline6);
+} catch {}
+let video1 = await videoWithData();
+let imageData2 = new ImageData(76, 132);
+try {
+renderBundleEncoder3.drawIndexed(32);
+} catch {}
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 1,
+  origin: { x: 184, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 1,
+  origin: { x: 32, y: 8, z: 0 },
+  aspect: 'all',
+}, {width: 256, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder2.clearBuffer(buffer1, 11756, 7676);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+window.someLabel = renderBundleEncoder1.label;
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder3.draw(40, 64, 48, 24);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 110, y: 1, z: 0 },
+  aspect: 'all',
+}, new Uint16Array(new ArrayBuffer(8)), /* required buffer size: 22 */
+{offset: 22, rowsPerImage: 196}, {width: 196, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(487, 687);
+let videoFrame1 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+try {
+canvas1.getContext('webgl2');
+} catch {}
+let querySet4 = device0.createQuerySet({
+label: '\u012e\u0fde\u7b95\u2779\u{1f768}\u943a',
+type: 'occlusion',
+count: 624,
+});
+try {
+renderBundleEncoder3.drawIndexed(16, 80);
+} catch {}
+try {
+commandEncoder5.copyBufferToBuffer(buffer0, 1644, buffer1, 52016, 4076);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline7 = await promise0;
+let gpuCanvasContext1 = offscreenCanvas1.getContext('webgpu');
+let canvas3 = document.createElement('canvas');
+try {
+offscreenCanvas2.getContext('webgl');
+} catch {}
+let bindGroupLayout5 = device0.createBindGroupLayout({
+label: '\ub750\ue1bb\ubfb8\u{1fcb4}\ue546\u{1f909}',
+entries: [],
+});
+let bindGroupLayout6 = pipeline7.getBindGroupLayout(0);
+let querySet5 = device0.createQuerySet({
+label: '\u{1fa77}\u{1f84f}\u{1fdc2}\u57a2',
+type: 'occlusion',
+count: 2739,
+});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder3.draw(24, 72, 56, 8);
+} catch {}
+try {
+renderBundleEncoder3.drawIndexed(48, 56, 56);
+} catch {}
+try {
+commandEncoder4.copyBufferToBuffer(buffer0, 32480, buffer1, 24648, 2320);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 2, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 240 widthInBlocks: 60 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 46860 */
+offset: 46860,
+rowsPerImage: 277,
+buffer: buffer1,
+}, {width: 60, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.clearBuffer(buffer1, 16284, 37984);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 2,
+  origin: { x: 16, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 428 */
+{offset: 428, bytesPerRow: 638}, {width: 272, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+label: '\uf6f0\u0488',
+code: `@group(0) @binding(561)
+var<storage, read_write> function1: array<u32>;
+
+@compute @workgroup_size(6, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec4<f32>,
+  @location(3) f1: vec4<f32>,
+  @location(1) f2: vec4<i32>,
+  @builtin(frag_depth) f3: f32,
+  @location(0) f4: vec2<u32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_index) a1: u32, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S0 {
+  @location(4) f0: f32,
+  @location(2) f1: f16,
+  @location(6) f2: vec2<f16>,
+  @location(13) f3: vec4<f32>,
+  @location(3) f4: i32
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec3<f16>, @location(15) a1: vec2<u32>, @location(7) a2: vec3<i32>, @builtin(instance_index) a3: u32, @location(12) a4: vec4<f32>, a5: S0) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let buffer3 = device0.createBuffer({size: 62511, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let querySet6 = device0.createQuerySet({
+type: 'occlusion',
+count: 1560,
+});
+let textureView4 = texture3.createView({label: '\u{1feb9}\u01ad\u006d\u0599\uf62d\u0fb4\u3df9\uce15\u329c\u{1ffdb}', mipLevelCount: 2});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler4 = device0.createSampler({
+label: '\u{1fcf8}\u3236\u6bc6\u017b\u21ce\u2c6b\u03a3\ubfd0\u6003',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+lodMinClamp: 11.966,
+lodMaxClamp: 90.285,
+});
+try {
+renderBundleEncoder1.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder3.draw(40, 48, 48, 64);
+} catch {}
+try {
+  await buffer3.mapAsync(GPUMapMode.WRITE, 0, 34900);
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(buffer2, 868, buffer1, 23256, 72);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 118, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 608 widthInBlocks: 152 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 40468 */
+offset: 39860,
+buffer: buffer1,
+}, {width: 152, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline8 = device0.createComputePipeline({
+label: '\u{1fd5f}\uc759\u{1f85f}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let img2 = await imageWithData(17, 34, '#943b7bb8', '#930aea29');
+let querySet7 = device0.createQuerySet({
+label: '\u{1fff3}\u0aa1\u2556\uab91\u{1f6b7}\u5277\u0c00\u{1fd0f}\uaf03\u7ee3\u0f58',
+type: 'occlusion',
+count: 2633,
+});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u0405\u8660\u0cff\ue5dd\u{1fdbb}',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder3.drawIndexed(8, 16, 64, -152, 80);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(6, buffer0, 14616, 1009);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 20, y: 0, z: 0 },
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(24)), /* required buffer size: 632 */
+{offset: 632}, {width: 293, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline9 = await device0.createComputePipelineAsync({
+label: '\u83f6\u1261\u5883\u{1ff76}\u07c6\ud542\u5a67\u7ca2\u2118',
+layout: 'auto',
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline10 = device0.createRenderPipeline({
+label: '\u032b\u001c\u4175\ub307\u7e80\u{1fae0}\u04ee\u{1fa05}\u{1fc0c}\u{1fd9a}\u7887',
+layout: pipelineLayout1,
+multisample: {
+count: 4,
+mask: 0x2ceb7c5,
+},
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'zero',
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+stencilBack: {
+failOp: 'zero',
+depthFailOp: 'zero',
+},
+stencilReadMask: 2416,
+stencilWriteMask: 3552,
+depthBias: 39,
+depthBiasSlopeScale: 87,
+depthBiasClamp: 16,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 856,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 804,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x4',
+offset: 600,
+shaderLocation: 3,
+}, {
+format: 'float16x2',
+offset: 572,
+shaderLocation: 4,
+}, {
+format: 'uint8x2',
+offset: 692,
+shaderLocation: 15,
+}, {
+format: 'sint32x2',
+offset: 16,
+shaderLocation: 7,
+}, {
+format: 'float16x4',
+offset: 776,
+shaderLocation: 13,
+}, {
+format: 'unorm16x4',
+offset: 224,
+shaderLocation: 6,
+}, {
+format: 'float32',
+offset: 784,
+shaderLocation: 1,
+}, {
+format: 'snorm8x4',
+offset: 300,
+shaderLocation: 2,
+}, {
+format: 'float32x2',
+offset: 300,
+shaderLocation: 12,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+try {
+  await promise1;
+} catch {}
+let adapter1 = await navigator.gpu.requestAdapter();
+let bindGroup1 = device0.createBindGroup({
+label: '\u2df1\u{1fbe9}\u{1ff5f}\u{1f9ce}\u{1ff9b}\u00d0\u0e7d',
+layout: bindGroupLayout5,
+entries: [],
+});
+let commandEncoder7 = device0.createCommandEncoder({label: '\u{1f992}\u2f31\ua9d0\u00af\u{1fb45}\u0fd3\u{1fca4}\u3865\u0225\u{1fef2}'});
+let imageBitmap1 = await createImageBitmap(video1);
+let commandEncoder8 = device0.createCommandEncoder({label: '\u{1f77c}\u{1fc69}\u2d8d\u{1fa80}\u0c95\u{1f9a8}\u9b11'});
+let querySet8 = device0.createQuerySet({
+label: '\u0d1c\u0542\u03f8\u2007',
+type: 'occlusion',
+count: 1959,
+});
+try {
+renderBundleEncoder3.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer0, 'uint16', 36162);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(2, buffer0, 4580);
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout({
+  label: '\u7568\u6ea2\u9ab7\u076b',
+  bindGroupLayouts: [bindGroupLayout2, bindGroupLayout2, bindGroupLayout3, bindGroupLayout2]
+});
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint32', 24896, 2120);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(3, buffer0, 22200, 2969);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 4,
+  origin: { x: 0, y: 1, z: 3 },
+  aspect: 'all',
+}, new ArrayBuffer(40), /* required buffer size: 3910461 */
+{offset: 748, bytesPerRow: 301, rowsPerImage: 220}, {width: 6, height: 10, depthOrArrayLayers: 60});
+} catch {}
+let pipeline11 = await device0.createComputePipelineAsync({
+label: '\u0586\u0a96\u0b47\u0897\u{1fe3d}\ub913\u{1f66a}\u0685',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let renderBundle4 = renderBundleEncoder0.finish();
+try {
+renderBundleEncoder3.draw(32, 64, 16, 32);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(51, undefined, 2765062406, 561794035);
+} catch {}
+let arrayBuffer0 = buffer2.getMappedRange(1144, 12);
+try {
+device0.queue.submit([
+commandBuffer0,
+]);
+} catch {}
+let promise2 = navigator.gpu.requestAdapter({
+});
+let offscreenCanvas3 = new OffscreenCanvas(636, 815);
+let querySet9 = device0.createQuerySet({
+label: '\u623e\uc87f',
+type: 'occlusion',
+count: 1948,
+});
+pseudoSubmit(device0, commandEncoder3);
+let texture11 = device0.createTexture({
+label: '\u8de8\u9396\ucc05',
+size: [660, 48, 1],
+mipLevelCount: 7,
+format: 'astc-10x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder3 = commandEncoder4.beginComputePass();
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  label: '\u04f2\u{1fcde}\u{1f9bb}\u{1fb72}\u{1f9d0}\uac38\u09cc\u0212\u{1f795}\ua281',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder3.draw(40, 40);
+} catch {}
+try {
+renderBundleEncoder1.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 864, y: 88, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder7.clearBuffer(buffer1, 30856, 12808);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 673 */
+{offset: 673}, {width: 32, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+canvas2.getContext('webgl2');
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+layout: bindGroupLayout3,
+entries: [],
+});
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout3, bindGroupLayout1, bindGroupLayout5, bindGroupLayout5]});
+pseudoSubmit(device0, commandEncoder4);
+let texture12 = device0.createTexture({
+label: '\u0652\u{1fe1e}\u{1f74a}\u{1f927}\u0eab',
+size: {width: 32, height: 45, depthOrArrayLayers: 453},
+mipLevelCount: 8,
+sampleCount: 1,
+dimension: '3d',
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u80ea\ucade\u2ca3\u828a',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup1, new Uint32Array(4528), 1386, 0);
+} catch {}
+try {
+renderBundleEncoder1.draw(48, 8, 24, 16);
+} catch {}
+try {
+commandEncoder8.copyBufferToBuffer(buffer3, 49760, buffer1, 48840, 1424);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img3 = await imageWithData(12, 153, '#ca4ef2ca', '#4eb33394');
+let bindGroup3 = device0.createBindGroup({
+layout: bindGroupLayout3,
+entries: [],
+});
+let querySet10 = device0.createQuerySet({
+label: '\uca0d\u{1f64d}\u7cd5',
+type: 'occlusion',
+count: 3763,
+});
+let commandBuffer2 = commandEncoder5.finish();
+let computePassEncoder4 = commandEncoder7.beginComputePass({label: '\u5562\uc058\ue7be\u2857\u5087\u6b10'});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup1, new Uint32Array(8291), 2293, 0);
+} catch {}
+try {
+renderBundleEncoder3.draw(64, 24, 72, 0);
+} catch {}
+try {
+renderBundleEncoder1.drawIndexed(8, 80, 32, 568, 72);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['depth24plus', 'rgba16float', 'rgba16float'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 57200, new Float32Array(44402), 30362, 364);
+} catch {}
+let pipeline12 = await device0.createRenderPipelineAsync({
+layout: pipelineLayout2,
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rg8sint'}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'bgra8unorm', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'invert',
+passOp: 'replace',
+},
+stencilReadMask: 2192,
+stencilWriteMask: 2631,
+depthBias: 89,
+depthBiasSlopeScale: 21,
+depthBiasClamp: 26,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1012,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 1002,
+shaderLocation: 15,
+}, {
+format: 'float32x2',
+offset: 896,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 1364,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x4',
+offset: 632,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 1352,
+attributes: [{
+format: 'unorm16x2',
+offset: 52,
+shaderLocation: 12,
+}, {
+format: 'float16x4',
+offset: 316,
+shaderLocation: 4,
+}, {
+format: 'sint16x2',
+offset: 124,
+shaderLocation: 7,
+}, {
+format: 'snorm16x2',
+offset: 348,
+shaderLocation: 1,
+}, {
+format: 'float16x4',
+offset: 1304,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32',
+offset: 680,
+shaderLocation: 13,
+}],
+}
+]
+},
+});
+let shaderModule3 = device0.createShaderModule({
+label: '\u{1ff1c}\u91e5\u0b16\ua100\u5eab',
+code: `@group(1) @binding(43)
+var<storage, read_write> parameter0: array<u32>;
+@group(1) @binding(257)
+var<storage, read_write> parameter1: array<u32>;
+
+@compute @workgroup_size(3, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec2<f32>,
+  @location(3) f1: vec4<u32>,
+  @location(4) f2: vec4<f32>,
+  @location(1) f3: vec4<f32>,
+  @location(0) f4: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(4) a0: vec3<i32>, @location(1) a1: vec2<i32>, @location(10) a2: u32, @builtin(sample_mask) a3: u32, @builtin(sample_index) a4: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(10) f0: u32,
+  @location(4) f1: vec3<i32>,
+  @builtin(position) f2: vec4<f32>,
+  @location(1) f3: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec3<f16>, @location(2) a1: i32, @location(15) a2: vec4<u32>, @location(0) a3: f16, @builtin(vertex_index) a4: u32, @location(14) a5: vec3<u32>, @location(10) a6: f16, @location(7) a7: vec2<f16>, @location(4) a8: vec4<f16>, @location(13) a9: vec4<u32>, @location(3) a10: vec3<f16>, @location(5) a11: vec4<f16>, @location(6) a12: vec3<i32>, @location(9) a13: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+});
+let bindGroupLayout7 = device0.createBindGroupLayout({
+label: '\u5f42\u0456\u{1f9d1}\u8b44\u{1f871}\u84ef\u0bd8\u04df\u{1f65b}',
+entries: [{
+binding: 791,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d' },
+}],
+});
+try {
+computePassEncoder4.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer0, 'uint32', 19248, 1622);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(5, buffer0, 31080, 6101);
+} catch {}
+let pipeline13 = device0.createComputePipeline({
+label: '\uc626\u9af3',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+document.body.prepend(img2);
+let textureView5 = texture8.createView({label: '\u9457\uf5c9\u5026\u8b4a\ue094\u78cf', mipLevelCount: 6, arrayLayerCount: 1});
+let renderBundle5 = renderBundleEncoder2.finish({});
+try {
+renderBundleEncoder1.drawIndexed(64, 32, 0, 40, 16);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline14 = await device0.createRenderPipelineAsync({
+label: '\u0737\u01cb\u{1fa78}',
+layout: pipelineLayout1,
+multisample: {
+count: 4,
+mask: 0x7b6bb422,
+},
+fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'rgba8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one', dstFactor: 'src-alpha-saturated'},
+alpha: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'dst'},
+},
+  writeMask: GPUColorWrite.ALL
+}, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'one-minus-src'},
+alpha: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'constant'},
+},
+  writeMask: 0
+}, undefined, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'dst'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'dst-alpha'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE
+}]
+},
+vertex: {
+  module: shaderModule3,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 264,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 96,
+shaderLocation: 0,
+}, {
+format: 'sint8x4',
+offset: 140,
+shaderLocation: 6,
+}, {
+format: 'unorm16x4',
+offset: 208,
+shaderLocation: 3,
+}, {
+format: 'uint16x2',
+offset: 180,
+shaderLocation: 14,
+}, {
+format: 'unorm16x2',
+offset: 148,
+shaderLocation: 8,
+}, {
+format: 'float32x3',
+offset: 220,
+shaderLocation: 5,
+}, {
+format: 'sint32',
+offset: 148,
+shaderLocation: 2,
+}, {
+format: 'sint32',
+offset: 12,
+shaderLocation: 9,
+}, {
+format: 'snorm16x2',
+offset: 104,
+shaderLocation: 4,
+}, {
+format: 'unorm16x4',
+offset: 20,
+shaderLocation: 7,
+}, {
+format: 'uint16x2',
+offset: 172,
+shaderLocation: 13,
+}, {
+format: 'float32x3',
+offset: 216,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 1844,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x4',
+offset: 256,
+shaderLocation: 15,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let bindGroup4 = device0.createBindGroup({
+label: '\u{1fa55}\u2870\u02df\uc550\u971f\ueed3\u{1febe}\ue25c\ubb4f',
+layout: bindGroupLayout5,
+entries: [],
+});
+let buffer4 = device0.createBuffer({
+  label: '\u09de\u067e\ucfe5\u74e2\u{1f8c1}',
+  size: 11643,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX
+});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({label: '\u767a\u0680\u49ce\ue997', colorFormats: ['rg8uint', 'r16uint', 'rgba16uint', 'rgba16sint']});
+try {
+renderBundleEncoder1.setVertexBuffer(5, buffer0, 7088, 17903);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+alphaMode: 'premultiplied',
+});
+} catch {}
+let promise3 = device0.createRenderPipelineAsync({
+label: '\u079e\u{1fe31}\u0e7b',
+layout: pipelineLayout2,
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: 0}, {format: 'rg8sint', writeMask: GPUColorWrite.RED}, undefined, {format: 'rg32float', writeMask: 0}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'one'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+failOp: 'zero',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2962,
+stencilWriteMask: 632,
+depthBias: 27,
+depthBiasSlopeScale: 30,
+depthBiasClamp: 10,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x2',
+offset: 324,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 648,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1956,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1632,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 792,
+attributes: [],
+},
+{
+arrayStride: 1084,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1384,
+attributes: [],
+},
+{
+arrayStride: 28,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 0,
+shaderLocation: 15,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let gpuCanvasContext2 = canvas3.getContext('webgpu');
+document.body.prepend(img1);
+let buffer5 = device0.createBuffer({
+  label: '\u29b7\u1cae\u7683\uc637\ucdef\u6b63\u02b1',
+  size: 26760,
+  usage: GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true
+});
+let computePassEncoder5 = commandEncoder8.beginComputePass({label: '\u3039\u{1fc17}\u{1fa40}\u0543\u6c3f\u2cd4\u{1fca0}\u82cf'});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  label: '\ua25a\u{1f66c}\u09c4\u{1fc74}\u{1f81a}\u1ca4',
+  colorFormats: ['rg8uint', 'r16uint', 'rgba16uint', 'rgba16sint'],
+  sampleCount: 1
+});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder1.draw(8, 48, 64, 48);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(4, buffer0, 35352, 321);
+} catch {}
+try {
+commandEncoder2.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 28176 */
+offset: 28176,
+bytesPerRow: 0,
+rowsPerImage: 290,
+buffer: buffer0,
+}, {
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 8, y: 2, z: 36 },
+  aspect: 'all',
+}, {width: 0, height: 8, depthOrArrayLayers: 71});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let canvas4 = document.createElement('canvas');
+let bindGroupLayout8 = device0.createBindGroupLayout({
+label: '\u{1fef0}\u653e\u0994',
+entries: [{
+binding: 289,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}, {
+binding: 934,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}],
+});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(3, bindGroup4, new Uint32Array(1982), 830, 0);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(2, buffer0, 35804);
+} catch {}
+try {
+commandEncoder7.copyBufferToBuffer(buffer2, 1044, buffer1, 17504, 188);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 3,
+  origin: { x: 10, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 112 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 43600 */
+offset: 43600,
+buffer: buffer1,
+}, {width: 70, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-5x5-unorm', 'bgra8unorm', 'bgra8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline15 = device0.createComputePipeline({
+label: '\ue6a2\u0300\u{1ff73}\u214b\u{1ffc2}\u9368\u{1fb15}\ufc99',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let gpuCanvasContext3 = canvas4.getContext('webgpu');
+let bindGroupLayout9 = device0.createBindGroupLayout({
+label: '\ua831\u{1fd1c}\u{1fa9c}',
+entries: [{
+binding: 297,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+}, {
+binding: 794,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+}],
+});
+let textureView6 = texture2.createView({label: '\u095f\ueca9', dimension: '2d-array', baseMipLevel: 4, mipLevelCount: 1});
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup4);
+} catch {}
+let pipeline16 = await device0.createRenderPipelineAsync({
+label: '\u2739\u1219\u8194\uaab8\u{1fd49}',
+layout: pipelineLayout2,
+fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: 0}, {
+  format: 'rgba8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'dst'},
+alpha: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'dst'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED
+}, {format: 'rg16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'dst-alpha'},
+alpha: {operation: 'add', srcFactor: 'one-minus-src-alpha', dstFactor: 'dst-alpha'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED
+}]
+},
+vertex: {
+  module: shaderModule3,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 904,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 640,
+shaderLocation: 2,
+}, {
+format: 'uint32x4',
+offset: 92,
+shaderLocation: 15,
+}, {
+format: 'unorm16x4',
+offset: 324,
+shaderLocation: 5,
+}, {
+format: 'float32',
+offset: 492,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 1544,
+attributes: [{
+format: 'uint32x2',
+offset: 1368,
+shaderLocation: 14,
+}, {
+format: 'unorm8x4',
+offset: 504,
+shaderLocation: 0,
+}, {
+format: 'sint8x4',
+offset: 1340,
+shaderLocation: 9,
+}, {
+format: 'snorm8x2',
+offset: 58,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 48,
+attributes: [{
+format: 'unorm8x4',
+offset: 36,
+shaderLocation: 10,
+}, {
+format: 'unorm16x2',
+offset: 8,
+shaderLocation: 3,
+}, {
+format: 'sint32x3',
+offset: 16,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 64,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 76,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 356,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 976,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 320,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x2',
+offset: 708,
+shaderLocation: 13,
+}],
+}
+]
+},
+});
+document.body.prepend(video0);
+let offscreenCanvas4 = new OffscreenCanvas(40, 165);
+let commandEncoder9 = device0.createCommandEncoder({label: '\u{1ff9a}\u{1fde8}\u0fa3\u2c10\u0731\uf360\u{1fc9a}'});
+let sampler5 = device0.createSampler({
+label: '\u0e2c\u6da1\u0ee8\u285f\u6cd4\u395e\ub942',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 12.676,
+lodMaxClamp: 35.726,
+});
+try {
+renderBundleEncoder1.drawIndexed(32, 48, 0, 256);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(0, buffer0, 27620, 8981);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder9.copyBufferToBuffer(buffer2, 856, buffer1, 32048, 144);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let canvas5 = document.createElement('canvas');
+let commandEncoder10 = device0.createCommandEncoder({label: '\u0b3f\u2cc2\u{1fd98}\u9a64\u3fb0\u{1f956}\u{1f81d}\ud1c6\u{1fa0d}\u0a69'});
+pseudoSubmit(device0, commandEncoder9);
+let texture13 = device0.createTexture({
+label: '\u0b9b\uc213\u0122',
+size: {width: 120, height: 120, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'astc-10x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+renderBundleEncoder3.draw(64, 56);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(5, buffer0, 26464, 6705);
+} catch {}
+try {
+commandEncoder2.clearBuffer(buffer4, 88, 5056);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise4 = adapter1.requestDevice({
+label: '\u{1fd8b}\u6422\u07ee\u9800',
+});
+let pipelineLayout4 = device0.createPipelineLayout({label: '\u0e61\u0916\u009c\u8cbb\u2499\ud621', bindGroupLayouts: [bindGroupLayout9, bindGroupLayout1]});
+let commandEncoder11 = device0.createCommandEncoder({label: '\u{1f8e6}\u{1fc0d}\u{1fd0c}\u47b6\u459e\u{1fb0d}\u{1f900}\u081a'});
+let commandBuffer3 = commandEncoder11.finish({
+});
+let texture14 = device0.createTexture({
+size: [330, 24, 1],
+mipLevelCount: 6,
+format: 'astc-6x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView7 = texture9.createView({
+  label: '\u0353\ub180\u0944\u{1f6d1}\ud03c\u0cb9\u00f1\u04e1\u{1f721}\u6734',
+  dimension: '2d-array',
+  baseMipLevel: 0,
+  mipLevelCount: 4
+});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder1.draw(16, 56, 64, 0);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(5, buffer0, 28488, 4856);
+} catch {}
+try {
+commandEncoder10.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 2,
+  origin: { x: 20, y: 5, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture13,
+  mipLevel: 2,
+  origin: { x: 30, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 20, depthOrArrayLayers: 0});
+} catch {}
+let pipeline17 = await promise3;
+let buffer6 = device0.createBuffer({
+  label: '\u048e\u6f6c\u{1f81d}\u18ab\u15f2\u{1fba9}\u9df1\uaa7f\ud0bb',
+  size: 37096,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX
+});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder3.draw(24, 80, 32, 48);
+} catch {}
+try {
+commandEncoder7.copyBufferToBuffer(buffer2, 1308, buffer4, 11396, 0);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline18 = device0.createComputePipeline({
+label: '\ue4bf\uf43e\u02ae\u{1fe2a}\u{1ff43}\u04bd\ub482\u{1f742}\ub558\u{1fd23}\u0018',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+},
+});
+let computePassEncoder6 = commandEncoder7.beginComputePass();
+let renderBundle6 = renderBundleEncoder5.finish({label: '\ud86e\u54ba\ue060\u01e7\u0aea\u0564\u022f\u{1fea1}\u{1fcd4}\u0fbd'});
+try {
+renderBundleEncoder1.draw(40, 32);
+} catch {}
+try {
+renderBundleEncoder3.drawIndexed(0, 24, 8, 160, 24);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(6, buffer0, 11632, 2389);
+} catch {}
+try {
+commandEncoder10.copyBufferToBuffer(buffer3, 1368, buffer1, 45760, 7424);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({
+  label: '\u{1ff71}\u61c6\u00c2\u0cc4\ub9c9\u94fe\ud76b\u{1f764}\u0d3a',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true
+});
+let sampler6 = device0.createSampler({
+label: '\u0387\u0b55\u364c\u{1f773}\ufb75\ub0cd\ua895\u691b\u38b9\u9562\u5eaa',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMaxClamp: 52.359,
+});
+try {
+computePassEncoder6.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup2, new Uint32Array(6625), 2236, 0);
+} catch {}
+try {
+renderBundleEncoder1.draw(24, 80);
+} catch {}
+try {
+commandEncoder10.copyBufferToBuffer(buffer0, 1344, buffer1, 58372, 456);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder10.copyBufferToTexture({
+/* bytesInLastRow: 80 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 20408 */
+offset: 20408,
+buffer: buffer0,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 238, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 20, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 720, new BigUint64Array(64032), 46279, 6272);
+} catch {}
+let texture15 = device0.createTexture({
+size: [128, 180, 1],
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let computePassEncoder7 = commandEncoder10.beginComputePass({label: '\u15fc\ua395\u59b2\u0846\uffe6\u3d99\u0934\u0b27\u4d13\u1417\u{1f6bb}'});
+try {
+renderBundleEncoder11.setVertexBuffer(5, buffer6, 25220);
+} catch {}
+let promise5 = navigator.gpu.requestAdapter({
+});
+let imageBitmap2 = await createImageBitmap(canvas0);
+let buffer7 = device0.createBuffer({label: '\ub82c\uff68\u0844\u0acd\u{1f782}\uf43a', size: 42040, usage: GPUBufferUsage.MAP_READ});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({
+  label: '\ub3b0\u78f5\u{1fafc}\ua4ce\u1118',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler7 = device0.createSampler({
+label: '\u1a06\u04c9\u{1f945}\u7a22\u{1fdd5}\ued7c\u1b29\u{1f86d}\uc44f\u{1f819}\u0074',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 75.708,
+lodMaxClamp: 82.629,
+});
+try {
+renderBundleEncoder1.draw(40, 32, 16, 80);
+} catch {}
+try {
+renderBundleEncoder1.drawIndexed(0, 0, 8, -392, 40);
+} catch {}
+try {
+commandEncoder2.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let canvas6 = document.createElement('canvas');
+let commandBuffer4 = commandEncoder2.finish({
+label: '\u0ed7\u728e\u471b\uf776\u05b0\u0af9\u9a61\u051e\u7f12',
+});
+let texture16 = device0.createTexture({
+label: '\uf8b7\u9102\u9ebf\uccd2\u85b9\u01a6\u0e84\uf710\u9e6e\u856f\u028d',
+size: {width: 320, height: 2, depthOrArrayLayers: 222},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let querySet11 = device0.createQuerySet({
+label: '\u0152\ubeff\u7301\u{1f987}\u{1f6f7}',
+type: 'occlusion',
+count: 217,
+});
+let texture17 = device0.createTexture({
+label: '\ubc8f\u{1f93e}\u043a\uf402\u7278',
+size: {width: 4302, height: 40, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'astc-6x5-unorm',
+usage: GPUTextureUsage.COPY_DST,
+});
+let sampler8 = device0.createSampler({
+label: '\u1437\u424d\u{1fb7c}\u0788',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 25.696,
+lodMaxClamp: 97.178,
+compare: 'less-equal',
+});
+try {
+computePassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder3.draw(40, 16);
+} catch {}
+try {
+renderBundleEncoder1.setPipeline(pipeline10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 1, y: 0, z: 57 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 338094 */
+{offset: 926, bytesPerRow: 172, rowsPerImage: 245}, {width: 3, height: 1, depthOrArrayLayers: 9});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+offscreenCanvas4.getContext('webgl');
+} catch {}
+let textureView8 = texture11.createView({
+  label: '\u6dcf\u117e\u{1ff97}\u462f\u8fd0\u{1fdb6}\u08df\ub4c8\u05ff',
+  baseMipLevel: 5,
+  arrayLayerCount: 1
+});
+try {
+renderBundleEncoder3.setBindGroup(3, bindGroup0, new Uint32Array(4531), 3915, 0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer6, 'uint16', 1272, 26294);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline6);
+} catch {}
+let promise6 = device0.createRenderPipelineAsync({
+layout: pipelineLayout3,
+multisample: {
+count: 4,
+mask: 0x730bfc31,
+},
+fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {
+  format: 'rgba8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'constant', dstFactor: 'one-minus-dst'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'dst-alpha'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'rg16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, undefined, {format: 'rg16float'}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+},
+stencilReadMask: 3010,
+depthBias: 0,
+depthBiasSlopeScale: 17,
+depthBiasClamp: 43,
+},
+vertex: {
+  module: shaderModule3,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1228,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x2',
+offset: 808,
+shaderLocation: 14,
+}, {
+format: 'sint32',
+offset: 1068,
+shaderLocation: 2,
+}, {
+format: 'float32x3',
+offset: 1120,
+shaderLocation: 8,
+}, {
+format: 'snorm8x4',
+offset: 60,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x4',
+offset: 1464,
+shaderLocation: 13,
+}, {
+format: 'snorm16x4',
+offset: 420,
+shaderLocation: 0,
+}, {
+format: 'sint8x4',
+offset: 456,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 1132,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x4',
+offset: 944,
+shaderLocation: 10,
+}, {
+format: 'uint32x2',
+offset: 596,
+shaderLocation: 15,
+}, {
+format: 'unorm16x2',
+offset: 536,
+shaderLocation: 3,
+}, {
+format: 'unorm10-10-10-2',
+offset: 500,
+shaderLocation: 7,
+}, {
+format: 'sint16x2',
+offset: 836,
+shaderLocation: 6,
+}, {
+format: 'unorm16x4',
+offset: 132,
+shaderLocation: 5,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+unclippedDepth: false,
+},
+});
+pseudoSubmit(device0, commandEncoder8);
+let texture18 = device0.createTexture({
+label: '\u0719\u3a09\u0f69\ufc9e\uaace\u51e6\ucb20\u{1faff}\uad9d\u2a44',
+size: {width: 32, height: 45, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+dimension: '2d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm-srgb'],
+});
+let sampler9 = device0.createSampler({
+label: '\u07a6\u{1fe05}\u64a7\u{1f840}\ua591',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 37.936,
+lodMaxClamp: 40.610,
+});
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder3.draw(32);
+} catch {}
+try {
+commandEncoder10.copyBufferToTexture({
+/* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 6848 */
+offset: 6848,
+bytesPerRow: 256,
+buffer: buffer0,
+}, {
+  texture: texture13,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 50, height: 55, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame2 = new VideoFrame(imageBitmap1, {timestamp: 0});
+let renderBundle7 = renderBundleEncoder11.finish({label: '\u5f00\u0cb2\u6b3f'});
+try {
+renderBundleEncoder1.draw(80, 16, 40, 64);
+} catch {}
+try {
+  await buffer7.mapAsync(GPUMapMode.READ, 37496);
+} catch {}
+try {
+commandEncoder10.copyBufferToTexture({
+/* bytesInLastRow: 96 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 28208 */
+offset: 28208,
+buffer: buffer0,
+}, {
+  texture: texture2,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 48, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder10.clearBuffer(buffer1, 33216, 8300);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline19 = device0.createRenderPipeline({
+label: '\ue606\ue618\u0966\u0bad\u069c\u{1fcfa}\u0699\u{1fae7}\u{1f6c3}\u0330',
+layout: pipelineLayout1,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'zero', dstFactor: 'dst-alpha'},
+alpha: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'dst-alpha'},
+},
+  writeMask: GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'keep',
+passOp: 'zero',
+},
+stencilReadMask: 3512,
+depthBiasSlopeScale: 44,
+depthBiasClamp: 22,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 72,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x4',
+offset: 28,
+shaderLocation: 14,
+}, {
+format: 'unorm16x2',
+offset: 64,
+shaderLocation: 8,
+}, {
+format: 'sint32x3',
+offset: 32,
+shaderLocation: 4,
+}, {
+format: 'sint8x4',
+offset: 48,
+shaderLocation: 6,
+}, {
+format: 'uint16x4',
+offset: 20,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 1512,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 736,
+shaderLocation: 5,
+}],
+}
+]
+},
+});
+let img4 = await imageWithData(62, 128, '#26b57398', '#bf648230');
+let commandEncoder12 = device0.createCommandEncoder({label: '\u16ff\u00d8\ue3f0'});
+let querySet12 = device0.createQuerySet({
+label: '\u0fda\u0a4b\u476b',
+type: 'occlusion',
+count: 4050,
+});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  label: '\u{1f7ce}\u84e1\u7dbd\u9191\uee74\u{1f8c5}\u{1fe9a}',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8',
+  stencilReadOnly: false
+});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup2, new Uint32Array(8139), 6287, 0);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup3, []);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(8, 72, 32, 72);
+} catch {}
+try {
+commandEncoder12.clearBuffer(buffer1, 46168, 1528);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let texture19 = device0.createTexture({
+label: '\u92b9\u5618\u0170\u{1fa69}\u0a37\u0785',
+size: {width: 4134, height: 5, depthOrArrayLayers: 143},
+mipLevelCount: 6,
+sampleCount: 1,
+format: 'astc-6x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-6x5-unorm-srgb', 'astc-6x5-unorm', 'astc-6x5-unorm-srgb'],
+});
+let renderBundle8 = renderBundleEncoder1.finish({label: '\u{1f69f}\u8057\u72fb\ucb56\ub52f'});
+try {
+computePassEncoder6.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder3.draw(48, 16);
+} catch {}
+video0.height = 79;
+canvas6.height = 192;
+let canvas7 = document.createElement('canvas');
+let img5 = await imageWithData(153, 179, '#c2acf060', '#8c60d131');
+try {
+offscreenCanvas3.getContext('2d');
+} catch {}
+let commandEncoder13 = device0.createCommandEncoder();
+let computePassEncoder8 = commandEncoder12.beginComputePass({});
+try {
+commandEncoder10.clearBuffer(buffer4, 6428, 4444);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let canvas8 = document.createElement('canvas');
+let bindGroupLayout10 = device0.createBindGroupLayout({
+label: '\u{1ffe6}\u0429\u572d\uaed6\u0f4d\ue742\u0a9c\u3f3f\ub08f',
+entries: [{
+binding: 20,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}],
+});
+let querySet13 = device0.createQuerySet({
+label: '\u63d5\u{1fe77}\ue79b',
+type: 'occlusion',
+count: 1,
+});
+let computePassEncoder9 = commandEncoder10.beginComputePass();
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({
+  label: '\u2a16\u06d1\u770b\u0bff\u9d0d\ua35f\u36d5',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let sampler10 = device0.createSampler({
+label: '\u{1ffde}\u8433\u12e7\u7431\u0b83\u31d1\u0de7\u{1fee6}\u07e2\u{1ff7f}',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 12.103,
+lodMaxClamp: 83.330,
+compare: 'greater-equal',
+});
+let pipeline20 = await device0.createComputePipelineAsync({
+layout: pipelineLayout3,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let querySet14 = device0.createQuerySet({
+label: '\u2c1f\u6e93\u4585',
+type: 'occlusion',
+count: 2625,
+});
+let sampler11 = device0.createSampler({
+label: '\u46a6\ud622\u0aa6\uf051\uf6b7\u0bf5\uf1e1\u3d04\u095e\u395d',
+addressModeU: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMaxClamp: 97.553,
+});
+try {
+renderBundleEncoder8.draw(80, 32);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(16, 56, 48);
+} catch {}
+try {
+commandEncoder13.clearBuffer(buffer4, 9784, 336);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth24plus'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let pipeline21 = device0.createRenderPipeline({
+layout: pipelineLayout0,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: 0}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, undefined, {format: 'rg32float'}, {format: 'bgra8unorm', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'zero',
+depthFailOp: 'keep',
+passOp: 'decrement-clamp',
+},
+stencilWriteMask: 4085,
+depthBias: 34,
+depthBiasClamp: 89,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1504,
+attributes: [{
+format: 'snorm16x2',
+offset: 588,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 840,
+attributes: [{
+format: 'sint8x4',
+offset: 160,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 1400,
+attributes: [],
+},
+{
+arrayStride: 1576,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x2',
+offset: 500,
+shaderLocation: 12,
+}, {
+format: 'unorm8x2',
+offset: 1526,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 1856,
+attributes: [],
+},
+{
+arrayStride: 840,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32',
+offset: 484,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 912,
+shaderLocation: 14,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+let querySet15 = device0.createQuerySet({
+label: '\u6858\u7579\u2b82\u5992',
+type: 'occlusion',
+count: 106,
+});
+let textureView9 = texture11.createView({label: '\u0ea1\u7857', dimension: '2d', baseMipLevel: 3});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 424, new DataView(new ArrayBuffer(35965)), 28313, 1900);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 5,
+  origin: { x: 12, y: 0, z: 59 },
+  aspect: 'all',
+}, new Int16Array(arrayBuffer0), /* required buffer size: 3319043 */
+{offset: 806, bytesPerRow: 359, rowsPerImage: 237}, {width: 108, height: 0, depthOrArrayLayers: 40});
+} catch {}
+let pipeline22 = await device0.createComputePipelineAsync({
+label: '\u{1f807}\u{1fcbb}\u{1fa58}\ubad0\u0a60\u0172',
+layout: 'auto',
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let renderBundle9 = renderBundleEncoder3.finish();
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup2, new Uint32Array(8641), 7330, 0);
+} catch {}
+try {
+renderBundleEncoder8.draw(56, 0);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(80, 80, 32, 488, 40);
+} catch {}
+try {
+buffer1.destroy();
+} catch {}
+let pipeline23 = device0.createComputePipeline({
+label: '\u{1fc08}\ub421\u324d\u0f26\u{1fe40}\ucc54\ufa6e\ue5b1',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+document.body.prepend(canvas3);
+let shaderModule4 = device0.createShaderModule({
+label: '\u6a9a\ub697\uc1e5\ue614\u099d',
+code: `@group(1) @binding(257)
+var<storage, read_write> type0: array<u32>;
+@group(0) @binding(794)
+var<storage, read_write> field0: array<u32>;
+@group(0) @binding(297)
+var<storage, read_write> field1: array<u32>;
+@group(1) @binding(43)
+var<storage, read_write> parameter2: array<u32>;
+
+@compute @workgroup_size(5, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(3) f1: vec4<i32>,
+  @location(1) f2: vec4<u32>,
+  @location(2) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S1 {
+  @location(6) f0: vec2<f16>,
+  @location(1) f1: vec2<f32>,
+  @location(13) f2: f16,
+  @location(9) f3: vec2<u32>,
+  @location(11) f4: f16,
+  @location(7) f5: vec4<f16>,
+  @location(15) f6: vec2<f32>,
+  @location(4) f7: vec4<u32>,
+  @location(0) f8: i32,
+  @location(2) f9: vec3<f16>,
+  @location(12) f10: vec3<f32>,
+  @location(14) f11: f16
+}
+
+@vertex
+fn vertex0(a0: S1, @location(5) a1: vec3<i32>, @builtin(instance_index) a2: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let renderBundle10 = renderBundleEncoder0.finish({label: '\u{1fde0}\u{1f849}\u{1fdc9}\u0772\u{1fa34}\ud023\u8ef1\udb3f\u{1fe80}\ue80f'});
+try {
+renderBundleEncoder8.draw(32, 0, 0, 64);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 631 */
+{offset: 599, bytesPerRow: 117}, {width: 20, height: 8, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder({label: '\u0a6c\ubd4b\u057b\ueebe\u0dd5\u079a\u0618'});
+let querySet16 = device0.createQuerySet({
+label: '\ud1df\u0b2a\u{1fbff}\u80d3\u{1fbad}\u72a4\ubc43',
+type: 'occlusion',
+count: 2149,
+});
+let texture20 = device0.createTexture({
+label: '\u{1fd73}\u{1fe80}\u3a41\u57b0\u{1fda8}\u0aed\u0e8d\u{1f7b5}',
+size: {width: 32, height: 45, depthOrArrayLayers: 254},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm'],
+});
+let renderBundle11 = renderBundleEncoder7.finish({label: '\u690e\u4adc\uf0a0'});
+try {
+computePassEncoder6.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder8.draw(32, 40);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer0, 'uint32', 11116, 11276);
+} catch {}
+try {
+commandEncoder14.clearBuffer(buffer4, 5392, 1220);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer4,
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 9744, new BigUint64Array(39881), 26186, 84);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let bindGroupLayout11 = device0.createBindGroupLayout({
+label: '\ud78d\u{1f6bf}\ufc2a\u0285\u0e26\u806f\u26d5\u09bd',
+entries: [{
+binding: 297,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 823,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+}],
+});
+let pipelineLayout5 = device0.createPipelineLayout({label: '\u094e\u0304\u0b34\u8eb8\ucbb9\ua695\u03c3\ufe72\u0ab3\ua742', bindGroupLayouts: []});
+let computePassEncoder10 = commandEncoder13.beginComputePass();
+try {
+renderBundleEncoder8.draw(64, 16, 56, 24);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(32, 32, 16, 320, 56);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(4, buffer6);
+} catch {}
+let arrayBuffer1 = buffer5.getMappedRange();
+try {
+commandEncoder14.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 3,
+  origin: { x: 32, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 53504 */
+offset: 53504,
+bytesPerRow: 0,
+buffer: buffer1,
+}, {width: 0, height: 16, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let video2 = await videoWithData();
+try {
+adapter1.label = '\u{1fd2c}\u{1fef8}\u0024\u0527\u{1f998}\u0975\ub19e\u012f\u1699\ub32c';
+} catch {}
+let querySet17 = device0.createQuerySet({
+label: '\u0bfb\u077f',
+type: 'occlusion',
+count: 2662,
+});
+let texture21 = device0.createTexture({
+label: '\u{1fed2}\u0374\uaa26\ud409\u6ea0\u9f9c\u0fa4\u068b\uebab',
+size: [660],
+dimension: '1d',
+format: 'r32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+});
+try {
+renderBundleEncoder9.draw(72);
+} catch {}
+try {
+computePassEncoder10.insertDebugMarker('\u9dcf');
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer3,
+commandBuffer2,
+commandBuffer1,
+]);
+} catch {}
+document.body.prepend(img0);
+let bindGroupLayout12 = device0.createBindGroupLayout({
+label: '\u{1f9ad}\u5fd4\u1eb6\u0fc3\ue119\u8ced\u0e20\u0e42',
+entries: [],
+});
+try {
+renderBundleEncoder10.setIndexBuffer(buffer4, 'uint32', 5716, 1787);
+} catch {}
+try {
+commandEncoder14.copyBufferToBuffer(buffer2, 64, buffer1, 11048, 1060);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder14.copyBufferToTexture({
+/* bytesInLastRow: 2360 widthInBlocks: 590 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 34380 */
+offset: 34380,
+buffer: buffer0,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: { x: 13, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 590, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder14.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 3,
+  origin: { x: 96, y: 16, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderBundleEncoder9.pushDebugGroup('\u0e11');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 3,
+  origin: { x: 66, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(186), /* required buffer size: 186 */
+{offset: 186}, {width: 168, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder15 = device0.createCommandEncoder({label: '\ubce8\ue802\u0fb5\uf6d2\u5781\udbdb\u008e\u0ef2\ueecf\u07bf'});
+let computePassEncoder11 = commandEncoder14.beginComputePass({});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup1, new Uint32Array(3016), 1155, 0);
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder9.draw(32, 0, 72, 80);
+} catch {}
+let arrayBuffer2 = buffer3.getMappedRange(0, 12164);
+try {
+commandEncoder15.copyBufferToBuffer(buffer3, 38544, buffer4, 5964, 4464);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+renderBundleEncoder9.popDebugGroup();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.prepend(img1);
+gc();
+let externalTexture0 = device0.importExternalTexture({
+source: video2,
+colorSpace: 'srgb',
+});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(16, 0, 32, -400);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer4, 'uint16', 11484);
+} catch {}
+try {
+commandEncoder12.copyBufferToBuffer(buffer0, 13788, buffer1, 7980, 5984);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer1, 1584, 9776);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+canvas8.getContext('webgl');
+} catch {}
+let renderBundle12 = renderBundleEncoder14.finish({label: '\u{1fdd6}\u00f9\u4b4c\u5cf6\ue164'});
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(7, buffer0, 2888, 1093);
+} catch {}
+let promise8 = device0.createRenderPipelineAsync({
+label: '\u9724\u6bea\u0a26\u02bc',
+layout: pipelineLayout3,
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.GREEN}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'constant', dstFactor: 'one-minus-dst'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilWriteMask: 3062,
+depthBias: 76,
+depthBiasClamp: 11,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1892,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 1736,
+shaderLocation: 6,
+}, {
+format: 'snorm16x4',
+offset: 376,
+shaderLocation: 1,
+}, {
+format: 'float32x2',
+offset: 1532,
+shaderLocation: 2,
+}, {
+format: 'sint8x2',
+offset: 680,
+shaderLocation: 3,
+}, {
+format: 'float32x3',
+offset: 1344,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 2044,
+attributes: [{
+format: 'uint32x3',
+offset: 1736,
+shaderLocation: 15,
+}, {
+format: 'snorm8x4',
+offset: 112,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 1256,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 984,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 1540,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x2',
+offset: 424,
+shaderLocation: 7,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+},
+});
+let canvas9 = document.createElement('canvas');
+let imageBitmap3 = await createImageBitmap(canvas9);
+let textureView10 = texture3.createView({label: '\u7389\u1378\u{1f9c5}\u3d02\u0b0e\uef5f\u{1f890}\ufe97'});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup1, new Uint32Array(5074), 959, 0);
+} catch {}
+try {
+renderBundleEncoder8.draw(8);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(56, 32, 8, 752, 40);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer4, 'uint16', 888);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(3, buffer6, 26104, 5575);
+} catch {}
+try {
+commandEncoder12.copyBufferToTexture({
+/* bytesInLastRow: 9424 widthInBlocks: 589 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 30736 */
+offset: 30736,
+bytesPerRow: 9472,
+rowsPerImage: 283,
+buffer: buffer0,
+}, {
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 414, y: 10, z: 0 },
+  aspect: 'all',
+}, {width: 3534, height: 20, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline24 = await device0.createRenderPipelineAsync({
+label: '\ua852\ubbd6\u6955\u079a\ue9f9\u05ff\u5b62\u{1f808}',
+layout: pipelineLayout5,
+multisample: {
+count: 4,
+mask: 0x268b2af5,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, undefined, {format: 'rg32float'}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+}
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-wrap',
+},
+depthBias: 62,
+depthBiasSlopeScale: 62,
+depthBiasClamp: 30,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1140,
+attributes: [{
+format: 'unorm16x2',
+offset: 460,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 1284,
+attributes: [],
+},
+{
+arrayStride: 1936,
+attributes: [],
+},
+{
+arrayStride: 1320,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 1124,
+shaderLocation: 15,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: false,
+},
+});
+let gpuCanvasContext4 = canvas9.getContext('webgpu');
+let offscreenCanvas5 = new OffscreenCanvas(389, 700);
+try {
+canvas7.getContext('webgpu');
+} catch {}
+let buffer8 = device0.createBuffer({
+  label: '\u{1fe5c}\ubf05\u{1fac0}\u4015\u3419',
+  size: 15463,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let texture22 = device0.createTexture({
+label: '\u0c55\u{1fc75}\uf27a',
+size: {width: 128, height: 180, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'astc-4x4-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+commandEncoder12.clearBuffer(buffer8, 13800, 156);
+dissociateBuffer(device0, buffer8);
+} catch {}
+let pipeline25 = device0.createRenderPipeline({
+layout: pipelineLayout4,
+fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE}, {
+  format: 'rgba16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'rgba16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+failOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2788,
+stencilWriteMask: 1256,
+depthBias: 62,
+depthBiasSlopeScale: 56,
+depthBiasClamp: 97,
+},
+vertex: {
+  module: shaderModule4,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1124,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 1000,
+shaderLocation: 12,
+}, {
+format: 'float32x3',
+offset: 1084,
+shaderLocation: 11,
+}, {
+format: 'sint32x3',
+offset: 848,
+shaderLocation: 0,
+}, {
+format: 'unorm10-10-10-2',
+offset: 20,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 688,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 316,
+shaderLocation: 7,
+}, {
+format: 'float16x4',
+offset: 620,
+shaderLocation: 1,
+}, {
+format: 'uint32x2',
+offset: 228,
+shaderLocation: 4,
+}, {
+format: 'sint32x4',
+offset: 292,
+shaderLocation: 5,
+}, {
+format: 'float32x4',
+offset: 52,
+shaderLocation: 6,
+}, {
+format: 'uint32x3',
+offset: 136,
+shaderLocation: 9,
+}, {
+format: 'unorm16x2',
+offset: 316,
+shaderLocation: 14,
+}, {
+format: 'snorm8x2',
+offset: 172,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 748,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 28,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x2',
+offset: 6,
+shaderLocation: 2,
+}],
+}
+]
+},
+});
+gc();
+let img6 = await imageWithData(135, 166, '#ffda90ed', '#6247a69b');
+let shaderModule5 = device0.createShaderModule({
+code: `@group(1) @binding(257)
+var<storage, read_write> local0: array<u32>;
+@group(1) @binding(43)
+var<storage, read_write> function2: array<u32>;
+
+@compute @workgroup_size(7, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<u32>,
+  @location(0) f1: vec3<u32>,
+  @location(1) f2: u32,
+  @location(3) f3: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(12) a0: vec2<f32>, @location(9) a1: vec4<u32>, @builtin(position) a2: vec4<f32>, @builtin(sample_mask) a3: u32, @builtin(sample_index) a4: u32, @builtin(front_facing) a5: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(12) f4: vec2<f32>,
+  @builtin(position) f5: vec4<f32>,
+  @location(9) f6: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: i32, @location(6) a1: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroupLayout13 = device0.createBindGroupLayout({
+label: '\u063b\u0d74\ua7cc\u0a3e\u0e49\uda01\u{1ff01}\ueff7\uce37',
+entries: [{
+binding: 674,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}],
+});
+try {
+renderBundleEncoder9.drawIndexed(64);
+} catch {}
+try {
+commandEncoder12.copyBufferToBuffer(buffer2, 1144, buffer4, 4336, 68);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder12.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 1,
+  origin: { x: 0, y: 8, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 208 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 51824 */
+offset: 51824,
+bytesPerRow: 512,
+buffer: buffer1,
+}, {width: 52, height: 80, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+computePassEncoder2.pushDebugGroup('\u{1fb4c}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 20, y: 5, z: 48 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 6977582 */
+{offset: 692, bytesPerRow: 162, rowsPerImage: 210}, {width: 9, height: 18, depthOrArrayLayers: 206});
+} catch {}
+let pipeline26 = device0.createRenderPipeline({
+label: '\u0b3b\u0f90\uade1\u0a3b\ue547\u{1fef9}\u{1f7a7}\u0da0',
+layout: pipelineLayout4,
+multisample: {
+},
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'src'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'dst'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 550,
+stencilWriteMask: 3510,
+depthBias: 58,
+depthBiasSlopeScale: 31,
+depthBiasClamp: 24,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 428,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 70,
+shaderLocation: 1,
+}, {
+format: 'sint32x4',
+offset: 160,
+shaderLocation: 7,
+}, {
+format: 'unorm10-10-10-2',
+offset: 224,
+shaderLocation: 2,
+}, {
+format: 'uint32',
+offset: 168,
+shaderLocation: 15,
+}, {
+format: 'snorm8x4',
+offset: 392,
+shaderLocation: 4,
+}, {
+format: 'snorm8x2',
+offset: 404,
+shaderLocation: 13,
+}, {
+format: 'float32x3',
+offset: 368,
+shaderLocation: 6,
+}, {
+format: 'snorm8x2',
+offset: 362,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 1692,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1596,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x2',
+offset: 64,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let videoFrame3 = new VideoFrame(offscreenCanvas2, {timestamp: 0});
+let bindGroup5 = device0.createBindGroup({
+label: '\ub55f\u{1fdd9}\u7544\u080e\u{1fed7}\u009a',
+layout: bindGroupLayout1,
+entries: [{
+binding: 257,
+resource: externalTexture0
+}, {
+binding: 43,
+resource: externalTexture0
+}],
+});
+let querySet18 = device0.createQuerySet({
+label: '\u0da7\u002c\u{1f75c}\ufed3\u{1fd92}\u{1ff61}\u3639\u9387\u{1ff35}\u0145',
+type: 'occlusion',
+count: 3809,
+});
+let textureView11 = texture16.createView({label: '\ub19c\u8df6\u2259\u{1fb37}\u00e9\u{1f8b7}\u0a2b\u7397\u1067', baseMipLevel: 3, mipLevelCount: 3});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({
+  label: '\u72ba\u74d3\u9a2e\u{1fe4e}\u310f\u80c0\uc256\u025b\ub506',
+  colorFormats: ['rg8uint', 'r16uint', 'rgba16uint', 'rgba16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let arrayBuffer3 = buffer3.getMappedRange(12168, 4180);
+try {
+buffer6.unmap();
+} catch {}
+try {
+commandEncoder12.copyBufferToBuffer(buffer0, 15840, buffer4, 956, 9292);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer8, 9280, 340);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 2060, new BigUint64Array(51781), 41624, 728);
+} catch {}
+let pipeline27 = await device0.createRenderPipelineAsync({
+label: '\u0976\u{1feaa}\u1d13\u{1fb22}\ud643\u4eda\u0b6a\uc283\u02f7\u3195',
+layout: pipelineLayout3,
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg8sint'}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'bgra8unorm', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'invert',
+passOp: 'replace',
+},
+stencilReadMask: 3113,
+depthBias: 50,
+depthBiasSlopeScale: 81,
+depthBiasClamp: 33,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 704,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x2',
+offset: 120,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 424,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x2',
+offset: 12,
+shaderLocation: 15,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'none',
+unclippedDepth: true,
+},
+});
+let video3 = await videoWithData();
+let commandBuffer5 = commandEncoder12.finish({
+label: '\udde0\uc73c\u2d54\u5d1e\u{1fb3b}\u{1f924}\u08c8\u90af\ufbc4',
+});
+let texture23 = device0.createTexture({
+size: [32, 45, 1],
+mipLevelCount: 3,
+sampleCount: 1,
+dimension: '2d',
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+computePassEncoder6.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder9.draw(32, 40);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgba16float'],
+colorSpace: 'display-p3',
+});
+} catch {}
+let pipeline28 = device0.createComputePipeline({
+layout: pipelineLayout5,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let buffer9 = device0.createBuffer({label: '\u7262\u0a93\u01c3', size: 20488, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX});
+let textureView12 = texture23.createView({dimension: '2d-array', aspect: 'all', baseMipLevel: 1, mipLevelCount: 1});
+try {
+renderBundleEncoder8.drawIndexed(80, 24);
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView13 = texture7.createView({
+  label: '\u628b\uc931\uf088\ua475\u3cef\u0c18\u099e\u9f5a',
+  dimension: '2d-array',
+  format: 'astc-8x5-unorm',
+  baseMipLevel: 1,
+  mipLevelCount: 2
+});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({
+  label: '\ufd02\u7366\u{1f650}\u{1f9c6}',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+try {
+renderBundleEncoder8.drawIndexed(32, 32, 32, -144, 64);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(1, buffer0);
+} catch {}
+try {
+querySet17.destroy();
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer5,
+]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(974), /* required buffer size: 974 */
+{offset: 974, bytesPerRow: 267}, {width: 0, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+label: '\u{1ffb1}\u1528\u9946\u0e5b\u0be4\u{1fd89}',
+layout: bindGroupLayout4,
+entries: [],
+});
+let commandEncoder16 = device0.createCommandEncoder({});
+let textureView14 = texture10.createView({label: '\uffda\u02c7\u0550\u{1f74e}\u2400\u2f84\u0e57\u7d8f\ud462', baseMipLevel: 2, mipLevelCount: 3});
+let computePassEncoder12 = commandEncoder15.beginComputePass({});
+let renderBundle13 = renderBundleEncoder18.finish({label: '\u003e\u0971\u5382\u718c\u0d42\uf40b\u68aa\u080e\u619f'});
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+commandEncoder16.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 0,
+  origin: { x: 530, y: 8, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 55152 */
+offset: 55152,
+bytesPerRow: 0,
+buffer: buffer1,
+}, {width: 0, height: 32, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 8328, new Int16Array(36535), 30571, 444);
+} catch {}
+let gpuCanvasContext5 = canvas6.getContext('webgpu');
+try {
+  await promise7;
+} catch {}
+let imageBitmap4 = await createImageBitmap(canvas1);
+let pipelineLayout6 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout6, bindGroupLayout2, bindGroupLayout10, bindGroupLayout13]});
+let commandEncoder17 = device0.createCommandEncoder({label: '\u{1fb3f}\uc52a\u{1fcb5}\u28d1\u{1f9a1}\u87fb\u9c91\u{1fc58}\u2882'});
+let texture24 = device0.createTexture({
+size: {width: 1320, height: 96, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'etc2-rgba8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgba8unorm-srgb', 'etc2-rgba8unorm'],
+});
+let textureView15 = texture12.createView({baseMipLevel: 3, mipLevelCount: 2});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({
+  label: '\u2d43\u{1f653}\u6916\u{1f67b}\u3b39\u85e0\uf1e4\ue98c',
+  colorFormats: ['bgra8unorm-srgb', 'rgba16uint', 'r8uint', 'rg11b10ufloat', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler12 = device0.createSampler({
+label: '\u3eee\ufd56\u0e5a\uf371\u630b',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 92.193,
+lodMaxClamp: 96.378,
+maxAnisotropy: 14,
+});
+try {
+renderBundleEncoder9.drawIndexed(56, 32, 32, 408, 56);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer9, 'uint16', 17330, 93);
+} catch {}
+gc();
+let querySet19 = device0.createQuerySet({
+label: '\u8a12\u39c8\u{1fec5}\u{1fa45}\u0e37\uba2f\u1365\u61de\u{1ffdc}',
+type: 'occlusion',
+count: 3250,
+});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup6, new Uint32Array(9895), 5415, 0);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(8, 16, 48, -592);
+} catch {}
+try {
+querySet4.destroy();
+} catch {}
+let arrayBuffer4 = buffer5.getMappedRange(26760, 0);
+try {
+  await buffer8.mapAsync(GPUMapMode.READ, 0, 2876);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 2760, new BigUint64Array(27294), 6871, 36);
+} catch {}
+let bindGroupLayout14 = device0.createBindGroupLayout({
+label: '\u0f7b\ue21e\uf2c0\u035c\uf700\u08f7',
+entries: [],
+});
+let buffer10 = device0.createBuffer({
+  label: '\u0520\u34c4\u00fc\u{1ff66}',
+  size: 8122,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let querySet20 = device0.createQuerySet({
+label: '\u{1fc95}\u0307\u{1fef0}\u2668',
+type: 'occlusion',
+count: 3120,
+});
+let texture25 = device0.createTexture({
+label: '\u1954\u{1fbdf}\ud748\u{1f7a0}\u70ee\u761d\ucf14\u{1f631}\u{1fff9}\u{1fe2b}',
+size: {width: 160, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+sampleCount: 1,
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg8snorm', 'rg8snorm', 'rg8snorm'],
+});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({
+  label: '\u0990\u00f7\u{1fe85}\u33a6\u0892\ua383\u8bad\uc851',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8'
+});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup3, new Uint32Array(579), 231, 0);
+} catch {}
+try {
+commandEncoder16.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 56, y: 36, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 55136 */
+offset: 55136,
+bytesPerRow: 0,
+buffer: buffer1,
+}, {width: 0, height: 100, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+canvas5.getContext('webgl');
+} catch {}
+let texture26 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder13 = commandEncoder17.beginComputePass();
+try {
+computePassEncoder10.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(40);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer3, 55524, buffer1, 50560, 2424);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+offscreenCanvas5.getContext('webgl');
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+label: '\u7add\u084e\u0669\ue850\u{1f9e6}\ue19d\u6b78',
+code: `@group(1) @binding(43)
+var<storage, read_write> local1: array<u32>;
+@group(0) @binding(794)
+var<storage, read_write> parameter3: array<u32>;
+@group(1) @binding(257)
+var<storage, read_write> type1: array<u32>;
+
+@compute @workgroup_size(5, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S3 {
+  @location(14) f0: vec4<f32>,
+  @builtin(sample_index) f1: u32,
+  @location(8) f2: vec2<u32>,
+  @builtin(front_facing) f3: bool,
+  @location(2) f4: i32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec2<u32>,
+  @location(1) f1: vec3<i32>,
+  @location(3) f2: vec2<f32>,
+  @builtin(sample_mask) f3: u32,
+  @location(4) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(13) a0: vec2<f16>, @builtin(position) a1: vec4<f32>, @location(12) a2: vec4<f32>, a3: S3, @location(6) a4: vec3<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S2 {
+  @location(6) f0: vec2<f32>,
+  @location(3) f1: u32
+}
+struct VertexOutput0 {
+  @location(0) f7: f16,
+  @location(10) f8: vec4<f16>,
+  @location(14) f9: vec4<f32>,
+  @location(12) f10: vec4<f32>,
+  @location(15) f11: vec2<f16>,
+  @location(6) f12: vec3<f32>,
+  @location(2) f13: i32,
+  @location(13) f14: vec2<f16>,
+  @location(8) f15: vec2<u32>,
+  @builtin(position) f16: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec4<u32>, @location(5) a1: f16, a2: S2, @location(4) a3: vec2<i32>, @location(1) a4: i32, @location(7) a5: u32, @location(8) a6: f32, @location(10) a7: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+pseudoSubmit(device0, commandEncoder10);
+let texture27 = device0.createTexture({
+label: '\u4215\u0c60\ufe03\u0a0a\u09be\ub710\ua59a',
+size: [1320, 96, 1],
+mipLevelCount: 5,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x6-unorm'],
+});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({
+  label: '\u33c8\u0579\u55e2\u84d8\u{1fc3c}\u9ccb\u0681\uab72\u26cf\u3e8b\u0224',
+  colorFormats: ['bgra8unorm-srgb', 'rgba16uint', 'r8uint', 'rg11b10ufloat', 'r8uint'],
+  stencilReadOnly: true
+});
+let sampler13 = device0.createSampler({
+label: '\u06b4\ucc24\u{1f9df}\u000e\u198f\u{1fa20}\u8801\ue73c',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 51.659,
+lodMaxClamp: 69.568,
+});
+try {
+renderBundleEncoder6.setBindGroup(1, bindGroup0, []);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(24, 72, 48);
+} catch {}
+try {
+  await buffer10.mapAsync(GPUMapMode.READ, 0, 3092);
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer2, 1064, buffer10, 5608, 276);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+/* bytesInLastRow: 452 widthInBlocks: 113 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 12536 */
+offset: 12536,
+buffer: buffer0,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 98, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 113, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline29 = await device0.createComputePipelineAsync({
+layout: pipelineLayout4,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+},
+});
+let videoFrame4 = new VideoFrame(video1, {timestamp: 0});
+let textureView16 = texture11.createView({baseMipLevel: 3, mipLevelCount: 3});
+try {
+renderBundleEncoder17.drawIndexed(24);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(7, buffer0, 13656, 170);
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer0, 7024, buffer1, 19112, 3588);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let videoFrame5 = new VideoFrame(videoFrame3, {timestamp: 0});
+let shaderModule7 = device0.createShaderModule({
+label: '\ud05c\uf2f1\udd13\ufadb\u{1fc58}',
+code: `@group(1) @binding(43)
+var<storage, read_write> global1: array<u32>;
+@group(0) @binding(794)
+var<storage, read_write> i0: array<u32>;
+@group(1) @binding(257)
+var<storage, read_write> field2: array<u32>;
+@group(0) @binding(297)
+var<storage, read_write> function3: array<u32>;
+
+@compute @workgroup_size(8, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S5 {
+  @builtin(position) f0: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(3) f0: vec4<i32>,
+  @location(2) f1: vec4<u32>,
+  @location(1) f2: u32,
+  @location(0) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, a1: S5, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S4 {
+  @location(15) f0: vec4<u32>,
+  @builtin(vertex_index) f1: u32,
+  @builtin(instance_index) f2: u32,
+  @location(13) f3: vec4<u32>,
+  @location(2) f4: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec4<u32>, @location(1) a1: vec2<f16>, a2: S4, @location(0) a3: u32, @location(5) a4: vec3<u32>, @location(14) a5: vec4<f32>, @location(7) a6: f16, @location(12) a7: u32, @location(9) a8: vec4<u32>, @location(10) a9: vec4<u32>, @location(4) a10: f32, @location(6) a11: vec2<i32>, @location(8) a12: vec3<f16>, @location(11) a13: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let textureView17 = texture4.createView({});
+let computePassEncoder14 = commandEncoder16.beginComputePass({label: '\u2378\u2225\ucb2b\u5fba\u2b7f'});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(8, 72);
+} catch {}
+let arrayBuffer5 = buffer7.getMappedRange(40328, 544);
+try {
+computePassEncoder11.pushDebugGroup('\u3b1e');
+} catch {}
+let videoFrame6 = new VideoFrame(canvas7, {timestamp: 0});
+try {
+window.someLabel = commandEncoder10.label;
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+label: '\u6ebe\u{1f8f1}\u{1f6b3}',
+code: `@group(1) @binding(803)
+var<storage, read_write> field3: array<u32>;
+@group(0) @binding(803)
+var<storage, read_write> i1: array<u32>;
+@group(3) @binding(803)
+var<storage, read_write> type2: array<u32>;
+@group(0) @binding(788)
+var<storage, read_write> type3: array<u32>;
+@group(1) @binding(788)
+var<storage, read_write> type4: array<u32>;
+@group(3) @binding(788)
+var<storage, read_write> field4: array<u32>;
+
+@compute @workgroup_size(6, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(3) f1: vec2<f32>,
+  @location(1) f2: vec3<i32>,
+  @location(4) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(11) a0: vec4<u32>, @location(0) a1: vec3<i32>, @location(4) a2: vec2<i32>, @location(9) a3: f16, @location(13) a4: vec4<f16>, @builtin(front_facing) a5: bool, @location(14) a6: vec3<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S6 {
+  @location(2) f0: u32,
+  @location(7) f1: vec2<f16>,
+  @location(8) f2: vec3<f16>,
+  @location(10) f3: f32,
+  @location(12) f4: f32,
+  @location(0) f5: vec3<f32>,
+  @location(11) f6: vec3<u32>,
+  @location(15) f7: vec4<u32>
+}
+struct VertexOutput0 {
+  @location(0) f17: vec3<i32>,
+  @location(13) f18: vec4<f16>,
+  @location(4) f19: vec2<i32>,
+  @builtin(position) f20: vec4<f32>,
+  @location(11) f21: vec4<u32>,
+  @location(14) f22: vec3<i32>,
+  @location(9) f23: f16
+}
+
+@vertex
+fn vertex0(a0: S6, @location(3) a1: vec2<i32>, @location(6) a2: vec4<f32>, @location(9) a3: vec4<f16>, @location(1) a4: vec4<i32>, @location(13) a5: f16, @location(4) a6: vec2<f32>, @location(14) a7: vec3<f32>, @location(5) a8: i32, @builtin(vertex_index) a9: u32, @builtin(instance_index) a10: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let querySet21 = device0.createQuerySet({
+label: '\u0df9\u{1f835}\uead6\u{1fa08}\u2a47\u{1ff87}\u{1fedf}\u00d3\u0925\u0b56\u{1f80e}',
+type: 'occlusion',
+count: 1455,
+});
+let renderBundle14 = renderBundleEncoder4.finish();
+try {
+renderBundleEncoder17.setVertexBuffer(3, buffer0, 20588, 1350);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: { x: 49, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 665 */
+{offset: 665, bytesPerRow: 2563}, {width: 606, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline30 = device0.createRenderPipeline({
+layout: pipelineLayout0,
+multisample: {
+count: 4,
+mask: 0x49a273fd,
+},
+fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba16uint', writeMask: 0}, {format: 'rgba16sint', writeMask: GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 994,
+stencilWriteMask: 2578,
+depthBias: 74,
+},
+vertex: {
+  module: shaderModule7,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 208,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x4',
+offset: 132,
+shaderLocation: 7,
+}, {
+format: 'uint16x4',
+offset: 48,
+shaderLocation: 12,
+}, {
+format: 'uint32x4',
+offset: 68,
+shaderLocation: 11,
+}, {
+format: 'snorm8x4',
+offset: 28,
+shaderLocation: 4,
+}, {
+format: 'sint32',
+offset: 68,
+shaderLocation: 6,
+}, {
+format: 'uint8x4',
+offset: 24,
+shaderLocation: 0,
+}, {
+format: 'uint32',
+offset: 64,
+shaderLocation: 13,
+}, {
+format: 'uint32',
+offset: 60,
+shaderLocation: 2,
+}, {
+format: 'uint16x4',
+offset: 48,
+shaderLocation: 5,
+}, {
+format: 'uint32x3',
+offset: 152,
+shaderLocation: 15,
+}, {
+format: 'uint8x2',
+offset: 40,
+shaderLocation: 9,
+}, {
+format: 'unorm8x2',
+offset: 86,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 1084,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x2',
+offset: 496,
+shaderLocation: 8,
+}, {
+format: 'uint8x4',
+offset: 272,
+shaderLocation: 10,
+}, {
+format: 'unorm10-10-10-2',
+offset: 912,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 376,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 696,
+attributes: [{
+format: 'uint16x2',
+offset: 420,
+shaderLocation: 3,
+}],
+}
+]
+},
+});
+let shaderModule9 = device0.createShaderModule({
+label: '\u{1f886}\u{1fe6d}\u{1fbf8}\udefd\u{1fb79}\u{1fb03}\u6716\u{1fcfa}\uc94a\u30e8',
+code: `@group(1) @binding(788)
+var<storage, read_write> field5: array<u32>;
+@group(1) @binding(803)
+var<storage, read_write> local2: array<u32>;
+@group(0) @binding(561)
+var<storage, read_write> i2: array<u32>;
+@group(3) @binding(674)
+var<storage, read_write> field6: array<u32>;
+@group(2) @binding(20)
+var<storage, read_write> i3: array<u32>;
+
+@compute @workgroup_size(8, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @builtin(sample_mask) f1: u32,
+  @location(2) f2: vec4<u32>,
+  @location(0) f3: vec4<f32>,
+  @location(3) f4: vec3<f32>,
+  @location(4) f5: vec2<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(sample_mask) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(6) a0: vec4<f32>, @location(4) a1: vec4<i32>, @location(12) a2: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+pseudoSubmit(device0, commandEncoder7);
+let renderBundle15 = renderBundleEncoder7.finish({label: '\u02fb\u0ed4\u6671\udc89\u6017\u{1fccb}'});
+try {
+renderBundleEncoder9.drawIndexed(8, 40, 0);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let bindGroup7 = device0.createBindGroup({
+label: '\ubccc\u0b81',
+layout: bindGroupLayout3,
+entries: [],
+});
+try {
+computePassEncoder13.setPipeline(pipeline3);
+} catch {}
+let pipeline31 = device0.createComputePipeline({
+label: '\u{1f8dc}\u2352\u7666\u045e\u0143\u0b73\u3e04',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+canvas2.height = 144;
+let offscreenCanvas6 = new OffscreenCanvas(445, 934);
+let buffer11 = device0.createBuffer({
+  label: '\u9093\u{1f827}\u0774\uffe7\u060e\u{1fa3a}',
+  size: 62138,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+pseudoSubmit(device0, commandEncoder13);
+let texture28 = device0.createTexture({
+label: '\uf7d6\u0e66\ua6b6\u0351\ucb40\u13a6\u{1fe54}\u581d\ua574\u7446\u6b9f',
+size: [219],
+dimension: '1d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({
+  colorFormats: ['bgra8unorm-srgb', 'rgba16uint', 'r8uint', 'rg11b10ufloat', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle16 = renderBundleEncoder16.finish({label: '\u05d3\u{1fa51}'});
+let sampler14 = device0.createSampler({
+label: '\u8210\u91fe',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 69.932,
+lodMaxClamp: 91.988,
+compare: 'greater-equal',
+});
+try {
+renderBundleEncoder17.draw(48, 48);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 5252, new DataView(new ArrayBuffer(41623)), 5812, 14600);
+} catch {}
+canvas2.width = 730;
+let video4 = await videoWithData();
+let bindGroup8 = device0.createBindGroup({
+label: '\u6067\u6e71\udd6b\u0d18\ued40\u{1fff1}\u90e1\u4c2f',
+layout: bindGroupLayout1,
+entries: [{
+binding: 43,
+resource: externalTexture0
+}, {
+binding: 257,
+resource: externalTexture0
+}],
+});
+pseudoSubmit(device0, commandEncoder14);
+let texture29 = device0.createTexture({
+label: '\u7aa2\u{1f828}',
+size: [1670, 160, 1],
+mipLevelCount: 8,
+format: 'astc-10x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler15 = device0.createSampler({
+label: '\u89be\u0aef\u{1f9cb}\ud163',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 30.303,
+lodMaxClamp: 85.374,
+maxAnisotropy: 15,
+});
+try {
+renderBundleEncoder8.drawIndexed(48, 64);
+} catch {}
+try {
+computePassEncoder11.insertDebugMarker('\uc620');
+} catch {}
+let bindGroupLayout15 = device0.createBindGroupLayout({
+label: '\u882d\u0296\ud892\u2779\u{1faaa}\u0428\u{1fc82}\u0369\uaf8c\u450b',
+entries: [{
+binding: 432,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d' },
+}, {
+binding: 927,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+}, {
+binding: 151,
+visibility: 0,
+externalTexture: {},
+}],
+});
+let textureView18 = texture23.createView({label: '\u3640\u0696\u0ca5\u{1feca}\u{1f77e}\u{1fe5d}\u0421', dimension: '2d-array', mipLevelCount: 1});
+let renderBundle17 = renderBundleEncoder23.finish({label: '\u1cc6\u1375\u2a6d\u973c\u{1f90c}'});
+let sampler16 = device0.createSampler({
+label: '\u50cc\u66ee\u45e3\u{1faf4}\uee00\u{1fbb8}\u0f68\u{1fdd9}',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 95.715,
+maxAnisotropy: 19,
+});
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+commandEncoder15.copyBufferToTexture({
+/* bytesInLastRow: 2012 widthInBlocks: 503 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 5120 */
+offset: 3108,
+bytesPerRow: 2048,
+buffer: buffer0,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: { x: 141, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 503, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['astc-10x6-unorm-srgb', 'bgra8unorm', 'bgra8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let pipeline32 = await device0.createComputePipelineAsync({
+label: '\u3e4a\u303d\u3b53\u0e35\u7e45\ub9dc\u0fe0\uc367\u5205\u0e35\u{1fbe6}',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+offscreenCanvas0.height = 583;
+let commandEncoder18 = device0.createCommandEncoder({});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({
+  colorFormats: [undefined, 'r16uint', 'rg32uint', 'rg16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+let renderBundle18 = renderBundleEncoder0.finish({});
+try {
+renderBundleEncoder9.drawIndexed(48, 0, 72, -656);
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(buffer3, 7200, buffer10, 3172, 3752);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer10);
+} catch {}
+let canvas10 = document.createElement('canvas');
+let bindGroup9 = device0.createBindGroup({
+label: '\u8ba6\u8940\u227a\u132c\ucd46\u8941\u{1f6b7}',
+layout: bindGroupLayout1,
+entries: [{
+binding: 43,
+resource: externalTexture0
+}, {
+binding: 257,
+resource: externalTexture0
+}],
+});
+let commandEncoder19 = device0.createCommandEncoder();
+let textureView19 = texture1.createView({label: '\ueabf\u03ee\u9119\u845a'});
+let computePassEncoder15 = commandEncoder15.beginComputePass();
+let renderBundle19 = renderBundleEncoder19.finish({label: '\u{1ff0c}\u0d2e\u5a27\ud763\u{1fa30}\u5f6d\ue374\u05a1\u0c92'});
+let sampler17 = device0.createSampler({
+label: '\u03b3\ud6e9\u015c\u{1fd9b}\u44e4\uc991\u{1fb82}\u{1f8e8}\u0f6e',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 52.079,
+lodMaxClamp: 93.333,
+});
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(0, bindGroup1, new Uint32Array(4984), 4462, 0);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext5.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['eac-rg11snorm', 'rgba16float', 'r32float'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 2,
+  origin: { x: 5, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 283 */
+{offset: 251}, {width: 16, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let renderBundle20 = renderBundleEncoder7.finish({});
+try {
+renderBundleEncoder8.draw(32, 72);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(0, buffer6, 36332, 444);
+} catch {}
+let querySet22 = device0.createQuerySet({
+type: 'occlusion',
+count: 1645,
+});
+let sampler18 = device0.createSampler({
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 69.653,
+lodMaxClamp: 83.057,
+maxAnisotropy: 11,
+});
+try {
+renderBundleEncoder9.draw(16);
+} catch {}
+try {
+commandEncoder18.copyTextureToBuffer({
+  texture: texture14,
+  mipLevel: 2,
+  origin: { x: 30, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 36304 */
+offset: 36304,
+buffer: buffer1,
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline33 = device0.createRenderPipeline({
+label: '\u6801\u38db\u05a4\u3632',
+layout: pipelineLayout3,
+multisample: {
+count: 4,
+mask: 0xc9a632cc,
+},
+fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: 0}, {
+  format: 'rgba8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'dst'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'one-minus-src-alpha'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, undefined, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'dst'},
+alpha: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'constant'},
+},
+  writeMask: 0
+}]
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'replace',
+depthFailOp: 'decrement-wrap',
+passOp: 'invert',
+},
+stencilReadMask: 1628,
+stencilWriteMask: 1780,
+depthBias: 97,
+depthBiasClamp: 74,
+},
+vertex: {
+  module: shaderModule3,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 848,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 88,
+shaderLocation: 4,
+}, {
+format: 'uint32x3',
+offset: 756,
+shaderLocation: 14,
+}, {
+format: 'sint32x3',
+offset: 420,
+shaderLocation: 9,
+}, {
+format: 'float32x3',
+offset: 432,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 304,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 16,
+shaderLocation: 15,
+}, {
+format: 'unorm10-10-10-2',
+offset: 80,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 740,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x4',
+offset: 568,
+shaderLocation: 13,
+}, {
+format: 'snorm16x4',
+offset: 240,
+shaderLocation: 5,
+}, {
+format: 'snorm16x2',
+offset: 188,
+shaderLocation: 10,
+}, {
+format: 'sint8x2',
+offset: 554,
+shaderLocation: 6,
+}, {
+format: 'unorm10-10-10-2',
+offset: 100,
+shaderLocation: 8,
+}, {
+format: 'float16x2',
+offset: 56,
+shaderLocation: 3,
+}, {
+format: 'sint8x2',
+offset: 722,
+shaderLocation: 2,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+},
+});
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+gc();
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+commandEncoder19.copyBufferToBuffer(buffer2, 584, buffer11, 56192, 116);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer11);
+} catch {}
+let img7 = await imageWithData(294, 99, '#95f21c07', '#0aad8b56');
+let bindGroup10 = device0.createBindGroup({
+label: '\uf890\u{1fa15}\u43f5\u3636\u{1fbc5}\u0651\u{1fb4c}\u5758\u0a82',
+layout: bindGroupLayout1,
+entries: [{
+binding: 43,
+resource: externalTexture0
+}, {
+binding: 257,
+resource: externalTexture0
+}],
+});
+let computePassEncoder16 = commandEncoder18.beginComputePass({});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({
+  label: '\u{1fd49}\u65a2\u{1fef6}\ub03a\u{1ffcf}\u756e\u09bb\u0ab6\u{1ff3a}',
+  colorFormats: [undefined, 'r16uint', 'rg32uint', 'rg16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder8.draw(48);
+} catch {}
+try {
+renderBundleEncoder13.setPipeline(pipeline10);
+} catch {}
+gc();
+let canvas11 = document.createElement('canvas');
+try {
+offscreenCanvas6.getContext('bitmaprenderer');
+} catch {}
+let shaderModule10 = device0.createShaderModule({
+label: '\u6ad0\u08be\u0cd8\u0aa4\u792b\u03dd\u0d12\u6cc2\u8174',
+code: `@group(0) @binding(561)
+var<storage, read_write> global2: array<u32>;
+
+@compute @workgroup_size(6, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<i32>,
+  @location(0) f1: vec4<u32>,
+  @location(1) f2: vec4<u32>,
+  @location(2) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(13) a0: vec4<f32>, @location(8) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S7 {
+  @location(15) f0: vec2<u32>,
+  @location(2) f1: i32,
+  @location(7) f2: vec4<f32>,
+  @location(4) f3: f32
+}
+struct VertexOutput0 {
+  @location(14) f24: vec2<f16>,
+  @builtin(position) f25: vec4<f32>,
+  @location(8) f26: u32,
+  @location(11) f27: vec3<u32>,
+  @location(12) f28: u32,
+  @location(15) f29: u32,
+  @location(7) f30: f16,
+  @location(13) f31: vec4<f32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, a1: S7, @location(14) a2: vec4<u32>, @location(3) a3: vec4<u32>, @location(13) a4: i32, @location(1) a5: f16, @location(10) a6: vec3<f32>, @location(12) a7: vec2<f16>, @location(5) a8: vec4<f16>, @location(6) a9: vec2<f32>, @location(0) a10: i32, @location(9) a11: u32, @location(8) a12: vec4<f16>, @location(11) a13: vec3<f16>, @builtin(instance_index) a14: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let textureView20 = texture5.createView({dimension: '2d-array'});
+let computePassEncoder17 = commandEncoder19.beginComputePass({label: '\ubef4\u13f6\u{1f63a}\ufb45\u5b35\u608e\u5a6d\u{1f983}\u0176'});
+try {
+computePassEncoder16.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 5396, new Int16Array(35927), 10658, 1496);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(6, buffer6);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let pipeline34 = await device0.createComputePipelineAsync({
+label: '\u0706\ue10c\u04ea\u0720\u1501\u{1fd41}\u07e9\u{1fc11}\u0891\u0372\u0334',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline35 = await device0.createRenderPipelineAsync({
+label: '\u1926\u870a\u98c5\u{1f67e}\u4ced\u43aa',
+layout: pipelineLayout2,
+fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint'}, {format: 'rg8sint', writeMask: GPUColorWrite.GREEN}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'dst', dstFactor: 'constant'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}]
+},
+vertex: {
+  module: shaderModule8,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1204,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x4',
+offset: 232,
+shaderLocation: 7,
+}, {
+format: 'unorm16x4',
+offset: 580,
+shaderLocation: 14,
+}, {
+format: 'uint32x4',
+offset: 416,
+shaderLocation: 11,
+}, {
+format: 'unorm10-10-10-2',
+offset: 248,
+shaderLocation: 0,
+}, {
+format: 'snorm8x2',
+offset: 898,
+shaderLocation: 9,
+}, {
+format: 'uint32x2',
+offset: 208,
+shaderLocation: 2,
+}, {
+format: 'float32',
+offset: 368,
+shaderLocation: 6,
+}, {
+format: 'sint32x4',
+offset: 64,
+shaderLocation: 3,
+}, {
+format: 'sint32',
+offset: 68,
+shaderLocation: 1,
+}, {
+format: 'float16x4',
+offset: 760,
+shaderLocation: 10,
+}, {
+format: 'unorm16x2',
+offset: 56,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 1324,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 1036,
+shaderLocation: 8,
+}, {
+format: 'float32',
+offset: 132,
+shaderLocation: 13,
+}, {
+format: 'uint32x2',
+offset: 684,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 536,
+attributes: [{
+format: 'sint16x2',
+offset: 196,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 1140,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 872,
+shaderLocation: 12,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let adapter2 = await promise5;
+let buffer12 = device0.createBuffer({
+  label: '\uf577\uf1d3\u08e7\u{1f8fd}\u{1fd77}\u{1ff85}\u7e89\uab39\ue9e2',
+  size: 41068,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: true
+});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup3, new Uint32Array(2867), 383, 0);
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline13);
+} catch {}
+let pipeline36 = await promise8;
+let querySet23 = device0.createQuerySet({
+label: '\u0caf\u7f91\u5f5f\u9ebb\ua3fb',
+type: 'occlusion',
+count: 2213,
+});
+let sampler19 = device0.createSampler({
+label: '\u89f4\ued7c\u0505\u07c6\ub96f\ucec6\u0a9e\u0670\u{1fd52}\uc00b',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 80.146,
+lodMaxClamp: 91.791,
+});
+try {
+renderBundleEncoder17.draw(32, 72, 80, 40);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer6, 'uint16');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 19580, new DataView(new ArrayBuffer(7277)), 4569, 164);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 483 */
+{offset: 483, bytesPerRow: 34}, {width: 20, height: 10, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img2);
+let commandEncoder20 = device0.createCommandEncoder({label: '\ub8dc\u{1f87d}\ua972\u{1f7f1}\u2135'});
+let computePassEncoder18 = commandEncoder20.beginComputePass({});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({
+  label: '\ub523\u0738\u{1ff9e}\u04b0\u0c35',
+  colorFormats: ['bgra8unorm-srgb', 'rgba16uint', 'r8uint', 'rg11b10ufloat', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+try {
+gpuCanvasContext4.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['astc-10x5-unorm', 'astc-8x6-unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroupLayout16 = device0.createBindGroupLayout({
+entries: [],
+});
+let bindGroup11 = device0.createBindGroup({
+label: '\u3fd4\u{1f689}\u8053\u0710',
+layout: bindGroupLayout4,
+entries: [],
+});
+let buffer13 = device0.createBuffer({
+  label: '\u{1fd0f}\u{1fe25}\ub2b5\u0db3\u65e8\u4233\u0819\u05b4\u66e9',
+  size: 60176,
+  usage: GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true
+});
+let querySet24 = device0.createQuerySet({
+label: '\u873b\u00e6\u060f\ub470\u4421\u0a4c\u5969\ua431',
+type: 'occlusion',
+count: 2345,
+});
+try {
+computePassEncoder18.setPipeline(pipeline31);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 12200);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer0, 'uint32', 25324, 540);
+} catch {}
+let promise9 = adapter2.requestDevice({
+label: '\ufbc2\u18cc\ua107\u66f1\u{1fa58}\u037c\u{1f7f8}\u{1fae8}\u{1f72a}\uf5d7',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+});
+let buffer14 = device0.createBuffer({size: 14420, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let querySet25 = device0.createQuerySet({
+label: '\uc287\u{1fd1b}\uc1db\u0cd4\u{1f885}',
+type: 'occlusion',
+count: 932,
+});
+let texture30 = device0.createTexture({
+label: '\u5d9b\uf6a6\u7655\u08bd\u0c7e\u03a1',
+size: [64, 90, 1],
+mipLevelCount: 7,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({
+  label: '\u2392\u0aad',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8'
+});
+let renderBundle21 = renderBundleEncoder13.finish({label: '\u00cb\u9994\u0314\uf503\u4296\u0fc8\u59e0\u0c57'});
+let sampler20 = device0.createSampler({
+label: '\u0bc4\uf748\u{1f72c}\ua219\u01bd',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 77.003,
+lodMaxClamp: 92.916,
+maxAnisotropy: 1,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 1, y: 11, z: 71 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 2957067 */
+{offset: 507, bytesPerRow: 296, rowsPerImage: 120}, {width: 28, height: 29, depthOrArrayLayers: 84});
+} catch {}
+let pipeline37 = device0.createComputePipeline({
+label: '\u0870\u05a6\u3809\u{1fa08}\u0e0d\ubabf\ud6e5\u0723\u0bbb\u137f',
+layout: 'auto',
+compute: {
+module: shaderModule10,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let texture31 = device0.createTexture({
+label: '\u0164\u{1f8bb}\u0a03\u{1fcd8}\u{1feb5}\u{1f632}\u{1f7f6}\u7305',
+size: {width: 1320, height: 96, depthOrArrayLayers: 1},
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x6-unorm', 'astc-8x6-unorm-srgb', 'astc-8x6-unorm'],
+});
+try {
+computePassEncoder2.popDebugGroup();
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder({label: '\uc710\u0655\uc60f\ubacc\u6428\u{1fbe9}\u57bf\u0e72'});
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(40, 80, 48, -360);
+} catch {}
+try {
+commandEncoder17.copyBufferToBuffer(buffer3, 20872, buffer11, 44476, 4992);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder17.clearBuffer(buffer1, 46108, 2200);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(querySet15, 77, 5, buffer12, 38144);
+} catch {}
+let pipeline38 = device0.createRenderPipeline({
+label: '\ubf07\u0105\uc1de\u{1f6d0}\u3223\u0f75\u07fa\u{1fed0}\ud371\ucbcc\u2c46',
+layout: pipelineLayout6,
+fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r16uint', writeMask: 0}, {format: 'rgba16uint', writeMask: 0}, {format: 'rgba16sint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'greater-equal',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 2333,
+stencilWriteMask: 376,
+depthBiasSlopeScale: 53,
+depthBiasClamp: 89,
+},
+vertex: {
+  module: shaderModule4,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 936,
+attributes: [{
+format: 'unorm16x4',
+offset: 888,
+shaderLocation: 12,
+}, {
+format: 'snorm8x2',
+offset: 908,
+shaderLocation: 15,
+}, {
+format: 'uint8x2',
+offset: 678,
+shaderLocation: 9,
+}, {
+format: 'sint16x4',
+offset: 400,
+shaderLocation: 0,
+}, {
+format: 'uint32x3',
+offset: 884,
+shaderLocation: 4,
+}, {
+format: 'unorm10-10-10-2',
+offset: 48,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 920,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 308,
+shaderLocation: 5,
+}, {
+format: 'unorm8x4',
+offset: 236,
+shaderLocation: 2,
+}, {
+format: 'unorm16x2',
+offset: 708,
+shaderLocation: 13,
+}, {
+format: 'unorm8x4',
+offset: 840,
+shaderLocation: 14,
+}, {
+format: 'float32x4',
+offset: 440,
+shaderLocation: 11,
+}, {
+format: 'float32x4',
+offset: 348,
+shaderLocation: 1,
+}, {
+format: 'float16x2',
+offset: 584,
+shaderLocation: 6,
+}],
+}
+]
+},
+});
+let renderBundle22 = renderBundleEncoder24.finish({label: '\uaf20\u3922\u66b0\ud189\uc919\u6fef\ub961'});
+let sampler21 = device0.createSampler({
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 46.247,
+lodMaxClamp: 94.026,
+maxAnisotropy: 3,
+});
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer12, 408);
+} catch {}
+try {
+renderBundleEncoder8.drawIndirect(buffer12, 1240);
+} catch {}
+try {
+commandEncoder21.copyBufferToBuffer(buffer3, 55932, buffer9, 17004, 3048);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder21.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 68, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 1188 widthInBlocks: 297 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 21160 */
+offset: 21160,
+buffer: buffer1,
+}, {width: 297, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder17.clearBuffer(buffer8, 4752, 5944);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+canvas11.getContext('webgpu');
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(80, 16, 24, 584, 80);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer12, 22604);
+} catch {}
+try {
+commandEncoder21.resolveQuerySet(querySet24, 1289, 141, buffer12, 15104);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 8724, new Int16Array(5059), 922, 2164);
+} catch {}
+let canvas12 = document.createElement('canvas');
+let bindGroup12 = device0.createBindGroup({
+label: '\u050d\u{1f869}\u8a96\ufc9c',
+layout: bindGroupLayout16,
+entries: [],
+});
+let pipelineLayout7 = device0.createPipelineLayout({
+  label: '\uad98\u03ae\u0da8\u91d7\u06cc\u1f2e\u57a3',
+  bindGroupLayouts: [bindGroupLayout2, bindGroupLayout0, bindGroupLayout8, bindGroupLayout16]
+});
+let buffer15 = device0.createBuffer({size: 6209, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandBuffer6 = commandEncoder17.finish({
+label: '\u279d\u31ca',
+});
+let texture32 = device0.createTexture({
+label: '\u05bb\u774a\u064e\u{1f743}\u8960\u5e98\u0c0f\u0c38\ud0e1\u0723\u50df',
+size: {width: 40, height: 1, depthOrArrayLayers: 1},
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexedIndirect(buffer15, 5944);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer6, 'uint16', 4230);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let textureView21 = texture17.createView({
+  label: '\uaa5d\ub29e\u2aaa\u0666\u6c35\u86bc\u{1fef7}',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 3
+});
+try {
+computePassEncoder18.end();
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer0, 'uint16', 9024, 23290);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(6, buffer6, 24428);
+} catch {}
+let bindGroupLayout17 = device0.createBindGroupLayout({
+entries: [{
+binding: 274,
+visibility: 0,
+storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '2d' },
+}, {
+binding: 887,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'non-filtering' },
+}],
+});
+let bindGroup13 = device0.createBindGroup({
+label: '\u1c37\u09f8\u09ac\u2436\u050d\ua5a6',
+layout: bindGroupLayout11,
+entries: [{
+binding: 297,
+resource: externalTexture0
+}, {
+binding: 823,
+resource: textureView12
+}],
+});
+let buffer16 = device0.createBuffer({label: '\ucfdc\ub054\u085e\uae0c', size: 62825, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let querySet26 = device0.createQuerySet({
+label: '\u825f\u5cc7',
+type: 'occlusion',
+count: 248,
+});
+let textureView22 = texture3.createView({dimension: '2d-array', baseMipLevel: 1});
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer15, 5920);
+} catch {}
+try {
+querySet9.destroy();
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(buffer2, 848, buffer10, 7952, 80);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder21.copyTextureToBuffer({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 32716 */
+offset: 32716,
+bytesPerRow: 256,
+buffer: buffer1,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 33400, new BigUint64Array(63711), 24430, 1940);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 1,
+  origin: { x: 1530, y: 5, z: 0 },
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 1570 */
+{offset: 978, rowsPerImage: 203}, {width: 222, height: 5, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext6 = canvas10.getContext('webgpu');
+let commandEncoder22 = device0.createCommandEncoder();
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({
+  label: '\u20f1\uf7cf\u077e\uf978\u{1fef0}\u0f1b\u{1ff01}',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+renderBundleEncoder9.draw(80, 16, 48);
+} catch {}
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 4,
+  origin: { x: 0, y: 1, z: 15 },
+  aspect: 'all',
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 214, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder11.popDebugGroup();
+} catch {}
+try {
+commandEncoder21.insertDebugMarker('\u3d4f');
+} catch {}
+let pipeline39 = device0.createRenderPipeline({
+layout: pipelineLayout6,
+multisample: {
+count: 4,
+mask: 0xf4a8bf37,
+},
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'bgra8unorm', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'keep',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilWriteMask: 1056,
+depthBiasSlopeScale: 0,
+depthBiasClamp: 63,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1924,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1452,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 320,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x4',
+offset: 248,
+shaderLocation: 12,
+}, {
+format: 'sint32x2',
+offset: 300,
+shaderLocation: 3,
+}, {
+format: 'sint8x4',
+offset: 268,
+shaderLocation: 7,
+}, {
+format: 'unorm16x4',
+offset: 220,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 1140,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 120,
+shaderLocation: 1,
+}, {
+format: 'uint16x2',
+offset: 1128,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 44,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x2',
+offset: 32,
+shaderLocation: 2,
+}, {
+format: 'float16x4',
+offset: 24,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 452,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 700,
+attributes: [{
+format: 'float32x3',
+offset: 668,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+let commandBuffer7 = commandEncoder16.finish({
+label: '\u0db8\u0037\udcde\u23e7\u0b0f',
+});
+try {
+computePassEncoder16.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(2, bindGroup12, new Uint32Array(9099), 1224, 0);
+} catch {}
+try {
+renderBundleEncoder8.drawIndirect(buffer12, 29864);
+} catch {}
+try {
+commandEncoder22.copyBufferToBuffer(buffer2, 116, buffer16, 10116, 120);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder21.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 54, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 4,
+  origin: { x: 42, y: 0, z: 132 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer3), /* required buffer size: 369 */
+{offset: 369, bytesPerRow: 735}, {width: 192, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let pipeline40 = await device0.createComputePipelineAsync({
+label: '\u3725\u44f8\u90be\u2e3d\u{1ffa0}\u{1fdb3}\u0284\u5089',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let texture33 = device0.createTexture({
+size: {width: 128, height: 180, depthOrArrayLayers: 1},
+format: 'astc-4x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView23 = texture33.createView({label: '\u01c4\u{1fce8}\u7a7c\u03b5\u0323\u{1f70e}\u062f\uc23a\u6044\u{1fe83}\u{1fd3b}'});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({
+  label: '\uc01a\uca12\u3b5d\u1177\u85a9',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder8.drawIndexed(56, 40, 24);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer15, 2092);
+} catch {}
+try {
+commandEncoder21.copyBufferToTexture({
+/* bytesInLastRow: 128 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 32208 */
+offset: 32208,
+buffer: buffer0,
+}, {
+  texture: texture27,
+  mipLevel: 4,
+  origin: { x: 16, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 64, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 9892, new BigUint64Array(59229), 20521, 128);
+} catch {}
+let pipeline41 = device0.createComputePipeline({
+label: '\u04c3\uaf38\u7cb2\u2c16\u8c65\u23e7\u0506\u0e80\u85f1',
+layout: 'auto',
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline42 = device0.createRenderPipeline({
+label: '\u{1fe6f}\u23b9\u{1f779}',
+layout: pipelineLayout0,
+multisample: {
+mask: 0x105fe53f,
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 1892,
+depthBiasSlopeScale: 53,
+depthBiasClamp: 93,
+},
+vertex: {
+  module: shaderModule8,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 1776,
+shaderLocation: 9,
+}, {
+format: 'unorm16x2',
+offset: 980,
+shaderLocation: 14,
+}, {
+format: 'snorm8x4',
+offset: 8,
+shaderLocation: 10,
+}, {
+format: 'unorm16x2',
+offset: 92,
+shaderLocation: 8,
+}, {
+format: 'float16x4',
+offset: 1312,
+shaderLocation: 7,
+}, {
+format: 'uint8x4',
+offset: 1168,
+shaderLocation: 15,
+}, {
+format: 'sint32x3',
+offset: 208,
+shaderLocation: 5,
+}, {
+format: 'sint16x2',
+offset: 208,
+shaderLocation: 1,
+}, {
+format: 'float16x2',
+offset: 312,
+shaderLocation: 12,
+}, {
+format: 'uint16x4',
+offset: 688,
+shaderLocation: 11,
+}, {
+format: 'unorm10-10-10-2',
+offset: 852,
+shaderLocation: 13,
+}, {
+format: 'float32x2',
+offset: 708,
+shaderLocation: 4,
+}, {
+format: 'sint32x4',
+offset: 1276,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 1724,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 820,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 4,
+shaderLocation: 6,
+}, {
+format: 'uint32x3',
+offset: 340,
+shaderLocation: 2,
+}, {
+format: 'float32x3',
+offset: 364,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let pipelineLayout8 = device0.createPipelineLayout({
+  label: '\u08db\u6952\u6676\ufea0\u{1f7b9}\u31a4\uf725',
+  bindGroupLayouts: [bindGroupLayout10, bindGroupLayout1, bindGroupLayout5, bindGroupLayout6]
+});
+let textureView24 = texture26.createView({dimension: '2d-array', baseMipLevel: 0});
+let renderBundle23 = renderBundleEncoder25.finish({label: '\u{1ff8f}\u20b5\u0e09\uce71'});
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder17.draw(72, 80, 64, 40);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer15, 348);
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(buffer12, 15852, buffer4, 3088, 3320);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder21.clearBuffer(buffer10, 5656, 900);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 3968, new DataView(new ArrayBuffer(23074)), 21338, 520);
+} catch {}
+gc();
+let commandEncoder23 = device0.createCommandEncoder({label: '\u042b\u1fac'});
+let computePassEncoder19 = commandEncoder21.beginComputePass();
+let renderBundle24 = renderBundleEncoder13.finish();
+try {
+renderBundleEncoder8.drawIndexedIndirect(buffer12, 220);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer15, 1240);
+} catch {}
+try {
+commandEncoder23.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 54288 */
+offset: 54288,
+buffer: buffer11,
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer11);
+} catch {}
+let pipeline43 = device0.createComputePipeline({
+label: '\u{1fce4}\u9e5c\u{1fbb9}\ua112\uccdb\u2cb6\u0e76\u0977\uc364',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let gpuCanvasContext7 = canvas12.getContext('webgpu');
+let renderBundle25 = renderBundleEncoder15.finish({label: '\u0b9c\u{1f7e4}\u41e2\u{1fc8f}'});
+try {
+computePassEncoder16.dispatchWorkgroups(5, 2, 5);
+} catch {}
+try {
+computePassEncoder19.end();
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(0, 32, 32, 16, 16);
+} catch {}
+try {
+commandEncoder22.clearBuffer(buffer8, 13652, 468);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 6844, new DataView(new ArrayBuffer(24784)), 5706, 11300);
+} catch {}
+let texture34 = device0.createTexture({
+label: '\u06d5\u{1fe9c}\u0147\u05e2\u8613\u019d\u0fff\u496d\u708d\u{1fbd0}',
+size: [40, 1, 80],
+dimension: '3d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rg8sint', 'rg8sint'],
+});
+try {
+renderBundleEncoder17.drawIndexed(24, 16, 16, 744, 40);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexedIndirect(buffer15, 2208);
+} catch {}
+let arrayBuffer6 = buffer12.getMappedRange(0, 10964);
+try {
+commandEncoder20.copyTextureToBuffer({
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 16, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 20 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 1548 */
+offset: 1548,
+rowsPerImage: 117,
+buffer: buffer11,
+}, {width: 10, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder21.clearBuffer(buffer8, 4220, 712);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+device: device0,
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline44 = await device0.createComputePipelineAsync({
+layout: pipelineLayout0,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({
+  label: '\u{1f6b9}\uc077',
+  colorFormats: ['bgra8unorm-srgb', 'rgba16uint', 'r8uint', 'rg11b10ufloat', 'r8uint'],
+  depthReadOnly: true
+});
+let renderBundle26 = renderBundleEncoder11.finish({label: '\u{1fd2f}\ufede\u0252\uee2d\ud206\ub8a2\u46e6\u{1fc7b}\u{1fdb5}\u{1ffbe}'});
+let arrayBuffer7 = buffer10.getMappedRange(0, 1768);
+try {
+buffer11.unmap();
+} catch {}
+try {
+commandEncoder23.copyBufferToBuffer(buffer3, 19368, buffer14, 4556, 7980);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 3,
+  origin: { x: 32, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 554 */
+{offset: 554}, {width: 16, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout18 = device0.createBindGroupLayout({
+entries: [{
+binding: 109,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+}, {
+binding: 606,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+}, {
+binding: 218,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+}],
+});
+let buffer17 = device0.createBuffer({
+  label: '\u0b64\u0361\ua689\ub59a\u{1fb34}\u0284\u{1f910}\u081a\u0fea\u{1fac0}',
+  size: 19313,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let commandEncoder24 = device0.createCommandEncoder({label: '\u0062\u{1ff95}\ua49d\ue665\u{1f732}\u4eef\u1720\u{1ffeb}'});
+let querySet27 = device0.createQuerySet({
+label: '\u2d20\u{1f889}\u93f9\u272a\u12b7\ub94f\u018b\u675f',
+type: 'occlusion',
+count: 1084,
+});
+let textureView25 = texture11.createView({label: '\uf84a\u93a3', baseMipLevel: 1, mipLevelCount: 5});
+let computePassEncoder20 = commandEncoder23.beginComputePass({label: '\u914d\ubad1'});
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder9.draw(0);
+} catch {}
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 397, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline45 = device0.createComputePipeline({
+label: '\u{1f7bc}\u4354\ue987\uf59d\u0ded',
+layout: 'auto',
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline46 = await device0.createRenderPipelineAsync({
+label: '\ua0c4\u566f\u{1f8f5}',
+layout: pipelineLayout8,
+multisample: {
+mask: 0xecf82bbe,
+},
+fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba16sint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilWriteMask: 2105,
+depthBias: 16,
+depthBiasClamp: 38,
+},
+vertex: {
+  module: shaderModule4,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 896,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 346,
+shaderLocation: 5,
+}, {
+format: 'float32x4',
+offset: 728,
+shaderLocation: 13,
+}, {
+format: 'float16x2',
+offset: 336,
+shaderLocation: 15,
+}, {
+format: 'unorm8x2',
+offset: 456,
+shaderLocation: 2,
+}, {
+format: 'sint8x4',
+offset: 108,
+shaderLocation: 0,
+}, {
+format: 'uint32x2',
+offset: 120,
+shaderLocation: 4,
+}, {
+format: 'float32',
+offset: 72,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 68,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 36,
+shaderLocation: 11,
+}, {
+format: 'snorm16x2',
+offset: 48,
+shaderLocation: 7,
+}, {
+format: 'uint16x4',
+offset: 48,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x2',
+offset: 484,
+shaderLocation: 14,
+}, {
+format: 'float16x4',
+offset: 132,
+shaderLocation: 12,
+}, {
+format: 'snorm8x2',
+offset: 522,
+shaderLocation: 1,
+}],
+}
+]
+},
+});
+let imageBitmap5 = await createImageBitmap(offscreenCanvas1);
+let sampler22 = device0.createSampler({
+label: '\u7248\u{1ff23}\u{1fc03}\u5aad\u{1fb79}',
+addressModeU: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 59.805,
+lodMaxClamp: 60.296,
+maxAnisotropy: 11,
+});
+try {
+computePassEncoder20.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder8.draw(80, 48, 16);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer15, 5168);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: { x: 32, y: 40, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture30,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 10, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder21.clearBuffer(buffer1, 21068, 22040);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+let adapter3 = await promise2;
+let bindGroupLayout19 = device0.createBindGroupLayout({
+label: '\u{1fe9d}\ue75b\uca96\u9768\u0e3a\u084d\uc91a\u008d',
+entries: [{
+binding: 805,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}, {
+binding: 304,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '3d' },
+}],
+});
+let commandBuffer8 = commandEncoder21.finish({
+label: '\u16ef\u{1f6bd}\u0a10\ua984\u0f3e\u3f53',
+});
+let texture35 = device0.createTexture({
+label: '\u{1f710}\u09ab\u0a4a\ua5e8\u0072\u3c84\u827f\u078a\u6138\u{1fc75}',
+size: [80],
+dimension: '1d',
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r32uint'],
+});
+let renderBundle27 = renderBundleEncoder29.finish({});
+let sampler23 = device0.createSampler({
+label: '\u072a\ubd93\u80f8\u0b7d\u0714\u{1f614}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 17.840,
+});
+try {
+renderBundleEncoder12.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder17.draw(8, 56, 72);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer12, 17240);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline39);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture20,
+  mipLevel: 3,
+  origin: { x: 0, y: 3, z: 7 },
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder20.clearBuffer(buffer12);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer8,
+]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 3, y: 1, z: 168 },
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(16)), /* required buffer size: 258062 */
+{offset: 835, bytesPerRow: 667, rowsPerImage: 115}, {width: 27, height: 41, depthOrArrayLayers: 4});
+} catch {}
+canvas5.width = 941;
+let texture36 = device0.createTexture({
+label: '\u0b1b\u074c\ua068\u{1fa00}\ue863\ue569\u3a8a',
+size: [125, 80, 192],
+mipLevelCount: 6,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-5x5-unorm'],
+});
+let textureView26 = texture30.createView({label: '\u9593\u014e\u0faa', dimension: '2d-array', baseMipLevel: 4});
+let renderBundle28 = renderBundleEncoder27.finish({label: '\u6a51\u0453'});
+try {
+renderBundleEncoder17.drawIndirect(buffer12, 19076);
+} catch {}
+try {
+buffer5.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 8920, new Int16Array(38569), 3460, 2612);
+} catch {}
+let img8 = await imageWithData(298, 196, '#c2801653', '#bd10400d');
+let videoFrame7 = new VideoFrame(img4, {timestamp: 0});
+let commandEncoder25 = device0.createCommandEncoder({label: '\ud728\u0ae7\u{1fc6a}\u8d72'});
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({
+  colorFormats: ['bgra8unorm-srgb', 'rgba16uint', 'r8uint', 'rg11b10ufloat', 'r8uint'],
+  stencilReadOnly: true
+});
+let renderBundle29 = renderBundleEncoder8.finish({label: '\u0079\u{1fc6c}\u9ce1\uc63d\u18f5\u3afb\uc4f6\u69f2\ubf81\u0726'});
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(64, 48, 48, 416, 32);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(5, buffer0, 25248, 11248);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: { x: 89, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 816 */
+{offset: 816, rowsPerImage: 85}, {width: 68, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule11 = device0.createShaderModule({
+label: '\u72ac\u6c20\u0f91\u1e3f\u{1f62b}',
+code: `@group(2) @binding(934)
+var<storage, read_write> i4: array<u32>;
+@group(1) @binding(561)
+var<storage, read_write> function4: array<u32>;
+@group(2) @binding(289)
+var<storage, read_write> local3: array<u32>;
+@group(0) @binding(788)
+var<storage, read_write> field7: array<u32>;
+@group(0) @binding(803)
+var<storage, read_write> type5: array<u32>;
+
+@compute @workgroup_size(3, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec3<f32>,
+  @location(4) f1: vec4<u32>,
+  @location(1) f2: vec4<u32>,
+  @location(0) f3: vec4<f32>,
+  @location(2) f4: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(11) a0: vec2<f16>, @location(0) a1: vec3<f32>, @location(15) a2: vec4<u32>, @location(10) a3: vec2<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S8 {
+  @location(8) f0: vec2<f16>
+}
+struct VertexOutput0 {
+  @location(0) f32: vec3<f32>,
+  @location(10) f33: vec2<f16>,
+  @location(11) f34: vec2<f16>,
+  @location(15) f35: vec4<u32>,
+  @builtin(position) f36: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec2<f32>, @location(12) a1: vec4<u32>, @location(11) a2: vec2<f32>, @location(10) a3: vec2<f16>, a4: S8, @location(1) a5: i32, @location(6) a6: u32, @location(14) a7: vec2<f32>, @builtin(instance_index) a8: u32, @location(4) a9: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+});
+let buffer18 = device0.createBuffer({
+  label: '\u1234\u0b61\u6880\u0b1b\u{1ff77}\u0745\u0d29\uefb8\uf53a\u1ff2\u22d3',
+  size: 20160,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true
+});
+let textureView27 = texture13.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 1});
+try {
+renderBundleEncoder17.draw(56, 24);
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 94, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder25.clearBuffer(buffer10, 7928, 76);
+dissociateBuffer(device0, buffer10);
+} catch {}
+let pipeline47 = device0.createRenderPipeline({
+label: '\u31c1\u0739\u0e39\u00be\u{1f707}',
+layout: pipelineLayout0,
+fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: 0}, {format: 'r16uint', writeMask: GPUColorWrite.GREEN}, {format: 'rgba16uint', writeMask: 0}, {format: 'rgba16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}]
+},
+vertex: {
+  module: shaderModule5,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x2',
+offset: 144,
+shaderLocation: 6,
+}, {
+format: 'sint8x4',
+offset: 728,
+shaderLocation: 15,
+}],
+}
+]
+},
+});
+try {
+renderBundleEncoder17.drawIndexed(80);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+let pipeline48 = device0.createRenderPipeline({
+label: '\u6500\u0d32\u{1f663}\u{1ff98}\u098f\u856b\ubba1\ue95e\u{1fe65}\u45ea',
+layout: pipelineLayout7,
+fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'src'},
+alpha: {operation: 'subtract', srcFactor: 'src', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rgba16uint', writeMask: GPUColorWrite.BLUE}, {format: 'r8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rg11b10ufloat'}, {format: 'r8uint'}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'zero',
+depthFailOp: 'decrement-wrap',
+passOp: 'invert',
+},
+stencilReadMask: 2972,
+stencilWriteMask: 898,
+depthBias: 70,
+depthBiasSlopeScale: 2,
+depthBiasClamp: 28,
+},
+vertex: {
+  module: shaderModule11,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1320,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32',
+offset: 488,
+shaderLocation: 6,
+}, {
+format: 'uint32x3',
+offset: 844,
+shaderLocation: 4,
+}, {
+format: 'sint16x2',
+offset: 176,
+shaderLocation: 1,
+}, {
+format: 'unorm16x4',
+offset: 448,
+shaderLocation: 9,
+}, {
+format: 'float32x3',
+offset: 512,
+shaderLocation: 10,
+}, {
+format: 'float16x2',
+offset: 360,
+shaderLocation: 14,
+}, {
+format: 'float16x2',
+offset: 136,
+shaderLocation: 11,
+}, {
+format: 'uint8x2',
+offset: 1112,
+shaderLocation: 12,
+}, {
+format: 'unorm8x4',
+offset: 84,
+shaderLocation: 8,
+}],
+}
+]
+},
+});
+let img9 = await imageWithData(44, 199, '#a2aac7e3', '#eda8d366');
+let commandEncoder26 = device0.createCommandEncoder();
+let commandBuffer9 = commandEncoder25.finish({
+label: '\u0971\u{1ffa5}\u9261\u8fe0\uef51\u4e7b\u9f20',
+});
+let texture37 = device0.createTexture({
+label: '\u{1fdbc}\uc3d6\u4416\u5aab\ueccf\u3a45\udb29',
+size: {width: 84, height: 80, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x10-unorm', 'astc-12x10-unorm'],
+});
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({label: '\u34bf\u281c\u09fd', colorFormats: ['rg8uint', 'r16uint', 'rgba16uint', 'rgba16sint']});
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup9, new Uint32Array(2427), 1759, 0);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline47);
+} catch {}
+try {
+commandEncoder22.copyBufferToBuffer(buffer3, 61852, buffer14, 6064, 636);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder20.clearBuffer(buffer16, 22936, 25892);
+dissociateBuffer(device0, buffer16);
+} catch {}
+let pipeline49 = device0.createComputePipeline({
+label: '\u6c7b\ua61e\uefe2',
+layout: 'auto',
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline50 = await device0.createRenderPipelineAsync({
+label: '\u26a8\u{1fbcb}\u84ae\u0804\u{1ff60}\u{1f75a}\u6781\uf991\uf161\u4aea\u119e',
+layout: pipelineLayout1,
+multisample: {
+count: 4,
+mask: 0xcf5992f,
+},
+fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.ALL}, {format: 'rgba16uint'}, {format: 'rgba16sint'}]
+},
+vertex: {
+  module: shaderModule5,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1664,
+attributes: [{
+format: 'sint32x2',
+offset: 524,
+shaderLocation: 15,
+}, {
+format: 'snorm8x4',
+offset: 16,
+shaderLocation: 6,
+}],
+}
+]
+},
+});
+let commandEncoder27 = device0.createCommandEncoder();
+let texture38 = gpuCanvasContext4.getCurrentTexture();
+let renderBundle30 = renderBundleEncoder18.finish({});
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+renderBundleEncoder12.draw(32, 80, 8);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexedIndirect(buffer15, 5856);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(6, buffer6, 31056, 2721);
+} catch {}
+try {
+querySet12.destroy();
+} catch {}
+try {
+commandEncoder26.copyTextureToTexture({
+  texture: texture31,
+  mipLevel: 0,
+  origin: { x: 176, y: 84, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: { x: 232, y: 6, z: 0 },
+  aspect: 'all',
+}, {width: 1080, height: 6, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup14 = device0.createBindGroup({
+label: '\u02bc\u{1fb5b}\u0b0d\u2828\u93e5\u306a\ua1f8\u370d\ufa2e',
+layout: bindGroupLayout12,
+entries: [],
+});
+let pipelineLayout9 = device0.createPipelineLayout({label: '\u{1fbeb}\u9f62\ua75d', bindGroupLayouts: [bindGroupLayout1]});
+let texture39 = device0.createTexture({
+label: '\ud550\u5430\ubf76\u8fd5\u44cc',
+size: {width: 330, height: 24, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'astc-10x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder12.draw(40, 8, 32);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(3, buffer15, 2432, 2300);
+} catch {}
+try {
+commandEncoder27.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 3,
+  origin: { x: 0, y: 12, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 84, y: 132, z: 0 },
+  aspect: 'all',
+}, {width: 12, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline51 = device0.createComputePipeline({
+label: '\u3ad2\u0bf6\u0f88\ud7f8\u092c\u080c\u41d4',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let bindGroupLayout20 = pipeline49.getBindGroupLayout(3);
+let textureView28 = texture17.createView({
+  label: '\u0481\u3071\u066d\u2bdb\uc864\ub604\u0361\ueeab\u0d94',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  arrayLayerCount: 1
+});
+let renderBundleEncoder33 = device0.createRenderBundleEncoder({
+  label: '\ud48b\u{1fffc}\u3303\u37fc',
+  colorFormats: ['rg16uint', 'rg32float', 'r16uint', 'rg16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder32.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+commandEncoder27.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 10564, new DataView(new ArrayBuffer(43807)), 41413, 1164);
+} catch {}
+let pipeline52 = device0.createRenderPipeline({
+label: '\u7439\u{1f69f}\u1b22',
+layout: 'auto',
+multisample: {
+count: 4,
+mask: 0x414da1a,
+},
+fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.BLUE}, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+vertex: {
+  module: shaderModule8,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1112,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 500,
+shaderLocation: 1,
+}, {
+format: 'float32',
+offset: 996,
+shaderLocation: 4,
+}, {
+format: 'sint8x2',
+offset: 796,
+shaderLocation: 5,
+}, {
+format: 'snorm8x2',
+offset: 164,
+shaderLocation: 12,
+}, {
+format: 'snorm16x4',
+offset: 416,
+shaderLocation: 6,
+}, {
+format: 'sint16x2',
+offset: 236,
+shaderLocation: 3,
+}, {
+format: 'uint16x2',
+offset: 596,
+shaderLocation: 15,
+}, {
+format: 'snorm16x2',
+offset: 384,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 760,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 684,
+shaderLocation: 0,
+}, {
+format: 'snorm8x2',
+offset: 610,
+shaderLocation: 14,
+}, {
+format: 'snorm8x2',
+offset: 482,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 1760,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 1516,
+shaderLocation: 2,
+}, {
+format: 'unorm16x2',
+offset: 176,
+shaderLocation: 9,
+}, {
+format: 'float32x4',
+offset: 396,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 1428,
+attributes: [{
+format: 'float32x3',
+offset: 1276,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 512,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1292,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 2000,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 284,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x3',
+offset: 72,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+video4.height = 102;
+let videoFrame8 = new VideoFrame(canvas10, {timestamp: 0});
+let computePassEncoder21 = commandEncoder20.beginComputePass({});
+try {
+renderBundleEncoder9.draw(40);
+} catch {}
+try {
+commandEncoder22.copyBufferToBuffer(buffer2, 396, buffer1, 852, 240);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer9,
+]);
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+let commandEncoder28 = device0.createCommandEncoder({label: '\u08af\uf280\u0982\udd5c\u8ab0'});
+let renderBundle31 = renderBundleEncoder2.finish({});
+try {
+computePassEncoder21.setPipeline(pipeline45);
+} catch {}
+try {
+renderBundleEncoder12.drawIndirect(buffer15, 88);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer3, 32888, buffer11, 40304, 5288);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 13244, new Float32Array(16986), 1485, 224);
+} catch {}
+let pipeline53 = device0.createComputePipeline({
+label: '\u0009\ubf5d\u8b9b\u94d7',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+},
+});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+gc();
+let img10 = await imageWithData(87, 253, '#9ea2e79d', '#2c99c76a');
+try {
+externalTexture0.label = '\u0fb2\u0295\u0915';
+} catch {}
+let shaderModule12 = device0.createShaderModule({
+code: `@group(0) @binding(20)
+var<storage, read_write> type6: array<u32>;
+@group(1) @binding(257)
+var<storage, read_write> function5: array<u32>;
+@group(1) @binding(43)
+var<storage, read_write> parameter4: array<u32>;
+
+@compute @workgroup_size(4, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<f32>,
+  @location(0) f1: vec4<f32>,
+  @location(4) f2: u32,
+  @location(2) f3: u32,
+  @location(1) f4: vec4<u32>,
+  @location(6) f5: vec3<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S9 {
+  @builtin(instance_index) f0: u32,
+  @location(6) f1: vec2<f16>,
+  @builtin(vertex_index) f2: u32,
+  @location(10) f3: vec3<u32>,
+  @location(14) f4: vec2<f32>,
+  @location(3) f5: vec2<i32>,
+  @location(11) f6: vec4<f32>,
+  @location(7) f7: vec2<u32>
+}
+struct VertexOutput0 {
+  @location(12) f37: vec4<u32>,
+  @builtin(position) f38: vec4<f32>,
+  @location(11) f39: f32,
+  @location(6) f40: i32
+}
+
+@vertex
+fn vertex0(a0: S9, @location(0) a1: vec3<u32>, @location(13) a2: vec3<i32>, @location(1) a3: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup12, new Uint32Array(5517), 2902, 0);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexed(0);
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer16, 40200, 4348);
+dissociateBuffer(device0, buffer16);
+} catch {}
+canvas2.height = 999;
+let video5 = await videoWithData();
+let pipelineLayout10 = device0.createPipelineLayout({label: '\u482e\u29a2\u02aa\ubb1c', bindGroupLayouts: []});
+let commandEncoder29 = device0.createCommandEncoder({label: '\u3b5d\ubcec\u04a1\u05bc'});
+let querySet28 = device0.createQuerySet({
+label: '\ub426\u0149\u{1f73d}\uf31b\u{1f71e}\u00b7\ua956\u{1f69c}\u4c9b\u6a8d',
+type: 'occlusion',
+count: 342,
+});
+let texture40 = device0.createTexture({
+size: [128, 180, 1],
+mipLevelCount: 6,
+dimension: '2d',
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8a1unorm'],
+});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({
+  colorFormats: [undefined, 'r16uint', 'rg32uint', 'rg16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder12.draw(16, 8, 16);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexed(80, 72, 72, 96, 72);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer3, 8672, buffer4, 2384, 6732);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder22.clearBuffer(buffer8, 14260, 120);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 0, y: 48, z: 141 },
+  aspect: 'all',
+}, new Float32Array(arrayBuffer0), /* required buffer size: 22933767 */
+{offset: 599, bytesPerRow: 473, rowsPerImage: 240}, {width: 59, height: 5, depthOrArrayLayers: 203});
+} catch {}
+let pipeline54 = await device0.createComputePipelineAsync({
+label: '\u01f6\u2a4a\ub8e4\u4582\ua94d\u7f79\u{1f9b1}\u0be8',
+layout: pipelineLayout10,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+},
+});
+try {
+  await promise10;
+} catch {}
+let videoFrame9 = new VideoFrame(videoFrame4, {timestamp: 0});
+try {
+computePassEncoder21.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexed(80, 0, 80, 248, 64);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(0, buffer15, 2564, 2552);
+} catch {}
+let arrayBuffer8 = buffer10.getMappedRange(1768, 1176);
+try {
+commandEncoder24.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 7840 */
+offset: 7840,
+bytesPerRow: 256,
+buffer: buffer11,
+}, {width: 16, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder29.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 6,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 1,
+  origin: { x: 160, y: 40, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder18.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let querySet29 = device0.createQuerySet({
+type: 'occlusion',
+count: 2787,
+});
+let textureView29 = texture0.createView({dimension: '2d-array', baseMipLevel: 6, mipLevelCount: 2});
+try {
+renderBundleEncoder21.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer15, 3040);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer3, 2340, buffer16, 17700, 42036);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer16);
+} catch {}
+let pipeline55 = await device0.createRenderPipelineAsync({
+label: '\ucc85\u{1f733}\u6a4c\u3e57',
+layout: pipelineLayout2,
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: 0}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, undefined, {
+  format: 'rg32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'zero'},
+},
+  writeMask: 0
+}]
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 372,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x4',
+offset: 272,
+shaderLocation: 8,
+}, {
+format: 'snorm8x4',
+offset: 284,
+shaderLocation: 5,
+}, {
+format: 'sint8x4',
+offset: 236,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 1228,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x4',
+offset: 716,
+shaderLocation: 7,
+}, {
+format: 'float32',
+offset: 804,
+shaderLocation: 6,
+}, {
+format: 'uint16x4',
+offset: 240,
+shaderLocation: 10,
+}, {
+format: 'uint8x4',
+offset: 264,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 856,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1320,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 1862,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 1704,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32',
+offset: 1464,
+shaderLocation: 1,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'front',
+},
+});
+let pipelineLayout11 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout6, bindGroupLayout13, bindGroupLayout19, bindGroupLayout14]});
+let querySet30 = device0.createQuerySet({
+label: '\u02a6\u4f67\u08f0\u59f0\u9cb7',
+type: 'occlusion',
+count: 2718,
+});
+let texture41 = device0.createTexture({
+label: '\u8249\u2717\u4379\uc5d6\u00da\u14b7\u78a4\u3d18\u8075\u{1fcd1}',
+size: {width: 32},
+sampleCount: 1,
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg32sint', 'rg32sint'],
+});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder9.draw(64, 16, 40, 32);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline47);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer0, 6636, buffer10, 6652, 1280);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder27.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 0,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 112 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 35952 */
+offset: 35952,
+bytesPerRow: 256,
+rowsPerImage: 210,
+buffer: buffer1,
+}, {width: 56, height: 75, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder({});
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder9.draw(64);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer12, 13176);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline47);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer2, 284, buffer4, 1832, 824);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder29.clearBuffer(buffer4, 9928, 1080);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(querySet14, 2604, 19, buffer12, 27392);
+} catch {}
+let pipeline56 = device0.createRenderPipeline({
+layout: pipelineLayout7,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.RED}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'src-alpha-saturated'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'always',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'equal',
+depthFailOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 282,
+stencilWriteMask: 186,
+depthBiasSlopeScale: 91,
+depthBiasClamp: 87,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1992,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 662,
+shaderLocation: 4,
+}, {
+format: 'sint32x2',
+offset: 772,
+shaderLocation: 6,
+}, {
+format: 'float16x4',
+offset: 832,
+shaderLocation: 5,
+}, {
+format: 'snorm16x4',
+offset: 984,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 196,
+attributes: [{
+format: 'float16x4',
+offset: 116,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 1820,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 892,
+shaderLocation: 12,
+}],
+}
+]
+},
+});
+try {
+  await promise11;
+} catch {}
+let textureView30 = texture4.createView({label: '\u546f\uc768\u4e94\ucaa4\u8266', format: 'bgra8unorm-srgb'});
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({
+  label: '\uccd2\u5060\u805d',
+  colorFormats: [undefined, 'r16uint', 'rg32uint', 'rg16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder9.draw(16, 48);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer12, 31740);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer9, 'uint32');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16uint', 'bgra8unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer7,
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 9264, new BigUint64Array(16703), 8039, 660);
+} catch {}
+let querySet31 = device0.createQuerySet({
+label: '\u026f\u9211\ucc9f',
+type: 'occlusion',
+count: 422,
+});
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({
+  label: '\u{1fa18}\u{1fc24}\u{1f730}\u{1f8d3}\u624c\u843b\u{1f8bb}\u0651\u{1fdb2}',
+  colorFormats: ['rg8uint', 'r16uint', 'rgba16uint', 'rgba16sint']
+});
+try {
+renderBundleEncoder9.draw(72, 56, 16, 64);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexedIndirect(buffer12, 21500);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(7, buffer6, 25772, 5598);
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(buffer3, 37416, buffer4, 11604, 20);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer14);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+renderBundleEncoder21.pushDebugGroup('\u0a09');
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+colorSpace: 'srgb',
+});
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+let shaderModule13 = device0.createShaderModule({
+label: '\u16ac\uc36d\u{1f8bd}\u7f47\u{1fd40}\u0138',
+code: `@group(0) @binding(43)
+var<storage, read_write> field8: array<u32>;
+@group(0) @binding(257)
+var<storage, read_write> parameter5: array<u32>;
+
+@compute @workgroup_size(2, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<u32>,
+  @location(1) f1: vec2<u32>,
+  @location(0) f2: vec2<u32>,
+  @location(3) f3: vec4<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S10 {
+  @location(8) f0: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(13) a0: vec3<i32>, @location(4) a1: vec3<f32>, @location(11) a2: vec2<u32>, @location(14) a3: vec3<i32>, a4: S10, @builtin(instance_index) a5: u32, @location(6) a6: i32, @location(15) a7: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroup15 = device0.createBindGroup({
+layout: bindGroupLayout1,
+entries: [{
+binding: 257,
+resource: externalTexture0
+}, {
+binding: 43,
+resource: externalTexture0
+}],
+});
+let querySet32 = device0.createQuerySet({
+label: '\ufb2b\u0e91',
+type: 'occlusion',
+count: 2856,
+});
+let textureView31 = texture12.createView({
+  label: '\u89ca\u0284\u{1fadf}\u{1ff02}\ufa49\u7c87',
+  format: 'rgba32uint',
+  baseMipLevel: 3,
+  arrayLayerCount: 1
+});
+let renderBundle32 = renderBundleEncoder8.finish({});
+try {
+renderBundleEncoder33.setIndexBuffer(buffer6, 'uint16', 25688);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline47);
+} catch {}
+let arrayBuffer9 = buffer13.getMappedRange(26584);
+try {
+commandEncoder27.copyBufferToBuffer(buffer2, 704, buffer12, 20356, 84);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder30.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 7,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(canvas8);
+let offscreenCanvas7 = new OffscreenCanvas(307, 228);
+let bindGroup16 = device0.createBindGroup({
+label: '\u9f5f\u01d2\u{1fe08}\u066c\u4f76\ue517\uf1b8\u8746',
+layout: bindGroupLayout11,
+entries: [{
+binding: 823,
+resource: textureView20
+}, {
+binding: 297,
+resource: externalTexture0
+}],
+});
+let buffer19 = device0.createBuffer({
+  label: '\u036f\u3b0f',
+  size: 24468,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true
+});
+let renderBundleEncoder37 = device0.createRenderBundleEncoder({
+  label: '\udd54\u5861\u{1fd2a}\ud96d',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle33 = renderBundleEncoder8.finish();
+try {
+renderBundleEncoder12.draw(48, 8);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer15, 656);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline47);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 7772, new DataView(new ArrayBuffer(17811)), 13376, 1844);
+} catch {}
+let gpuCanvasContext8 = offscreenCanvas7.getContext('webgpu');
+let promise13 = navigator.gpu.requestAdapter({
+});
+let videoFrame10 = new VideoFrame(video0, {timestamp: 0});
+let bindGroup17 = device0.createBindGroup({
+label: '\u{1fdeb}\u32b4\ue700\uda83\u7686',
+layout: bindGroupLayout5,
+entries: [],
+});
+let commandBuffer10 = commandEncoder29.finish({
+label: '\u9cbe\u{1ff26}\uedab\u{1fca4}',
+});
+let pipeline57 = device0.createRenderPipeline({
+label: '\u6b0c\u7edb\uc61b\u086b\uf7aa\u06af\u273e',
+layout: pipelineLayout8,
+fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r16uint'}, {format: 'rgba16uint', writeMask: 0}, {format: 'rgba16sint'}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 2017,
+stencilWriteMask: 1268,
+depthBias: 62,
+depthBiasSlopeScale: 97,
+depthBiasClamp: 26,
+},
+vertex: {
+  module: shaderModule7,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x2',
+offset: 432,
+shaderLocation: 12,
+}, {
+format: 'float32x3',
+offset: 1092,
+shaderLocation: 4,
+}, {
+format: 'uint8x4',
+offset: 24,
+shaderLocation: 9,
+}, {
+format: 'uint32x4',
+offset: 1716,
+shaderLocation: 10,
+}, {
+format: 'snorm16x2',
+offset: 416,
+shaderLocation: 14,
+}, {
+format: 'uint16x4',
+offset: 288,
+shaderLocation: 5,
+}, {
+format: 'uint8x4',
+offset: 1272,
+shaderLocation: 15,
+}, {
+format: 'uint16x2',
+offset: 576,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32',
+offset: 760,
+shaderLocation: 2,
+}, {
+format: 'sint32',
+offset: 1364,
+shaderLocation: 6,
+}, {
+format: 'uint8x2',
+offset: 726,
+shaderLocation: 0,
+}, {
+format: 'float32',
+offset: 1688,
+shaderLocation: 1,
+}, {
+format: 'unorm16x4',
+offset: 1068,
+shaderLocation: 8,
+}, {
+format: 'uint16x4',
+offset: 1492,
+shaderLocation: 3,
+}, {
+format: 'uint16x2',
+offset: 664,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 580,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x3',
+offset: 968,
+shaderLocation: 7,
+}],
+}
+]
+},
+});
+let bindGroup18 = device0.createBindGroup({
+label: '\u{1fe13}\u{1fd33}\u83ba\uc866\u0e79\ud953',
+layout: bindGroupLayout11,
+entries: [{
+binding: 823,
+resource: textureView27
+}, {
+binding: 297,
+resource: externalTexture0
+}],
+});
+let querySet33 = device0.createQuerySet({
+label: '\u0c77\u0148\u2ff7\u065f',
+type: 'occlusion',
+count: 3771,
+});
+let texture42 = device0.createTexture({
+label: '\u796e\ud248\u{1f633}\u1c83\u0543\u7b1a\ubc92\u8954\u054b\u2b3d\u{1f801}',
+size: [330, 24, 1],
+sampleCount: 4,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth16unorm'],
+});
+let sampler24 = device0.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 32.826,
+lodMaxClamp: 92.101,
+});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup7, new Uint32Array(2050), 739, 0);
+} catch {}
+try {
+computePassEncoder21.end();
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 16148);
+} catch {}
+try {
+renderBundleEncoder36.drawIndirect(buffer15, 1796);
+} catch {}
+try {
+commandEncoder30.copyBufferToTexture({
+/* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 31943 */
+offset: 31941,
+buffer: buffer0,
+}, {
+  texture: texture16,
+  mipLevel: 5,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder28.resolveQuerySet(querySet33, 2355, 515, buffer12, 17152);
+} catch {}
+let pipeline58 = device0.createRenderPipeline({
+label: '\u0aa5\u2c9f\uead2\u1839\ue564\ue03a\ud6a2',
+layout: pipelineLayout3,
+fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rgba16uint'}, {format: 'rgba16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+vertex: {
+  module: shaderModule10,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1708,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 24,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 8,
+shaderLocation: 7,
+}, {
+format: 'uint32x4',
+offset: 0,
+shaderLocation: 15,
+}, {
+format: 'uint16x4',
+offset: 0,
+shaderLocation: 14,
+}, {
+format: 'sint8x4',
+offset: 0,
+shaderLocation: 2,
+}, {
+format: 'sint32x2',
+offset: 8,
+shaderLocation: 0,
+}, {
+format: 'float32x2',
+offset: 0,
+shaderLocation: 11,
+}, {
+format: 'uint16x2',
+offset: 4,
+shaderLocation: 9,
+}, {
+format: 'float32x3',
+offset: 8,
+shaderLocation: 4,
+}, {
+format: 'float16x2',
+offset: 12,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 1064,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 876,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 96,
+shaderLocation: 8,
+}, {
+format: 'unorm16x2',
+offset: 460,
+shaderLocation: 10,
+}, {
+format: 'sint16x2',
+offset: 208,
+shaderLocation: 13,
+}, {
+format: 'uint16x2',
+offset: 784,
+shaderLocation: 3,
+}, {
+format: 'unorm16x2',
+offset: 220,
+shaderLocation: 1,
+}, {
+format: 'snorm8x2',
+offset: 540,
+shaderLocation: 5,
+}, {
+format: 'float32x2',
+offset: 228,
+shaderLocation: 12,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let textureView32 = texture4.createView({label: '\u0ab3\u50ff\u{1f9fd}\uc336\u1d2d\ua606\ueef0\u{1f92b}\u01c1\u7c86'});
+let renderBundle34 = renderBundleEncoder4.finish({label: '\u47cb\u7d6d\u9d8c\u0621'});
+let sampler25 = device0.createSampler({
+label: '\u{1fc7f}\u{1f825}\u048e\u92db\ua091\u08ec\uba8a\ue284\ub2d7',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 24.805,
+lodMaxClamp: 33.908,
+compare: 'less',
+});
+try {
+renderBundleEncoder17.drawIndirect(buffer15, 5008);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer9, 'uint32', 1696, 2821);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(0, buffer0);
+} catch {}
+let arrayBuffer10 = buffer7.getMappedRange(37496, 1064);
+try {
+commandEncoder20.resolveQuerySet(querySet4, 168, 113, buffer12, 13568);
+} catch {}
+let videoFrame11 = new VideoFrame(canvas12, {timestamp: 0});
+let texture43 = device0.createTexture({
+size: [64, 90, 1],
+mipLevelCount: 4,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+commandEncoder20.resolveQuerySet(querySet27, 867, 140, buffer12, 25600);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 9256, new DataView(new ArrayBuffer(36226)), 29557, 2864);
+} catch {}
+let pipeline59 = device0.createRenderPipeline({
+label: '\u8ea5\ucf61\u{1fdf6}\u434b\u0c65\u833a\u2349\u09a1',
+layout: pipelineLayout8,
+multisample: {
+mask: 0xb06d2141,
+},
+fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'rgba8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-src'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {format: 'rg16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, undefined, {format: 'rg16float'}]
+},
+vertex: {
+  module: shaderModule3,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1292,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 68,
+shaderLocation: 4,
+}, {
+format: 'unorm16x2',
+offset: 812,
+shaderLocation: 7,
+}, {
+format: 'uint32x2',
+offset: 36,
+shaderLocation: 15,
+}, {
+format: 'sint16x2',
+offset: 1144,
+shaderLocation: 9,
+}, {
+format: 'uint8x2',
+offset: 136,
+shaderLocation: 14,
+}, {
+format: 'snorm8x4',
+offset: 404,
+shaderLocation: 8,
+}, {
+format: 'uint8x2',
+offset: 310,
+shaderLocation: 13,
+}, {
+format: 'sint32x2',
+offset: 408,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 620,
+attributes: [{
+format: 'float32',
+offset: 320,
+shaderLocation: 10,
+}, {
+format: 'unorm16x4',
+offset: 424,
+shaderLocation: 0,
+}, {
+format: 'float32',
+offset: 64,
+shaderLocation: 5,
+}, {
+format: 'sint32',
+offset: 320,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 1832,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x4',
+offset: 912,
+shaderLocation: 3,
+}],
+}
+]
+},
+});
+let shaderModule14 = device0.createShaderModule({
+label: '\u0b11\u0c20\u02fe\u85ee\u{1f74c}\u49f9\u0813\u07ac',
+code: `@group(1) @binding(257)
+var<storage, read_write> function6: array<u32>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S11 {
+  @location(2) f0: vec2<u32>,
+  @location(9) f1: vec4<i32>,
+  @builtin(sample_index) f2: u32,
+  @builtin(position) f3: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec3<u32>,
+  @location(1) f1: vec4<u32>,
+  @location(3) f2: vec3<f32>,
+  @location(4) f3: vec4<u32>,
+  @builtin(sample_mask) f4: u32,
+  @location(0) f5: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(7) a0: i32, a1: S11, @builtin(sample_mask) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(2) f41: vec2<u32>,
+  @location(9) f42: vec4<i32>,
+  @location(7) f43: i32,
+  @builtin(position) f44: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(3) a0: i32, @location(9) a1: vec4<u32>, @location(8) a2: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder31 = device0.createCommandEncoder();
+let texture44 = device0.createTexture({
+label: '\u0343\uffe3\uc53f\u3b07\u8952\u{1f6b0}\u13be\u{1f69e}\u4639\u0fd1',
+size: {width: 110, height: 20, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'astc-10x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x10-unorm-srgb', 'astc-10x10-unorm', 'astc-10x10-unorm-srgb'],
+});
+let textureView33 = texture35.createView({label: '\ufbd4\u0109\u75af\u36fe'});
+let renderBundle35 = renderBundleEncoder13.finish({label: '\uf223\u0ab0\u9c3c\u{1f70e}\u09f0\u0e38\u0422'});
+let sampler26 = device0.createSampler({
+label: '\uc215\u1ac6\ub201\ua10d\u{1fb94}\u04af\u2f7d\u0a8f\u{1f731}\u299b',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 31.640,
+lodMaxClamp: 51.698,
+maxAnisotropy: 17,
+});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup5, new Uint32Array(4289), 4038, 0);
+} catch {}
+try {
+renderBundleEncoder36.drawIndirect(buffer12, 25764);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer9, 'uint32', 9808, 5719);
+} catch {}
+try {
+commandEncoder26.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 5,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 6,
+  origin: { x: 0, y: 8, z: 0 },
+  aspect: 'all',
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline60 = device0.createComputePipeline({
+label: '\ud841\u1074\u{1f8f8}\u2cab\u2833\u00ca\u68fa',
+layout: pipelineLayout8,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline61 = device0.createRenderPipeline({
+label: '\u20fc\ub066\u{1f8e5}',
+layout: pipelineLayout8,
+fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r16uint', writeMask: 0}, {format: 'rgba16uint'}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 3330,
+stencilWriteMask: 1576,
+depthBias: 30,
+depthBiasSlopeScale: 4,
+depthBiasClamp: 46,
+},
+vertex: {
+  module: shaderModule10,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1808,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32',
+offset: 616,
+shaderLocation: 0,
+}, {
+format: 'float32x2',
+offset: 892,
+shaderLocation: 8,
+}, {
+format: 'snorm16x2',
+offset: 1736,
+shaderLocation: 12,
+}, {
+format: 'unorm8x4',
+offset: 572,
+shaderLocation: 1,
+}, {
+format: 'unorm8x2',
+offset: 434,
+shaderLocation: 11,
+}, {
+format: 'unorm16x4',
+offset: 356,
+shaderLocation: 4,
+}, {
+format: 'snorm16x2',
+offset: 1476,
+shaderLocation: 5,
+}, {
+format: 'uint8x4',
+offset: 780,
+shaderLocation: 3,
+}, {
+format: 'unorm10-10-10-2',
+offset: 652,
+shaderLocation: 7,
+}, {
+format: 'float32',
+offset: 60,
+shaderLocation: 10,
+}, {
+format: 'sint32',
+offset: 220,
+shaderLocation: 13,
+}, {
+format: 'float32x4',
+offset: 488,
+shaderLocation: 6,
+}, {
+format: 'uint32x3',
+offset: 684,
+shaderLocation: 9,
+}, {
+format: 'uint32x3',
+offset: 576,
+shaderLocation: 14,
+}, {
+format: 'uint16x4',
+offset: 1200,
+shaderLocation: 15,
+}, {
+format: 'sint32x3',
+offset: 1004,
+shaderLocation: 2,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'front',
+},
+});
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline47);
+} catch {}
+try {
+commandEncoder31.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: { x: 0, y: 40, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture43,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder24.resolveQuerySet(querySet25, 590, 279, buffer12, 256);
+} catch {}
+try {
+renderBundleEncoder21.popDebugGroup();
+} catch {}
+let imageData3 = new ImageData(108, 212);
+let commandEncoder32 = device0.createCommandEncoder({});
+let commandBuffer11 = commandEncoder24.finish({
+label: '\u{1f658}\u45bf\u490e\u09e5\u0122\ub6c7',
+});
+let textureView34 = texture39.createView({label: '\ufa70\u33fd\u0026\ub007\u{1f73b}\u89cf\u0ea4', baseMipLevel: 6, mipLevelCount: 1});
+try {
+computePassEncoder20.dispatchWorkgroups(5, 3, 1);
+} catch {}
+try {
+commandEncoder18.clearBuffer(buffer4, 5548, 800);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder28.resolveQuerySet(querySet23, 2032, 12, buffer12, 35584);
+} catch {}
+try {
+  await promise12;
+} catch {}
+try {
+renderBundleEncoder12.drawIndirect(buffer15, 1932);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder33 = device0.createCommandEncoder({label: '\u8567\u0790\u323d\uf593\u0c77\u88ec'});
+let computePassEncoder22 = commandEncoder18.beginComputePass({label: '\u{1f898}\u16c4\u083e\ubede\ub59d\u0b63\u0ce7\u0e21\ud9d3\u0e0d\u{1febd}'});
+try {
+computePassEncoder22.setPipeline(pipeline32);
+} catch {}
+try {
+querySet4.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 416, new DataView(new ArrayBuffer(41833)), 18829, 1528);
+} catch {}
+let pipeline62 = device0.createComputePipeline({
+label: '\u09fc\u{1f863}\u211c\u0848\u84fc\ub145\u3bb0\ua8f3\u{1fad9}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline63 = device0.createRenderPipeline({
+layout: pipelineLayout7,
+multisample: {
+count: 4,
+},
+fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+vertex: {
+  module: shaderModule10,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1764,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 156,
+shaderLocation: 4,
+}, {
+format: 'float32x2',
+offset: 1284,
+shaderLocation: 1,
+}, {
+format: 'sint32x3',
+offset: 372,
+shaderLocation: 0,
+}, {
+format: 'float32x2',
+offset: 1608,
+shaderLocation: 6,
+}, {
+format: 'uint16x4',
+offset: 928,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 1416,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 448,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 1380,
+shaderLocation: 14,
+}, {
+format: 'sint16x2',
+offset: 344,
+shaderLocation: 13,
+}, {
+format: 'snorm16x2',
+offset: 508,
+shaderLocation: 5,
+}, {
+format: 'uint8x2',
+offset: 14,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 0,
+attributes: [{
+format: 'snorm8x4',
+offset: 792,
+shaderLocation: 8,
+}, {
+format: 'unorm8x4',
+offset: 836,
+shaderLocation: 11,
+}, {
+format: 'sint32',
+offset: 1024,
+shaderLocation: 2,
+}, {
+format: 'snorm16x4',
+offset: 1844,
+shaderLocation: 10,
+}, {
+format: 'uint16x2',
+offset: 1580,
+shaderLocation: 3,
+}, {
+format: 'float32',
+offset: 496,
+shaderLocation: 7,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+let textureView35 = texture41.createView({label: '\u029f\u0ae0\uca8a\uc183\u0f6d\u0244\u7b7e\u4272', baseMipLevel: 0});
+let computePassEncoder23 = commandEncoder28.beginComputePass({label: '\u{1fbf1}\u{1f77e}\u611e\u0092\u{1fae4}'});
+try {
+computePassEncoder22.dispatchWorkgroups(4, 5);
+} catch {}
+try {
+computePassEncoder20.dispatchWorkgroupsIndirect(buffer15, 2964);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup2, new Uint32Array(4378), 1204, 0);
+} catch {}
+try {
+renderBundleEncoder17.draw(8, 0, 24, 72);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer12, 19788);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(7, buffer15, 1156, 500);
+} catch {}
+let arrayBuffer11 = buffer3.getMappedRange(16352, 14116);
+try {
+commandEncoder26.resolveQuerySet(querySet13, 0, 1, buffer12, 27136);
+} catch {}
+let img11 = await imageWithData(298, 288, '#dd20136d', '#679569a0');
+let texture45 = device0.createTexture({
+label: '\u04cf\u012e\u03e0\u0e80\uf2d7\u{1fdae}\uf5a4\u{1fee2}\uc7c6\uc876',
+size: [320, 2, 37],
+mipLevelCount: 2,
+sampleCount: 1,
+dimension: '3d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle36 = renderBundleEncoder6.finish({});
+let promise14 = buffer14.mapAsync(GPUMapMode.READ, 0, 4192);
+try {
+commandEncoder22.copyBufferToBuffer(buffer17, 11556, buffer14, 8948, 3300);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer7), /* required buffer size: 685 */
+{offset: 613}, {width: 36, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline64 = await device0.createRenderPipelineAsync({
+label: '\u0120\u{1f76a}\u09c1\u896e\u74cf\u0a74\u0062\u{1fd95}',
+layout: pipelineLayout1,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'constant'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {format: 'rgba16uint'}, {format: 'r8uint'}, {
+  format: 'rg11b10ufloat',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'src'},
+},
+  writeMask: 0
+}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'invert',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilWriteMask: 2691,
+depthBiasSlopeScale: 7,
+depthBiasClamp: 49,
+},
+vertex: {
+  module: shaderModule11,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 884,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x2',
+offset: 776,
+shaderLocation: 10,
+}, {
+format: 'float16x2',
+offset: 116,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 104,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x3',
+offset: 4,
+shaderLocation: 6,
+}, {
+format: 'sint32',
+offset: 80,
+shaderLocation: 1,
+}, {
+format: 'unorm16x2',
+offset: 44,
+shaderLocation: 11,
+}, {
+format: 'uint16x4',
+offset: 28,
+shaderLocation: 4,
+}, {
+format: 'snorm16x4',
+offset: 60,
+shaderLocation: 14,
+}, {
+format: 'uint32',
+offset: 76,
+shaderLocation: 12,
+}, {
+format: 'float16x4',
+offset: 72,
+shaderLocation: 8,
+}],
+}
+]
+},
+});
+let imageBitmap6 = await createImageBitmap(imageData2);
+let querySet34 = device0.createQuerySet({
+label: '\u0467\u7b96\u0e50\uee1f\uf248\u{1fecd}',
+type: 'occlusion',
+count: 1732,
+});
+let texture46 = gpuCanvasContext3.getCurrentTexture();
+let textureView36 = texture3.createView({
+  label: '\u{1f90c}\u9db8\uc7f3\u01ea\u0806\u7939\u6837\u03a2\ua771\u{1f60b}\u863d',
+  dimension: '2d-array'
+});
+let renderBundleEncoder38 = device0.createRenderBundleEncoder({
+  label: '\u18f2\u00c7\u55ab\u{1ffd3}',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder22.dispatchWorkgroups(3);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(1, buffer0);
+} catch {}
+try {
+commandEncoder31.copyBufferToBuffer(buffer0, 31032, buffer9, 15384, 2080);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+/* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 26704 */
+offset: 26704,
+buffer: buffer0,
+}, {
+  texture: texture0,
+  mipLevel: 4,
+  origin: { x: 32, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 40, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline65 = device0.createComputePipeline({
+label: '\u9676\ua8a7\u{1fac0}\u0ecd\u94fa\u111c\u{1f94a}\u{1f64c}\u8833\u0b05',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+},
+});
+let promise15 = device0.createRenderPipelineAsync({
+label: '\udb18\u8b6b\ue039\u0db2\u2418\u9d16\u6cfd\uac62\u94f9',
+layout: pipelineLayout4,
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint'}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined, {
+  format: 'rg32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'bgra8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater-equal',
+depthFailOp: 'zero',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 336,
+stencilWriteMask: 328,
+depthBias: 83,
+depthBiasClamp: 64,
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 484,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32',
+offset: 356,
+shaderLocation: 6,
+}, {
+format: 'uint8x2',
+offset: 380,
+shaderLocation: 7,
+}, {
+format: 'uint32x3',
+offset: 36,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 1356,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 16,
+shaderLocation: 5,
+}, {
+format: 'sint16x2',
+offset: 740,
+shaderLocation: 4,
+}, {
+format: 'uint8x2',
+offset: 1022,
+shaderLocation: 14,
+}, {
+format: 'sint16x2',
+offset: 344,
+shaderLocation: 1,
+}, {
+format: 'snorm8x4',
+offset: 1196,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 1508,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x4',
+offset: 660,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+pseudoSubmit(device0, commandEncoder30);
+try {
+renderBundleEncoder31.setVertexBuffer(0, buffer6);
+} catch {}
+try {
+  await buffer11.mapAsync(GPUMapMode.READ, 0, 17516);
+} catch {}
+try {
+computePassEncoder2.insertDebugMarker('\u{1f6c7}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 2,
+  origin: { x: 30, y: 10, z: 1 },
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer1), /* required buffer size: 208 */
+{offset: 208, bytesPerRow: 861}, {width: 360, height: 20, depthOrArrayLayers: 0});
+} catch {}
+let pipeline66 = device0.createRenderPipeline({
+label: '\u132b\ubf17\u0af3\uf575\u81e0\u{1feb2}\u765e',
+layout: pipelineLayout11,
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'src-alpha', dstFactor: 'one-minus-src'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA
+}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 551,
+stencilWriteMask: 1362,
+depthBias: 66,
+depthBiasSlopeScale: 95,
+depthBiasClamp: 88,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1404,
+attributes: [{
+format: 'sint16x4',
+offset: 1252,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 1824,
+attributes: [],
+},
+{
+arrayStride: 1384,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 564,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+},
+});
+let renderBundle37 = renderBundleEncoder38.finish({label: '\u1720\u{1f639}\u0a2d\u0d08\uad48\u36a7\u07ca\u{1fcd9}'});
+try {
+renderBundleEncoder26.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder9.draw(64, 8, 80, 0);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer15, 5004);
+} catch {}
+try {
+renderBundleEncoder36.drawIndirect(buffer15, 5352);
+} catch {}
+try {
+commandEncoder33.resolveQuerySet(querySet13, 0, 1, buffer12, 28928);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 12780, new DataView(new ArrayBuffer(12004)), 4777, 1572);
+} catch {}
+let shaderModule15 = device0.createShaderModule({
+label: '\u0d46\u{1fa60}\u6eb2\u0c4c\u1993\u4e68\uaf5e\ufaab\ud808',
+code: `@group(1) @binding(788)
+var<storage, read_write> type7: array<u32>;
+@group(2) @binding(20)
+var<storage, read_write> local4: array<u32>;
+@group(0) @binding(561)
+var<storage, read_write> parameter6: array<u32>;
+@group(3) @binding(674)
+var<storage, read_write> i5: array<u32>;
+
+@compute @workgroup_size(8, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S13 {
+  @location(9) f0: vec4<f32>,
+  @location(5) f1: vec3<f16>,
+  @location(12) f2: f32,
+  @location(13) f3: vec4<f16>,
+  @location(6) f4: vec3<i32>,
+  @builtin(front_facing) f5: bool,
+  @location(1) f6: f32,
+  @location(10) f7: vec3<f16>,
+  @location(15) f8: f32,
+  @location(2) f9: vec2<f16>,
+  @location(3) f10: i32,
+  @location(8) f11: vec4<f32>,
+  @builtin(sample_index) f12: u32,
+  @builtin(position) f13: vec4<f32>,
+  @builtin(sample_mask) f14: u32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(1) f1: u32,
+  @location(3) f2: vec4<i32>,
+  @location(2) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(14) a0: vec2<i32>, a1: S13) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S12 {
+  @location(12) f0: i32,
+  @location(9) f1: vec4<f16>,
+  @location(14) f2: vec3<i32>,
+  @builtin(vertex_index) f3: u32,
+  @location(5) f4: vec3<f16>,
+  @location(7) f5: vec2<f16>,
+  @location(4) f6: vec2<u32>,
+  @location(1) f7: f16,
+  @location(6) f8: vec2<u32>
+}
+struct VertexOutput0 {
+  @location(2) f45: vec2<f16>,
+  @location(13) f46: vec4<f16>,
+  @location(8) f47: vec4<f32>,
+  @location(14) f48: vec2<i32>,
+  @location(5) f49: vec3<f16>,
+  @location(12) f50: f32,
+  @location(15) f51: f32,
+  @builtin(position) f52: vec4<f32>,
+  @location(10) f53: vec3<f16>,
+  @location(6) f54: vec3<i32>,
+  @location(9) f55: vec4<f32>,
+  @location(1) f56: f32,
+  @location(3) f57: i32
+}
+
+@vertex
+fn vertex0(a0: S12, @location(3) a1: vec4<f16>, @location(13) a2: vec3<i32>, @location(0) a3: f32, @location(8) a4: vec3<i32>, @location(15) a5: vec2<u32>, @builtin(instance_index) a6: u32, @location(11) a7: f16, @location(2) a8: vec3<f16>, @location(10) a9: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let querySet35 = device0.createQuerySet({
+type: 'occlusion',
+count: 1762,
+});
+let textureView37 = texture25.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+let sampler27 = device0.createSampler({
+label: '\u077b\u0a30\u9207\u0541\ua568\u5946\u3a03',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 3.474,
+compare: 'less',
+maxAnisotropy: 9,
+});
+try {
+computePassEncoder22.dispatchWorkgroupsIndirect(buffer12, 27676);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder12.draw(40, 56, 32, 16);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer15, 6000);
+} catch {}
+try {
+commandEncoder31.copyBufferToBuffer(buffer2, 540, buffer14, 2052, 828);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder27.clearBuffer(buffer11, 43428, 10024);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 188, y: 0, z: 0 },
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer2), /* required buffer size: 684 */
+{offset: 560}, {width: 31, height: 1, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let offscreenCanvas8 = new OffscreenCanvas(589, 623);
+let bindGroupLayout21 = device0.createBindGroupLayout({
+entries: [{
+binding: 690,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}, {
+binding: 635,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+}],
+});
+let texture47 = gpuCanvasContext3.getCurrentTexture();
+let computePassEncoder24 = commandEncoder22.beginComputePass();
+let renderBundle38 = renderBundleEncoder6.finish({label: '\u05f8\u0162'});
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer12, 14132);
+} catch {}
+try {
+renderBundleEncoder36.drawIndirect(buffer12, 2728);
+} catch {}
+let promise16 = device0.createRenderPipelineAsync({
+label: '\u66b0\u0473\u{1f747}\u0f59\u809b',
+layout: pipelineLayout8,
+fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba16sint'}]
+},
+vertex: {
+  module: shaderModule4,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 756,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x2',
+offset: 556,
+shaderLocation: 15,
+}, {
+format: 'float32',
+offset: 96,
+shaderLocation: 13,
+}, {
+format: 'snorm8x2',
+offset: 702,
+shaderLocation: 14,
+}, {
+format: 'unorm8x4',
+offset: 164,
+shaderLocation: 7,
+}, {
+format: 'unorm16x2',
+offset: 592,
+shaderLocation: 12,
+}, {
+format: 'sint8x2',
+offset: 76,
+shaderLocation: 0,
+}, {
+format: 'uint8x2',
+offset: 388,
+shaderLocation: 4,
+}, {
+format: 'float32x2',
+offset: 376,
+shaderLocation: 6,
+}, {
+format: 'snorm16x4',
+offset: 732,
+shaderLocation: 1,
+}, {
+format: 'snorm16x4',
+offset: 548,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 24,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 1248,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x2',
+offset: 224,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 1320,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1112,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1956,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1908,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 364,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32',
+offset: 296,
+shaderLocation: 5,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+  await promise14;
+} catch {}
+document.body.prepend(canvas11);
+let offscreenCanvas9 = new OffscreenCanvas(747, 191);
+let pipelineLayout12 = device0.createPipelineLayout({
+  label: '\u2be5\u76f1\uecdb\ue296\uf285',
+  bindGroupLayouts: [bindGroupLayout12, bindGroupLayout10, bindGroupLayout8]
+});
+let querySet36 = device0.createQuerySet({
+label: '\u0675\u09a1\u01f9\u2897\u{1f902}\u2b97\u317c\u{1faf7}\uda9c\u6c8a',
+type: 'occlusion',
+count: 99,
+});
+let textureView38 = texture19.createView({
+  label: '\u0bce\uf1c5\u0db9\u3f71\u0550\u0b68',
+  format: 'astc-6x5-unorm-srgb',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+  baseArrayLayer: 15,
+  arrayLayerCount: 121
+});
+let computePassEncoder25 = commandEncoder26.beginComputePass({label: '\u0d68\u063d\u{1f83e}\u{1fec0}\u{1fb15}\ua898\u7db5\u{1fd5a}\ue25f'});
+let renderBundleEncoder39 = device0.createRenderBundleEncoder({
+  label: '\u3724\u5346',
+  colorFormats: ['bgra8unorm-srgb', 'rgba16uint', 'r8uint', 'rg11b10ufloat', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler28 = device0.createSampler({
+label: '\u{1fad9}\u0281',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 22.298,
+lodMaxClamp: 67.028,
+maxAnisotropy: 13,
+});
+try {
+computePassEncoder20.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(1, buffer0, 27524, 6030);
+} catch {}
+try {
+commandEncoder32.resolveQuerySet(querySet26, 209, 22, buffer12, 12288);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: { x: 396, y: 0, z: 30 },
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer3), /* required buffer size: 995720 */
+{offset: 276, bytesPerRow: 2087, rowsPerImage: 68}, {width: 762, height: 5, depthOrArrayLayers: 8});
+} catch {}
+let pipeline67 = device0.createComputePipeline({
+layout: pipelineLayout3,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup18, new Uint32Array(1153), 719, 0);
+} catch {}
+try {
+renderBundleEncoder9.draw(8, 64, 64, 48);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer15, 1124);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline58);
+} catch {}
+try {
+commandEncoder32.copyTextureToBuffer({
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 48, y: 168, z: 1 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 224 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 44368 */
+offset: 44368,
+rowsPerImage: 79,
+buffer: buffer16,
+}, {width: 56, height: 4, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+});
+} catch {}
+let texture48 = gpuCanvasContext6.getCurrentTexture();
+let renderBundle39 = renderBundleEncoder18.finish();
+try {
+computePassEncoder23.setPipeline(pipeline62);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(72, 56, 56);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexedIndirect(buffer15, 5652);
+} catch {}
+try {
+commandEncoder15.resolveQuerySet(querySet18, 1641, 1001, buffer12, 15104);
+} catch {}
+try {
+commandEncoder20.insertDebugMarker('\u0fe4');
+} catch {}
+let canvas13 = document.createElement('canvas');
+let commandEncoder34 = device0.createCommandEncoder({});
+let renderBundle40 = renderBundleEncoder25.finish({label: '\u25e6\u0e57\uf344\uc96f\u{1f79f}\u0155\u5367\u2331\u4042\u0696\uc7ae'});
+let sampler29 = device0.createSampler({
+label: '\ua6dc\u{1fcba}\u{1f6a2}\ua666',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+lodMaxClamp: 74.105,
+compare: 'never',
+});
+try {
+computePassEncoder22.dispatchWorkgroupsIndirect(buffer15, 5428);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 40688);
+} catch {}
+try {
+commandEncoder34.clearBuffer(buffer1, 4816, 30852);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer11,
+]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 6 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer2), /* required buffer size: 163951 */
+{offset: 195, bytesPerRow: 86, rowsPerImage: 190}, {width: 3, height: 5, depthOrArrayLayers: 11});
+} catch {}
+let pipeline68 = device0.createComputePipeline({
+label: '\u9798\u06a1\u0f85',
+layout: pipelineLayout12,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+offscreenCanvas8.getContext('webgl');
+} catch {}
+let bindGroupLayout22 = device0.createBindGroupLayout({
+label: '\u03e2\u0a75\ub08e\u7e84\u{1fb07}\u27d5\uc43f\u{1fb65}\u02a9',
+entries: [{
+binding: 578,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+}],
+});
+let texture49 = device0.createTexture({
+label: '\u5bbf\uc5d5\ua77a\u9cdd\ub4a1\u0a59\u42df\ufb88\u{1f7b6}',
+size: [2060, 90, 1],
+mipLevelCount: 2,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder26 = commandEncoder27.beginComputePass({});
+try {
+computePassEncoder20.dispatchWorkgroups(2, 1, 3);
+} catch {}
+try {
+renderBundleEncoder9.draw(72);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 40024);
+} catch {}
+try {
+renderBundleEncoder12.drawIndirect(buffer15, 952);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer9, 'uint16', 11002, 855);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(4, buffer6, 4824);
+} catch {}
+let promise17 = buffer17.mapAsync(GPUMapMode.WRITE, 1584, 4272);
+try {
+device0.queue.submit([
+commandBuffer6,
+commandBuffer10,
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 10668, new Int16Array(14111), 6845, 420);
+} catch {}
+let pipeline69 = await device0.createComputePipelineAsync({
+label: '\u1cf6\u{1f691}\ue641\u{1f964}',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule10,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let canvas14 = document.createElement('canvas');
+let bindGroupLayout23 = device0.createBindGroupLayout({
+label: '\u0cc8\u{1f9b6}\u9fd6\u07ff\ub1ef',
+entries: [{
+binding: 487,
+visibility: 0,
+externalTexture: {},
+}, {
+binding: 486,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'bgra8unorm', access: 'write-only', viewDimension: '3d' },
+}],
+});
+let pipelineLayout13 = device0.createPipelineLayout({label: '\u{1f8fe}\u2466', bindGroupLayouts: [bindGroupLayout12]});
+let texture50 = device0.createTexture({
+label: '\u1513\u{1f82b}\ua888\ubf7e\u824d\u4975\u0521',
+size: {width: 660, height: 48, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x12-unorm', 'astc-12x12-unorm', 'astc-12x12-unorm-srgb'],
+});
+let computePassEncoder27 = commandEncoder34.beginComputePass({});
+let renderBundle41 = renderBundleEncoder35.finish({label: '\ufde3\u987f\u6f17'});
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer15, 5144);
+} catch {}
+try {
+renderBundleEncoder12.drawIndirect(buffer12, 8772);
+} catch {}
+try {
+commandEncoder20.resolveQuerySet(querySet2, 575, 317, buffer12, 35584);
+} catch {}
+let gpuCanvasContext9 = canvas14.getContext('webgpu');
+try {
+computePassEncoder26.setPipeline(pipeline49);
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(buffer12, 428, buffer18, 19232, 800);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer18);
+} catch {}
+let gpuCanvasContext10 = canvas13.getContext('webgpu');
+let texture51 = device0.createTexture({
+label: '\u937c\u0f58\u1dff',
+size: {width: 320},
+dimension: '1d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgba8unorm-srgb', 'rgba8unorm'],
+});
+let textureView39 = texture45.createView({baseMipLevel: 1, baseArrayLayer: 0});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup4, new Uint32Array(317), 61, 0);
+} catch {}
+try {
+renderBundleEncoder12.draw(0);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(3, buffer6, 31704, 2117);
+} catch {}
+try {
+  await promise17;
+} catch {}
+let img12 = await imageWithData(186, 3, '#47ba8089', '#72d63cbf');
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+try {
+computePassEncoder17.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(2, bindGroup8, new Uint32Array(1724), 238, 0);
+} catch {}
+try {
+renderBundleEncoder9.draw(16, 8, 0);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexedIndirect(buffer15, 304);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 45532, new Int16Array(8837), 2712, 1220);
+} catch {}
+let pipeline70 = await promise15;
+gc();
+try {
+offscreenCanvas9.getContext('webgpu');
+} catch {}
+let commandEncoder35 = device0.createCommandEncoder({label: '\u9ab2\u09c0\u1479\u0956\u{1f66e}\u04b2'});
+let querySet37 = device0.createQuerySet({
+type: 'occlusion',
+count: 699,
+});
+try {
+renderBundleEncoder17.draw(80, 24, 72, 40);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer15, 5748);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(6, buffer6, 14340, 12900);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder35.copyBufferToBuffer(buffer12, 28736, buffer10, 220, 6008);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder31.clearBuffer(buffer11, 27736, 20248);
+dissociateBuffer(device0, buffer11);
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+let video6 = await videoWithData();
+let imageBitmap7 = await createImageBitmap(canvas5);
+let computePassEncoder28 = commandEncoder20.beginComputePass({label: '\ue9d2\u6c4e\u6b84\u0752\u4a79\u{1f81d}\uc456\u0f01\u{1fa51}\u0f31\u{1fa3e}'});
+let renderBundleEncoder40 = device0.createRenderBundleEncoder({
+  label: '\u{1fbf9}\u0f57\u2e72\u51e8\uf1c7\u0900',
+  colorFormats: ['r8uint', 'rgba8sint', 'rg8uint', 'rg32uint', undefined, 'rg8uint', undefined, 'bgra8unorm-srgb'],
+  stencilReadOnly: true
+});
+let sampler30 = device0.createSampler({
+label: '\uf875\u37d7',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 7.856,
+lodMaxClamp: 10.491,
+maxAnisotropy: 11,
+});
+try {
+renderBundleEncoder40.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+commandEncoder33.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 3056 */
+offset: 3056,
+bytesPerRow: 0,
+buffer: buffer0,
+}, {
+  texture: texture44,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let texture52 = device0.createTexture({
+label: '\u213d\u15d4\u7862',
+size: [320, 2, 503],
+mipLevelCount: 9,
+dimension: '3d',
+format: 'rg32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let computePassEncoder29 = commandEncoder33.beginComputePass({});
+let renderBundleEncoder41 = device0.createRenderBundleEncoder({
+  label: '\u1de3\u{1fd2b}\u01ca\uf784\uc106',
+  colorFormats: ['rg16uint', 'rg32float', 'r16uint', 'rg16sint'],
+  depthReadOnly: true
+});
+let externalTexture1 = device0.importExternalTexture({
+source: videoFrame6,
+});
+try {
+renderBundleEncoder32.setPipeline(pipeline47);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(59, undefined);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer12, 24280, buffer1, 40620, 256);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder31.copyTextureToBuffer({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 44356 */
+offset: 44356,
+rowsPerImage: 46,
+buffer: buffer1,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 0,
+  origin: { x: 160, y: 2, z: 3 },
+  aspect: 'all',
+}, arrayBuffer11, /* required buffer size: 2270345 */
+{offset: 605, bytesPerRow: 362, rowsPerImage: 190}, {width: 50, height: 0, depthOrArrayLayers: 34});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: canvas14,
+  origin: { x: 135, y: 59 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 7,
+  origin: { x: 1, y: 1, z: 2 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData4 = new ImageData(92, 28);
+let bindGroupLayout24 = device0.createBindGroupLayout({
+label: '\u0a25\u6320\u070a\u0e89\u5605\u544f\ubeb5',
+entries: [{
+binding: 283,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+}],
+});
+let commandBuffer12 = commandEncoder32.finish();
+let texture53 = device0.createTexture({
+label: '\u33d7\uf0ec\u0147',
+size: [1320, 96, 1],
+mipLevelCount: 2,
+sampleCount: 1,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-8x8-unorm', 'astc-8x8-unorm'],
+});
+let computePassEncoder30 = commandEncoder31.beginComputePass({});
+let renderBundle42 = renderBundleEncoder39.finish({label: '\u06a2\u67d7\u0b08\u{1f8e6}\ua9e1'});
+try {
+renderBundleEncoder32.setBindGroup(1, bindGroup12, new Uint32Array(1919), 1277, 0);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(2, buffer6, 7104, 24370);
+} catch {}
+try {
+renderBundleEncoder37.pushDebugGroup('\u{1fbb5}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 5,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 20959 */
+{offset: 350, bytesPerRow: 92, rowsPerImage: 56}, {width: 1, height: 1, depthOrArrayLayers: 5});
+} catch {}
+let promise19 = device0.createComputePipelineAsync({
+layout: pipelineLayout1,
+compute: {
+module: shaderModule10,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let bindGroup19 = device0.createBindGroup({
+label: '\u0af3\ud720\ubc43\uab03\u0953\u{1f76b}',
+layout: bindGroupLayout11,
+entries: [{
+binding: 823,
+resource: textureView6
+}, {
+binding: 297,
+resource: externalTexture1
+}],
+});
+let querySet38 = device0.createQuerySet({
+label: '\uefcb\u0cca\u{1faed}\u0464',
+type: 'occlusion',
+count: 1991,
+});
+try {
+computePassEncoder28.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexed(0);
+} catch {}
+try {
+renderBundleEncoder36.drawIndirect(buffer12, 28172);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(4, buffer15, 2956, 610);
+} catch {}
+let arrayBuffer12 = buffer2.getMappedRange(1104, 4);
+try {
+commandEncoder15.resolveQuerySet(querySet16, 824, 943, buffer12, 30976);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 2 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 807298 */
+{offset: 626, bytesPerRow: 260, rowsPerImage: 141}, {width: 19, height: 1, depthOrArrayLayers: 23});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise20 = device0.createRenderPipelineAsync({
+label: '\u5e4c\u03cf\u04d7\u0b2e\u299b\u51ed\uf105\u03ef',
+layout: pipelineLayout9,
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint'}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, undefined, {format: 'rg32float'}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'zero', dstFactor: 'constant'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2385,
+depthBias: 37,
+depthBiasSlopeScale: 20,
+depthBiasClamp: 64,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1568,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x4',
+offset: 1400,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 228,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1104,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 2008,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 1884,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+unclippedDepth: true,
+},
+});
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let bindGroup20 = device0.createBindGroup({
+label: '\ufaf4\u23c6\u6cad',
+layout: bindGroupLayout16,
+entries: [],
+});
+let renderBundleEncoder42 = device0.createRenderBundleEncoder({
+  label: '\u5b78\ubb80\u{1f768}\u{1f625}\u0545\u2dad\u7c73\u{1f735}\uc5df',
+  colorFormats: [undefined, 'r16uint', 'rg32uint', 'rg16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+let renderBundle43 = renderBundleEncoder11.finish({label: '\u0ecc\u57be\ua545'});
+try {
+computePassEncoder29.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder9.draw(40, 48, 56);
+} catch {}
+try {
+buffer12.destroy();
+} catch {}
+let commandEncoder36 = device0.createCommandEncoder();
+let computePassEncoder31 = commandEncoder15.beginComputePass();
+let renderBundleEncoder43 = device0.createRenderBundleEncoder({
+  label: '\u0623\u8807\u946e\uef7c\u0d60\u436f\u0c55',
+  colorFormats: ['r8uint', undefined, 'rg8sint'],
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+computePassEncoder20.dispatchWorkgroups(1, 5, 5);
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline49);
+} catch {}
+try {
+renderBundleEncoder32.draw(56, 72, 0, 0);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(2, buffer0, 34372, 1081);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture48,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 200, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 13660, new BigUint64Array(53077), 29152, 188);
+} catch {}
+let renderBundleEncoder44 = device0.createRenderBundleEncoder({
+  label: '\u3d74\u0a0b\ub179\u0bfe\u3028\u5a9c\ua598\u234a\u{1f641}',
+  colorFormats: ['rg8uint', 'r16uint', 'rgba16uint', 'rgba16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup13, new Uint32Array(9684), 4936, 0);
+} catch {}
+try {
+renderBundleEncoder32.draw(72, 32, 40, 16);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexed(32, 8, 56, 760, 32);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer15, 328);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer15, 2624);
+} catch {}
+try {
+buffer10.destroy();
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 1,
+  origin: { x: 530, y: 70, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture29,
+  mipLevel: 2,
+  origin: { x: 130, y: 15, z: 0 },
+  aspect: 'all',
+}, {width: 210, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder36.clearBuffer(buffer4, 5232, 3800);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let pipelineLayout14 = device0.createPipelineLayout({label: '\u5588\uaeda\ua385', bindGroupLayouts: []});
+let renderBundle44 = renderBundleEncoder10.finish({label: '\u54f6\u{1f95d}\u0f5e\u1559\u{1fe36}\u71bd\ufcc8\u43d7\u09b1'});
+try {
+computePassEncoder22.dispatchWorkgroups(2, 3, 5);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer0, 'uint32', 10256, 19258);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(6, buffer0, 21732, 2341);
+} catch {}
+try {
+commandEncoder35.copyBufferToBuffer(buffer12, 13036, buffer10, 7500, 92);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder35.copyBufferToTexture({
+/* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 3296 */
+offset: 3296,
+bytesPerRow: 256,
+buffer: buffer12,
+}, {
+  texture: texture13,
+  mipLevel: 1,
+  origin: { x: 30, y: 10, z: 1 },
+  aspect: 'all',
+}, {width: 20, height: 35, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm'],
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 41116, new BigUint64Array(60013), 45799, 1260);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 16, y: 0, z: 0 },
+  aspect: 'all',
+}, new DataView(arrayBuffer8), /* required buffer size: 717 */
+{offset: 557}, {width: 40, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline71 = await promise16;
+try {
+  await promise18;
+} catch {}
+let renderBundleEncoder45 = device0.createRenderBundleEncoder({
+  label: '\u0407\uf9bd\u{1f723}\u0d35\u{1fb04}\u0a70\u08d2\u39ae\u0390\u9400',
+  colorFormats: ['rg16uint', 'rg32float', 'r16uint', 'rg16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle45 = renderBundleEncoder32.finish({label: '\uf479\u{1fbd4}\u2bbc\u0fd8\u98aa\u282f\u0f18\u0892'});
+try {
+computePassEncoder20.dispatchWorkgroupsIndirect(buffer12, 39580);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer12, 16896);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: { x: 920, y: 25, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture29,
+  mipLevel: 1,
+  origin: { x: 0, y: 5, z: 0 },
+  aspect: 'all',
+}, {width: 690, height: 65, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder35.clearBuffer(buffer18, 2356);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder36.resolveQuerySet(querySet12, 2115, 832, buffer12, 3072);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer12,
+]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, new Int32Array(arrayBuffer3), /* required buffer size: 1762 */
+{offset: 86, bytesPerRow: 1810, rowsPerImage: 141}, {width: 419, height: 1, depthOrArrayLayers: 1});
+} catch {}
+canvas5.height = 438;
+let offscreenCanvas10 = new OffscreenCanvas(1013, 91);
+let commandEncoder37 = device0.createCommandEncoder({label: '\u{1fef3}\u{1fd01}\u5109\ud53a\u229f\udd31\u09a2\uc3e2\u0c3e'});
+let texture54 = device0.createTexture({
+label: '\u{1fab6}\u0528',
+size: [1320],
+dimension: '1d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder17.drawIndirect(buffer12, 7732);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer6, 'uint16', 21932, 6599);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(6, buffer15, 3732, 1759);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 31}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 4,
+  origin: { x: 5, y: 0, z: 30 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 15, height: 0, depthOrArrayLayers: 1});
+} catch {}
+offscreenCanvas3.height = 319;
+let querySet39 = device0.createQuerySet({
+type: 'occlusion',
+count: 853,
+});
+try {
+computePassEncoder20.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder17.draw(8, 56, 8, 16);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer12, 37996);
+} catch {}
+try {
+commandEncoder35.clearBuffer(buffer14, 13680);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+renderBundleEncoder37.popDebugGroup();
+} catch {}
+let videoFrame12 = new VideoFrame(offscreenCanvas4, {timestamp: 0});
+let shaderModule16 = device0.createShaderModule({
+label: '\uc372\u{1f8ae}\ua04f\u068c\u0aa2\u06ac\u40f1\u0b5a\u{1f678}\u{1f71c}\u{1ff13}',
+code: `
+
+@compute @workgroup_size(2, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(frag_depth) f0: f32,
+  @location(0) f1: vec4<u32>,
+  @location(4) f2: vec3<f32>,
+  @location(1) f3: vec4<f32>,
+  @location(3) f4: vec4<i32>,
+  @location(2) f5: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @location(11) a1: vec2<i32>, @builtin(sample_index) a2: u32, @location(5) a3: vec2<i32>, @location(4) a4: vec4<f16>, @location(3) a5: vec2<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(14) f58: f16,
+  @location(3) f59: vec2<u32>,
+  @location(1) f60: vec4<i32>,
+  @location(8) f61: vec4<u32>,
+  @location(11) f62: vec2<i32>,
+  @location(0) f63: f32,
+  @builtin(position) f64: vec4<f32>,
+  @location(9) f65: vec3<u32>,
+  @location(15) f66: i32,
+  @location(4) f67: vec4<f16>,
+  @location(13) f68: vec3<u32>,
+  @location(5) f69: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(13) a0: u32, @location(14) a1: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let texture55 = device0.createTexture({
+label: '\u0265\u9e42\u0b82\u078c\u{1fd30}\u0aea',
+size: [2640, 192, 1],
+mipLevelCount: 10,
+format: 'rg8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg8unorm', 'rg8unorm'],
+});
+try {
+computePassEncoder17.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(1, bindGroup11, new Uint32Array(2156), 1556, 0);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexed(0, 32, 80, -648, 16);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer6, 'uint16', 9480, 13224);
+} catch {}
+try {
+commandEncoder37.resolveQuerySet(querySet26, 63, 19, buffer12, 4096);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise21 = device0.createComputePipelineAsync({
+label: '\u0a00\u0158\uca96\u{1feb7}\u5bc3',
+layout: pipelineLayout10,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+},
+});
+canvas0.height = 839;
+let computePassEncoder32 = commandEncoder35.beginComputePass({});
+try {
+computePassEncoder30.setPipeline(pipeline67);
+} catch {}
+try {
+renderBundleEncoder17.draw(0, 24, 0, 72);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexed(16, 48, 16);
+} catch {}
+try {
+renderBundleEncoder44.setPipeline(pipeline58);
+} catch {}
+try {
+commandEncoder36.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 16040, new DataView(new ArrayBuffer(26062)), 19107, 3048);
+} catch {}
+let computePassEncoder33 = commandEncoder36.beginComputePass({label: '\ue8ba\u09cb\u06ce\u0866\u1c7f'});
+let renderBundle46 = renderBundleEncoder31.finish({label: '\u09c7\ua2a8\u027f\ue1c3\u{1fc51}\ud26b\u{1fd6b}\u{1f7c9}'});
+try {
+renderBundleEncoder28.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexed(32, 8, 24, 712, 48);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer12, 20804);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer4, 'uint16', 7254, 2125);
+} catch {}
+let promise22 = buffer16.mapAsync(GPUMapMode.READ, 0, 59408);
+try {
+commandEncoder37.clearBuffer(buffer12, 24184);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder37.resolveQuerySet(querySet18, 2220, 607, buffer12, 8960);
+} catch {}
+let querySet40 = device0.createQuerySet({
+label: '\ud3ed\u8452\u0d5a\u0130\u66c3\u5cb3\u92c7\u0214\u77a2\u068f\u66e1',
+type: 'occlusion',
+count: 47,
+});
+let textureView40 = texture5.createView({label: '\u7d65\u3e68\u0774', dimension: '2d-array', aspect: 'all'});
+let renderBundle47 = renderBundleEncoder21.finish();
+try {
+computePassEncoder28.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline49);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer12, 28196);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+commandEncoder37.copyTextureToBuffer({
+  texture: texture49,
+  mipLevel: 1,
+  origin: { x: 290, y: 10, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 1136 widthInBlocks: 71 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 8016 */
+offset: 6880,
+bytesPerRow: 1280,
+buffer: buffer12,
+}, {width: 710, height: 10, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder37.copyTextureToTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 24, y: 155, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture30,
+  mipLevel: 1,
+  origin: { x: 8, y: 30, z: 1 },
+  aspect: 'all',
+}, {width: 8, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgba8unorm-srgb'],
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 1,
+  origin: { x: 35, y: 0, z: 1 },
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer10), /* required buffer size: 547604 */
+{offset: 519, bytesPerRow: 319, rowsPerImage: 245}, {width: 123, height: 0, depthOrArrayLayers: 8});
+} catch {}
+let videoFrame13 = new VideoFrame(img5, {timestamp: 0});
+let bindGroupLayout25 = pipeline66.getBindGroupLayout(2);
+let commandEncoder38 = device0.createCommandEncoder({label: '\uac3e\uf204\u{1fc02}\u{1fa9e}\u2b3d\ud7eb\u0483\ue895\u0a25\ub323'});
+pseudoSubmit(device0, commandEncoder26);
+try {
+computePassEncoder27.setBindGroup(2, bindGroup13, new Uint32Array(2878), 583, 0);
+} catch {}
+let arrayBuffer13 = buffer14.getMappedRange(0, 3124);
+try {
+buffer4.unmap();
+} catch {}
+try {
+commandEncoder37.clearBuffer(buffer10, 4, 1108);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 6240, new BigUint64Array(37251), 35381, 404);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 713 */
+{offset: 713, rowsPerImage: 269}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img7,
+  origin: { x: 162, y: 47 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 8,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext11 = offscreenCanvas10.getContext('webgpu');
+let bindGroupLayout26 = device0.createBindGroupLayout({
+label: '\u499f\u05bd\ucd20\u6f5b\u3a99',
+entries: [{
+binding: 423,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}],
+});
+let bindGroup21 = device0.createBindGroup({
+label: '\u6f44\u740b\u0146\u3e44\u0bb9\u{1fb5c}\ub713\u0234\ucc3e\u01a7',
+layout: bindGroupLayout1,
+entries: [{
+binding: 257,
+resource: externalTexture1
+}, {
+binding: 43,
+resource: externalTexture0
+}],
+});
+let querySet41 = device0.createQuerySet({
+type: 'occlusion',
+count: 1749,
+});
+let renderBundle48 = renderBundleEncoder5.finish({label: '\u0135\u{1f750}\u940d\u0e39'});
+try {
+renderBundleEncoder12.drawIndirect(buffer12, 36600);
+} catch {}
+try {
+commandEncoder37.copyBufferToBuffer(buffer2, 672, buffer16, 50420, 636);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 11484, new BigUint64Array(57805), 54259, 16);
+} catch {}
+let pipeline72 = await device0.createRenderPipelineAsync({
+label: '\u26cc\ue3d0\ubf09\u{1f7ec}\u254d\u0d3f\u01bb\u{1fbf8}\u0479',
+layout: pipelineLayout14,
+multisample: {
+count: 4,
+mask: 0x5dfc6a81,
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+failOp: 'increment-wrap',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'keep',
+},
+stencilReadMask: 1397,
+stencilWriteMask: 340,
+depthBias: 75,
+depthBiasSlopeScale: 8,
+depthBiasClamp: 12,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 1728,
+shaderLocation: 7,
+}, {
+format: 'uint32x3',
+offset: 996,
+shaderLocation: 15,
+}, {
+format: 'snorm8x2',
+offset: 962,
+shaderLocation: 1,
+}, {
+format: 'unorm8x2',
+offset: 948,
+shaderLocation: 2,
+}, {
+format: 'snorm8x4',
+offset: 1528,
+shaderLocation: 12,
+}, {
+format: 'float32x3',
+offset: 1168,
+shaderLocation: 13,
+}, {
+format: 'unorm16x4',
+offset: 1804,
+shaderLocation: 6,
+}, {
+format: 'sint32x3',
+offset: 84,
+shaderLocation: 3,
+}, {
+format: 'float16x2',
+offset: 424,
+shaderLocation: 4,
+}],
+}
+]
+},
+});
+let imageData5 = new ImageData(16, 28);
+let querySet42 = device0.createQuerySet({
+label: '\ue38b\u00d1\u{1f61e}\u273e\u2523\u{1fa52}\u931f\u{1fa11}\u{1fb84}\u{1f9d4}',
+type: 'occlusion',
+count: 235,
+});
+try {
+computePassEncoder22.dispatchWorkgroups(4, 4);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer15, 5300);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline58);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(4, buffer0, 34224, 1262);
+} catch {}
+try {
+computePassEncoder28.pushDebugGroup('\u095e');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 320, height: 2, depthOrArrayLayers: 503}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 0, y: 11 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: { x: 77, y: 0, z: 448 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let querySet43 = device0.createQuerySet({
+label: '\u8cf4\u9546\u{1fa07}',
+type: 'occlusion',
+count: 1021,
+});
+let renderBundleEncoder46 = device0.createRenderBundleEncoder({
+  label: '\u26e2\uf8e9',
+  colorFormats: [undefined, 'r16uint', 'rg32uint', 'rg16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder9.drawIndexed(72, 64, 0);
+} catch {}
+try {
+commandEncoder37.copyBufferToBuffer(buffer17, 3068, buffer1, 16376, 13288);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder38.copyBufferToTexture({
+/* bytesInLastRow: 30 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 40742 */
+offset: 40742,
+buffer: buffer12,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 3, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder37.resolveQuerySet(querySet35, 321, 1037, buffer12, 4096);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 320, height: 2, depthOrArrayLayers: 503}
+*/
+{
+  source: video3,
+  origin: { x: 2, y: 4 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: { x: 300, y: 0, z: 496 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 12, height: 2, depthOrArrayLayers: 1});
+} catch {}
+let commandBuffer13 = commandEncoder37.finish({
+label: '\u01eb\u{1f6fc}\ud0ac',
+});
+let computePassEncoder34 = commandEncoder38.beginComputePass();
+try {
+renderBundleEncoder17.setVertexBuffer(7, buffer6, 2016);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 1660, new Int16Array(683), 435);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: { x: 0, y: 5, z: 0 },
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 1396 */
+{offset: 484, bytesPerRow: 64}, {width: 8, height: 75, depthOrArrayLayers: 1});
+} catch {}
+let canvas15 = document.createElement('canvas');
+let promise23 = adapter0.requestAdapterInfo();
+let texture56 = device0.createTexture({
+label: '\ue090\u41cf\uf1c0\uae59\ua413\u0bf6\u24de\u03e3\u349c\u{1fe13}',
+size: {width: 32, height: 45, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView41 = texture13.createView({format: 'astc-10x5-unorm', baseMipLevel: 2, mipLevelCount: 1});
+try {
+renderBundleEncoder17.drawIndexed(16, 56, 0, -208);
+} catch {}
+try {
+renderBundleEncoder44.drawIndexedIndirect(buffer15, 5876);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer12, 13200);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(2, buffer15, 2400, 2004);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+computePassEncoder28.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['etc2-rgba8unorm', 'r8uint', 'rgba16float'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 396, new Float32Array(17941), 11071, 1764);
+} catch {}
+let imageData6 = new ImageData(208, 216);
+try {
+device0.label = '\uc290\u{1f704}\ua00c';
+} catch {}
+let pipelineLayout15 = device0.createPipelineLayout({
+  label: '\u60a7\ud89b',
+  bindGroupLayouts: [bindGroupLayout7, bindGroupLayout21, bindGroupLayout4, bindGroupLayout25]
+});
+let commandEncoder39 = device0.createCommandEncoder();
+let textureView42 = texture28.createView({label: '\u01da\u7dd7\u65eb\u09b5\u{1fa56}', format: 'rgba8uint'});
+let renderBundle49 = renderBundleEncoder40.finish({label: '\u{1fa07}\u129d\u{1fdad}\u0e84\u0b37\u{1fbaa}\u521b\u371f\u002a\u0604'});
+let sampler31 = device0.createSampler({
+label: '\u8f43\u00d0\u0b58\u4820\u0c57\u036f\u4b3c\ua021',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 86.148,
+maxAnisotropy: 4,
+});
+try {
+computePassEncoder22.dispatchWorkgroups(1, 3, 3);
+} catch {}
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+renderBundleEncoder36.drawIndexed(56, 32, 80, 448, 0);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexedIndirect(buffer12, 22532);
+} catch {}
+try {
+renderBundleEncoder36.drawIndirect(buffer15, 3980);
+} catch {}
+let promise24 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise24;
+} catch {}
+let commandEncoder40 = device0.createCommandEncoder({label: '\u{1fc21}\u0cba\u2eb6\u91b0\u{1fe21}\u05c0\u6dd2\u{1fb52}\uc921\u7c7d'});
+let textureView43 = texture27.createView({label: '\u7022\u5bcd\ub35e', dimension: '2d-array', baseMipLevel: 4});
+let renderBundleEncoder47 = device0.createRenderBundleEncoder({
+  label: '\u6f0c\u84ff\u0254\ue754',
+  colorFormats: ['r8uint', 'rgba8sint', 'rg8uint', 'rg32uint', undefined, 'rg8uint', undefined, 'bgra8unorm-srgb']
+});
+try {
+renderBundleEncoder28.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer15, 4876);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(6, buffer6, 15816, 20442);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder40.copyBufferToBuffer(buffer2, 56, buffer9, 5880, 732);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder39.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 1,
+  origin: { x: 0, y: 15, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture30,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 5, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder40.resolveQuerySet(querySet22, 1587, 32, buffer12, 16384);
+} catch {}
+let pipeline73 = await device0.createComputePipelineAsync({
+label: '\u2848\u0f49\uf42b\u7e58\u{1fc97}\u{1fdc7}',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline74 = await device0.createRenderPipelineAsync({
+label: '\u{1fe7e}\u3e44\uc2d9\u08b9\u4f6d',
+layout: pipelineLayout15,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.BLUE}, {format: 'rgba16uint'}, {format: 'r8uint'}, {format: 'rg11b10ufloat', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilReadMask: 1520,
+stencilWriteMask: 1987,
+depthBias: 52,
+depthBiasSlopeScale: 10,
+depthBiasClamp: 85,
+},
+vertex: {
+  module: shaderModule11,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 368,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 260,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 1244,
+attributes: [{
+format: 'unorm8x2',
+offset: 1194,
+shaderLocation: 14,
+}, {
+format: 'uint32x4',
+offset: 372,
+shaderLocation: 6,
+}, {
+format: 'snorm16x4',
+offset: 92,
+shaderLocation: 11,
+}, {
+format: 'uint8x2',
+offset: 998,
+shaderLocation: 12,
+}, {
+format: 'sint32x2',
+offset: 340,
+shaderLocation: 1,
+}, {
+format: 'unorm16x4',
+offset: 1120,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 524,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 948,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x2',
+offset: 696,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 348,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1832,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x4',
+offset: 488,
+shaderLocation: 4,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+},
+});
+try {
+renderBundleEncoder12.draw(64, 72, 32, 32);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(4, buffer15, 3132, 1609);
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer19);
+dissociateBuffer(device0, buffer19);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let promise25 = device0.queue.onSubmittedWorkDone();
+let pipeline75 = device0.createRenderPipeline({
+label: '\u52a0\u0713\u0422\u08d4\u50d7',
+layout: pipelineLayout10,
+fragment: {
+  module: shaderModule13,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {
+  format: 'rgba16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rgba16sint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'replace',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilReadMask: 2864,
+stencilWriteMask: 997,
+depthBiasSlopeScale: 99,
+depthBiasClamp: 61,
+},
+vertex: {
+  module: shaderModule13,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1684,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1068,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32',
+offset: 816,
+shaderLocation: 11,
+}, {
+format: 'sint32',
+offset: 904,
+shaderLocation: 6,
+}, {
+format: 'snorm16x4',
+offset: 620,
+shaderLocation: 4,
+}, {
+format: 'sint32x2',
+offset: 36,
+shaderLocation: 15,
+}, {
+format: 'sint8x4',
+offset: 968,
+shaderLocation: 13,
+}, {
+format: 'sint8x4',
+offset: 420,
+shaderLocation: 8,
+}, {
+format: 'sint32',
+offset: 960,
+shaderLocation: 14,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'front',
+},
+});
+let commandEncoder41 = device0.createCommandEncoder();
+let texture57 = device0.createTexture({
+label: '\u08fa\ua5f1\u3476',
+size: {width: 32, height: 45, depthOrArrayLayers: 1},
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x5-unorm', 'astc-8x5-unorm', 'astc-8x5-unorm-srgb'],
+});
+let computePassEncoder35 = commandEncoder40.beginComputePass();
+let renderBundle50 = renderBundleEncoder5.finish({label: '\u50cf\u5ee9\u036b'});
+try {
+renderBundleEncoder30.setVertexBuffer(4, buffer0, 4944);
+} catch {}
+try {
+commandEncoder41.copyBufferToBuffer(buffer2, 1036, buffer10, 1056, 188);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: videoFrame13,
+  origin: { x: 104, y: 74 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 7,
+  origin: { x: 1, y: 1, z: 3 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise23;
+} catch {}
+gc();
+let computePassEncoder36 = commandEncoder41.beginComputePass({label: '\u7839\u0e80\u91fc\u0e53\uc018\u9a4f\u627e'});
+let renderBundle51 = renderBundleEncoder38.finish();
+try {
+renderBundleEncoder36.drawIndirect(buffer12, 10004);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(2, buffer0);
+} catch {}
+let pipeline76 = await promise20;
+let gpuCanvasContext12 = canvas15.getContext('webgpu');
+try {
+  await promise22;
+} catch {}
+let computePassEncoder37 = commandEncoder39.beginComputePass({label: '\u{1f6e6}\u016f\u48fb\u02f0\u3851\uce56\u5693\u04e1\u5fc7\u{1fb31}\u01b7'});
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 21496);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(6, buffer0, 27700, 4418);
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer19);
+dissociateBuffer(device0, buffer19);
+} catch {}
+let imageBitmap8 = await createImageBitmap(canvas3);
+let querySet44 = device0.createQuerySet({
+label: '\ua1ec\ua85a\u0169\uee15\u063a',
+type: 'occlusion',
+count: 881,
+});
+let texture58 = device0.createTexture({
+label: '\ue31c\ub839\ub418\u{1fcb6}\u02c7\u2ffa',
+size: [660, 48, 1],
+mipLevelCount: 6,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['depth24plus-stencil8', 'depth24plus-stencil8', 'depth24plus-stencil8'],
+});
+let renderBundle52 = renderBundleEncoder29.finish({label: '\u7114\uf324\u3ba4\u04f6\u0a13\udc91\u05f1\u2915\u{1f951}\ub4fe'});
+try {
+computePassEncoder22.dispatchWorkgroups(2, 1, 3);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer15, 4208);
+} catch {}
+try {
+commandEncoder23.copyBufferToBuffer(buffer2, 1372, buffer18, 7156, 4);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer1, 6396, 35460);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder23.resolveQuerySet(querySet37, 118, 454, buffer12, 36096);
+} catch {}
+let pipeline77 = await promise6;
+let imageBitmap9 = await createImageBitmap(videoFrame8);
+let querySet45 = device0.createQuerySet({
+label: '\u83dd\u0824\u6b3d',
+type: 'occlusion',
+count: 1520,
+});
+let renderBundle53 = renderBundleEncoder39.finish({label: '\ue2d3\u75db\u0ac8\u8340\u{1fb40}\u0ae6\uc3f0\u8955\u051b'});
+try {
+computePassEncoder23.end();
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline49);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexed(32, 32, 16);
+} catch {}
+try {
+commandEncoder23.copyBufferToBuffer(buffer2, 1108, buffer14, 3292, 168);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder23.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 2,
+  origin: { x: 0, y: 15, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture13,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 10, height: 10, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 10316, new DataView(new ArrayBuffer(3816)), 1551, 248);
+} catch {}
+try {
+  await promise25;
+} catch {}
+let pipelineLayout16 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout3, bindGroupLayout5, bindGroupLayout2]});
+let textureView44 = texture3.createView({label: '\u8c13\u{1f7d6}\u{1f89b}\ue0f0\u4a12\ucf30\uedea', mipLevelCount: 1});
+let renderBundleEncoder48 = device0.createRenderBundleEncoder({
+  colorFormats: [undefined, 'r16uint', 'rg32uint', 'rg16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let sampler32 = device0.createSampler({
+label: '\ube66\u9ad0\uc5bb\u1bc7',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 26.163,
+lodMaxClamp: 78.885,
+maxAnisotropy: 7,
+});
+let externalTexture2 = device0.importExternalTexture({
+label: '\u72dc\u5538\ue715\ub664\udb9e\u029f\u{1ff52}\u97cd\u{1fa75}',
+source: videoFrame10,
+});
+try {
+renderBundleEncoder12.drawIndirect(buffer12, 11596);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(5, buffer6, 22908);
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(buffer3, 26388, buffer10, 6188, 188);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder23.copyTextureToBuffer({
+  texture: texture54,
+  mipLevel: 0,
+  origin: { x: 101, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 3996 widthInBlocks: 999 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 13240 */
+offset: 13240,
+rowsPerImage: 114,
+buffer: buffer1,
+}, {width: 999, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: { x: 1024, y: 56, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 3,
+  origin: { x: 16, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 136, height: 8, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder23.resolveQuerySet(querySet25, 653, 36, buffer12, 36096);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 17440, new Float32Array(62697), 18716, 500);
+} catch {}
+let renderBundleEncoder49 = device0.createRenderBundleEncoder({
+  label: '\ued6f\u06c8\ue2a3\u0d34\u{1fe94}\u1219\u0ee6',
+  colorFormats: ['rg8uint', 'r16uint', 'rgba16uint', 'rgba16sint'],
+  stencilReadOnly: true
+});
+let renderBundle54 = renderBundleEncoder22.finish({label: '\u{1fae9}\u{1f653}\u0d53'});
+let sampler33 = device0.createSampler({
+label: '\u{1fa29}\u0ce2\u0f2c\u{1fda2}\u64d4\u64e5',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 50.346,
+lodMaxClamp: 77.560,
+maxAnisotropy: 15,
+});
+try {
+computePassEncoder22.dispatchWorkgroups(2, 2, 4);
+} catch {}
+try {
+renderBundleEncoder44.drawIndexedIndirect(buffer12, 21692);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(2, buffer0);
+} catch {}
+let promise26 = device0.queue.onSubmittedWorkDone();
+let textureView45 = texture10.createView({
+  label: '\u{1f855}\u{1fedf}\u{1fd62}\u9262\ua900\u{1fe0f}\ufb2a\u{1fcad}',
+  dimension: '2d-array',
+  baseMipLevel: 0,
+  mipLevelCount: 4
+});
+let renderBundleEncoder50 = device0.createRenderBundleEncoder({
+  label: '\ubbc0\u53a8\u9c1f\u5313\u6ba8\u9d8f\u0197',
+  colorFormats: ['r8uint', 'rgba8sint', 'rg8uint', 'rg32uint', undefined, 'rg8uint', undefined, 'bgra8unorm-srgb'],
+  sampleCount: 1
+});
+let renderBundle55 = renderBundleEncoder44.finish();
+try {
+renderBundleEncoder43.setBindGroup(0, bindGroup3, new Uint32Array(2533), 1043, 0);
+} catch {}
+try {
+renderBundleEncoder9.draw(72, 64, 64, 0);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer15, 64);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(0, buffer15, 2708);
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(buffer2, 1188, buffer9, 7128, 72);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer10, 2668, 3548);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 4,
+  origin: { x: 0, y: 1, z: 2 },
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 197075 */
+{offset: 863, bytesPerRow: 197, rowsPerImage: 166}, {width: 2, height: 0, depthOrArrayLayers: 7});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas12);
+let offscreenCanvas11 = new OffscreenCanvas(209, 735);
+try {
+await adapter3.requestAdapterInfo();
+} catch {}
+try {
+renderBundleEncoder12.draw(8, 48);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(48, 40, 48);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer15, 2268);
+} catch {}
+try {
+renderBundleEncoder43.setIndexBuffer(buffer9, 'uint16', 10818, 5275);
+} catch {}
+try {
+commandEncoder23.copyTextureToBuffer({
+  texture: texture46,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 12972 */
+offset: 12972,
+buffer: buffer9,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture({
+  texture: texture54,
+  mipLevel: 0,
+  origin: { x: 476, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture20,
+  mipLevel: 1,
+  origin: { x: 0, y: 13, z: 67 },
+  aspect: 'all',
+}, {width: 11, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer4, 804, 4104);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+offscreenCanvas11.getContext('bitmaprenderer');
+} catch {}
+let textureView46 = texture3.createView({label: '\u09c1\u6235\u59ca\ud7ea\u46ab', mipLevelCount: 1});
+let computePassEncoder38 = commandEncoder28.beginComputePass({label: '\u0e05\u0b5f\ub4f8\ua6bd\u849e\u0479\u7881'});
+try {
+renderBundleEncoder17.drawIndexed(80);
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer1, 3284, 26248);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 1, depthOrArrayLayers: 251}
+*/
+{
+  source: img1,
+  origin: { x: 2, y: 84 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 1,
+  origin: { x: 21, y: 1, z: 89 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 37, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let canvas16 = document.createElement('canvas');
+try {
+canvas16.getContext('webgl2');
+} catch {}
+let commandEncoder42 = device0.createCommandEncoder({label: '\u0354\u{1fe89}\u20fb\u{1ffc4}\u{1fd78}\u94ec\ue614'});
+let textureView47 = texture31.createView({label: '\u2cb0\u07e3\u571d\ud684\udb4f', dimension: '2d-array', arrayLayerCount: 1});
+let computePassEncoder39 = commandEncoder42.beginComputePass({label: '\u004a\u0a0b\u0d5f\u7b52\u6042\u1644\u5787\u096d\u{1fab8}\u71fa'});
+try {
+renderBundleEncoder12.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer12, 21120);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer12, 25452);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm'],
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 1432, new Float32Array(37595), 18566, 3872);
+} catch {}
+try {
+  await promise26;
+} catch {}
+let device1 = await promise9;
+let commandEncoder43 = device0.createCommandEncoder({label: '\u7fcb\u{1fe77}\ud8e3\u{1fb6e}\ude69\u28a3'});
+let textureView48 = texture3.createView({
+  label: '\ua9a0\u{1ffd3}\u22c4\ued66\u147e\ucd98\u00b9\u{1ffa3}\u{1f679}\u9dd2',
+  aspect: 'all',
+  baseMipLevel: 0
+});
+try {
+renderBundleEncoder47.setBindGroup(2, bindGroup3, new Uint32Array(3539), 186, 0);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer15, 2108);
+} catch {}
+try {
+renderBundleEncoder12.drawIndirect(buffer12, 35004);
+} catch {}
+try {
+commandEncoder43.copyBufferToBuffer(buffer0, 15636, buffer14, 1008, 5540);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder23.copyTextureToTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 24, height: 35, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderBundleEncoder34.insertDebugMarker('\u56d5');
+} catch {}
+video6.height = 107;
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let querySet46 = device1.createQuerySet({
+label: '\u0d11\u{1fb8a}',
+type: 'occlusion',
+count: 783,
+});
+let texture59 = device1.createTexture({
+label: '\ufd8e\u50aa\u0bc6\u7f74\u{1f86b}\u2f36\ue252',
+size: [1920, 1, 1481],
+mipLevelCount: 8,
+sampleCount: 1,
+dimension: '3d',
+format: 'rgba32sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba32sint'],
+});
+let bindGroupLayout27 = device1.createBindGroupLayout({
+label: '\uf571\u{1f750}\u2e26\u3a4d\u{1fb9f}\u6fdc\u{1fe0f}\u015d\u0052\u841d',
+entries: [],
+});
+let sampler34 = device1.createSampler({
+label: '\u0fe4\u091e\ucd67\uc4a7\u9576\u0d2a\u117e\u97c0',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 58.970,
+lodMaxClamp: 94.620,
+maxAnisotropy: 4,
+});
+let imageBitmap10 = await createImageBitmap(imageData2);
+let shaderModule17 = device0.createShaderModule({
+label: '\u206c\u{1fada}\ueb4e\ud56b',
+code: `@group(1) @binding(257)
+var<storage, read_write> local5: array<u32>;
+@group(3) @binding(561)
+var<storage, read_write> parameter7: array<u32>;
+@group(1) @binding(43)
+var<storage, read_write> local6: array<u32>;
+@group(0) @binding(20)
+var<storage, read_write> type8: array<u32>;
+
+@compute @workgroup_size(6, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S14 {
+  @location(0) f0: vec2<i32>,
+  @location(14) f1: vec2<i32>,
+  @location(7) f2: vec2<f16>,
+  @location(1) f3: vec3<f32>,
+  @location(8) f4: vec3<f32>,
+  @location(10) f5: vec4<f32>,
+  @location(2) f6: vec4<u32>,
+  @location(3) f7: vec2<f16>,
+  @location(4) f8: i32,
+  @location(9) f9: f32,
+  @location(13) f10: vec4<u32>,
+  @location(15) f11: f16,
+  @location(12) f12: i32,
+  @location(6) f13: vec2<u32>,
+  @location(5) f14: vec3<i32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(0) f1: vec4<u32>,
+  @location(1) f2: vec4<f32>,
+  @location(4) f3: vec4<f32>,
+  @builtin(frag_depth) f4: f32
+}
+
+@fragment
+fn fragment0(a0: S14, @builtin(front_facing) a1: bool, @builtin(position) a2: vec4<f32>, @builtin(sample_mask) a3: u32, @builtin(sample_index) a4: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f70: vec4<f32>,
+  @location(13) f71: vec4<u32>,
+  @location(4) f72: i32,
+  @location(10) f73: vec4<f32>,
+  @location(2) f74: vec4<u32>,
+  @location(5) f75: vec3<i32>,
+  @location(9) f76: f32,
+  @location(6) f77: vec2<u32>,
+  @location(14) f78: vec2<i32>,
+  @location(3) f79: vec2<f16>,
+  @location(12) f80: i32,
+  @location(1) f81: vec3<f32>,
+  @location(15) f82: f16,
+  @location(0) f83: vec2<i32>,
+  @location(7) f84: vec2<f16>,
+  @location(8) f85: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: i32, @location(10) a1: vec3<f16>, @builtin(vertex_index) a2: u32, @location(6) a3: vec3<i32>, @location(11) a4: u32, @location(12) a5: f32, @location(7) a6: vec2<f32>, @location(5) a7: u32, @location(8) a8: f32, @location(14) a9: i32, @location(2) a10: vec3<u32>, @location(0) a11: vec3<f16>, @location(13) a12: vec3<f32>, @location(9) a13: vec4<u32>, @location(15) a14: f16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+});
+let bindGroupLayout28 = device0.createBindGroupLayout({
+label: '\ufa63\ua802\uc8cd',
+entries: [{
+binding: 143,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 362,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+let bindGroup22 = device0.createBindGroup({
+label: '\u015f\uf9a0\u921c',
+layout: bindGroupLayout4,
+entries: [],
+});
+let computePassEncoder40 = commandEncoder23.beginComputePass({label: '\u4100\u13d3\u38df\u2755\u2a1f\u08d6\uc98f\u5e2e\u{1f7b3}\u{1ffc0}'});
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup13, new Uint32Array(1891), 993, 0);
+} catch {}
+try {
+renderBundleEncoder36.draw(8, 64, 24, 40);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexed(80, 64, 24, -608, 40);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer15, 2004);
+} catch {}
+try {
+texture15.destroy();
+} catch {}
+try {
+commandEncoder43.clearBuffer(buffer11, 3720, 14140);
+dissociateBuffer(device0, buffer11);
+} catch {}
+let pipeline78 = await device0.createComputePipelineAsync({
+label: '\ub715\uebf6\ucd0b\u6503\ud91a\ud45d',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let shaderModule18 = device0.createShaderModule({
+label: '\u{1fbf7}\u{1ff34}\u367e\u0829\ufda3\u786d\u{1fd80}\u29cd\u77d7\u{1f8f4}',
+code: `@group(1) @binding(43)
+var<storage, read_write> type9: array<u32>;
+
+@compute @workgroup_size(8, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: u32,
+  @location(5) f1: vec3<u32>,
+  @location(7) f2: vec4<f32>,
+  @location(2) f3: vec4<u32>,
+  @location(3) f4: vec2<u32>,
+  @location(1) f5: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(2) a1: i32, @location(14) a2: f16, @location(1) a3: vec3<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+let bindGroup23 = device0.createBindGroup({
+label: '\ud263\u{1fc5d}\u0d76\u3e5f\udc75\u70c8\ua3ad\u{1fcc3}',
+layout: bindGroupLayout3,
+entries: [],
+});
+let computePassEncoder41 = commandEncoder43.beginComputePass();
+try {
+computePassEncoder24.setPipeline(pipeline60);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer15, 4916);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer9, 'uint16', 6964);
+} catch {}
+let pipeline79 = device0.createRenderPipeline({
+label: '\u00c5\u2514\u0f0f\u0395',
+layout: pipelineLayout9,
+multisample: {
+mask: 0x79aa5561,
+},
+fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rgba16uint', writeMask: 0}, {format: 'r8uint', writeMask: 0}, {
+  format: 'rg11b10ufloat',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'dst', dstFactor: 'one-minus-dst'},
+},
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+vertex: {
+  module: shaderModule12,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 88,
+attributes: [{
+format: 'snorm8x4',
+offset: 60,
+shaderLocation: 14,
+}, {
+format: 'snorm16x4',
+offset: 16,
+shaderLocation: 1,
+}, {
+format: 'uint8x4',
+offset: 68,
+shaderLocation: 0,
+}, {
+format: 'float16x4',
+offset: 44,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 1956,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x2',
+offset: 1000,
+shaderLocation: 7,
+}, {
+format: 'uint16x4',
+offset: 944,
+shaderLocation: 10,
+}, {
+format: 'sint32x4',
+offset: 1368,
+shaderLocation: 3,
+}, {
+format: 'sint16x2',
+offset: 720,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 1148,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1420,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 108,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 28,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let pipelineLayout17 = device1.createPipelineLayout({
+  label: '\u{1f70c}\u0d87\u{1fa97}',
+  bindGroupLayouts: [bindGroupLayout27, bindGroupLayout27, bindGroupLayout27]
+});
+let texture60 = device1.createTexture({
+label: '\u{1faff}\u89b1\u{1fa14}',
+size: {width: 2805, height: 480, depthOrArrayLayers: 190},
+mipLevelCount: 7,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-5x5-unorm-srgb'],
+});
+let sampler35 = device1.createSampler({
+label: '\u00a0\ud7c0\u3aa0\u2d9e\u0c58\u45d4\u0c36\u0d1a',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'nearest',
+lodMinClamp: 4.185,
+lodMaxClamp: 19.002,
+});
+try {
+gpuCanvasContext2.configure({
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.destroy();
+} catch {}
+let offscreenCanvas12 = new OffscreenCanvas(919, 641);
+let videoFrame14 = new VideoFrame(offscreenCanvas9, {timestamp: 0});
+offscreenCanvas7.width = 410;
+let imageData7 = new ImageData(144, 84);
+try {
+adapter0.label = '\u0f5a\u0cae\u{1f970}';
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55) };
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer12, 22368);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(5, buffer15, 2768, 2411);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 8508, new BigUint64Array(59691), 3962, 356);
+} catch {}
+let promise27 = device0.createComputePipelineAsync({
+label: '\u5152\ue4be\u8053\ua86c\u47fa\u5222',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let sampler36 = device0.createSampler({
+label: '\u0fa6\u{1fa1f}\u0f7b\u{1febb}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 0.095,
+lodMaxClamp: 94.725,
+compare: 'greater',
+});
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer12, 24856);
+} catch {}
+let promise28 = buffer2.mapAsync(GPUMapMode.WRITE, 0, 936);
+try {
+computePassEncoder9.pushDebugGroup('\u{1fc66}');
+} catch {}
+try {
+computePassEncoder9.popDebugGroup();
+} catch {}
+let pipeline80 = await device0.createRenderPipelineAsync({
+layout: pipelineLayout10,
+fragment: {
+  module: shaderModule15,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rgba16uint', writeMask: GPUColorWrite.BLUE}, {format: 'rgba16sint'}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 3363,
+depthBias: 81,
+},
+vertex: {
+  module: shaderModule15,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x4',
+offset: 884,
+shaderLocation: 5,
+}, {
+format: 'sint32',
+offset: 936,
+shaderLocation: 8,
+}, {
+format: 'unorm16x2',
+offset: 1820,
+shaderLocation: 11,
+}, {
+format: 'sint32x3',
+offset: 2008,
+shaderLocation: 14,
+}, {
+format: 'float32x3',
+offset: 1872,
+shaderLocation: 3,
+}, {
+format: 'float32x2',
+offset: 1272,
+shaderLocation: 10,
+}, {
+format: 'sint8x4',
+offset: 808,
+shaderLocation: 12,
+}, {
+format: 'unorm8x2',
+offset: 834,
+shaderLocation: 9,
+}, {
+format: 'sint16x4',
+offset: 1060,
+shaderLocation: 13,
+}, {
+format: 'uint32x4',
+offset: 1024,
+shaderLocation: 6,
+}, {
+format: 'float32x3',
+offset: 828,
+shaderLocation: 7,
+}, {
+format: 'uint8x2',
+offset: 538,
+shaderLocation: 4,
+}, {
+format: 'snorm8x4',
+offset: 792,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 1256,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x2',
+offset: 284,
+shaderLocation: 15,
+}, {
+format: 'float32x3',
+offset: 312,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 344,
+attributes: [{
+format: 'float16x4',
+offset: 20,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let gpuCanvasContext13 = offscreenCanvas12.getContext('webgpu');
+let shaderModule19 = device0.createShaderModule({
+label: '\u2932\u8dea',
+code: `@group(1) @binding(803)
+var<storage, read_write> local7: array<u32>;
+@group(2) @binding(20)
+var<storage, read_write> i6: array<u32>;
+@group(3) @binding(674)
+var<storage, read_write> field9: array<u32>;
+
+@compute @workgroup_size(8, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S15 {
+  @location(15) f0: vec2<f32>,
+  @location(7) f1: vec3<f32>,
+  @location(13) f2: vec2<u32>,
+  @location(0) f3: vec4<f16>,
+  @location(10) f4: vec4<f32>,
+  @location(4) f5: f16,
+  @location(11) f6: vec4<f16>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<i32>,
+  @location(5) f1: vec2<u32>,
+  @location(6) f2: vec3<i32>,
+  @location(4) f3: vec4<u32>,
+  @location(3) f4: vec3<f32>,
+  @location(1) f5: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(3) a0: vec4<f32>, @location(2) a1: vec3<u32>, @location(6) a2: vec3<i32>, @location(14) a3: vec3<f16>, @location(8) a4: vec2<i32>, @location(1) a5: vec3<f16>, @builtin(position) a6: vec4<f32>, @builtin(front_facing) a7: bool, @location(5) a8: vec4<f16>, @location(12) a9: vec2<u32>, a10: S15, @builtin(sample_mask) a11: u32, @builtin(sample_index) a12: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(7) f86: vec3<f32>,
+  @location(13) f87: vec2<u32>,
+  @location(15) f88: vec2<f32>,
+  @location(2) f89: vec3<u32>,
+  @builtin(position) f90: vec4<f32>,
+  @location(14) f91: vec3<f16>,
+  @location(1) f92: vec3<f16>,
+  @location(11) f93: vec4<f16>,
+  @location(6) f94: vec3<i32>,
+  @location(5) f95: vec4<f16>,
+  @location(12) f96: vec2<u32>,
+  @location(10) f97: vec4<f32>,
+  @location(8) f98: vec2<i32>,
+  @location(0) f99: vec4<f16>,
+  @location(3) f100: vec4<f32>,
+  @location(4) f101: f16
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec3<u32>, @location(12) a1: vec3<u32>, @builtin(instance_index) a2: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let texture61 = device0.createTexture({
+label: '\u4abc\u6c26',
+size: [320, 2, 55],
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView49 = texture38.createView({dimension: '2d-array', format: 'astc-10x5-unorm'});
+let renderBundle56 = renderBundleEncoder46.finish({label: '\u577a\u0a2f\u08fc\u5d7b\u6b74\u5257'});
+try {
+computePassEncoder28.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 14696);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let bindGroupLayout29 = device0.createBindGroupLayout({
+label: '\u0591\u{1f8b4}\u1148\u031e\u9ee5\u0a5d\u736f\u0ad0\u8822',
+entries: [{
+binding: 258,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '2d' },
+}, {
+binding: 79,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+}, {
+binding: 245,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}],
+});
+let bindGroup24 = device0.createBindGroup({
+label: '\u63ca\u{1fbf5}\u2223\u09cc',
+layout: bindGroupLayout14,
+entries: [],
+});
+let commandEncoder44 = device0.createCommandEncoder({label: '\uc196\u06b0\u9356\uc204\ub1ac\u0a50\u2e64\u{1fe66}\u{1fcac}\u0c25'});
+let computePassEncoder42 = commandEncoder44.beginComputePass({label: '\u87d0\u{1ffa8}'});
+let sampler37 = device0.createSampler({
+label: '\udbea\u{1fade}\u15dd\u{1fee5}',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 51.193,
+lodMaxClamp: 86.489,
+});
+try {
+renderBundleEncoder36.draw(64, 72, 80, 8);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexedIndirect(buffer15, 4);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(1, buffer6, 12056, 9528);
+} catch {}
+let promise29 = device0.queue.onSubmittedWorkDone();
+let pipeline81 = device0.createRenderPipeline({
+label: '\udaa0\u0afb\u{1fa5f}\u7540\u47a4\u96c8',
+layout: pipelineLayout11,
+multisample: {
+mask: 0x7c1f8c7f,
+},
+fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba16uint'}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {
+  format: 'rg11b10ufloat',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'zero'},
+alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'dst'},
+},
+  writeMask: 0
+}, {format: 'r8uint'}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2139,
+stencilWriteMask: 1167,
+depthBias: 3,
+depthBiasClamp: 83,
+},
+vertex: {
+  module: shaderModule9,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1544,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x2',
+offset: 184,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 672,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 80,
+shaderLocation: 6,
+}, {
+format: 'sint32',
+offset: 276,
+shaderLocation: 4,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'front',
+},
+});
+let video7 = await videoWithData();
+let imageBitmap11 = await createImageBitmap(imageBitmap10);
+let textureView50 = texture13.createView({label: '\u0880\u0074\u1a17\u7d03', baseMipLevel: 3});
+try {
+computePassEncoder40.setPipeline(pipeline40);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer4, 'uint32', 10764, 815);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture61,
+  mipLevel: 0,
+  origin: { x: 5, y: 2, z: 8 },
+  aspect: 'all',
+}, arrayBuffer12, /* required buffer size: 2362133 */
+{offset: 605, bytesPerRow: 2808, rowsPerImage: 29}, {width: 314, height: 0, depthOrArrayLayers: 30});
+} catch {}
+try {
+  await promise29;
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let bindGroupLayout30 = device0.createBindGroupLayout({
+label: '\u576f\u04e0\ucf51\u{1f95a}\u35cc\u2c49\u8090\u478f',
+entries: [],
+});
+let bindGroup25 = device0.createBindGroup({
+label: '\u028c\u0300\u{1f745}',
+layout: bindGroupLayout26,
+entries: [{
+binding: 423,
+resource: sampler14
+}],
+});
+let querySet47 = device0.createQuerySet({
+label: '\uf749\u8c61\u0d1d',
+type: 'occlusion',
+count: 771,
+});
+let texture62 = device0.createTexture({
+label: '\u{1fe6a}\u0086\uee39\u{1ffdf}\u058a\u{1fee2}\u0a35\u002a\u003c',
+size: {width: 2640, height: 192, depthOrArrayLayers: 1},
+mipLevelCount: 10,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x12-unorm', 'astc-12x12-unorm-srgb'],
+});
+let sampler38 = device0.createSampler({
+label: '\u3576\u0f94\u0c09\ua536\u0057\u036b\u{1fb8d}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 88.737,
+lodMaxClamp: 95.862,
+});
+try {
+computePassEncoder24.setBindGroup(1, bindGroup3, new Uint32Array(6127), 283, 0);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(24, 32, 16, 608, 72);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(4, buffer0, 8972, 6954);
+} catch {}
+try {
+querySet47.destroy();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 2, y: 1, z: 1 },
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer1), /* required buffer size: 776 */
+{offset: 776}, {width: 106, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline82 = await device0.createRenderPipelineAsync({
+label: '\u0aa2\u0715\u{1ff16}\udda5\u0b1e\u{1f8db}\u04a3\uec1d\u0e19\u02fb',
+layout: pipelineLayout9,
+fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint'}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-src-alpha'},
+},
+  writeMask: GPUColorWrite.BLUE
+}]
+},
+vertex: {
+  module: shaderModule8,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 1536,
+shaderLocation: 12,
+}, {
+format: 'uint32x3',
+offset: 288,
+shaderLocation: 15,
+}, {
+format: 'float32x2',
+offset: 1956,
+shaderLocation: 7,
+}, {
+format: 'uint32',
+offset: 808,
+shaderLocation: 11,
+}, {
+format: 'uint16x4',
+offset: 1588,
+shaderLocation: 2,
+}, {
+format: 'snorm8x2',
+offset: 622,
+shaderLocation: 0,
+}, {
+format: 'sint32x4',
+offset: 844,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 536,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x2',
+offset: 100,
+shaderLocation: 13,
+}, {
+format: 'float32x4',
+offset: 172,
+shaderLocation: 9,
+}, {
+format: 'float32x4',
+offset: 408,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 1408,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm16x2',
+offset: 992,
+shaderLocation: 6,
+}, {
+format: 'sint32x4',
+offset: 424,
+shaderLocation: 5,
+}, {
+format: 'snorm16x2',
+offset: 244,
+shaderLocation: 8,
+}, {
+format: 'unorm16x4',
+offset: 592,
+shaderLocation: 4,
+}, {
+format: 'float32',
+offset: 412,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 844,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x4',
+offset: 680,
+shaderLocation: 1,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: false,
+},
+});
+try {
+renderBundleEncoder36.drawIndexed(64);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer9, 'uint32', 6268, 8648);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+let promise30 = buffer14.mapAsync(GPUMapMode.READ);
+try {
+computePassEncoder34.pushDebugGroup('\ufec2');
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 13004, new DataView(new ArrayBuffer(46352)), 20060, 6664);
+} catch {}
+let commandEncoder45 = device0.createCommandEncoder();
+let textureView51 = texture48.createView({dimension: '2d'});
+try {
+renderBundleEncoder26.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexed(40, 56, 56, -8, 0);
+} catch {}
+try {
+renderBundleEncoder12.drawIndirect(buffer15, 5744);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(buffer0, 37088, buffer12, 7012, 20);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder45.copyTextureToTexture({
+  texture: texture53,
+  mipLevel: 1,
+  origin: { x: 88, y: 16, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 536, y: 8, z: 1 },
+  aspect: 'all',
+}, {width: 496, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas11.width = 856;
+let sampler39 = device1.createSampler({
+label: '\uefc0\u5738\u0c8c\ud3e8\u{1f7a1}\u{1f9fc}\u0f24\u34dc\u0fcd',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 13.486,
+maxAnisotropy: 11,
+});
+let bindGroupLayout31 = device0.createBindGroupLayout({
+label: '\u366d\u4b8d\u0de8\u3381\u84e5\u0493',
+entries: [{
+binding: 26,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}, {
+binding: 748,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+}],
+});
+let querySet48 = device0.createQuerySet({
+label: '\u09d0\u0611\u068e\u{1f710}\u{1ffe4}\ub3eb\u1f96\u{1f90d}',
+type: 'occlusion',
+count: 789,
+});
+let sampler40 = device0.createSampler({
+label: '\u6a3d\u0b88',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 10.954,
+lodMaxClamp: 53.892,
+});
+try {
+computePassEncoder38.end();
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline32);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer12, 36716);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 3,
+  origin: { x: 10, y: 1, z: 19 },
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(56)), /* required buffer size: 209884 */
+{offset: 79, bytesPerRow: 213, rowsPerImage: 197}, {width: 22, height: 0, depthOrArrayLayers: 6});
+} catch {}
+let renderBundle57 = renderBundleEncoder12.finish();
+try {
+renderBundleEncoder43.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder36.draw(0, 64);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder28.resolveQuerySet(querySet25, 641, 77, buffer12, 8448);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 2092, new BigUint64Array(42947), 26101, 180);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: offscreenCanvas8,
+  origin: { x: 461, y: 467 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 7,
+  origin: { x: 0, y: 1, z: 3 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline83 = device0.createRenderPipeline({
+label: '\u{1f8c3}\u{1f641}\u2dd2\ua902',
+layout: pipelineLayout11,
+fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.RED}, {format: 'rgba8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg16float', writeMask: 0}, undefined, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'invert',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+failOp: 'keep',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilReadMask: 2811,
+stencilWriteMask: 3934,
+depthBias: 69,
+depthBiasSlopeScale: 24,
+},
+vertex: {
+  module: shaderModule16,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 772,
+attributes: [],
+},
+{
+arrayStride: 2024,
+attributes: [],
+},
+{
+arrayStride: 2024,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x4',
+offset: 1656,
+shaderLocation: 14,
+}, {
+format: 'uint32',
+offset: 1560,
+shaderLocation: 13,
+}],
+}
+]
+},
+});
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+canvas15.width = 623;
+let video8 = await videoWithData();
+let texture63 = device0.createTexture({
+label: '\u0510\uefca\u31c1\u096f\u{1fbbf}\ua793\ucf56\u{1f6cb}\u{1fd85}',
+size: {width: 438},
+mipLevelCount: 1,
+dimension: '1d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler41 = device0.createSampler({
+label: '\uc7d4\uc241\uf8aa\u{1fde5}\u0b2d\u921a\u3648\u5011\u07dc\uc6e6\u{1f9fa}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 32.633,
+lodMaxClamp: 91.349,
+compare: 'not-equal',
+});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup20, new Uint32Array(3795), 3106, 0);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder9.draw(24, 40, 0, 8);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer15, 5032);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+let pipeline84 = await device0.createRenderPipelineAsync({
+label: '\u{1fc87}\u8f90\u6efb\u{1f799}\ud511',
+layout: pipelineLayout8,
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint'}, {format: 'rg8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, undefined, {format: 'rg32float', writeMask: 0}, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilReadMask: 2105,
+stencilWriteMask: 813,
+depthBias: 80,
+depthBiasSlopeScale: 6,
+depthBiasClamp: 16,
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1196,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x4',
+offset: 292,
+shaderLocation: 14,
+}, {
+format: 'sint32x3',
+offset: 696,
+shaderLocation: 1,
+}, {
+format: 'snorm16x4',
+offset: 216,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 2016,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 638,
+shaderLocation: 8,
+}, {
+format: 'uint32x2',
+offset: 1312,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 688,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x2',
+offset: 316,
+shaderLocation: 5,
+}, {
+format: 'sint16x4',
+offset: 636,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 1368,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x4',
+offset: 1224,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 416,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32',
+offset: 288,
+shaderLocation: 10,
+}],
+}
+]
+},
+});
+let canvas17 = document.createElement('canvas');
+try {
+await adapter3.requestAdapterInfo();
+} catch {}
+let bindGroup26 = device0.createBindGroup({
+layout: bindGroupLayout1,
+entries: [{
+binding: 43,
+resource: externalTexture0
+}, {
+binding: 257,
+resource: externalTexture1
+}],
+});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup21, new Uint32Array(8949), 1991, 0);
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline43);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer15, 2400);
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 32, y: 36, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 24, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 48, height: 132, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder45.clearBuffer(buffer11, 23136, 31404);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+computePassEncoder34.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 31}
+*/
+{
+  source: img4,
+  origin: { x: 14, y: 40 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 4,
+  origin: { x: 5, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise31 = device0.createComputePipelineAsync({
+label: '\u{1ff3c}\u{1f987}\u2326\u004f\u{1f910}\u015e',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline85 = device0.createRenderPipeline({
+layout: pipelineLayout14,
+fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, undefined, {format: 'rg32float'}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'src'},
+},
+  writeMask: GPUColorWrite.BLUE
+}]
+},
+vertex: {
+  module: shaderModule8,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1904,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x4',
+offset: 1160,
+shaderLocation: 3,
+}, {
+format: 'snorm16x2',
+offset: 1860,
+shaderLocation: 4,
+}, {
+format: 'float16x4',
+offset: 1784,
+shaderLocation: 7,
+}, {
+format: 'snorm16x2',
+offset: 1644,
+shaderLocation: 0,
+}, {
+format: 'sint32x2',
+offset: 1264,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 788,
+attributes: [{
+format: 'uint32',
+offset: 236,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 904,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x2',
+offset: 722,
+shaderLocation: 13,
+}, {
+format: 'snorm16x4',
+offset: 484,
+shaderLocation: 12,
+}, {
+format: 'snorm8x4',
+offset: 148,
+shaderLocation: 14,
+}, {
+format: 'unorm10-10-10-2',
+offset: 748,
+shaderLocation: 6,
+}, {
+format: 'uint8x2',
+offset: 138,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 272,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x2',
+offset: 148,
+shaderLocation: 8,
+}, {
+format: 'sint16x4',
+offset: 136,
+shaderLocation: 1,
+}, {
+format: 'uint16x2',
+offset: 16,
+shaderLocation: 2,
+}, {
+format: 'unorm8x2',
+offset: 192,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 168,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 1560,
+shaderLocation: 10,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+},
+});
+let img13 = await imageWithData(41, 284, '#96cadc40', '#8ce5fb7f');
+let commandEncoder46 = device0.createCommandEncoder({label: '\u8fb7\u{1fb2d}\u34a5\udf95\udb8b\u06de'});
+try {
+renderBundleEncoder42.setBindGroup(1, bindGroup20, []);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline79);
+} catch {}
+let pipeline86 = await promise21;
+let videoFrame15 = new VideoFrame(img7, {timestamp: 0});
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+gc();
+try {
+canvas17.getContext('2d');
+} catch {}
+let buffer20 = device0.createBuffer({
+  label: '\u03c4\u782d\u{1f9aa}\u0f5d\u1ab8',
+  size: 4976,
+  usage: GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true
+});
+let textureView52 = texture48.createView({
+  label: '\u4176\u0205\u0d80\u{1fd70}\u90c5\u09d2\u0d08\u{1f84b}',
+  dimension: '2d-array',
+  baseArrayLayer: 0
+});
+let computePassEncoder43 = commandEncoder28.beginComputePass({label: '\u{1f68f}\u1941\ueb4b\u{1ff3a}\u{1f87f}\u91f3\u3d7d'});
+try {
+commandEncoder46.copyBufferToBuffer(buffer17, 13692, buffer18, 3656, 4900);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder46.copyTextureToBuffer({
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 40, y: 40, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 144 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 50432 */
+offset: 45424,
+bytesPerRow: 256,
+buffer: buffer1,
+}, {width: 72, height: 100, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder46.clearBuffer(buffer12);
+dissociateBuffer(device0, buffer12);
+} catch {}
+let pipeline87 = await device0.createComputePipelineAsync({
+label: '\u8bd8\u27a8',
+layout: 'auto',
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let renderBundleEncoder51 = device0.createRenderBundleEncoder({
+  label: '\u{1f68a}\u9d49\u7094\u358c\u07b1\ucae1\ufd11\udb65\u5244',
+  colorFormats: ['rgba8sint', 'rgba32sint', 'rg8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup0, new Uint32Array(2254), 1127, 0);
+} catch {}
+try {
+renderBundleEncoder20.drawIndirect(buffer12, 34196);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer6, 'uint16', 15702, 15727);
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(buffer12, 30444, buffer14, 8332, 2852);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder46.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 4,
+  origin: { x: 20, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture13,
+  mipLevel: 3,
+  origin: { x: 10, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 5, depthOrArrayLayers: 1});
+} catch {}
+let pipeline88 = device0.createRenderPipeline({
+label: '\u0176\u0d69\u0dec\u055b\u0421',
+layout: 'auto',
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint'}, {format: 'rg8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined, {format: 'rg32float'}, {
+  format: 'bgra8unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}]
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 52,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 16,
+shaderLocation: 4,
+}, {
+format: 'uint16x2',
+offset: 8,
+shaderLocation: 3,
+}, {
+format: 'float32x3',
+offset: 40,
+shaderLocation: 5,
+}, {
+format: 'float32x4',
+offset: 36,
+shaderLocation: 8,
+}, {
+format: 'sint8x4',
+offset: 44,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 876,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 16,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x2',
+offset: 8,
+shaderLocation: 7,
+}, {
+format: 'uint16x2',
+offset: 4,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 1912,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x3',
+offset: 1168,
+shaderLocation: 6,
+}, {
+format: 'uint8x2',
+offset: 956,
+shaderLocation: 14,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: false,
+},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+gc();
+try {
+renderBundleEncoder36.drawIndexed(0, 64, 8);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline79);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(buffer3, 55704, buffer10, 120, 2684);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder17.draw(40, 64, 40, 8);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(72, 72, 48, 192, 56);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer12, 26160);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(1, buffer0, 14864);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(buffer0, 15964, buffer11, 59276, 1672);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder45.clearBuffer(buffer14);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder45.resolveQuerySet(querySet15, 75, 7, buffer12, 10240);
+} catch {}
+try {
+  await promise30;
+} catch {}
+let shaderModule20 = device0.createShaderModule({
+label: '\u{1fc20}\ud790\u{1ff13}\u{1fac1}\ua1bc\u{1faa8}\u87d5\ud76d\u02c0\u{1feca}\u9c34',
+code: `@group(0) @binding(561)
+var<storage, read_write> function7: array<u32>;
+
+@compute @workgroup_size(1, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3<u32>,
+  @location(2) f1: vec4<i32>,
+  @location(7) f2: i32,
+  @location(6) f3: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(9) a0: vec2<i32>, @location(1) a1: vec2<i32>, @location(2) a2: vec2<f32>, @location(8) a3: vec3<f32>, @location(11) a4: vec3<f32>, @builtin(position) a5: vec4<f32>, @builtin(front_facing) a6: bool, @builtin(sample_mask) a7: u32, @builtin(sample_index) a8: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(2) f102: vec2<f32>,
+  @builtin(position) f103: vec4<f32>,
+  @location(8) f104: vec3<f32>,
+  @location(11) f105: vec3<f32>,
+  @location(1) f106: vec2<i32>,
+  @location(9) f107: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: f16, @location(14) a1: vec4<i32>, @location(5) a2: f16, @location(9) a3: vec2<f16>, @location(3) a4: vec2<f16>, @location(2) a5: vec4<f32>, @location(10) a6: vec4<f16>, @location(1) a7: vec3<f16>, @location(12) a8: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+});
+let commandBuffer14 = commandEncoder45.finish({
+label: '\u{1f79b}\uf7ce\uc77f\u0c25\u24fe\u05ed\ue3a9\ub6c9\u9c62\u1d9d',
+});
+let texture64 = device0.createTexture({
+label: '\u1df1\u96ba\u{1fffb}\ua888',
+size: [4895, 200, 21],
+mipLevelCount: 5,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-5x5-unorm-srgb', 'astc-5x5-unorm'],
+});
+let computePassEncoder44 = commandEncoder46.beginComputePass({label: '\uf142\u{1fd75}\u5ecb\u0f8d\u04e3\u{1f633}\u0d11\u1b5b'});
+try {
+computePassEncoder22.dispatchWorkgroups(2);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline44);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer13,
+]);
+} catch {}
+let pipeline89 = await device0.createComputePipelineAsync({
+layout: pipelineLayout14,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let adapter4 = await navigator.gpu.requestAdapter({
+});
+let querySet49 = device0.createQuerySet({
+label: '\u03f3\uadde\u{1f86c}\u1d08\u{1f70f}\u1615\u{1ffff}\udfe4\uc6ba\u15b2',
+type: 'occlusion',
+count: 2670,
+});
+let sampler42 = device0.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 83.373,
+});
+try {
+computePassEncoder33.setPipeline(pipeline78);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(4, buffer0, 28624);
+} catch {}
+let promise32 = adapter4.requestAdapterInfo();
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let querySet50 = device1.createQuerySet({
+label: '\u473c\u09f0\u{1f912}\ud4bd\u26b1\u0381\u04b5\u{1fcda}\u996b',
+type: 'occlusion',
+count: 2165,
+});
+let textureView53 = texture60.createView({
+  label: '\u{1fe54}\uab92\ud2ea\u7a3a\u045b',
+  format: 'astc-5x5-unorm-srgb',
+  baseMipLevel: 1,
+  mipLevelCount: 6,
+  baseArrayLayer: 96,
+  arrayLayerCount: 69
+});
+let sampler43 = device0.createSampler({
+label: '\u0bc5\ua448',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 89.689,
+lodMaxClamp: 92.638,
+compare: 'always',
+});
+try {
+renderBundleEncoder20.drawIndexed(48, 80, 40, -784, 72);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 6972, new BigUint64Array(38920), 17405, 356);
+} catch {}
+let bindGroupLayout32 = device0.createBindGroupLayout({
+label: '\u{1f965}\uecf9\uaef2\ue389\u{1f722}\u{1f901}\u{1f7a0}\u0b70',
+entries: [{
+binding: 730,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+}],
+});
+let querySet51 = device0.createQuerySet({
+label: '\ufc61\udae7',
+type: 'occlusion',
+count: 1978,
+});
+try {
+computePassEncoder40.dispatchWorkgroups(3, 1);
+} catch {}
+try {
+computePassEncoder43.end();
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(2, bindGroup3, []);
+} catch {}
+try {
+renderBundleEncoder17.draw(24, 80);
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(buffer17, 3444, buffer12, 24992, 4676);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer14);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+computePassEncoder33.pushDebugGroup('\u3f13');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 31}
+*/
+{
+  source: img7,
+  origin: { x: 234, y: 83 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 2 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 9, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise28;
+} catch {}
+let promise33 = navigator.gpu.requestAdapter({
+});
+let texture65 = device0.createTexture({
+label: '\u067e\u3cf6\u{1fce0}\u{1f730}\u7a4c\ue6ca\u{1fdc4}',
+size: [204, 100, 1],
+mipLevelCount: 2,
+sampleCount: 1,
+dimension: '2d',
+format: 'astc-12x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x10-unorm-srgb', 'astc-12x10-unorm'],
+});
+let computePassEncoder45 = commandEncoder28.beginComputePass();
+try {
+computePassEncoder26.setPipeline(pipeline69);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(8, 64, 40, 320);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 13420);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 3,
+  origin: { x: 0, y: 5, z: 0 },
+  aspect: 'all',
+}, new DataView(arrayBuffer8), /* required buffer size: 390 */
+{offset: 390}, {width: 20, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas13 = new OffscreenCanvas(813, 858);
+let canvas18 = document.createElement('canvas');
+let querySet52 = device0.createQuerySet({
+label: '\uc205\ud1b0\ufc9d',
+type: 'occlusion',
+count: 3066,
+});
+let renderBundleEncoder52 = device0.createRenderBundleEncoder({
+  label: '\u2a3c\u03b1\u0636\u06ac\u00ff',
+  colorFormats: ['bgra8unorm-srgb', 'rgba16uint', 'r8uint', 'rg11b10ufloat', 'r8uint'],
+  depthReadOnly: true
+});
+let renderBundle58 = renderBundleEncoder5.finish({});
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 29388);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer4, 'uint32');
+} catch {}
+try {
+window.someLabel = externalTexture2.label;
+} catch {}
+let bindGroup27 = device0.createBindGroup({
+label: '\u7c6c\u{1fbb2}\u072b\u0495\u5843\u0627\u{1fab8}\u{1ffe5}\u0b3d',
+layout: bindGroupLayout1,
+entries: [{
+binding: 257,
+resource: externalTexture1
+}, {
+binding: 43,
+resource: externalTexture2
+}],
+});
+let querySet53 = device0.createQuerySet({
+label: '\u{1ffb9}\u1b43\u1c86\u075b\u0dbd\ub40a',
+type: 'occlusion',
+count: 963,
+});
+try {
+renderBundleEncoder47.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexedIndirect(buffer15, 4380);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 5, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 402, y: 268 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 6,
+  origin: { x: 2, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline90 = device0.createComputePipeline({
+label: '\u{1f8ef}\u238b',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+  await promise32;
+} catch {}
+let commandEncoder47 = device0.createCommandEncoder({label: '\u2a7b\u{1f7f7}\u0dc7\uc06d\u{1f709}\u4a10\ue5cd'});
+let computePassEncoder46 = commandEncoder47.beginComputePass({});
+let renderBundle59 = renderBundleEncoder11.finish({label: '\u05d7\u{1fe8f}\u{1fb11}\u0fc7'});
+try {
+renderBundleEncoder34.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder36.draw(16, 8, 0, 32);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 12084);
+} catch {}
+canvas0.width = 471;
+let querySet54 = device0.createQuerySet({
+label: '\u{1fef8}\u052c\ua887\u2750\u0f8f\u062c\u07e4\u9f35\u05c6\u9c82\ue0f2',
+type: 'occlusion',
+count: 1622,
+});
+try {
+computePassEncoder33.popDebugGroup();
+} catch {}
+let canvas19 = document.createElement('canvas');
+let promise34 = adapter1.requestAdapterInfo();
+let sampler44 = device0.createSampler({
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 1.194,
+lodMaxClamp: 92.453,
+});
+try {
+renderBundleEncoder36.drawIndexed(48, 72, 24);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer12, 20984);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 1, depthOrArrayLayers: 15}
+*/
+{
+  source: video2,
+  origin: { x: 2, y: 16 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 5,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 8, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+document.body.prepend(canvas14);
+let bindGroupLayout33 = device0.createBindGroupLayout({
+label: '\u{1fcfd}\u0a09\u5210\u{1f79c}\u05da\u0a48\udec6',
+entries: [{
+binding: 989,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}, {
+binding: 910,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba16float', access: 'write-only', viewDimension: '1d' },
+}, {
+binding: 913,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '2d-array' },
+}],
+});
+pseudoSubmit(device0, commandEncoder34);
+let textureView54 = texture33.createView({label: '\u1b03\u0322\u5ca9\ua673\u{1f798}', dimension: '2d-array', mipLevelCount: 1});
+try {
+renderBundleEncoder36.drawIndexed(72, 8, 80, 528, 72);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 34444);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(3, buffer6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 1, depthOrArrayLayers: 125}
+*/
+{
+  source: videoFrame14,
+  origin: { x: 288, y: 33 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 2,
+  origin: { x: 10, y: 0, z: 55 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 26, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas20 = document.createElement('canvas');
+try {
+adapter2.label = '\u{1fcea}\u{1fc16}\u9af9\u{1fe52}';
+} catch {}
+try {
+canvas19.getContext('2d');
+} catch {}
+let querySet55 = device0.createQuerySet({
+label: '\u{1fef7}\ua8ea\ue6fa\u972b\u{1ffbd}\u87fa\u340d\u0cf8',
+type: 'occlusion',
+count: 1016,
+});
+pseudoSubmit(device0, commandEncoder44);
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder36.draw(8, 32, 32, 0);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(40, 8);
+} catch {}
+try {
+renderBundleEncoder36.drawIndirect(buffer15, 1360);
+} catch {}
+try {
+computePassEncoder35.insertDebugMarker('\u{1fb2e}');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 14952, new Float32Array(52055), 4694, 1288);
+} catch {}
+let gpuCanvasContext14 = offscreenCanvas13.getContext('webgpu');
+let img14 = await imageWithData(84, 264, '#03b02af8', '#37d26940');
+try {
+renderBundleEncoder52.setPipeline(pipeline79);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 320, height: 2, depthOrArrayLayers: 503}
+*/
+{
+  source: canvas4,
+  origin: { x: 186, y: 51 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: { x: 216, y: 0, z: 185 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 98, height: 2, depthOrArrayLayers: 1});
+} catch {}
+let pipeline91 = await device0.createComputePipelineAsync({
+label: '\uaeda\u{1f953}',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let promise35 = device0.createRenderPipelineAsync({
+label: '\ud0a8\u13ec\u8943\ua9df\u572c\u0e2b\u0eb2\u0fb9\u{1f6dc}',
+layout: 'auto',
+fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint'}, {format: 'r16uint'}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}]
+},
+vertex: {
+  module: shaderModule10,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 484,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x2',
+offset: 292,
+shaderLocation: 6,
+}, {
+format: 'uint16x4',
+offset: 72,
+shaderLocation: 15,
+}, {
+format: 'sint8x2',
+offset: 4,
+shaderLocation: 0,
+}, {
+format: 'snorm8x2',
+offset: 132,
+shaderLocation: 7,
+}, {
+format: 'float16x2',
+offset: 376,
+shaderLocation: 4,
+}, {
+format: 'uint32x4',
+offset: 308,
+shaderLocation: 3,
+}, {
+format: 'unorm16x2',
+offset: 160,
+shaderLocation: 8,
+}, {
+format: 'uint8x4',
+offset: 416,
+shaderLocation: 9,
+}, {
+format: 'uint32x3',
+offset: 436,
+shaderLocation: 14,
+}, {
+format: 'unorm16x4',
+offset: 168,
+shaderLocation: 1,
+}, {
+format: 'float32x4',
+offset: 356,
+shaderLocation: 11,
+}, {
+format: 'float32x4',
+offset: 332,
+shaderLocation: 12,
+}, {
+format: 'sint16x2',
+offset: 296,
+shaderLocation: 13,
+}, {
+format: 'snorm8x4',
+offset: 300,
+shaderLocation: 10,
+}, {
+format: 'snorm8x2',
+offset: 134,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 20,
+attributes: [{
+format: 'sint32x2',
+offset: 12,
+shaderLocation: 2,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: false,
+},
+});
+let shaderModule21 = device0.createShaderModule({
+label: '\u03ca\u0bdd\u1d4f\u583b\u4787\u70bc\u7608\u80bf\u00a1\u2053',
+code: `@group(0) @binding(561)
+var<storage, read_write> field10: array<u32>;
+@group(1) @binding(788)
+var<storage, read_write> type10: array<u32>;
+@group(1) @binding(803)
+var<storage, read_write> parameter8: array<u32>;
+@group(3) @binding(674)
+var<storage, read_write> global3: array<u32>;
+@group(2) @binding(20)
+var<storage, read_write> parameter9: array<u32>;
+
+@compute @workgroup_size(7, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(1) f1: vec4<i32>,
+  @location(3) f2: vec2<f32>,
+  @location(2) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(position) a2: vec4<f32>, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S16 {
+  @location(11) f0: vec2<i32>,
+  @location(0) f1: vec3<u32>,
+  @location(13) f2: vec3<f32>,
+  @location(5) f3: vec3<f16>,
+  @location(1) f4: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec3<i32>, a1: S16, @location(15) a2: vec4<i32>, @location(12) a3: vec4<u32>, @location(14) a4: vec2<i32>, @location(8) a5: vec2<i32>, @location(6) a6: vec4<u32>, @location(9) a7: vec2<i32>, @location(3) a8: vec3<u32>, @location(4) a9: vec4<f32>, @location(2) a10: vec4<f16>, @location(10) a11: u32, @builtin(instance_index) a12: u32, @builtin(vertex_index) a13: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let renderBundle60 = renderBundleEncoder18.finish({label: '\uf11c\u4855\u3a89\u523a\udc19\ua5d2\u084b\u{1f84a}'});
+try {
+renderBundleEncoder52.draw(8, 32, 72, 56);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: { x: 123, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 577 */
+{offset: 577}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline92 = device0.createComputePipeline({
+label: '\u{1fc43}\u{1f674}\u7cb9\u01ae',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+},
+});
+let pipeline93 = device0.createRenderPipeline({
+label: '\ud23e\u0d50\u{1ffc7}\u{1f731}\u0e0e\u05dc\ue0fa\u984c',
+layout: pipelineLayout16,
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {format: 'rg8sint', writeMask: GPUColorWrite.BLUE}, undefined, {format: 'rg32float'}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'one-minus-src-alpha'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilReadMask: 721,
+stencilWriteMask: 1456,
+depthBiasSlopeScale: 10,
+depthBiasClamp: 33,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 260,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 1484,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 168,
+attributes: [{
+format: 'float32',
+offset: 28,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+try {
+canvas18.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder48 = device0.createCommandEncoder({label: '\u{1f942}\u8090\u{1f9bd}\ud0b9\u51e6\u9c43\u07f7\u0514'});
+let querySet56 = device0.createQuerySet({
+label: '\u0981\u0721\u3a30\u3e08\ub1d5',
+type: 'occlusion',
+count: 3823,
+});
+let texture66 = device0.createTexture({
+label: '\u970f\u0fa4',
+size: {width: 438},
+dimension: '1d',
+format: 'rgba8sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8sint', 'rgba8sint', 'rgba8sint'],
+});
+let renderBundleEncoder53 = device0.createRenderBundleEncoder({
+  label: '\u{1fa60}\u8287\ue52f\ub1bd\u9efd\u{1f6e5}\u19e4',
+  colorFormats: ['rg8uint', 'r16uint', 'rgba16uint', 'rgba16sint']
+});
+let renderBundle61 = renderBundleEncoder0.finish();
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup3, new Uint32Array(8196), 5335, 0);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexedIndirect(buffer12, 8476);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(1, buffer0, 32380, 472);
+} catch {}
+let promise36 = device0.createComputePipelineAsync({
+label: '\u8044\u2925\uc6f9',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let gpuCanvasContext15 = canvas20.getContext('webgpu');
+canvas3.width = 392;
+let bindGroup28 = device1.createBindGroup({
+label: '\uca66\u687e\u{1fda9}\u0778\u3151\u8934',
+layout: bindGroupLayout27,
+entries: [],
+});
+let commandEncoder49 = device1.createCommandEncoder({label: '\uea20\u071a\u0c80\ufb4a\u05ba\u07c9'});
+let computePassEncoder47 = commandEncoder49.beginComputePass({label: '\u087e\u570e\uff96\ub7ac\u0174\u0285\u{1fb05}\u0dd4'});
+try {
+adapter0.label = '\uabcb\u95c3\u06fc\u3267\u{1ffe8}\u058c';
+} catch {}
+try {
+  await promise34;
+} catch {}
+let commandEncoder50 = device0.createCommandEncoder({});
+let commandBuffer15 = commandEncoder50.finish({
+label: '\uc86b\u{1fd8b}\u682a\u4692\u{1fd30}\uae46\u{1fe9d}\u{1f7e4}\ue87c',
+});
+let textureView55 = texture23.createView({label: '\u126a\ud570\u6d5a\u{1ff42}\uf7bd\uaee2\u05ee', dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder48 = commandEncoder48.beginComputePass({label: '\u07ef\u6bbd'});
+let renderBundle62 = renderBundleEncoder12.finish({label: '\uaba1\u006b\u2bfc\u{1f7c3}\udbb7\u8888\uf2b4'});
+try {
+computePassEncoder40.dispatchWorkgroups(1, 5, 1);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(6, buffer0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+computePassEncoder27.pushDebugGroup('\u0691');
+} catch {}
+let buffer21 = device0.createBuffer({label: '\u8f8c\u521a', size: 43968, usage: GPUBufferUsage.MAP_WRITE, mappedAtCreation: true});
+let texture67 = device0.createTexture({
+size: {width: 876},
+dimension: '1d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundleEncoder54 = device0.createRenderBundleEncoder({
+  colorFormats: [undefined, 'r32float', 'rgba16sint', 'r16float', 'rgb10a2uint', 'rg16uint', 'r32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle63 = renderBundleEncoder4.finish({label: '\u7791\uca86\ufeaa\ue414\uc89e\u{1f741}\u0a9d\u6f37\u{1fcc2}\u034a'});
+try {
+renderBundleEncoder49.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder36.draw(24, 56, 72, 16);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexed(56, 80, 80, -176, 64);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline79);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 9480, new BigUint64Array(28882), 12487, 168);
+} catch {}
+let canvas21 = document.createElement('canvas');
+let imageData8 = new ImageData(92, 228);
+try {
+canvas21.getContext('webgpu');
+} catch {}
+try {
+computePassEncoder47.setBindGroup(2, bindGroup28, new Uint32Array(6872), 5385, 0);
+} catch {}
+document.body.prepend(video2);
+let shaderModule22 = device0.createShaderModule({
+label: '\ud7e0\u04a6\u0cab\u0537\u{1f8b4}\u8db9\u08eb\u6c65\ubf1c\u969e',
+code: `@group(2) @binding(934)
+var<storage, read_write> i7: array<u32>;
+@group(1) @binding(20)
+var<storage, read_write> i8: array<u32>;
+@group(2) @binding(289)
+var<storage, read_write> global4: array<u32>;
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec2<f32>,
+  @location(1) f1: vec3<i32>,
+  @location(0) f2: u32,
+  @location(4) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @location(10) a1: vec3<f32>, @location(7) a2: vec4<f16>, @builtin(sample_mask) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f108: vec4<f32>,
+  @location(7) f109: vec4<f16>,
+  @location(10) f110: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec2<f16>, @location(7) a1: vec3<i32>, @location(2) a2: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder51 = device0.createCommandEncoder({label: '\u2586\u{1fbe4}\u5b1d\ue18e\u0c68\u5dea'});
+let renderBundleEncoder55 = device0.createRenderBundleEncoder({
+  label: '\ube9e\u0a03\u0c2d\uf71c\u444a\u490f\u5627\u06df',
+  colorFormats: ['r8unorm', 'rgb10a2uint', 'rg16sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline79);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder51.clearBuffer(buffer8, 9428, 3636);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder51.resolveQuerySet(querySet13, 0, 0, buffer12, 9472);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 10356, new DataView(new ArrayBuffer(8302)), 4274, 816);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+window.someLabel = externalTexture2.label;
+} catch {}
+let texture68 = device0.createTexture({
+size: {width: 40, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+computePassEncoder48.setPipeline(pipeline31);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer12, 33648);
+} catch {}
+try {
+commandEncoder51.clearBuffer(buffer18);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer14,
+]);
+} catch {}
+gc();
+let buffer22 = device0.createBuffer({
+  label: '\u2661\ub116\ubd0d\u05f4\u4851',
+  size: 2082,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX
+});
+try {
+renderBundleEncoder36.draw(48, 64, 56, 0);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexedIndirect(buffer12, 8104);
+} catch {}
+try {
+renderBundleEncoder51.setVertexBuffer(1, buffer6, 24180, 5151);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 269 */
+{offset: 269}, {width: 20, height: 0, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(video6);
+let buffer23 = device0.createBuffer({
+  label: '\u01e8\u4b7f\u9809\u0495\u02be',
+  size: 22412,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true
+});
+let texture69 = device0.createTexture({
+label: '\u4495\uee5b\u00f1\ucea6\u48eb\u3bbd\u00a9\u52ef\u5756',
+size: {width: 438, height: 1, depthOrArrayLayers: 679},
+mipLevelCount: 1,
+sampleCount: 1,
+dimension: '3d',
+format: 'rg8uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundleEncoder56 = device0.createRenderBundleEncoder({
+  label: '\u0680\u0a30',
+  colorFormats: [undefined, 'r16uint', 'rg32uint', 'rg16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+let renderBundle64 = renderBundleEncoder11.finish({label: '\ufbbd\u{1f667}\u0089\u{1fe55}\u0b8b\u16b0'});
+let sampler45 = device0.createSampler({
+label: '\u9de5\u0a19\u07ed\u0bb7\u5c29\ue2d6\u660c\u0051',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 99.169,
+});
+try {
+commandEncoder51.resolveQuerySet(querySet2, 461, 480, buffer12, 12032);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x10-unorm-srgb', 'astc-12x10-unorm', 'rgba16float', 'rgba16float'],
+});
+} catch {}
+let pipeline94 = device0.createComputePipeline({
+label: '\u269a\u96fb\u9c50\u0d59\u0187',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule21,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let commandEncoder52 = device0.createCommandEncoder({label: '\u{1fa41}\u04b2\u4397\uea1b\uf398'});
+pseudoSubmit(device0, commandEncoder19);
+let texture70 = device0.createTexture({
+label: '\u1577\uafc8',
+size: {width: 330},
+dimension: '1d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r16sint', 'r16sint'],
+});
+let renderBundle65 = renderBundleEncoder16.finish({});
+try {
+renderBundleEncoder48.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexed(8, 24, 80, 160);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexedIndirect(buffer12, 21536);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer9, 'uint32');
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(3, buffer0, 30784);
+} catch {}
+try {
+commandEncoder51.copyBufferToBuffer(buffer3, 12168, buffer4, 4120, 3612);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth32float-stencil8', 'etc2-rgba8unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer15,
+]);
+} catch {}
+let bindGroupLayout34 = device0.createBindGroupLayout({
+label: '\u{1f867}\u7533\uc2ec\u7870\u00b8',
+entries: [{
+binding: 55,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32uint', access: 'write-only', viewDimension: '3d' },
+}, {
+binding: 222,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+}, {
+binding: 926,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}],
+});
+let renderBundleEncoder57 = device0.createRenderBundleEncoder({
+  label: '\u062a\u0719\u{1fe79}\u843f\u62b1\u1f7a\uc87e\u0c28\ua44b',
+  colorFormats: ['bgra8unorm-srgb', 'rgba16uint', 'r8uint', 'rg11b10ufloat', 'r8uint']
+});
+let sampler46 = device0.createSampler({
+addressModeU: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 31.945,
+lodMaxClamp: 82.466,
+maxAnisotropy: 4,
+});
+try {
+computePassEncoder22.dispatchWorkgroups(4, 5, 3);
+} catch {}
+try {
+computePassEncoder30.end();
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(3, bindGroup1, new Uint32Array(8539), 3298, 0);
+} catch {}
+try {
+commandEncoder51.copyBufferToBuffer(buffer23, 7348, buffer8, 9420, 3040);
+dissociateBuffer(device0, buffer23);
+dissociateBuffer(device0, buffer8);
+} catch {}
+let pipeline95 = await promise35;
+let shaderModule23 = device0.createShaderModule({
+label: '\u{1ff69}\u0a2f\u0e8d\u3efc\u{1fd8a}\ued95\u908d',
+code: `@group(0) @binding(43)
+var<storage, read_write> parameter10: array<u32>;
+@group(0) @binding(257)
+var<storage, read_write> parameter11: array<u32>;
+
+@compute @workgroup_size(5, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S18 {
+  @builtin(sample_mask) f0: u32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(1) f1: vec4<u32>,
+  @location(3) f2: vec3<f32>,
+  @location(4) f3: u32,
+  @location(2) f4: vec2<u32>
+}
+
+@fragment
+fn fragment0(@location(4) a0: vec2<u32>, @location(0) a1: vec4<f16>, @location(7) a2: u32, a3: S18, @builtin(sample_index) a4: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S17 {
+  @location(9) f0: vec4<f32>,
+  @location(7) f1: vec2<f16>
+}
+struct VertexOutput0 {
+  @location(0) f111: vec4<f16>,
+  @location(4) f112: vec2<u32>,
+  @location(7) f113: u32,
+  @builtin(position) f114: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(0) a0: vec2<f16>, @location(8) a1: vec2<i32>, a2: S17, @location(6) a3: vec4<i32>, @location(10) a4: vec4<u32>, @location(12) a5: vec2<f16>, @location(5) a6: vec2<u32>, @location(15) a7: vec2<u32>, @location(14) a8: vec3<i32>, @location(2) a9: vec4<f32>, @location(4) a10: vec3<i32>, @location(13) a11: vec2<f16>, @builtin(instance_index) a12: u32, @location(3) a13: vec3<f16>, @builtin(vertex_index) a14: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let computePassEncoder49 = commandEncoder31.beginComputePass({label: '\u9e67\u67f4\u04f8'});
+try {
+computePassEncoder45.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexed(24, 0, 72, 672, 8);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(3, buffer0);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+try {
+commandEncoder52.copyTextureToBuffer({
+  texture: texture62,
+  mipLevel: 0,
+  origin: { x: 636, y: 60, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 272 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 7232 */
+offset: 3888,
+bytesPerRow: 512,
+rowsPerImage: 72,
+buffer: buffer16,
+}, {width: 204, height: 84, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder51.copyTextureToTexture({
+  texture: texture48,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 5, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let video9 = await videoWithData();
+let renderBundle66 = renderBundleEncoder49.finish({label: '\u{1f962}\u3633\u1788'});
+try {
+computePassEncoder37.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder36.draw(8, 64, 72, 64);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(80);
+} catch {}
+try {
+renderBundleEncoder26.drawIndirect(buffer22, 276);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(6, buffer0, 18452);
+} catch {}
+try {
+commandEncoder52.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 5,
+  origin: { x: 10, y: 5, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: { x: 10, y: 45, z: 1 },
+  aspect: 'all',
+}, {width: 40, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline96 = await device0.createRenderPipelineAsync({
+label: '\u524b\u5d45\ua322\u0393',
+layout: pipelineLayout14,
+fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  targets: [undefined, {format: 'r32float', writeMask: 0}, {format: 'rgba16sint', writeMask: 0}, {format: 'r16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.RED}, {format: 'rg16uint', writeMask: 0}, {format: 'r32sint'}]
+},
+vertex: {
+  module: shaderModule19,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1840,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x2',
+offset: 932,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 1192,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 842,
+shaderLocation: 12,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+document.body.prepend(img10);
+let imageBitmap12 = await createImageBitmap(offscreenCanvas2);
+let offscreenCanvas14 = new OffscreenCanvas(570, 1016);
+let shaderModule24 = device0.createShaderModule({
+label: '\u540b\u246f\u6eab\u{1fa66}\ufd77\u3a83\u0c7a',
+code: `@group(0) @binding(561)
+var<storage, read_write> global5: array<u32>;
+
+@compute @workgroup_size(7, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<u32>,
+  @location(2) f1: vec4<i32>,
+  @location(0) f2: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let texture71 = device0.createTexture({
+label: '\u06db\u{1ffc4}\u{1fb66}\u{1f9fd}\u703c\u{1fdfb}\u52cb\u{1fa9f}\u{1f9a0}\u{1f725}\u4528',
+size: {width: 2640, height: 192, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'etc2-rgb8a1unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView56 = texture31.createView({
+  label: '\u88bb\u6928\u0427\u378e\udd8f\u02fb\u436f\u{1fac2}\u0c6d',
+  format: 'astc-8x6-unorm',
+  baseArrayLayer: 0
+});
+let computePassEncoder50 = commandEncoder51.beginComputePass({label: '\u0f69\u{1fd30}\uecce\uc25f\ue217\u{1ff84}'});
+let renderBundle67 = renderBundleEncoder48.finish({label: '\u{1ff38}\u0777\u0215'});
+let sampler47 = device0.createSampler({
+label: '\u{1f8c2}\ucbed\uf289\u{1ffa1}\u013b\u8049\uf38f\u589a\ua335\u{1fdcd}',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 10.030,
+lodMaxClamp: 43.851,
+maxAnisotropy: 7,
+});
+try {
+renderBundleEncoder30.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder20.draw(16, 48, 80, 72);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(0, buffer6);
+} catch {}
+try {
+commandEncoder52.copyTextureToBuffer({
+  texture: texture47,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 62824 */
+offset: 62820,
+buffer: buffer16,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(querySet30, 760, 1233, buffer12, 2560);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float'],
+colorSpace: 'srgb',
+});
+} catch {}
+let pipeline97 = await device0.createComputePipelineAsync({
+label: '\u{1fdd9}\u0b22\u4773\u5ec2\uef5f\u0231\u0909\ubb15\u78b9\ucc52',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+},
+});
+try {
+renderBundleEncoder56.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder52.draw(32, 16);
+} catch {}
+try {
+renderBundleEncoder30.drawIndirect(buffer22, 556);
+} catch {}
+let commandEncoder53 = device0.createCommandEncoder({label: '\u{1fd7f}\u327a'});
+let texture72 = device0.createTexture({
+label: '\u{1fecc}\u0418\u061d\u{1fdb5}\u06c5\u{1f75e}\u7a7b\u0886\uecf3\ua140',
+size: [160],
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rg32sint', 'rg32sint'],
+});
+try {
+computePassEncoder22.dispatchWorkgroups(1, 1, 3);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(3, bindGroup15, new Uint32Array(1946), 1615, 0);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexed(8, 40, 16, 608, 16);
+} catch {}
+try {
+renderBundleEncoder52.drawIndirect(buffer22, 808);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline79);
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(buffer17, 9988, buffer10, 8040, 4);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+computePassEncoder27.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 769 */
+{offset: 753}, {width: 8, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandBuffer16 = commandEncoder53.finish({
+label: '\u04ac\u0d39',
+});
+let textureView57 = texture12.createView({label: '\u0130\uae8c\u77ba\u14f0\u962c\u0bbd\u7408\ueb56\u2c8d\u03e3\ud1ae', baseMipLevel: 7});
+try {
+renderBundleEncoder26.drawIndexed(40, 8, 24, -368, 32);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 26868);
+} catch {}
+try {
+buffer18.destroy();
+} catch {}
+let pipeline98 = await device0.createRenderPipelineAsync({
+label: '\u0d76\u31d6\u905b\u{1fcbc}',
+layout: pipelineLayout14,
+fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'src-alpha', dstFactor: 'zero'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'r8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {
+  format: 'rg11b10ufloat',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'dst-alpha', dstFactor: 'zero'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED
+}, {format: 'r8uint'}]
+},
+vertex: {
+  module: shaderModule9,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 92,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x4',
+offset: 20,
+shaderLocation: 12,
+}, {
+format: 'sint32x4',
+offset: 28,
+shaderLocation: 4,
+}, {
+format: 'unorm8x4',
+offset: 84,
+shaderLocation: 6,
+}],
+}
+]
+},
+});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+gc();
+try {
+await adapter4.requestAdapterInfo();
+} catch {}
+pseudoSubmit(device0, commandEncoder20);
+try {
+renderBundleEncoder17.drawIndexed(32, 0, 80, 512, 24);
+} catch {}
+try {
+renderBundleEncoder57.setVertexBuffer(1, buffer15, 5960);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+commandEncoder52.copyTextureToBuffer({
+  texture: texture47,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 39424 */
+offset: 39420,
+rowsPerImage: 128,
+buffer: buffer16,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(querySet45, 840, 119, buffer12, 11520);
+} catch {}
+try {
+renderBundleEncoder17.insertDebugMarker('\u74b3');
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer16,
+]);
+} catch {}
+let pipeline99 = device0.createRenderPipeline({
+label: '\u0f4a\u001d\u81a8\u12ea\u{1fa21}\u9582\u{1fc21}\u{1fe3f}\u8c46',
+layout: pipelineLayout7,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: 0}, {format: 'rg8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, undefined, {format: 'rg32float', writeMask: 0}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-src'},
+alpha: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'zero'},
+},
+  writeMask: 0
+}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3341,
+stencilWriteMask: 1457,
+depthBias: 80,
+depthBiasClamp: 96,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1316,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 564,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 840,
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 300,
+shaderLocation: 5,
+}, {
+format: 'uint32x4',
+offset: 708,
+shaderLocation: 12,
+}, {
+format: 'float32',
+offset: 128,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 1172,
+attributes: [],
+},
+{
+arrayStride: 1856,
+attributes: [],
+},
+{
+arrayStride: 1200,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint16x4',
+offset: 1080,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 156,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1132,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 752,
+shaderLocation: 14,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'back',
+},
+});
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let shaderModule25 = device0.createShaderModule({
+label: '\u9e54\u5086\u0758',
+code: `@group(1) @binding(43)
+var<storage, read_write> type11: array<u32>;
+@group(3) @binding(561)
+var<storage, read_write> type12: array<u32>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(8) a0: vec4<f16>, @location(1) a1: f32, @location(3) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(5) f115: vec3<i32>,
+  @location(9) f116: vec4<i32>,
+  @location(11) f117: vec4<f32>,
+  @location(4) f118: vec2<u32>,
+  @location(0) f119: vec2<u32>,
+  @location(8) f120: vec4<f16>,
+  @builtin(position) f121: vec4<f32>,
+  @location(12) f122: vec2<f16>,
+  @location(14) f123: vec3<f32>,
+  @location(1) f124: f32,
+  @location(6) f125: f32,
+  @location(2) f126: vec4<f32>,
+  @location(15) f127: vec4<i32>,
+  @location(10) f128: vec3<u32>,
+  @location(3) f129: u32
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroup29 = device0.createBindGroup({
+layout: bindGroupLayout1,
+entries: [{
+binding: 257,
+resource: externalTexture2
+}, {
+binding: 43,
+resource: externalTexture2
+}],
+});
+let commandEncoder54 = device0.createCommandEncoder({label: '\u0c9b\u2efa\uc1cc\u{1f77e}\u7539\u{1ff63}\u{1f642}\u0f84\u{1fd10}'});
+let textureView58 = texture65.createView({
+  label: '\u6aca\u90b8\u{1f6c6}\u00d9\u9cd0\u6b44\ufb25\u{1f98e}',
+  dimension: '2d-array',
+  baseMipLevel: 0,
+  mipLevelCount: 1
+});
+let renderBundleEncoder58 = device0.createRenderBundleEncoder({
+  label: '\u{1fd49}\uba14\ua262\u6b8b',
+  colorFormats: ['rg16uint', 'rg32float', 'r16uint', 'rg16sint'],
+  depthReadOnly: true
+});
+try {
+computePassEncoder40.dispatchWorkgroupsIndirect(buffer22, 980);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 7324, new DataView(new ArrayBuffer(22664)), 17644);
+} catch {}
+let pipeline100 = device0.createRenderPipeline({
+label: '\u2f67\u0a6b\u3842\ubf4d\u094a\u05be\u18ed',
+layout: pipelineLayout0,
+fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint'}, {format: 'rg8sint'}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALPHA}, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALL}]
+},
+vertex: {
+  module: shaderModule8,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 184,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 66,
+shaderLocation: 9,
+}, {
+format: 'float32x3',
+offset: 8,
+shaderLocation: 0,
+}, {
+format: 'float16x4',
+offset: 100,
+shaderLocation: 10,
+}, {
+format: 'unorm8x4',
+offset: 128,
+shaderLocation: 12,
+}, {
+format: 'sint32',
+offset: 8,
+shaderLocation: 5,
+}, {
+format: 'sint32x2',
+offset: 108,
+shaderLocation: 3,
+}, {
+format: 'float32x2',
+offset: 172,
+shaderLocation: 8,
+}, {
+format: 'float32',
+offset: 44,
+shaderLocation: 6,
+}, {
+format: 'float32x4',
+offset: 116,
+shaderLocation: 4,
+}, {
+format: 'snorm8x2',
+offset: 24,
+shaderLocation: 13,
+}, {
+format: 'uint32x4',
+offset: 140,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 0,
+attributes: [{
+format: 'float16x2',
+offset: 708,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 960,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1224,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x3',
+offset: 620,
+shaderLocation: 15,
+}, {
+format: 'uint8x2',
+offset: 186,
+shaderLocation: 11,
+}, {
+format: 'sint16x2',
+offset: 760,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 252,
+attributes: [],
+},
+{
+arrayStride: 1052,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x2',
+offset: 276,
+shaderLocation: 14,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let imageBitmap13 = await createImageBitmap(videoFrame14);
+let textureView59 = texture8.createView({
+  label: '\u0322\u04fe\uf239\u0943\u36e9\u6304\u0c15\ue50f\u67dc\u826a\u6b6a',
+  baseMipLevel: 1,
+  mipLevelCount: 6
+});
+try {
+renderBundleEncoder26.draw(40);
+} catch {}
+try {
+renderBundleEncoder53.setPipeline(pipeline58);
+} catch {}
+try {
+commandEncoder54.copyBufferToBuffer(buffer12, 22292, buffer1, 50064, 684);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(querySet42, 81, 119, buffer12, 35840);
+} catch {}
+let promise37 = adapter0.requestAdapterInfo();
+try {
+offscreenCanvas14.getContext('webgl');
+} catch {}
+let commandEncoder55 = device0.createCommandEncoder({label: '\u2366\uab34\u4978\u010b'});
+let renderBundleEncoder59 = device0.createRenderBundleEncoder({
+  label: '\u062a\uea4e',
+  colorFormats: [undefined, 'r32float', 'rgba16sint', 'r16float', 'rgb10a2uint', 'rg16uint', 'r32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler48 = device0.createSampler({
+label: '\ud44c\u6201\ua9ec\uc00e\ud460\u0521',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 64.904,
+lodMaxClamp: 92.838,
+compare: 'equal',
+});
+try {
+renderBundleEncoder51.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(16, 56, 56, 640, 8);
+} catch {}
+try {
+renderBundleEncoder59.setVertexBuffer(6, buffer0, 26828, 8658);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 4856, new DataView(new ArrayBuffer(3686)), 1069, 932);
+} catch {}
+let promise38 = navigator.gpu.requestAdapter();
+let buffer24 = device0.createBuffer({
+  label: '\uca4d\u879b\u66c0\u{1fbe6}\u036c\u{1fe62}\u3e65\u9c4f',
+  size: 25384,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX
+});
+let texture73 = device0.createTexture({
+label: '\u2a6d\u09c2',
+size: {width: 320, height: 2, depthOrArrayLayers: 239},
+dimension: '3d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgb10a2uint', 'rgb10a2uint'],
+});
+let renderBundle68 = renderBundleEncoder38.finish({label: '\u9ccd\u023c\u9ed3\u2d1c\u7ad7\u{1fab3}\u07c3\u07a3\u5d97\u035e'});
+try {
+renderBundleEncoder45.setVertexBuffer(5, buffer15, 3968, 841);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(buffer23, 10144, buffer10, 4812, 2652);
+dissociateBuffer(device0, buffer23);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture62,
+  mipLevel: 3,
+  origin: { x: 24, y: 0, z: 0 },
+  aspect: 'all',
+}, new BigInt64Array(new ArrayBuffer(24)), /* required buffer size: 1028 */
+{offset: 692}, {width: 252, height: 12, depthOrArrayLayers: 1});
+} catch {}
+let pipeline101 = device0.createRenderPipeline({
+label: '\u07e0\u0cd1\u{1f6f1}\u01ad\u{1ffc4}\u0ba8\ua552\uf5a9\u8ee7',
+layout: pipelineLayout6,
+multisample: {
+count: 4,
+mask: 0x9bd729b0,
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint', writeMask: 0}, {format: 'rg8sint', writeMask: GPUColorWrite.GREEN}, undefined, {format: 'rg32float', writeMask: 0}, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 1933,
+stencilWriteMask: 4014,
+depthBias: 25,
+depthBiasSlopeScale: 24,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 224,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 192,
+shaderLocation: 8,
+}, {
+format: 'uint32x2',
+offset: 92,
+shaderLocation: 12,
+}, {
+format: 'snorm8x2',
+offset: 96,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 692,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 820,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x4',
+offset: 748,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 1570,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 1584,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1784,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1860,
+attributes: [{
+format: 'sint8x4',
+offset: 948,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let computePassEncoder51 = commandEncoder54.beginComputePass({label: '\u1dff\ub97a\u0f20\u1534\uaf8a\u22d4'});
+let renderBundleEncoder60 = device0.createRenderBundleEncoder({
+  label: '\uc982\u11b0\u{1f82f}\u22fd\u1dde',
+  colorFormats: ['rg8sint', 'rgba32sint'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder51.setBindGroup(3, bindGroup10, new Uint32Array(920), 59, 0);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder9.draw(16, 24, 24, 80);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(72, 64, 32, 328, 72);
+} catch {}
+try {
+commandEncoder55.clearBuffer(buffer10, 5516, 800);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+computePassEncoder40.dispatchWorkgroups(1, 2, 3);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+let bindGroup30 = device0.createBindGroup({
+layout: bindGroupLayout1,
+entries: [{
+binding: 43,
+resource: externalTexture2
+}, {
+binding: 257,
+resource: externalTexture1
+}],
+});
+let textureView60 = texture39.createView({baseMipLevel: 4, arrayLayerCount: 1});
+let renderBundleEncoder61 = device0.createRenderBundleEncoder({colorFormats: ['rgba16sint', 'rgba16uint'], depthStencilFormat: 'depth24plus-stencil8'});
+let renderBundle69 = renderBundleEncoder7.finish({label: '\u0711\u0c8a\u{1fbcf}\u1144\uc1e1\u{1fa56}\u0402\u{1fa18}\u{1fa39}'});
+let externalTexture3 = device0.importExternalTexture({
+label: '\u7369\u5a72\u{1f86e}\u2cc8\u82d4\u827c\u2377\u07b2',
+source: videoFrame4,
+colorSpace: 'display-p3',
+});
+try {
+computePassEncoder24.end();
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline32);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexed(48, 80, 72);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer22, 1964);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder55.copyTextureToTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 0, y: 44, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 0, y: 48, z: 0 },
+  aspect: 'all',
+}, {width: 124, height: 76, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder55.resolveQuerySet(querySet41, 271, 1225, buffer12, 768);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+}, new BigInt64Array(new ArrayBuffer(48)), /* required buffer size: 845 */
+{offset: 769, rowsPerImage: 138}, {width: 38, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: imageBitmap13,
+  origin: { x: 445, y: 189 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 7,
+  origin: { x: 1, y: 1, z: 2 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipelineLayout18 = device0.createPipelineLayout({
+  label: '\u{1f9c8}\u{1fe9b}\u7b14\u3bd8\u010d\u0cfa\u7e93\u2544\u9cfd\uf81d\u0df5',
+  bindGroupLayouts: [bindGroupLayout8, bindGroupLayout26]
+});
+let querySet57 = device0.createQuerySet({
+label: '\u0cd6\ue069\u{1ff3c}\u19e1\u{1f83e}\u39fc\u{1f671}\u4508\u066f',
+type: 'occlusion',
+count: 77,
+});
+try {
+commandEncoder22.copyBufferToBuffer(buffer0, 30188, buffer18, 6832, 1256);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+  await promise37;
+} catch {}
+let img15 = await imageWithData(166, 267, '#3cc76c3a', '#bf26e326');
+let querySet58 = device0.createQuerySet({
+label: '\uf3e5\u{1fb1b}\u03cd\u0ed7\ubefd\u82ef\u{1fe12}\ub235\u04ea\u2724',
+type: 'occlusion',
+count: 2993,
+});
+let computePassEncoder52 = commandEncoder55.beginComputePass({label: '\uc186\u1e84'});
+try {
+computePassEncoder40.dispatchWorkgroups(2, 3, 2);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(0, bindGroup30, new Uint32Array(5008), 4887, 0);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexedIndirect(buffer15, 3260);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline79);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 4856, new Float32Array(36450), 30819, 2344);
+} catch {}
+let video10 = await videoWithData();
+document.body.prepend(video1);
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageBitmap14 = await createImageBitmap(img4);
+try {
+device1.label = '\u017a\u5115\u5763\u08df\u76ee\u435f';
+} catch {}
+let commandEncoder56 = device0.createCommandEncoder({label: '\uaafe\ub20c'});
+pseudoSubmit(device0, commandEncoder51);
+let textureView61 = texture13.createView({label: '\u698a\u{1feb6}\u7a74\ub00d\u0c15\uf5c7', dimension: '2d-array', baseMipLevel: 3});
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline53);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexed(48, 16, 40);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexedIndirect(buffer15, 4440);
+} catch {}
+try {
+commandEncoder56.resolveQuerySet(querySet27, 412, 151, buffer12, 27392);
+} catch {}
+let pipeline102 = device0.createComputePipeline({
+layout: 'auto',
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let video11 = await videoWithData();
+video2.width = 247;
+let bindGroup31 = device0.createBindGroup({
+label: '\u{1fc05}\u0209\u6160\u06d9\u8897\u{1fa2e}\ua35c\u0935\u{1fc42}\u{1f864}',
+layout: bindGroupLayout10,
+entries: [{
+binding: 20,
+resource: externalTexture1
+}],
+});
+let querySet59 = device0.createQuerySet({
+label: '\u{1fc19}\u{1fbc7}\u90af\u06fb\ue6d5\u0cd8',
+type: 'occlusion',
+count: 2898,
+});
+let textureView62 = texture71.createView({
+  label: '\u8931\u00eb\ua061\u0622\u{1fa02}\u394d\u0f08\u047e\u5b2d',
+  dimension: '2d-array',
+  format: 'etc2-rgb8a1unorm-srgb',
+  baseMipLevel: 2
+});
+try {
+computePassEncoder51.end();
+} catch {}
+try {
+renderBundleEncoder52.setPipeline(pipeline98);
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(buffer2, 328, buffer8, 9988, 848);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float'],
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 17836, new Float32Array(35690), 10913, 324);
+} catch {}
+let pipeline103 = await promise19;
+let pipeline104 = await device0.createRenderPipelineAsync({
+label: '\ud2f9\u01f3\ua51c\udf82\u05b0\u{1fb6e}\u0400\u{1f6e7}',
+layout: pipelineLayout5,
+multisample: {
+mask: 0x1c07fb51,
+},
+fragment: {
+  module: shaderModule17,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg16float', writeMask: 0}, undefined, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'dst'},
+alpha: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'one-minus-dst-alpha'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'replace',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilWriteMask: 2959,
+depthBiasSlopeScale: 5,
+},
+vertex: {
+  module: shaderModule17,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 452,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x4',
+offset: 208,
+shaderLocation: 7,
+}, {
+format: 'sint32',
+offset: 236,
+shaderLocation: 1,
+}, {
+format: 'sint32',
+offset: 136,
+shaderLocation: 6,
+}, {
+format: 'float32x3',
+offset: 88,
+shaderLocation: 10,
+}, {
+format: 'uint32x3',
+offset: 48,
+shaderLocation: 5,
+}, {
+format: 'uint32',
+offset: 60,
+shaderLocation: 9,
+}, {
+format: 'snorm16x4',
+offset: 156,
+shaderLocation: 0,
+}, {
+format: 'snorm16x2',
+offset: 4,
+shaderLocation: 15,
+}, {
+format: 'sint32',
+offset: 68,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x2',
+offset: 1382,
+shaderLocation: 2,
+}, {
+format: 'snorm8x2',
+offset: 1930,
+shaderLocation: 8,
+}, {
+format: 'uint32x3',
+offset: 1204,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 1844,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 816,
+shaderLocation: 12,
+}, {
+format: 'float16x2',
+offset: 896,
+shaderLocation: 13,
+}],
+}
+]
+},
+});
+document.body.prepend(video1);
+gc();
+let canvas22 = document.createElement('canvas');
+try {
+canvas22.getContext('2d');
+} catch {}
+canvas16.width = 108;
+let computePassEncoder53 = commandEncoder22.beginComputePass({});
+try {
+renderBundleEncoder30.drawIndexed(56, 32, 64);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(3, buffer6, 33560, 2184);
+} catch {}
+try {
+commandEncoder33.clearBuffer(buffer14);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: { x: 51, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer11, /* required buffer size: 159 */
+{offset: 159, rowsPerImage: 60}, {width: 41, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let device2 = await promise4;
+let imageBitmap15 = await createImageBitmap(offscreenCanvas0);
+document.body.prepend(video5);
+try {
+videoFrame9.close();
+} catch {}
+try {
+await adapter4.requestAdapterInfo();
+} catch {}
+let img16 = await imageWithData(160, 224, '#3236082d', '#9f68f256');
+pseudoSubmit(device0, commandEncoder55);
+try {
+renderBundleEncoder36.drawIndirect(buffer12, 28512);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(2, buffer0, 36016, 461);
+} catch {}
+try {
+commandEncoder56.resolveQuerySet(querySet11, 158, 48, buffer12, 16384);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 2,
+  origin: { x: 6, y: 0, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 178 */
+{offset: 178, bytesPerRow: 95}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let sampler49 = device0.createSampler({
+label: '\u{1f7f0}\u792c\u0f14\u{1fcd8}\u09e1\ucb0c\u78d9',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 98.972,
+lodMaxClamp: 99.762,
+});
+try {
+renderBundleEncoder52.draw(64, 80, 80, 32);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexed(80, 32, 64, 112, 80);
+} catch {}
+try {
+renderBundleEncoder53.drawIndirect(buffer22, 372);
+} catch {}
+try {
+commandEncoder52.clearBuffer(buffer16, 7616, 6264);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 7532, new BigUint64Array(29671), 23879, 368);
+} catch {}
+let videoFrame16 = videoFrame10.clone();
+gc();
+let renderBundleEncoder62 = device0.createRenderBundleEncoder({label: '\u{1f84c}\u1f1a', colorFormats: ['rg8uint', 'r16uint', 'rgba16uint', 'rgba16sint']});
+try {
+renderBundleEncoder26.drawIndexed(64, 72);
+} catch {}
+try {
+renderBundleEncoder51.setVertexBuffer(2, buffer15);
+} catch {}
+try {
+commandEncoder56.clearBuffer(buffer1, 32072, 984);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+computePassEncoder33.insertDebugMarker('\u53d9');
+} catch {}
+let pipeline105 = await promise31;
+let imageBitmap16 = await createImageBitmap(imageBitmap7);
+let videoFrame17 = new VideoFrame(img11, {timestamp: 0});
+let querySet60 = device2.createQuerySet({
+label: '\ubfe6\u6ed8\u05c7\u56f6\u0768\uf8a7\u040c\u0fe6\uf10d',
+type: 'occlusion',
+count: 4036,
+});
+let texture74 = device2.createTexture({
+label: '\ue496\u5295\ufbe3',
+size: [540, 1, 201],
+mipLevelCount: 10,
+dimension: '3d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba16sint', 'rgba16sint'],
+});
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+try {
+commandEncoder56.copyTextureToTexture({
+  texture: texture72,
+  mipLevel: 0,
+  origin: { x: 13, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline106 = await device0.createComputePipelineAsync({
+label: '\u2359\u{1f6ac}\ub58f',
+layout: 'auto',
+compute: {
+module: shaderModule23,
+entryPoint: 'compute0',
+},
+});
+let imageBitmap17 = await createImageBitmap(offscreenCanvas2);
+let buffer25 = device2.createBuffer({size: 63523, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let querySet61 = device2.createQuerySet({
+label: '\u6385\u{1f852}\u{1f688}\ub0b7\u8089\u0d1e\u3cd7',
+type: 'occlusion',
+count: 1351,
+});
+let textureView63 = texture74.createView({label: '\u6a6e\u0c24\ua937\ub0b7\uf8ba\u{1fc7e}\u{1fcc8}\u3e4a\ud606\u036c\u9783', mipLevelCount: 1});
+let commandEncoder57 = device0.createCommandEncoder({label: '\u{1fb5b}\u{1f730}\u00fd\u0354\u6431'});
+let querySet62 = device0.createQuerySet({
+label: '\u{1f9ba}\uc53e\uaa2a\u{1fa0b}\u16d4\u59cc\ub7d0',
+type: 'occlusion',
+count: 313,
+});
+try {
+computePassEncoder41.setPipeline(pipeline23);
+} catch {}
+try {
+commandEncoder54.copyBufferToBuffer(buffer3, 9908, buffer11, 13928, 37412);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(querySet6, 82, 26, buffer12, 37376);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb', 'bgra8unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+adapter4.label = '\u000e\u{1fdf3}\u{1f662}\uf2ed\u{1fc07}\u0856\u0550\uee7b';
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let bindGroupLayout35 = device0.createBindGroupLayout({
+label: '\u9916\u{1f959}\u072a\ua94d\u{1fd5f}',
+entries: [],
+});
+let renderBundle70 = renderBundleEncoder59.finish({label: '\u0a2e\u0f56\u{1f7f0}\u0a85\u{1f9d7}\u194f'});
+try {
+renderBundleEncoder20.drawIndexedIndirect(buffer22, 1620);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer15, 6200);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder33.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture11,
+  mipLevel: 3,
+  origin: { x: 60, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder2.insertDebugMarker('\u{1f605}');
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img13);
+let video12 = await videoWithData();
+let commandEncoder58 = device2.createCommandEncoder({});
+let computePassEncoder54 = commandEncoder58.beginComputePass();
+let commandEncoder59 = device0.createCommandEncoder({label: '\u{1fab8}\uf6a7\u0178\u{1fd2a}\u3cd0\u07eb\u06a6'});
+let renderBundleEncoder63 = device0.createRenderBundleEncoder({
+  label: '\u9131\ud895\u0fab\u4cf4\u4f5d',
+  colorFormats: ['rg8uint', 'r16uint', 'rgba16uint', 'rgba16sint'],
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder44.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+computePassEncoder39.setBindGroup(0, bindGroup10, new Uint32Array(6117), 2135, 0);
+} catch {}
+try {
+renderBundleEncoder62.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder53.draw(8, 40, 64, 56);
+} catch {}
+let promise39 = device0.queue.onSubmittedWorkDone();
+let pipeline107 = await device0.createRenderPipelineAsync({
+label: '\u{1fc36}\ubdce\u082b\u{1fe6a}\u5af1',
+layout: pipelineLayout4,
+fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rg16float', writeMask: GPUColorWrite.GREEN}, undefined, {format: 'rg16float', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'keep',
+depthFailOp: 'invert',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+failOp: 'increment-wrap',
+depthFailOp: 'increment-wrap',
+},
+depthBiasSlopeScale: 83,
+depthBiasClamp: 44,
+},
+vertex: {
+  module: shaderModule16,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 920,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 152,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 1580,
+attributes: [],
+},
+{
+arrayStride: 1032,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x3',
+offset: 48,
+shaderLocation: 14,
+}],
+}
+]
+},
+});
+video4.height = 80;
+let renderBundle71 = renderBundleEncoder41.finish({label: '\u{1f903}\u09e1\u3f6e\u052c\ua5c9\u{1fcdc}\u{1f8e3}\u{1ff6f}\u9f3a\u5f9f\u1b52'});
+let sampler50 = device0.createSampler({
+addressModeU: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 6.889,
+lodMaxClamp: 54.349,
+});
+try {
+renderBundleEncoder60.setBindGroup(2, bindGroup12, new Uint32Array(1128), 742, 0);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexedIndirect(buffer22, 1560);
+} catch {}
+try {
+renderBundleEncoder53.drawIndirect(buffer12, 1216);
+} catch {}
+try {
+renderBundleEncoder62.setPipeline(pipeline71);
+} catch {}
+let promise40 = device0.popErrorScope();
+try {
+commandEncoder57.copyBufferToBuffer(buffer3, 23180, buffer18, 5632, 648);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder54.copyTextureToTexture({
+  texture: texture68,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'depth-only',
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: { x: 173, y: 5, z: 0 },
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder54.resolveQuerySet(querySet5, 1151, 19, buffer12, 24576);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 1, depthOrArrayLayers: 251}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 25, y: 35 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 1,
+  origin: { x: 63, y: 0, z: 153 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline108 = await device0.createRenderPipelineAsync({
+label: '\ucef4\u3e35\ua5c2\u{1ffc8}\u01e3\u{1f6a0}',
+layout: pipelineLayout16,
+fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint', writeMask: 0}, {format: 'rg8sint'}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALPHA}, {format: 'bgra8unorm'}]
+},
+vertex: {
+  module: shaderModule8,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 444,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 200,
+shaderLocation: 5,
+}, {
+format: 'uint32',
+offset: 288,
+shaderLocation: 11,
+}, {
+format: 'sint16x2',
+offset: 72,
+shaderLocation: 3,
+}, {
+format: 'unorm8x4',
+offset: 28,
+shaderLocation: 14,
+}, {
+format: 'snorm16x4',
+offset: 164,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 1188,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 640,
+shaderLocation: 4,
+}, {
+format: 'unorm16x2',
+offset: 412,
+shaderLocation: 6,
+}, {
+format: 'sint16x4',
+offset: 932,
+shaderLocation: 1,
+}, {
+format: 'unorm10-10-10-2',
+offset: 1056,
+shaderLocation: 7,
+}, {
+format: 'float32x2',
+offset: 1016,
+shaderLocation: 9,
+}, {
+format: 'uint16x2',
+offset: 588,
+shaderLocation: 2,
+}, {
+format: 'uint32x2',
+offset: 312,
+shaderLocation: 15,
+}, {
+format: 'unorm16x2',
+offset: 680,
+shaderLocation: 10,
+}, {
+format: 'unorm16x2',
+offset: 824,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 724,
+attributes: [{
+format: 'float32x2',
+offset: 592,
+shaderLocation: 8,
+}, {
+format: 'float32x2',
+offset: 628,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let querySet63 = device0.createQuerySet({
+label: '\u09dc\u6256\u0100',
+type: 'occlusion',
+count: 2615,
+});
+let computePassEncoder55 = commandEncoder57.beginComputePass();
+try {
+renderBundleEncoder36.setVertexBuffer(6, buffer15, 5124, 144);
+} catch {}
+try {
+commandEncoder52.clearBuffer(buffer9, 5892);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+computePassEncoder48.insertDebugMarker('\u8541');
+} catch {}
+let promise41 = device0.createComputePipelineAsync({
+label: '\u731d\u374c\u051d\u7527\u{1f8a3}\u6c08\u0d96',
+layout: pipelineLayout13,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+},
+});
+let imageBitmap18 = await createImageBitmap(videoFrame11);
+gc();
+let promise42 = navigator.gpu.requestAdapter({
+});
+let img17 = await imageWithData(204, 40, '#0f12ee16', '#497a0a65');
+pseudoSubmit(device2, commandEncoder58);
+try {
+await device2.popErrorScope();
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55) };
+} catch {}
+try {
+device1.label = '\u5184\u0705\u9e72\ubbd1\u{1f732}\u257c\u{1f72c}\u01ae\ucd4e\u2e98';
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let imageBitmap19 = await createImageBitmap(canvas13);
+let videoFrame18 = new VideoFrame(offscreenCanvas3, {timestamp: 0});
+let img18 = await imageWithData(146, 280, '#5c65218e', '#8fc88cf9');
+let imageData9 = new ImageData(192, 168);
+let commandEncoder60 = device2.createCommandEncoder();
+let renderBundleEncoder64 = device2.createRenderBundleEncoder({colorFormats: ['r8unorm', undefined], depthStencilFormat: 'depth24plus-stencil8', depthReadOnly: true});
+video3.height = 128;
+let imageBitmap20 = await createImageBitmap(offscreenCanvas2);
+let adapter5 = await promise38;
+let renderBundleEncoder65 = device2.createRenderBundleEncoder({
+  label: '\u0ba3\u7f62',
+  colorFormats: ['r8unorm', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true
+});
+try {
+computePassEncoder22.dispatchWorkgroups(2);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+commandEncoder54.resolveQuerySet(querySet11, 100, 103, buffer12, 7168);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 36964, new DataView(new ArrayBuffer(48144)), 527, 16728);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let imageBitmap21 = await createImageBitmap(videoFrame10);
+let buffer26 = device2.createBuffer({size: 9723, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let commandEncoder61 = device2.createCommandEncoder({label: '\u09fa\u15f6\u0172\u1716'});
+pseudoSubmit(device2, commandEncoder61);
+let textureView64 = texture74.createView({aspect: 'all', baseMipLevel: 1, mipLevelCount: 1});
+let computePassEncoder56 = commandEncoder60.beginComputePass({label: '\u39ac\u4ebf\u8e72\u0b9f\ub3a7\u9a58\u4541\u{1fbca}\ucfd0'});
+try {
+computePassEncoder56.insertDebugMarker('\u{1f677}');
+} catch {}
+let sampler51 = device0.createSampler({
+label: '\u05e5\u08b0\uad75\u00d7\u06c8\u{1ff3a}\uf6a5\u006b\u022b',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 39.358,
+lodMaxClamp: 64.078,
+});
+try {
+renderBundleEncoder62.draw(8, 24, 8, 64);
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(buffer24, 15596, buffer1, 50372, 6000);
+dissociateBuffer(device0, buffer24);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder56.copyTextureToTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: { x: 118, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 19, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 35, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(querySet11, 174, 36, buffer12, 25344);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 9420, new Int16Array(10684), 1650, 2340);
+} catch {}
+gc();
+let texture75 = device2.createTexture({
+label: '\u0cf3\uec0e\u0998\u4501',
+size: [420],
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder66 = device2.createRenderBundleEncoder({
+  colorFormats: ['r8unorm', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder64.setVertexBuffer(6, buffer26, 4480, 4780);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let querySet64 = device2.createQuerySet({
+label: '\u09c6\u462b\u0ea5\u2d83\u6574\u{1fad2}',
+type: 'occlusion',
+count: 1070,
+});
+pseudoSubmit(device2, commandEncoder60);
+try {
+renderBundleEncoder65.insertDebugMarker('\u{1f89f}');
+} catch {}
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+let video13 = await videoWithData();
+canvas10.width = 701;
+let bindGroupLayout36 = device2.createBindGroupLayout({
+label: '\u{1fab4}\u6d18\u5273',
+entries: [{
+binding: 241,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '2d-array' },
+}],
+});
+let pipelineLayout19 = device2.createPipelineLayout({bindGroupLayouts: [bindGroupLayout36, bindGroupLayout36, bindGroupLayout36]});
+let renderBundle72 = renderBundleEncoder64.finish();
+try {
+device2.queue.writeBuffer(buffer25, 1920, new DataView(new ArrayBuffer(41803)), 9272, 19708);
+} catch {}
+let promise43 = device2.queue.onSubmittedWorkDone();
+canvas5.width = 928;
+let commandEncoder62 = device2.createCommandEncoder({});
+let renderBundleEncoder67 = device2.createRenderBundleEncoder({
+  label: '\u0a82\u5646\u05a1',
+  colorFormats: ['r8unorm', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true
+});
+let video14 = await videoWithData();
+let bindGroupLayout37 = device2.createBindGroupLayout({
+label: '\uaa8a\u6eb6\u8bd5\u0339\uaa64\u0b07',
+entries: [{
+binding: 385,
+visibility: 0,
+sampler: { type: 'filtering' },
+}, {
+binding: 771,
+visibility: 0,
+externalTexture: {},
+}],
+});
+let querySet65 = device2.createQuerySet({
+label: '\u08da\u0572\u130e\u{1fa22}\u7973\ua558\u{1febd}\u{1f93a}\u{1fef5}\u741f\u0385',
+type: 'occlusion',
+count: 2133,
+});
+let renderBundle73 = renderBundleEncoder67.finish({label: '\u{1f8f0}\u33ea\u8c08'});
+let sampler52 = device2.createSampler({
+label: '\u629b\u0c63\u091f\u94aa\u09a3\u46d6\uc946\ue2fb\ub35e',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+minFilter: 'nearest',
+lodMaxClamp: 91.509,
+});
+let buffer27 = device2.createBuffer({
+  label: '\u{1fbad}\u80c6\u99f0\uee0e\u00f6\ub55a',
+  size: 29043,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let commandEncoder63 = device2.createCommandEncoder({label: '\u{1fbe7}\u07b3\u716a\u{1f67a}\u84ed\ueb54'});
+try {
+renderBundleEncoder65.setVertexBuffer(3, buffer26);
+} catch {}
+try {
+device2.pushErrorScope('internal');
+} catch {}
+try {
+gpuCanvasContext13.configure({
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg32float', 'rgba32sint', 'bgra8unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let canvas23 = document.createElement('canvas');
+let buffer28 = device0.createBuffer({
+  label: '\u9919\u705e\u0183\ua48d\u54ba',
+  size: 5688,
+  usage: GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true
+});
+let commandBuffer17 = commandEncoder56.finish({
+label: '\ud7ce\u{1f81a}\u6a85\u{1f87e}\u0afe\u0a44\u9852\ubb63\u{1f7c7}\ub0a3',
+});
+let computePassEncoder57 = commandEncoder33.beginComputePass({label: '\u{1fd68}\u1c3e\uee0a\u9b39\u0a8c\u062f\u{1ff3c}\u{1f90a}\ua8c1\uc0de'});
+let renderBundleEncoder68 = device0.createRenderBundleEncoder({
+  label: '\u06fb\ub73a\u{1ffa9}\u63ac\uf0d6\u{1fc64}',
+  colorFormats: ['bgra8unorm-srgb', 'rgba16uint', 'r8uint', 'rg11b10ufloat', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle74 = renderBundleEncoder32.finish({});
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 1,
+  origin: { x: 5, y: 7, z: 63 },
+  aspect: 'all',
+}, {
+  texture: texture20,
+  mipLevel: 2,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+}, {width: 7, height: 7, depthOrArrayLayers: 23});
+} catch {}
+try {
+commandEncoder54.clearBuffer(buffer14);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 2972, new Float32Array(65225), 63709, 696);
+} catch {}
+let promise44 = device0.createRenderPipelineAsync({
+label: '\uc0e9\ub67f\u0b06',
+layout: pipelineLayout1,
+fragment: {
+  module: shaderModule22,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'never',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+depthFailOp: 'decrement-clamp',
+passOp: 'invert',
+},
+stencilReadMask: 3153,
+stencilWriteMask: 3822,
+depthBiasClamp: 92,
+},
+vertex: {
+  module: shaderModule22,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1632,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 1624,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 1348,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 496,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 240,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1144,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 308,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 168,
+shaderLocation: 2,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'back',
+},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.prepend(img2);
+try {
+renderBundleEncoder65.setVertexBuffer(3, buffer26, 576, 6134);
+} catch {}
+try {
+commandEncoder62.copyBufferToBuffer(buffer26, 7908, buffer25, 20064, 1084);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer25, 33612, new BigUint64Array(63757), 22840, 2464);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let computePassEncoder58 = commandEncoder62.beginComputePass({label: '\u{1fe45}\u485b\u02a1'});
+let renderBundleEncoder69 = device2.createRenderBundleEncoder({colorFormats: ['r8unorm', undefined], depthStencilFormat: 'depth24plus-stencil8', depthReadOnly: true});
+try {
+commandEncoder63.copyBufferToBuffer(buffer26, 9376, buffer27, 5036, 12);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer27);
+} catch {}
+let gpuCanvasContext16 = canvas23.getContext('webgpu');
+let commandBuffer18 = commandEncoder59.finish({
+label: '\ub9f2\ud1a8\u1ae3\u{1f860}\u9ea6\ue5e9',
+});
+let texture76 = device0.createTexture({
+label: '\uafff\u{1f6bf}\u052a\u{1f795}\u0e2f\u795c\u0b9a\u4333\u4193\u{1f901}',
+size: {width: 60, height: 60, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-5x5-unorm', 'astc-5x5-unorm', 'astc-5x5-unorm-srgb'],
+});
+let textureView65 = texture14.createView({label: '\u44a6\uf392\u033f\u1560\u00da\ueb28\uf0d7', mipLevelCount: 5});
+let computePassEncoder59 = commandEncoder54.beginComputePass();
+try {
+renderBundleEncoder20.drawIndirect(buffer22, 568);
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+gc();
+let imageData10 = new ImageData(80, 60);
+let imageData11 = new ImageData(188, 176);
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder64 = device0.createCommandEncoder();
+try {
+computePassEncoder40.setBindGroup(0, bindGroup4, new Uint32Array(608), 243, 0);
+} catch {}
+try {
+computePassEncoder40.dispatchWorkgroupsIndirect(buffer22, 284);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer12, 17572);
+} catch {}
+try {
+renderBundleEncoder53.drawIndirect(buffer22, 1300);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer4, 'uint32', 1080, 839);
+} catch {}
+try {
+commandEncoder64.resolveQuerySet(querySet27, 946, 113, buffer12, 14080);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 200, y: 8, z: 0 },
+  aspect: 'all',
+}, arrayBuffer11, /* required buffer size: 13674 */
+{offset: 74, bytesPerRow: 1712, rowsPerImage: 108}, {width: 808, height: 64, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder65 = device2.createCommandEncoder({label: '\u1d4c\u9094\u{1f8a6}\uf521\u4ebf\u{1fa43}\u{1fb79}\u0f29\u5575\u{1fed5}\ue3ba'});
+let textureView66 = texture74.createView({label: '\uec0d\u0a0e', baseMipLevel: 6, mipLevelCount: 1});
+try {
+renderBundleEncoder65.setVertexBuffer(3, buffer26, 1716, 5660);
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer26, 988, buffer25, 25664, 4936);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['stencil8', 'bgra8unorm', 'bgra8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let texture77 = device0.createTexture({
+label: '\ubd19\u426c\u07b0\u{1fb58}\u{1fef1}\u4746\ufbd2\u{1f617}\ud3d5',
+size: [128, 180, 1],
+mipLevelCount: 4,
+format: 'etc2-rgb8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['etc2-rgb8unorm', 'etc2-rgb8unorm-srgb'],
+});
+let computePassEncoder60 = commandEncoder52.beginComputePass({});
+let renderBundleEncoder70 = device0.createRenderBundleEncoder({
+  label: '\ue94c\uf64b\u0abb\u5677',
+  colorFormats: [undefined, 'r16uint', 'rg32uint', 'rg16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+try {
+computePassEncoder36.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+commandEncoder64.copyTextureToTexture({
+  texture: texture39,
+  mipLevel: 4,
+  origin: { x: 10, y: 6, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture39,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder64.resolveQuerySet(querySet12, 2738, 390, buffer12, 13568);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 15308, new DataView(new ArrayBuffer(21924)), 9752, 140);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video13,
+  origin: { x: 7, y: 15 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas15 = new OffscreenCanvas(364, 221);
+try {
+offscreenCanvas15.getContext('webgl');
+} catch {}
+let querySet66 = device2.createQuerySet({
+type: 'occlusion',
+count: 422,
+});
+try {
+commandEncoder65.clearBuffer(buffer25, 32352, 27860);
+dissociateBuffer(device2, buffer25);
+} catch {}
+document.body.prepend(img7);
+canvas0.width = 970;
+try {
+commandBuffer12.label = '\u0bfe\u3aa2\u{1f8ab}\ua49a\u{1f826}\ua1cb\u{1fc45}\u9ce5\u66b8';
+} catch {}
+let buffer29 = device0.createBuffer({
+  label: '\u05d4\u093a\u{1f829}\u1bd9\u{1fc61}\u0e0a\u3022\u37ab\u49df\uf1bd\u72df',
+  size: 34968,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true
+});
+try {
+computePassEncoder55.end();
+} catch {}
+try {
+computePassEncoder31.setPipeline(pipeline40);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(7, buffer0, 29156, 1200);
+} catch {}
+try {
+commandEncoder64.copyTextureToTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: { x: 5, y: 0, z: 1 },
+  aspect: 'depth-only',
+}, {
+  texture: texture68,
+  mipLevel: 4,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture78 = device2.createTexture({
+size: [1680, 1, 1],
+mipLevelCount: 5,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['depth32float', 'depth32float'],
+});
+let sampler53 = device2.createSampler({
+label: '\u{1fe39}\u{1f875}\uba19\u088b\u{1f6a7}\u63a3\u907b\u95f4\u4b2e\uef02\u78f9',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 70.080,
+});
+try {
+commandEncoder63.copyBufferToBuffer(buffer26, 2248, buffer27, 22360, 2944);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let offscreenCanvas16 = new OffscreenCanvas(230, 559);
+try {
+offscreenCanvas16.getContext('webgl2');
+} catch {}
+let querySet67 = device0.createQuerySet({
+label: '\u873d\uc99d\u{1fcac}\u0b8a\u388e\ue435\u0c02\u0b92\u6664\u{1fe7a}',
+type: 'occlusion',
+count: 1390,
+});
+let textureView67 = texture66.createView({label: '\u40fd\ue740\ub2a7\u6eaf\u9ed2\ua8b9'});
+let renderBundle75 = renderBundleEncoder25.finish();
+let sampler54 = device0.createSampler({
+label: '\ub4c8\u0219\u5849\u7f3d\u4eec\u71ff\u0774',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 71.704,
+lodMaxClamp: 89.171,
+maxAnisotropy: 12,
+});
+try {
+computePassEncoder33.dispatchWorkgroups(3, 4, 4);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(7, buffer6);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer17,
+]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: imageBitmap11,
+  origin: { x: 74, y: 108 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 7,
+  origin: { x: 1, y: 1, z: 2 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline109 = await promise44;
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55) };
+} catch {}
+let buffer30 = device2.createBuffer({label: '\uc700\u10cf', size: 15940, usage: GPUBufferUsage.COPY_DST, mappedAtCreation: true});
+let texture79 = device2.createTexture({
+label: '\u8054\u0860\uc791\u0115\u02d6\u5974\u{1f7f4}',
+size: [48, 7, 100],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba32float', 'rgba32float'],
+});
+let sampler55 = device2.createSampler({
+label: '\ua406\u0334\uf621\ub5c4\u247f\u723f',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 96.780,
+lodMaxClamp: 98.474,
+});
+try {
+renderBundleEncoder65.setVertexBuffer(0, buffer26, 2556, 4534);
+} catch {}
+let offscreenCanvas17 = new OffscreenCanvas(551, 942);
+let imageBitmap22 = await createImageBitmap(canvas11);
+let texture80 = device2.createTexture({
+size: {width: 840, height: 1, depthOrArrayLayers: 63},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba16sint', 'rgba16sint', 'rgba16sint'],
+});
+let renderBundleEncoder71 = device2.createRenderBundleEncoder({
+  label: '\u67ac\u7b1a\u98ac\u19a1\u0123\ueddf\u{1fad7}\u0eff',
+  colorFormats: ['r8unorm', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true
+});
+let renderBundle76 = renderBundleEncoder65.finish({label: '\u8439\u5af5\u9aa3\u06e7\uf34a\u90fa'});
+try {
+renderBundleEncoder66.setVertexBuffer(0, buffer26);
+} catch {}
+let promise45 = buffer27.mapAsync(GPUMapMode.READ, 0, 13180);
+try {
+commandEncoder65.copyBufferToBuffer(buffer26, 5628, buffer30, 388, 592);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 3, height: 1, depthOrArrayLayers: 6}
+*/
+{
+  source: canvas5,
+  origin: { x: 204, y: 276 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 4,
+  origin: { x: 3, y: 0, z: 4 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let canvas24 = document.createElement('canvas');
+let textureView68 = texture38.createView({format: 'astc-8x6-unorm-srgb'});
+let sampler56 = device0.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 85.838,
+lodMaxClamp: 87.439,
+maxAnisotropy: 15,
+});
+try {
+computePassEncoder44.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder9.draw(0);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexed(48, 0, 24, -152);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer4, 'uint32', 5416, 1748);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline79);
+} catch {}
+let promise46 = buffer16.mapAsync(GPUMapMode.READ, 0, 2452);
+try {
+commandEncoder57.copyBufferToBuffer(buffer3, 40300, buffer8, 6072, 8180);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas3,
+  origin: { x: 2, y: 1 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView69 = texture74.createView({format: 'rgba16sint', baseMipLevel: 3, mipLevelCount: 4});
+try {
+device2.queue.writeBuffer(buffer25, 31108, new DataView(new ArrayBuffer(51095)), 37970, 9092);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 1, y: 0, z: 4 },
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer13), /* required buffer size: 194399 */
+{offset: 861, bytesPerRow: 411, rowsPerImage: 12}, {width: 23, height: 3, depthOrArrayLayers: 40});
+} catch {}
+video0.height = 158;
+let commandEncoder66 = device2.createCommandEncoder({label: '\u9b9e\u{1f9b6}\u{1fe2e}\u7c2d\uf8a7\u0195\u212d'});
+let renderBundleEncoder72 = device2.createRenderBundleEncoder({
+  label: '\u00cf\u052f\ub7ca\u812f\u{1f9db}\u0122\u{1fa78}\u0861\u0769',
+  colorFormats: ['r8unorm', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1,
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+try {
+  await promise46;
+} catch {}
+gc();
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let promise47 = navigator.gpu.requestAdapter({
+});
+let shaderModule26 = device0.createShaderModule({
+label: '\ue88e\u{1f671}\uacf1\ud7cd\u212d\u56e3\u{1ff38}\u02b4\ua839',
+code: `@group(0) @binding(257)
+var<storage, read_write> local8: array<u32>;
+@group(0) @binding(43)
+var<storage, read_write> function8: array<u32>;
+
+@compute @workgroup_size(6, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<i32>,
+  @location(0) f1: vec2<u32>,
+  @location(4) f2: vec4<f32>,
+  @location(3) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(14) a0: vec3<f16>, @location(9) a1: vec4<u32>, @location(12) a2: vec2<f16>, @location(5) a3: vec3<f16>, @location(1) a4: vec2<f32>, @location(15) a5: vec2<u32>, @location(10) a6: vec3<i32>, @location(11) a7: vec4<u32>, @location(13) a8: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let textureView70 = texture77.createView({label: '\ue1b5\u02f0', dimension: '2d-array', mipLevelCount: 1});
+let renderBundleEncoder73 = device0.createRenderBundleEncoder({
+  label: '\u0107\u67d7\u05f5\u{1ff43}\uec82\u3e90\u6320\u4368\u0e47',
+  colorFormats: ['rgba32sint', 'rgb10a2uint'],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+let renderBundle77 = renderBundleEncoder52.finish({label: '\u718b\u53d9\u4e71\u{1fd60}\u50e0\u3918\uda67\u{1f763}\u0294\u94c8\u{1fdf6}'});
+try {
+computePassEncoder32.setBindGroup(2, bindGroup5, new Uint32Array(6695), 3430, 0);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline97);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline110 = await device0.createRenderPipelineAsync({
+layout: pipelineLayout11,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule25,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'one-minus-dst'},
+alpha: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'dst'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}]
+},
+vertex: {module: shaderModule25, entryPoint: 'vertex0', buffers: [
+
+]},
+primitive: {
+topology: 'triangle-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let gpuCanvasContext17 = canvas24.getContext('webgpu');
+gc();
+let canvas25 = document.createElement('canvas');
+let video15 = await videoWithData();
+let buffer31 = device2.createBuffer({
+  label: '\uc8d7\uc9b7\uac48\u5a4d\ua10c\u01de\uf95c\u0a3e\u{1fad8}',
+  size: 35123,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false
+});
+let commandEncoder67 = device2.createCommandEncoder();
+let querySet68 = device2.createQuerySet({
+label: '\u0202\ue552\u4876\u2cf8',
+type: 'occlusion',
+count: 2553,
+});
+let texture81 = device2.createTexture({
+size: {width: 96, height: 15, depthOrArrayLayers: 192},
+dimension: '3d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let computePassEncoder61 = commandEncoder66.beginComputePass({label: '\u0dab\u32d5\u047a\u{1f739}\u{1fce8}\u{1fc4a}\u{1f828}\u{1f975}\u53ed\u660f\ua936'});
+try {
+device2.queue.writeBuffer(buffer25, 11540, new BigUint64Array(48962), 36791, 4908);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 0,
+  origin: { x: 16, y: 1, z: 2 },
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer9), /* required buffer size: 11404826 */
+{offset: 90, bytesPerRow: 242, rowsPerImage: 252}, {width: 1, height: 4, depthOrArrayLayers: 188});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 3, height: 1, depthOrArrayLayers: 6}
+*/
+{
+  source: imageBitmap22,
+  origin: { x: 222, y: 145 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 4,
+  origin: { x: 3, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise40;
+} catch {}
+let querySet69 = device2.createQuerySet({
+label: '\u526d\u{1fd51}\u7989\u{1ffe4}\u0ed3\u9081\ud609\u6290\u9f75',
+type: 'occlusion',
+count: 3006,
+});
+let renderBundle78 = renderBundleEncoder64.finish();
+try {
+querySet66.destroy();
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer26, 5604, buffer30, 8220, 2216);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer30);
+} catch {}
+let textureView71 = texture10.createView({baseMipLevel: 7, mipLevelCount: 1});
+try {
+computePassEncoder34.setBindGroup(1, bindGroup3, new Uint32Array(1042), 4, 0);
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline53);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexed(48, 72, 72, -640, 64);
+} catch {}
+try {
+renderBundleEncoder20.drawIndirect(buffer22, 1384);
+} catch {}
+try {
+renderBundleEncoder57.setIndexBuffer(buffer9, 'uint32', 12160, 4405);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline98);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(4, buffer22, 1900);
+} catch {}
+try {
+commandEncoder64.resolveQuerySet(querySet19, 1330, 1198, buffer12, 29440);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 31}
+*/
+{
+  source: canvas18,
+  origin: { x: 57, y: 9 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 4,
+  origin: { x: 19, y: 1, z: 9 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let shaderModule27 = device2.createShaderModule({
+label: '\ufbc8\u{1fa28}\u{1fa4c}\u0d9e\u05af\u2365\ue0e9\ue4ac',
+code: `@group(1) @binding(241)
+var<storage, read_write> global6: array<u32>;
+@group(0) @binding(241)
+var<storage, read_write> field11: array<u32>;
+@group(2) @binding(241)
+var<storage, read_write> i9: array<u32>;
+
+@compute @workgroup_size(5, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S19 {
+  @location(4) f0: vec2<f16>,
+  @location(14) f1: vec2<u32>,
+  @builtin(vertex_index) f2: u32,
+  @location(12) f3: vec3<i32>,
+  @location(0) f4: vec2<u32>,
+  @location(7) f5: vec4<u32>,
+  @location(15) f6: vec3<f16>,
+  @location(11) f7: vec4<f16>,
+  @location(10) f8: vec4<f32>,
+  @location(6) f9: vec4<f16>,
+  @builtin(instance_index) f10: u32,
+  @location(5) f11: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec2<i32>, @location(9) a1: vec4<i32>, @location(3) a2: vec2<u32>, @location(1) a3: vec2<f16>, @location(13) a4: vec2<f16>, @location(8) a5: vec3<u32>, a6: S19) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let externalTexture4 = device2.importExternalTexture({
+source: videoFrame14,
+colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder71.setVertexBuffer(7, buffer26, 736, 2207);
+} catch {}
+try {
+commandEncoder67.copyBufferToBuffer(buffer26, 6196, buffer27, 14296, 3000);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer27);
+} catch {}
+let promise48 = device2.queue.onSubmittedWorkDone();
+let pipeline111 = device2.createComputePipeline({
+label: '\u0037\u{1f82b}\u097c\ua059\u{1f6b7}\u0593\u1148\u827b\u69b9\u0b54\u{1fe8c}',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule27,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let promise49 = device2.createRenderPipelineAsync({
+layout: 'auto',
+fragment: {
+  module: shaderModule27,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'zero',
+},
+stencilReadMask: 2120,
+stencilWriteMask: 166,
+depthBias: 92,
+depthBiasSlopeScale: 100,
+depthBiasClamp: 21,
+},
+vertex: {
+  module: shaderModule27,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 648,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 76,
+shaderLocation: 1,
+}, {
+format: 'snorm16x4',
+offset: 12,
+shaderLocation: 15,
+}, {
+format: 'uint32x4',
+offset: 140,
+shaderLocation: 0,
+}, {
+format: 'unorm8x2',
+offset: 130,
+shaderLocation: 4,
+}, {
+format: 'sint32',
+offset: 204,
+shaderLocation: 2,
+}, {
+format: 'uint16x2',
+offset: 148,
+shaderLocation: 3,
+}, {
+format: 'sint8x4',
+offset: 344,
+shaderLocation: 5,
+}, {
+format: 'float32x3',
+offset: 592,
+shaderLocation: 13,
+}, {
+format: 'unorm16x2',
+offset: 584,
+shaderLocation: 11,
+}, {
+format: 'uint16x2',
+offset: 252,
+shaderLocation: 7,
+}, {
+format: 'uint8x2',
+offset: 476,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 1304,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 800,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 312,
+shaderLocation: 9,
+}, {
+format: 'sint8x2',
+offset: 482,
+shaderLocation: 12,
+}, {
+format: 'float16x2',
+offset: 556,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 1452,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 364,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 680,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 0,
+attributes: [],
+},
+{
+arrayStride: 1880,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 456,
+shaderLocation: 10,
+}],
+}
+]
+},
+});
+let video16 = await videoWithData();
+let imageBitmap23 = await createImageBitmap(offscreenCanvas6);
+let bindGroup32 = device2.createBindGroup({
+label: '\ue69a\ube00\u05ea\u5093\uf772\u0b2c\u15b4\u{1fcd5}\u090a\u0c97\u0e36',
+layout: bindGroupLayout37,
+entries: [{
+binding: 385,
+resource: sampler55
+}, {
+binding: 771,
+resource: externalTexture4
+}],
+});
+let querySet70 = device2.createQuerySet({
+label: '\u008e\u{1fe9a}',
+type: 'occlusion',
+count: 254,
+});
+try {
+computePassEncoder61.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+renderBundleEncoder71.insertDebugMarker('\u{1f839}');
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let imageData12 = new ImageData(140, 168);
+let videoFrame19 = new VideoFrame(video15, {timestamp: 0});
+let gpuCanvasContext18 = canvas25.getContext('webgpu');
+let buffer32 = device2.createBuffer({label: '\u017a\u0404\u32cb\u0ffa', size: 63020, usage: GPUBufferUsage.MAP_WRITE, mappedAtCreation: true});
+let texture82 = device2.createTexture({
+size: [540, 1, 1],
+mipLevelCount: 4,
+sampleCount: 1,
+format: 'r16uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+try {
+renderBundleEncoder69.setVertexBuffer(1, buffer26, 1540, 5558);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer25, 1964, new DataView(new ArrayBuffer(10239)), 5955, 1412);
+} catch {}
+let gpuCanvasContext19 = offscreenCanvas17.getContext('webgpu');
+try {
+adapter5.label = '\u5cfe\u{1f9f7}\u0f13\u{1fe8b}';
+} catch {}
+let bindGroupLayout38 = device0.createBindGroupLayout({
+label: '\u{1ff5d}\u{1fa6a}\u09c8',
+entries: [{
+binding: 232,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}, {
+binding: 670,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'rgba16uint', access: 'write-only', viewDimension: '2d' },
+}, {
+binding: 270,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d-array' },
+}],
+});
+let texture83 = device0.createTexture({
+label: '\u0504\ub3c7\u02ea\ub74d\ud1fe\u0b78\u04c7',
+size: {width: 330, height: 24, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+dimension: '2d',
+format: 'astc-6x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-6x6-unorm', 'astc-6x6-unorm-srgb'],
+});
+try {
+computePassEncoder40.dispatchWorkgroupsIndirect(buffer15, 2900);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer22, 476);
+} catch {}
+try {
+commandEncoder64.copyBufferToBuffer(buffer17, 9016, buffer8, 6928, 5600);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder57.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture20,
+  mipLevel: 2,
+  origin: { x: 0, y: 4, z: 40 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer18,
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 10944, new Int16Array(48110), 1823, 252);
+} catch {}
+let pipeline112 = await device0.createRenderPipelineAsync({
+layout: pipelineLayout18,
+fragment: {
+  module: shaderModule18,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: GPUColorWrite.ALL}, {format: 'rgba8sint'}, {format: 'rg8uint', writeMask: 0}, {format: 'rg32uint', writeMask: 0}, undefined, {format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'src-alpha', dstFactor: 'src-alpha-saturated'},
+},
+  writeMask: 0
+}]
+},
+vertex: {
+  module: shaderModule18,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1660,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1576,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1788,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1824,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1384,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 1116,
+shaderLocation: 2,
+}, {
+format: 'snorm8x4',
+offset: 576,
+shaderLocation: 14,
+}, {
+format: 'uint32',
+offset: 556,
+shaderLocation: 1,
+}],
+}
+]
+},
+primitive: {
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+canvas3.height = 299;
+gc();
+let imageData13 = new ImageData(156, 88);
+let offscreenCanvas18 = new OffscreenCanvas(3, 140);
+let bindGroupLayout39 = device2.createBindGroupLayout({
+label: '\u3071\u1d90\u820c\uc328\u12c4\u0e16\u{1f958}\u{1fb01}\u0d95',
+entries: [{
+binding: 311,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d' },
+}, {
+binding: 583,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}],
+});
+let texture84 = device2.createTexture({
+label: '\u1d57\uca38\u{1fa7f}\u{1fa69}\ue8cd\uc964\u0ec6\u9c09',
+size: [15],
+dimension: '1d',
+format: 'r8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup32, new Uint32Array(1091), 653, 0);
+} catch {}
+try {
+renderBundleEncoder69.setBindGroup(0, bindGroup32, new Uint32Array(389), 262, 0);
+} catch {}
+try {
+renderBundleEncoder66.setVertexBuffer(4, buffer26);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: imageBitmap18,
+  origin: { x: 29, y: 38 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame20 = new VideoFrame(offscreenCanvas2, {timestamp: 0});
+try {
+adapter0.label = '\u19b6\u0405\u{1fcac}';
+} catch {}
+let querySet71 = device2.createQuerySet({
+label: '\u06f3\u{1fefd}\uf212',
+type: 'occlusion',
+count: 3790,
+});
+let sampler57 = device2.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 86.644,
+maxAnisotropy: 11,
+});
+try {
+computePassEncoder58.setBindGroup(1, bindGroup32, new Uint32Array(4360), 1134, 0);
+} catch {}
+try {
+renderBundleEncoder72.setBindGroup(0, bindGroup32, new Uint32Array(8219), 5454, 0);
+} catch {}
+let promise50 = buffer25.mapAsync(GPUMapMode.READ, 58720, 1912);
+try {
+commandEncoder65.clearBuffer(buffer25, 63108, 104);
+dissociateBuffer(device2, buffer25);
+} catch {}
+let promise51 = device2.queue.onSubmittedWorkDone();
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: imageData6,
+  origin: { x: 87, y: 61 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let device3 = await adapter5.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+});
+let bindGroupLayout40 = pipeline30.getBindGroupLayout(0);
+let commandEncoder68 = device0.createCommandEncoder({label: '\u65bf\udc1e\u082d\u4208\u0faf\u11d3\ua39a\u9079\u0486'});
+let computePassEncoder62 = commandEncoder64.beginComputePass({label: '\u6e28\u8841\u{1feba}'});
+try {
+computePassEncoder45.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline41);
+} catch {}
+try {
+renderBundleEncoder26.drawIndirect(buffer22, 644);
+} catch {}
+try {
+commandEncoder57.copyBufferToTexture({
+/* bytesInLastRow: 624 widthInBlocks: 39 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 39760 */
+offset: 39760,
+bytesPerRow: 768,
+buffer: buffer12,
+}, {
+  texture: texture62,
+  mipLevel: 2,
+  origin: { x: 168, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 468, height: 36, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+let imageData14 = new ImageData(88, 164);
+try {
+offscreenCanvas18.getContext('webgpu');
+} catch {}
+gc();
+let renderBundleEncoder74 = device0.createRenderBundleEncoder({
+  label: '\u3c63\uf04e\u{1fd70}\u0f0e\u0144\u07cc',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+let sampler58 = device0.createSampler({
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 86.578,
+});
+try {
+computePassEncoder62.setPipeline(pipeline40);
+} catch {}
+try {
+commandEncoder68.copyBufferToBuffer(buffer24, 10132, buffer16, 56744, 2388);
+dissociateBuffer(device0, buffer24);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 6052, new DataView(new ArrayBuffer(46156)), 12228, 14272);
+} catch {}
+let canvas26 = document.createElement('canvas');
+gc();
+let bindGroup33 = device2.createBindGroup({
+label: '\u0764\u6c05\u0ad8\u{1f82b}',
+layout: bindGroupLayout37,
+entries: [{
+binding: 385,
+resource: sampler55
+}, {
+binding: 771,
+resource: externalTexture4
+}],
+});
+let textureView72 = texture79.createView({label: '\u{1f68a}\uefe2\u0ab4\u017c\uadad\u02b6\u{1f779}', baseMipLevel: 4});
+let computePassEncoder63 = commandEncoder67.beginComputePass({label: '\u9685\u0041'});
+let sampler59 = device2.createSampler({
+label: '\u{1fd3b}\u5085\u{1f79a}\u6057',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 22.596,
+lodMaxClamp: 39.331,
+});
+try {
+computePassEncoder63.setBindGroup(2, bindGroup32, new Uint32Array(2490), 350, 0);
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer26, 52, buffer31, 10856, 4272);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer31);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 3,
+  origin: { x: 1, y: 0, z: 2 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 52843 */
+{offset: 507, bytesPerRow: 152, rowsPerImage: 43}, {width: 3, height: 1, depthOrArrayLayers: 9});
+} catch {}
+let pipeline113 = device2.createComputePipeline({
+layout: pipelineLayout19,
+compute: {
+module: shaderModule27,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+try {
+  await promise43;
+} catch {}
+let canvas27 = document.createElement('canvas');
+let shaderModule28 = device2.createShaderModule({
+label: '\u{1fa10}\u03e9\u0dab\u53da\ude4f\u07ab',
+code: `@group(1) @binding(241)
+var<storage, read_write> i10: array<u32>;
+@group(2) @binding(241)
+var<storage, read_write> parameter12: array<u32>;
+
+@compute @workgroup_size(1, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<i32>,
+  @builtin(frag_depth) f1: f32,
+  @location(0) f2: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(11) a0: vec3<f16>, @location(7) a1: f32, @location(3) a2: vec2<f32>, @location(6) a3: vec3<f16>, @location(14) a4: vec3<f16>, @builtin(vertex_index) a5: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroupLayout41 = device2.createBindGroupLayout({
+label: '\uc0cd\u{1fc86}\u5ad4\u3244\u9463\u2fea',
+entries: [{
+binding: 240,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+}, {
+binding: 448,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}, {
+binding: 697,
+visibility: 0,
+storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '2d-array' },
+}],
+});
+let querySet72 = device2.createQuerySet({
+label: '\u4488\u0aad\u{1fb5c}\ud172\u7f99\u4fb8\u1dcb\uca0b',
+type: 'occlusion',
+count: 1909,
+});
+let texture85 = device2.createTexture({
+size: {width: 204, height: 160, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+dimension: '2d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let sampler60 = device2.createSampler({
+label: '\u4df1\u{1fab8}\ud0e0\u{1fa14}\u0a02\uc54f\u07a4\u0cd3\u6e43\u254e\u4809',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+lodMaxClamp: 44.913,
+});
+let bindGroupLayout42 = device0.createBindGroupLayout({
+label: '\u02c3\u{1fc82}',
+entries: [{
+binding: 951,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+}],
+});
+let texture86 = device0.createTexture({
+label: '\u75f2\u13a6\u8b9f\u{1fbe5}\u{1f71e}\u{1fb36}\u{1ff6a}\uc9f4\u7298',
+size: {width: 192, height: 200, depthOrArrayLayers: 175},
+mipLevelCount: 5,
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x10-unorm', 'astc-12x10-unorm', 'astc-12x10-unorm'],
+});
+let computePassEncoder64 = commandEncoder68.beginComputePass();
+try {
+renderBundleEncoder30.draw(64);
+} catch {}
+try {
+renderBundleEncoder26.drawIndirect(buffer12, 17792);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(4, buffer6, 22984, 13253);
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(buffer17, 16632, buffer18, 17628, 1384);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder57.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 13, y: 16, z: 176 },
+  aspect: 'all',
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 222, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder57.resolveQuerySet(querySet54, 884, 629, buffer12, 19456);
+} catch {}
+try {
+  await promise45;
+} catch {}
+let imageBitmap24 = await createImageBitmap(videoFrame16);
+let texture87 = device2.createTexture({
+label: '\u0477\u0fd2\ub23d\u{1ff3d}',
+size: {width: 25, height: 20, depthOrArrayLayers: 72},
+mipLevelCount: 6,
+dimension: '3d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['r8snorm', 'r8snorm'],
+});
+try {
+commandEncoder63.clearBuffer(buffer31, 4732, 29000);
+dissociateBuffer(device2, buffer31);
+} catch {}
+let gpuCanvasContext20 = canvas26.getContext('webgpu');
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let bindGroupLayout43 = device3.createBindGroupLayout({
+label: '\u17c6\u9d69\uc70a\ue5bb\u9916\ub0e7\u7b21\u92cd\u0d8d',
+entries: [{
+binding: 365,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d-array' },
+}, {
+binding: 95,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+document.body.prepend(canvas22);
+try {
+canvas27.getContext('webgpu');
+} catch {}
+try {
+window.someLabel = bindGroupLayout43.label;
+} catch {}
+let bindGroupLayout44 = device3.createBindGroupLayout({
+label: '\u{1f71a}\u0af4\u0c55\u{1f70d}',
+entries: [{
+binding: 983,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '1d' },
+}, {
+binding: 469,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '3d' },
+}, {
+binding: 83,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '3d' },
+}],
+});
+try {
+renderBundleEncoder69.setBindGroup(0, bindGroup32);
+} catch {}
+let arrayBuffer14 = buffer27.getMappedRange(3656, 5752);
+try {
+  await promise39;
+} catch {}
+let querySet73 = device0.createQuerySet({
+label: '\u053a\u{1fa66}\ue1d0\ua403\u3448',
+type: 'occlusion',
+count: 566,
+});
+let texture88 = device0.createTexture({
+size: [438, 1, 72],
+dimension: '3d',
+format: 'rg16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16float'],
+});
+try {
+renderBundleEncoder26.drawIndexed(0, 72, 16);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexedIndirect(buffer12, 20216);
+} catch {}
+try {
+renderBundleEncoder53.drawIndirect(buffer15, 756);
+} catch {}
+let arrayBuffer15 = buffer11.getMappedRange(0, 7104);
+try {
+commandEncoder57.clearBuffer(buffer10, 6248, 4);
+dissociateBuffer(device0, buffer10);
+} catch {}
+let bindGroupLayout45 = device3.createBindGroupLayout({
+label: '\u03fe\u2bf2\u{1f74a}\u0b8a\u5c77\u{1f9a1}\u030e\u5e20\u0662\u0aa6',
+entries: [],
+});
+let buffer33 = device3.createBuffer({
+  label: '\u0eb1\u{1fd14}\u0886\u9b0d\u{1ff23}\u{1f8a3}',
+  size: 56191,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let texture89 = device3.createTexture({
+label: '\u{1fcc9}\u0694\u03c8\u{1f978}\u{1fda6}',
+size: {width: 1434, height: 1, depthOrArrayLayers: 222},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb'],
+});
+document.body.prepend(img10);
+let buffer34 = device2.createBuffer({label: '\u065e\u074e\u0c69\u0d26\u73e1\u7edb\u1eb1', size: 15948, usage: GPUBufferUsage.COPY_DST});
+let commandEncoder69 = device2.createCommandEncoder({label: '\ud64b\u0527\uc50b\u8eef\u09f1\u06e6\u{1f718}\u{1fb41}\u4b2d\ua26d\u37c7'});
+let textureView73 = texture81.createView({label: '\u7674\ud4fd\ue138'});
+let renderBundleEncoder75 = device2.createRenderBundleEncoder({
+  label: '\u7c8f\ua8e5\u6a8a\u796a',
+  colorFormats: ['r8uint', 'bgra8unorm', 'rg32float', 'rg32uint', 'r32float']
+});
+let renderBundle79 = renderBundleEncoder69.finish({label: '\ubb5d\u{1fe4d}\u1d81\u1cb2'});
+try {
+commandEncoder65.copyBufferToBuffer(buffer26, 5324, buffer27, 17332, 1116);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 6, height: 1, depthOrArrayLayers: 12}
+*/
+{
+  source: videoFrame20,
+  origin: { x: 365, y: 683 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 3,
+  origin: { x: 2, y: 1, z: 4 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let shaderModule29 = device0.createShaderModule({
+label: '\u35c8\u0dc7\ude16\u{1fd7d}\u0e34\u535f\ueb5b\u095e\u0729',
+code: `@group(2) @binding(803)
+var<storage, read_write> parameter13: array<u32>;
+
+@compute @workgroup_size(1, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<i32>,
+  @location(1) f1: vec2<u32>,
+  @location(2) f2: vec4<u32>,
+  @location(0) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S20 {
+  @location(1) f0: vec3<i32>,
+  @location(0) f1: u32,
+  @location(6) f2: vec2<i32>,
+  @location(10) f3: i32
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec2<f16>, @location(15) a1: f32, @location(11) a2: vec4<f32>, @location(4) a3: f16, @location(7) a4: vec4<f16>, a5: S20, @location(5) a6: u32, @location(12) a7: vec4<u32>, @location(13) a8: vec4<f32>, @location(2) a9: vec4<f16>, @location(9) a10: vec4<f16>, @location(3) a11: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder70 = device0.createCommandEncoder({label: '\u248d\u0cf3\u0ea6\u73ef\u6b5c'});
+pseudoSubmit(device0, commandEncoder23);
+try {
+renderBundleEncoder26.drawIndirect(buffer15, 2856);
+} catch {}
+try {
+renderBundleEncoder51.setIndexBuffer(buffer9, 'uint32');
+} catch {}
+let pipeline114 = device0.createComputePipeline({
+layout: pipelineLayout6,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let bindGroupLayout46 = device0.createBindGroupLayout({
+label: '\ub40a\u8cb7\u6b99\u09fd\u9dce\ua2fd\u{1fc27}\ua421\u4370\ubcc6\u0c20',
+entries: [{
+binding: 883,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+}],
+});
+let bindGroupLayout47 = pipeline95.getBindGroupLayout(0);
+let commandEncoder71 = device0.createCommandEncoder({label: '\u0d2b\u97fd\u0428\u{1f84a}\u3d5f\u91a2\u683a\u{1f620}\u06e7\u03c2\u0fd8'});
+let renderBundle80 = renderBundleEncoder41.finish({label: '\uaf72\u0860\u{1fc3d}\u36df\u0f1c\u0ac6\ua70a'});
+try {
+renderBundleEncoder9.draw(64, 64, 56, 40);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer22, 1756);
+} catch {}
+try {
+renderBundleEncoder30.drawIndirect(buffer22, 1744);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(6, buffer15, 5000, 507);
+} catch {}
+try {
+commandEncoder57.copyTextureToBuffer({
+  texture: texture31,
+  mipLevel: 0,
+  origin: { x: 616, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 512 widthInBlocks: 32 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 28016 */
+offset: 28016,
+bytesPerRow: 512,
+rowsPerImage: 173,
+buffer: buffer12,
+}, {width: 256, height: 24, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder57.resolveQuerySet(querySet48, 767, 9, buffer12, 9728);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+try {
+  await promise48;
+} catch {}
+canvas10.height = 674;
+let imageBitmap25 = await createImageBitmap(canvas5);
+let commandEncoder72 = device3.createCommandEncoder({label: '\ud629\uf086\u21a8\u{1ffb6}\u76df\u0feb\ud67f'});
+let sampler61 = device3.createSampler({
+label: '\u05d4\u50c3\u3bdf\u3845\u0165',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 31.937,
+lodMaxClamp: 92.694,
+});
+try {
+texture89.destroy();
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device3,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let promise52 = device3.queue.onSubmittedWorkDone();
+let texture90 = device2.createTexture({
+label: '\u8677\ua2bf\u02b0\uff36',
+size: {width: 420, height: 1, depthOrArrayLayers: 6},
+mipLevelCount: 3,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth16unorm', 'depth16unorm', 'depth16unorm'],
+});
+let computePassEncoder65 = commandEncoder65.beginComputePass();
+let renderBundle81 = renderBundleEncoder66.finish({label: '\u0b69\u0d7b\u00a8\u6ecc\u{1fb5f}\u0b1b\u070b\u8782\u0bb1\u{1f791}'});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup32, new Uint32Array(1672), 656, 0);
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline111);
+} catch {}
+try {
+renderBundleEncoder75.setBindGroup(1, bindGroup33);
+} catch {}
+let arrayBuffer16 = buffer30.getMappedRange(8040, 7244);
+let pipeline115 = device2.createRenderPipeline({
+label: '\u{1ffb7}\u{1fac2}\ue459\u083e\u4c3c\u0e76\u1060\ud710\u0fb6\u02e4',
+layout: pipelineLayout19,
+multisample: {
+count: 4,
+mask: 0x64cbc36b,
+},
+fragment: {
+  module: shaderModule27,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined]
+},
+vertex: {
+  module: shaderModule27,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1928,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x2',
+offset: 276,
+shaderLocation: 13,
+}, {
+format: 'unorm8x4',
+offset: 1844,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 504,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x4',
+offset: 196,
+shaderLocation: 14,
+}, {
+format: 'sint8x4',
+offset: 32,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 1532,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1388,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32',
+offset: 420,
+shaderLocation: 2,
+}, {
+format: 'snorm8x4',
+offset: 728,
+shaderLocation: 1,
+}, {
+format: 'uint16x4',
+offset: 4,
+shaderLocation: 0,
+}, {
+format: 'uint32x4',
+offset: 180,
+shaderLocation: 8,
+}, {
+format: 'snorm8x4',
+offset: 1016,
+shaderLocation: 15,
+}, {
+format: 'unorm8x4',
+offset: 824,
+shaderLocation: 6,
+}, {
+format: 'sint16x4',
+offset: 120,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 956,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1376,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32',
+offset: 264,
+shaderLocation: 7,
+}, {
+format: 'sint32x4',
+offset: 404,
+shaderLocation: 9,
+}, {
+format: 'unorm16x2',
+offset: 372,
+shaderLocation: 4,
+}, {
+format: 'uint16x2',
+offset: 88,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 36,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 0,
+shaderLocation: 10,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+},
+});
+document.body.prepend(canvas14);
+let commandEncoder73 = device3.createCommandEncoder({label: '\uace2\u2856\u03f7\u{1ff84}\u{1f6a3}\u0ebd\u5321'});
+let textureView74 = texture89.createView({});
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+let adapter6 = await navigator.gpu.requestAdapter({
+});
+let offscreenCanvas19 = new OffscreenCanvas(866, 990);
+try {
+offscreenCanvas19.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder74 = device2.createCommandEncoder({label: '\u9195\uaf60\u0d16\u{1f897}\u3355\u658c\uf679\ua5bc\u{1fbd9}\ue01d'});
+let textureView75 = texture75.createView({label: '\u6147\u303a', dimension: '1d'});
+let renderBundleEncoder76 = device2.createRenderBundleEncoder({
+  label: '\u46a6\u0d77\u1860\u7a9b\u4032\u013a\u08fb',
+  colorFormats: ['bgra8unorm', undefined, undefined, 'rgba16float', 'bgra8unorm-srgb', 'rgba8sint'],
+  depthReadOnly: true
+});
+let sampler62 = device2.createSampler({
+label: '\u5446\u{1f7bd}\u3194\u0084\ubdcb\u7613\u23b6\u5e22',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 23.377,
+lodMaxClamp: 42.886,
+maxAnisotropy: 2,
+});
+try {
+commandEncoder69.copyBufferToBuffer(buffer26, 4912, buffer31, 24784, 2400);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer31);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8snorm', 'rgba8unorm', 'rgba8unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture90,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new Int16Array(arrayBuffer4), /* required buffer size: 83739 */
+{offset: 73, bytesPerRow: 326, rowsPerImage: 64}, {width: 105, height: 1, depthOrArrayLayers: 5});
+} catch {}
+document.body.prepend(video16);
+let texture91 = device3.createTexture({
+label: '\u{1ff95}\ua4c7\u798d\u059a\u5507\u{1fd27}\u{1f9a2}',
+size: [96, 48, 1],
+mipLevelCount: 7,
+format: 'eac-r11unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['eac-r11unorm', 'eac-r11unorm'],
+});
+let shaderModule30 = device2.createShaderModule({
+label: '\u013f\u{1ff51}\u06cf\uf1a7\ud92b\u2fd2\u25ca',
+code: `@group(2) @binding(241)
+var<storage, read_write> parameter14: array<u32>;
+@group(0) @binding(241)
+var<storage, read_write> parameter15: array<u32>;
+
+@compute @workgroup_size(3, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: u32,
+  @builtin(sample_mask) f1: u32,
+  @location(0) f2: vec2<f32>,
+  @builtin(frag_depth) f3: f32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S21 {
+  @location(1) f0: vec2<f32>,
+  @location(14) f1: vec2<i32>,
+  @location(6) f2: u32,
+  @location(11) f3: vec4<f32>,
+  @builtin(vertex_index) f4: u32,
+  @location(0) f5: i32,
+  @location(8) f6: f32,
+  @location(2) f7: vec3<f32>,
+  @location(9) f8: vec3<f32>,
+  @location(4) f9: vec4<u32>,
+  @location(15) f10: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec2<i32>, @location(12) a1: vec4<u32>, @location(3) a2: vec2<u32>, @location(5) a3: f16, @location(10) a4: vec4<f32>, @builtin(instance_index) a5: u32, a6: S21, @location(13) a7: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder75 = device2.createCommandEncoder({label: '\u06c5\u{1fc20}\u048c\u{1f8e2}\u5ab9'});
+let texture92 = device2.createTexture({
+label: '\uda9a\u0ee3\u795f\u0190\u0725\uf4fc\u{1f8c5}\ufd0f\u0748',
+size: {width: 25, height: 20, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16float', 'rg16float', 'rg16float'],
+});
+let textureView76 = texture82.createView({baseMipLevel: 1, mipLevelCount: 1});
+try {
+computePassEncoder61.setPipeline(pipeline111);
+} catch {}
+try {
+renderBundleEncoder72.insertDebugMarker('\u6d5e');
+} catch {}
+try {
+gpuCanvasContext16.configure({
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'r8unorm', 'rgba8snorm'],
+colorSpace: 'srgb',
+});
+} catch {}
+let img19 = await imageWithData(83, 226, '#f8a649a6', '#39462d0e');
+let querySet74 = device0.createQuerySet({
+label: '\u0808\ud62d\u0dbf\u00d4\u0e05\u2cbf\u8d9a\u091e\u{1fb99}\u0b41',
+type: 'occlusion',
+count: 3907,
+});
+let computePassEncoder66 = commandEncoder71.beginComputePass({label: '\uae5f\u{1fb0a}\u5adc\u{1f66a}\u{1fdf9}\u{1fa65}\u0207'});
+try {
+computePassEncoder59.dispatchWorkgroups(1, 2, 5);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(32, 80);
+} catch {}
+try {
+renderBundleEncoder53.drawIndirect(buffer12, 38072);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(0, buffer22, 420, 1335);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: imageBitmap21,
+  origin: { x: 3, y: 14 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+window.someLabel = device3.label;
+} catch {}
+let bindGroupLayout48 = device3.createBindGroupLayout({
+label: '\u6f3b\u2d44\u0235\u9e7e\u5297\u04b4\ucfb6\u9a4d\ua5a5',
+entries: [{
+binding: 554,
+visibility: 0,
+buffer: { type: 'storage', minBindingSize: 937657, hasDynamicOffset: false },
+}, {
+binding: 230,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '2d-array' },
+}],
+});
+let buffer35 = device3.createBuffer({
+  label: '\u{1ff70}\u1414',
+  size: 30737,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX
+});
+pseudoSubmit(device3, commandEncoder73);
+let computePassEncoder67 = commandEncoder72.beginComputePass({label: '\u02f5\u02d6\u{1fb3b}\u0482\ueb5e\u380b\u60c6\u0b8a'});
+try {
+device3.pushErrorScope('validation');
+} catch {}
+let promise53 = buffer33.mapAsync(GPUMapMode.WRITE, 13328, 1792);
+let commandEncoder76 = device3.createCommandEncoder({label: '\u7898\u6a8c\u08eb\ub819\u7e9c\ufdcd\u3410\u4b63\u2b06\u{1fc73}'});
+try {
+device3.queue.writeBuffer(buffer35, 22132, new Float32Array(49871), 38032, 1396);
+} catch {}
+let canvas28 = document.createElement('canvas');
+try {
+await adapter2.requestAdapterInfo();
+} catch {}
+try {
+canvas28.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder77 = device0.createCommandEncoder({label: '\ue0fc\u02a9\u{1fe17}\u0e76\ue551\u0e4a'});
+let querySet75 = device0.createQuerySet({
+label: '\u{1fb4d}\u8bc6\u8d63\u{1f81c}\u{1fe15}\u0b9b',
+type: 'occlusion',
+count: 1974,
+});
+let texture93 = gpuCanvasContext11.getCurrentTexture();
+let textureView77 = texture2.createView({
+  label: '\u04b7\u0708\u{1fb33}\u063d\ufc22\ud5b1\u00ac\u{1f96c}\ub9cb\uf2d2\u6eb3',
+  dimension: '2d-array',
+  format: 'astc-8x6-unorm-srgb',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 0
+});
+let renderBundle82 = renderBundleEncoder47.finish({label: '\u2cf3\u6452\uc44e\u91d7\u0e58\ue2f2\u6f54\u0a98\u6846\u{1fc5f}\u64e9'});
+try {
+renderBundleEncoder53.draw(56);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer22, 92);
+} catch {}
+try {
+renderBundleEncoder62.drawIndirect(buffer22, 376);
+} catch {}
+try {
+commandEncoder57.copyTextureToTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 72, y: 5, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture56,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 15, depthOrArrayLayers: 1});
+} catch {}
+let promise54 = device0.queue.onSubmittedWorkDone();
+let pipeline116 = device0.createRenderPipeline({
+label: '\ua2d0\udf95\u425b\u3ef1\u0f93\uad11\u0cb2\u{1f88f}\u3628\ue99d',
+layout: pipelineLayout9,
+fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: GPUColorWrite.ALL}, undefined, {format: 'rg8sint'}]
+},
+vertex: {
+  module: shaderModule20,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 52,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1372,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 220,
+shaderLocation: 10,
+}, {
+format: 'unorm8x4',
+offset: 380,
+shaderLocation: 8,
+}, {
+format: 'unorm8x2',
+offset: 704,
+shaderLocation: 5,
+}, {
+format: 'float32',
+offset: 316,
+shaderLocation: 2,
+}, {
+format: 'float32x2',
+offset: 640,
+shaderLocation: 3,
+}, {
+format: 'sint8x4',
+offset: 596,
+shaderLocation: 14,
+}, {
+format: 'float32x2',
+offset: 636,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 1232,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 860,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x2',
+offset: 776,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 1868,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x2',
+offset: 1340,
+shaderLocation: 12,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+unclippedDepth: true,
+},
+});
+let video17 = await videoWithData();
+let offscreenCanvas20 = new OffscreenCanvas(82, 926);
+try {
+offscreenCanvas20.getContext('2d');
+} catch {}
+let shaderModule31 = device0.createShaderModule({
+label: '\u2f07\ue7a3\u0f0f\u6a80\u{1f97b}\u{1fe72}\u0123\ua235\u9b0e',
+code: `@group(2) @binding(788)
+var<storage, read_write> global7: array<u32>;
+@group(2) @binding(803)
+var<storage, read_write> field12: array<u32>;
+
+@compute @workgroup_size(5, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec2<f32>,
+  @location(0) f1: vec4<i32>,
+  @location(1) f2: vec4<i32>,
+  @builtin(frag_depth) f3: f32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(9) a0: vec4<u32>, @location(2) a1: i32, @location(5) a2: u32, @location(15) a3: vec3<u32>, @location(3) a4: f16, @location(14) a5: u32, @location(11) a6: vec3<u32>, @location(4) a7: f16, @location(7) a8: vec2<u32>, @location(8) a9: vec2<u32>, @location(0) a10: vec2<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let texture94 = device0.createTexture({
+label: '\u1059\u0d52\u{1f9eb}',
+size: [876, 1, 99],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'r8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8unorm', 'r8unorm', 'r8unorm'],
+});
+try {
+computePassEncoder46.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+computePassEncoder31.dispatchWorkgroups(2);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline43);
+} catch {}
+let arrayBuffer17 = buffer21.getMappedRange(0, 20284);
+try {
+commandEncoder57.resolveQuerySet(querySet15, 64, 21, buffer12, 17152);
+} catch {}
+let promise55 = adapter6.requestDevice({
+label: '\ue26b\u2658\uf4f9\u34e0\u0263\udb4a\u6597\u{1fbc0}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-astc',
+'indirect-first-instance',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 33,
+maxVertexBufferArrayStride: 19063,
+maxStorageTexturesPerShaderStage: 18,
+maxStorageBuffersPerShaderStage: 23,
+maxDynamicStorageBuffersPerPipelineLayout: 837,
+maxBindingsPerBindGroup: 8283,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 14820,
+maxTextureDimension2D: 9960,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 265419649,
+maxUniformBuffersPerShaderStage: 40,
+maxInterStageShaderVariables: 87,
+maxInterStageShaderComponents: 80,
+},
+});
+let offscreenCanvas21 = new OffscreenCanvas(471, 650);
+try {
+offscreenCanvas21.getContext('2d');
+} catch {}
+let querySet76 = device0.createQuerySet({
+label: '\u0bcc\u04c1\u0185\u{1f6a1}\u0a86\uc309\uf06c\u7ffa\u{1fc6c}\u080c',
+type: 'occlusion',
+count: 462,
+});
+try {
+renderBundleEncoder37.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder30.draw(80, 16, 72, 56);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexed(16, 80);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder70.resolveQuerySet(querySet1, 1460, 422, buffer12, 23552);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 5132, new Float32Array(20370), 19277);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 62}
+*/
+{
+  source: offscreenCanvas8,
+  origin: { x: 312, y: 390 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 3,
+  origin: { x: 26, y: 0, z: 37 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let renderBundleEncoder77 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder60.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(buffer12, 7244, buffer11, 52312, 6616);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer11);
+} catch {}
+let pipeline117 = device0.createRenderPipeline({
+label: '\u{1fe30}\ue8fc\u040d\u{1fe57}\u{1f750}\u0150\ua5cb\ue333\u3d06\u9753\u0d3f',
+layout: pipelineLayout11,
+multisample: {
+count: 4,
+mask: 0xefb72299,
+},
+fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'rgba16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rgba16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+vertex: {
+  module: shaderModule10,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1048,
+attributes: [{
+format: 'uint32',
+offset: 4,
+shaderLocation: 14,
+}, {
+format: 'uint32x3',
+offset: 528,
+shaderLocation: 15,
+}, {
+format: 'unorm8x2',
+offset: 80,
+shaderLocation: 5,
+}, {
+format: 'sint16x4',
+offset: 188,
+shaderLocation: 2,
+}, {
+format: 'float32',
+offset: 248,
+shaderLocation: 10,
+}, {
+format: 'snorm16x4',
+offset: 936,
+shaderLocation: 12,
+}, {
+format: 'sint16x4',
+offset: 976,
+shaderLocation: 0,
+}, {
+format: 'float32x4',
+offset: 24,
+shaderLocation: 7,
+}, {
+format: 'unorm10-10-10-2',
+offset: 704,
+shaderLocation: 8,
+}, {
+format: 'sint32',
+offset: 500,
+shaderLocation: 13,
+}, {
+format: 'uint32x2',
+offset: 524,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 1148,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 0,
+attributes: [{
+format: 'unorm16x2',
+offset: 1676,
+shaderLocation: 11,
+}, {
+format: 'snorm16x2',
+offset: 48,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 476,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x4',
+offset: 368,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 1680,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 380,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 836,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 768,
+shaderLocation: 1,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+  await promise51;
+} catch {}
+let img20 = await imageWithData(99, 277, '#81aff9ad', '#d0181be1');
+let computePassEncoder68 = commandEncoder57.beginComputePass({label: '\u475a\ufdf2\u8ae9\u1f9c\ufae2\ubc8e\u0dba\u03d1\u0c74\u{1fa28}\u07eb'});
+try {
+renderBundleEncoder36.setBindGroup(3, bindGroup6, new Uint32Array(819), 494, 0);
+} catch {}
+try {
+renderBundleEncoder26.draw(0);
+} catch {}
+try {
+renderBundleEncoder62.drawIndirect(buffer15, 4512);
+} catch {}
+try {
+renderBundleEncoder57.setIndexBuffer(buffer9, 'uint32', 15328, 5074);
+} catch {}
+try {
+commandEncoder70.copyTextureToBuffer({
+  texture: texture42,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'depth-only',
+}, {
+/* bytesInLastRow: 660 widthInBlocks: 330 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 54224 */
+offset: 54224,
+bytesPerRow: 768,
+rowsPerImage: 237,
+buffer: buffer1,
+}, {width: 330, height: 24, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline118 = device0.createRenderPipeline({
+label: '\u0bc1\ub87d',
+layout: pipelineLayout13,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule25,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}]
+},
+vertex: {module: shaderModule25, entryPoint: 'vertex0', buffers: [
+
+]},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let bindGroupLayout49 = device0.createBindGroupLayout({
+label: '\u4a07\u{1feb3}\uf006\ue47f\u{1f7cd}\u4256\u5229\u5455\u0f31',
+entries: [],
+});
+let commandEncoder78 = device0.createCommandEncoder({label: '\u{1f996}\u0a1f\u9ba9\u5658\u9884\u3ec7\u0ed5\udf5c\u0da4'});
+try {
+computePassEncoder37.setPipeline(pipeline32);
+} catch {}
+try {
+renderBundleEncoder73.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexed(16, 72);
+} catch {}
+try {
+renderBundleEncoder53.drawIndirect(buffer12, 31916);
+} catch {}
+try {
+renderBundleEncoder63.setVertexBuffer(1, buffer6);
+} catch {}
+let querySet77 = device2.createQuerySet({
+label: '\u8e9f\u{1f6f6}\u{1f6ec}\u0901',
+type: 'occlusion',
+count: 988,
+});
+let renderBundleEncoder78 = device2.createRenderBundleEncoder({
+  label: '\u25dd\u0608\u03f1\u07fb\u1d31\u3b77\u{1f788}\u426a',
+  colorFormats: ['r8uint', 'bgra8unorm', 'rg32float', 'rg32uint', 'r32float'],
+  stencilReadOnly: true
+});
+let renderBundle83 = renderBundleEncoder76.finish();
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 48, height: 7, depthOrArrayLayers: 100}
+*/
+{
+  source: canvas4,
+  origin: { x: 229, y: 81 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: { x: 26, y: 0, z: 47 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 5, depthOrArrayLayers: 1});
+} catch {}
+let pipeline119 = await device2.createComputePipelineAsync({
+layout: pipelineLayout19,
+compute: {
+module: shaderModule27,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+video9.height = 222;
+let pipelineLayout20 = device3.createPipelineLayout({
+  label: '\u0fe4\u8545\u78ee\ubfc5\u{1fc63}\u0564\u56b1',
+  bindGroupLayouts: [bindGroupLayout44, bindGroupLayout48]
+});
+let sampler63 = device3.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 40.021,
+lodMaxClamp: 53.775,
+maxAnisotropy: 10,
+});
+let querySet78 = device2.createQuerySet({
+label: '\u1ffb\u{1fa54}\u064f\u3f0e\uffea\u757e\u64a5\u3d4e\u0822',
+type: 'occlusion',
+count: 2376,
+});
+let computePassEncoder69 = commandEncoder69.beginComputePass({label: '\ua85c\u0b53\u{1f946}\u94bc\u5efe\u0b37\u055a'});
+let arrayBuffer18 = buffer32.getMappedRange();
+try {
+commandEncoder75.copyBufferToBuffer(buffer26, 6988, buffer25, 10724, 2568);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+commandEncoder63.copyTextureToBuffer({
+  texture: texture92,
+  mipLevel: 1,
+  origin: { x: 4, y: 5, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 3684 */
+offset: 3660,
+buffer: buffer34,
+}, {width: 6, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer34);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 24, height: 3, depthOrArrayLayers: 50}
+*/
+{
+  source: img1,
+  origin: { x: 5, y: 95 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 20, y: 1, z: 13 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder63.clearBuffer(buffer27, 5080, 11328);
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let video18 = await videoWithData();
+let commandEncoder79 = device3.createCommandEncoder({label: '\u990d\ua81c\u02ff\u068b\u0d3a\u{1ff20}\u5cff\u0bce\u0595\u{1ff4e}'});
+let commandEncoder80 = device3.createCommandEncoder();
+let buffer36 = device2.createBuffer({
+  label: '\ub009\ua04d',
+  size: 44824,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM
+});
+try {
+renderBundleEncoder75.setBindGroup(2, bindGroup32, []);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+try {
+commandEncoder63.copyTextureToTexture({
+  texture: texture79,
+  mipLevel: 2,
+  origin: { x: 5, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 3, y: 3, z: 6 },
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 19});
+} catch {}
+try {
+commandEncoder63.clearBuffer(buffer27, 27156, 368);
+dissociateBuffer(device2, buffer27);
+} catch {}
+let promise56 = device2.queue.onSubmittedWorkDone();
+let imageData15 = new ImageData(52, 152);
+let commandEncoder81 = device0.createCommandEncoder({label: '\ud6ed\u{1ffe2}\u{1fc8b}\uc8bd'});
+try {
+renderBundleEncoder34.setVertexBuffer(1, buffer0, 24568);
+} catch {}
+try {
+commandEncoder81.copyBufferToBuffer(buffer0, 25488, buffer10, 996, 5724);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer10);
+} catch {}
+let texture95 = device2.createTexture({
+label: '\u{1fa11}\udf8a\u1639\u8efb\u{1fbfa}\u1379\ub48c\ue9e0\u9802\u5aa2\u0a73',
+size: [540, 1, 792],
+mipLevelCount: 3,
+dimension: '3d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm'],
+});
+let renderBundle84 = renderBundleEncoder71.finish({label: '\u07ad\ua376'});
+try {
+commandEncoder63.clearBuffer(buffer30);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer36, 25992, new Float32Array(53233), 5010, 3080);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 3, height: 1, depthOrArrayLayers: 6}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 184, y: 88 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 4,
+  origin: { x: 2, y: 1, z: 2 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline120 = device2.createComputePipeline({
+label: '\u002e\u0ae8\u{1f787}\u897f\ue6aa\ud827',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule28,
+entryPoint: 'compute0',
+},
+});
+let bindGroup34 = device0.createBindGroup({
+layout: bindGroupLayout4,
+entries: [],
+});
+let buffer37 = device0.createBuffer({size: 20886, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let querySet79 = device0.createQuerySet({
+type: 'occlusion',
+count: 1098,
+});
+let texture96 = device0.createTexture({
+label: '\u02de\u0b2f\u8677\u548a\ucb1a\u0e12\u018a',
+size: {width: 330, height: 24, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['depth24plus', 'depth24plus', 'depth24plus'],
+});
+let renderBundle85 = renderBundleEncoder56.finish({label: '\u0d74\udd19\u78d0\uf17f\u2eca\u2b3a'});
+try {
+renderBundleEncoder20.draw(56);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexed(80, 0, 8, -440);
+} catch {}
+try {
+renderBundleEncoder63.setPipeline(pipeline95);
+} catch {}
+try {
+commandEncoder77.resolveQuerySet(querySet51, 833, 668, buffer37, 9984);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer9), /* required buffer size: 497 */
+{offset: 497}, {width: 40, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise54;
+} catch {}
+let querySet80 = device2.createQuerySet({
+label: '\u{1fcfa}\u8185',
+type: 'occlusion',
+count: 3739,
+});
+pseudoSubmit(device2, commandEncoder75);
+let renderBundle86 = renderBundleEncoder66.finish({label: '\ua15d\uc4f1\u0d34\uc307\ue802\u{1fb84}'});
+try {
+renderBundleEncoder78.setVertexBuffer(7, buffer26);
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(buffer26, 5660, buffer36, 11320, 172);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer36);
+} catch {}
+try {
+commandEncoder63.clearBuffer(buffer36);
+dissociateBuffer(device2, buffer36);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 48, height: 7, depthOrArrayLayers: 100}
+*/
+{
+  source: canvas21,
+  origin: { x: 159, y: 50 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: { x: 0, y: 3, z: 4 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 37, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter1.label = '\uecc0\uede9\ue165\u06fb';
+} catch {}
+let video19 = await videoWithData();
+try {
+await device3.popErrorScope();
+} catch {}
+try {
+texture91.destroy();
+} catch {}
+try {
+commandEncoder76.clearBuffer(buffer35, 3684, 6584);
+dissociateBuffer(device3, buffer35);
+} catch {}
+let bindGroupLayout50 = device0.createBindGroupLayout({
+label: '\u535c\u8862\u4454\u{1f8ef}\u0150\u01d1\u5b71\u0e93\u{1fb8d}\ueeed',
+entries: [],
+});
+let pipelineLayout21 = device0.createPipelineLayout({
+  label: '\u0d88\ueff1\u45dd',
+  bindGroupLayouts: [bindGroupLayout47, bindGroupLayout5, bindGroupLayout14, bindGroupLayout1]
+});
+let texture97 = device0.createTexture({
+label: '\ua89c\u5aa0\u0208\u0d07\ua1b0\u{1fa30}\u051e\u{1fa2c}',
+size: [32, 45, 811],
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+});
+let computePassEncoder70 = commandEncoder77.beginComputePass({label: '\u00d8\u0950'});
+let renderPassEncoder0 = commandEncoder70.beginRenderPass({
+label: '\u34cf\u081a\u0f48\u159a\u97f1\u0544\u5e29',
+colorAttachments: [{
+  view: textureView71,
+  clearValue: { r: 870.2, g: -284.4, b: -702.1, a: 624.5, },
+  loadOp: 'load',
+  storeOp: 'store'
+}],
+occlusionQuerySet: querySet8,
+maxDrawCount: 603623897,
+});
+try {
+computePassEncoder59.dispatchWorkgroups(2, 4, 3);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -950.5, g: 117.5, b: -434.4, a: 631.3, });
+} catch {}
+try {
+renderPassEncoder0.setViewport(1.500, 0.00383, 3.224, 0.3532, 0.5927, 0.6589);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder62.drawIndexedIndirect(buffer15, 4900);
+} catch {}
+try {
+commandEncoder78.copyTextureToTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: { x: 17, y: 1, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 23, y: 1, z: 1 },
+  aspect: 'all',
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer38 = device3.createBuffer({
+  label: '\u0898\u0ab6\ue9fa\u8018\u08ef\ucdee\u0865\u32b5',
+  size: 15083,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let texture98 = device3.createTexture({
+size: [60, 96, 1],
+mipLevelCount: 6,
+dimension: '2d',
+format: 'rg16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16float', 'rg16float', 'rg16float'],
+});
+let adapter7 = await navigator.gpu.requestAdapter({
+});
+let shaderModule32 = device3.createShaderModule({
+label: '\u0efb\u{1f6bd}\ud5b6\u{1ffa4}',
+code: `@group(0) @binding(983)
+var<storage, read_write> i11: array<u32>;
+@group(1) @binding(554)
+var<storage, read_write> local9: array<u32>;
+@group(0) @binding(469)
+var<storage, read_write> parameter16: array<u32>;
+@group(0) @binding(83)
+var<storage, read_write> function9: array<u32>;
+
+@compute @workgroup_size(7, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S22 {
+  @location(6) f0: vec4<f32>,
+  @location(8) f1: u32,
+  @location(15) f2: vec2<u32>,
+  @location(13) f3: vec2<u32>,
+  @builtin(sample_index) f4: u32,
+  @builtin(sample_mask) f5: u32
+}
+struct FragmentOutput0 {
+  @location(3) f0: vec3<u32>,
+  @builtin(sample_mask) f1: u32
+}
+
+@fragment
+fn fragment0(@location(10) a0: vec2<u32>, @location(5) a1: vec3<f16>, @builtin(front_facing) a2: bool, a3: S22) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(8) f130: u32,
+  @location(5) f131: vec3<f16>,
+  @location(15) f132: vec2<u32>,
+  @location(13) f133: vec2<u32>,
+  @location(10) f134: vec2<u32>,
+  @builtin(position) f135: vec4<f32>,
+  @location(6) f136: vec4<f32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @builtin(instance_index) a1: u32, @location(4) a2: f16, @location(15) a3: vec3<u32>, @location(5) a4: vec4<i32>, @location(3) a5: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder82 = device3.createCommandEncoder({label: '\u0aa9\u177d\u{1fce0}\uac0c\u9640\u7982\uc071'});
+pseudoSubmit(device3, commandEncoder79);
+let texture99 = device3.createTexture({
+label: '\u1993\u{1f877}',
+size: [64, 5, 7],
+mipLevelCount: 2,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['depth24plus-stencil8', 'depth24plus-stencil8'],
+});
+let textureView78 = texture99.createView({
+  label: '\u0405\u{1fbf6}\u3581\u05c2\u{1fea2}\u{1fb36}\u88ae\u6336\u02a7',
+  format: 'depth24plus-stencil8',
+  mipLevelCount: 1,
+  baseArrayLayer: 2,
+  arrayLayerCount: 3
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let video20 = await videoWithData();
+try {
+if (!arrayBuffer17.detached) { new Uint8Array(arrayBuffer17).fill(0x55) };
+} catch {}
+let promise57 = adapter7.requestAdapterInfo();
+let texture100 = gpuCanvasContext5.getCurrentTexture();
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -756.6, g: 370.8, b: -696.8, a: -702.3, });
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(3755);
+} catch {}
+try {
+renderBundleEncoder68.setPipeline(pipeline98);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas11,
+  origin: { x: 730, y: 3 },
+  flipY: true,
+}, {
+  texture: texture100,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+pseudoSubmit(device3, commandEncoder82);
+try {
+device3.queue.writeBuffer(buffer35, 21088, new DataView(new ArrayBuffer(1409)), 229, 876);
+} catch {}
+let pipeline121 = await device3.createComputePipelineAsync({
+label: '\u{1fbe6}\u154b',
+layout: pipelineLayout20,
+compute: {
+module: shaderModule32,
+entryPoint: 'compute0',
+},
+});
+let shaderModule33 = device0.createShaderModule({
+label: '\ua1ab\u{1fbfb}\u9708\ud41e\u5287\ub2df\u78a5',
+code: `@group(1) @binding(803)
+var<storage, read_write> parameter17: array<u32>;
+@group(3) @binding(788)
+var<storage, read_write> parameter18: array<u32>;
+@group(1) @binding(788)
+var<storage, read_write> local10: array<u32>;
+@group(0) @binding(788)
+var<storage, read_write> function10: array<u32>;
+
+@compute @workgroup_size(4, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(frag_depth) f0: f32,
+  @location(7) f1: vec2<i32>,
+  @location(0) f2: vec4<i32>,
+  @builtin(sample_mask) f3: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(1) a0: f32, @builtin(vertex_index) a1: u32, @location(6) a2: vec2<i32>, @location(9) a3: vec4<f32>, @location(14) a4: vec2<u32>, @location(4) a5: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+});
+let querySet81 = device0.createQuerySet({
+label: '\u{1feea}\u{1fbc8}\u0284\u9ec7\u88bb',
+type: 'occlusion',
+count: 2039,
+});
+let texture101 = device0.createTexture({
+label: '\u050f\u7ac7\uf62a',
+size: [1320, 96, 1],
+mipLevelCount: 9,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-8x8-unorm'],
+});
+let renderBundleEncoder79 = device0.createRenderBundleEncoder({
+  label: '\u{1f718}\u1d70',
+  colorFormats: ['rgba32uint', 'rg16sint', 'rgb10a2unorm', 'r32float', undefined],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle87 = renderBundleEncoder59.finish();
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(3, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder0.setViewport(3.226, 0.1775, 0.8456, 0.3505, 0.6274, 0.9419);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder53.draw(48);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder78.resolveQuerySet(querySet9, 955, 519, buffer37, 15360);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData14,
+  origin: { x: 39, y: 133 },
+  flipY: false,
+}, {
+  texture: texture93,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline122 = await device0.createRenderPipelineAsync({
+label: '\u5cc1\u082f\u{1ff2f}\u030b\u{1fe0e}\ua127\ua02d\u040e\u0c72\u1add',
+layout: pipelineLayout9,
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg8sint'}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'constant', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}]
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 204,
+shaderLocation: 10,
+}, {
+format: 'sint16x4',
+offset: 1288,
+shaderLocation: 1,
+}, {
+format: 'uint32x2',
+offset: 1576,
+shaderLocation: 14,
+}, {
+format: 'snorm8x2',
+offset: 598,
+shaderLocation: 6,
+}, {
+format: 'sint16x4',
+offset: 656,
+shaderLocation: 4,
+}, {
+format: 'uint16x4',
+offset: 284,
+shaderLocation: 3,
+}, {
+format: 'float32x2',
+offset: 1372,
+shaderLocation: 8,
+}, {
+format: 'snorm16x4',
+offset: 112,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 456,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 960,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x2',
+offset: 822,
+shaderLocation: 7,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+},
+});
+offscreenCanvas17.height = 239;
+let textureView79 = texture91.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 4});
+try {
+computePassEncoder67.end();
+} catch {}
+try {
+device3.queue.writeBuffer(buffer35, 30452, new Float32Array(58655), 35309, 68);
+} catch {}
+try {
+  await promise50;
+} catch {}
+let shaderModule34 = device2.createShaderModule({
+label: '\ufee8\u6698\u8fcb',
+code: `@group(0) @binding(241)
+var<storage, read_write> parameter19: array<u32>;
+@group(2) @binding(241)
+var<storage, read_write> type13: array<u32>;
+
+@compute @workgroup_size(6, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<f32>,
+  @location(5) f1: vec4<i32>,
+  @location(4) f2: vec4<f32>,
+  @location(0) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool, @builtin(sample_mask) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f137: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec4<i32>, @location(1) a1: vec2<f16>, @location(3) a2: vec4<f32>, @location(12) a3: vec4<f32>, @location(5) a4: i32, @location(7) a5: vec4<f16>, @builtin(vertex_index) a6: u32, @location(2) a7: vec3<f32>, @builtin(instance_index) a8: u32, @location(9) a9: vec4<f16>, @location(14) a10: vec4<f16>, @location(4) a11: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let textureView80 = texture75.createView({label: '\u969e\u5dd2', mipLevelCount: 1});
+try {
+computePassEncoder63.setBindGroup(1, bindGroup33);
+} catch {}
+try {
+computePassEncoder61.end();
+} catch {}
+let promise58 = device2.queue.onSubmittedWorkDone();
+let img21 = await imageWithData(41, 190, '#fb454c81', '#09e93d62');
+let shaderModule35 = device0.createShaderModule({
+label: '\u60cf\u{1fa1e}\u03e4\u998a\u6a03\u1bc2',
+code: `@group(0) @binding(794)
+var<storage, read_write> local11: array<u32>;
+@group(0) @binding(297)
+var<storage, read_write> parameter20: array<u32>;
+@group(1) @binding(43)
+var<storage, read_write> function11: array<u32>;
+@group(1) @binding(257)
+var<storage, read_write> i12: array<u32>;
+
+@compute @workgroup_size(3, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S24 {
+  @location(5) f0: vec2<f16>,
+  @builtin(front_facing) f1: bool,
+  @location(1) f2: vec4<f32>,
+  @builtin(position) f3: vec4<f32>,
+  @location(13) f4: vec3<f32>,
+  @location(10) f5: vec3<f32>,
+  @builtin(sample_index) f6: u32,
+  @location(8) f7: vec3<i32>,
+  @location(6) f8: i32,
+  @location(11) f9: vec3<f32>,
+  @location(7) f10: vec2<u32>,
+  @location(12) f11: vec2<f32>,
+  @builtin(sample_mask) f12: u32,
+  @location(4) f13: vec2<f16>,
+  @location(15) f14: f16,
+  @location(0) f15: vec4<u32>,
+  @location(2) f16: vec2<u32>,
+  @location(9) f17: vec2<f32>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<i32>,
+  @location(0) f1: vec2<i32>,
+  @builtin(sample_mask) f2: u32
+}
+
+@fragment
+fn fragment0(a0: S24, @location(14) a1: f16) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S23 {
+  @location(7) f0: vec2<f32>,
+  @location(2) f1: u32,
+  @location(14) f2: vec4<i32>,
+  @location(8) f3: vec2<f16>
+}
+struct VertexOutput0 {
+  @location(9) f138: vec2<f32>,
+  @location(8) f139: vec3<i32>,
+  @location(10) f140: vec3<f32>,
+  @builtin(position) f141: vec4<f32>,
+  @location(1) f142: vec4<f32>,
+  @location(5) f143: vec2<f16>,
+  @location(15) f144: f16,
+  @location(6) f145: i32,
+  @location(11) f146: vec3<f32>,
+  @location(7) f147: vec2<u32>,
+  @location(2) f148: vec2<u32>,
+  @location(0) f149: vec4<u32>,
+  @location(13) f150: vec3<f32>,
+  @location(4) f151: vec2<f16>,
+  @location(14) f152: f16,
+  @location(12) f153: vec2<f32>
+}
+
+@vertex
+fn vertex0(a0: S23, @location(11) a1: vec4<f16>, @location(3) a2: vec3<f16>, @location(15) a3: vec3<i32>, @location(0) a4: i32, @location(10) a5: vec2<f16>, @location(9) a6: vec4<i32>, @location(4) a7: vec2<u32>, @location(5) a8: vec2<u32>, @builtin(vertex_index) a9: u32, @location(13) a10: vec3<u32>, @location(6) a11: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+});
+let renderBundle88 = renderBundleEncoder79.finish({label: '\ud48b\u396d\u{1fd90}'});
+try {
+computePassEncoder22.dispatchWorkgroupsIndirect(buffer15, 5864);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer22, 156, 496);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup19, new Uint32Array(9359), 7299, 0);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer15, 4672);
+} catch {}
+try {
+renderBundleEncoder26.drawIndirect(buffer22, 1012);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(6, buffer6, 11752, 12487);
+} catch {}
+try {
+commandEncoder78.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 1,
+  origin: { x: 10, y: 45, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture13,
+  mipLevel: 2,
+  origin: { x: 10, y: 5, z: 1 },
+  aspect: 'all',
+}, {width: 10, height: 10, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder78.insertDebugMarker('\u341e');
+} catch {}
+let texture102 = device3.createTexture({
+label: '\u56ed\u0070\u06de\u04c0',
+size: [228, 3, 16],
+mipLevelCount: 6,
+sampleCount: 1,
+dimension: '3d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['r8snorm', 'r8snorm'],
+});
+let computePassEncoder71 = commandEncoder80.beginComputePass({});
+try {
+computePassEncoder71.setPipeline(pipeline121);
+} catch {}
+try {
+commandEncoder72.copyTextureToTexture({
+  texture: texture102,
+  mipLevel: 2,
+  origin: { x: 6, y: 1, z: 2 },
+  aspect: 'all',
+}, {
+  texture: texture102,
+  mipLevel: 0,
+  origin: { x: 16, y: 3, z: 6 },
+  aspect: 'all',
+}, {width: 51, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device3.queue.writeBuffer(buffer35, 15536, new Int16Array(7935), 2266, 76);
+} catch {}
+let pipeline123 = device3.createComputePipeline({
+label: '\u0a1d\u61fa\u2a78\u{1fca2}\udc61\u2712\u69e8\ub4bf\u063c',
+layout: pipelineLayout20,
+compute: {
+module: shaderModule32,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let sampler64 = device2.createSampler({
+label: '\u0c4a\ub909\ubb0c\u0fb2\u4827\u026b',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 29.915,
+lodMaxClamp: 76.290,
+});
+try {
+renderBundleEncoder78.setBindGroup(1, bindGroup33);
+} catch {}
+try {
+commandEncoder66.copyTextureToBuffer({
+  texture: texture78,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'depth-only',
+}, {
+/* bytesInLastRow: 840 widthInBlocks: 210 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 43232 */
+offset: 42392,
+bytesPerRow: 1024,
+rowsPerImage: 183,
+buffer: buffer36,
+}, {width: 210, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer36);
+} catch {}
+try {
+commandEncoder66.copyTextureToTexture({
+  texture: texture92,
+  mipLevel: 0,
+  origin: { x: 5, y: 10, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture92,
+  mipLevel: 0,
+  origin: { x: 3, y: 13, z: 1 },
+  aspect: 'all',
+}, {width: 13, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder66.clearBuffer(buffer30, 1140);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+try {
+commandEncoder76.copyTextureToBuffer({
+  texture: texture91,
+  mipLevel: 2,
+  origin: { x: 0, y: 8, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 24 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 3640 */
+offset: 3640,
+buffer: buffer35,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout51 = device2.createBindGroupLayout({
+label: '\u0796\ud55b\u{1fed3}\u5622\u{1ff23}\u727b\u{1f914}\u8029\u01a8\u0814',
+entries: [],
+});
+try {
+computePassEncoder63.setPipeline(pipeline119);
+} catch {}
+let querySet82 = device0.createQuerySet({
+label: '\uafc8\u{1f6db}\u6bfc\u{1fea1}',
+type: 'occlusion',
+count: 3403,
+});
+let commandBuffer19 = commandEncoder81.finish({
+label: '\u003c\u8b86\ua6c8\u3386\u2431\u0a2f\u{1ffd6}\ua199\u{1f931}\u0742',
+});
+let computePassEncoder72 = commandEncoder78.beginComputePass({label: '\u{1f950}\u14f3\u9e20\u0a81\u{1f919}\u0570\u06fe\ua0e0\u1075\u8d90'});
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -21.40, g: 55.39, b: -837.2, a: 356.7, });
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer12, 9300);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline79);
+} catch {}
+try {
+renderBundleEncoder70.setVertexBuffer(2, buffer0, 300, 10605);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer19,
+]);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas22 = new OffscreenCanvas(868, 108);
+let renderBundleEncoder80 = device0.createRenderBundleEncoder({
+  label: '\u{1f734}\ud52c\u7c8d\u0428\u{1f65b}\u{1fc9e}\u{1fcaa}\u002a\u{1fe42}\u0d20\u05fb',
+  colorFormats: ['r8unorm', 'rgb10a2uint', 'rg16sint'],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+let sampler65 = device0.createSampler({
+label: '\u5dd1\ue39c\u642a\u{1fc2c}',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 88.349,
+maxAnisotropy: 10,
+});
+try {
+renderBundleEncoder54.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder68.drawIndexed(56, 0);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexedIndirect(buffer22, 104);
+} catch {}
+try {
+renderBundleEncoder54.setVertexBuffer(7, buffer6, 6640, 6784);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let arrayBuffer19 = buffer14.getMappedRange(0, 2312);
+try {
+device0.queue.writeBuffer(buffer4, 1668, new Int16Array(2427), 1584, 80);
+} catch {}
+let video21 = await videoWithData();
+try {
+device1.queue.label = '\u{1fa4f}\u0e6c\u0eaa\u{1fcef}';
+} catch {}
+let bindGroup35 = device1.createBindGroup({
+label: '\u09c0\u0314\u077e\u296c\u31c0\u09dc\u05ce\u1f75',
+layout: bindGroupLayout27,
+entries: [],
+});
+let pipelineLayout22 = device1.createPipelineLayout({
+  label: '\u8f21\u{1fb07}\u9069',
+  bindGroupLayouts: [bindGroupLayout27, bindGroupLayout27, bindGroupLayout27]
+});
+let textureView81 = texture60.createView({
+  label: '\uac39\ub58c\u0975\u7c18\u{1fdb4}\ue347\u39ef\u{1fdeb}\u05e1\u9fbd',
+  dimension: '2d',
+  format: 'astc-5x5-unorm-srgb',
+  baseMipLevel: 6,
+  mipLevelCount: 1,
+  baseArrayLayer: 150
+});
+let gpuCanvasContext21 = offscreenCanvas22.getContext('webgpu');
+let img22 = await imageWithData(260, 53, '#55c4446d', '#f237a102');
+let imageData16 = new ImageData(36, 84);
+let videoFrame21 = new VideoFrame(videoFrame4, {timestamp: 0});
+let commandEncoder83 = device2.createCommandEncoder({});
+let texture103 = device2.createTexture({
+label: '\u{1ff95}\ud922',
+size: [2160, 1, 64],
+mipLevelCount: 12,
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgb10a2unorm'],
+});
+try {
+computePassEncoder69.end();
+} catch {}
+try {
+gpuCanvasContext8.configure({
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba8unorm', 'rg8uint', 'rgba8unorm-srgb', 'r32sint'],
+colorSpace: 'srgb',
+});
+} catch {}
+let promise59 = device2.createComputePipelineAsync({
+label: '\u0ea4\u{1fe0f}\u0a48\ub31a\uc541',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule27,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let imageData17 = new ImageData(188, 176);
+let texture104 = device2.createTexture({
+label: '\ubd81\u{1fc0e}\u0db7\uabd4',
+size: {width: 24},
+dimension: '1d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg11b10ufloat'],
+});
+let renderBundle89 = renderBundleEncoder67.finish({label: '\uf500\u0f6d\u206d\u{1fe35}\u0a68\u{1fa1f}\u0e86'});
+let sampler66 = device2.createSampler({
+label: '\u03e0\u{1f704}\u0070\u{1fd89}\u83ab\uca4d\u022b\u8420\u44ee\u7036\u0c7b',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMaxClamp: 96.909,
+compare: 'never',
+maxAnisotropy: 1,
+});
+try {
+computePassEncoder63.setBindGroup(1, bindGroup32);
+} catch {}
+try {
+commandEncoder72.copyBufferToBuffer(buffer38, 6684, buffer35, 11360, 4340);
+dissociateBuffer(device3, buffer38);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder72.copyBufferToTexture({
+/* bytesInLastRow: 12 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 24109 */
+offset: 14381,
+bytesPerRow: 256,
+rowsPerImage: 38,
+buffer: buffer35,
+}, {
+  texture: texture102,
+  mipLevel: 3,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 12, height: 0, depthOrArrayLayers: 2});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame22 = videoFrame0.clone();
+let shaderModule36 = device2.createShaderModule({
+label: '\u5043\u{1fd33}\u1c40',
+code: `@group(1) @binding(241)
+var<storage, read_write> function12: array<u32>;
+@group(2) @binding(241)
+var<storage, read_write> global8: array<u32>;
+
+@compute @workgroup_size(4, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec3<f32>,
+  @location(0) f1: u32,
+  @location(3) f2: vec2<u32>,
+  @location(1) f3: vec4<f32>,
+  @location(2) f4: vec3<f32>,
+  @location(5) f5: vec4<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(4) a0: vec2<f16>, @location(9) a1: vec3<f32>, @location(0) a2: vec3<f32>, @location(5) a3: vec3<f32>, @location(2) a4: vec2<i32>, @location(12) a5: vec4<f32>, @location(13) a6: i32, @location(15) a7: vec3<f32>, @location(1) a8: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let querySet83 = device2.createQuerySet({
+label: '\uf10c\uf45c\u0dd7\u07d2\u2d78\u5e56\u{1f83e}\u3a5a\uf2a9\u196f\u05db',
+type: 'occlusion',
+count: 3276,
+});
+let renderBundleEncoder81 = device2.createRenderBundleEncoder({
+  label: '\udd58\u{1fd5f}\ufade\u1b87\uc06a\u{1f6e1}\u0c49\u03e1\u00ee\u8ea2',
+  colorFormats: ['r8unorm', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+let sampler67 = device2.createSampler({
+label: '\uff1e\ud226\ua503\u061b\u271a\u07ed\u{1fd92}\u{1f857}\uc463\u{1ff6b}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 36.589,
+lodMaxClamp: 58.333,
+});
+try {
+computePassEncoder65.setBindGroup(3, bindGroup32, new Uint32Array(5688), 4933, 0);
+} catch {}
+try {
+renderBundleEncoder72.setBindGroup(2, bindGroup32, []);
+} catch {}
+try {
+await device2.popErrorScope();
+} catch {}
+let arrayBuffer20 = buffer27.getMappedRange(9408, 3152);
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 3, height: 1, depthOrArrayLayers: 6}
+*/
+{
+  source: canvas2,
+  origin: { x: 489, y: 809 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 4,
+  origin: { x: 2, y: 1, z: 6 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise53;
+} catch {}
+let imageBitmap26 = await createImageBitmap(offscreenCanvas6);
+try {
+  await promise57;
+} catch {}
+gc();
+let renderBundleEncoder82 = device0.createRenderBundleEncoder({
+  label: '\u0e99\uab80\u476e\uc395',
+  colorFormats: ['rgba8sint', 'rgba32sint', 'rg16float', 'rg16sint', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+let renderBundle90 = renderBundleEncoder37.finish({});
+try {
+renderBundleEncoder82.setIndexBuffer(buffer9, 'uint32', 1636, 14321);
+} catch {}
+let canvas29 = document.createElement('canvas');
+let bindGroup36 = device2.createBindGroup({
+layout: bindGroupLayout51,
+entries: [],
+});
+let texture105 = device2.createTexture({
+label: '\u{1fb0a}\u3012\uebf3\u2684\ua191\u8eef',
+size: [5280, 1, 176],
+mipLevelCount: 10,
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgb9e5ufloat'],
+});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup32, new Uint32Array(7566), 887, 0);
+} catch {}
+try {
+renderBundleEncoder81.setBindGroup(2, bindGroup36, new Uint32Array(421), 291, 0);
+} catch {}
+try {
+commandEncoder83.clearBuffer(buffer31, 34836, 12);
+dissociateBuffer(device2, buffer31);
+} catch {}
+let gpuCanvasContext22 = canvas29.getContext('webgpu');
+let querySet84 = device3.createQuerySet({
+label: '\ud7da\ufab5\u2dd0\u6dc3\u01a4\u{1f90b}\ua65f\u0a91\u0509',
+type: 'occlusion',
+count: 1894,
+});
+let textureView82 = texture102.createView({label: '\u{1f6d9}\ub2e2\u{1ff06}\u5de9\u2aae', aspect: 'all', baseMipLevel: 4});
+let sampler68 = device3.createSampler({
+label: '\u{1fe1a}\u7ee3\u01dd\u3846\u1a47\u{1fc98}\uf284\ub6bc\u{1f991}',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 73.656,
+lodMaxClamp: 86.797,
+});
+try {
+commandEncoder72.copyBufferToBuffer(buffer33, 24048, buffer35, 22776, 6348);
+dissociateBuffer(device3, buffer33);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder76.copyTextureToTexture({
+  texture: texture102,
+  mipLevel: 2,
+  origin: { x: 16, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture102,
+  mipLevel: 0,
+  origin: { x: 51, y: 0, z: 5 },
+  aspect: 'all',
+}, {width: 41, height: 1, depthOrArrayLayers: 3});
+} catch {}
+try {
+commandEncoder72.clearBuffer(buffer35, 12864, 12568);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer35, 7248, new Int16Array(44946), 41985, 984);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture102,
+  mipLevel: 4,
+  origin: { x: 6, y: 0, z: 0 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer17), /* required buffer size: 508 */
+{offset: 507}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device3.destroy();
+} catch {}
+let videoFrame23 = new VideoFrame(videoFrame21, {timestamp: 0});
+let bindGroup37 = device2.createBindGroup({
+layout: bindGroupLayout37,
+entries: [{
+binding: 771,
+resource: externalTexture4
+}, {
+binding: 385,
+resource: sampler62
+}],
+});
+let commandEncoder84 = device2.createCommandEncoder({label: '\u{1ff61}\u{1f703}\u0af6\u{1fd65}\u0fbb'});
+let renderBundleEncoder83 = device2.createRenderBundleEncoder({
+  label: '\u0ccd\uabe1\u0710',
+  colorFormats: ['bgra8unorm', undefined, undefined, 'rgba16float', 'bgra8unorm-srgb', 'rgba8sint']
+});
+try {
+computePassEncoder58.setPipeline(pipeline113);
+} catch {}
+try {
+renderBundleEncoder72.setVertexBuffer(0, buffer26);
+} catch {}
+try {
+commandEncoder74.clearBuffer(buffer25, 49496, 12244);
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline124 = device2.createRenderPipeline({
+label: '\u0b63\ue751\ubdfc\uc0a1\u{1fff5}\u{1ff7c}',
+layout: pipelineLayout19,
+multisample: {
+count: 4,
+mask: 0xa6c4d309,
+},
+fragment: {
+  module: shaderModule36,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'bgra8unorm', writeMask: 0}, {format: 'rg32float', writeMask: GPUColorWrite.BLUE}, {format: 'rg32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater',
+depthFailOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 114,
+stencilWriteMask: 31,
+depthBias: 61,
+depthBiasSlopeScale: 7,
+depthBiasClamp: 50,
+},
+vertex: {
+  module: shaderModule36,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1672,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x2',
+offset: 1556,
+shaderLocation: 1,
+}, {
+format: 'sint32x2',
+offset: 1280,
+shaderLocation: 2,
+}, {
+format: 'snorm8x4',
+offset: 392,
+shaderLocation: 4,
+}, {
+format: 'float32x3',
+offset: 832,
+shaderLocation: 12,
+}, {
+format: 'snorm8x4',
+offset: 1228,
+shaderLocation: 5,
+}, {
+format: 'snorm16x4',
+offset: 584,
+shaderLocation: 0,
+}, {
+format: 'sint8x4',
+offset: 916,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 744,
+attributes: [{
+format: 'float32x2',
+offset: 688,
+shaderLocation: 15,
+}, {
+format: 'unorm8x4',
+offset: 532,
+shaderLocation: 9,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+},
+});
+document.body.prepend(img15);
+let bindGroup38 = device1.createBindGroup({
+label: '\u0988\u0d53\u3eff\u2b07\uda56',
+layout: bindGroupLayout27,
+entries: [],
+});
+let textureView83 = texture59.createView({baseMipLevel: 3, mipLevelCount: 1});
+let commandEncoder85 = device1.createCommandEncoder({label: '\u{1f7ce}\ub1a2\u6db8\u79c3\u8d0d\u2632\u5831\uf3e4\u{1f824}\u{1f920}\u9c76'});
+let textureView84 = texture10.createView({
+  label: '\u0c5a\ub127\u1db0\uf1db\u5009\ub69c\u0e5e\u0ae0\ua34b\ubd33',
+  dimension: '2d-array',
+  baseMipLevel: 3
+});
+try {
+computePassEncoder53.setPipeline(pipeline78);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(1598);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(534);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer22);
+} catch {}
+try {
+renderBundleEncoder62.drawIndexedIndirect(buffer22, 552);
+} catch {}
+try {
+commandEncoder85.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 28992 */
+offset: 28992,
+buffer: buffer0,
+}, {
+  texture: texture30,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 15244, new Int16Array(21601), 12988, 28);
+} catch {}
+let pipeline125 = device0.createRenderPipeline({
+label: '\u6c3d\u{1f8a5}\u{1fab7}\u{1f8cd}\u0c41\u0e9d\u066d\u0e8a',
+layout: pipelineLayout18,
+multisample: {
+mask: 0xaed6dab1,
+},
+fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r8uint', writeMask: 0}, undefined, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilReadMask: 1822,
+depthBias: 93,
+depthBiasSlopeScale: 11,
+depthBiasClamp: 19,
+},
+vertex: {
+  module: shaderModule20,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 960,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x2',
+offset: 864,
+shaderLocation: 3,
+}, {
+format: 'sint8x4',
+offset: 744,
+shaderLocation: 12,
+}, {
+format: 'sint8x2',
+offset: 868,
+shaderLocation: 14,
+}, {
+format: 'unorm8x4',
+offset: 816,
+shaderLocation: 2,
+}, {
+format: 'float16x4',
+offset: 336,
+shaderLocation: 10,
+}, {
+format: 'unorm8x2',
+offset: 844,
+shaderLocation: 1,
+}, {
+format: 'unorm8x2',
+offset: 556,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 1724,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x4',
+offset: 504,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1400,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 400,
+shaderLocation: 5,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+canvas26.height = 891;
+try {
+  await promise58;
+} catch {}
+gc();
+let video22 = await videoWithData();
+let imageBitmap27 = await createImageBitmap(videoFrame5);
+let texture106 = device0.createTexture({
+label: '\u80c6\u0a63\u{1f614}',
+size: [64],
+dimension: '1d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['r8snorm'],
+});
+let textureView85 = texture100.createView({label: '\u9ca8\ue6e2\u3c53\ud597\u895a', dimension: '2d-array', format: 'eac-rg11snorm'});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup6, []);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer0, 13644, 19642);
+} catch {}
+try {
+renderBundleEncoder68.drawIndirect(buffer22, 1928);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(1, buffer24, 9752, 9292);
+} catch {}
+try {
+  await promise52;
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+video6.height = 148;
+offscreenCanvas18.height = 326;
+let imageData18 = new ImageData(112, 132);
+try {
+window.someLabel = commandEncoder40.label;
+} catch {}
+let querySet85 = device0.createQuerySet({
+label: '\u{1ff62}\u5ed0\u0c3b\uade3\uf5a3\u0ab1\u{1ff01}',
+type: 'occlusion',
+count: 3255,
+});
+try {
+computePassEncoder22.dispatchWorkgroups(2, 4, 1);
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setViewport(0.9961, 0.1283, 1.888, 0.01577, 0.9754, 0.9780);
+} catch {}
+try {
+commandEncoder85.resolveQuerySet(querySet14, 1334, 178, buffer37, 12544);
+} catch {}
+document.body.prepend(video4);
+let offscreenCanvas23 = new OffscreenCanvas(149, 178);
+let shaderModule37 = device0.createShaderModule({
+label: '\u0ec2\u{1feef}\u0c8b\uad17\ub415\u029d\u0d49\u09dc',
+code: `@group(1) @binding(803)
+var<storage, read_write> function13: array<u32>;
+@group(1) @binding(788)
+var<storage, read_write> function14: array<u32>;
+@group(0) @binding(561)
+var<storage, read_write> type14: array<u32>;
+@group(2) @binding(20)
+var<storage, read_write> i13: array<u32>;
+@group(3) @binding(674)
+var<storage, read_write> parameter21: array<u32>;
+
+@compute @workgroup_size(4, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @location(7) f1: vec2<f32>,
+  @location(3) f2: vec4<i32>,
+  @location(1) f3: vec4<i32>,
+  @location(2) f4: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(sample_index) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandBuffer20 = commandEncoder85.finish();
+pseudoSubmit(device0, commandEncoder38);
+let texture107 = device0.createTexture({
+label: '\u{1fd65}\ue10d\u{1f826}\ud887\u{1f9a1}\u0cdc\ufce6\ua588\u4ea4\u{1f6a3}',
+size: [80, 1, 1635],
+dimension: '3d',
+format: 'rg16uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+try {
+renderPassEncoder0.setStencilReference(2196);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(8);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(0, buffer6, 31308);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm', 'rgba8unorm', 'rgba8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer20,
+]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData10,
+  origin: { x: 49, y: 52 },
+  flipY: false,
+}, {
+  texture: texture100,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline126 = device0.createRenderPipeline({
+label: '\u9e15\u{1fd95}\u{1f71d}\ud765',
+layout: pipelineLayout14,
+fragment: {
+  module: shaderModule15,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint'}, {format: 'r16uint', writeMask: GPUColorWrite.RED}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rgba16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}]
+},
+vertex: {
+  module: shaderModule15,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 48,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 4,
+shaderLocation: 13,
+}, {
+format: 'sint32',
+offset: 20,
+shaderLocation: 8,
+}, {
+format: 'float32',
+offset: 36,
+shaderLocation: 1,
+}, {
+format: 'uint32x2',
+offset: 4,
+shaderLocation: 6,
+}, {
+format: 'unorm8x2',
+offset: 44,
+shaderLocation: 7,
+}, {
+format: 'uint32x3',
+offset: 8,
+shaderLocation: 15,
+}, {
+format: 'unorm10-10-10-2',
+offset: 36,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 1824,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 596,
+shaderLocation: 11,
+}, {
+format: 'uint32',
+offset: 1308,
+shaderLocation: 4,
+}, {
+format: 'unorm10-10-10-2',
+offset: 1408,
+shaderLocation: 5,
+}, {
+format: 'sint32',
+offset: 1512,
+shaderLocation: 14,
+}, {
+format: 'snorm8x4',
+offset: 528,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 844,
+attributes: [{
+format: 'float32x4',
+offset: 112,
+shaderLocation: 9,
+}, {
+format: 'sint8x2',
+offset: 184,
+shaderLocation: 12,
+}, {
+format: 'unorm16x2',
+offset: 284,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 428,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 520,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x4',
+offset: 412,
+shaderLocation: 2,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas23.getContext('2d');
+} catch {}
+let shaderModule38 = device0.createShaderModule({
+label: '\ue414\u{1f68f}',
+code: `@group(1) @binding(803)
+var<storage, read_write> global9: array<u32>;
+@group(3) @binding(674)
+var<storage, read_write> parameter22: array<u32>;
+@group(2) @binding(20)
+var<storage, read_write> i14: array<u32>;
+@group(1) @binding(788)
+var<storage, read_write> type15: array<u32>;
+
+@compute @workgroup_size(1, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @location(2) f1: vec4<f32>,
+  @location(6) f2: vec4<f32>,
+  @location(1) f3: vec3<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(11) a0: f16, @location(13) a1: f32, @location(2) a2: vec2<f32>, @location(5) a3: vec2<f32>, @location(6) a4: vec2<f16>, @location(15) a5: vec2<f16>, @location(10) a6: vec3<f32>, @location(0) a7: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let commandEncoder86 = device0.createCommandEncoder({label: '\u{1fbe8}\u{1f9af}\u41d9\u0762\u9ea5\u55f3\u09e1\ufb08\u028c'});
+let textureView86 = texture28.createView({label: '\u4545\ua4c7\u38c0\u3f0b\u{1fc4c}\u{1fb9b}', arrayLayerCount: 1});
+try {
+computePassEncoder57.setPipeline(pipeline86);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexedIndirect(buffer22, 1008);
+} catch {}
+try {
+renderBundleEncoder80.setVertexBuffer(7, buffer37, 12560, 2046);
+} catch {}
+try {
+texture35.destroy();
+} catch {}
+let pipeline127 = device0.createRenderPipeline({
+layout: pipelineLayout0,
+multisample: {
+count: 4,
+mask: 0xcdcd8865,
+},
+fragment: {
+  module: shaderModule15,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: 0}, {format: 'r16uint'}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgba16sint', writeMask: 0}]
+},
+vertex: {
+  module: shaderModule15,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 792,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 720,
+shaderLocation: 5,
+}, {
+format: 'uint32x3',
+offset: 100,
+shaderLocation: 15,
+}, {
+format: 'sint8x2',
+offset: 424,
+shaderLocation: 8,
+}, {
+format: 'uint32x3',
+offset: 740,
+shaderLocation: 4,
+}, {
+format: 'unorm16x2',
+offset: 316,
+shaderLocation: 3,
+}, {
+format: 'float16x4',
+offset: 528,
+shaderLocation: 11,
+}, {
+format: 'sint32',
+offset: 640,
+shaderLocation: 14,
+}, {
+format: 'unorm8x2',
+offset: 598,
+shaderLocation: 2,
+}, {
+format: 'sint32',
+offset: 236,
+shaderLocation: 12,
+}, {
+format: 'unorm8x2',
+offset: 502,
+shaderLocation: 9,
+}, {
+format: 'float16x2',
+offset: 544,
+shaderLocation: 0,
+}, {
+format: 'sint32x3',
+offset: 8,
+shaderLocation: 13,
+}, {
+format: 'float32x4',
+offset: 528,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 1644,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 400,
+shaderLocation: 7,
+}, {
+format: 'uint32x3',
+offset: 1564,
+shaderLocation: 6,
+}, {
+format: 'float32x4',
+offset: 1508,
+shaderLocation: 10,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let offscreenCanvas24 = new OffscreenCanvas(332, 937);
+let videoFrame24 = new VideoFrame(img0, {timestamp: 0});
+try {
+gpuCanvasContext22.unconfigure();
+} catch {}
+try {
+window.someLabel = device1.label;
+} catch {}
+let imageBitmap28 = await createImageBitmap(canvas10);
+let video23 = await videoWithData();
+try {
+adapter5.label = '\u{1fe72}\u{1fbdc}\u{1feae}\u{1ff2a}';
+} catch {}
+try {
+computePassEncoder57.dispatchWorkgroupsIndirect(buffer22, 1236);
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline29);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(2, 0, 3, 0);
+} catch {}
+try {
+renderPassEncoder0.setViewport(1.488, 0.1082, 1.529, 0.3566, 0.2817, 0.7339);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer9, 'uint32', 8192, 4158);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer37, 80, 1598);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer22, 1112);
+} catch {}
+let promise60 = buffer8.mapAsync(GPUMapMode.READ, 0, 5940);
+try {
+commandEncoder86.copyBufferToBuffer(buffer12, 14360, buffer4, 8440, 40);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder86.copyTextureToBuffer({
+  texture: texture36,
+  mipLevel: 2,
+  origin: { x: 30, y: 0, z: 54 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 5472 */
+offset: 5472,
+bytesPerRow: 0,
+rowsPerImage: 72,
+buffer: buffer1,
+}, {width: 0, height: 15, depthOrArrayLayers: 138});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder86.copyTextureToTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: { x: 16, y: 25, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture30,
+  mipLevel: 2,
+  origin: { x: 8, y: 20, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise61 = device0.queue.onSubmittedWorkDone();
+let pipeline128 = device0.createRenderPipeline({
+label: '\ua6bb\u7cac\ud966\u2c3f\u1472\u{1f933}\u71d2\u0bf6\u9f2c\ufc5e\u0d0f',
+layout: pipelineLayout6,
+multisample: {
+count: 4,
+},
+fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint'}, {format: 'rgba8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN
+}, undefined, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'zero', dstFactor: 'dst-alpha'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'replace',
+},
+stencilReadMask: 3345,
+depthBias: 65,
+depthBiasSlopeScale: 84,
+},
+vertex: {
+  module: shaderModule16,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1160,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x2',
+offset: 152,
+shaderLocation: 13,
+}, {
+format: 'unorm16x2',
+offset: 252,
+shaderLocation: 14,
+}],
+}
+]
+},
+});
+video7.height = 2;
+let bindGroupLayout52 = device0.createBindGroupLayout({
+label: '\u5434\uc9ec\u5bd6\u{1fb36}\uab96\u13c4',
+entries: [{
+binding: 822,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+}, {
+binding: 56,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '2d-array' },
+}, {
+binding: 516,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}],
+});
+let textureView87 = texture73.createView({arrayLayerCount: 1});
+let renderBundle91 = renderBundleEncoder0.finish({label: '\u5f4f\u{1f7bc}\uaa14'});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup4, new Uint32Array(7712), 3471, 0);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(1571);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder53.draw(32, 80, 48);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder86.copyBufferToBuffer(buffer12, 5796, buffer11, 54244, 1708);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer39 = device0.createBuffer({label: '\u5045\u{1fda1}\u05f0\u0d59\u11e9\u9a5a\u{1f9b4}', size: 58249, usage: GPUBufferUsage.MAP_WRITE});
+let textureView88 = texture43.createView({
+  label: '\u{1f838}\ude85\ue2d2\u01d9\u{1f74c}\ufc1b',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 1
+});
+let renderBundleEncoder84 = device0.createRenderBundleEncoder({
+  label: '\u1167\u1e5e\u{1fa6a}\u0ccb\u0625\u614e\u01ad',
+  colorFormats: ['rg16uint', 'rg32float', 'r16uint', 'rg16sint'],
+  depthReadOnly: true
+});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup10, new Uint32Array(2662), 1768, 0);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 598.4, g: 23.12, b: -221.2, a: 890.7, });
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(3476);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer9, 'uint32', 10188, 9103);
+} catch {}
+try {
+renderBundleEncoder73.setBindGroup(0, bindGroup16, new Uint32Array(2485), 1166, 0);
+} catch {}
+let promise62 = buffer39.mapAsync(GPUMapMode.WRITE, 28880, 4376);
+try {
+commandEncoder86.copyBufferToBuffer(buffer2, 116, buffer8, 6896, 920);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder86.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 1,
+  origin: { x: 4, y: 20, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 88, y: 116, z: 0 },
+  aspect: 'all',
+}, {width: 32, height: 60, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder86.resolveQuerySet(querySet52, 837, 1915, buffer12, 256);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 8960, new DataView(new ArrayBuffer(965)), 801, 160);
+} catch {}
+let pipeline129 = device0.createRenderPipeline({
+label: '\u069f\u3235\u052a\u{1ff84}\u0c0e\u8eb6\uf44b',
+layout: pipelineLayout3,
+multisample: {
+mask: 0x41239aa5,
+},
+fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rgba8unorm', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'rg16float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, undefined, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'src-alpha-saturated'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+}
+}]
+},
+vertex: {
+  module: shaderModule3,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1120,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 416,
+shaderLocation: 0,
+}, {
+format: 'unorm8x4',
+offset: 1032,
+shaderLocation: 3,
+}, {
+format: 'sint32x4',
+offset: 980,
+shaderLocation: 6,
+}, {
+format: 'sint8x4',
+offset: 1048,
+shaderLocation: 9,
+}, {
+format: 'uint8x2',
+offset: 670,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 888,
+attributes: [{
+format: 'unorm16x4',
+offset: 460,
+shaderLocation: 4,
+}, {
+format: 'unorm10-10-10-2',
+offset: 780,
+shaderLocation: 7,
+}, {
+format: 'unorm16x4',
+offset: 436,
+shaderLocation: 8,
+}, {
+format: 'snorm8x4',
+offset: 224,
+shaderLocation: 5,
+}, {
+format: 'sint32x3',
+offset: 492,
+shaderLocation: 2,
+}, {
+format: 'uint32x4',
+offset: 596,
+shaderLocation: 13,
+}, {
+format: 'unorm8x4',
+offset: 352,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 500,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1232,
+attributes: [],
+},
+{
+arrayStride: 232,
+attributes: [],
+},
+{
+arrayStride: 212,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 40,
+shaderLocation: 14,
+}],
+}
+]
+},
+});
+try {
+offscreenCanvas24.getContext('2d');
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline119);
+} catch {}
+let device4 = await adapter7.requestDevice({
+requiredFeatures: [
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 56,
+maxVertexAttributes: 18,
+maxVertexBufferArrayStride: 8941,
+maxStorageTexturesPerShaderStage: 9,
+maxStorageBuffersPerShaderStage: 17,
+maxDynamicStorageBuffersPerPipelineLayout: 24823,
+maxBindingsPerBindGroup: 6818,
+maxTextureDimension1D: 12394,
+maxTextureDimension2D: 10494,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 159452209,
+maxUniformBuffersPerShaderStage: 23,
+maxInterStageShaderVariables: 90,
+maxInterStageShaderComponents: 87,
+maxSamplersPerShaderStage: 22,
+},
+});
+let img23 = await imageWithData(114, 239, '#cb4a84a1', '#f5703767');
+let videoFrame25 = new VideoFrame(offscreenCanvas2, {timestamp: 0});
+let computePassEncoder73 = commandEncoder72.beginComputePass({label: '\u{1fc32}\u90fd'});
+let sampler69 = device3.createSampler({
+label: '\ubd70\u09b9\u{1fa61}\ua2f4\u{1fb84}\u7754',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 59.807,
+lodMaxClamp: 76.244,
+maxAnisotropy: 4,
+});
+try {
+commandEncoder76.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 22324 */
+offset: 22324,
+buffer: buffer35,
+}, {
+  texture: texture102,
+  mipLevel: 5,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+gpuCanvasContext16.configure({
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture102,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 430 */
+{offset: 430}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise63 = device3.queue.onSubmittedWorkDone();
+let pipeline130 = device3.createRenderPipeline({
+label: '\u{1f713}\u{1f888}\udb58\u{1f729}\u0211\u05ad\u8f9e',
+layout: pipelineLayout20,
+fragment: {module: shaderModule32, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 1143,
+stencilWriteMask: 3496,
+depthBiasSlopeScale: 46,
+depthBiasClamp: 48,
+},
+vertex: {
+  module: shaderModule32,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1544,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 288,
+shaderLocation: 4,
+}, {
+format: 'uint8x4',
+offset: 480,
+shaderLocation: 15,
+}, {
+format: 'sint32x3',
+offset: 260,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 804,
+attributes: [{
+format: 'unorm16x4',
+offset: 320,
+shaderLocation: 3,
+}],
+}
+]
+},
+});
+let querySet86 = device4.createQuerySet({
+label: '\u30a6\u{1fabb}\u{1fd58}',
+type: 'occlusion',
+count: 721,
+});
+let texture108 = device4.createTexture({
+size: {width: 96, height: 10, depthOrArrayLayers: 237},
+mipLevelCount: 7,
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgba16uint'],
+});
+let renderBundleEncoder85 = device4.createRenderBundleEncoder({
+  label: '\u0573\u0d1c\u0055\u0abb\ucbe3\u204e\u0d37\u0cdb\u0ff8',
+  colorFormats: ['rg16sint', 'rgba8unorm-srgb'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+let offscreenCanvas25 = new OffscreenCanvas(524, 781);
+try {
+adapter1.label = '\uf79a\u7461';
+} catch {}
+let bindGroupLayout53 = device4.createBindGroupLayout({
+label: '\ue00c\ufdb6',
+entries: [],
+});
+let renderBundleEncoder86 = device4.createRenderBundleEncoder({
+  label: '\uab77\u377a\ub441\u{1ffbe}\u{1f920}\uf160\u067c\u{1f6d3}\ucf70\u03f8\u12fb',
+  colorFormats: ['rg16sint', 'rgba8unorm-srgb'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+let sampler70 = device4.createSampler({
+label: '\u1c62\u5b8e\ub6af',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 76.455,
+lodMaxClamp: 83.673,
+});
+try {
+renderBundleEncoder86.setVertexBuffer(37, undefined);
+} catch {}
+try {
+offscreenCanvas25.getContext('2d');
+} catch {}
+let pipelineLayout23 = device4.createPipelineLayout({bindGroupLayouts: [bindGroupLayout53, bindGroupLayout53, bindGroupLayout53, bindGroupLayout53]});
+let commandEncoder87 = device4.createCommandEncoder({label: '\ua83e\u83f2\ubae9\u0e80\u0177\u2ccd\u{1fcca}\u9961'});
+let querySet87 = device4.createQuerySet({
+label: '\u{1fcf9}\u421e\u06b4\u158a\uece2\u0961\uaf5f',
+type: 'occlusion',
+count: 333,
+});
+let textureView89 = texture108.createView({dimension: '2d', format: 'rgba16uint', baseMipLevel: 4, mipLevelCount: 1, baseArrayLayer: 44});
+let canvas30 = document.createElement('canvas');
+try {
+window.someLabel = sampler70.label;
+} catch {}
+let computePassEncoder74 = commandEncoder87.beginComputePass({});
+try {
+renderBundleEncoder86.pushDebugGroup('\u8c32');
+} catch {}
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img24 = await imageWithData(34, 199, '#7b989b41', '#20dc5677');
+let bindGroupLayout54 = device4.createBindGroupLayout({
+label: '\u{1facf}\u{1fcf2}\u3dec\uf7b5\u{1fcde}\u{1faa1}\u{1fb21}\ua746\u{1f626}\u68e3\u1cfc',
+entries: [{
+binding: 2018,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'filtering' },
+}, {
+binding: 2479,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'comparison' },
+}, {
+binding: 3217,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}],
+});
+let querySet88 = device4.createQuerySet({
+label: '\u{1fec6}\u0318',
+type: 'occlusion',
+count: 1912,
+});
+try {
+renderBundleEncoder86.popDebugGroup();
+} catch {}
+let querySet89 = device4.createQuerySet({
+label: '\u82f4\u7c9f\ufcf1\u892c\u3127\u310f\u0e9e\u43e9\ufa7a\u{1fe97}\u0206',
+type: 'occlusion',
+count: 3229,
+});
+document.body.prepend(video23);
+try {
+canvas30.getContext('2d');
+} catch {}
+let shaderModule39 = device2.createShaderModule({
+label: '\uecdb\uc595\u05aa\u{1fb71}',
+code: `@group(2) @binding(241)
+var<storage, read_write> local12: array<u32>;
+@group(1) @binding(241)
+var<storage, read_write> parameter23: array<u32>;
+@group(0) @binding(241)
+var<storage, read_write> function15: array<u32>;
+
+@compute @workgroup_size(7, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S26 {
+  @location(14) f0: vec4<i32>,
+  @location(3) f1: vec3<f16>
+}
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(4) f1: vec4<f32>,
+  @location(5) f2: vec4<i32>,
+  @location(3) f3: vec4<f32>,
+  @location(0) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(15) a0: u32, @location(4) a1: vec4<f32>, @location(6) a2: i32, @location(8) a3: vec3<u32>, a4: S26, @location(7) a5: vec4<f16>, @location(13) a6: f16, @builtin(front_facing) a7: bool, @location(11) a8: vec4<f16>, @location(9) a9: i32, @location(2) a10: vec4<i32>, @location(5) a11: vec4<u32>, @location(0) a12: vec4<f16>, @builtin(sample_index) a13: u32, @builtin(position) a14: vec4<f32>, @builtin(sample_mask) a15: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S25 {
+  @location(0) f0: vec2<f32>,
+  @location(15) f1: vec3<i32>,
+  @location(1) f2: vec3<u32>,
+  @location(7) f3: vec2<f16>,
+  @location(6) f4: vec4<f32>,
+  @location(10) f5: vec3<f16>,
+  @location(2) f6: f16,
+  @location(4) f7: vec4<f16>,
+  @location(5) f8: vec3<i32>,
+  @location(3) f9: f32,
+  @location(11) f10: vec3<i32>,
+  @location(8) f11: u32,
+  @builtin(vertex_index) f12: u32,
+  @builtin(instance_index) f13: u32,
+  @location(9) f14: vec3<i32>,
+  @location(14) f15: u32,
+  @location(12) f16: vec2<u32>,
+  @location(13) f17: vec2<i32>
+}
+struct VertexOutput0 {
+  @location(9) f154: i32,
+  @location(6) f155: i32,
+  @builtin(position) f156: vec4<f32>,
+  @location(8) f157: vec3<u32>,
+  @location(3) f158: vec3<f16>,
+  @location(15) f159: u32,
+  @location(13) f160: f16,
+  @location(4) f161: vec4<f32>,
+  @location(14) f162: vec4<i32>,
+  @location(0) f163: vec4<f16>,
+  @location(5) f164: vec4<u32>,
+  @location(2) f165: vec4<i32>,
+  @location(11) f166: vec4<f16>,
+  @location(7) f167: vec4<f16>
+}
+
+@vertex
+fn vertex0(a0: S25) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+try {
+device2.queue.writeBuffer(buffer36, 7904, new Int16Array(42413), 11131, 14140);
+} catch {}
+gc();
+let bindGroupLayout55 = pipeline124.getBindGroupLayout(1);
+let buffer40 = device2.createBuffer({size: 30121, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture109 = device2.createTexture({
+label: '\ud41d\u0601\u{1f70c}\u5eb0\u8cfd\u6652\u65c5\ub9a9\u0587\u0faf\u71df',
+size: {width: 96},
+dimension: '1d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgba8unorm-srgb', 'rgba8unorm'],
+});
+try {
+commandEncoder83.copyBufferToBuffer(buffer26, 3276, buffer40, 9704, 1268);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer40);
+} catch {}
+let shaderModule40 = device2.createShaderModule({
+code: `@group(2) @binding(241)
+var<storage, read_write> parameter24: array<u32>;
+
+@compute @workgroup_size(6, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool) -> @builtin(sample_mask) u32 {
+return u32();
+}
+
+struct S27 {
+  @location(10) f0: vec3<f16>,
+  @location(9) f1: i32,
+  @location(11) f2: vec2<u32>,
+  @location(3) f3: vec3<f32>,
+  @location(4) f4: vec3<f32>,
+  @location(7) f5: f16,
+  @location(13) f6: f16,
+  @location(6) f7: vec2<f32>,
+  @builtin(vertex_index) f8: u32,
+  @builtin(instance_index) f9: u32
+}
+
+@vertex
+fn vertex0(a0: S27, @location(1) a1: vec2<i32>, @location(14) a2: vec4<f32>, @location(15) a3: f16, @location(8) a4: vec2<f32>, @location(0) a5: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+let computePassEncoder75 = commandEncoder83.beginComputePass({label: '\uda54\ubc5d\u4e3a\u20e7\u6639\u0bba\u{1f9e9}'});
+let sampler71 = device2.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 61.769,
+lodMaxClamp: 63.123,
+});
+try {
+computePassEncoder75.setPipeline(pipeline120);
+} catch {}
+try {
+renderBundleEncoder78.setBindGroup(0, bindGroup37, []);
+} catch {}
+try {
+renderBundleEncoder75.setVertexBuffer(0, buffer26, 9072, 502);
+} catch {}
+try {
+commandEncoder69.copyBufferToBuffer(buffer26, 76, buffer27, 15716, 5776);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture105,
+  mipLevel: 2,
+  origin: { x: 53, y: 0, z: 0 },
+  aspect: 'all',
+}, new Float64Array(new ArrayBuffer(40)), /* required buffer size: 919 */
+{offset: 919}, {width: 494, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder88 = device1.createCommandEncoder({label: '\u{1fa3b}\u72ed\u9b58\u2c39\uf69e\uf267\ud095'});
+let texture110 = device1.createTexture({
+label: '\u0f7f\ua7ce\u050f',
+size: {width: 5160, height: 112, depthOrArrayLayers: 162},
+mipLevelCount: 11,
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['eac-rg11snorm', 'eac-rg11snorm', 'eac-rg11snorm'],
+});
+let computePassEncoder76 = commandEncoder88.beginComputePass({label: '\u{1fdc4}\u8c49\u8043\u1b33\u86d2\u1f44\u5855\u0080\u0c57\u0833\u{1fe5c}'});
+let video24 = await videoWithData();
+try {
+adapter1.label = '\u1033\u0206\ubb6c\uc727\u160a\u06db';
+} catch {}
+let texture111 = device1.createTexture({
+label: '\u3262\u0714\u{1f85a}\u0995\u4763\u6b2e\u{1fe5b}',
+size: {width: 1290, height: 28, depthOrArrayLayers: 162},
+mipLevelCount: 10,
+dimension: '2d',
+format: 'depth24plus',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth24plus', 'depth24plus'],
+});
+let renderBundleEncoder87 = device1.createRenderBundleEncoder({
+  colorFormats: ['rg16sint', 'rgba8unorm-srgb', 'rgba32sint', 'rg8unorm', 'r16sint'],
+  stencilReadOnly: true
+});
+let renderBundle92 = renderBundleEncoder87.finish({label: '\u9434\uc1fa\ub86b\ud529'});
+let sampler72 = device0.createSampler({
+label: '\ud2bb\u560d\uaf45\u{1fda8}\ucbb8\u{1fc26}\u{1f77c}\u0f4f\u07b0',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 30.056,
+maxAnisotropy: 14,
+});
+try {
+computePassEncoder44.setBindGroup(2, bindGroup4, new Uint32Array(3194), 623, 0);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+commandEncoder86.copyTextureToBuffer({
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 45, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 564 widthInBlocks: 141 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 11140 */
+offset: 11140,
+buffer: buffer18,
+}, {width: 141, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 2, y: 7 },
+  flipY: true,
+}, {
+  texture: texture93,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline131 = device0.createComputePipeline({
+layout: pipelineLayout13,
+compute: {
+module: shaderModule29,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+document.body.prepend(img6);
+try {
+renderBundleEncoder78.setBindGroup(2, bindGroup37);
+} catch {}
+let promise64 = device2.popErrorScope();
+let pipeline132 = await promise49;
+video24.width = 151;
+let bindGroup39 = device3.createBindGroup({
+label: '\uf8f2\u{1f796}\u6425\u{1fd1e}\u7fd9\ucd00\u{1fe9c}\ud420\u0939',
+layout: bindGroupLayout45,
+entries: [],
+});
+let querySet90 = device3.createQuerySet({
+label: '\u39c7\u32ac\u0276\u6241\u4e1e\u0e99',
+type: 'occlusion',
+count: 708,
+});
+let texture112 = device3.createTexture({
+label: '\u0232\u0fe1',
+size: {width: 240},
+mipLevelCount: 1,
+dimension: '1d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgb10a2uint', 'rgb10a2uint'],
+});
+try {
+computePassEncoder73.setBindGroup(0, bindGroup39, new Uint32Array(3183), 2665, 0);
+} catch {}
+try {
+commandEncoder76.clearBuffer(buffer35, 3520, 19360);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer35, 29040, new Float32Array(14810), 12666, 132);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+offscreenCanvas25.width = 248;
+let canvas31 = document.createElement('canvas');
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let video25 = await videoWithData();
+let bindGroup40 = device0.createBindGroup({
+layout: bindGroupLayout35,
+entries: [],
+});
+let texture113 = device0.createTexture({
+label: '\u{1fd1b}\u85a2\u608b\u0790\u{1f61f}',
+size: {width: 80, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+dimension: '2d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+});
+let sampler73 = device0.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 78.742,
+lodMaxClamp: 99.347,
+compare: 'greater',
+maxAnisotropy: 15,
+});
+try {
+renderBundleEncoder61.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexedIndirect(buffer12, 4952);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: canvas8,
+  origin: { x: 238, y: 119 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 7,
+  origin: { x: 0, y: 1, z: 3 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline133 = device0.createComputePipeline({
+label: '\ubc7a\u2fac\u53d1\u0def\u{1f8f3}\u6870\u{1f8ce}\ud8ef',
+layout: pipelineLayout13,
+compute: {
+module: shaderModule38,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let gpuCanvasContext23 = canvas31.getContext('webgpu');
+let shaderModule41 = device2.createShaderModule({
+label: '\uaa3b\u{1ff33}\ued56\u329c\ue146',
+code: `@group(1) @binding(241)
+var<storage, read_write> parameter25: array<u32>;
+@group(0) @binding(241)
+var<storage, read_write> type16: array<u32>;
+
+@compute @workgroup_size(8, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S28 {
+  @location(10) f0: vec2<u32>,
+  @location(4) f1: vec2<f32>,
+  @location(7) f2: f16,
+  @location(9) f3: vec2<f16>,
+  @location(11) f4: vec4<u32>,
+  @location(6) f5: vec3<u32>,
+  @location(8) f6: vec3<i32>,
+  @location(15) f7: vec2<f32>,
+  @location(3) f8: vec2<f32>,
+  @location(14) f9: vec2<f32>,
+  @location(5) f10: vec2<f32>,
+  @location(12) f11: vec3<f16>,
+  @builtin(front_facing) f12: bool
+}
+
+@fragment
+fn fragment0(@location(13) a0: f32, a1: S28, @builtin(sample_mask) a2: u32, @builtin(sample_index) a3: u32, @builtin(position) a4: vec4<f32>) -> @builtin(frag_depth) f32 {
+return f32();
+}
+
+struct VertexOutput0 {
+  @location(4) f168: vec2<f32>,
+  @location(10) f169: vec2<u32>,
+  @location(12) f170: vec3<f16>,
+  @location(3) f171: vec2<f32>,
+  @location(14) f172: vec2<f32>,
+  @location(11) f173: vec4<u32>,
+  @location(5) f174: vec2<f32>,
+  @location(13) f175: f32,
+  @location(9) f176: vec2<f16>,
+  @location(15) f177: vec2<f32>,
+  @builtin(position) f178: vec4<f32>,
+  @location(6) f179: vec3<u32>,
+  @location(8) f180: vec3<i32>,
+  @location(7) f181: f16
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let texture114 = device2.createTexture({
+label: '\u3a20\u{1f849}\u2d5d\u{1fb59}\u0315',
+size: [540],
+dimension: '1d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm'],
+});
+let textureView90 = texture92.createView({label: '\uaee2\u0305\ud8ad', dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder75.setPipeline(pipeline111);
+} catch {}
+try {
+commandEncoder66.copyBufferToBuffer(buffer26, 7524, buffer34, 3700, 1188);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer34);
+} catch {}
+try {
+commandEncoder74.copyTextureToTexture({
+  texture: texture79,
+  mipLevel: 3,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture79,
+  mipLevel: 4,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 5});
+} catch {}
+let pipeline134 = device2.createComputePipeline({
+label: '\ue68e\u00be\uf9a1\u0613\u{1fde6}\u8690\u88cb',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule40,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+gc();
+let texture115 = device2.createTexture({
+label: '\u0f67\ub9f6\u{1fd6e}\u5487\u093f\u2958\u{1fd64}\u0829',
+size: [420],
+dimension: '1d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rg8snorm'],
+});
+let textureView91 = texture115.createView({mipLevelCount: 1});
+let renderBundleEncoder88 = device2.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'depth24plus-stencil8', depthReadOnly: true, stencilReadOnly: true});
+try {
+commandEncoder84.clearBuffer(buffer30, 11648);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture90,
+  mipLevel: 1,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+}, new Int32Array(arrayBuffer9), /* required buffer size: 442478 */
+{offset: 878, bytesPerRow: 690, rowsPerImage: 160}, {width: 210, height: 0, depthOrArrayLayers: 5});
+} catch {}
+let querySet91 = device0.createQuerySet({
+label: '\u{1f883}\u02b4\u02d3\u76d9\u0129\u9d15\u9e56\u7a95',
+type: 'occlusion',
+count: 3724,
+});
+let computePassEncoder77 = commandEncoder86.beginComputePass({});
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder26.draw(72, 80);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(72, 72);
+} catch {}
+try {
+renderBundleEncoder74.setVertexBuffer(61, undefined);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+querySet56.destroy();
+} catch {}
+let imageData19 = new ImageData(104, 148);
+let texture116 = device4.createTexture({
+label: '\uac23\u0923\u1bf3',
+size: {width: 4320, height: 96, depthOrArrayLayers: 177},
+mipLevelCount: 4,
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundle93 = renderBundleEncoder86.finish({label: '\u{1f927}\ua42f\u0a6f\u{1fdf8}'});
+let sampler74 = device4.createSampler({
+label: '\ub9ab\u0740',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+});
+let commandEncoder89 = device2.createCommandEncoder({label: '\uad66\u600d'});
+try {
+renderBundleEncoder83.setVertexBuffer(7, buffer26, 1580, 381);
+} catch {}
+try {
+commandEncoder66.insertDebugMarker('\u8968');
+} catch {}
+try {
+if (!arrayBuffer15.detached) { new Uint8Array(arrayBuffer15).fill(0x55) };
+} catch {}
+gc();
+let imageBitmap29 = await createImageBitmap(imageData13);
+let canvas32 = document.createElement('canvas');
+let imageData20 = new ImageData(244, 168);
+let textureView92 = texture116.createView({
+  label: '\u{1fe15}\ua09e\u6121\ud9ff\u2ec1\u59e7\u4cf2\u9424\u059a\u0129',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 110
+});
+let renderBundleEncoder89 = device4.createRenderBundleEncoder({
+  label: '\u8018\u0e3d\u857b\u883e\u48c5\u4b9e\u56de\u0fe1\u{1ffe3}\u{1fc95}',
+  colorFormats: ['rg16sint', 'rgba8unorm-srgb'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let renderBundle94 = renderBundleEncoder85.finish({label: '\u0e60\uaf1c\u{1feb8}\u{1fb5e}'});
+try {
+  await promise56;
+} catch {}
+let offscreenCanvas26 = new OffscreenCanvas(751, 471);
+let shaderModule42 = device0.createShaderModule({
+label: '\u0b18\u239b\uba98\u80f6\u02b7',
+code: `@group(1) @binding(20)
+var<storage, read_write> parameter26: array<u32>;
+@group(2) @binding(289)
+var<storage, read_write> type17: array<u32>;
+
+@compute @workgroup_size(4, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @builtin(frag_depth) f1: f32,
+  @location(2) f2: vec2<f32>,
+  @location(3) f3: vec2<f32>,
+  @location(1) f4: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(11) a0: vec4<i32>, @location(3) a1: vec2<f16>, @location(10) a2: vec4<i32>, @location(5) a3: vec2<i32>, @builtin(sample_index) a4: u32, @location(8) a5: vec2<i32>, @location(15) a6: vec4<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(2) f182: u32,
+  @location(14) f183: vec4<f16>,
+  @location(3) f184: vec2<f16>,
+  @location(15) f185: vec4<f16>,
+  @location(0) f186: u32,
+  @location(8) f187: vec2<i32>,
+  @location(4) f188: vec3<f32>,
+  @builtin(position) f189: vec4<f32>,
+  @location(5) f190: vec2<i32>,
+  @location(7) f191: vec2<f32>,
+  @location(6) f192: vec4<f16>,
+  @location(11) f193: vec4<i32>,
+  @location(9) f194: vec4<i32>,
+  @location(10) f195: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: f32, @location(8) a1: vec2<f32>, @location(9) a2: vec3<u32>, @location(4) a3: vec2<u32>, @location(13) a4: u32, @location(2) a5: u32, @location(11) a6: f16, @location(5) a7: vec3<f32>, @builtin(instance_index) a8: u32, @location(6) a9: f32, @location(14) a10: f32, @location(1) a11: vec4<f16>, @location(15) a12: vec2<f32>, @location(12) a13: u32, @location(3) a14: i32, @builtin(vertex_index) a15: u32, @location(7) a16: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let pipelineLayout24 = device0.createPipelineLayout({
+  label: '\u6819\u519e\u6dbe\u5d13',
+  bindGroupLayouts: [bindGroupLayout6, bindGroupLayout47, bindGroupLayout18, bindGroupLayout4]
+});
+try {
+renderBundleEncoder45.setBindGroup(0, bindGroup24, new Uint32Array(4875), 3656, 0);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexed(64, 24);
+} catch {}
+try {
+renderBundleEncoder68.drawIndirect(buffer15, 5504);
+} catch {}
+try {
+renderBundleEncoder53.setIndexBuffer(buffer6, 'uint16', 32796, 2679);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 9516, new BigUint64Array(37199), 26858, 164);
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas26.getContext('2d');
+} catch {}
+pseudoSubmit(device4, commandEncoder87);
+let textureView93 = texture116.createView({
+  label: '\u{1ffa5}\u0a70\u92dd\u0146\u57af\u{1f978}\u{1fbb7}\u1eda\u{1ff47}\ucec1',
+  mipLevelCount: 1,
+  baseArrayLayer: 86,
+  arrayLayerCount: 81
+});
+let externalTexture5 = device4.importExternalTexture({
+source: video13,
+colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder89.setVertexBuffer(33, undefined);
+} catch {}
+let commandEncoder90 = device4.createCommandEncoder({label: '\u036e\u9fa5\u5951\u{1fdec}\u{1ff45}\u{1fd92}\ueab6\u06a5\u144c'});
+try {
+canvas32.getContext('2d');
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let shaderModule43 = device0.createShaderModule({
+label: '\u0419\udc22\u{1f7ca}\u7c42\u{1f669}\u886d\uac78\u0908\uf013\u530c',
+code: `@group(0) @binding(561)
+var<storage, read_write> parameter27: array<u32>;
+@group(3) @binding(43)
+var<storage, read_write> function16: array<u32>;
+@group(3) @binding(257)
+var<storage, read_write> function17: array<u32>;
+
+@compute @workgroup_size(3, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(5) f0: vec4<u32>,
+  @builtin(frag_depth) f1: f32,
+  @location(2) f2: vec4<i32>,
+  @location(3) f3: vec2<f32>,
+  @location(1) f4: vec2<f32>,
+  @location(4) f5: vec4<u32>,
+  @location(6) f6: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S29 {
+  @location(11) f0: vec4<u32>,
+  @location(10) f1: vec3<f32>,
+  @location(14) f2: vec4<f16>,
+  @location(0) f3: vec2<i32>,
+  @location(6) f4: vec4<f32>,
+  @location(9) f5: f32,
+  @location(13) f6: vec4<u32>,
+  @location(4) f7: vec4<f32>,
+  @location(15) f8: vec2<f32>,
+  @location(12) f9: u32,
+  @location(1) f10: vec4<i32>,
+  @location(3) f11: vec4<f32>,
+  @builtin(vertex_index) f12: u32
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec2<u32>, @location(8) a1: vec3<f16>, @location(7) a2: vec2<u32>, @location(5) a3: vec3<f16>, a4: S29, @builtin(instance_index) a5: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let renderBundle95 = renderBundleEncoder7.finish({label: '\ue0bf\uaf43'});
+try {
+renderBundleEncoder58.setBindGroup(3, bindGroup31);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer22, 1632);
+} catch {}
+try {
+buffer28.destroy();
+} catch {}
+try {
+gpuCanvasContext9.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16float', 'astc-8x8-unorm-srgb', 'rgba32float'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 8236, new Float32Array(64268), 36244, 2984);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(16)), /* required buffer size: 955 */
+{offset: 955, bytesPerRow: 114, rowsPerImage: 65}, {width: 32, height: 40, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder90 = device2.createRenderBundleEncoder({
+  label: '\u{1fe42}\u{1f688}\u0fc9\u0660\uc818\u5e0c\uc52e\u068c\u054d\ufc72\u05d4',
+  colorFormats: ['bgra8unorm', 'rgba8unorm', 'rgba32sint', undefined],
+  depthReadOnly: true
+});
+let renderBundle96 = renderBundleEncoder66.finish({label: '\u{1fa8b}\u{1fe66}\u9564\ud8f8\u7d52\u93ab\u{1fbe9}\u0883\u961a\u20ee\u006b'});
+let sampler75 = device2.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 74.190,
+lodMaxClamp: 78.651,
+compare: 'less-equal',
+});
+try {
+commandEncoder66.copyBufferToBuffer(buffer26, 1752, buffer27, 28208, 248);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer27);
+} catch {}
+let pipeline135 = device2.createRenderPipeline({
+label: '\u0df1\u5d6f\u2d42\u0bc7\uea09\u0bfd\ub1e7\ua906\uf4ba',
+layout: pipelineLayout19,
+multisample: {
+count: 4,
+mask: 0xf70abdde,
+},
+fragment: {
+  module: shaderModule39,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, undefined, undefined, {format: 'rgba16float', writeMask: 0}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.BLUE}, {format: 'rgba8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'less',
+failOp: 'invert',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'keep',
+},
+stencilReadMask: 2594,
+stencilWriteMask: 2090,
+depthBias: 13,
+depthBiasSlopeScale: 29,
+depthBiasClamp: 30,
+},
+vertex: {
+  module: shaderModule39,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1568,
+attributes: [{
+format: 'snorm16x4',
+offset: 1444,
+shaderLocation: 0,
+}, {
+format: 'sint8x4',
+offset: 1464,
+shaderLocation: 11,
+}, {
+format: 'float32x2',
+offset: 1264,
+shaderLocation: 10,
+}, {
+format: 'uint32',
+offset: 1160,
+shaderLocation: 8,
+}, {
+format: 'float32x3',
+offset: 76,
+shaderLocation: 2,
+}, {
+format: 'uint32x2',
+offset: 1184,
+shaderLocation: 14,
+}, {
+format: 'sint16x4',
+offset: 240,
+shaderLocation: 9,
+}, {
+format: 'float32x3',
+offset: 1200,
+shaderLocation: 3,
+}, {
+format: 'unorm16x2',
+offset: 1112,
+shaderLocation: 6,
+}, {
+format: 'sint32x3',
+offset: 48,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 68,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x2',
+offset: 0,
+shaderLocation: 12,
+}, {
+format: 'sint8x4',
+offset: 40,
+shaderLocation: 5,
+}, {
+format: 'float16x4',
+offset: 48,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 980,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1460,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 524,
+shaderLocation: 7,
+}, {
+format: 'uint32x2',
+offset: 624,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 1152,
+attributes: [],
+},
+{
+arrayStride: 1888,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 1742,
+shaderLocation: 15,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+},
+});
+video20.width = 114;
+let pipelineLayout25 = device0.createPipelineLayout({label: '\ud758\u02b7\ue52c\u4839', bindGroupLayouts: []});
+let querySet92 = device0.createQuerySet({
+type: 'occlusion',
+count: 3628,
+});
+try {
+computePassEncoder72.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexedIndirect(buffer22, 1780);
+} catch {}
+try {
+renderBundleEncoder68.drawIndirect(buffer15, 1480);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap13,
+  origin: { x: 734, y: 183 },
+  flipY: false,
+}, {
+  texture: texture93,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline136 = device0.createComputePipeline({
+label: '\uc875\u0f8f\u249f',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule42,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let promise65 = device0.createRenderPipelineAsync({
+layout: pipelineLayout15,
+multisample: {
+count: 4,
+mask: 0x14c969df,
+},
+fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint'}, undefined, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'equal',
+depthFailOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 700,
+stencilWriteMask: 4021,
+depthBias: 94,
+depthBiasClamp: 33,
+},
+vertex: {
+  module: shaderModule20,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1408,
+attributes: [{
+format: 'float32x4',
+offset: 1236,
+shaderLocation: 2,
+}, {
+format: 'float32',
+offset: 708,
+shaderLocation: 10,
+}, {
+format: 'snorm8x4',
+offset: 940,
+shaderLocation: 9,
+}, {
+format: 'sint8x2',
+offset: 1044,
+shaderLocation: 12,
+}, {
+format: 'unorm16x4',
+offset: 884,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 764,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x4',
+offset: 404,
+shaderLocation: 1,
+}, {
+format: 'sint8x2',
+offset: 220,
+shaderLocation: 14,
+}, {
+format: 'unorm8x2',
+offset: 244,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 404,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 828,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 2028,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1352,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1324,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 572,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 144,
+shaderLocation: 8,
+}],
+}
+]
+},
+});
+let buffer41 = device4.createBuffer({
+  label: '\u0b0a\u{1fa4a}\u2e83',
+  size: 63861,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false
+});
+let querySet93 = device4.createQuerySet({
+label: '\u07c9\ua4fc\u1312\u{1ff98}\u0964\u0803\u{1fa18}\u{1fd13}\u1b26\u{1f9bf}',
+type: 'occlusion',
+count: 277,
+});
+let renderBundle97 = renderBundleEncoder89.finish({label: '\u{1f9f7}\u{1fe06}\u629e\u9435'});
+let querySet94 = device2.createQuerySet({
+label: '\u0b36\u0ba2\u5971\u03a7\u182f\ucd79\u{1f888}\u0c2a\u{1fcab}\u7fed\u8463',
+type: 'occlusion',
+count: 3931,
+});
+let renderBundle98 = renderBundleEncoder75.finish({label: '\u0e3b\ued06\u5b5c\uc3a4\uecda\ue731\uc957\u{1f9f3}\u4587\u5527'});
+try {
+computePassEncoder65.pushDebugGroup('\u{1faf2}');
+} catch {}
+try {
+device2.queue.writeBuffer(buffer31, 7288, new Int16Array(64290), 18230, 6776);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture104,
+  mipLevel: 0,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer13), /* required buffer size: 971 */
+{offset: 947, bytesPerRow: 139}, {width: 6, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let video26 = await videoWithData();
+try {
+buffer41.destroy();
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture116,
+  mipLevel: 0,
+  origin: { x: 1302, y: 25, z: 98 },
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 429068 */
+{offset: 756, bytesPerRow: 22544, rowsPerImage: 83}, {width: 2815, height: 19, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let adapter8 = await promise33;
+video24.height = 101;
+try {
+adapter7.label = '\u{1fe91}\u0e26\u45d2\u9882\u8192\u{1fa98}';
+} catch {}
+try {
+window.someLabel = pipeline120.label;
+} catch {}
+let querySet95 = device2.createQuerySet({
+label: '\uc1ad\u1664\u{1fb8f}\u7d5d\ua92f\u0e8e\u0058\ua8bb\u755c',
+type: 'occlusion',
+count: 389,
+});
+let texture117 = device2.createTexture({
+label: '\u117d\u0ec6\u5e68\ua6c7\u6a0f\u0d4a\u6182\u0613\u05f4',
+size: {width: 1080},
+dimension: '1d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView94 = texture75.createView({label: '\u{1fb95}\u0f1f\u{1f882}\u0426\uadcc\u5c0c'});
+let renderBundle99 = renderBundleEncoder75.finish({label: '\u91db\u{1f8e0}\u{1fdcb}\u8539\uc302\u{1f8fc}\ubb2e\u{1fe89}'});
+let sampler76 = device2.createSampler({
+label: '\u0f24\uddd6\u{1fac8}\ud81e\u08f3\u0171\u1ff9\u8270\u0919\u{1fbbb}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 71.824,
+lodMaxClamp: 99.118,
+});
+try {
+computePassEncoder58.setPipeline(pipeline113);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth16unorm', 'depth24plus-stencil8', 'rgba8unorm-srgb', 'rgba32float'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 48, height: 7, depthOrArrayLayers: 100}
+*/
+{
+  source: videoFrame16,
+  origin: { x: 1, y: 3 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: { x: 21, y: 1, z: 34 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 12, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder91 = device2.createCommandEncoder({label: '\u0725\u09cb\u0d96\uedf4\uc8ce'});
+try {
+renderBundleEncoder81.setBindGroup(3, bindGroup36, new Uint32Array(1003), 26, 0);
+} catch {}
+try {
+commandEncoder66.clearBuffer(buffer27, 19852, 6776);
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture90,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 2 },
+  aspect: 'depth-only',
+}, new BigUint64Array(arrayBuffer12), /* required buffer size: 6713 */
+{offset: 721, bytesPerRow: 428, rowsPerImage: 14}, {width: 210, height: 0, depthOrArrayLayers: 2});
+} catch {}
+let pipeline137 = await promise59;
+let img25 = await imageWithData(74, 67, '#9868326a', '#2fa4cbf2');
+let commandEncoder92 = device4.createCommandEncoder({label: '\u{1f7cc}\u4635\u05f7\ue9e6\u{1f79e}'});
+let textureView95 = texture116.createView({baseMipLevel: 3, baseArrayLayer: 116, arrayLayerCount: 6});
+let sampler77 = device4.createSampler({
+label: '\u{1f6f1}\u{1fafe}\ueb72\u{1f9a7}\u520d\uabf2\u{1f81e}\ufea3',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMaxClamp: 92.748,
+compare: 'greater-equal',
+});
+try {
+gpuCanvasContext8.configure({
+device: device4,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule44 = device0.createShaderModule({
+label: '\u0ee6\u4801',
+code: `@group(3) @binding(805)
+var<storage, read_write> local13: array<u32>;
+@group(0) @binding(791)
+var<storage, read_write> parameter28: array<u32>;
+@group(1) @binding(635)
+var<storage, read_write> i15: array<u32>;
+@group(1) @binding(690)
+var<storage, read_write> parameter29: array<u32>;
+@group(3) @binding(304)
+var<storage, read_write> field13: array<u32>;
+
+@compute @workgroup_size(7, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S31 {
+  @builtin(front_facing) f0: bool
+}
+struct FragmentOutput0 {
+  @location(3) f0: vec4<i32>,
+  @location(2) f1: vec4<u32>,
+  @location(0) f2: vec2<u32>,
+  @builtin(sample_mask) f3: u32,
+  @location(1) f4: u32
+}
+
+@fragment
+fn fragment0(@location(1) a0: vec4<i32>, @builtin(sample_mask) a1: u32, @builtin(position) a2: vec4<f32>, @location(7) a3: u32, @location(10) a4: vec4<i32>, @location(12) a5: vec2<f16>, @location(9) a6: vec3<u32>, @location(14) a7: vec2<i32>, @location(13) a8: vec2<i32>, @location(6) a9: vec2<f16>, @location(11) a10: i32, a11: S31) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S30 {
+  @location(15) f0: vec2<f32>,
+  @location(14) f1: vec3<f32>,
+  @location(4) f2: vec2<f16>,
+  @location(2) f3: vec4<f16>,
+  @location(0) f4: vec4<f16>
+}
+struct VertexOutput0 {
+  @location(1) f196: vec4<i32>,
+  @location(9) f197: vec3<u32>,
+  @location(0) f198: vec3<f32>,
+  @location(13) f199: vec2<i32>,
+  @location(11) f200: i32,
+  @location(7) f201: u32,
+  @location(14) f202: vec2<i32>,
+  @location(12) f203: vec2<f16>,
+  @location(3) f204: vec2<u32>,
+  @builtin(position) f205: vec4<f32>,
+  @location(10) f206: vec4<i32>,
+  @location(6) f207: vec2<f16>
+}
+
+@vertex
+fn vertex0(a0: S30, @location(1) a1: vec4<u32>, @location(3) a2: vec4<u32>, @location(7) a3: vec2<i32>, @location(8) a4: vec2<f16>, @location(6) a5: vec4<i32>, @location(5) a6: u32, @location(11) a7: vec4<i32>, @location(12) a8: vec4<f16>, @location(10) a9: i32, @location(9) a10: vec4<u32>, @location(13) a11: vec4<f16>, @builtin(instance_index) a12: u32, @builtin(vertex_index) a13: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let renderBundle100 = renderBundleEncoder30.finish();
+let sampler78 = device0.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 12.922,
+lodMaxClamp: 51.165,
+maxAnisotropy: 13,
+});
+try {
+computePassEncoder62.dispatchWorkgroups(3, 4);
+} catch {}
+try {
+renderBundleEncoder62.drawIndexedIndirect(buffer22, 1136);
+} catch {}
+try {
+renderBundleEncoder50.setPipeline(pipeline112);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 6832, new DataView(new ArrayBuffer(5610)), 243, 2032);
+} catch {}
+let bindGroupLayout56 = device2.createBindGroupLayout({
+label: '\u{1f624}\u{1fae1}\u7b5c\uded7\u0dbc\ube34',
+entries: [{
+binding: 628,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+}],
+});
+let computePassEncoder78 = commandEncoder91.beginComputePass({label: '\u05ba\u71bd\u06ea\u2dbd\u0e5b\ud24e\u8a33\u1420\u{1ffac}\ueadb\u2fee'});
+let pipeline138 = device2.createComputePipeline({
+layout: pipelineLayout19,
+compute: {
+module: shaderModule34,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let videoFrame26 = new VideoFrame(img10, {timestamp: 0});
+offscreenCanvas19.width = 941;
+let shaderModule45 = device0.createShaderModule({
+label: '\uf3e9\u{1ff85}\u066b\u02e2\u{1f6ba}\u01d9\uc147\ue02a',
+code: `@group(1) @binding(43)
+var<storage, read_write> function18: array<u32>;
+@group(0) @binding(297)
+var<storage, read_write> type18: array<u32>;
+
+@compute @workgroup_size(3, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec3<i32>,
+  @location(4) f2: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroupLayout57 = device0.createBindGroupLayout({
+label: '\u{1fb40}\u1bac\u920a\u0126\u6893\u3754\u{1ff88}',
+entries: [{
+binding: 728,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+}, {
+binding: 411,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}],
+});
+let querySet96 = device0.createQuerySet({
+label: '\u865c\u4e12\u{1fa73}\u{1fc93}',
+type: 'occlusion',
+count: 963,
+});
+let sampler79 = device0.createSampler({
+label: '\udc2d\u3784\u0714\u0f5f\u{1fed6}',
+addressModeU: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 11.208,
+lodMaxClamp: 43.184,
+maxAnisotropy: 18,
+});
+try {
+renderBundleEncoder54.setBindGroup(3, bindGroup31);
+} catch {}
+try {
+renderBundleEncoder63.drawIndexed(24, 16, 40, 368, 0);
+} catch {}
+try {
+renderBundleEncoder20.drawIndirect(buffer15, 1816);
+} catch {}
+video13.width = 203;
+gc();
+let textureView96 = texture108.createView({
+  label: '\ub201\u0bd7\u8d6d\u{1fe7a}\u0b94\u0755\u0ae9\u{1fdc3}\u3869',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+  baseArrayLayer: 38,
+  arrayLayerCount: 96
+});
+try {
+buffer41.destroy();
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+try {
+computePassEncoder53.end();
+} catch {}
+try {
+renderBundleEncoder26.drawIndexedIndirect(buffer22, 1208);
+} catch {}
+try {
+commandEncoder22.copyBufferToBuffer(buffer12, 1216, buffer14, 5516, 8444);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder22.copyTextureToBuffer({
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 72, y: 88, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 32912 */
+offset: 30272,
+bytesPerRow: 256,
+buffer: buffer12,
+}, {width: 20, height: 44, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+computePassEncoder5.insertDebugMarker('\u08d2');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video4,
+  origin: { x: 12, y: 13 },
+  flipY: true,
+}, {
+  texture: texture100,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise62;
+} catch {}
+let img26 = await imageWithData(169, 135, '#4e62dc6b', '#2c082b26');
+try {
+window.someLabel = device4.label;
+} catch {}
+try {
+commandEncoder92.label = '\u{1f939}\u08fb\u{1fa44}\u8247\uabde\u0326\u{1fb85}\u759c';
+} catch {}
+let querySet97 = device4.createQuerySet({
+label: '\u01a5\ud96b\ub0c9\u4da4\u091c\ufbc3\ud5f8\u3e9e',
+type: 'occlusion',
+count: 2384,
+});
+let commandBuffer21 = commandEncoder92.finish();
+let texture118 = device4.createTexture({
+label: '\ue10e\ucc20\u{1f7e1}\u09f3\u0150\u05de\u070a',
+size: {width: 192, height: 20, depthOrArrayLayers: 203},
+mipLevelCount: 4,
+dimension: '2d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+});
+let textureView97 = texture116.createView({
+  label: '\ufdb3\u3d71\u8672\u68f7\u9553\u{1fe7e}\u{1ff71}\u8ac7\u36a6',
+  baseMipLevel: 3,
+  baseArrayLayer: 163,
+  arrayLayerCount: 2
+});
+let sampler80 = device4.createSampler({
+label: '\u{1fcd1}\ub748\u{1fb99}\u1612\u4d37\u{1fe86}\udd43\ub3e7\u{1fd59}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 2.947,
+lodMaxClamp: 44.795,
+maxAnisotropy: 5,
+});
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+try {
+  await promise60;
+} catch {}
+let videoFrame27 = new VideoFrame(img11, {timestamp: 0});
+let querySet98 = device2.createQuerySet({
+label: '\uf886\udf86\u0539\u0de5\u0abe\u{1ffdd}',
+type: 'occlusion',
+count: 1781,
+});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+  await buffer40.mapAsync(GPUMapMode.READ, 0, 22716);
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(buffer26, 160, buffer34, 13068, 24);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer34);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 5,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 33029 */
+{offset: 480, bytesPerRow: 269, rowsPerImage: 121}, {width: 0, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 24, height: 3, depthOrArrayLayers: 50}
+*/
+{
+  source: canvas17,
+  origin: { x: 49, y: 49 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 4, y: 0, z: 27 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline139 = device2.createRenderPipeline({
+label: '\u67b7\u1234\u{1f91a}\u0617\u6e17\u0153\uc54c\u057a',
+layout: pipelineLayout19,
+multisample: {
+mask: 0xed519586,
+},
+fragment: {
+  module: shaderModule30,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'constant'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'equal',
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'zero',
+depthFailOp: 'increment-wrap',
+passOp: 'invert',
+},
+stencilReadMask: 364,
+stencilWriteMask: 876,
+depthBiasSlopeScale: 85,
+},
+vertex: {
+  module: shaderModule30,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 1768,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x4',
+offset: 672,
+shaderLocation: 1,
+}, {
+format: 'uint32x4',
+offset: 1032,
+shaderLocation: 4,
+}, {
+format: 'snorm8x4',
+offset: 1612,
+shaderLocation: 10,
+}, {
+format: 'sint8x2',
+offset: 1032,
+shaderLocation: 13,
+}, {
+format: 'unorm8x2',
+offset: 134,
+shaderLocation: 2,
+}, {
+format: 'float16x2',
+offset: 72,
+shaderLocation: 9,
+}, {
+format: 'sint8x2',
+offset: 1670,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 592,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 188,
+shaderLocation: 5,
+}, {
+format: 'float32x3',
+offset: 460,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x2',
+offset: 648,
+shaderLocation: 3,
+}, {
+format: 'sint16x2',
+offset: 816,
+shaderLocation: 7,
+}, {
+format: 'sint16x2',
+offset: 1032,
+shaderLocation: 0,
+}, {
+format: 'uint32',
+offset: 1484,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 808,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x2',
+offset: 508,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 264,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x2',
+offset: 228,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 1332,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 688,
+attributes: [],
+},
+{
+arrayStride: 1964,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 1752,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+unclippedDepth: false,
+},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise61;
+} catch {}
+try {
+window.someLabel = shaderModule6.label;
+} catch {}
+let computePassEncoder79 = commandEncoder22.beginComputePass();
+try {
+computePassEncoder44.setBindGroup(3, bindGroup8, new Uint32Array(2205), 331, 0);
+} catch {}
+try {
+computePassEncoder60.end();
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer12, 31944);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(2, buffer0);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(querySet76, 294, 157, buffer37, 14080);
+} catch {}
+video13.height = 267;
+let querySet99 = device4.createQuerySet({
+label: '\u7ce4\u{1fcfb}',
+type: 'occlusion',
+count: 3186,
+});
+let textureView98 = texture116.createView({label: '\u0b3d\ucc3f\u{1fc1b}\ue1e2', dimension: '2d', baseMipLevel: 1, mipLevelCount: 2, baseArrayLayer: 43});
+let computePassEncoder80 = commandEncoder90.beginComputePass();
+let offscreenCanvas27 = new OffscreenCanvas(16, 205);
+let commandEncoder93 = device2.createCommandEncoder();
+try {
+renderBundleEncoder88.setVertexBuffer(2, buffer26, 8596, 339);
+} catch {}
+try {
+computePassEncoder65.popDebugGroup();
+} catch {}
+try {
+device2.queue.writeBuffer(buffer36, 31408, new BigUint64Array(7516), 2926, 784);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 0,
+  origin: { x: 68, y: 4, z: 28 },
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 1103226 */
+{offset: 762, bytesPerRow: 90, rowsPerImage: 85}, {width: 27, height: 10, depthOrArrayLayers: 145});
+} catch {}
+try {
+offscreenCanvas27.getContext('2d');
+} catch {}
+let pipelineLayout26 = device2.createPipelineLayout({label: '\u833c\ud58d\u0625\u0df7\ua437\u3aba\u007b', bindGroupLayouts: []});
+let computePassEncoder81 = commandEncoder89.beginComputePass({label: '\u{1fd9f}\u0dc4\u7fcc\u9d45\uecb8\u{1fda1}'});
+try {
+renderBundleEncoder90.setBindGroup(2, bindGroup36);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture115,
+  mipLevel: 0,
+  origin: { x: 59, y: 1, z: 0 },
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(16)), /* required buffer size: 184 */
+{offset: 184}, {width: 344, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame28 = new VideoFrame(video7, {timestamp: 0});
+let bindGroup41 = device4.createBindGroup({
+label: '\ufc41\u{1fa80}',
+layout: bindGroupLayout53,
+entries: [],
+});
+pseudoSubmit(device4, commandEncoder90);
+let textureView99 = texture116.createView({baseMipLevel: 3, baseArrayLayer: 33, arrayLayerCount: 40});
+let renderBundleEncoder91 = device4.createRenderBundleEncoder({
+  label: '\u{1fc2b}\ubf14\u{1fd35}\ue17e\u0f67\ub630\u65c6',
+  colorFormats: ['rg16sint', 'rgba8unorm-srgb'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder91.setIndexBuffer(buffer41, 'uint16', 41386, 17184);
+} catch {}
+try {
+device4.queue.submit([
+]);
+} catch {}
+let textureView100 = texture0.createView({
+  label: '\u{1fd12}\u87c0\ub431\u{1f99e}\u{1f8a9}',
+  dimension: '2d-array',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  arrayLayerCount: 1
+});
+let sampler81 = device0.createSampler({
+label: '\uf06b\u0c97\u{1f682}',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMaxClamp: 98.510,
+maxAnisotropy: 1,
+});
+try {
+computePassEncoder62.dispatchWorkgroupsIndirect(buffer22, 972);
+} catch {}
+try {
+renderBundleEncoder63.drawIndexed(32, 32, 8, -368, 32);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer22, 1476);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline39);
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(buffer12, 40176, buffer18, 10608, 752);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder52.clearBuffer(buffer18);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 52924, new Int16Array(37637), 11273, 2816);
+} catch {}
+let pipeline140 = device0.createComputePipeline({
+label: '\u0667\u9d9f\u{1f82f}\u2b19\u0dcb\u0e68\uc473\u{1fdd6}',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule19,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let bindGroup42 = device3.createBindGroup({
+label: '\u0762\u1f33\u{1ff85}\u{1fbc5}\ub896\u057d',
+layout: bindGroupLayout45,
+entries: [],
+});
+let textureView101 = texture91.createView({
+  label: '\u0d07\u1277\u1eeb\udfbe\u67c7\u0087\u56b0\u2f71\u4c87',
+  dimension: '2d-array',
+  baseMipLevel: 5,
+  mipLevelCount: 1
+});
+let sampler82 = device2.createSampler({
+label: '\u{1f6fb}\ub423\u01d4\u526c\u0eaa',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 46.425,
+});
+try {
+commandEncoder76.clearBuffer(buffer35, 7152, 940);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder76.insertDebugMarker('\u5e87');
+} catch {}
+let buffer42 = device0.createBuffer({size: 38563, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let textureView102 = texture7.createView({label: '\u{1f9ae}\u{1f617}', format: 'astc-8x5-unorm', baseMipLevel: 1});
+let computePassEncoder82 = commandEncoder52.beginComputePass({});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder59.dispatchWorkgroupsIndirect(buffer15, 1736);
+} catch {}
+try {
+renderBundleEncoder73.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder9.draw(24, 32, 48);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(24, 48, 56, -128, 80);
+} catch {}
+try {
+renderBundleEncoder36.drawIndirect(buffer12, 35616);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(1, buffer6);
+} catch {}
+let promise66 = device0.createRenderPipelineAsync({
+label: '\u{1f6dd}\u0d64\uf1b3\u0e22\u62a6\u8527\uca11\u3026',
+layout: pipelineLayout3,
+multisample: {
+count: 4,
+},
+fragment: {
+  module: shaderModule29,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba16uint'}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}]
+},
+vertex: {
+  module: shaderModule29,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 1488,
+attributes: [{
+format: 'unorm8x4',
+offset: 1332,
+shaderLocation: 15,
+}, {
+format: 'sint32x4',
+offset: 1440,
+shaderLocation: 1,
+}, {
+format: 'unorm10-10-10-2',
+offset: 324,
+shaderLocation: 4,
+}, {
+format: 'float32',
+offset: 928,
+shaderLocation: 8,
+}, {
+format: 'sint32x2',
+offset: 456,
+shaderLocation: 6,
+}, {
+format: 'uint8x2',
+offset: 444,
+shaderLocation: 0,
+}, {
+format: 'unorm8x4',
+offset: 884,
+shaderLocation: 7,
+}, {
+format: 'uint16x2',
+offset: 1432,
+shaderLocation: 12,
+}, {
+format: 'uint32',
+offset: 944,
+shaderLocation: 5,
+}, {
+format: 'unorm8x2',
+offset: 474,
+shaderLocation: 9,
+}, {
+format: 'float32',
+offset: 1440,
+shaderLocation: 2,
+}, {
+format: 'unorm8x4',
+offset: 380,
+shaderLocation: 13,
+}, {
+format: 'sint32x2',
+offset: 236,
+shaderLocation: 10,
+}, {
+format: 'sint8x2',
+offset: 8,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 616,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x2',
+offset: 300,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+offscreenCanvas14.height = 825;
+let textureView103 = texture97.createView({label: '\u654f\u0763', baseMipLevel: 1, mipLevelCount: 1});
+let renderBundleEncoder92 = device0.createRenderBundleEncoder({
+  label: '\u6ad9\ua2e8\u56ff\u{1ffb8}\u35f5\u3fac\u335c',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true
+});
+let renderBundle101 = renderBundleEncoder46.finish();
+try {
+renderBundleEncoder60.setBindGroup(1, bindGroup5, new Uint32Array(1477), 340, 0);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexedIndirect(buffer22, 960);
+} catch {}
+try {
+renderBundleEncoder68.drawIndirect(buffer12, 16428);
+} catch {}
+let texture119 = device2.createTexture({
+label: '\u314c\u{1fea0}\u6d7d\uc451\u0e8a\uced8\u6dbe\ude69',
+size: [25],
+dimension: '1d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm-srgb', 'rgba8unorm'],
+});
+let renderBundle102 = renderBundleEncoder67.finish({label: '\u1c56\u0da0\u{1f882}\u{1fb4d}\u0688\u0dce\uc434\u49fc'});
+try {
+renderBundleEncoder72.setBindGroup(3, bindGroup33);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer34, 8604, new BigUint64Array(4700), 2244, 688);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 6, height: 1, depthOrArrayLayers: 12}
+*/
+{
+  source: canvas27,
+  origin: { x: 182, y: 112 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 10 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let video27 = await videoWithData();
+let bindGroupLayout58 = device4.createBindGroupLayout({
+label: '\u{1f80a}\u0c75',
+entries: [],
+});
+let renderBundleEncoder93 = device4.createRenderBundleEncoder({
+  colorFormats: ['rg16sint', 'rgba8unorm-srgb'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+let bindGroup43 = device1.createBindGroup({
+label: '\u{1fff9}\u8071\u037e\u9b32',
+layout: bindGroupLayout27,
+entries: [],
+});
+let renderBundle103 = renderBundleEncoder87.finish({label: '\u0905\ub0dd'});
+let video28 = await videoWithData();
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let device5 = await promise55;
+let commandEncoder94 = device2.createCommandEncoder();
+let querySet100 = device2.createQuerySet({
+label: '\u8e6e\ua809\u{1f6e3}\u026e\u62bf\u0195\u26f9\u0865',
+type: 'occlusion',
+count: 1639,
+});
+let texture120 = device2.createTexture({
+label: '\u{1fff6}\u47de\u{1f900}\u65bc\u7c48\u83e2\u3267\uce7d\u08ae',
+size: {width: 30},
+dimension: '1d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [],
+});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup33);
+} catch {}
+try {
+computePassEncoder81.setBindGroup(0, bindGroup32, new Uint32Array(6596), 2799, 0);
+} catch {}
+try {
+commandEncoder69.copyBufferToBuffer(buffer26, 8652, buffer25, 6528, 856);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 24, height: 3, depthOrArrayLayers: 50}
+*/
+{
+  source: canvas8,
+  origin: { x: 273, y: 149 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 3, y: 0, z: 24 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 10, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame29 = new VideoFrame(imageBitmap25, {timestamp: 0});
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let buffer43 = device4.createBuffer({
+  label: '\u8b40\u032a\u{1fe61}\u46a7\ubb85\u087c\u{1f8cd}\u0937\ufbc4',
+  size: 621,
+  usage: GPUBufferUsage.MAP_READ
+});
+let texture121 = device4.createTexture({
+label: '\uac95\ufe6b\u0bef',
+size: [240, 640, 1],
+mipLevelCount: 4,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let renderBundle104 = renderBundleEncoder86.finish();
+let sampler83 = device4.createSampler({
+label: '\ued2e\u094a\ufbfc\ucee2',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 22.197,
+lodMaxClamp: 90.614,
+maxAnisotropy: 7,
+});
+try {
+renderBundleEncoder91.setBindGroup(1, bindGroup41, new Uint32Array(2562), 1804, 0);
+} catch {}
+try {
+buffer43.destroy();
+} catch {}
+let bindGroupLayout59 = device4.createBindGroupLayout({
+label: '\u093e\u73c3\u{1fe90}\uf6a9\u5eeb\uec4b\uf865\u07bd\u{1fde4}',
+entries: [{
+binding: 2052,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+}],
+});
+let bindGroup44 = device4.createBindGroup({
+label: '\u3f4d\u{1fc73}\u0ce3\u{1fd59}\u{1f7db}\u8dd0\ue7fc\u8080\u08c9\uf447\u92c7',
+layout: bindGroupLayout59,
+entries: [{
+binding: 2052,
+resource: sampler70
+}],
+});
+let textureView104 = texture108.createView({
+  label: '\u05f9\u{1f6df}\u{1ff56}\u01c9',
+  dimension: '2d',
+  aspect: 'all',
+  mipLevelCount: 5,
+  baseArrayLayer: 37
+});
+try {
+gpuCanvasContext17.configure({
+device: device4,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'astc-8x6-unorm-srgb', 'eac-rg11unorm'],
+alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup45 = device4.createBindGroup({
+layout: bindGroupLayout53,
+entries: [],
+});
+let pipelineLayout27 = device4.createPipelineLayout({
+  label: '\u0042\u0d7c\u0fd4\uf46c',
+  bindGroupLayouts: [bindGroupLayout58, bindGroupLayout53, bindGroupLayout58]
+});
+let querySet101 = device4.createQuerySet({
+label: '\u0442\u04d6\ue8fe\u{1f7c0}\uae83\u0916\ueecc\ub93d\u{1ff4f}\u0e92',
+type: 'occlusion',
+count: 501,
+});
+try {
+gpuCanvasContext9.configure({
+device: device4,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgba8sint', 'rg11b10ufloat', 'bgra8unorm', 'bgra8unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture116,
+  mipLevel: 1,
+  origin: { x: 931, y: 24, z: 140 },
+  aspect: 'all',
+}, new Int8Array(arrayBuffer18), /* required buffer size: 65237 */
+{offset: 588, bytesPerRow: 4055}, {width: 478, height: 16, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let bindGroup46 = device2.createBindGroup({
+label: '\u92a8\u05da\u01a8\u4aef\u{1fd7e}\u3839\u99ae\uee9f',
+layout: bindGroupLayout37,
+entries: [{
+binding: 385,
+resource: sampler64
+}, {
+binding: 771,
+resource: externalTexture4
+}],
+});
+let querySet102 = device2.createQuerySet({
+label: '\u0b1c\u7662\u0552',
+type: 'occlusion',
+count: 2710,
+});
+let textureView105 = texture90.createView({
+  label: '\udd07\u1bc9\uda28\u050e\ua1d7\u083b\u0599\u103d',
+  dimension: '2d',
+  aspect: 'depth-only',
+  mipLevelCount: 2,
+  baseArrayLayer: 2
+});
+let computePassEncoder83 = commandEncoder69.beginComputePass({label: '\u32d2\u{1fe91}'});
+let renderBundle105 = renderBundleEncoder76.finish({label: '\u016a\u1d11\u0254\ua47c\ubc9c\u16c9\ue998\u0ef5\u{1f67a}\u0866'});
+try {
+renderBundleEncoder83.setBindGroup(1, bindGroup32, new Uint32Array(3112), 2233, 0);
+} catch {}
+try {
+renderBundleEncoder90.setVertexBuffer(7, buffer26, 4512, 5170);
+} catch {}
+try {
+commandEncoder63.copyTextureToTexture({
+  texture: texture79,
+  mipLevel: 0,
+  origin: { x: 4, y: 0, z: 7 },
+  aspect: 'all',
+}, {
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 3, y: 2, z: 15 },
+  aspect: 'all',
+}, {width: 13, height: 0, depthOrArrayLayers: 23});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let pipeline141 = device2.createRenderPipeline({
+label: '\uf459\u6c97\u0df8\u691d\u085d\u5a25\uc04a\u00c5\ubf1d\ub126\u1e38',
+layout: pipelineLayout19,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule34,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, undefined, undefined, {format: 'rgba16float', writeMask: 0}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'src-alpha'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED
+}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}]
+},
+vertex: {
+  module: shaderModule34,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 420,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x2',
+offset: 176,
+shaderLocation: 7,
+}, {
+format: 'float32x3',
+offset: 68,
+shaderLocation: 4,
+}, {
+format: 'float16x2',
+offset: 144,
+shaderLocation: 12,
+}, {
+format: 'unorm16x2',
+offset: 348,
+shaderLocation: 1,
+}, {
+format: 'sint8x2',
+offset: 116,
+shaderLocation: 10,
+}, {
+format: 'unorm10-10-10-2',
+offset: 392,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 288,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm16x4',
+offset: 24,
+shaderLocation: 14,
+}, {
+format: 'snorm16x2',
+offset: 200,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 668,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 468,
+attributes: [{
+format: 'sint32x2',
+offset: 20,
+shaderLocation: 5,
+}, {
+format: 'unorm16x4',
+offset: 76,
+shaderLocation: 2,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let video29 = await videoWithData();
+let imageBitmap30 = await createImageBitmap(offscreenCanvas2);
+let commandEncoder95 = device0.createCommandEncoder({label: '\u3492\u0127\u03d2\u{1f6fc}\u0e2b\u8ca1\u{1fd61}\u{1fa29}'});
+let texture122 = device0.createTexture({
+label: '\u127f\u79ed\uc61e\udf72\u9f82\u0180',
+size: {width: 64, height: 90, depthOrArrayLayers: 1},
+sampleCount: 1,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x5-unorm'],
+});
+let computePassEncoder84 = commandEncoder95.beginComputePass({});
+let renderBundleEncoder94 = device0.createRenderBundleEncoder({
+  label: '\u04e2\u84f9\u0177',
+  colorFormats: ['rg16uint', 'rg32float', 'r16uint', 'rg16sint'],
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder70.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder50.draw(64, 8, 32);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(1, buffer24);
+} catch {}
+let pipeline142 = device0.createComputePipeline({
+label: '\u032a\u8ee8',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline143 = await promise66;
+let adapter9 = await navigator.gpu.requestAdapter();
+let video30 = await videoWithData();
+let commandEncoder96 = device0.createCommandEncoder({label: '\u{1f814}\u37be\u06b8\u0676\u06e4'});
+let renderBundle106 = renderBundleEncoder0.finish();
+let sampler84 = device0.createSampler({
+label: '\u2171\uaada\u{1f6d3}\u15e7\u8b26\u{1f6d9}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 1.593,
+lodMaxClamp: 49.866,
+compare: 'greater-equal',
+});
+try {
+computePassEncoder68.setBindGroup(3, bindGroup16, new Uint32Array(795), 317, 0);
+} catch {}
+try {
+computePassEncoder31.dispatchWorkgroups(3);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(1, bindGroup1, []);
+} catch {}
+try {
+renderBundleEncoder36.draw(40, 64, 40, 48);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexed(16, 64, 32, 48, 40);
+} catch {}
+try {
+renderBundleEncoder62.setPipeline(pipeline58);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+try {
+device1.label = '\u3cd9\u0fa2\u36b9';
+} catch {}
+let adapter10 = await promise47;
+let videoFrame30 = new VideoFrame(videoFrame5, {timestamp: 0});
+let promise67 = adapter8.requestAdapterInfo();
+try {
+renderBundleEncoder73.setBindGroup(0, bindGroup25, new Uint32Array(6834), 5329, 0);
+} catch {}
+try {
+renderBundleEncoder63.drawIndirect(buffer12, 24136);
+} catch {}
+try {
+commandEncoder96.copyBufferToBuffer(buffer23, 7532, buffer10, 2172, 5132);
+dissociateBuffer(device0, buffer23);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder96.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+gpuCanvasContext18.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer42, 4832, new Float32Array(41419), 23961, 1076);
+} catch {}
+try {
+device0.destroy();
+} catch {}
+try {
+  await promise67;
+} catch {}
+document.body.prepend(video30);
+let imageData21 = new ImageData(100, 184);
+let offscreenCanvas28 = new OffscreenCanvas(657, 237);
+gc();
+gc();
+try {
+offscreenCanvas28.getContext('webgl2');
+} catch {}
+let img27 = await imageWithData(136, 182, '#b915c74a', '#fd8a36b3');
+let buffer44 = device5.createBuffer({
+  label: '\ue0ba\u0e21\u{1f787}\uab0f\u950f\u07c4\u{1fcb3}\u0c75\u6ba4',
+  size: 64499,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE
+});
+let device6 = await adapter9.requestDevice({
+label: '\u0e98\u163f\u060c\ua35e\u{1f84b}\u0244',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 41,
+maxVertexAttributes: 24,
+maxVertexBufferArrayStride: 8695,
+maxStorageTexturesPerShaderStage: 27,
+maxStorageBuffersPerShaderStage: 26,
+maxDynamicStorageBuffersPerPipelineLayout: 35303,
+maxBindingsPerBindGroup: 5882,
+maxTextureDimension1D: 11985,
+maxTextureDimension2D: 9906,
+maxVertexBuffers: 10,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 100293634,
+maxUniformBuffersPerShaderStage: 37,
+maxInterStageShaderComponents: 65,
+maxSamplersPerShaderStage: 21,
+},
+});
+let canvas33 = document.createElement('canvas');
+try {
+canvas33.getContext('webgl');
+} catch {}
+let querySet103 = device5.createQuerySet({
+label: '\u4160\ue517\uc61e\u051e\ue5fd\u{1f6eb}\u{1fdd2}\u04f3\u0247\u845f\ufdda',
+type: 'occlusion',
+count: 1565,
+});
+let renderBundleEncoder95 = device5.createRenderBundleEncoder({
+  label: '\u0adf\u07ce\u{1f6cd}\u8e89\u34ca\u041a\uaea3\u1154\u576e\u3f96',
+  colorFormats: ['r8unorm', 'rgba8unorm', undefined],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle107 = renderBundleEncoder95.finish({});
+let sampler85 = device5.createSampler({
+label: '\u70d7\u{1f8f1}\u9fda',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 41.927,
+});
+let imageData22 = new ImageData(4, 188);
+let texture123 = device5.createTexture({
+label: '\u5632\u0b6a\u90d3\uc988\u1cba\ua83c\u849c\u{1fe27}',
+size: [4224],
+dimension: '1d',
+format: 'rgba8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba8sint', 'rgba8sint', 'rgba8sint'],
+});
+let textureView106 = texture123.createView({label: '\u{1fd1d}\u5f3a\u06e5\ub396'});
+let renderBundle108 = renderBundleEncoder95.finish();
+try {
+device5.addEventListener('uncapturederror', e => { log('device5.uncapturederror'); log(e); e.label = device5.label; });
+} catch {}
+try {
+device5.destroy();
+} catch {}
+video16.height = 10;
+let imageData23 = new ImageData(176, 236);
+gc();
+let device7 = await adapter10.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 61,
+maxVertexAttributes: 25,
+maxVertexBufferArrayStride: 31519,
+maxStorageTexturesPerShaderStage: 14,
+maxStorageBuffersPerShaderStage: 34,
+maxDynamicStorageBuffersPerPipelineLayout: 44716,
+maxBindingsPerBindGroup: 3750,
+maxTextureDimension1D: 11463,
+maxTextureDimension2D: 14801,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 236744093,
+maxUniformBuffersPerShaderStage: 36,
+maxInterStageShaderVariables: 38,
+maxInterStageShaderComponents: 84,
+maxSamplersPerShaderStage: 17,
+},
+});
+let video31 = await videoWithData();
+try {
+  await promise63;
+} catch {}
+let commandEncoder97 = device6.createCommandEncoder({label: '\ufa0f\u4add\u1d99\u410f\u{1feae}\u8915\u052f\u0900\u0f97\u{1fb3b}\u05cf'});
+let canvas34 = document.createElement('canvas');
+let buffer45 = device6.createBuffer({label: '\u8f17\u{1ff90}\u0477\u5a78', size: 54497, usage: GPUBufferUsage.UNIFORM});
+let sampler86 = device6.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 98.853,
+lodMaxClamp: 99.075,
+});
+try {
+device4.queue.writeTexture({
+  texture: texture116,
+  mipLevel: 1,
+  origin: { x: 11, y: 1, z: 13 },
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 2222502 */
+{offset: 734, bytesPerRow: 9032, rowsPerImage: 211}, {width: 1116, height: 35, depthOrArrayLayers: 2});
+} catch {}
+let commandEncoder98 = device6.createCommandEncoder();
+let sampler87 = device6.createSampler({
+label: '\u002f\u0643\u4379\u3313\u0efc',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMaxClamp: 80.605,
+});
+try {
+gpuCanvasContext6.configure({
+device: device6,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm-srgb', 'astc-8x8-unorm'],
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+  await promise64;
+} catch {}
+try {
+canvas34.getContext('2d');
+} catch {}
+try {
+adapter0.label = '\ufdf5\u065a\u478b\ua1da\u0958\u{1fdb4}\u8f6a\u{1fb21}\u2ede\u087b\u091d';
+} catch {}
+let buffer46 = device2.createBuffer({
+  label: '\u7746\u001c\u65ef\u9e0d\u0918\u7bf2\ue789\u1ad3\u0cfc\u7b91',
+  size: 46705,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false
+});
+let querySet104 = device2.createQuerySet({
+label: '\u1bb3\u0928\u052a\u2220\u{1fb75}\u073f\u3581',
+type: 'occlusion',
+count: 1645,
+});
+try {
+renderBundleEncoder83.setVertexBuffer(3, buffer46, 2196, 15102);
+} catch {}
+try {
+commandEncoder66.clearBuffer(buffer36);
+dissociateBuffer(device2, buffer36);
+} catch {}
+try {
+commandEncoder74.resolveQuerySet(querySet60, 2185, 104, buffer46, 25856);
+} catch {}
+let pipeline144 = device2.createComputePipeline({
+label: '\u0796\ub9f6\u23fe\u{1f964}\u09d4\u0512',
+layout: pipelineLayout26,
+compute: {
+module: shaderModule30,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let canvas35 = document.createElement('canvas');
+let texture124 = device6.createTexture({
+label: '\u098a\ub934\u0fa9\u0b28',
+size: {width: 880, height: 16, depthOrArrayLayers: 43},
+mipLevelCount: 6,
+format: 'eac-r11unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['eac-r11unorm'],
+});
+let textureView107 = texture124.createView({
+  label: '\ue506\ua072\u{1f87f}\u0a9f\u45ef\u0388\u0b33',
+  dimension: '2d',
+  aspect: 'all',
+  mipLevelCount: 1,
+  baseArrayLayer: 34
+});
+let renderBundleEncoder96 = device6.createRenderBundleEncoder({
+  label: '\u0423\u04a4\u7f8f\u{1f900}\u{1ff22}\u0c6b\u06d2\u{1f8f0}\u79fc\u{1f9f6}',
+  colorFormats: ['rg32float', 'rg11b10ufloat', undefined, 'rg11b10ufloat', 'rgba8uint'],
+  sampleCount: 4
+});
+try {
+commandEncoder98.copyTextureToTexture({
+  texture: texture124,
+  mipLevel: 4,
+  origin: { x: 32, y: 0, z: 2 },
+  aspect: 'all',
+}, {
+  texture: texture124,
+  mipLevel: 3,
+  origin: { x: 88, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 16, height: 0, depthOrArrayLayers: 41});
+} catch {}
+let promise68 = device6.queue.onSubmittedWorkDone();
+document.body.prepend(img26);
+try {
+await adapter2.requestAdapterInfo();
+} catch {}
+try {
+renderBundleEncoder81.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+renderBundleEncoder90.setBindGroup(0, bindGroup32, new Uint32Array(9718), 3985, 0);
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer26, 6816, buffer31, 1044, 1776);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer31);
+} catch {}
+try {
+commandEncoder94.copyBufferToTexture({
+/* bytesInLastRow: 976 widthInBlocks: 488 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 2522 */
+offset: 2522,
+buffer: buffer26,
+}, {
+  texture: texture117,
+  mipLevel: 0,
+  origin: { x: 137, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 488, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer26);
+} catch {}
+try {
+commandEncoder84.resolveQuerySet(querySet78, 2223, 0, buffer46, 42496);
+} catch {}
+let pipeline145 = device2.createRenderPipeline({
+label: '\u011c\u03b9\u01cf\u7a1b\u0d4e\ucef7\u0b55',
+layout: pipelineLayout19,
+fragment: {
+  module: shaderModule30,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'src'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+}
+}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 150,
+stencilWriteMask: 1921,
+depthBias: 23,
+depthBiasSlopeScale: 49,
+depthBiasClamp: 100,
+},
+vertex: {
+  module: shaderModule30,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 736,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x4',
+offset: 584,
+shaderLocation: 6,
+}, {
+format: 'sint8x2',
+offset: 468,
+shaderLocation: 7,
+}, {
+format: 'unorm10-10-10-2',
+offset: 672,
+shaderLocation: 2,
+}, {
+format: 'uint16x4',
+offset: 72,
+shaderLocation: 4,
+}, {
+format: 'snorm16x4',
+offset: 596,
+shaderLocation: 5,
+}, {
+format: 'sint32x4',
+offset: 84,
+shaderLocation: 14,
+}, {
+format: 'float16x2',
+offset: 472,
+shaderLocation: 11,
+}, {
+format: 'uint32x3',
+offset: 536,
+shaderLocation: 3,
+}, {
+format: 'unorm16x4',
+offset: 592,
+shaderLocation: 1,
+}, {
+format: 'uint8x4',
+offset: 324,
+shaderLocation: 12,
+}, {
+format: 'float32x3',
+offset: 108,
+shaderLocation: 8,
+}, {
+format: 'float32',
+offset: 364,
+shaderLocation: 15,
+}, {
+format: 'sint8x2',
+offset: 446,
+shaderLocation: 13,
+}, {
+format: 'float16x2',
+offset: 704,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 820,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 600,
+shaderLocation: 0,
+}, {
+format: 'unorm16x2',
+offset: 524,
+shaderLocation: 9,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: false,
+},
+});
+let video32 = await videoWithData();
+let imageBitmap31 = await createImageBitmap(offscreenCanvas0);
+offscreenCanvas11.height = 597;
+try {
+await device7.popErrorScope();
+} catch {}
+let imageBitmap32 = await createImageBitmap(imageBitmap10);
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+let promise69 = navigator.gpu.requestAdapter({
+powerPreference: 'low-power',
+});
+try {
+canvas35.getContext('webgl');
+} catch {}
+let bindGroupLayout60 = device7.createBindGroupLayout({
+label: '\uc08b\u0698\u1c45',
+entries: [],
+});
+let texture125 = device7.createTexture({
+label: '\u30ae\u2f0c\u7ec5\u53fa\u3ee4\u{1fe06}\u7779\udce6',
+size: {width: 4336},
+dimension: '1d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['rg8sint'],
+});
+try {
+gpuCanvasContext19.unconfigure();
+} catch {}
+try {
+  await promise68;
+} catch {}
+let renderBundleEncoder97 = device2.createRenderBundleEncoder({
+  label: '\udfed\u0cd7\u{1fe31}\u{1feb8}',
+  colorFormats: ['r8unorm', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1
+});
+let renderBundle109 = renderBundleEncoder90.finish({label: '\udc17\u3c70\u0823\u0e7f\u08ef\udddf\uad05'});
+let sampler88 = device2.createSampler({
+label: '\u4e95\u3b4a\u1bbc\u016e\u0401\uabbd\uddf4',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 24.722,
+lodMaxClamp: 66.691,
+maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder72.setBindGroup(1, bindGroup46, new Uint32Array(8523), 7918, 0);
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(buffer26, 204, buffer30, 11416, 4276);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+commandEncoder63.copyTextureToBuffer({
+  texture: texture87,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 5 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 6 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 34198 */
+offset: 34192,
+buffer: buffer36,
+}, {width: 6, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer36);
+} catch {}
+try {
+commandEncoder66.clearBuffer(buffer36);
+dissociateBuffer(device2, buffer36);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer36, 6900, new Float32Array(3895));
+} catch {}
+let pipeline146 = await device2.createRenderPipelineAsync({
+label: '\u721f\u7923\u2b9c\u028e',
+layout: pipelineLayout19,
+fragment: {
+  module: shaderModule27,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+failOp: 'increment-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3961,
+stencilWriteMask: 3471,
+depthBiasClamp: 63,
+},
+vertex: {
+  module: shaderModule27,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1560,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32',
+offset: 52,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 1216,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x4',
+offset: 800,
+shaderLocation: 6,
+}, {
+format: 'unorm16x4',
+offset: 848,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 732,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x3',
+offset: 652,
+shaderLocation: 14,
+}, {
+format: 'snorm16x4',
+offset: 404,
+shaderLocation: 4,
+}, {
+format: 'float16x4',
+offset: 400,
+shaderLocation: 11,
+}, {
+format: 'float32x2',
+offset: 352,
+shaderLocation: 13,
+}, {
+format: 'sint8x4',
+offset: 56,
+shaderLocation: 2,
+}, {
+format: 'sint32',
+offset: 540,
+shaderLocation: 12,
+}, {
+format: 'uint8x2',
+offset: 684,
+shaderLocation: 8,
+}, {
+format: 'sint32x2',
+offset: 412,
+shaderLocation: 9,
+}, {
+format: 'uint32x2',
+offset: 712,
+shaderLocation: 3,
+}, {
+format: 'snorm8x2',
+offset: 604,
+shaderLocation: 10,
+}, {
+format: 'sint8x4',
+offset: 720,
+shaderLocation: 5,
+}, {
+format: 'uint16x2',
+offset: 344,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 116,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 70,
+shaderLocation: 1,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+},
+});
+let offscreenCanvas29 = new OffscreenCanvas(120, 535);
+let video33 = await videoWithData();
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let offscreenCanvas30 = new OffscreenCanvas(418, 480);
+let bindGroupLayout61 = device7.createBindGroupLayout({
+label: '\u{1f6f2}\u0955\u019e\u0641\u0e38\u028c\ub49a\u0d17',
+entries: [{
+binding: 2644,
+visibility: 0,
+externalTexture: {},
+}, {
+binding: 993,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}],
+});
+let querySet105 = device7.createQuerySet({
+type: 'occlusion',
+count: 2507,
+});
+let texture126 = device7.createTexture({
+label: '\u{1fcc0}\u{1f70c}\u0c4c\u05e1\u6773\u00bb',
+size: {width: 200, height: 4, depthOrArrayLayers: 27},
+mipLevelCount: 4,
+sampleCount: 1,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8unorm'],
+});
+let renderBundleEncoder98 = device7.createRenderBundleEncoder({
+  label: '\u808a\u5d49\u{1fe61}\u{1fbfe}\udd61\u0737\u9cb6\u00ae\u05a9\u{1f9fe}',
+  colorFormats: ['rg16float'],
+  depthReadOnly: true
+});
+let gpuCanvasContext24 = offscreenCanvas29.getContext('webgpu');
+let bindGroup47 = device7.createBindGroup({
+layout: bindGroupLayout60,
+entries: [],
+});
+let querySet106 = device7.createQuerySet({
+label: '\ud98b\uf313\u{1fc65}\u{1fff0}\u{1ffab}\u2f23\ube44\u22ee',
+type: 'occlusion',
+count: 2732,
+});
+let renderBundleEncoder99 = device7.createRenderBundleEncoder({
+  label: '\u059c\u4aba\u065b\u{1f616}\u0c45\uad98\u049a\u16ac',
+  colorFormats: ['rg16float'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle110 = renderBundleEncoder98.finish({label: '\u{1f8cc}\uc391\u{1ff5d}\u1ba3\u974f\u0a2d\ud2ce'});
+let sampler89 = device7.createSampler({
+label: '\u{1fa7f}\u2c01\u{1f957}\u{1fc1d}\u0692\u0eeb\ufd0b\u558e\uad57\u72c4\ub74b',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 6.200,
+lodMaxClamp: 36.591,
+});
+try {
+gpuCanvasContext21.configure({
+device: device7,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba16float', 'rgba16float', 'eac-rg11unorm'],
+colorSpace: 'srgb',
+});
+} catch {}
+let imageBitmap33 = await createImageBitmap(videoFrame27);
+let texture127 = device6.createTexture({
+size: {width: 96, height: 80, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let gpuCanvasContext25 = offscreenCanvas30.getContext('webgpu');
+let promise70 = adapter6.requestAdapterInfo();
+let commandEncoder99 = device6.createCommandEncoder();
+let texture128 = device6.createTexture({
+size: {width: 3, height: 1, depthOrArrayLayers: 238},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder100 = device6.createRenderBundleEncoder({
+  label: '\u09c4\uc642\u08ea\u5d7f\u6203',
+  colorFormats: ['rg32float', 'rg11b10ufloat', undefined, 'rg11b10ufloat', 'rgba8uint'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+await adapter4.requestAdapterInfo();
+} catch {}
+let commandEncoder100 = device4.createCommandEncoder({label: '\u8ff1\u45d8\uaef4\u7e2f\u0e88\u0792'});
+let texture129 = gpuCanvasContext8.getCurrentTexture();
+let textureView108 = texture121.createView({
+  label: '\u{1fb75}\u2252\u8abe\uaae4\uc139',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  arrayLayerCount: 1
+});
+let renderBundleEncoder101 = device4.createRenderBundleEncoder({
+  label: '\u090e\u48a9',
+  colorFormats: ['rg16sint', 'rgba8unorm-srgb'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder93.setBindGroup(3, bindGroup44, new Uint32Array(7988), 1270, 0);
+} catch {}
+try {
+device4.destroy();
+} catch {}
+let imageBitmap34 = await createImageBitmap(img3);
+let sampler90 = device2.createSampler({
+label: '\u08ef\u64c7\ud49f\u040c\ua126\u176a\u5381\u1f53\u0ecd\u0982\u91ff',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 87.518,
+lodMaxClamp: 87.920,
+compare: 'greater',
+});
+try {
+commandEncoder84.copyBufferToBuffer(buffer26, 7268, buffer36, 17156, 1876);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer36);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer31, 15108, new Int16Array(10867), 1182, 4900);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 12, height: 1, depthOrArrayLayers: 25}
+*/
+{
+  source: canvas9,
+  origin: { x: 287, y: 90 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 2,
+  origin: { x: 3, y: 0, z: 10 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 9, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline147 = await device2.createRenderPipelineAsync({
+label: '\u2b45\u0776\u{1f900}\uee80',
+layout: pipelineLayout26,
+multisample: {
+count: 4,
+mask: 0x900d00b1,
+},
+fragment: {module: shaderModule40, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+passOp: 'keep',
+},
+stencilBack: {
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 64,
+stencilWriteMask: 3926,
+depthBias: 73,
+depthBiasClamp: 99,
+},
+vertex: {
+  module: shaderModule40,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 588,
+shaderLocation: 3,
+}, {
+format: 'unorm10-10-10-2',
+offset: 1844,
+shaderLocation: 10,
+}, {
+format: 'float32',
+offset: 768,
+shaderLocation: 14,
+}, {
+format: 'snorm8x2',
+offset: 32,
+shaderLocation: 0,
+}, {
+format: 'snorm8x2',
+offset: 1018,
+shaderLocation: 13,
+}, {
+format: 'sint8x4',
+offset: 620,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 316,
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 24,
+shaderLocation: 7,
+}, {
+format: 'unorm8x4',
+offset: 108,
+shaderLocation: 15,
+}, {
+format: 'float32x3',
+offset: 236,
+shaderLocation: 8,
+}, {
+format: 'uint32',
+offset: 288,
+shaderLocation: 11,
+}, {
+format: 'float32x2',
+offset: 196,
+shaderLocation: 4,
+}, {
+format: 'sint32x2',
+offset: 160,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 1960,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x4',
+offset: 1264,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+cullMode: 'front',
+},
+});
+try {
+gpuCanvasContext25.unconfigure();
+} catch {}
+gc();
+let imageData24 = new ImageData(248, 228);
+let bindGroupLayout62 = device2.createBindGroupLayout({
+label: '\u12f2\u86a3\u030f\ub562\u001e\uafce\u087b\u709e\ua631\u0988',
+entries: [{
+binding: 920,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'comparison' },
+}, {
+binding: 478,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+}, {
+binding: 334,
+visibility: 0,
+externalTexture: {},
+}],
+});
+let commandBuffer22 = commandEncoder84.finish({
+});
+let textureView109 = texture103.createView({
+  label: '\u{1fb1c}\u0b85\u484c\u{1fbba}\u0771\ua37d\u8641\ud882',
+  baseMipLevel: 10,
+  baseArrayLayer: 35,
+  arrayLayerCount: 10
+});
+let computePassEncoder85 = commandEncoder74.beginComputePass({label: '\u{1fdb4}\u{1f93f}\u573c\uccfb'});
+let renderBundleEncoder102 = device2.createRenderBundleEncoder({
+  label: '\u2e8b\ub308\u0e64\ua694\u1e3a',
+  colorFormats: ['bgra8unorm', 'rgba8unorm', 'rgba32sint', undefined]
+});
+try {
+computePassEncoder65.setPipeline(pipeline138);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 3,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, new Int32Array(arrayBuffer15), /* required buffer size: 327309 */
+{offset: 775, bytesPerRow: 153, rowsPerImage: 194}, {width: 2, height: 1, depthOrArrayLayers: 12});
+} catch {}
+let pipeline148 = await device2.createRenderPipelineAsync({
+label: '\u74d2\u0c63\u06dc\u1d4c\u57d5\u{1fe5f}\u0455\u4fe5\u{1f7b9}\uedf4',
+layout: 'auto',
+multisample: {
+mask: 0x6ab8d2a0,
+},
+fragment: {module: shaderModule40, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'invert',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'zero',
+depthFailOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 3695,
+stencilWriteMask: 2544,
+depthBias: 42,
+depthBiasSlopeScale: 46,
+depthBiasClamp: 36,
+},
+vertex: {
+  module: shaderModule40,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1912,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x4',
+offset: 1572,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 1748,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x2',
+offset: 1420,
+shaderLocation: 13,
+}, {
+format: 'unorm16x2',
+offset: 720,
+shaderLocation: 0,
+}, {
+format: 'float16x2',
+offset: 1448,
+shaderLocation: 15,
+}, {
+format: 'snorm8x2',
+offset: 1246,
+shaderLocation: 10,
+}, {
+format: 'sint32',
+offset: 56,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 1944,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x2',
+offset: 1092,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 1732,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 1604,
+shaderLocation: 1,
+}, {
+format: 'float32',
+offset: 1668,
+shaderLocation: 14,
+}, {
+format: 'float32x4',
+offset: 864,
+shaderLocation: 7,
+}, {
+format: 'snorm16x2',
+offset: 364,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 1436,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x2',
+offset: 1404,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 204,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 348,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 200,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 172,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'none',
+},
+});
+gc();
+let textureView110 = texture125.createView({format: 'rg8sint', mipLevelCount: 1, arrayLayerCount: 1});
+try {
+renderBundleEncoder99.setBindGroup(5, bindGroup47, new Uint32Array(1850), 695, 0);
+} catch {}
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55) };
+} catch {}
+let canvas36 = document.createElement('canvas');
+let bindGroup48 = device7.createBindGroup({
+label: '\u{1fe3b}\u833b',
+layout: bindGroupLayout60,
+entries: [],
+});
+let sampler91 = device7.createSampler({
+label: '\ub1b3\u6aea\u075b\u{1fdb2}\u{1fa38}\u{1fe58}\u288f\uf5b0',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 13.706,
+lodMaxClamp: 84.671,
+maxAnisotropy: 14,
+});
+try {
+renderBundleEncoder99.setVertexBuffer(20, undefined, 3736152090, 312105631);
+} catch {}
+offscreenCanvas20.height = 106;
+let videoFrame31 = new VideoFrame(videoFrame5, {timestamp: 0});
+let offscreenCanvas31 = new OffscreenCanvas(314, 61);
+try {
+adapter6.label = '\u0a34\ufc69\udcd4\u8f6a\u{1fb4f}\ua5df\u{1fb50}';
+} catch {}
+let videoFrame32 = new VideoFrame(videoFrame24, {timestamp: 0});
+try {
+window.someLabel = device1.queue.label;
+} catch {}
+try {
+if (!arrayBuffer18.detached) { new Uint8Array(arrayBuffer18).fill(0x55) };
+} catch {}
+let texture130 = device7.createTexture({
+label: '\uba06\u2709\u0e00\u2ad1',
+size: {width: 3060, height: 66, depthOrArrayLayers: 33},
+mipLevelCount: 3,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let sampler92 = device7.createSampler({
+label: '\u27d6\u2438\u4c13\u8ae1\u0b49\ueac1\u7c48\u{1fe74}\ubb62',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 75.855,
+lodMaxClamp: 92.766,
+maxAnisotropy: 15,
+});
+try {
+await device7.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext26 = canvas36.getContext('webgpu');
+let shaderModule46 = device2.createShaderModule({
+label: '\u{1fa35}\u161f\u25de\u{1fb2d}\u06d8\u66b9\u0663\u0e34',
+code: `@group(1) @binding(241)
+var<storage, read_write> type19: array<u32>;
+
+@compute @workgroup_size(1, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(0) f1: vec4<f32>,
+  @location(2) f2: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S32 {
+  @location(6) f0: vec2<u32>,
+  @location(2) f1: vec2<f32>,
+  @location(13) f2: i32,
+  @location(11) f3: u32,
+  @location(14) f4: vec4<i32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(5) a1: f16, @location(9) a2: i32, @location(10) a3: vec2<f32>, @location(12) a4: vec3<f32>, @location(7) a5: vec3<i32>, @location(8) a6: f16, @location(0) a7: i32, @location(15) a8: vec2<f32>, @location(4) a9: vec2<i32>, @location(1) a10: vec4<u32>, @location(3) a11: vec3<u32>, a12: S32, @builtin(vertex_index) a13: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let commandEncoder101 = device2.createCommandEncoder();
+pseudoSubmit(device2, commandEncoder89);
+let textureView111 = texture78.createView({
+  label: '\ub217\u04c5\u01b9\u4154\ubdc4\u076e',
+  dimension: '2d-array',
+  aspect: 'all',
+  format: 'depth32float',
+  baseMipLevel: 1,
+  mipLevelCount: 2
+});
+try {
+renderBundleEncoder88.setVertexBuffer(6, buffer46, 27420, 5606);
+} catch {}
+try {
+commandEncoder66.copyBufferToBuffer(buffer26, 9200, buffer27, 24804, 392);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+gpuCanvasContext18.configure({
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer31, 17336, new DataView(new ArrayBuffer(1229)), 896, 84);
+} catch {}
+let gpuCanvasContext27 = offscreenCanvas31.getContext('webgpu');
+try {
+  await promise70;
+} catch {}
+document.body.prepend(img7);
+let promise71 = adapter9.requestAdapterInfo();
+let querySet107 = device2.createQuerySet({
+label: '\u224e\u0f81\u22d0\u199b\u622f\u7bb0\u0b8e\u05ec',
+type: 'occlusion',
+count: 1846,
+});
+let texture131 = device2.createTexture({
+label: '\u01fc\u8688\u846b\u6f18\uaedc\u72b3',
+size: [1080, 1, 1304],
+mipLevelCount: 8,
+dimension: '3d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+device2.queue.writeBuffer(buffer31, 23556, new DataView(new ArrayBuffer(50540)), 49715, 264);
+} catch {}
+try {
+  await promise71;
+} catch {}
+let querySet108 = device6.createQuerySet({
+label: '\u5e9a\u2301\u0331\u05de\ua568\u0400\u0a19\u0f04\ua8cb',
+type: 'occlusion',
+count: 2632,
+});
+let renderBundle111 = renderBundleEncoder96.finish({label: '\u{1fd56}\u783a\u92d1'});
+try {
+gpuCanvasContext14.configure({
+device: device6,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba8uint', 'rg32float', 'astc-10x8-unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let buffer47 = device6.createBuffer({
+  label: '\ub703\u6d89\u0051\u083f\ue9e5\u04c2\u835e\u80ed\u7147',
+  size: 61041,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let commandBuffer23 = commandEncoder99.finish();
+try {
+commandEncoder97.copyTextureToTexture({
+  texture: texture124,
+  mipLevel: 5,
+  origin: { x: 12, y: 4, z: 20 },
+  aspect: 'all',
+}, {
+  texture: texture124,
+  mipLevel: 3,
+  origin: { x: 32, y: 4, z: 11 },
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 23});
+} catch {}
+try {
+device6.queue.writeBuffer(buffer47, 12832, new Int16Array(31209), 25298, 2956);
+} catch {}
+let img28 = await imageWithData(93, 104, '#5b0fd7ea', '#bfaab4c2');
+let commandEncoder102 = device6.createCommandEncoder({label: '\u{1fe65}\u3624\u{1fc02}\uf16a\ud2c9\u0dff\ue761\u6cf8\u{1fa42}'});
+let texture132 = device6.createTexture({
+label: '\u9513\u{1fc0e}\u{1ff25}\u9faf\u917d\u95ae\u66a4\u{1f636}',
+size: [15],
+dimension: '1d',
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['r8unorm', 'r8unorm'],
+});
+let renderBundle112 = renderBundleEncoder100.finish({label: '\u{1f718}\ua4e7\uecba\ucbb1'});
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+let adapter11 = await promise69;
+try {
+renderBundle92.label = '\u{1ff19}\u{1f745}\u0798';
+} catch {}
+document.body.prepend(video15);
+let img29 = await imageWithData(136, 207, '#00f31f91', '#94e8c2d2');
+try {
+renderBundleEncoder99.setBindGroup(4, bindGroup47, new Uint32Array(8299), 6113, 0);
+} catch {}
+let device8 = await adapter11.requestDevice({
+label: '\u{1fe15}\u3106\u9541\u{1f9f6}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 52,
+maxVertexAttributes: 26,
+maxVertexBufferArrayStride: 35588,
+maxStorageTexturesPerShaderStage: 8,
+maxStorageBuffersPerShaderStage: 18,
+maxDynamicStorageBuffersPerPipelineLayout: 8054,
+maxBindingsPerBindGroup: 4736,
+maxTextureDimension1D: 8997,
+maxTextureDimension2D: 9180,
+maxVertexBuffers: 11,
+maxUniformBufferBindingSize: 27880921,
+maxUniformBuffersPerShaderStage: 13,
+maxInterStageShaderVariables: 33,
+maxInterStageShaderComponents: 63,
+maxSamplersPerShaderStage: 19,
+},
+});
+let adapter12 = await navigator.gpu.requestAdapter({
+});
+let promise72 = adapter12.requestDevice({
+label: '\u5488\u099f\u{1f770}\ucac5\u0521\u0507\u{1ff98}\u{1f64a}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 63,
+maxVertexAttributes: 25,
+maxVertexBufferArrayStride: 35389,
+maxStorageTexturesPerShaderStage: 39,
+maxStorageBuffersPerShaderStage: 37,
+maxDynamicStorageBuffersPerPipelineLayout: 52339,
+maxBindingsPerBindGroup: 9290,
+maxTextureDimension1D: 14178,
+maxTextureDimension2D: 15880,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 164015924,
+maxUniformBuffersPerShaderStage: 37,
+maxInterStageShaderVariables: 82,
+maxInterStageShaderComponents: 99,
+maxSamplersPerShaderStage: 19,
+},
+});
+try {
+adapter12.label = '\u4931\u8df0\u077d\u03d9\ub400';
+} catch {}
+let renderBundleEncoder103 = device7.createRenderBundleEncoder({colorFormats: ['rg16float'], depthReadOnly: false});
+let sampler93 = device7.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 49.159,
+lodMaxClamp: 88.514,
+maxAnisotropy: 19,
+});
+let videoFrame33 = new VideoFrame(offscreenCanvas18, {timestamp: 0});
+try {
+device8.label = '\u41ab\u0499\u{1f69a}\u{1f621}\u03b2\u{1ff65}\u0af0';
+} catch {}
+let texture133 = device8.createTexture({
+label: '\u1bb7\u0813\u7c1f\u320c\u0f84',
+size: {width: 3240, height: 110, depthOrArrayLayers: 179},
+mipLevelCount: 3,
+format: 'astc-10x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x10-unorm-srgb', 'astc-10x10-unorm-srgb', 'astc-10x10-unorm-srgb'],
+});
+let img30 = await imageWithData(237, 153, '#3e22e513', '#06cce2c5');
+try {
+if (!arrayBuffer20.detached) { new Uint8Array(arrayBuffer20).fill(0x55) };
+} catch {}
+let imageData25 = new ImageData(224, 72);
+try {
+gpuCanvasContext8.configure({
+device: device8,
+format: 'astc-5x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-5x4-unorm-srgb', 'astc-5x4-unorm', 'astc-5x4-unorm', 'astc-5x4-unorm'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device8.queue.writeTexture({
+  texture: texture133,
+  mipLevel: 0,
+  origin: { x: 10, y: 100, z: 23 },
+  aspect: 'all',
+}, arrayBuffer20, /* required buffer size: 467730 */
+{offset: 466, bytesPerRow: 4768, rowsPerImage: 7}, {width: 2930, height: 0, depthOrArrayLayers: 15});
+} catch {}
+let offscreenCanvas32 = new OffscreenCanvas(558, 845);
+let querySet109 = device3.createQuerySet({
+type: 'occlusion',
+count: 746,
+});
+let texture134 = device3.createTexture({
+label: '\u085b\u3b38',
+size: [384, 192, 1],
+mipLevelCount: 3,
+format: 'etc2-rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let pipeline149 = device3.createRenderPipeline({
+label: '\u0e95\u9d1f',
+layout: pipelineLayout20,
+fragment: {module: shaderModule32, entryPoint: 'fragment0', targets: []},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 1391,
+stencilWriteMask: 3550,
+depthBias: 52,
+depthBiasSlopeScale: 52,
+depthBiasClamp: 8,
+},
+vertex: {
+  module: shaderModule32,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 456,
+attributes: [{
+format: 'uint32x4',
+offset: 312,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 20,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x4',
+offset: 8,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 768,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 436,
+shaderLocation: 3,
+}, {
+format: 'sint32x4',
+offset: 496,
+shaderLocation: 5,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let gpuCanvasContext28 = offscreenCanvas32.getContext('webgpu');
+document.body.prepend(canvas12);
+let offscreenCanvas33 = new OffscreenCanvas(336, 204);
+let imageData26 = new ImageData(200, 140);
+let img31 = await imageWithData(194, 200, '#08245857', '#1973f1e1');
+let imageBitmap35 = await createImageBitmap(video18);
+try {
+offscreenCanvas33.getContext('webgl2');
+} catch {}
+let buffer48 = device8.createBuffer({
+  label: '\u0c54\ua82f\u0d6f\ua4ab\u091b\ua413\u{1f990}\u31ed\ua550',
+  size: 53735,
+  usage: GPUBufferUsage.MAP_READ
+});
+let commandEncoder103 = device8.createCommandEncoder({label: '\u55f8\u090e\u6b81\ue490\u0f52\ub7a1\u0656\u{1ff03}\u{1f718}\u2b29'});
+let texture135 = device8.createTexture({
+label: '\u{1f84f}\u3196\u0be9\u{1fd5a}\u0846\u02e0\u0faf\uaa00',
+size: {width: 2215, height: 5, depthOrArrayLayers: 118},
+mipLevelCount: 9,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-5x5-unorm-srgb', 'astc-5x5-unorm', 'astc-5x5-unorm-srgb'],
+});
+let textureView112 = texture133.createView({
+  label: '\u1b40\u{1fa69}\u{1f83b}\udb56\u{1f89d}\u{1fdd3}\u1ce8\u6f36\u0aa2\u62cb',
+  dimension: '2d',
+  mipLevelCount: 2,
+  baseArrayLayer: 77
+});
+let computePassEncoder86 = commandEncoder103.beginComputePass({label: '\u5c3d\u{1fc2d}\u62de\u01fe\ue2b8\u0cf8\uedcb'});
+try {
+computePassEncoder86.end();
+} catch {}
+try {
+await adapter9.requestAdapterInfo();
+} catch {}
+document.body.prepend(img26);
+let img32 = await imageWithData(223, 52, '#2d48f247', '#bbe08c2f');
+let video34 = await videoWithData();
+let imageData27 = new ImageData(88, 196);
+canvas24.height = 27;
+let computePassEncoder87 = commandEncoder63.beginComputePass({});
+let renderBundle113 = renderBundleEncoder78.finish({label: '\ua2ef\u0653\u842f\udaea\uee36\u{1f636}\u6e2e\ued1a\u610c'});
+let sampler94 = device2.createSampler({
+label: '\u7696\uacc9\u2954\u{1fa2f}\ufa66\u{1f976}\u{1fe6c}\u{1f7cb}\u{1f817}',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 46.519,
+lodMaxClamp: 49.630,
+});
+try {
+renderBundleEncoder102.setBindGroup(1, bindGroup46);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 48, height: 7, depthOrArrayLayers: 100}
+*/
+{
+  source: imageBitmap24,
+  origin: { x: 3, y: 15 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: { x: 21, y: 5, z: 59 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline150 = device2.createRenderPipeline({
+layout: 'auto',
+multisample: {
+count: 4,
+mask: 0x61112d0,
+},
+fragment: {
+  module: shaderModule46,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm'}, {format: 'rgba8unorm', writeMask: 0}, {format: 'rgba32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, undefined]
+},
+vertex: {
+  module: shaderModule46,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 1628,
+shaderLocation: 4,
+}, {
+format: 'float16x4',
+offset: 1268,
+shaderLocation: 8,
+}, {
+format: 'unorm8x2',
+offset: 1578,
+shaderLocation: 2,
+}, {
+format: 'unorm8x4',
+offset: 1648,
+shaderLocation: 5,
+}, {
+format: 'unorm8x4',
+offset: 1228,
+shaderLocation: 15,
+}, {
+format: 'uint32x4',
+offset: 964,
+shaderLocation: 11,
+}, {
+format: 'unorm10-10-10-2',
+offset: 1376,
+shaderLocation: 12,
+}, {
+format: 'sint16x4',
+offset: 280,
+shaderLocation: 13,
+}, {
+format: 'sint32x3',
+offset: 1444,
+shaderLocation: 14,
+}, {
+format: 'uint32x3',
+offset: 1616,
+shaderLocation: 3,
+}, {
+format: 'uint32',
+offset: 1596,
+shaderLocation: 1,
+}, {
+format: 'unorm16x2',
+offset: 608,
+shaderLocation: 10,
+}, {
+format: 'sint16x4',
+offset: 828,
+shaderLocation: 9,
+}, {
+format: 'sint32x3',
+offset: 676,
+shaderLocation: 0,
+}, {
+format: 'sint32',
+offset: 396,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 468,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 2008,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x4',
+offset: 1744,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: false,
+},
+});
+let commandEncoder104 = device8.createCommandEncoder({label: '\u{1fd54}\ud3ea\u93ae\u8138\u4403\u0f07\u{1f6aa}\u3512\u3137\u0ccd'});
+let texture136 = device8.createTexture({
+label: '\u05a6\u09b5',
+size: [320, 96, 21],
+mipLevelCount: 9,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-8x8-unorm', 'astc-8x8-unorm-srgb', 'astc-8x8-unorm'],
+});
+let textureView113 = texture136.createView({
+  label: '\u{1f858}\uf86b\u3a35\u03c7\u{1f7cc}',
+  dimension: '2d',
+  format: 'astc-8x8-unorm',
+  baseMipLevel: 5,
+  mipLevelCount: 1,
+  baseArrayLayer: 15
+});
+offscreenCanvas27.height = 12;
+try {
+pipelineLayout25.label = '\uc090\u{1fd8a}\u{1f806}';
+} catch {}
+let commandBuffer24 = commandEncoder98.finish({
+});
+let textureView114 = texture132.createView({label: '\uf4ef\ue835\u{1f8db}\u0ad4\u5417\u9e5e\u{1f9fc}\u7a48\u17bb'});
+let computePassEncoder88 = commandEncoder97.beginComputePass({label: '\u70ef\u76fa\u02ae\u01d4\u0536\u2a93\u{1ff4d}\ua9f3\uc3c8'});
+try {
+device6.queue.writeTexture({
+  texture: texture124,
+  mipLevel: 3,
+  origin: { x: 0, y: 4, z: 0 },
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(16)), /* required buffer size: 208060 */
+{offset: 723, bytesPerRow: 389, rowsPerImage: 13}, {width: 108, height: 0, depthOrArrayLayers: 42});
+} catch {}
+document.body.prepend(video13);
+let textureView115 = texture84.createView({label: '\u0da7\u4ba5\u46f1\u4713', aspect: 'all'});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup46, new Uint32Array(1), 0, 0);
+} catch {}
+try {
+commandEncoder94.resolveQuerySet(querySet60, 2767, 841, buffer46, 38656);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 24, height: 3, depthOrArrayLayers: 50}
+*/
+{
+  source: video20,
+  origin: { x: 3, y: 7 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 0, y: 2, z: 36 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageData28 = new ImageData(80, 32);
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let adapter13 = await navigator.gpu.requestAdapter({
+powerPreference: 'high-performance',
+});
+let sampler95 = device8.createSampler({
+label: '\u{1fe8e}\u134b\u0727\u{1fca8}\u01df\u{1f836}\u5163\ucde9',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 86.751,
+lodMaxClamp: 92.360,
+maxAnisotropy: 8,
+});
+try {
+buffer48.destroy();
+} catch {}
+offscreenCanvas31.height = 718;
+document.body.prepend(canvas36);
+offscreenCanvas4.width = 534;
+let adapter14 = await navigator.gpu.requestAdapter({
+});
+try {
+renderBundleEncoder83.setBindGroup(1, bindGroup36);
+} catch {}
+try {
+commandEncoder66.clearBuffer(buffer25, 5844, 51848);
+dissociateBuffer(device2, buffer25);
+} catch {}
+canvas10.width = 11;
+gc();
+canvas21.width = 671;
+let videoFrame34 = new VideoFrame(imageBitmap19, {timestamp: 0});
+let promise73 = navigator.gpu.requestAdapter();
+let device9 = await adapter13.requestDevice({
+label: '\ud7ce\u{1f7b9}\u470e\u1670\u97ca\u0ac3\u0e8c\u{1f76a}\u{1fdca}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+});
+document.body.prepend(video0);
+try {
+commandEncoder102.clearBuffer(buffer47, 628, 35024);
+dissociateBuffer(device6, buffer47);
+} catch {}
+try {
+device6.queue.writeBuffer(buffer47, 18140, new Int16Array(45381), 18198, 15628);
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture124,
+  mipLevel: 3,
+  origin: { x: 12, y: 0, z: 11 },
+  aspect: 'all',
+}, arrayBuffer20, /* required buffer size: 1090467 */
+{offset: 495, bytesPerRow: 234, rowsPerImage: 274}, {width: 96, height: 0, depthOrArrayLayers: 18});
+} catch {}
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup49 = device2.createBindGroup({
+label: '\u5618\u0719\u792c\u{1fd1b}\uc382\u7957\udf66\u2ed3\u{1f616}\ucb75',
+layout: bindGroupLayout37,
+entries: [{
+binding: 385,
+resource: sampler52
+}, {
+binding: 771,
+resource: externalTexture4
+}],
+});
+try {
+computePassEncoder85.setBindGroup(1, bindGroup49, new Uint32Array(4513), 1512, 0);
+} catch {}
+try {
+commandEncoder93.clearBuffer(buffer34);
+dissociateBuffer(device2, buffer34);
+} catch {}
+let pipeline151 = device2.createComputePipeline({
+label: '\uc363\u2be3\ud2a7\u{1fe40}\u84e9\ud3c5\u3750\u8925\u0530\u0043',
+layout: pipelineLayout26,
+compute: {
+module: shaderModule28,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline152 = await device2.createRenderPipelineAsync({
+label: '\u0ae8\u{1f8d4}',
+layout: pipelineLayout19,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule34,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'dst', dstFactor: 'src'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+}
+}, undefined, undefined, {format: 'rgba16float'}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL
+}, {format: 'rgba8sint', writeMask: 0}]
+},
+vertex: {
+  module: shaderModule34,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32',
+offset: 1800,
+shaderLocation: 14,
+}, {
+format: 'float32x3',
+offset: 1004,
+shaderLocation: 3,
+}, {
+format: 'float32x2',
+offset: 1112,
+shaderLocation: 2,
+}, {
+format: 'sint8x2',
+offset: 818,
+shaderLocation: 10,
+}, {
+format: 'unorm16x4',
+offset: 1184,
+shaderLocation: 7,
+}, {
+format: 'unorm8x4',
+offset: 2028,
+shaderLocation: 9,
+}, {
+format: 'float32',
+offset: 1696,
+shaderLocation: 12,
+}, {
+format: 'float32x4',
+offset: 832,
+shaderLocation: 1,
+}, {
+format: 'float32x4',
+offset: 1224,
+shaderLocation: 4,
+}, {
+format: 'sint32x4',
+offset: 1012,
+shaderLocation: 5,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+},
+});
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+let imageData29 = new ImageData(44, 32);
+let renderBundleEncoder104 = device9.createRenderBundleEncoder({
+  label: '\u43a9\u0b9a\u06ab\uef6b\ub9ce\uc41d\u9628\uf67a\uf90b',
+  colorFormats: ['rgba16float', 'rgba32uint', 'rgb10a2uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let buffer49 = device2.createBuffer({size: 46012, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let texture137 = device2.createTexture({
+label: '\u{1f784}\u6dde\u{1f801}\u07c1\u{1ffe2}\u0654\u0c1f\u0807\u7563',
+size: [30],
+dimension: '1d',
+format: 'rg16uint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+let computePassEncoder89 = commandEncoder94.beginComputePass();
+let renderBundleEncoder105 = device2.createRenderBundleEncoder({label: '\u00aa\u2b4e\u0cff', colorFormats: ['bgra8unorm', 'rgba8unorm', 'rgba32sint', undefined]});
+try {
+computePassEncoder83.setBindGroup(0, bindGroup46, new Uint32Array(9898), 5409, 0);
+} catch {}
+try {
+renderBundleEncoder97.setBindGroup(0, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder97.setVertexBuffer(3, buffer26, 280, 6621);
+} catch {}
+let arrayBuffer21 = buffer27.getMappedRange(12608, 204);
+try {
+commandEncoder66.resolveQuerySet(querySet65, 1948, 17, buffer46, 19456);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture131,
+  mipLevel: 0,
+  origin: { x: 104, y: 0, z: 917 },
+  aspect: 'all',
+}, new ArrayBuffer(2314239), /* required buffer size: 2314239 */
+{offset: 895, bytesPerRow: 3774, rowsPerImage: 6}, {width: 914, height: 1, depthOrArrayLayers: 103});
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+try {
+if (!arrayBuffer21.detached) { new Uint8Array(arrayBuffer21).fill(0x55) };
+} catch {}
+let promise74 = adapter14.requestDevice({
+label: '\u{1f7dd}\u5059\u8014\u0051\u0413\u{1ff19}\u0a1f\u{1fc65}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxColorAttachmentBytesPerSample: 50,
+maxVertexAttributes: 22,
+maxVertexBufferArrayStride: 64417,
+maxStorageTexturesPerShaderStage: 22,
+maxStorageBuffersPerShaderStage: 15,
+maxDynamicStorageBuffersPerPipelineLayout: 6134,
+maxBindingsPerBindGroup: 1630,
+maxTextureDimension1D: 12361,
+maxTextureDimension2D: 12570,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 256,
+maxUniformBufferBindingSize: 174875661,
+maxUniformBuffersPerShaderStage: 16,
+maxInterStageShaderVariables: 27,
+maxInterStageShaderComponents: 84,
+maxSamplersPerShaderStage: 16,
+},
+});
+let canvas37 = document.createElement('canvas');
+let imageBitmap36 = await createImageBitmap(imageData29);
+try {
+canvas37.getContext('webgpu');
+} catch {}
+try {
+window.someLabel = device2.label;
+} catch {}
+let commandEncoder105 = device2.createCommandEncoder({label: '\u1e32\u{1faff}\u{1f9c4}\u{1faa4}\uf6dc\ub16b\u{1fff0}\u4f7a'});
+let querySet110 = device2.createQuerySet({
+label: '\u{1ffd1}\u1063\u00a0\u9b74\u0e22',
+type: 'occlusion',
+count: 1588,
+});
+let textureView116 = texture137.createView({});
+let computePassEncoder90 = commandEncoder93.beginComputePass({label: '\u{1fdff}\u0a22\ufeac\u9921\u0684\u39d2'});
+try {
+computePassEncoder85.end();
+} catch {}
+try {
+renderBundleEncoder88.setBindGroup(1, bindGroup49, new Uint32Array(648), 561, 0);
+} catch {}
+try {
+renderBundleEncoder81.setVertexBuffer(0, buffer46, 14068);
+} catch {}
+try {
+commandEncoder101.copyTextureToTexture({
+  texture: texture109,
+  mipLevel: 0,
+  origin: { x: 63, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture119,
+  mipLevel: 0,
+  origin: { x: 17, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 7, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderBundleEncoder88.insertDebugMarker('\u0849');
+} catch {}
+let pipeline153 = device2.createComputePipeline({
+label: '\ub5ac\u{1f6ba}\u6aea\u9618\u1959\udd89\u044f\uf517',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule46,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline154 = device2.createRenderPipeline({
+label: '\u004d\u53f3\u0bc1\u0f17',
+layout: pipelineLayout26,
+multisample: {
+count: 4,
+mask: 0x8c7686e1,
+},
+fragment: {module: shaderModule40, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 3917,
+depthBias: 8,
+depthBiasSlopeScale: 4,
+depthBiasClamp: 58,
+},
+vertex: {
+  module: shaderModule40,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 808,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 20,
+shaderLocation: 3,
+}, {
+format: 'uint16x4',
+offset: 608,
+shaderLocation: 11,
+}, {
+format: 'snorm8x4',
+offset: 756,
+shaderLocation: 7,
+}, {
+format: 'sint32x3',
+offset: 212,
+shaderLocation: 1,
+}, {
+format: 'snorm8x2',
+offset: 534,
+shaderLocation: 10,
+}, {
+format: 'unorm16x2',
+offset: 776,
+shaderLocation: 0,
+}, {
+format: 'unorm10-10-10-2',
+offset: 728,
+shaderLocation: 6,
+}, {
+format: 'sint32',
+offset: 20,
+shaderLocation: 9,
+}, {
+format: 'unorm16x4',
+offset: 16,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 1388,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1224,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x4',
+offset: 1084,
+shaderLocation: 14,
+}, {
+format: 'unorm16x2',
+offset: 644,
+shaderLocation: 8,
+}, {
+format: 'snorm16x4',
+offset: 584,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 16,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1928,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 512,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x4',
+offset: 168,
+shaderLocation: 4,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+},
+});
+document.body.prepend(video14);
+let canvas38 = document.createElement('canvas');
+let renderBundle114 = renderBundleEncoder99.finish({label: '\uc0d7\u{1f91c}\u6847'});
+try {
+renderBundleEncoder103.setBindGroup(10, bindGroup48);
+} catch {}
+let gpuCanvasContext29 = canvas38.getContext('webgpu');
+let bindGroupLayout63 = device6.createBindGroupLayout({
+label: '\u0e1e\u22b5\uf9d0\u4e82\u400b\u1702\u9946\u0dd0',
+entries: [{
+binding: 5070,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+}],
+});
+let querySet111 = device9.createQuerySet({
+label: '\u{1fdad}\u08b0\u0b74\u0cfa',
+type: 'occlusion',
+count: 2600,
+});
+let renderBundleEncoder106 = device9.createRenderBundleEncoder({
+  colorFormats: ['rgba16float', 'rgba32uint', 'rgb10a2uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder106.setVertexBuffer(42, undefined, 619901384, 3164504200);
+} catch {}
+let img33 = await imageWithData(213, 9, '#9c7a7cbb', '#df83b042');
+offscreenCanvas32.height = 162;
+let videoFrame35 = new VideoFrame(imageBitmap21, {timestamp: 0});
+let pipelineLayout28 = device6.createPipelineLayout({
+  label: '\u{1f8f5}\u0606\ubf7a\u{1ff0c}\ua1d0\u0faf\u641c\u{1f604}\u0a9e',
+  bindGroupLayouts: [bindGroupLayout63, bindGroupLayout63, bindGroupLayout63, bindGroupLayout63, bindGroupLayout63, bindGroupLayout63]
+});
+let commandEncoder106 = device6.createCommandEncoder();
+let querySet112 = device6.createQuerySet({
+label: '\u9678\u0041\u{1f600}\u095a\u{1fc1a}\ub295\u03a2\ub9d5\ubadd',
+type: 'occlusion',
+count: 2720,
+});
+let commandBuffer25 = commandEncoder106.finish({
+label: '\u3997\ue58a\uea0d\uce16\u006a\u2173\u0f2b\u5d1f\u5235\u0cac\u0d7e',
+});
+let renderBundleEncoder107 = device6.createRenderBundleEncoder({
+  label: '\u0461\u0e81\u8909\u{1fb8a}\uea30\u065e\u{1f991}\ufe21\u097c\u0991',
+  colorFormats: ['rg32float', 'rg11b10ufloat', undefined, 'rg11b10ufloat', 'rgba8uint'],
+  sampleCount: 4
+});
+let sampler96 = device6.createSampler({
+label: '\u5071\u{1f79d}\u0d74\u{1f679}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 67.698,
+lodMaxClamp: 80.852,
+});
+try {
+commandEncoder102.clearBuffer(buffer47, 8088, 7692);
+dissociateBuffer(device6, buffer47);
+} catch {}
+try {
+device6.queue.writeBuffer(buffer47, 42764, new DataView(new ArrayBuffer(52995)), 14344, 11676);
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let promise75 = navigator.gpu.requestAdapter({
+});
+let sampler97 = device2.createSampler({
+label: '\u2813\ube0e\ua3e8\u26a7\u04f8\uf22a\u{1fca9}\u0a35\u0906\u{1ffb7}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 60.945,
+lodMaxClamp: 94.474,
+});
+try {
+renderBundleEncoder105.setVertexBuffer(4, buffer46, 1620);
+} catch {}
+try {
+commandEncoder66.copyBufferToBuffer(buffer26, 4464, buffer25, 19288, 240);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+commandEncoder101.copyTextureToBuffer({
+  texture: texture105,
+  mipLevel: 1,
+  origin: { x: 152, y: 0, z: 115 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 8704 widthInBlocks: 2176 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 16868 */
+offset: 16868,
+buffer: buffer31,
+}, {width: 2176, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer31);
+} catch {}
+try {
+commandEncoder105.clearBuffer(buffer31, 32380, 824);
+dissociateBuffer(device2, buffer31);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb'],
+colorSpace: 'display-p3',
+});
+} catch {}
+let canvas39 = document.createElement('canvas');
+let offscreenCanvas34 = new OffscreenCanvas(941, 702);
+let img34 = await imageWithData(149, 111, '#0e977015', '#d6da5d4f');
+let bindGroupLayout64 = device6.createBindGroupLayout({
+label: '\u05d4\u044b\ua96e\ub4ed\u35ac\u8464\u{1ff77}',
+entries: [{
+binding: 5734,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+}, {
+binding: 2694,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '1d' },
+}],
+});
+try {
+gpuCanvasContext3.configure({
+device: device6,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['astc-12x10-unorm'],
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+offscreenCanvas34.getContext('webgl2');
+} catch {}
+let bindGroupLayout65 = device9.createBindGroupLayout({
+label: '\u9e7e\u{1fd05}\u5398\u0417\u0857\u{1fdf8}\u{1f90d}\u7fb9',
+entries: [{
+binding: 573,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+}, {
+binding: 342,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}],
+});
+let buffer50 = device9.createBuffer({
+  label: '\u08c4\u345d\u{1fd34}\ue05a\u005b\u9b25\ua0b1\u0a8b\uf1bf\u{1fd46}',
+  size: 36391,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE
+});
+let sampler98 = device9.createSampler({
+label: '\u2a31\ubd73\u{1f978}\u98cc\u3c41\u008b\ua4ca\u06c5\u0025',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 91.054,
+lodMaxClamp: 98.180,
+compare: 'equal',
+maxAnisotropy: 17,
+});
+try {
+device1.label = '\u{1f958}\u2abe';
+} catch {}
+let renderBundleEncoder108 = device7.createRenderBundleEncoder({colorFormats: ['rg16float'], depthReadOnly: false, stencilReadOnly: true});
+let sampler99 = device7.createSampler({
+label: '\uf12f\u0c97\u0572\u0dfc',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 6.853,
+lodMaxClamp: 39.977,
+maxAnisotropy: 13,
+});
+try {
+renderBundleEncoder108.setBindGroup(4, bindGroup47);
+} catch {}
+document.body.prepend(img32);
+let commandEncoder107 = device7.createCommandEncoder({label: '\u4029\u034b\u{1fda4}\u616f\u81af\u{1f8db}'});
+let querySet113 = device7.createQuerySet({
+label: '\u{1f6db}\u3c4c\ud02b\u71d8\u{1fb7b}',
+type: 'occlusion',
+count: 1314,
+});
+let sampler100 = device7.createSampler({
+label: '\uaaa8\u{1fde7}\uf61b\u0a17\u17a6\u05ee\u{1f86c}\u0afc\u{1fc9f}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 41.904,
+maxAnisotropy: 15,
+});
+try {
+await device7.popErrorScope();
+} catch {}
+try {
+await adapter2.requestAdapterInfo();
+} catch {}
+video19.width = 232;
+canvas31.height = 687;
+let videoFrame36 = new VideoFrame(imageBitmap26, {timestamp: 0});
+let textureView117 = texture132.createView({format: 'r8unorm'});
+try {
+buffer47.unmap();
+} catch {}
+try {
+gpuCanvasContext11.configure({
+device: device6,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm', 'rg16sint', 'rgba8unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+gc();
+let renderBundleEncoder109 = device6.createRenderBundleEncoder({
+  label: '\ub41a\u{1f608}\u7b93\u{1fd28}\u{1ff50}\u26b4\u{1fee4}\u{1fee8}\ue939',
+  colorFormats: ['rg32float', 'rg11b10ufloat', undefined, 'rg11b10ufloat', 'rgba8uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let gpuCanvasContext30 = canvas39.getContext('webgpu');
+let img35 = await imageWithData(252, 261, '#f9a8c34a', '#d1e0fee9');
+let textureView118 = texture124.createView({label: '\u01cd\uaf89\u1ead', baseMipLevel: 3, mipLevelCount: 2, baseArrayLayer: 26, arrayLayerCount: 10});
+try {
+commandEncoder102.clearBuffer(buffer47, 30376, 26688);
+dissociateBuffer(device6, buffer47);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+device: device6,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas35 = new OffscreenCanvas(775, 38);
+try {
+window.someLabel = device1.label;
+} catch {}
+let renderBundle115 = renderBundleEncoder104.finish({label: '\u018e\u0afb\u0594\u79fc\u0d80\u{1f895}\u0150\u0666\ua124\u0681\u4473'});
+try {
+renderBundleEncoder106.setVertexBuffer(25, undefined);
+} catch {}
+try {
+buffer50.unmap();
+} catch {}
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup50 = device7.createBindGroup({
+label: '\u014f\u{1fdba}\u1296\u{1f8f9}\u286a',
+layout: bindGroupLayout60,
+entries: [],
+});
+let pipelineLayout29 = device7.createPipelineLayout({
+  label: '\uc6d0\u{1feef}\ud042\ub16b',
+  bindGroupLayouts: [bindGroupLayout61, bindGroupLayout61, bindGroupLayout60, bindGroupLayout61, bindGroupLayout61, bindGroupLayout61, bindGroupLayout61, bindGroupLayout60, bindGroupLayout60, bindGroupLayout60]
+});
+let querySet114 = device7.createQuerySet({
+label: '\u3806\u{1f9ba}\u{1f721}\u0060\u{1f716}',
+type: 'occlusion',
+count: 3225,
+});
+let textureView119 = texture130.createView({aspect: 'stencil-only', baseMipLevel: 2, baseArrayLayer: 15, arrayLayerCount: 8});
+let renderBundle116 = renderBundleEncoder99.finish({label: '\u00fd\u9d1b'});
+let gpuCanvasContext31 = offscreenCanvas35.getContext('webgpu');
+let imageData30 = new ImageData(84, 208);
+try {
+window.someLabel = commandEncoder98.label;
+} catch {}
+try {
+commandEncoder102.clearBuffer(buffer47, 27780, 23868);
+dissociateBuffer(device6, buffer47);
+} catch {}
+let img36 = await imageWithData(209, 96, '#edb8550e', '#63556f9e');
+let buffer51 = device8.createBuffer({
+  label: '\u0399\u7e9f\u6983\u0d66\ud6de\u0adb\u{1f836}\ucdd6',
+  size: 41439,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let commandBuffer26 = commandEncoder103.finish({
+label: '\u{1faa0}\u8f13\u0cec\u{1fc3f}',
+});
+let videoFrame37 = new VideoFrame(canvas20, {timestamp: 0});
+offscreenCanvas29.height = 366;
+try {
+adapter14.label = '\uf9ab\u{1fc5d}\u07b7\u3737\u7f93\ud544';
+} catch {}
+let querySet115 = device6.createQuerySet({
+type: 'occlusion',
+count: 2754,
+});
+let computePassEncoder91 = commandEncoder102.beginComputePass({label: '\u2f1a\u08a4\ufe23\u879d\u5434\u7b08'});
+let renderBundleEncoder110 = device6.createRenderBundleEncoder({
+  label: '\u0bd9\u8706\ub676',
+  colorFormats: ['rg32float', 'rg11b10ufloat', undefined, 'rg11b10ufloat', 'rgba8uint'],
+  sampleCount: 4
+});
+let sampler101 = device6.createSampler({
+label: '\u0855\u0ffb\u0345',
+magFilter: 'linear',
+minFilter: 'nearest',
+lodMinClamp: 27.907,
+lodMaxClamp: 97.917,
+});
+let commandEncoder108 = device7.createCommandEncoder({label: '\u{1f738}\u{1f768}'});
+let texture138 = device7.createTexture({
+label: '\ueb42\u51e0\u{1f8fb}\u0b52\u01b0',
+size: {width: 5606},
+dimension: '1d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundle117 = renderBundleEncoder103.finish({label: '\u050e\u0706\ud869\u1ec5\u0f7e\u002e\u1e25\u{1f8d6}'});
+try {
+await device7.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder92 = commandEncoder104.beginComputePass({label: '\u3b42\u30a1\u{1f7c9}\u543f\u0fe7'});
+document.body.prepend(canvas37);
+canvas29.height = 316;
+let querySet116 = device7.createQuerySet({
+type: 'occlusion',
+count: 934,
+});
+try {
+gpuCanvasContext8.configure({
+device: device7,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['bgra8unorm', 'astc-8x8-unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture138,
+  mipLevel: 0,
+  origin: { x: 1644, y: 1, z: 1 },
+  aspect: 'all',
+}, arrayBuffer11, /* required buffer size: 453 */
+{offset: 453, rowsPerImage: 60}, {width: 151, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas19.width = 35;
+let videoFrame38 = new VideoFrame(offscreenCanvas8, {timestamp: 0});
+let adapter15 = await navigator.gpu.requestAdapter({
+});
+let shaderModule47 = device7.createShaderModule({
+label: '\u0b42\u14a1\uaf8f\u{1ff26}',
+code: `@group(0) @binding(993)
+var<storage, read_write> parameter30: array<u32>;
+@group(0) @binding(2644)
+var<storage, read_write> field14: array<u32>;
+@group(3) @binding(993)
+var<storage, read_write> function19: array<u32>;
+@group(6) @binding(2644)
+var<storage, read_write> i16: array<u32>;
+@group(3) @binding(2644)
+var<storage, read_write> field15: array<u32>;
+@group(5) @binding(993)
+var<storage, read_write> global10: array<u32>;
+@group(4) @binding(2644)
+var<storage, read_write> i17: array<u32>;
+@group(1) @binding(993)
+var<storage, read_write> parameter31: array<u32>;
+@group(4) @binding(993)
+var<storage, read_write> type20: array<u32>;
+
+@compute @workgroup_size(5, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S33 {
+  @builtin(vertex_index) f0: u32,
+  @location(17) f1: vec2<f32>,
+  @location(20) f2: vec2<i32>,
+  @builtin(instance_index) f3: u32,
+  @location(13) f4: vec3<u32>,
+  @location(9) f5: vec3<i32>,
+  @location(7) f6: vec2<f16>,
+  @location(16) f7: vec4<f32>,
+  @location(5) f8: vec4<f32>,
+  @location(8) f9: f32,
+  @location(6) f10: f16
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec3<f16>, @location(18) a1: vec2<f16>, @location(23) a2: vec4<f32>, a3: S33, @location(15) a4: vec3<i32>, @location(19) a5: vec2<i32>, @location(3) a6: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+let textureView120 = texture126.createView({
+  label: '\ub788\udcff\ud615\u1aa7\u{1fb9e}\u826f\ufbca\u0ced\ua201\u{1f7cc}',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 12
+});
+let renderBundleEncoder111 = device7.createRenderBundleEncoder({label: '\u0d78\u0458\u1cc2\u6331', colorFormats: ['rg16float'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderBundleEncoder111.setVertexBuffer(53, undefined, 1654486242, 2401168264);
+} catch {}
+let promise76 = device7.createComputePipelineAsync({
+label: '\u595a\uc99c\u0b49\u{1fb23}\uac5c\u7a5c',
+layout: pipelineLayout29,
+compute: {
+module: shaderModule47,
+entryPoint: 'compute0',
+},
+});
+let pipeline155 = device7.createRenderPipeline({
+layout: pipelineLayout29,
+multisample: {
+},
+fragment: {
+  module: shaderModule47,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg16float',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'one-minus-src'},
+alpha: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'one-minus-dst'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE
+}]
+},
+vertex: {
+  module: shaderModule47,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 8184,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 7824,
+shaderLocation: 23,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x2',
+offset: 5844,
+shaderLocation: 17,
+}],
+},
+{
+arrayStride: 7224,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x2',
+offset: 5472,
+shaderLocation: 6,
+}, {
+format: 'unorm8x4',
+offset: 1688,
+shaderLocation: 2,
+}, {
+format: 'sint16x4',
+offset: 5012,
+shaderLocation: 19,
+}, {
+format: 'snorm8x4',
+offset: 4056,
+shaderLocation: 8,
+}, {
+format: 'sint32x2',
+offset: 3088,
+shaderLocation: 15,
+}, {
+format: 'snorm16x4',
+offset: 1736,
+shaderLocation: 18,
+}, {
+format: 'float16x2',
+offset: 108,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 5840,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x2',
+offset: 5658,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 31236,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 18508,
+shaderLocation: 13,
+}, {
+format: 'sint32x3',
+offset: 9420,
+shaderLocation: 9,
+}, {
+format: 'uint8x4',
+offset: 14128,
+shaderLocation: 3,
+}, {
+format: 'sint32x4',
+offset: 29964,
+shaderLocation: 20,
+}, {
+format: 'float16x4',
+offset: 4948,
+shaderLocation: 5,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let renderBundleEncoder112 = device8.createRenderBundleEncoder({colorFormats: ['rg8sint'], stencilReadOnly: true});
+try {
+device8.queue.submit([
+commandBuffer26,
+]);
+} catch {}
+video9.width = 216;
+let adapter16 = await navigator.gpu.requestAdapter();
+let img37 = await imageWithData(223, 226, '#a4c9e8ab', '#3312c924');
+let imageData31 = new ImageData(4, 140);
+let renderBundle118 = renderBundleEncoder37.finish({label: '\ud9df\ue35d\ub3b5\u8e72\u01f3\u0bc6'});
+try {
+renderBundleEncoder54.setBindGroup(0, bindGroup29, new Uint32Array(5555), 936, 0);
+} catch {}
+try {
+renderBundleEncoder68.draw(0, 16, 0, 48);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+commandEncoder96.copyTextureToBuffer({
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 9, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 1216 widthInBlocks: 304 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 30456 */
+offset: 30456,
+buffer: buffer12,
+}, {width: 304, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+let pipeline156 = device0.createRenderPipeline({
+label: '\u03b5\u0ee0\ue71a\uf0e7\u{1fa21}\u{1fc9a}\u0377\u{1fdaf}\ub829\udea6',
+layout: pipelineLayout11,
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint'}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, undefined, {format: 'rg32float'}, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}]
+},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3014,
+stencilWriteMask: 710,
+depthBias: 12,
+depthBiasSlopeScale: 95,
+depthBiasClamp: 94,
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1800,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x2',
+offset: 868,
+shaderLocation: 5,
+}, {
+format: 'uint32x3',
+offset: 1384,
+shaderLocation: 14,
+}, {
+format: 'uint8x2',
+offset: 252,
+shaderLocation: 10,
+}, {
+format: 'unorm8x2',
+offset: 666,
+shaderLocation: 8,
+}, {
+format: 'sint32',
+offset: 1252,
+shaderLocation: 1,
+}, {
+format: 'snorm8x4',
+offset: 1360,
+shaderLocation: 6,
+}, {
+format: 'uint16x2',
+offset: 1396,
+shaderLocation: 3,
+}, {
+format: 'sint8x4',
+offset: 556,
+shaderLocation: 4,
+}, {
+format: 'uint32x4',
+offset: 1440,
+shaderLocation: 7,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+document.body.prepend(video18);
+let device10 = await adapter15.requestDevice({
+label: '\u8fe9\u5a47\u0c3c',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 41,
+maxVertexAttributes: 22,
+maxVertexBufferArrayStride: 6947,
+maxStorageTexturesPerShaderStage: 39,
+maxStorageBuffersPerShaderStage: 29,
+maxDynamicStorageBuffersPerPipelineLayout: 38944,
+maxBindingsPerBindGroup: 8830,
+maxTextureDimension1D: 10181,
+maxTextureDimension2D: 16223,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 256,
+maxUniformBufferBindingSize: 92724221,
+maxUniformBuffersPerShaderStage: 30,
+maxInterStageShaderVariables: 53,
+maxInterStageShaderComponents: 67,
+maxSamplersPerShaderStage: 21,
+},
+});
+let video35 = await videoWithData();
+let promise77 = adapter5.requestAdapterInfo();
+let pipelineLayout30 = device9.createPipelineLayout({label: '\u6373\u227c\u02d0', bindGroupLayouts: []});
+let texture139 = device9.createTexture({
+label: '\u{1fb39}\u8bb4\u8fd9\u2b9a\u{1f8d7}\u0a44\u{1fda0}',
+size: {width: 80, height: 192, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x6-unorm-srgb', 'astc-8x6-unorm'],
+});
+let sampler102 = device9.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 48.220,
+lodMaxClamp: 57.480,
+});
+try {
+buffer50.unmap();
+} catch {}
+let video36 = await videoWithData();
+pseudoSubmit(device3, commandEncoder80);
+let textureView121 = texture102.createView({label: '\ubf33\udc0c\u8eda\ue3c5\u{1ff1d}\ube24\u06f4\u0043\u8c4d', baseMipLevel: 2});
+let computePassEncoder93 = commandEncoder76.beginComputePass({label: '\u{1f7d2}\u{1f69d}\u0bb9\u08cb'});
+try {
+computePassEncoder93.setBindGroup(2, bindGroup39, new Uint32Array(8647), 3018, 0);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer35, 26128, new Float32Array(38495), 27179, 624);
+} catch {}
+try {
+  await promise77;
+} catch {}
+let device11 = await promise72;
+let texture140 = device11.createTexture({
+label: '\u2afc\u080b\u3b13\u03f8\udbeb\u0b99\u0a67\u0787\u4db1',
+size: {width: 640, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture141 = device10.createTexture({
+label: '\u{1fe1c}\u{1fe53}\u2996\u08d8\u95ec',
+size: {width: 64, height: 3, depthOrArrayLayers: 1},
+sampleCount: 4,
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16float', 'rg16float', 'rg16float'],
+});
+gc();
+let renderBundle119 = renderBundleEncoder104.finish();
+try {
+buffer50.unmap();
+} catch {}
+try {
+gpuCanvasContext17.configure({
+device: device9,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+try {
+querySet106.label = '\u74c3\u0018\u0893\u{1f644}\u1eb7\u0913\u010f\uc85f\u0e73';
+} catch {}
+pseudoSubmit(device7, commandEncoder107);
+try {
+renderBundleEncoder111.setBindGroup(4, bindGroup48, new Uint32Array(1814), 1496, 0);
+} catch {}
+let imageBitmap37 = await createImageBitmap(offscreenCanvas26);
+let shaderModule48 = device6.createShaderModule({
+label: '\u059b\uade5\u0ae1\u86cf\u{1f937}\u075b\u085c',
+code: `@group(4) @binding(5070)
+var<storage, read_write> global11: array<u32>;
+@group(2) @binding(5070)
+var<storage, read_write> i18: array<u32>;
+@group(5) @binding(5070)
+var<storage, read_write> function20: array<u32>;
+@group(0) @binding(5070)
+var<storage, read_write> i19: array<u32>;
+@group(3) @binding(5070)
+var<storage, read_write> type21: array<u32>;
+
+@compute @workgroup_size(4, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec3<f32>,
+  @builtin(sample_mask) f1: u32,
+  @location(3) f2: vec4<f32>,
+  @location(4) f3: vec4<u32>,
+  @location(0) f4: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(10) a1: u32, @builtin(instance_index) a2: u32, @location(13) a3: vec4<i32>, @location(8) a4: vec4<f32>, @location(0) a5: vec2<f16>, @location(19) a6: vec2<f16>, @location(7) a7: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+});
+let pipelineLayout31 = device6.createPipelineLayout({
+  label: '\u029a\u{1ff56}\u126f\u5c43\u8b1c\ubd55',
+  bindGroupLayouts: [bindGroupLayout63, bindGroupLayout63, bindGroupLayout64]
+});
+let querySet117 = device6.createQuerySet({
+label: '\u0d87\udcc8\u0178\u{1fe2a}\ub511\u08a1',
+type: 'occlusion',
+count: 2173,
+});
+try {
+buffer47.unmap();
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture124,
+  mipLevel: 0,
+  origin: { x: 136, y: 8, z: 20 },
+  aspect: 'all',
+}, new ArrayBuffer(4183370), /* required buffer size: 4183370 */
+{offset: 766, bytesPerRow: 1261, rowsPerImage: 195}, {width: 564, height: 8, depthOrArrayLayers: 18});
+} catch {}
+let pipeline157 = await device6.createComputePipelineAsync({
+label: '\u0cfa\u{1f81a}\u0c3f',
+layout: pipelineLayout28,
+compute: {
+module: shaderModule48,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let offscreenCanvas36 = new OffscreenCanvas(659, 343);
+let bindGroupLayout66 = device11.createBindGroupLayout({
+label: '\u8588\u9720\u{1f900}\u{1fee4}\u0a17\u{1fcfc}\u{1fd17}\u66b2\u{1fe90}\u{1fc1e}',
+entries: [{
+binding: 8165,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+}, {
+binding: 3085,
+visibility: 0,
+sampler: { type: 'non-filtering' },
+}, {
+binding: 899,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+}],
+});
+let renderBundleEncoder113 = device11.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb', 'r8uint', 'rgba16float'], sampleCount: 4, stencilReadOnly: true});
+let promise78 = device11.popErrorScope();
+let commandEncoder109 = device11.createCommandEncoder({label: '\uecaa\u0f36\u6dff\ua5da\u{1f6b3}\u0288\ud063\u{1f897}'});
+let texture142 = device11.createTexture({
+label: '\u9986\u075f\ud6da\u{1f9d3}',
+size: [2880, 1, 1],
+mipLevelCount: 7,
+format: 'rg32float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder94 = commandEncoder109.beginComputePass({label: '\u{1fe82}\u1de7\u049d\u{1ffb3}\u{1f776}\u0770\u0c80\u02b1\u08fc\uf567\u{1fb08}'});
+let renderBundle120 = renderBundleEncoder113.finish({label: '\u{1fabb}\uf04f\u{1fb5e}\u0de2\u0f41\u3902\u{1feb5}'});
+try {
+texture142.destroy();
+} catch {}
+try {
+gpuCanvasContext5.configure({
+device: device11,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+});
+} catch {}
+let commandEncoder110 = device3.createCommandEncoder();
+try {
+computePassEncoder93.setBindGroup(3, bindGroup39, new Uint32Array(9292), 5225, 0);
+} catch {}
+let pipeline158 = await device3.createRenderPipelineAsync({
+layout: pipelineLayout20,
+fragment: {module: shaderModule32, entryPoint: 'fragment0', targets: []},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilWriteMask: 1054,
+depthBias: 79,
+depthBiasSlopeScale: 13,
+},
+vertex: {
+  module: shaderModule32,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1500,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x2',
+offset: 1164,
+shaderLocation: 15,
+}, {
+format: 'snorm8x4',
+offset: 1040,
+shaderLocation: 3,
+}, {
+format: 'snorm16x2',
+offset: 1308,
+shaderLocation: 4,
+}, {
+format: 'sint16x4',
+offset: 544,
+shaderLocation: 5,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+offscreenCanvas20.height = 568;
+let bindGroupLayout67 = device7.createBindGroupLayout({
+label: '\u08ed\u0243\uce66\u05f8',
+entries: [{
+binding: 3612,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+}, {
+binding: 3352,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+}, {
+binding: 2255,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+}],
+});
+let sampler103 = device7.createSampler({
+label: '\u5f1e\u50e9',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+lodMinClamp: 69.247,
+lodMaxClamp: 97.544,
+});
+try {
+renderBundleEncoder111.setBindGroup(0, bindGroup48);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+device: device7,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm-srgb'],
+alphaMode: 'opaque',
+});
+} catch {}
+let pipeline159 = await promise76;
+let sampler104 = device10.createSampler({
+label: '\u7917\u490d\uaa55\u38a2\u4b73\u07e7\u6b4e\u3703\u1f31\ua470\u09db',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMaxClamp: 51.324,
+});
+let querySet118 = device10.createQuerySet({
+label: '\u06e1\ub296\ud456\ub115',
+type: 'occlusion',
+count: 2925,
+});
+let texture143 = device10.createTexture({
+label: '\u3fe6\u{1f6bb}\u{1fe13}\ucd27\u8b03\u65ed\ub131\u33af',
+size: {width: 12, height: 120, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let videoFrame39 = new VideoFrame(canvas21, {timestamp: 0});
+let shaderModule49 = device6.createShaderModule({
+label: '\ud1c8\u1838\u8644\u{1f963}\udf6e\u01ee\u{1fcf0}\u7c1d\u0777\u0c5f\u0127',
+code: `@group(4) @binding(5070)
+var<storage, read_write> global12: array<u32>;
+@group(0) @binding(5070)
+var<storage, read_write> local14: array<u32>;
+@group(3) @binding(5070)
+var<storage, read_write> global13: array<u32>;
+@group(5) @binding(5070)
+var<storage, read_write> local15: array<u32>;
+
+@compute @workgroup_size(6, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec4<u32>,
+  @location(3) f1: vec4<f32>,
+  @builtin(sample_mask) f2: u32,
+  @location(0) f3: vec3<f32>,
+  @location(1) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S34 {
+  @location(19) f0: vec4<i32>,
+  @location(21) f1: vec2<u32>,
+  @location(0) f2: vec3<f16>,
+  @location(20) f3: vec2<i32>,
+  @location(7) f4: vec2<f16>,
+  @builtin(instance_index) f5: u32,
+  @location(5) f6: vec2<i32>,
+  @location(15) f7: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(13) a0: vec2<f32>, @location(14) a1: vec4<f32>, @location(17) a2: f32, @location(8) a3: vec4<f16>, @location(22) a4: vec2<u32>, @location(9) a5: vec3<u32>, @location(10) a6: i32, a7: S34, @location(4) a8: vec3<f16>, @builtin(vertex_index) a9: u32, @location(2) a10: vec4<u32>, @location(23) a11: vec2<i32>, @location(1) a12: vec4<i32>, @location(12) a13: vec3<u32>, @location(18) a14: vec2<f32>, @location(16) a15: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let querySet119 = device6.createQuerySet({
+label: '\uefd7\u0a46',
+type: 'occlusion',
+count: 3463,
+});
+let texture144 = device6.createTexture({
+label: '\u3a54\u1c6f\udf4f\u96de\ua4e8\u31d8\u8860\u8869',
+size: {width: 1, height: 1, depthOrArrayLayers: 624},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let textureView122 = texture124.createView({
+  label: '\u{1f613}\u{1f67d}\u806f\u{1fa8a}\u0e90\u{1f844}\u3aa2\u3cc4\u0c85',
+  dimension: '2d',
+  baseMipLevel: 4,
+  baseArrayLayer: 8
+});
+let sampler105 = device6.createSampler({
+label: '\u{1faa4}\u61fd\uec2f\u0a3a\u0e1f\u248c\uf2e5\u217f\u5d0b\u0baf',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 24.167,
+lodMaxClamp: 64.459,
+maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder110.setVertexBuffer(45, undefined, 3736379258, 70847252);
+} catch {}
+try {
+buffer47.destroy();
+} catch {}
+let promise79 = device6.createRenderPipelineAsync({
+label: '\u{1f7fb}\u0224\u{1f7ab}\u{1fb21}',
+layout: pipelineLayout28,
+fragment: {
+  module: shaderModule49,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg32float'}, {
+  format: 'rg11b10ufloat',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'dst'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'zero'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN
+}, undefined, {
+  format: 'rg11b10ufloat',
+  blend: {
+color: {operation: 'add', srcFactor: 'one', dstFactor: 'one-minus-dst-alpha'},
+alpha: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-src-alpha'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN
+}, {format: 'rgba8uint', writeMask: GPUColorWrite.GREEN}]
+},
+vertex: {
+  module: shaderModule49,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 3728,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x4',
+offset: 956,
+shaderLocation: 12,
+}, {
+format: 'uint32',
+offset: 3596,
+shaderLocation: 22,
+}, {
+format: 'snorm8x4',
+offset: 1784,
+shaderLocation: 18,
+}, {
+format: 'float16x2',
+offset: 2728,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 8636,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 6460,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 4360,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 188,
+shaderLocation: 7,
+}, {
+format: 'sint32x4',
+offset: 1848,
+shaderLocation: 19,
+}, {
+format: 'sint32',
+offset: 3300,
+shaderLocation: 23,
+}, {
+format: 'sint32',
+offset: 308,
+shaderLocation: 10,
+}, {
+format: 'sint32',
+offset: 3408,
+shaderLocation: 20,
+}, {
+format: 'float16x2',
+offset: 1624,
+shaderLocation: 16,
+}, {
+format: 'uint32',
+offset: 2376,
+shaderLocation: 9,
+}, {
+format: 'sint16x4',
+offset: 448,
+shaderLocation: 5,
+}, {
+format: 'float16x2',
+offset: 316,
+shaderLocation: 17,
+}, {
+format: 'float32',
+offset: 732,
+shaderLocation: 8,
+}, {
+format: 'unorm8x4',
+offset: 2292,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 7112,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 7396,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 624,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x4',
+offset: 24,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 1244,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x4',
+offset: 616,
+shaderLocation: 0,
+}, {
+format: 'uint8x4',
+offset: 696,
+shaderLocation: 21,
+}, {
+format: 'sint16x4',
+offset: 1120,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 5124,
+shaderLocation: 14,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let gpuCanvasContext32 = offscreenCanvas36.getContext('webgpu');
+try {
+  await promise78;
+} catch {}
+try {
+shaderModule49.label = '\u0e51\u039e\u08fe\ueafe\u{1fbf7}\u0b28\u078d\u6435\u0f07\ucbdd\u{1f97c}';
+} catch {}
+let commandEncoder111 = device6.createCommandEncoder({label: '\u5c28\u909b\u8412\ufd42\uae98\u641b\u7e87\u0ed7\u{1fcd3}'});
+let texture145 = device6.createTexture({
+size: {width: 15},
+sampleCount: 1,
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundle121 = renderBundleEncoder100.finish();
+let externalTexture6 = device6.importExternalTexture({
+label: '\u0e19\u{1fa85}\u0177\u{1fbe1}\u{1feb8}\ufecc\ub176',
+source: videoFrame13,
+colorSpace: 'display-p3',
+});
+try {
+commandEncoder111.copyTextureToTexture({
+  texture: texture124,
+  mipLevel: 2,
+  origin: { x: 116, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture124,
+  mipLevel: 3,
+  origin: { x: 52, y: 4, z: 0 },
+  aspect: 'all',
+}, {width: 60, height: 0, depthOrArrayLayers: 42});
+} catch {}
+let textureView123 = texture141.createView({label: '\uf5de\u5734', arrayLayerCount: 1});
+let renderBundleEncoder114 = device10.createRenderBundleEncoder({
+  label: '\u{1fd73}\ub839\ucd9b',
+  colorFormats: ['r8sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 1,
+  depthReadOnly: false,
+  stencilReadOnly: false
+});
+let sampler106 = device10.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 14.189,
+lodMaxClamp: 26.682,
+compare: 'equal',
+});
+let commandBuffer27 = commandEncoder108.finish({
+label: '\u29db\u{1facf}\u0817\u242c\ubbfc\ud59b',
+});
+let texture146 = device7.createTexture({
+label: '\u05e7\u0f88\u323b\u{1f793}\u{1f622}\u9535\ub1cc\u{1f706}',
+size: {width: 232, height: 224, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8unorm-srgb'],
+});
+let renderBundleEncoder115 = device7.createRenderBundleEncoder({
+  label: '\u50cd\u{1fda7}\ub761\u8f5f\u07b7\u567d\u8b3e\u0fab\u0beb\ua3db\u97c1',
+  colorFormats: ['rg16float'],
+  sampleCount: 1
+});
+let pipeline160 = device7.createComputePipeline({
+label: '\uc86c\u7dbf\u0b58\uc9a2',
+layout: pipelineLayout29,
+compute: {
+module: shaderModule47,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let canvas40 = document.createElement('canvas');
+try {
+sampler80.label = '\u5d3f\u12cd\ub776\u{1fa05}\u{1ffe2}\u{1f7d6}\u8ab2\udb77';
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer18.detached) { new Uint8Array(arrayBuffer18).fill(0x55) };
+} catch {}
+let texture147 = device6.createTexture({
+label: '\u{1fa1d}\u0531\uf18b\u00d3\u5393\u0809\u5724\u3929\ue052\u08c5',
+size: [3520],
+dimension: '1d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle122 = renderBundleEncoder100.finish();
+try {
+computePassEncoder91.pushDebugGroup('\uafc7');
+} catch {}
+document.body.prepend(img8);
+gc();
+let offscreenCanvas37 = new OffscreenCanvas(936, 797);
+let gpuCanvasContext33 = offscreenCanvas37.getContext('webgpu');
+let imageData32 = new ImageData(124, 136);
+let sampler107 = device11.createSampler({
+label: '\u8e97\u{1f694}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 23.175,
+});
+try {
+gpuCanvasContext2.configure({
+device: device11,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['astc-8x6-unorm', 'astc-10x10-unorm', 'rgb10a2uint'],
+colorSpace: 'srgb',
+});
+} catch {}
+gc();
+let canvas41 = document.createElement('canvas');
+let querySet120 = device2.createQuerySet({
+label: '\u0a0b\u0ef5\ucf40\u96ae\u{1fdea}\u{1fae7}\u10dd\ub99e\uf69d\u0a33',
+type: 'occlusion',
+count: 1804,
+});
+try {
+computePassEncoder75.setPipeline(pipeline153);
+} catch {}
+let arrayBuffer22 = buffer30.getMappedRange(1912, 3272);
+try {
+commandEncoder105.clearBuffer(buffer31, 17368, 11408);
+dissociateBuffer(device2, buffer31);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 48, height: 7, depthOrArrayLayers: 100}
+*/
+{
+  source: videoFrame24,
+  origin: { x: 8, y: 42 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: { x: 7, y: 1, z: 14 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 16, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let pipeline161 = device2.createComputePipeline({
+label: '\u7e04\uf6bb\u02a4\u3a18\u132b',
+layout: pipelineLayout26,
+compute: {
+module: shaderModule36,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline162 = device2.createRenderPipeline({
+layout: pipelineLayout19,
+fragment: {
+  module: shaderModule39,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, undefined, undefined, {format: 'rgba16float', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rgba8sint', writeMask: GPUColorWrite.BLUE}]
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'invert',
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'not-equal',
+depthFailOp: 'decrement-clamp',
+passOp: 'zero',
+},
+depthBias: 97,
+depthBiasSlopeScale: 30,
+depthBiasClamp: 76,
+},
+vertex: {
+  module: shaderModule39,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 296,
+attributes: [{
+format: 'sint16x4',
+offset: 60,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 1060,
+attributes: [{
+format: 'sint32',
+offset: 576,
+shaderLocation: 15,
+}, {
+format: 'uint16x4',
+offset: 660,
+shaderLocation: 8,
+}, {
+format: 'uint16x4',
+offset: 476,
+shaderLocation: 12,
+}, {
+format: 'sint16x2',
+offset: 904,
+shaderLocation: 11,
+}, {
+format: 'uint16x2',
+offset: 592,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x2',
+offset: 160,
+shaderLocation: 13,
+}, {
+format: 'sint16x2',
+offset: 108,
+shaderLocation: 9,
+}, {
+format: 'uint32x4',
+offset: 88,
+shaderLocation: 14,
+}, {
+format: 'snorm8x2',
+offset: 1566,
+shaderLocation: 6,
+}, {
+format: 'unorm8x4',
+offset: 124,
+shaderLocation: 4,
+}, {
+format: 'unorm8x4',
+offset: 248,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 240,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 56,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 20,
+shaderLocation: 2,
+}, {
+format: 'unorm16x2',
+offset: 44,
+shaderLocation: 7,
+}, {
+format: 'snorm16x2',
+offset: 8,
+shaderLocation: 0,
+}, {
+format: 'unorm10-10-10-2',
+offset: 20,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'back',
+},
+});
+let img38 = await imageWithData(290, 254, '#1201b2fc', '#957d5a01');
+let textureView124 = texture138.createView({label: '\u2139\uc220\u8a96'});
+let renderBundle123 = renderBundleEncoder115.finish({label: '\u785f\uf7a1\u{1f8ea}\ub482'});
+try {
+await device7.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas32);
+let texture148 = device7.createTexture({
+label: '\u2afc\u384e',
+size: {width: 845, height: 1, depthOrArrayLayers: 420},
+mipLevelCount: 4,
+sampleCount: 1,
+dimension: '3d',
+format: 'r32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['r32float', 'r32float', 'r32float'],
+});
+try {
+gpuCanvasContext3.configure({
+device: device7,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device7.queue.submit([
+commandBuffer27,
+]);
+} catch {}
+try {
+device7.queue.copyExternalImageToTexture(/*
+{width: 845, height: 1, depthOrArrayLayers: 420}
+*/
+{
+  source: imageData29,
+  origin: { x: 9, y: 25 },
+  flipY: true,
+}, {
+  texture: texture148,
+  mipLevel: 0,
+  origin: { x: 192, y: 1, z: 249 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video4.height = 55;
+try {
+canvas40.getContext('webgl2');
+} catch {}
+let adapter17 = await promise13;
+let device12 = await adapter17.requestDevice({
+label: '\u426f\uc550\ucd69\u{1fbe9}\uae5a\u9ef4\u{1fc58}\ub9c9',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 52,
+maxVertexAttributes: 25,
+maxVertexBufferArrayStride: 65141,
+maxStorageTexturesPerShaderStage: 7,
+maxStorageBuffersPerShaderStage: 9,
+maxDynamicStorageBuffersPerPipelineLayout: 34483,
+maxBindingsPerBindGroup: 9649,
+maxTextureDimension1D: 13699,
+maxTextureDimension2D: 13434,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 196350669,
+maxUniformBuffersPerShaderStage: 20,
+maxInterStageShaderVariables: 38,
+maxInterStageShaderComponents: 90,
+maxSamplersPerShaderStage: 22,
+},
+});
+let buffer52 = device9.createBuffer({
+  label: '\u{1f7d3}\u0e01\u{1f86c}\u0251\u69cb\u2e0f',
+  size: 63474,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE
+});
+let commandEncoder112 = device9.createCommandEncoder({});
+let texture149 = device9.createTexture({
+label: '\u2ab1\u7330\ufca1',
+size: [72, 40, 1],
+mipLevelCount: 4,
+format: 'astc-6x5-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-6x5-unorm-srgb', 'astc-6x5-unorm-srgb'],
+});
+let textureView125 = texture139.createView({
+  label: '\ub9b2\ue6f2\u{1f81e}\u0d17\ua623\u0ea6\uc4d0',
+  dimension: '2d-array',
+  format: 'astc-8x6-unorm',
+  baseMipLevel: 6,
+  baseArrayLayer: 0
+});
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+let img39 = await imageWithData(256, 44, '#780f32be', '#e45e4679');
+let imageData33 = new ImageData(236, 32);
+let computePassEncoder95 = commandEncoder101.beginComputePass({label: '\u{1ff83}\udec0\u4569\u{1fce4}\ucf6e\uc820\u3104\u05e4'});
+let renderBundle124 = renderBundleEncoder75.finish({label: '\u3183\u{1f7b5}\u{1ff13}\u3b02\u032d\u61be\u92d9\u8b26\ua994'});
+try {
+computePassEncoder63.setPipeline(pipeline120);
+} catch {}
+try {
+renderBundleEncoder97.setPipeline(pipeline146);
+} catch {}
+try {
+renderBundleEncoder81.setVertexBuffer(2, buffer26, 3816, 4370);
+} catch {}
+try {
+commandEncoder105.copyBufferToBuffer(buffer26, 8728, buffer30, 8704, 860);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+device2.queue.submit([
+commandBuffer22,
+]);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 24, height: 3, depthOrArrayLayers: 50}
+*/
+{
+  source: canvas5,
+  origin: { x: 530, y: 156 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 6 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 13, height: 3, depthOrArrayLayers: 1});
+} catch {}
+let pipeline163 = device2.createComputePipeline({
+label: '\u0847\u00dd\u{1f7c3}\u00c8\ufbc6\u6380\u02a4',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule46,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline164 = device2.createRenderPipeline({
+layout: 'auto',
+fragment: {module: shaderModule41, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'replace',
+depthFailOp: 'decrement-clamp',
+passOp: 'replace',
+},
+depthBias: 93,
+depthBiasSlopeScale: 19,
+depthBiasClamp: 35,
+},
+vertex: {
+  module: shaderModule41,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1060,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1696,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 648,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+},
+});
+let commandEncoder113 = device8.createCommandEncoder();
+let querySet121 = device8.createQuerySet({
+label: '\u4304\u{1f941}\u0fd3',
+type: 'occlusion',
+count: 3872,
+});
+let texture150 = device8.createTexture({
+label: '\u488b\u{1fbfc}\u2ced',
+size: [928, 1, 175],
+mipLevelCount: 10,
+dimension: '3d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [],
+});
+let computePassEncoder96 = commandEncoder113.beginComputePass({label: '\u6bac\u{1f7a5}'});
+let renderBundleEncoder116 = device8.createRenderBundleEncoder({
+  label: '\u1b99\u2015\u035d\u{1fc2c}\ue97b\uce9b\ua529\u0a36\u816b\u{1f630}',
+  colorFormats: ['rgba8uint', 'rg8uint', 'rgb10a2uint'],
+  sampleCount: 4,
+  depthReadOnly: false
+});
+let shaderModule50 = device6.createShaderModule({
+label: '\u044d\u853d\u{1f90f}\u{1fab5}\u9b34',
+code: `@group(2) @binding(5070)
+var<storage, read_write> i20: array<u32>;
+@group(1) @binding(5070)
+var<storage, read_write> type22: array<u32>;
+@group(3) @binding(5070)
+var<storage, read_write> global14: array<u32>;
+@group(4) @binding(5070)
+var<storage, read_write> field16: array<u32>;
+@group(5) @binding(5070)
+var<storage, read_write> field17: array<u32>;
+
+@compute @workgroup_size(7, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(3) f1: vec4<f32>,
+  @location(1) f2: vec4<f32>,
+  @location(4) f3: vec4<u32>,
+  @location(0) f4: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(11) a0: vec4<f32>, @location(1) a1: vec2<i32>, @location(8) a2: i32, @location(14) a3: vec3<f16>, @location(13) a4: u32, @location(15) a5: vec3<i32>, @location(3) a6: vec3<u32>, @location(0) a7: vec3<u32>, @location(4) a8: vec4<u32>, @location(2) a9: vec2<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S35 {
+  @location(7) f0: vec2<u32>,
+  @location(21) f1: u32,
+  @location(18) f2: f32,
+  @builtin(vertex_index) f3: u32,
+  @location(13) f4: f32
+}
+struct VertexOutput0 {
+  @location(8) f208: i32,
+  @location(4) f209: vec4<u32>,
+  @location(15) f210: vec3<i32>,
+  @location(11) f211: vec4<f32>,
+  @location(14) f212: vec3<f16>,
+  @location(2) f213: vec2<i32>,
+  @location(3) f214: vec3<u32>,
+  @builtin(position) f215: vec4<f32>,
+  @location(1) f216: vec2<i32>,
+  @location(13) f217: u32,
+  @location(0) f218: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec4<u32>, @location(10) a1: vec3<i32>, a2: S35, @location(1) a3: vec3<u32>, @location(4) a4: vec4<i32>, @location(9) a5: vec4<f16>, @location(15) a6: i32, @location(20) a7: vec3<i32>, @location(23) a8: vec4<u32>, @location(12) a9: vec3<u32>, @location(0) a10: f16, @location(14) a11: f32, @location(3) a12: vec2<f32>, @location(5) a13: vec4<f32>, @location(11) a14: vec3<u32>, @builtin(instance_index) a15: u32, @location(22) a16: vec4<u32>, @location(19) a17: u32, @location(2) a18: vec4<u32>, @location(8) a19: vec4<f16>, @location(16) a20: vec3<f16>, @location(17) a21: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let querySet122 = device6.createQuerySet({
+type: 'occlusion',
+count: 2084,
+});
+let texture151 = device6.createTexture({
+label: '\u2843\u0f0c\u07c0\u43ac',
+size: {width: 192, height: 132, depthOrArrayLayers: 114},
+mipLevelCount: 3,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-8x6-unorm', 'astc-8x6-unorm-srgb', 'astc-8x6-unorm'],
+});
+let textureView126 = texture151.createView({dimension: '2d', baseMipLevel: 1, baseArrayLayer: 15});
+let sampler108 = device6.createSampler({
+label: '\u6a39\ud29d\u0006\uabcb\u0bec\u117b\u{1fbcd}\u{1f632}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 87.272,
+compare: 'greater-equal',
+maxAnisotropy: 8,
+});
+try {
+device8.queue.label = '\u25d9\u0ad6\u{1fccb}\u883d\u{1fc6b}\ub923\u5a52\u46f6';
+} catch {}
+let querySet123 = device8.createQuerySet({
+label: '\u{1f694}\ud626\u0c5a\u060c\u59c7\u0193',
+type: 'occlusion',
+count: 2741,
+});
+let textureView127 = texture135.createView({dimension: '2d', format: 'astc-5x5-unorm-srgb', baseMipLevel: 2, baseArrayLayer: 73});
+try {
+renderBundleEncoder116.setVertexBuffer(29, undefined, 4049748586, 216284967);
+} catch {}
+let bindGroupLayout68 = device10.createBindGroupLayout({
+entries: [{
+binding: 7885,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '2d-array', sampleType: 'depth', multisampled: false },
+}, {
+binding: 3777,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '2d-array' },
+}],
+});
+let querySet124 = device10.createQuerySet({
+type: 'occlusion',
+count: 2673,
+});
+let textureView128 = texture143.createView({label: '\u{1fadb}\u5d56\ua919\ud463\u02a6\uadd6\u{1fd36}\u0a62\u0e47', baseMipLevel: 1});
+let renderBundle125 = renderBundleEncoder114.finish({label: '\uc780\u0da3\u7084\u1350\u0710\ub6f7\u0b48'});
+try {
+gpuCanvasContext30.configure({
+device: device10,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder114 = device8.createCommandEncoder({label: '\u116d\u047b\u995f\u5fbd\u6d0c\ua699\u02e1\ue5a0'});
+pseudoSubmit(device8, commandEncoder104);
+let texture152 = gpuCanvasContext9.getCurrentTexture();
+let textureView129 = texture135.createView({
+  label: '\uc221\ud86f',
+  dimension: '2d',
+  format: 'astc-5x5-unorm',
+  baseMipLevel: 2,
+  mipLevelCount: 7,
+  baseArrayLayer: 8
+});
+try {
+renderBundleEncoder105.setBindGroup(3, bindGroup32, []);
+} catch {}
+try {
+renderBundleEncoder97.draw(0, 0, 48, 8);
+} catch {}
+try {
+renderBundleEncoder97.drawIndexedIndirect(buffer36, 12516);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer34, 12776, new DataView(new ArrayBuffer(24392)), 20552, 1436);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 24, height: 3, depthOrArrayLayers: 50}
+*/
+{
+  source: video16,
+  origin: { x: 7, y: 13 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 39 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 9, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+await adapter9.requestAdapterInfo();
+} catch {}
+let videoFrame40 = new VideoFrame(video29, {timestamp: 0});
+let commandEncoder115 = device12.createCommandEncoder({label: '\u69ea\u4a65\u0bcd\u0585\u4069\uad3e\u08c8\ue2de\ub603'});
+let texture153 = device12.createTexture({
+label: '\u0251\ua51d\uebc3\u1921\u{1fcd7}\u4761\ua544\u9f64\u0084\u5c7c',
+size: [160, 1, 149],
+mipLevelCount: 2,
+format: 'stencil8',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['stencil8'],
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend(canvas21);
+let img40 = await imageWithData(71, 116, '#482b95fc', '#d1ef858d');
+let bindGroupLayout69 = device10.createBindGroupLayout({
+label: '\u030b\ubd49\u1ec2\u0d90\u{1ff0b}\uf1cc\u6a92',
+entries: [],
+});
+let buffer53 = device10.createBuffer({
+  label: '\uecf9\uf589\u04c9\ub9a9\u5519\u0d1e\u01db\u013f\u2066\u01cb',
+  size: 57026,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM
+});
+let textureView130 = texture74.createView({label: '\u1e96\u5565\u4e7c\u1e94\u6367\u{1fda8}\ube03\u{1f853}\u0a2e', aspect: 'all', mipLevelCount: 6});
+try {
+computePassEncoder89.setBindGroup(3, bindGroup36, new Uint32Array(9438), 2860, 0);
+} catch {}
+try {
+renderBundleEncoder81.setVertexBuffer(1, buffer26, 1516);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture131,
+  mipLevel: 3,
+  origin: { x: 94, y: 0, z: 79 },
+  aspect: 'all',
+}, new Int8Array(arrayBuffer1), /* required buffer size: 862251 */
+{offset: 351, bytesPerRow: 325, rowsPerImage: 221}, {width: 17, height: 0, depthOrArrayLayers: 13});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 48, height: 7, depthOrArrayLayers: 100}
+*/
+{
+  source: imageBitmap22,
+  origin: { x: 677, y: 106 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: { x: 2, y: 0, z: 34 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 37, height: 5, depthOrArrayLayers: 1});
+} catch {}
+let pipeline165 = device2.createRenderPipeline({
+label: '\u{1fe18}\u{1f9d7}\u{1fa61}\u532f\u1232\uc2de\ua36d\ude10',
+layout: pipelineLayout19,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule34,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED
+}, undefined, undefined, {
+  format: 'rgba16float',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+}
+}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {format: 'rgba8sint'}]
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+},
+stencilReadMask: 2174,
+stencilWriteMask: 3361,
+depthBias: 9,
+depthBiasSlopeScale: 2,
+depthBiasClamp: 4,
+},
+vertex: {
+  module: shaderModule34,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1468,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x3',
+offset: 652,
+shaderLocation: 14,
+}, {
+format: 'sint8x2',
+offset: 776,
+shaderLocation: 10,
+}, {
+format: 'float32x3',
+offset: 1216,
+shaderLocation: 1,
+}, {
+format: 'float32x2',
+offset: 920,
+shaderLocation: 12,
+}, {
+format: 'unorm16x2',
+offset: 364,
+shaderLocation: 9,
+}, {
+format: 'snorm16x4',
+offset: 440,
+shaderLocation: 3,
+}, {
+format: 'float32x4',
+offset: 676,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 48,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 24,
+shaderLocation: 5,
+}, {
+format: 'unorm8x2',
+offset: 34,
+shaderLocation: 2,
+}, {
+format: 'snorm8x2',
+offset: 38,
+shaderLocation: 7,
+}],
+}
+]
+},
+});
+let offscreenCanvas38 = new OffscreenCanvas(654, 599);
+let buffer54 = device12.createBuffer({
+  label: '\u{1f72f}\ua037\u0a58\u063e\uf30b\u{1fa69}\u0fd4\ua97f\u{1ff94}\u{1ffab}\u6429',
+  size: 64184,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true
+});
+let texture154 = device12.createTexture({
+label: '\uc80d\udd39\u07d1\ub9e9\u036a\ueff7',
+size: [80, 1, 145],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let arrayBuffer23 = buffer54.getMappedRange(57968, 5068);
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+canvas40.width = 552;
+let img41 = await imageWithData(244, 177, '#5e4e0ee7', '#d9004c96');
+let video37 = await videoWithData();
+let imageBitmap38 = await createImageBitmap(videoFrame27);
+try {
+adapter4.label = '\u1170\uf425\u{1fa26}\u0b10\u1a5a\u190f\uc5e1\u{1fd98}\uc3cd\u5b3c';
+} catch {}
+let promise80 = navigator.gpu.requestAdapter();
+let shaderModule51 = device7.createShaderModule({
+label: '\u650b\u{1f931}\u3280\udd3a\u5abe\u0830\u{1f939}',
+code: `@group(5) @binding(993)
+var<storage, read_write> parameter32: array<u32>;
+@group(4) @binding(993)
+var<storage, read_write> parameter33: array<u32>;
+@group(0) @binding(2644)
+var<storage, read_write> local16: array<u32>;
+@group(0) @binding(993)
+var<storage, read_write> field18: array<u32>;
+@group(6) @binding(993)
+var<storage, read_write> global15: array<u32>;
+@group(6) @binding(2644)
+var<storage, read_write> type23: array<u32>;
+@group(5) @binding(2644)
+var<storage, read_write> function21: array<u32>;
+@group(3) @binding(2644)
+var<storage, read_write> i21: array<u32>;
+@group(1) @binding(2644)
+var<storage, read_write> local17: array<u32>;
+@group(3) @binding(993)
+var<storage, read_write> global16: array<u32>;
+
+@compute @workgroup_size(4, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S36 {
+  @location(1) f0: f32,
+  @builtin(vertex_index) f1: u32,
+  @location(24) f2: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec2<f16>, @location(8) a1: vec4<u32>, @location(0) a2: vec4<u32>, @location(17) a3: vec3<i32>, a4: S36, @location(23) a5: vec2<f16>, @location(2) a6: vec2<f16>, @location(4) a7: vec3<f32>, @location(11) a8: f16, @location(14) a9: vec4<i32>, @builtin(instance_index) a10: u32, @location(18) a11: vec4<u32>, @location(16) a12: vec4<i32>, @location(7) a13: vec2<f16>, @location(5) a14: vec2<i32>, @location(10) a15: vec4<f32>, @location(19) a16: vec3<f16>, @location(6) a17: vec2<u32>, @location(3) a18: vec4<f16>, @location(9) a19: f32, @location(22) a20: vec3<u32>, @location(20) a21: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let bindGroupLayout70 = device7.createBindGroupLayout({
+label: '\ub052\u03ae\u292b\u8ace\u{1f8b7}\uf296\u30a2\u{1ff00}\uc0d6\u2292\u{1fb4c}',
+entries: [{
+binding: 916,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+}, {
+binding: 1848,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}],
+});
+let commandEncoder116 = device7.createCommandEncoder({label: '\u83d0\u5826\ue7ff\u1c4f\ud939\u33a1\ub889\u06d9\u2266\u{1f8dc}\u{1fcbb}'});
+let renderBundle126 = renderBundleEncoder108.finish({label: '\ua0d2\u{1fff9}\u{1f85c}'});
+try {
+renderBundleEncoder111.setBindGroup(9, bindGroup50);
+} catch {}
+try {
+renderBundleEncoder111.setVertexBuffer(54, undefined, 1781810133, 883098312);
+} catch {}
+try {
+device7.queue.copyExternalImageToTexture(/*
+{width: 422, height: 1, depthOrArrayLayers: 210}
+*/
+{
+  source: imageBitmap33,
+  origin: { x: 267, y: 57 },
+  flipY: false,
+}, {
+  texture: texture148,
+  mipLevel: 1,
+  origin: { x: 357, y: 0, z: 115 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext34 = offscreenCanvas38.getContext('webgpu');
+let imageBitmap39 = await createImageBitmap(canvas20);
+let gpuCanvasContext35 = canvas41.getContext('webgpu');
+let offscreenCanvas39 = new OffscreenCanvas(724, 816);
+try {
+buffer48.destroy();
+} catch {}
+try {
+commandEncoder114.copyTextureToTexture({
+  texture: texture152,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture152,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout32 = device10.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout69, bindGroupLayout68, bindGroupLayout68, bindGroupLayout69, bindGroupLayout68, bindGroupLayout69, bindGroupLayout69, bindGroupLayout69, bindGroupLayout69, bindGroupLayout69]
+});
+try {
+gpuCanvasContext23.unconfigure();
+} catch {}
+let texture155 = gpuCanvasContext4.getCurrentTexture();
+let textureView131 = texture147.createView({label: '\u0008\u55c9\u{1f9ed}', dimension: '1d'});
+let video38 = await videoWithData();
+let commandEncoder117 = device2.createCommandEncoder({label: '\u9e25\u0cc5'});
+let renderBundle127 = renderBundleEncoder72.finish({label: '\u0ad7\u844a'});
+try {
+computePassEncoder58.setPipeline(pipeline151);
+} catch {}
+try {
+renderBundleEncoder102.setBindGroup(1, bindGroup32, new Uint32Array(5975), 4784, 0);
+} catch {}
+try {
+renderBundleEncoder97.drawIndirect(buffer36, 13320);
+} catch {}
+try {
+renderBundleEncoder97.setPipeline(pipeline139);
+} catch {}
+try {
+renderBundleEncoder102.setVertexBuffer(1, buffer26, 6684, 1167);
+} catch {}
+try {
+commandEncoder66.copyBufferToBuffer(buffer26, 3384, buffer31, 25760, 1748);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer31);
+} catch {}
+canvas41.width = 43;
+let commandEncoder118 = device10.createCommandEncoder({label: '\ub837\u031f\u0a68\u5cc5\u0dab\u0592\udcd1\u0ad4\u2af4'});
+let textureView132 = texture136.createView({format: 'astc-8x8-unorm', baseMipLevel: 7, baseArrayLayer: 4, arrayLayerCount: 16});
+let computePassEncoder97 = commandEncoder114.beginComputePass({label: '\u18ff\u8947\u{1fbb5}\udb91\u14cd\u62da\u89b2\u0303'});
+let renderBundle128 = renderBundleEncoder112.finish({});
+let sampler109 = device8.createSampler({
+label: '\u75f6\u1d82\ufa88\u055e\u00bf\u{1f982}\u0fec\u{1fffe}\u4ea2\u0b42\u964c',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 91.221,
+lodMaxClamp: 98.671,
+});
+try {
+device8.queue.writeTexture({
+  texture: texture152,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer22), /* required buffer size: 731 */
+{offset: 723}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(canvas21);
+let bindGroupLayout71 = device12.createBindGroupLayout({
+label: '\u0048\u1b7c\u006f',
+entries: [{
+binding: 2237,
+visibility: 0,
+sampler: { type: 'filtering' },
+}],
+});
+let commandEncoder119 = device12.createCommandEncoder({label: '\ue5eb\u{1f83f}\u{1f8fb}\u000a'});
+try {
+buffer54.destroy();
+} catch {}
+try {
+gpuCanvasContext13.configure({
+device: device12,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb', 'rg11b10ufloat', 'rg32uint', 'bgra8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device12.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 4}
+*/
+{
+  source: imageBitmap33,
+  origin: { x: 93, y: 170 },
+  flipY: false,
+}, {
+  texture: texture154,
+  mipLevel: 5,
+  origin: { x: 0, y: 1, z: 3 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+offscreenCanvas39.getContext('webgl2');
+} catch {}
+try {
+window.someLabel = device10.label;
+} catch {}
+let bindGroup51 = device10.createBindGroup({
+label: '\uedbb\u08ba\u{1f7d4}\u0b84\u1ca2\u{1fa49}\u{1fb38}',
+layout: bindGroupLayout69,
+entries: [],
+});
+let commandEncoder120 = device8.createCommandEncoder({});
+let textureView133 = texture135.createView({
+  label: '\ubd73\ub2b0\u5d46\u0a2f\u{1fe00}\u44c8\u5715\u{1fe84}\u0cdb\u0066\u5d4a',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 112
+});
+let renderBundleEncoder117 = device8.createRenderBundleEncoder({label: '\u{1f791}\u0a26\u{1f868}', colorFormats: ['rg8sint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder96.insertDebugMarker('\u0269');
+} catch {}
+try {
+renderBundleEncoder117.insertDebugMarker('\u6eea');
+} catch {}
+try {
+device8.queue.writeTexture({
+  texture: texture150,
+  mipLevel: 6,
+  origin: { x: 3, y: 0, z: 0 },
+  aspect: 'all',
+}, new Int8Array(arrayBuffer2), /* required buffer size: 51768 */
+{offset: 254, bytesPerRow: 232, rowsPerImage: 222}, {width: 5, height: 1, depthOrArrayLayers: 2});
+} catch {}
+let canvas42 = document.createElement('canvas');
+try {
+canvas42.getContext('2d');
+} catch {}
+let buffer55 = device8.createBuffer({
+  label: '\u0753\u1fea\u7f70',
+  size: 11980,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true
+});
+let texture156 = gpuCanvasContext6.getCurrentTexture();
+let sampler110 = device8.createSampler({
+label: '\uf421\u004b\u2e19\u{1f7e8}\ua073',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 27.395,
+lodMaxClamp: 74.609,
+maxAnisotropy: 10,
+});
+try {
+commandEncoder120.copyBufferToTexture({
+/* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 2344 */
+offset: 2344,
+buffer: buffer51,
+}, {
+  texture: texture152,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device8, buffer51);
+} catch {}
+try {
+commandEncoder120.clearBuffer(buffer55, 5564);
+dissociateBuffer(device8, buffer55);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+device: device8,
+format: 'rgba16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device8.queue.writeTexture({
+  texture: texture133,
+  mipLevel: 2,
+  origin: { x: 150, y: 0, z: 38 },
+  aspect: 'all',
+}, new ArrayBuffer(5890459), /* required buffer size: 5890459 */
+{offset: 897, bytesPerRow: 254, rowsPerImage: 177}, {width: 40, height: 10, depthOrArrayLayers: 132});
+} catch {}
+let commandEncoder121 = device12.createCommandEncoder({label: '\u{1f869}\u02b4\u0daa\u{1f933}\u801a\u0f7a\u52a6\u{1f80f}'});
+try {
+commandEncoder121.copyTextureToTexture({
+  texture: texture154,
+  mipLevel: 2,
+  origin: { x: 1, y: 1, z: 18 },
+  aspect: 'all',
+}, {
+  texture: texture154,
+  mipLevel: 3,
+  origin: { x: 5, y: 1, z: 5 },
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 13});
+} catch {}
+try {
+commandEncoder119.clearBuffer(buffer54);
+dissociateBuffer(device12, buffer54);
+} catch {}
+try {
+adapter11.label = '\u{1fde2}\u{1f813}\u6c09';
+} catch {}
+let textureView134 = texture140.createView({dimension: '2d-array', baseMipLevel: 3});
+let renderBundleEncoder118 = device11.createRenderBundleEncoder({
+  label: '\u1c12\u6764',
+  colorFormats: ['rgba8unorm-srgb', 'r8uint', 'rgba16float'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler111 = device11.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 58.502,
+lodMaxClamp: 92.427,
+});
+try {
+device11.queue.writeTexture({
+  texture: texture140,
+  mipLevel: 0,
+  origin: { x: 122, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer17, /* required buffer size: 861 */
+{offset: 861}, {width: 518, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise81 = device11.queue.onSubmittedWorkDone();
+let video39 = await videoWithData();
+let imageBitmap40 = await createImageBitmap(imageData8);
+let buffer56 = device11.createBuffer({
+  label: '\u{1f787}\u8df3\u3118\u0c97\u03b0',
+  size: 46981,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let commandEncoder122 = device11.createCommandEncoder({label: '\ubde7\u7dce\u0c04\uc227\u41b1\u{1f751}\u0aca\u49ab\uc678\u9c48\u54fa'});
+let texture157 = device11.createTexture({
+size: {width: 192, height: 96, depthOrArrayLayers: 228},
+mipLevelCount: 6,
+sampleCount: 1,
+format: 'rg16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundle129 = renderBundleEncoder113.finish({label: '\ue7f7\u9d9a\u1763\ue028\u084f\u9d4b\u0aaf\u9711\ubc1f\u9ea8'});
+let sampler112 = device11.createSampler({
+label: '\uc501\u6225\udbe7\u01fc\u12df',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+lodMinClamp: 99.620,
+lodMaxClamp: 99.978,
+});
+let querySet125 = device8.createQuerySet({
+label: '\uae4c\u02b4\u{1fc73}\u09c5\u{1fd73}',
+type: 'occlusion',
+count: 2759,
+});
+let textureView135 = texture150.createView({label: '\u5759\ub0c8\u0786\u1eac\u{1f9d8}\ua5b1\u0f94', baseMipLevel: 7, mipLevelCount: 3});
+try {
+  await buffer51.mapAsync(GPUMapMode.WRITE, 0, 28140);
+} catch {}
+let bindGroup52 = device9.createBindGroup({
+layout: bindGroupLayout65,
+entries: [{
+binding: 342,
+resource: sampler98
+}, {
+binding: 573,
+resource: textureView125
+}],
+});
+let renderBundleEncoder119 = device9.createRenderBundleEncoder({
+  colorFormats: [undefined, undefined, undefined, undefined, 'r16uint', 'rg16sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle130 = renderBundleEncoder119.finish();
+try {
+commandEncoder112.copyBufferToBuffer(buffer50, 26300, buffer52, 12088, 7672);
+dissociateBuffer(device9, buffer50);
+dissociateBuffer(device9, buffer52);
+} catch {}
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule52 = device6.createShaderModule({
+label: '\u8aa4\u0dc1\u625c\u9845\u03dc\u3bf7\ua119\u083b\u2156\u6e27\u{1f7f0}',
+code: `@group(4) @binding(5070)
+var<storage, read_write> parameter34: array<u32>;
+@group(5) @binding(5070)
+var<storage, read_write> parameter35: array<u32>;
+@group(2) @binding(5070)
+var<storage, read_write> i22: array<u32>;
+@group(1) @binding(5070)
+var<storage, read_write> parameter36: array<u32>;
+@group(3) @binding(5070)
+var<storage, read_write> function22: array<u32>;
+
+@compute @workgroup_size(5, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<f32>,
+  @location(4) f1: vec4<u32>,
+  @location(0) f2: vec3<f32>,
+  @location(1) f3: vec3<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S37 {
+  @location(17) f0: u32
+}
+
+@vertex
+fn vertex0(@location(6) a0: i32, @location(16) a1: f32, @location(7) a2: vec4<u32>, @location(14) a3: vec3<f16>, @builtin(instance_index) a4: u32, @location(11) a5: f32, @location(9) a6: f32, @location(4) a7: f32, a8: S37, @location(2) a9: vec2<f16>, @location(21) a10: vec2<u32>, @location(0) a11: f32, @location(13) a12: vec4<f16>, @location(12) a13: vec4<f16>, @location(3) a14: vec3<i32>, @builtin(vertex_index) a15: u32, @location(20) a16: vec4<f16>, @location(18) a17: vec2<u32>, @location(10) a18: vec4<f32>, @location(8) a19: vec4<f16>, @location(1) a20: vec4<f16>, @location(23) a21: vec4<u32>, @location(19) a22: vec3<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let textureView136 = texture128.createView({label: '\u8e22\uf2ea\u0ce2\u{1ffa9}', aspect: 'all', baseMipLevel: 4});
+try {
+computePassEncoder91.setPipeline(pipeline157);
+} catch {}
+try {
+commandEncoder111.clearBuffer(buffer47, 53696, 3960);
+dissociateBuffer(device6, buffer47);
+} catch {}
+let adapter18 = await navigator.gpu.requestAdapter({
+powerPreference: 'high-performance',
+});
+let canvas43 = document.createElement('canvas');
+let img42 = await imageWithData(93, 298, '#17599f3c', '#755f3f26');
+let commandEncoder123 = device10.createCommandEncoder({});
+pseudoSubmit(device10, commandEncoder123);
+let renderBundleEncoder120 = device10.createRenderBundleEncoder({
+  label: '\u0903\u7253\udf25\u0628\udb38',
+  colorFormats: ['r8sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder120.setBindGroup(4, bindGroup51);
+} catch {}
+try {
+  await promise81;
+} catch {}
+let offscreenCanvas40 = new OffscreenCanvas(215, 182);
+let imageBitmap41 = await createImageBitmap(videoFrame20);
+try {
+offscreenCanvas40.getContext('bitmaprenderer');
+} catch {}
+let texture158 = device0.createTexture({
+label: '\ua268\u0534\u{1fca6}\u3b88\u{1fafe}\u05d1\u7e63\ue757\u2d35\u82f7',
+size: {width: 1752},
+sampleCount: 1,
+dimension: '1d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['r16sint'],
+});
+try {
+renderBundleEncoder42.setBindGroup(3, bindGroup31);
+} catch {}
+try {
+renderBundleEncoder60.setBindGroup(3, bindGroup24, new Uint32Array(8162), 929, 0);
+} catch {}
+try {
+renderBundleEncoder17.draw(8, 64, 24);
+} catch {}
+try {
+renderBundleEncoder68.drawIndexedIndirect(buffer22, 1652);
+} catch {}
+try {
+renderBundleEncoder36.drawIndirect(buffer12, 13168);
+} catch {}
+let arrayBuffer24 = buffer21.getMappedRange(20288, 14196);
+try {
+buffer19.destroy();
+} catch {}
+try {
+commandEncoder96.copyTextureToBuffer({
+  texture: texture48,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 32928 */
+offset: 32928,
+rowsPerImage: 18,
+buffer: buffer42,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer42);
+} catch {}
+try {
+commandEncoder96.copyTextureToTexture({
+  texture: texture93,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 349, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder45.insertDebugMarker('\ucd8e');
+} catch {}
+let promise82 = adapter13.requestAdapterInfo();
+let bindGroupLayout72 = device6.createBindGroupLayout({
+label: '\ub11a\u{1f80d}\u{1fb28}\u78b0',
+entries: [{
+binding: 3129,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}, {
+binding: 2007,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}],
+});
+let texture159 = device6.createTexture({
+label: '\u3aef\uc3c8\uf7ed\uf074\u3cc3\uf5ef\u6758\ufed9\ud7af',
+size: {width: 880, height: 16, depthOrArrayLayers: 43},
+mipLevelCount: 3,
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['etc2-rgb8a1unorm'],
+});
+try {
+computePassEncoder91.pushDebugGroup('\u9c61');
+} catch {}
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline166 = await device6.createComputePipelineAsync({
+label: '\u4b15\u0995\u0dc3\u04e2\u0f38\u07f4\u2cc6\uf01d\u0fee',
+layout: pipelineLayout31,
+compute: {
+module: shaderModule52,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let bindGroup53 = device3.createBindGroup({
+label: '\u{1fdd9}\u0898\u9a39\u1f36\uf5d7\u89b3\u6e45\u{1f963}',
+layout: bindGroupLayout45,
+entries: [],
+});
+let textureView137 = texture99.createView({
+  label: '\u{1f9b4}\u0f17\u543a\u973e\u0213\u1340\u71a9\u7ffd\ue06d\u3a83',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  mipLevelCount: 1,
+  arrayLayerCount: 3
+});
+try {
+computePassEncoder73.setBindGroup(2, bindGroup53);
+} catch {}
+try {
+commandEncoder110.copyBufferToTexture({
+/* bytesInLastRow: 192 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 12704 */
+offset: 12704,
+bytesPerRow: 256,
+buffer: buffer35,
+}, {
+  texture: texture134,
+  mipLevel: 2,
+  origin: { x: 24, y: 4, z: 1 },
+  aspect: 'all',
+}, {width: 48, height: 40, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder110.copyTextureToBuffer({
+  texture: texture102,
+  mipLevel: 4,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 11 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 11660 */
+offset: 11660,
+rowsPerImage: 239,
+buffer: buffer35,
+}, {width: 11, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder110.copyTextureToTexture({
+  texture: texture102,
+  mipLevel: 5,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture102,
+  mipLevel: 0,
+  origin: { x: 180, y: 1, z: 1 },
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline167 = await device3.createRenderPipelineAsync({
+label: '\u2ec1\uaf25\u9422\ucada\uce8e\u4838\u9c96\u{1f8e9}\ufc27',
+layout: 'auto',
+fragment: {module: shaderModule32, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'not-equal',
+depthFailOp: 'increment-clamp',
+},
+stencilBack: {
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'keep',
+},
+stencilReadMask: 2391,
+stencilWriteMask: 849,
+depthBias: 95,
+depthBiasClamp: 2,
+},
+vertex: {
+  module: shaderModule32,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 216,
+attributes: [{
+format: 'unorm16x4',
+offset: 164,
+shaderLocation: 3,
+}, {
+format: 'sint32x4',
+offset: 152,
+shaderLocation: 5,
+}, {
+format: 'uint8x4',
+offset: 196,
+shaderLocation: 15,
+}, {
+format: 'float16x2',
+offset: 8,
+shaderLocation: 4,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+},
+});
+try {
+gpuCanvasContext33.unconfigure();
+} catch {}
+offscreenCanvas1.width = 701;
+try {
+window.someLabel = texture147.label;
+} catch {}
+let shaderModule53 = device6.createShaderModule({
+label: '\u23bf\u0feb\u0fb2',
+code: `@group(1) @binding(5070)
+var<storage, read_write> parameter37: array<u32>;
+@group(2) @binding(2694)
+var<storage, read_write> local18: array<u32>;
+@group(0) @binding(5070)
+var<storage, read_write> function23: array<u32>;
+
+@compute @workgroup_size(6, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S39 {
+  @builtin(sample_index) f0: u32
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(7) f1: vec3<i32>,
+  @location(0) f2: vec4<f32>,
+  @location(4) f3: vec4<u32>,
+  @location(3) f4: vec3<f32>
+}
+
+@fragment
+fn fragment0(a0: S39, @builtin(sample_mask) a1: u32, @builtin(position) a2: vec4<f32>, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S38 {
+  @location(23) f0: vec4<f16>,
+  @location(15) f1: vec2<f16>,
+  @location(8) f2: vec2<u32>,
+  @location(5) f3: vec4<f16>,
+  @location(22) f4: vec3<f32>,
+  @location(9) f5: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec3<u32>, @location(2) a1: f16, a2: S38, @location(16) a3: vec3<u32>, @location(10) a4: f32, @location(0) a5: i32, @location(21) a6: vec3<f16>, @location(4) a7: f32, @location(11) a8: vec4<f16>, @location(18) a9: vec3<f32>, @location(6) a10: vec4<f16>, @location(1) a11: vec3<u32>, @location(3) a12: vec3<f32>, @location(7) a13: vec4<u32>, @location(12) a14: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+let querySet126 = device6.createQuerySet({
+label: '\u4c53\u{1febb}',
+type: 'occlusion',
+count: 1486,
+});
+let sampler113 = device6.createSampler({
+label: '\u{1f8d0}\u{1f962}\u9443\u07b2\u{1fc3b}\u205b\ud4c0\ubc00',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 92.682,
+lodMaxClamp: 94.555,
+});
+try {
+commandEncoder111.copyTextureToBuffer({
+  texture: texture128,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 92 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 31312 */
+offset: 31312,
+bytesPerRow: 0,
+rowsPerImage: 114,
+buffer: buffer47,
+}, {width: 0, height: 0, depthOrArrayLayers: 48});
+dissociateBuffer(device6, buffer47);
+} catch {}
+try {
+computePassEncoder91.popDebugGroup();
+} catch {}
+try {
+computePassEncoder88.insertDebugMarker('\u0df8');
+} catch {}
+try {
+  await promise82;
+} catch {}
+let bindGroupLayout73 = device11.createBindGroupLayout({
+label: '\u{1fb17}\u078c\u8ffa\u{1f6b4}\u2f67\u0215',
+entries: [{
+binding: 7288,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '2d-array' },
+}, {
+binding: 3008,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 763472, hasDynamicOffset: false },
+}, {
+binding: 3438,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+let pipelineLayout33 = device11.createPipelineLayout({bindGroupLayouts: [bindGroupLayout73]});
+let texture160 = device11.createTexture({
+label: '\uccb8\u0abc\u08f3\u2809\u{1ff3b}\ua1a0\uda57',
+size: {width: 864, height: 60, depthOrArrayLayers: 200},
+mipLevelCount: 2,
+format: 'etc2-rgb8a1unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8a1unorm-srgb', 'etc2-rgb8a1unorm-srgb', 'etc2-rgb8a1unorm-srgb'],
+});
+let computePassEncoder98 = commandEncoder122.beginComputePass();
+let renderBundle131 = renderBundleEncoder118.finish({});
+try {
+gpuCanvasContext4.configure({
+device: device11,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float', 'astc-4x4-unorm-srgb'],
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let canvas44 = document.createElement('canvas');
+let texture161 = device12.createTexture({
+label: '\udda3\u0703',
+size: {width: 72, height: 10, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'depth32float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+commandEncoder121.insertDebugMarker('\uc301');
+} catch {}
+let imageData34 = new ImageData(208, 252);
+let bindGroupLayout74 = device2.createBindGroupLayout({
+label: '\u{1f6d5}\u77aa\u{1f847}\u{1fe0d}\u5dd7\u0def',
+entries: [],
+});
+let texture162 = device2.createTexture({
+label: '\u{1fb8a}\u5dad\u{1fd34}\u4bb6\ub0c2\u{1f8c3}\uee6b\u{1f72c}\u{1fc17}\uaf8f',
+size: {width: 192, height: 30, depthOrArrayLayers: 120},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'r8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['r8unorm', 'r8unorm', 'r8unorm'],
+});
+let textureView138 = texture120.createView({label: '\u{1f6e0}\u0b51\u0866\u03e1\u08e8\u77b7\u786c\u{1fdcf}'});
+let computePassEncoder99 = commandEncoder74.beginComputePass({label: '\ua3c3\u0453\u3c59\u5532\u08b0'});
+try {
+computePassEncoder87.setPipeline(pipeline151);
+} catch {}
+try {
+renderBundleEncoder97.draw(40, 24);
+} catch {}
+let promise83 = buffer49.mapAsync(GPUMapMode.READ);
+try {
+renderBundleEncoder97.insertDebugMarker('\uec8e');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture117,
+  mipLevel: 0,
+  origin: { x: 49, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer17, /* required buffer size: 1269 */
+{offset: 601, rowsPerImage: 142}, {width: 334, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 12, height: 1, depthOrArrayLayers: 25}
+*/
+{
+  source: img41,
+  origin: { x: 213, y: 38 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 12, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext36 = canvas44.getContext('webgpu');
+try {
+gpuCanvasContext22.unconfigure();
+} catch {}
+document.body.prepend(img5);
+try {
+device8.queue.writeTexture({
+  texture: texture152,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 374 */
+{offset: 374, bytesPerRow: 281}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise83;
+} catch {}
+let img43 = await imageWithData(245, 115, '#7e7870e1', '#3f446f07');
+let buffer57 = device2.createBuffer({
+  label: '\ub1a8\u0ca8\ue788\u08f1\u6a0d\u{1fe35}\ufe16',
+  size: 56095,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT
+});
+let renderBundle132 = renderBundleEncoder71.finish({label: '\u{1fea6}\u404f\u854f\u393e\u0760'});
+let sampler114 = device2.createSampler({
+label: '\u{1f9fd}\ubba4\u0bed\u498d\u{1f875}\u{1f80b}\u7a62\u{1fb21}\u6a23',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 68.076,
+maxAnisotropy: 3,
+});
+try {
+computePassEncoder78.setPipeline(pipeline144);
+} catch {}
+try {
+renderBundleEncoder97.draw(72, 8, 32, 56);
+} catch {}
+try {
+renderBundleEncoder97.drawIndexed(48, 64, 8, 112, 0);
+} catch {}
+try {
+renderBundleEncoder97.drawIndirect(buffer46, 20504);
+} catch {}
+let gpuCanvasContext37 = canvas43.getContext('webgpu');
+let imageBitmap42 = await createImageBitmap(imageBitmap36);
+try {
+await device8.popErrorScope();
+} catch {}
+try {
+commandEncoder120.clearBuffer(buffer55);
+dissociateBuffer(device8, buffer55);
+} catch {}
+try {
+renderBundleEncoder116.insertDebugMarker('\u63c1');
+} catch {}
+gc();
+let texture163 = device8.createTexture({
+label: '\u0f13\u0fb1\u{1fef4}\ua21b',
+size: {width: 15, height: 1, depthOrArrayLayers: 230},
+mipLevelCount: 3,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth16unorm', 'depth16unorm'],
+});
+let textureView139 = texture135.createView({format: 'astc-5x5-unorm-srgb', baseMipLevel: 6, baseArrayLayer: 55, arrayLayerCount: 26});
+let computePassEncoder100 = commandEncoder120.beginComputePass({label: '\u9d64\u{1fbe8}\u3aaa\u0e65\u9934\u01d0\uf451\u{1f892}\u0d8c\u7132\ue903'});
+let renderBundleEncoder121 = device8.createRenderBundleEncoder({label: '\u58b7\u0d82\ubfa9\u0b48\u13ae', colorFormats: ['rg8sint']});
+let sampler115 = device8.createSampler({
+label: '\u08c7\u{1ff6b}\uc639\u{1f96e}\ue6fa\u004a\u{1ff31}\u{1f6f6}\u44dc',
+addressModeU: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 86.014,
+lodMaxClamp: 98.238,
+compare: 'not-equal',
+});
+try {
+renderBundleEncoder117.pushDebugGroup('\ub2ca');
+} catch {}
+let canvas45 = document.createElement('canvas');
+let textureView140 = texture161.createView({dimension: '2d-array', aspect: 'depth-only'});
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame40.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  log('DONE');
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -985,9 +985,10 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
                     if (bufferSizeArgumentBufferIndex)
                         *(uint32_t*)[argumentEncoder[stage] constantDataAtIndex:*bufferSizeArgumentBufferIndex] = std::min<uint32_t>(entrySize, buffer.length);
                 }
-                if (buffer)
+                if (buffer) {
                     stageResources[metalRenderStage(stage)][resourceUsage - 1].append(buffer);
-                stageResourceUsages[metalRenderStage(stage)][resourceUsage - 1].append(makeBindGroupEntryUsageData(usageForBuffer(layoutBinding->type), entry.binding, apiBuffer));
+                    stageResourceUsages[metalRenderStage(stage)][resourceUsage - 1].append(makeBindGroupEntryUsageData(usageForBuffer(layoutBinding->type), entry.binding, apiBuffer));
+                }
             } else if (samplerIsPresent) {
                 auto* layoutBinding = hasBinding<WGPUSamplerBindingLayout>(bindGroupLayoutEntries, bindingIndex);
                 if (!layoutBinding) {
@@ -1065,11 +1066,12 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
 
                 if (stage != ShaderStage::Undefined)
                     [argumentEncoder[stage] setTexture:texture atIndex:index];
-                if (texture)
+                if (texture) {
                     stageResources[metalRenderStage(stage)][resourceUsage - 1].append(texture);
-                ASSERT(texture.parentRelativeLevel == apiTextureView.baseMipLevel());
-                ASSERT(texture.parentRelativeSlice == apiTextureView.baseArrayLayer());
-                stageResourceUsages[metalRenderStage(stage)][resourceUsage - 1].append(makeBindGroupEntryUsageData(textureEntry ? usageForTexture(*textureEntry) : (storageTextureEntry ? usageForStorageTexture(*storageTextureEntry) : BindGroupEntryUsage::ConstantTexture), entry.binding, apiTextureView));
+                    ASSERT(texture.parentRelativeLevel == apiTextureView.baseMipLevel());
+                    ASSERT(texture.parentRelativeSlice == apiTextureView.baseArrayLayer());
+                    stageResourceUsages[metalRenderStage(stage)][resourceUsage - 1].append(makeBindGroupEntryUsageData(textureEntry ? usageForTexture(*textureEntry) : (storageTextureEntry ? usageForStorageTexture(*storageTextureEntry) : BindGroupEntryUsage::ConstantTexture), entry.binding, apiTextureView));
+                }
             } else if (externalTextureIsPresent) {
                 if (!hasBinding<WGPUExternalTextureBindingLayout>(bindGroupLayoutEntries, bindingIndex)) {
                     generateAValidationError("Expected external texture but it was not present in the bind group layout"_s);

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -443,7 +443,7 @@ void ComputePassEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& grou
 
     Vector<const BindableResources*> resourceList;
     for (const auto& resource : group.resources()) {
-        if (resource.renderStages == BindGroup::MTLRenderStageCompute)
+        if (resource.renderStages == BindGroup::MTLRenderStageCompute && resource.mtlResources.size())
             [m_computeCommandEncoder useResources:&resource.mtlResources[0] count:resource.mtlResources.size() usage:resource.usage];
 
         ASSERT(resource.mtlResources.size() == resource.resourceUsages.size());

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -123,7 +123,7 @@ private:
     void addResource(RenderBundle::ResourcesContainer*, id<MTLResource>, MTLRenderStages, const BindGroupEntryUsageData::Resource&);
     void addResource(RenderBundle::ResourcesContainer*, id<MTLResource>, MTLRenderStages);
     bool icbNeedsToBeSplit(const RenderPipeline& a, const RenderPipeline& b);
-    void finalizeRenderCommand();
+    void finalizeRenderCommand(MTLIndirectCommandType);
     bool validToEncodeCommand() const;
     bool returnIfEncodingIsFinished(NSString* errorString);
     bool runIndexBufferValidation(uint32_t firstInstance, uint32_t instanceCount);

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -81,7 +81,7 @@ bool RenderBundleEncoder::returnIfEncodingIsFinished(NSString* errorString)
 }
 
 #define RETURN_IF_FINISHED() \
-if (returnIfEncodingIsFinished([NSString stringWithFormat:@"%s: failed as encoding has finished", __PRETTY_FUNCTION__])) \
+if (returnIfEncodingIsFinished([NSString stringWithFormat:@"%s: failed as encoding has finished", __PRETTY_FUNCTION__]) || !m_icbDescriptor) \
     return;
 
 static RenderBundleICBWithResources* makeRenderBundleICBWithResources(id<MTLIndirectCommandBuffer> icb, RenderBundle::ResourcesContainer* resources, id<MTLRenderPipelineState> renderPipelineState, id<MTLDepthStencilState> depthStencilState, MTLCullMode cullMode, MTLWinding frontFace, MTLDepthClipMode depthClipMode, float depthBias, float depthBiasSlopeScale, float depthBiasClamp, id<MTLBuffer> fragmentDynamicOffsetsBuffer, const RenderPipeline* pipeline)
@@ -97,6 +97,8 @@ static RenderBundleICBWithResources* makeRenderBundleICBWithResources(id<MTLIndi
             continue;
 
         ResourceUsageAndRenderStage *usageAndStage = [resources objectForKey:r];
+        if (!usageAndStage.renderStages || !usageAndStage.usage)
+            continue;
         stageResources[usageAndStage.renderStages - 1][usageAndStage.usage - 1].append(r);
         stageResourceUsages[usageAndStage.renderStages - 1][usageAndStage.usage - 1].append(BindGroupEntryUsageData { .usage = usageAndStage.entryUsage, .binding = usageAndStage.binding, .resource = usageAndStage.resource });
     }
@@ -364,15 +366,13 @@ void RenderBundleEncoder::draw(uint32_t vertexCount, uint32_t instanceCount, uin
 
         [icbCommand drawPrimitives:m_primitiveType vertexStart:firstVertex vertexCount:vertexCount instanceCount:instanceCount baseInstance:firstInstance];
     } else {
-        m_icbDescriptor.commandTypes |= MTLIndirectCommandTypeDraw;
-
         recordCommand([vertexCount, instanceCount, firstVertex, firstInstance, protectedThis = Ref { *this }] {
             protectedThis->draw(vertexCount, instanceCount, firstVertex, firstInstance);
             return true;
         });
     }
 
-    finalizeRenderCommand();
+    finalizeRenderCommand(MTLIndirectCommandTypeDraw);
 }
 
 uint32_t RenderBundleEncoder::maxVertexBufferIndex() const
@@ -421,10 +421,11 @@ NSString* RenderBundleEncoder::errorValidatingDrawIndexed() const
     return nil;
 }
 
-void RenderBundleEncoder::finalizeRenderCommand()
+void RenderBundleEncoder::finalizeRenderCommand(MTLIndirectCommandType commandTypes)
 {
     m_currentCommand = nil;
     ++m_currentCommandIndex;
+    m_icbDescriptor.commandTypes |= commandTypes;
 }
 
 
@@ -526,15 +527,13 @@ void RenderBundleEncoder::drawIndexed(uint32_t indexCount, uint32_t instanceCoun
 
         [icbCommand drawIndexedPrimitives:m_primitiveType indexCount:indexCount indexType:m_indexType indexBuffer:indexBuffer indexBufferOffset:(m_indexBufferOffset + firstIndexOffsetInBytes) instanceCount:instanceCount baseVertex:baseVertex baseInstance:firstInstance];
     } else {
-        m_icbDescriptor.commandTypes |= MTLIndirectCommandTypeDrawIndexed;
-
         recordCommand([indexCount, instanceCount, firstIndex, baseVertex, firstInstance, protectedThis = Ref { *this }] {
             protectedThis->drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
             return true;
         });
     }
 
-    finalizeRenderCommand();
+    finalizeRenderCommand(MTLIndirectCommandTypeDrawIndexed);
 }
 
 void RenderBundleEncoder::drawIndexedIndirect(const Buffer& indirectBuffer, uint64_t indirectOffset)
@@ -579,15 +578,13 @@ void RenderBundleEncoder::drawIndexedIndirect(const Buffer& indirectBuffer, uint
             return;
         }
 
-        m_icbDescriptor.commandTypes |= MTLIndirectCommandTypeDrawIndexed;
-
-        recordCommand([&indirectBuffer, indirectOffset, protectedThis = Ref { *this }] {
-            protectedThis->drawIndexedIndirect(indirectBuffer, indirectOffset);
+        recordCommand([indirectBuffer = Ref { indirectBuffer }, indirectOffset, protectedThis = Ref { *this }] {
+            protectedThis->drawIndexedIndirect(indirectBuffer.get(), indirectOffset);
             return true;
         });
     }
 
-    finalizeRenderCommand();
+    finalizeRenderCommand(MTLIndirectCommandTypeDrawIndexed);
 }
 
 void RenderBundleEncoder::drawIndirect(const Buffer& indirectBuffer, uint64_t indirectOffset)
@@ -611,8 +608,6 @@ void RenderBundleEncoder::drawIndirect(const Buffer& indirectBuffer, uint64_t in
             [icbCommand drawPrimitives:m_primitiveType vertexStart:contents->vertexStart vertexCount:contents->vertexCount instanceCount:contents->instanceCount baseInstance:contents->baseInstance];
         }
     } else {
-        m_icbDescriptor.commandTypes |= MTLIndirectCommandTypeDraw;
-
         if (!isValidToUseWith(indirectBuffer, *this)) {
             makeInvalid(@"drawIndirect: buffer was invalid");
             return;
@@ -628,13 +623,13 @@ void RenderBundleEncoder::drawIndirect(const Buffer& indirectBuffer, uint64_t in
             return;
         }
 
-        recordCommand([&indirectBuffer, indirectOffset, protectedThis = Ref { *this }] {
-            protectedThis->drawIndirect(indirectBuffer, indirectOffset);
+        recordCommand([indirectBuffer = Ref { indirectBuffer }, indirectOffset, protectedThis = Ref { *this }] {
+            protectedThis->drawIndirect(indirectBuffer.get(), indirectOffset);
             return true;
         });
     }
 
-    finalizeRenderCommand();
+    finalizeRenderCommand(MTLIndirectCommandTypeDraw);
 }
 
 void RenderBundleEncoder::endCurrentICB()
@@ -686,6 +681,7 @@ void RenderBundleEncoder::endCurrentICB()
     } else
         m_recordedCommands.remove(0, lastIndexOfRecordedCommand);
 
+    m_currentCommandIndex = commandCount - completedDraws;
     [m_icbArray addObject:makeRenderBundleICBWithResources(m_indirectCommandBuffer, m_resources, m_currentPipelineState, m_depthStencilState, m_cullMode, m_frontFace, m_depthClipMode, m_depthBias, m_depthBiasSlopeScale, m_depthBiasClamp, m_dynamicOffsetsFragmentBuffer, m_pipeline.get())];
     m_indirectCommandBuffer = nil;
     m_currentCommand = nil;
@@ -834,8 +830,8 @@ void RenderBundleEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& gro
         if (group.vertexArgumentBuffer())
             m_requiresMetalWorkaround = false;
 
-        recordCommand([groupIndex, &group, protectedThis = Ref { *this }, dynamicOffsets = WTFMove(dynamicOffsets)]() mutable {
-            protectedThis->setBindGroup(groupIndex, group, WTFMove(dynamicOffsets));
+        recordCommand([groupIndex, group = Ref { group }, protectedThis = Ref { *this }, dynamicOffsets = WTFMove(dynamicOffsets)]() mutable {
+            protectedThis->setBindGroup(groupIndex, group.get(), WTFMove(dynamicOffsets));
             return false;
         });
         return;
@@ -905,8 +901,8 @@ void RenderBundleEncoder::setIndexBuffer(const Buffer& buffer, WGPUIndexFormat f
             return;
         }
 
-        recordCommand([&buffer, format, offset, size, protectedThis = Ref { *this }] {
-            protectedThis->setIndexBuffer(buffer, format, offset, size);
+        recordCommand([buffer = Ref { buffer }, format, offset, size, protectedThis = Ref { *this }] {
+            protectedThis->setIndexBuffer(buffer.get(), format, offset, size);
             return false;
         });
         return;
@@ -1019,7 +1015,7 @@ void RenderBundleEncoder::setPipeline(const RenderPipeline& pipeline)
         if (m_pipeline && icbNeedsToBeSplit(*m_pipeline, pipeline) && !m_requiresMetalWorkaround)
             endCurrentICB();
 
-        recordCommand([&pipeline, protectedThis = Ref { *this }] {
+        recordCommand([pipeline = Ref { pipeline }, protectedThis = Ref { *this }] {
             protectedThis->setPipeline(pipeline);
             return false;
         });
@@ -1109,11 +1105,13 @@ void wgpuRenderBundleEncoderDrawIndexed(WGPURenderBundleEncoder renderBundleEnco
 
 void wgpuRenderBundleEncoderDrawIndexedIndirect(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset)
 {
+    RELEASE_ASSERT(indirectBuffer);
     WebGPU::fromAPI(renderBundleEncoder).drawIndexedIndirect(WebGPU::fromAPI(indirectBuffer), indirectOffset);
 }
 
 void wgpuRenderBundleEncoderDrawIndirect(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset)
 {
+    RELEASE_ASSERT(indirectBuffer);
     WebGPU::fromAPI(renderBundleEncoder).drawIndirect(WebGPU::fromAPI(indirectBuffer), indirectOffset);
 }
 

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -725,7 +725,7 @@ void RenderPassEncoder::executeBundles(Vector<std::reference_wrapper<RenderBundl
             ASSERT(icb.resources);
 
             for (const auto& resource : *icb.resources) {
-                if (resource.renderStages & (MTLRenderStageVertex | MTLRenderStageFragment))
+                if ((resource.renderStages & (MTLRenderStageVertex | MTLRenderStageFragment)) && resource.mtlResources.size())
                     [m_renderCommandEncoder useResources:&resource.mtlResources[0] count:resource.mtlResources.size() usage:resource.usage stages:resource.renderStages];
 
                 ASSERT(resource.mtlResources.size() == resource.resourceUsages.size());
@@ -849,7 +849,7 @@ void RenderPassEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& group
         m_bindGroupDynamicOffsets.set(groupIndex, Vector<uint32_t>(std::span { dynamicOffsets, dynamicOffsetCount }));
 
     for (const auto& resource : group.resources()) {
-        if (resource.renderStages & (MTLRenderStageVertex | MTLRenderStageFragment))
+        if ((resource.renderStages & (MTLRenderStageVertex | MTLRenderStageFragment)) && resource.mtlResources.size())
             [m_renderCommandEncoder useResources:&resource.mtlResources[0] count:resource.mtlResources.size() usage:resource.usage stages:resource.renderStages];
 
         ASSERT(resource.mtlResources.size() == resource.resourceUsages.size());


### PR DESCRIPTION
#### c368b1bcceb094886be6b37a8c21035280ce6782
<pre>
[WebGPU] useResources: should not be called on empty resource list
<a href="https://bugs.webkit.org/show_bug.cgi?id=273505">https://bugs.webkit.org/show_bug.cgi?id=273505</a>
&lt;radar://127230835&gt;

Reviewed by Dan Glastonbury.

Add additional validation to some render bundle commands
and writeTexture calls to ensure no metal validation errors occur
at runtime.

Confirmed no regressions to api CTS tests.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-273505-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-273505.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createBindGroup):
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::hasZeroDimension):
(WebGPU::CommandEncoder::copyTextureToBuffer):
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::setBindGroup):
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::writeTexture):
* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::makeRenderBundleICBWithResources):
(WebGPU::RenderBundleEncoder::draw):
(WebGPU::RenderBundleEncoder::finalizeRenderCommand):
(WebGPU::RenderBundleEncoder::drawIndexed):
(WebGPU::RenderBundleEncoder::drawIndexedIndirect):
(WebGPU::RenderBundleEncoder::drawIndirect):
(WebGPU::RenderBundleEncoder::endCurrentICB):
(WebGPU::RenderBundleEncoder::setBindGroup):
(WebGPU::RenderBundleEncoder::setIndexBuffer):
(WebGPU::RenderBundleEncoder::setPipeline):
(wgpuRenderBundleEncoderDrawIndexedIndirect):
(wgpuRenderBundleEncoderDrawIndirect):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::executeBundles):
(WebGPU::RenderPassEncoder::setBindGroup):

Canonical link: <a href="https://commits.webkit.org/278300@main">https://commits.webkit.org/278300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5f1c5947882f32408ae8f4fe83622e3130196f9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2387 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53356 "Build is in progress. Recent messages:Printed configuration; Checked out pull request") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/786 "Build is in progress. Recent messages:Running configuration") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/344 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40895 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27083 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43124 "Build is in progress. Recent messages:Running configuration; Running apply-patch; Running checkout-pull-request; Running run-api-tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/53356 "Build is in progress. Recent messages:Printed configuration; Checked out pull request") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24483 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/398 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8474 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43425 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46499 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/432 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54936 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25196 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48290 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26455 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Running apply-patch; Checked out pull request; Running compile-webkit") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43333 "Exiting early after 10 failures. 78 tests run. 1 flakes") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10989 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27320 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26185 "Build is in progress. Recent messages:Running apply-patch; Running checkout-pull-request; Running compile-webkit") | | | 
<!--EWS-Status-Bubble-End-->