### PR TITLE
Remove nsStringFromWebCoreString in favor of String::operator NSString*

### DIFF
--- a/Source/WebKit/NetworkProcess/mac/NetworkProcessMac.mm
+++ b/Source/WebKit/NetworkProcess/mac/NetworkProcessMac.mm
@@ -34,7 +34,6 @@
 #import "SandboxExtension.h"
 #import "SandboxInitializationParameters.h"
 #import "SecItemShim.h"
-#import "StringUtilities.h"
 #import "WKFoundation.h"
 #import <WebCore/CertificateInfo.h>
 #import <WebCore/LocalizedStrings.h>

--- a/Source/WebKit/Platform/mac/StringUtilities.h
+++ b/Source/WebKit/Platform/mac/StringUtilities.h
@@ -25,18 +25,12 @@
 
 #pragma once
 
-#import <WebKit/WKDeclarationSpecifiers.h>
-#import <wtf/Forward.h>
+OBJC_CLASS NSString;
 
 namespace WebKit {
 
-#ifdef __OBJC__
-
-// NOTE: This does not use String::operator NSString*() since that function
-// expects to be called on the thread running WebCore.
-NSString *nsStringFromWebCoreString(const String&);
+#if PLATFORM(MAC)
 NSString *formattedPhoneNumberString(NSString *originalPhoneNumber);
-
-#endif // defined(__OBJC__)
+#endif
 
 }

--- a/Source/WebKit/Platform/mac/StringUtilities.mm
+++ b/Source/WebKit/Platform/mac/StringUtilities.mm
@@ -26,18 +26,10 @@
 #import "config.h"
 #import "StringUtilities.h"
 
-#import "WKSharedAPICast.h"
-#import "WKStringCF.h"
-#import <JavaScriptCore/RegularExpression.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/text/StringBuilder.h>
 
 namespace WebKit {
-
-NSString *nsStringFromWebCoreString(const String& string)
-{
-    return string.isEmpty() ? @"" : adoptCF(WKStringCopyCFString(0, toAPI(string.impl()))).bridgingAutorelease();
-}
 
 #if ENABLE(TELEPHONE_NUMBER_DETECTION) && PLATFORM(MAC)
 
@@ -70,13 +62,6 @@ NSString *formattedPhoneNumberString(NSString *originalPhoneNumber)
         phoneNumberString = adoptCF(CFPhoneNumberCopyUnformattedRepresentation(phoneNumber.get()));
 
     return phoneNumberString.bridgingAutorelease();
-}
-
-#else
-
-NSString *formattedPhoneNumberString(NSString *)
-{
-    return nil;
 }
 
 #endif // ENABLE(TELEPHONE_NUMBER_DETECTION) && PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/API/C/mac/WKContextPrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKContextPrivateMac.mm
@@ -30,7 +30,6 @@
 #import "APIDictionary.h"
 #import "APINumber.h"
 #import "APIString.h"
-#import "StringUtilities.h"
 #import "WKAPICast.h"
 #import "WKPluginInformation.h"
 #import "WKSharedAPICast.h"

--- a/Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm
@@ -26,7 +26,6 @@
 #import "config.h"
 #import "WebPreferences.h"
 
-#import "StringUtilities.h"
 #import "WebPreferencesKeys.h"
 #import <WebCore/RealtimeMediaSourceCenter.h>
 #import <wtf/text/StringConcatenate.h>
@@ -180,7 +179,7 @@ void WebPreferences::platformUpdateStringValueForKey(const String& key, const St
     if (!m_identifier)
         return;
 
-    [[NSUserDefaults standardUserDefaults] setObject:nsStringFromWebCoreString(value) forKey:makeKey(m_identifier, m_keyPrefix, key)];
+    [[NSUserDefaults standardUserDefaults] setObject:value forKey:makeKey(m_identifier, m_keyPrefix, key)];
 }
 
 void WebPreferences::platformUpdateBoolValueForKey(const String& key, bool value)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -40,7 +40,6 @@
 #import "PlatformXRSystem.h"
 #import "RemoteLayerTreeNode.h"
 #import "RunningBoardServicesSPI.h"
-#import "StringUtilities.h"
 #import "TapHandlingResult.h"
 #import "UIKitSPI.h"
 #import "UndoOrRedo.h"

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -38,7 +38,6 @@
 #import "NativeWebWheelEvent.h"
 #import "NavigationState.h"
 #import "RemoteLayerTreeNode.h"
-#import "StringUtilities.h"
 #import "UndoOrRedo.h"
 #import "ViewGestureController.h"
 #import "ViewSnapshotStore.h"
@@ -892,7 +891,7 @@ void PageClientImpl::didSameDocumentNavigationForMainFrame(SameDocumentNavigatio
 
 void PageClientImpl::handleControlledElementIDResponse(const String& identifier)
 {
-    [webView() _handleControlledElementIDResponse:nsStringFromWebCoreString(identifier)];
+    [webView() _handleControlledElementIDResponse:identifier];
 }
 
 void PageClientImpl::didChangeBackgroundColor()

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -43,7 +43,6 @@
 #import "PlatformFontInfo.h"
 #import "RemoteLayerTreeHost.h"
 #import "RemoteLayerTreeNode.h"
-#import "StringUtilities.h"
 #import "TextChecker.h"
 #import "WKBrowsingContextControllerInternal.h"
 #import "WKQuickLookPreviewController.h"
@@ -156,7 +155,7 @@ void WebPageProxy::getIsSpeaking(CompletionHandler<void(bool)>&& completionHandl
 void WebPageProxy::speak(const String& string)
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
-    [NSApp speakString:nsStringFromWebCoreString(string)];
+    [NSApp speakString:string];
 }
 
 void WebPageProxy::stopSpeaking()

--- a/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
@@ -32,7 +32,6 @@
 #import "NativeWebMouseEvent.h"
 #import "PageClientImplMac.h"
 #import "PlatformPopupMenuData.h"
-#import "StringUtilities.h"
 #import "WebPopupItem.h"
 #import <pal/spi/mac/NSCellSPI.h>
 #import <pal/system/mac/PopupMenu.h>
@@ -88,14 +87,14 @@ void WebPopupMenuProxyMac::populate(const Vector<WebPopupItem>& items, NSFont *f
                 RetainPtr<NSArray> writingDirectionArray = adoptNS([[NSArray alloc] initWithObjects:writingDirectionNumber.get(), nil]);
                 [attributes setObject:writingDirectionArray.get() forKey:NSWritingDirectionAttributeName];
             }
-            RetainPtr<NSAttributedString> string = adoptNS([[NSAttributedString alloc] initWithString:nsStringFromWebCoreString(items[i].m_text) attributes:attributes.get()]);
+            RetainPtr<NSAttributedString> string = adoptNS([[NSAttributedString alloc] initWithString:items[i].m_text attributes:attributes.get()]);
 
             [menuItem setAttributedTitle:string.get()];
             // We set the title as well as the attributed title here. The attributed title will be displayed in the menu,
             // but typeahead will use the non-attributed string that doesn't contain any leading or trailing whitespace.
             [menuItem setTitle:[[string string] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]]];
             [menuItem setEnabled:items[i].m_isEnabled];
-            [menuItem setToolTip:nsStringFromWebCoreString(items[i].m_toolTip)];
+            [menuItem setToolTip:items[i].m_toolTip];
         }
     }
 }

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -49,7 +49,6 @@
 #import "RemoteLayerTreeDrawingAreaProxyMac.h"
 #import "RemoteObjectRegistry.h"
 #import "RemoteObjectRegistryMessages.h"
-#import "StringUtilities.h"
 #import "TextChecker.h"
 #import "TextCheckerState.h"
 #import "TiledCoreAnimationDrawingAreaProxy.h"
@@ -3767,7 +3766,7 @@ void WebViewImpl::sendToolTipMouseEntered()
 
 NSString *WebViewImpl::stringForToolTip(NSToolTipTag tag)
 {
-    return nsStringFromWebCoreString(m_page->toolTip());
+    return m_page->toolTip();
 }
 
 void WebViewImpl::toolTipChanged(const String& oldToolTip, const String& newToolTip)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
@@ -65,10 +65,6 @@
 #include <wtf/Atomics.h>
 #include <wtf/URL.h>
 
-#if PLATFORM(MAC)
-#include "StringUtilities.h"
-#endif
-
 #if PLATFORM(GTK)
 #include <WebCore/SelectionData.h>
 #endif


### PR DESCRIPTION
#### 6739e68573c53703077bdeb5c7c986e8130d7bc5
<pre>
Remove nsStringFromWebCoreString in favor of String::operator NSString*
<a href="https://bugs.webkit.org/show_bug.cgi?id=273567">https://bugs.webkit.org/show_bug.cgi?id=273567</a>
<a href="https://rdar.apple.com/127285782">rdar://127285782</a>

Reviewed by Geoffrey Garen.

Its name was not accurate, the comment was moved with it 12 years ago and isn&apos;t accurate any more.
Just remove some old code and use simpler equivalent code.

* Source/WebKit/NetworkProcess/mac/NetworkProcessMac.mm:
* Source/WebKit/Platform/mac/StringUtilities.h:
* Source/WebKit/Platform/mac/StringUtilities.mm:
(WebKit::nsStringFromWebCoreString): Deleted.
* Source/WebKit/UIProcess/API/C/mac/WKContextPrivateMac.mm:
* Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm:
(WebKit::WebPreferences::platformUpdateStringValueForKey):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::handleControlledElementIDResponse):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::speak):
* Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm:
(WebKit::WebPopupMenuProxyMac::populate):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::stringForToolTip):
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp:

Canonical link: <a href="https://commits.webkit.org/278278@main">https://commits.webkit.org/278278@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1c359fa07c8405e6bda2fcf10c5ef69ea716689

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2186 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53148 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/582 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40720 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52003 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42944 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21846 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24202 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8275 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46279 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54729 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24999 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/146 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48107 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 31 flakes 117 failures; Uploaded test results; 15 flakes 92 failures; Compiled WebKit; 92 failures; Running analyze-layout-tests-results") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26256 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47147 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27118 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7226 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25986 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->