### PR TITLE
[WebGPU] no need to clear destroyed textures

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2110,6 +2110,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-273323.html [ Pass Failure Timeout ]
 [ Debug ] fast/webgpu/fuzz-273573.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-273573.html [ Pass Failure Timeout ]
+[ Debug ] fast/webgpu/fuzz-273570.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-273570.html [ Pass Failure Timeout ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-273570-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-273570-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-273570.html
+++ b/LayoutTests/fast/webgpu/fuzz-273570.html
@@ -1,0 +1,26002 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter({
+});
+let device0 = await adapter0.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 57,
+maxVertexAttributes: 20,
+maxVertexBufferArrayStride: 14219,
+maxStorageTexturesPerShaderStage: 7,
+maxStorageBuffersPerShaderStage: 12,
+maxDynamicStorageBuffersPerPipelineLayout: 52383,
+maxBindingsPerBindGroup: 6778,
+maxTextureDimension1D: 10211,
+maxTextureDimension2D: 14968,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 70996102,
+maxUniformBuffersPerShaderStage: 43,
+maxInterStageShaderVariables: 84,
+maxInterStageShaderComponents: 110,
+},
+});
+let img0 = await imageWithData(115, 147, '#374f85c4', '#6c943550');
+let texture0 = device0.createTexture({
+size: [360, 60, 207],
+mipLevelCount: 9,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-5x5-unorm-srgb', 'astc-5x5-unorm', 'astc-5x5-unorm-srgb'],
+});
+try {
+texture0.label = '\u1b34\u{1fc30}\u{1ffeb}\u8e59\udcbf\u{1fafa}';
+} catch {}
+let texture1 = device0.createTexture({
+label: '\uf29e\u{1fb14}\u8417\u032e\u1754',
+size: [180],
+dimension: '1d',
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8unorm', 'r8unorm'],
+});
+let textureView0 = texture0.createView({label: '\u1f32\u25ff\ua2a0', dimension: '2d', baseMipLevel: 3, mipLevelCount: 3, baseArrayLayer: 108});
+let textureView1 = texture0.createView({
+  label: '\u1b5e\uf590\u0a7a\u4d19\u{1ff65}\udc48\u6fbb\ufbf7\u694e',
+  dimension: '2d',
+  mipLevelCount: 3,
+  baseArrayLayer: 7
+});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\uafbf\u{1f988}',
+  colorFormats: ['rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let textureView2 = texture0.createView({
+  label: '\u1cff\ue825\u3c4c\u{1ff93}\u02a8\u0d2e\u6085\u0e4f',
+  baseMipLevel: 2,
+  mipLevelCount: 5,
+  baseArrayLayer: 70,
+  arrayLayerCount: 75
+});
+let img1 = await imageWithData(43, 157, '#b907cc79', '#5bd65f75');
+let texture2 = device0.createTexture({
+size: [360, 60, 28],
+mipLevelCount: 7,
+sampleCount: 1,
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let canvas0 = document.createElement('canvas');
+let imageData0 = new ImageData(196, 60);
+let videoFrame0 = new VideoFrame(img1, {timestamp: 0});
+let textureView3 = texture0.createView({
+  label: '\u{1fea6}\u2d88\u{1fddc}\u4aa5\u{1fc57}',
+  mipLevelCount: 6,
+  baseArrayLayer: 83,
+  arrayLayerCount: 68
+});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let texture3 = device0.createTexture({
+label: '\u0147\u537c',
+size: {width: 183, height: 3, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+sampleCount: 1,
+dimension: '3d',
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let sampler0 = device0.createSampler({
+label: '\uab7a\u746c\ua186\uc68a\u1d9b\u15f3\u0281\u767d',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 64.090,
+lodMaxClamp: 81.796,
+});
+let querySet0 = device0.createQuerySet({
+label: '\u{1fd40}\u0ad1\u3577\u2ae6',
+type: 'occlusion',
+count: 3701,
+});
+let renderBundle0 = renderBundleEncoder0.finish({label: '\u{1fe08}\ub489\u1ca4\u3f69\u{1f7e4}\u5405\u0652\ue6e8\u968a'});
+let commandEncoder0 = device0.createCommandEncoder({label: '\u07f4\u191c\u0790\u3db7\u51dc\uce9d\u9f77'});
+let textureView4 = texture1.createView({label: '\u6746\u{1fe3b}'});
+let offscreenCanvas0 = new OffscreenCanvas(1010, 284);
+let commandEncoder1 = device0.createCommandEncoder();
+let texture4 = device0.createTexture({
+size: [1440, 240, 71],
+mipLevelCount: 7,
+sampleCount: 1,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-10x10-unorm', 'astc-10x10-unorm'],
+});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['rgba16sint'], depthStencilFormat: 'depth32float-stencil8', sampleCount: 4});
+try {
+renderBundleEncoder2.setVertexBuffer(22, undefined, 3713960814, 112388966);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 9, y: 0, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 699 */
+{offset: 699, rowsPerImage: 39}, {width: 63, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let querySet1 = device0.createQuerySet({
+label: '\u134b\u2329\ua087\u1721\uec3e\u094e\u4540',
+type: 'occlusion',
+count: 3872,
+});
+let texture5 = device0.createTexture({
+label: '\uf043\u22f7\u092f\u0a82\udafd',
+size: [180, 30, 1],
+mipLevelCount: 2,
+sampleCount: 1,
+format: 'astc-10x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-10x10-unorm', 'astc-10x10-unorm-srgb', 'astc-10x10-unorm-srgb'],
+});
+let renderBundle1 = renderBundleEncoder2.finish();
+try {
+renderBundleEncoder1.setVertexBuffer(22, undefined);
+} catch {}
+let commandEncoder2 = device0.createCommandEncoder({label: '\u{1f69b}\ufecb\u22a1\u0b08\u3a62\u11f8'});
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 98, y: 1, z: 0 },
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(16)), /* required buffer size: 2 */
+{offset: 2}, {width: 61, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise0 = device0.queue.onSubmittedWorkDone();
+let commandEncoder3 = device0.createCommandEncoder();
+try {
+renderBundleEncoder1.setVertexBuffer(60, undefined, 542890090);
+} catch {}
+let commandEncoder4 = device0.createCommandEncoder({});
+let querySet2 = device0.createQuerySet({
+label: '\uffa3\u49b6',
+type: 'occlusion',
+count: 2006,
+});
+let texture6 = device0.createTexture({
+label: '\u2767\u721d\u9ea0',
+size: {width: 1470},
+dimension: '1d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST,
+});
+let textureView5 = texture4.createView({label: '\u026e\u087d', dimension: '2d', baseMipLevel: 6, mipLevelCount: 1, baseArrayLayer: 52});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\uf1bc\u{1fbf8}\u22ea\ua05b\u54f7\ueb67\u{1f9fe}\u25da\u2096\u08c9',
+  colorFormats: ['rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+adapter0.label = '\u{1fdc0}\u02dd';
+} catch {}
+pseudoSubmit(device0, commandEncoder1);
+let computePassEncoder0 = commandEncoder4.beginComputePass({label: '\u0dc7\u63b1\u2cba\u{1f666}\u6329\u2067\ucc19\u{1f7a2}\uca2f\u17d0\u8e53'});
+try {
+await device0.popErrorScope();
+} catch {}
+let adapter1 = await navigator.gpu.requestAdapter({
+});
+let texture7 = device0.createTexture({
+label: '\u05ac\u0211\u{1fdbd}\u0106',
+size: {width: 5880, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r32sint', 'r32sint'],
+});
+try {
+commandEncoder0.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 1,
+  origin: { x: 30, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture5,
+  mipLevel: 1,
+  origin: { x: 30, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 50, height: 10, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 121, y: 3, z: 1 },
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(32)), /* required buffer size: 429 */
+{offset: 429}, {width: 57, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet3 = device0.createQuerySet({
+type: 'occlusion',
+count: 190,
+});
+let computePassEncoder1 = commandEncoder3.beginComputePass();
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\u675e\u3b22\u{1ff00}\u0766\uff3f',
+  colorFormats: ['rg8sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+let offscreenCanvas1 = new OffscreenCanvas(297, 893);
+try {
+adapter1.label = '\u0f31\uf4fb';
+} catch {}
+try {
+canvas0.getContext('webgpu');
+} catch {}
+let computePassEncoder2 = commandEncoder0.beginComputePass({label: '\ub7b5\u3173\ua7d2\u6c22\u593b\u856a\ubfb0\u024b'});
+try {
+renderBundleEncoder4.setVertexBuffer(59, undefined, 2072460661, 1172130707);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer0 = device0.createBuffer({label: '\u12c6\u7ecf\ub82c\u6ca7\u{1f776}\u5db4\u786c', size: 9441, usage: GPUBufferUsage.MAP_WRITE});
+let querySet4 = device0.createQuerySet({
+label: '\u7933\u59e4\u47dc',
+type: 'occlusion',
+count: 2375,
+});
+try {
+computePassEncoder0.insertDebugMarker('\u{1fc5c}');
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder();
+let textureView6 = texture6.createView({});
+let querySet5 = device0.createQuerySet({
+label: '\u0463\u0971\ucd63\ub298\u1ca6\u0606\u05c7',
+type: 'occlusion',
+count: 1611,
+});
+let renderBundle2 = renderBundleEncoder4.finish({label: '\u682a\u02d1\ue397\u85dc\u0dfd\u428b'});
+let promise1 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext0 = offscreenCanvas1.getContext('webgpu');
+let imageBitmap0 = await createImageBitmap(offscreenCanvas0);
+let imageData1 = new ImageData(236, 100);
+let bindGroupLayout0 = device0.createBindGroupLayout({
+label: '\u64ad\uf517\u011d\u{1f962}\u{1f8e7}',
+entries: [{
+binding: 4710,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 496180, hasDynamicOffset: true },
+}],
+});
+let texture8 = device0.createTexture({
+label: '\u0f29\ubbd1\u{1ffb7}\ubb46\uc057\u02fe\ue4cb\u1924\ufe9d\u04db\u{1f97b}',
+size: [1440, 240, 122],
+mipLevelCount: 8,
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let gpuCanvasContext1 = offscreenCanvas0.getContext('webgpu');
+try {
+  await promise1;
+} catch {}
+let imageData2 = new ImageData(136, 96);
+let querySet6 = device0.createQuerySet({
+label: '\ua2f3\u{1f8ff}\u51e1',
+type: 'occlusion',
+count: 1496,
+});
+let textureView7 = texture2.createView({label: '\uf5ea\ua43b\uc617\u04ef', dimension: '2d', baseMipLevel: 3, mipLevelCount: 2, baseArrayLayer: 8});
+let sampler1 = device0.createSampler({
+addressModeV: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 70.747,
+lodMaxClamp: 97.511,
+});
+try {
+commandEncoder2.insertDebugMarker('\uda33');
+} catch {}
+let canvas1 = document.createElement('canvas');
+try {
+canvas1.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder6 = device0.createCommandEncoder({label: '\u0610\u026f\u3ba8\u50c3'});
+let querySet7 = device0.createQuerySet({
+label: '\u5818\udb11\u4696\u{1f8e9}\u0c92\u5f6b\u5f06\u0796',
+type: 'occlusion',
+count: 372,
+});
+pseudoSubmit(device0, commandEncoder6);
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  label: '\u4548\u4e1d\u{1fa6a}\u0051\u5071',
+  colorFormats: ['rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+let commandEncoder7 = device0.createCommandEncoder({label: '\ud500\u6010\uf7bd\u7760\u1593\u3b48\ua90c'});
+try {
+commandEncoder2.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 96, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 43, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 10, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let imageData3 = new ImageData(160, 152);
+let videoFrame1 = new VideoFrame(canvas1, {timestamp: 0});
+let texture9 = device0.createTexture({
+label: '\u0eb3\u3575\u92f4\u{1f6ef}\ua7c0\u3371\u2656',
+size: {width: 112, height: 5, depthOrArrayLayers: 87},
+mipLevelCount: 2,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let computePassEncoder3 = commandEncoder7.beginComputePass({label: '\u02b9\u6599\u{1faae}\uf826\uca9a\u{1f6bf}\u{1f917}'});
+let computePassEncoder4 = commandEncoder2.beginComputePass({label: '\u065b\u3b2b\u{1ff9e}\u3c39\u059f'});
+let computePassEncoder5 = commandEncoder5.beginComputePass({label: '\u0400\u9d06\u23de\u{1fc24}\u4d46\u5356\u{1fc18}\u0472\u11d4'});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  label: '\u{1f61b}\u0c92\u8fa3\u529a\u0a83\u0434\u{1ff12}',
+  colorFormats: ['rg8sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+  await buffer0.mapAsync(GPUMapMode.WRITE, 4144, 4648);
+} catch {}
+let arrayBuffer0 = buffer0.getMappedRange(6440, 492);
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+offscreenCanvas1.width = 704;
+let imageData4 = new ImageData(92, 72);
+let renderBundle3 = renderBundleEncoder6.finish({});
+let sampler2 = device0.createSampler({
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 92.915,
+lodMaxClamp: 99.014,
+maxAnisotropy: 10,
+});
+try {
+renderBundleEncoder1.setVertexBuffer(11, undefined, 3398495130, 126258958);
+} catch {}
+let arrayBuffer1 = buffer0.getMappedRange(4144, 1428);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let querySet8 = device0.createQuerySet({
+label: '\u{1fd59}\u{1fac2}\u0dfa\u4c28\u83f3\u{1f66a}',
+type: 'occlusion',
+count: 3543,
+});
+let textureView8 = texture9.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 37});
+let renderBundle4 = renderBundleEncoder6.finish({label: '\uc6ce\u5ea9\u070b\ue5f2\u{1f649}\u{1f73b}\ud606\u{1fa0a}\u{1f685}\u3ecb'});
+let sampler3 = device0.createSampler({
+label: '\uca55\ub544\u0185\u730c',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMaxClamp: 85.324,
+});
+let renderBundle5 = renderBundleEncoder6.finish({label: '\u4d09\ud849\ub233'});
+let sampler4 = device0.createSampler({
+label: '\uf6da\ubcc2\u0df7\u6dbc\u5209\u5442',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 85.532,
+maxAnisotropy: 3,
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let buffer1 = device0.createBuffer({size: 9500, usage: GPUBufferUsage.MAP_READ, mappedAtCreation: true});
+let commandEncoder8 = device0.createCommandEncoder();
+let renderBundle6 = renderBundleEncoder4.finish({label: '\u9241\ub0a2\u89f9\u3eb2\u0ee3\u03ca\u0aad\uc1c6\u{1ffbb}\u8dc3\u3d0b'});
+try {
+renderBundleEncoder3.setVertexBuffer(74, undefined, 2732569864, 738451134);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 6,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(56)), /* required buffer size: 1327 */
+{offset: 991}, {width: 84, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(50, undefined);
+} catch {}
+canvas0.width = 765;
+let texture10 = device0.createTexture({
+label: '\u011a\u{1fb10}\u9eb0\u046d\u0d6a',
+size: {width: 576, height: 12, depthOrArrayLayers: 1},
+mipLevelCount: 10,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+renderBundleEncoder5.setVertexBuffer(28, undefined, 1304550158, 1831937090);
+} catch {}
+try {
+renderBundleEncoder5.insertDebugMarker('\u{1ff79}');
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+offscreenCanvas0.width = 695;
+let offscreenCanvas2 = new OffscreenCanvas(647, 213);
+let textureView9 = texture4.createView({dimension: '2d', format: 'astc-10x10-unorm', baseMipLevel: 5, mipLevelCount: 2, baseArrayLayer: 7});
+let sampler5 = device0.createSampler({
+label: '\u1132\u6f3e\u{1fa12}\ud5c1\uecc7\u08d5\u5088\u{1fedc}\u0fa0\u{1fdd6}\u63ba',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 15.119,
+lodMaxClamp: 25.095,
+});
+try {
+renderBundleEncoder1.setVertexBuffer(98, undefined);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 6,
+  origin: { x: 6, y: 0, z: 1 },
+  aspect: 'all',
+}, new Int16Array(arrayBuffer1), /* required buffer size: 345 */
+{offset: 345, rowsPerImage: 96}, {width: 14, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder9 = device0.createCommandEncoder({label: '\u{1f649}\uf872\u{1fb3f}\u9512\uf8d0\u5653\u{1f6e1}\ueb48\ufbbc\u0c62'});
+let arrayBuffer2 = buffer1.getMappedRange(0, 6116);
+let querySet9 = device0.createQuerySet({
+type: 'occlusion',
+count: 3027,
+});
+let texture11 = device0.createTexture({
+size: {width: 2400, height: 8, depthOrArrayLayers: 1},
+mipLevelCount: 12,
+format: 'etc2-rgb8a1unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8a1unorm', 'etc2-rgb8a1unorm-srgb'],
+});
+let computePassEncoder6 = commandEncoder9.beginComputePass({label: '\u{1f7e7}\uc69c\u06ef\u6d61\u7533\u0a11\u2bf2\u0e1d\uf0fd\u02e5\u0a70'});
+let renderBundle7 = renderBundleEncoder4.finish({label: '\u5125\u0c73\uf251\u9778\ua100'});
+let arrayBuffer3 = buffer1.getMappedRange(8688, 128);
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 2,
+  origin: { x: 84, y: 48, z: 117 },
+  aspect: 'all',
+}, {
+  texture: texture8,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 70 },
+  aspect: 'all',
+}, {width: 4, height: 4, depthOrArrayLayers: 5});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 9,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 842 */
+{offset: 842, rowsPerImage: 64}, {width: 0, height: 4, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let imageData5 = new ImageData(256, 228);
+try {
+offscreenCanvas2.getContext('webgl2');
+} catch {}
+let pipelineLayout0 = device0.createPipelineLayout({
+  label: '\u{1fe54}\u0c8f\ua338\u0903\u60b8\u6d75\u19b2\u{1f67f}\u{1ffbc}',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0]
+});
+let commandEncoder10 = device0.createCommandEncoder({label: '\u{1f94e}\u03b4\u08c4\u3faf\udd8d\uc906\u{1f949}'});
+let querySet10 = device0.createQuerySet({
+label: '\u70ba\u0905',
+type: 'occlusion',
+count: 2744,
+});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u72cd\uff37\u{1f6c5}\ua6fb\u7c0d\u7441\u7a0a',
+  colorFormats: ['rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder7.setVertexBuffer(55, undefined, 2600802974, 759794962);
+} catch {}
+try {
+  await promise2;
+} catch {}
+let querySet11 = device0.createQuerySet({
+label: '\uaa5c\u00f8\u7ed9\u409e\u{1f7e6}\ubdef\u0aec\ue2ae\ucbc2\u{1fc7a}',
+type: 'occlusion',
+count: 2125,
+});
+let texture12 = device0.createTexture({
+label: '\u51a9\uceba\ua5eb\ue228\u0998\u9314\u0ed8',
+size: {width: 288, height: 6, depthOrArrayLayers: 15},
+dimension: '3d',
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba32sint', 'rgba32sint'],
+});
+let textureView10 = texture4.createView({
+  label: '\u{1fa12}\uc949',
+  format: 'astc-10x10-unorm',
+  mipLevelCount: 2,
+  baseArrayLayer: 69,
+  arrayLayerCount: 2
+});
+let renderBundle8 = renderBundleEncoder3.finish({label: '\uc830\u{1f7ea}\u{1fe92}\udbc7\u03e2\u24b2\u726d\u2854'});
+let sampler6 = device0.createSampler({
+label: '\u77a4\u0df5\u77d0\u2795\u{1fb7d}\u840a\ud366\u1f17\u0650\u08c0\uc747',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 69.992,
+lodMaxClamp: 80.926,
+maxAnisotropy: 18,
+});
+try {
+texture3.destroy();
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder({label: '\u498c\u3e81'});
+let texture13 = device0.createTexture({
+size: [720, 120, 249],
+mipLevelCount: 7,
+sampleCount: 1,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundle9 = renderBundleEncoder3.finish({label: '\u9824\uf88f\u{1f985}\u0865\ud250\uc184'});
+try {
+buffer0.destroy();
+} catch {}
+document.body.prepend(canvas0);
+let imageData6 = new ImageData(116, 76);
+let buffer2 = device0.createBuffer({label: '\u{1f8eb}\u{1f69d}\ua382\u{1fa87}\ub455\u0064', size: 37000, usage: GPUBufferUsage.QUERY_RESOLVE});
+let sampler7 = device0.createSampler({
+label: '\u0751\u0b6d\u249d\u48c4\u0c73',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 87.663,
+lodMaxClamp: 98.975,
+maxAnisotropy: 17,
+});
+let texture14 = device0.createTexture({
+label: '\u{1fdee}\uc4d4\u0d10\u8ff7',
+size: {width: 180, height: 30, depthOrArrayLayers: 23},
+dimension: '3d',
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r32sint'],
+});
+let renderBundle10 = renderBundleEncoder7.finish({label: '\u025e\u05df'});
+try {
+commandEncoder10.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: { x: 135, y: 9, z: 7 },
+  aspect: 'all',
+}, {
+  texture: texture7,
+  mipLevel: 6,
+  origin: { x: 17, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder8.resolveQuerySet(querySet0, 2587, 111, buffer2, 25600);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(216), /* required buffer size: 216 */
+{offset: 216, rowsPerImage: 41}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+label: '\u06c1\ud0b0',
+code: `@group(3) @binding(4710)
+var<storage, read_write> parameter0: array<u32>;
+@group(4) @binding(4710)
+var<storage, read_write> global0: array<u32>;
+@group(0) @binding(4710)
+var<storage, read_write> global1: array<u32>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @builtin(frag_depth) f1: f32
+}
+
+@fragment
+fn fragment0(@location(31) a0: vec2<u32>, @location(27) a1: vec2<u32>, @location(42) a2: vec3<f16>, @location(80) a3: vec4<i32>, @location(34) a4: vec3<f16>, @location(68) a5: vec2<f32>, @builtin(front_facing) a6: bool, @location(21) a7: u32, @builtin(sample_mask) a8: u32, @location(77) a9: vec3<f32>, @location(41) a10: vec3<u32>, @location(9) a11: f32, @location(65) a12: vec3<i32>, @location(3) a13: i32, @location(28) a14: f32, @location(60) a15: vec2<i32>, @location(35) a16: vec3<f16>, @location(74) a17: vec4<f32>, @location(79) a18: vec4<f16>, @location(82) a19: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S0 {
+  @location(9) f0: vec2<f16>,
+  @location(6) f1: vec4<f32>,
+  @location(19) f2: vec4<i32>,
+  @builtin(instance_index) f3: u32,
+  @location(3) f4: vec2<f32>,
+  @location(13) f5: vec4<u32>,
+  @location(4) f6: vec2<f16>
+}
+struct VertexOutput0 {
+  @location(42) f0: vec3<f16>,
+  @location(65) f1: vec3<i32>,
+  @location(27) f2: vec2<u32>,
+  @location(81) f3: vec2<f16>,
+  @location(68) f4: vec2<f32>,
+  @location(25) f5: vec3<u32>,
+  @location(80) f6: vec4<i32>,
+  @location(79) f7: vec4<f16>,
+  @location(28) f8: f32,
+  @location(40) f9: f32,
+  @location(29) f10: u32,
+  @builtin(position) f11: vec4<f32>,
+  @location(82) f12: u32,
+  @location(12) f13: f32,
+  @location(72) f14: f32,
+  @location(74) f15: vec4<f32>,
+  @location(77) f16: vec3<f32>,
+  @location(31) f17: vec2<u32>,
+  @location(15) f18: vec3<u32>,
+  @location(34) f19: vec3<f16>,
+  @location(59) f20: vec2<f16>,
+  @location(37) f21: vec3<i32>,
+  @location(3) f22: i32,
+  @location(21) f23: u32,
+  @location(35) f24: vec3<f16>,
+  @location(41) f25: vec3<u32>,
+  @location(4) f26: vec4<f16>,
+  @location(60) f27: vec2<i32>,
+  @location(9) f28: f32
+}
+
+@vertex
+fn vertex0(@location(7) a0: u32, @location(17) a1: vec3<u32>, @location(18) a2: vec4<f32>, @location(12) a3: vec4<f16>, @location(16) a4: vec4<i32>, @builtin(vertex_index) a5: u32, @location(5) a6: vec4<u32>, @location(15) a7: i32, @location(10) a8: vec4<f16>, @location(14) a9: vec4<u32>, a10: S0, @location(11) a11: vec4<f32>, @location(1) a12: vec4<f16>, @location(8) a13: vec3<i32>, @location(2) a14: vec2<f32>, @location(0) a15: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let buffer3 = device0.createBuffer({
+  label: '\ua22a\u7a0f\u0966\ub809\u{1f9d3}\uce7b\u95b4\ud900',
+  size: 60969,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let textureView11 = texture1.createView({label: '\u00b8\u{1fa92}\u56dc'});
+try {
+commandEncoder8.clearBuffer(buffer3, 36736, 652);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline0 = device0.createComputePipeline({
+label: '\u2371\u0b44\u{1fff4}\u017f',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroupLayout1 = pipeline0.getBindGroupLayout(0);
+let commandEncoder12 = device0.createCommandEncoder({label: '\u21a1\u02b2\u6141\ub350\uf5a8'});
+let texture15 = device0.createTexture({
+label: '\u0665\u{1f7ed}\u03c7',
+size: {width: 1440, height: 240, depthOrArrayLayers: 202},
+mipLevelCount: 3,
+dimension: '2d',
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView12 = texture5.createView({aspect: 'all'});
+try {
+renderBundleEncoder1.setVertexBuffer(4, undefined, 181742902, 1965708471);
+} catch {}
+try {
+commandEncoder12.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 332, y: 28, z: 92 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 736 widthInBlocks: 92 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 15648 */
+offset: 1088,
+bytesPerRow: 768,
+buffer: buffer3,
+}, {width: 368, height: 76, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 28, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 8, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 22, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline1 = device0.createComputePipeline({
+label: '\u9d06\u0bc1\u8f22\u0ff0',
+layout: 'auto',
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+renderBundle6.label = '\u451a\u{1f9ec}';
+} catch {}
+let commandEncoder13 = device0.createCommandEncoder({label: '\udca0\uf63a\u{1fc8b}\u0c95\u920b\u{1f6cf}\u0320\u6fe7\u0699\u1a3c\uf4e3'});
+let textureView13 = texture7.createView({label: '\u10e1\u0a3a\ue7cb\u{1fdde}\ufa07\u05cc\u0cba\u6f3b\u013d', baseMipLevel: 3});
+let renderBundle11 = renderBundleEncoder6.finish({label: '\uccc5\u0dc9'});
+try {
+buffer0.unmap();
+} catch {}
+let video0 = await videoWithData();
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder11.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 7,
+  origin: { x: 16, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 1256 */
+offset: 1256,
+rowsPerImage: 122,
+buffer: buffer3,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder12.clearBuffer(buffer3, 55968, 4344);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 3,
+  origin: { x: 191, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 590 */
+{offset: 590, bytesPerRow: 581, rowsPerImage: 210}, {width: 87, height: 1, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let videoFrame2 = new VideoFrame(img1, {timestamp: 0});
+let buffer4 = device0.createBuffer({label: '\u337f\u0d99', size: 25448, usage: GPUBufferUsage.VERTEX, mappedAtCreation: true});
+let renderBundle12 = renderBundleEncoder5.finish({label: '\u{1f7da}\u0c1b\u{1fa36}\u790d\u{1ff67}\ub01f\u6ad1\uc9a9\u1ee6\uc751\u553f'});
+try {
+computePassEncoder6.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(8, buffer4, 19336, 3928);
+} catch {}
+try {
+commandEncoder13.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 136, y: 12, z: 74 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 928 widthInBlocks: 116 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 53800 */
+offset: 27272,
+bytesPerRow: 1024,
+buffer: buffer3,
+}, {width: 464, height: 104, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder8.resolveQuerySet(querySet10, 1917, 450, buffer2, 13824);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm-srgb', 'rgba8snorm', 'r8unorm', 'rg16uint'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 2,
+  origin: { x: 256, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(220), /* required buffer size: 220 */
+{offset: 220}, {width: 493, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline2 = await device0.createComputePipelineAsync({
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let textureView14 = texture4.createView({
+  label: '\u{1fbef}\u059f\u{1ff8c}\u9b62\ue501\u{1fbe3}\u044a',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 27
+});
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder8.clearBuffer(buffer3, 13584, 15152);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 3,
+  origin: { x: 11, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer3), /* required buffer size: 3529 */
+{offset: 949}, {width: 645, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline3 = device0.createComputePipeline({
+label: '\ud03f\u02e1\udf6a\u9fce\u{1ffae}\u0ed5\u062b\u3567\u794a',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+});
+let buffer5 = device0.createBuffer({size: 9432, usage: GPUBufferUsage.MAP_READ});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  label: '\u06c4\u0f41\u0850\ub7c5\u03f8\u{1f735}\u6218\u{1ff0a}\u5d99',
+  colorFormats: ['rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: { x: 29, y: 15, z: 8 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 494894 */
+{offset: 629, bytesPerRow: 535, rowsPerImage: 304}, {width: 115, height: 12, depthOrArrayLayers: 4});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline4 = device0.createRenderPipeline({
+label: '\uda4e\u0b47\u05bb\uea62',
+layout: pipelineLayout0,
+multisample: {
+mask: 0x3ff54c70,
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16sint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'invert',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 3643,
+stencilWriteMask: 87,
+depthBias: 20,
+depthBiasSlopeScale: 17,
+depthBiasClamp: 10,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 3672,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x4',
+offset: 580,
+shaderLocation: 5,
+}, {
+format: 'unorm16x4',
+offset: 1016,
+shaderLocation: 0,
+}, {
+format: 'snorm16x2',
+offset: 612,
+shaderLocation: 11,
+}, {
+format: 'sint32',
+offset: 2924,
+shaderLocation: 19,
+}, {
+format: 'uint32x4',
+offset: 700,
+shaderLocation: 14,
+}, {
+format: 'sint8x2',
+offset: 3224,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 4488,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 228,
+shaderLocation: 9,
+}, {
+format: 'sint32x4',
+offset: 880,
+shaderLocation: 15,
+}, {
+format: 'sint16x4',
+offset: 1396,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 5144,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x4',
+offset: 3572,
+shaderLocation: 18,
+}, {
+format: 'unorm16x2',
+offset: 4952,
+shaderLocation: 4,
+}, {
+format: 'float16x4',
+offset: 2124,
+shaderLocation: 1,
+}, {
+format: 'snorm16x2',
+offset: 784,
+shaderLocation: 2,
+}, {
+format: 'snorm16x2',
+offset: 996,
+shaderLocation: 10,
+}, {
+format: 'float32',
+offset: 3904,
+shaderLocation: 12,
+}, {
+format: 'uint32x4',
+offset: 4292,
+shaderLocation: 13,
+}, {
+format: 'uint16x2',
+offset: 3844,
+shaderLocation: 17,
+}, {
+format: 'uint32x2',
+offset: 2556,
+shaderLocation: 7,
+}, {
+format: 'unorm10-10-10-2',
+offset: 5036,
+shaderLocation: 3,
+}, {
+format: 'snorm8x2',
+offset: 3246,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+document.body.prepend(canvas0);
+let videoFrame3 = new VideoFrame(img0, {timestamp: 0});
+try {
+computePassEncoder0.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 10600, new Float32Array(4932), 3427, 48);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 2,
+  origin: { x: 190, y: 10, z: 39 },
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 179995 */
+{offset: 65, bytesPerRow: 366, rowsPerImage: 49}, {width: 140, height: 20, depthOrArrayLayers: 11});
+} catch {}
+let pipeline5 = await device0.createRenderPipelineAsync({
+label: '\u99d8\u{1fc99}\u{1f8c9}\uf0ec\u1dfd\ua623\u03b5\ub7e7\ucd23\udcd0',
+layout: pipelineLayout0,
+multisample: {
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'invert',
+},
+stencilBack: {
+failOp: 'zero',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilReadMask: 2667,
+stencilWriteMask: 1282,
+depthBias: 66,
+depthBiasSlopeScale: 59,
+depthBiasClamp: 57,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 10380,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 6716,
+shaderLocation: 16,
+}, {
+format: 'unorm8x2',
+offset: 3960,
+shaderLocation: 6,
+}, {
+format: 'float32',
+offset: 9076,
+shaderLocation: 18,
+}, {
+format: 'uint32',
+offset: 4468,
+shaderLocation: 17,
+}, {
+format: 'sint32x4',
+offset: 7472,
+shaderLocation: 15,
+}, {
+format: 'unorm16x4',
+offset: 1904,
+shaderLocation: 2,
+}, {
+format: 'uint32',
+offset: 8348,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 7012,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 2868,
+shaderLocation: 9,
+}, {
+format: 'sint32x4',
+offset: 8,
+shaderLocation: 19,
+}, {
+format: 'float32',
+offset: 1608,
+shaderLocation: 10,
+}, {
+format: 'uint32x3',
+offset: 4560,
+shaderLocation: 5,
+}, {
+format: 'unorm16x2',
+offset: 6344,
+shaderLocation: 3,
+}, {
+format: 'unorm16x4',
+offset: 900,
+shaderLocation: 0,
+}, {
+format: 'float32x3',
+offset: 6256,
+shaderLocation: 1,
+}, {
+format: 'sint8x4',
+offset: 2280,
+shaderLocation: 8,
+}, {
+format: 'snorm8x4',
+offset: 1300,
+shaderLocation: 11,
+}, {
+format: 'float16x4',
+offset: 684,
+shaderLocation: 12,
+}, {
+format: 'unorm16x2',
+offset: 2844,
+shaderLocation: 4,
+}, {
+format: 'uint16x2',
+offset: 3732,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x4',
+offset: 9444,
+shaderLocation: 13,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let device1 = await adapter1.requestDevice({
+label: '\ue975\u5d8d',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 36,
+maxVertexAttributes: 27,
+maxVertexBufferArrayStride: 35977,
+maxStorageTexturesPerShaderStage: 7,
+maxStorageBuffersPerShaderStage: 18,
+maxDynamicStorageBuffersPerPipelineLayout: 25456,
+maxBindingsPerBindGroup: 3699,
+maxTextureDimension1D: 11913,
+maxTextureDimension2D: 9489,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 155105638,
+maxUniformBuffersPerShaderStage: 30,
+maxInterStageShaderVariables: 50,
+maxInterStageShaderComponents: 91,
+maxSamplersPerShaderStage: 17,
+},
+});
+let imageBitmap1 = await createImageBitmap(imageData3);
+try {
+computePassEncoder5.setPipeline(pipeline0);
+} catch {}
+let promise3 = device0.createRenderPipelineAsync({
+label: '\u01eb\uacf4\u0070\uc7f5\u{1fd52}\u4990\u5a7a',
+layout: pipelineLayout0,
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'invert',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'invert',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilReadMask: 943,
+stencilWriteMask: 1064,
+depthBias: 76,
+depthBiasSlopeScale: 63,
+depthBiasClamp: 27,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 8060,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x2',
+offset: 3688,
+shaderLocation: 1,
+}, {
+format: 'unorm16x4',
+offset: 4688,
+shaderLocation: 4,
+}, {
+format: 'snorm16x2',
+offset: 3416,
+shaderLocation: 10,
+}, {
+format: 'snorm16x2',
+offset: 284,
+shaderLocation: 3,
+}, {
+format: 'sint8x2',
+offset: 5626,
+shaderLocation: 16,
+}, {
+format: 'float32x2',
+offset: 1996,
+shaderLocation: 2,
+}, {
+format: 'uint32x4',
+offset: 4000,
+shaderLocation: 5,
+}, {
+format: 'uint16x2',
+offset: 3736,
+shaderLocation: 17,
+}],
+},
+{
+arrayStride: 4692,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 2380,
+shaderLocation: 11,
+}, {
+format: 'snorm16x2',
+offset: 1712,
+shaderLocation: 9,
+}, {
+format: 'uint32',
+offset: 508,
+shaderLocation: 7,
+}, {
+format: 'sint8x2',
+offset: 3812,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 7320,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 8956,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x4',
+offset: 4840,
+shaderLocation: 19,
+}, {
+format: 'float32x3',
+offset: 4356,
+shaderLocation: 12,
+}, {
+format: 'sint8x4',
+offset: 3292,
+shaderLocation: 15,
+}, {
+format: 'snorm8x2',
+offset: 7000,
+shaderLocation: 18,
+}],
+},
+{
+arrayStride: 604,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 172,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 11344,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x2',
+offset: 5788,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 10188,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32',
+offset: 7924,
+shaderLocation: 0,
+}, {
+format: 'uint8x4',
+offset: 6048,
+shaderLocation: 13,
+}],
+}
+]
+},
+});
+let video1 = await videoWithData();
+let commandEncoder14 = device0.createCommandEncoder({});
+try {
+commandEncoder10.clearBuffer(buffer3, 44556, 13960);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(querySet11, 2019, 76, buffer2, 15616);
+} catch {}
+let video2 = await videoWithData();
+let renderBundleEncoder9 = device1.createRenderBundleEncoder({
+  label: '\u0b97\uc374',
+  colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle13 = renderBundleEncoder9.finish({label: '\u9547\uc74a\u08c1\u02e8\u4efe\u{1ff95}\ua939\u649d'});
+video0.height = 208;
+let renderBundle14 = renderBundleEncoder2.finish({});
+let sampler8 = device0.createSampler({
+label: '\u9939\u048c\uadf1\u{1fd15}',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 17.760,
+maxAnisotropy: 6,
+});
+try {
+commandEncoder12.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 128, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 42, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder15 = device1.createCommandEncoder();
+let computePassEncoder7 = commandEncoder15.beginComputePass({label: '\uc1d5\ueb8a\u04e8\u712a\u0803\u0dcd\u0567'});
+let imageBitmap2 = await createImageBitmap(img0);
+let commandEncoder16 = device0.createCommandEncoder({label: '\u5449\u0ed9\u8a60\u9b2b\uf6f2\u4b4f\u93a9\u7011\u0c1a\u3bf8'});
+let texture16 = device0.createTexture({
+label: '\u069c\u0c9e\u{1fe23}\u{1fd85}',
+size: [2400, 8, 1],
+mipLevelCount: 7,
+format: 'astc-5x4-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView15 = texture1.createView({label: '\uf9b6\u0924\u6d66\uf880\u4338\u05eb\u0625\u8c93\uc15e'});
+try {
+commandEncoder14.clearBuffer(buffer3, 26420, 34484);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline6 = device0.createComputePipeline({
+label: '\u91da\u284b\ud5af\u{1fd23}\u0609\u{1f881}\u074d\uc997\u6727',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipelineLayout1 = device0.createPipelineLayout({
+  label: '\u08bc\u{1fd8b}\u7be7\u9605\u06f7\uf2ec\ub260\u{1fe66}',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout1, bindGroupLayout0, bindGroupLayout1]
+});
+let buffer6 = device0.createBuffer({
+  label: '\u0887\u01c2\u0510\u{1ff2d}\u533b\u827d\ua87a\uebf7\u{1fda5}',
+  size: 5256,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true
+});
+let commandEncoder17 = device0.createCommandEncoder({});
+let textureView16 = texture9.createView({baseMipLevel: 1, baseArrayLayer: 56, arrayLayerCount: 6});
+let renderBundle15 = renderBundleEncoder7.finish({label: '\ufdbc\u0b7a\ud456'});
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(72)), /* required buffer size: 792 */
+{offset: 792}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline7 = device0.createRenderPipeline({
+label: '\u7f5d\u8799\u9ead\u7782\uffea\u4691\u{1f664}\u8633\u49df\u572a\u7456',
+layout: pipelineLayout1,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'equal',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+},
+stencilReadMask: 2760,
+stencilWriteMask: 319,
+depthBias: 78,
+depthBiasSlopeScale: 60,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 13500,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x4',
+offset: 12504,
+shaderLocation: 19,
+}, {
+format: 'float32x4',
+offset: 11068,
+shaderLocation: 11,
+}, {
+format: 'unorm10-10-10-2',
+offset: 9244,
+shaderLocation: 9,
+}, {
+format: 'unorm16x4',
+offset: 5360,
+shaderLocation: 18,
+}, {
+format: 'unorm16x2',
+offset: 3156,
+shaderLocation: 4,
+}, {
+format: 'uint8x2',
+offset: 6406,
+shaderLocation: 5,
+}, {
+format: 'sint8x2',
+offset: 1708,
+shaderLocation: 15,
+}, {
+format: 'snorm8x2',
+offset: 1456,
+shaderLocation: 10,
+}, {
+format: 'uint32x2',
+offset: 6656,
+shaderLocation: 13,
+}, {
+format: 'uint32x3',
+offset: 5308,
+shaderLocation: 17,
+}, {
+format: 'float32',
+offset: 9540,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 2412,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x4',
+offset: 1432,
+shaderLocation: 1,
+}, {
+format: 'float16x2',
+offset: 148,
+shaderLocation: 2,
+}, {
+format: 'snorm8x4',
+offset: 1612,
+shaderLocation: 6,
+}, {
+format: 'unorm8x2',
+offset: 2350,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 12512,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 8180,
+shaderLocation: 3,
+}, {
+format: 'sint16x2',
+offset: 6588,
+shaderLocation: 16,
+}, {
+format: 'sint32',
+offset: 1560,
+shaderLocation: 8,
+}, {
+format: 'uint32x4',
+offset: 4516,
+shaderLocation: 14,
+}, {
+format: 'uint32x2',
+offset: 4568,
+shaderLocation: 7,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let commandEncoder18 = device0.createCommandEncoder({});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\u01da\u2bfc\u07df\u09ec',
+  colorFormats: ['rg8sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle16 = renderBundleEncoder10.finish({label: '\udd9e\uba34\u0a6f\u5092\u52b3\u0e67\u0384\u3989'});
+try {
+commandEncoder18.resolveQuerySet(querySet7, 317, 51, buffer2, 7936);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let texture17 = device1.createTexture({
+label: '\u2c1f\u03cf\u9383\u04bd\u0dc9\u2627\u0a33',
+size: {width: 108, height: 768, depthOrArrayLayers: 223},
+mipLevelCount: 3,
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['r16sint'],
+});
+try {
+device1.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 1,
+  origin: { x: 22, y: 35, z: 3 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 363459 */
+{offset: 562, bytesPerRow: 109, rowsPerImage: 257}, {width: 18, height: 246, depthOrArrayLayers: 13});
+} catch {}
+document.body.prepend(canvas0);
+let imageData7 = new ImageData(16, 212);
+let commandEncoder19 = device1.createCommandEncoder({label: '\u7537\uee27\u{1f6af}\ufcc8\uaac4\u44ac\u{1ffe9}\u07fe\u2359'});
+pseudoSubmit(device1, commandEncoder19);
+let textureView17 = texture17.createView({
+  label: '\u9f87\u{1f7e2}\u2f5d\u{1f8fc}\uf08e\u{1ff5d}\u{1f817}\u4c7f',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 143
+});
+let commandEncoder20 = device1.createCommandEncoder({label: '\u9173\u{1fe41}\u0484'});
+let querySet12 = device1.createQuerySet({
+label: '\u9adf\u073a',
+type: 'occlusion',
+count: 122,
+});
+let computePassEncoder8 = commandEncoder20.beginComputePass();
+let sampler9 = device1.createSampler({
+label: '\u3d1f\uc3bd\u73dc\u3671\ue6cc\ud96e\u48ab\u{1ffab}\u{1f799}\u09e3',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+lodMinClamp: 56.885,
+lodMaxClamp: 85.067,
+});
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let texture18 = device0.createTexture({
+label: '\u096e\u{1fbde}\u4439\u{1ff69}\u0925\u{1fe5a}\u08e8',
+size: {width: 4800},
+dimension: '1d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rg11b10ufloat'],
+});
+let renderBundle17 = renderBundleEncoder4.finish({});
+try {
+commandEncoder8.resolveQuerySet(querySet2, 1434, 57, buffer2, 19456);
+} catch {}
+try {
+  await promise0;
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder();
+let querySet13 = device0.createQuerySet({
+label: '\u4ea0\u00d5\u0001\uaf0f\u{1fda2}',
+type: 'occlusion',
+count: 3437,
+});
+try {
+commandEncoder8.clearBuffer(buffer3, 18424, 14620);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['stencil8'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 30236, new BigUint64Array(19765), 91, 2156);
+} catch {}
+offscreenCanvas0.height = 949;
+let buffer7 = device1.createBuffer({label: '\u8961\uf8b3\u01a5', size: 34656, usage: GPUBufferUsage.INDEX});
+let querySet14 = device1.createQuerySet({
+type: 'occlusion',
+count: 2798,
+});
+let textureView18 = texture17.createView({
+  label: '\uc3b1\u0cbf\u095b',
+  dimension: '2d',
+  aspect: 'all',
+  format: 'r16sint',
+  mipLevelCount: 1,
+  baseArrayLayer: 87
+});
+let buffer8 = device1.createBuffer({
+  label: '\ud157\u{1fef0}\u048b\uef79\u95ef\u3914\u0cf5\u4897\udd93\u4fdc',
+  size: 11791,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let texture19 = gpuCanvasContext1.getCurrentTexture();
+let textureView19 = texture19.createView({label: '\u0886\ud602\u265d\u456c\u{1fdac}', dimension: '2d-array', baseMipLevel: 0, baseArrayLayer: 0});
+try {
+  await buffer8.mapAsync(GPUMapMode.READ, 0, 2028);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+try {
+adapter0.label = '\u2e0b\u44d7\uc102\uf1de\u034f\u{1fa50}\ubd97\ud233\udb01\u12ac\u8318';
+} catch {}
+let texture20 = device0.createTexture({
+label: '\u8b8f\u0507',
+size: {width: 1470, height: 1, depthOrArrayLayers: 152},
+mipLevelCount: 9,
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16sint'],
+});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({
+  label: '\ud47d\ua224\u4da3',
+  colorFormats: ['rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let renderBundle18 = renderBundleEncoder2.finish();
+try {
+renderBundleEncoder8.setVertexBuffer(2, buffer4, 19620, 3356);
+} catch {}
+try {
+renderBundleEncoder11.insertDebugMarker('\u2b8c');
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout({label: '\u39cb\ua0d4\u1eb6', bindGroupLayouts: []});
+let querySet15 = device0.createQuerySet({
+label: '\udec4\u{1fb4b}\u05ba\u0903\u50c2\u8102\u1eb9\u5950',
+type: 'occlusion',
+count: 2215,
+});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  label: '\u1f79\u7324\uac33\uc233',
+  colorFormats: ['rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder1.setVertexBuffer(1, buffer4, 1364, 22803);
+} catch {}
+try {
+querySet5.destroy();
+} catch {}
+try {
+commandEncoder21.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 10,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture11,
+  mipLevel: 4,
+  origin: { x: 112, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let texture21 = device0.createTexture({
+label: '\ua7f0\u03e7\u{1fe52}',
+size: {width: 144, height: 3, depthOrArrayLayers: 7},
+mipLevelCount: 8,
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let computePassEncoder9 = commandEncoder12.beginComputePass({label: '\u0c0c\u{1f818}'});
+try {
+renderBundleEncoder11.setVertexBuffer(4, buffer4, 12144);
+} catch {}
+try {
+  await buffer5.mapAsync(GPUMapMode.READ);
+} catch {}
+let pipeline8 = device0.createRenderPipeline({
+label: '\uba10\u8f42\ub3da\u0d81\u4cee\u{1f66a}',
+layout: pipelineLayout0,
+multisample: {
+mask: 0xc48871c2,
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2546,
+stencilWriteMask: 513,
+depthBias: 36,
+depthBiasSlopeScale: 89,
+depthBiasClamp: 45,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 6168,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 4244,
+shaderLocation: 9,
+}, {
+format: 'snorm8x4',
+offset: 3716,
+shaderLocation: 18,
+}, {
+format: 'float32x2',
+offset: 4400,
+shaderLocation: 6,
+}, {
+format: 'snorm8x2',
+offset: 2998,
+shaderLocation: 1,
+}, {
+format: 'float32x3',
+offset: 2552,
+shaderLocation: 10,
+}, {
+format: 'unorm8x4',
+offset: 4816,
+shaderLocation: 11,
+}, {
+format: 'sint32',
+offset: 3892,
+shaderLocation: 15,
+}, {
+format: 'uint8x4',
+offset: 4896,
+shaderLocation: 7,
+}, {
+format: 'snorm16x2',
+offset: 196,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 1736,
+shaderLocation: 17,
+}, {
+format: 'snorm8x4',
+offset: 2032,
+shaderLocation: 4,
+}, {
+format: 'sint16x4',
+offset: 28,
+shaderLocation: 19,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 13548,
+shaderLocation: 13,
+}, {
+format: 'unorm10-10-10-2',
+offset: 9496,
+shaderLocation: 2,
+}, {
+format: 'sint8x4',
+offset: 11972,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 2484,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32',
+offset: 1004,
+shaderLocation: 14,
+}, {
+format: 'sint32x2',
+offset: 588,
+shaderLocation: 16,
+}, {
+format: 'unorm8x2',
+offset: 550,
+shaderLocation: 0,
+}, {
+format: 'uint16x4',
+offset: 108,
+shaderLocation: 5,
+}, {
+format: 'snorm8x4',
+offset: 1376,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let querySet16 = device1.createQuerySet({
+label: '\ua291\u9cb4\u02b0\u3c6d\u01b4\u{1f80d}\u2d9f\u8caa\u0542\ue9f9\u1be1',
+type: 'occlusion',
+count: 935,
+});
+canvas0.width = 678;
+let commandEncoder22 = device0.createCommandEncoder({label: '\u0f7f\u{1fd07}\u{1fc43}\ueb7f\ud009\u4756\u{1fd3b}\u0bc5'});
+let querySet17 = device0.createQuerySet({
+label: '\u{1f874}\ub1f4\u925f\u{1fe7d}\ube1e\uc561\ub143\u399e',
+type: 'occlusion',
+count: 3814,
+});
+try {
+commandEncoder13.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 0,
+  origin: { x: 139, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 10580 widthInBlocks: 2645 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 56932 */
+offset: 56932,
+bytesPerRow: 10752,
+buffer: buffer3,
+}, {width: 2645, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline9 = await promise3;
+let renderBundle19 = renderBundleEncoder10.finish({});
+try {
+renderBundleEncoder1.setVertexBuffer(3, buffer4, 24916, 497);
+} catch {}
+try {
+commandEncoder10.resolveQuerySet(querySet3, 173, 15, buffer2, 15104);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: { x: 2117, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer3), /* required buffer size: 15225 */
+{offset: 557, bytesPerRow: 14719}, {width: 3667, height: 1, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(canvas0);
+let texture22 = device0.createTexture({
+label: '\u1224\u716d\u{1ff7e}\ueb84\u{1f7f4}\u{1fe79}\ucf5d\u39a7',
+size: {width: 720, height: 120, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-8x6-unorm'],
+});
+try {
+commandEncoder14.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 90 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 37696 */
+offset: 37696,
+bytesPerRow: 0,
+rowsPerImage: 226,
+buffer: buffer3,
+}, {width: 0, height: 5, depthOrArrayLayers: 29});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let commandBuffer0 = commandEncoder8.finish({
+label: '\ua99f\u0763\u0e1c\ubb92\u0a39',
+});
+let renderBundle20 = renderBundleEncoder0.finish({label: '\u{1f65a}\u191c\u4ca3\u2d0b\u{1f901}\ufcb6\u{1f997}\u0b5d\u092e\u{1f737}\u{1fc92}'});
+let promise4 = device0.popErrorScope();
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 34, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 145, y: 2, z: 1 },
+  aspect: 'all',
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 152, y: 0, z: 94 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 44962689 */
+{offset: 723, bytesPerRow: 3837, rowsPerImage: 217}, {width: 904, height: 0, depthOrArrayLayers: 55});
+} catch {}
+let textureView20 = texture8.createView({
+  label: '\u1466\u{1f67b}\ufd85\u0168\uaded\ubf74\u{1f609}',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 95
+});
+try {
+commandEncoder10.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let pipeline10 = await device0.createComputePipelineAsync({
+label: '\uca17\u09fd\u0112\u0f30\u5578\u8872\ua9cd\u86cc\u{1fed2}\u06e8',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let sampler10 = device1.createSampler({
+label: '\u6588\u8e37\u{1f6dc}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+maxAnisotropy: 1,
+});
+let externalTexture0 = device1.importExternalTexture({
+label: '\u6a97\u2bef\u179b\uf4e5\uc954\ua5dc\u0f5d\u9517\u878f\u7fda\u{1f9ad}',
+source: videoFrame3,
+colorSpace: 'srgb',
+});
+try {
+buffer7.unmap();
+} catch {}
+let imageBitmap3 = await createImageBitmap(img1);
+let textureView21 = texture17.createView({
+  label: '\u736e\u022d\ua680\u3ad6\u0682\u0ea5\u2656',
+  baseMipLevel: 2,
+  baseArrayLayer: 211,
+  arrayLayerCount: 8
+});
+let arrayBuffer4 = buffer8.getMappedRange(0, 1036);
+let adapter2 = await navigator.gpu.requestAdapter({
+powerPreference: 'high-performance',
+});
+let img2 = await imageWithData(255, 293, '#12f693d2', '#b25972c8');
+let textureView22 = texture17.createView({
+  label: '\udc0b\uda64\ub229\ua63d\u7977\u40f9',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 164
+});
+let renderBundle21 = renderBundleEncoder9.finish({label: '\ufd3b\u0f86\u364c\uf464\u31f5\ue156\u0664'});
+let arrayBuffer5 = buffer8.getMappedRange(1656, 116);
+let sampler11 = device1.createSampler({
+label: '\ub07f\u0d54',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 37.319,
+lodMaxClamp: 48.763,
+});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+pseudoSubmit(device0, commandEncoder13);
+let renderBundle22 = renderBundleEncoder6.finish({});
+let pipeline11 = device0.createRenderPipeline({
+label: '\u0842\ude3a\u0843\u0718\u8ecd',
+layout: pipelineLayout2,
+fragment: {module: shaderModule0, entryPoint: 'fragment0', targets: [{format: 'rgba16sint'}]},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'keep',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 2332,
+stencilWriteMask: 3425,
+depthBias: 2,
+depthBiasSlopeScale: 35,
+depthBiasClamp: 42,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 6256,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x3',
+offset: 2492,
+shaderLocation: 14,
+}, {
+format: 'float32x4',
+offset: 3596,
+shaderLocation: 1,
+}, {
+format: 'uint8x2',
+offset: 6068,
+shaderLocation: 17,
+}, {
+format: 'sint8x2',
+offset: 5980,
+shaderLocation: 15,
+}, {
+format: 'unorm8x4',
+offset: 3532,
+shaderLocation: 11,
+}, {
+format: 'unorm16x2',
+offset: 6168,
+shaderLocation: 2,
+}, {
+format: 'unorm16x2',
+offset: 952,
+shaderLocation: 3,
+}, {
+format: 'float32x2',
+offset: 5768,
+shaderLocation: 0,
+}, {
+format: 'sint32x3',
+offset: 4616,
+shaderLocation: 16,
+}, {
+format: 'uint8x4',
+offset: 6116,
+shaderLocation: 13,
+}, {
+format: 'float32x3',
+offset: 5508,
+shaderLocation: 9,
+}, {
+format: 'uint8x2',
+offset: 3050,
+shaderLocation: 5,
+}, {
+format: 'unorm16x2',
+offset: 6076,
+shaderLocation: 4,
+}, {
+format: 'snorm16x4',
+offset: 3888,
+shaderLocation: 6,
+}, {
+format: 'float32x3',
+offset: 4072,
+shaderLocation: 18,
+}, {
+format: 'sint32x4',
+offset: 1516,
+shaderLocation: 8,
+}, {
+format: 'sint32',
+offset: 5948,
+shaderLocation: 19,
+}, {
+format: 'snorm16x4',
+offset: 5384,
+shaderLocation: 10,
+}, {
+format: 'uint8x2',
+offset: 3072,
+shaderLocation: 7,
+}, {
+format: 'snorm8x2',
+offset: 5930,
+shaderLocation: 12,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let bindGroupLayout2 = device1.createBindGroupLayout({
+label: '\u4f66\u75df\u0d79\u0cfe\ubfae\u71a6\ufa7f\u302f\u{1f8d8}',
+entries: [{
+binding: 704,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}, {
+binding: 1300,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+}],
+});
+let texture23 = device1.createTexture({
+size: [96, 4, 1],
+mipLevelCount: 7,
+format: 'eac-rg11unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['eac-rg11unorm', 'eac-rg11unorm'],
+});
+let textureView23 = texture23.createView({label: '\u0c6c\u{1f7a5}\ubb7a\u74a9\uc751\u06b4\u05cf\u{1fe16}', baseMipLevel: 0, mipLevelCount: 4});
+let sampler12 = device1.createSampler({
+label: '\u058d\u0f63\u527b\u7db8\u4c96\ubd84\ue339',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 95.585,
+maxAnisotropy: 14,
+});
+try {
+window.someLabel = querySet11.label;
+} catch {}
+let commandEncoder23 = device0.createCommandEncoder({label: '\u6efc\u0e75\u{1ff7a}\u0448\u{1fc07}\u0613\ucb5d\u{1fb98}\u01ca\ua621\u0895'});
+let texture24 = device0.createTexture({
+label: '\u04c6\u03cb\u3b5e\u4310\u3905\ub718',
+size: [1440, 240, 1],
+mipLevelCount: 6,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x12-unorm', 'astc-12x12-unorm', 'astc-12x12-unorm'],
+});
+let renderBundle23 = renderBundleEncoder1.finish({label: '\u38e5\u{1f79b}\ufb6c\u{1f9c4}\u8061\u0a01\u018d\u0970\u{1fc1c}\u{1fad7}'});
+gc();
+try {
+renderBundleEncoder12.setVertexBuffer(1, buffer4, 15940, 488);
+} catch {}
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: { x: 72, y: 1, z: 17 },
+  aspect: 'all',
+}, {
+  texture: texture7,
+  mipLevel: 4,
+  origin: { x: 161, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 101, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'astc-6x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-4x4-unorm', 'astc-6x5-unorm', 'r16sint'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 46112, new Int16Array(10746), 1753, 5208);
+} catch {}
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  label: '\u{1f99d}\u03ac\u0071\u{1fdf4}\u049c\u{1f9e2}\u1c5b\u1590\u{1f6e7}\u{1fafe}',
+  colorFormats: ['r8sint', 'rg16float', 'rgba16float'],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+try {
+commandEncoder11.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let pipeline12 = await device0.createRenderPipelineAsync({
+label: '\u4d2e\u{1fda1}\u6f2c\u{1f65e}\u0b4c',
+layout: 'auto',
+multisample: {
+mask: 0x9303a3e9,
+},
+fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rgba16sint'}]},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'keep',
+passOp: 'replace',
+},
+stencilReadMask: 1750,
+depthBiasSlopeScale: 48,
+depthBiasClamp: 57,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1596,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 1336,
+shaderLocation: 5,
+}, {
+format: 'uint32',
+offset: 48,
+shaderLocation: 13,
+}, {
+format: 'uint8x4',
+offset: 240,
+shaderLocation: 17,
+}, {
+format: 'unorm10-10-10-2',
+offset: 312,
+shaderLocation: 12,
+}, {
+format: 'uint16x4',
+offset: 1252,
+shaderLocation: 7,
+}, {
+format: 'float16x2',
+offset: 1524,
+shaderLocation: 4,
+}, {
+format: 'unorm16x4',
+offset: 1416,
+shaderLocation: 2,
+}, {
+format: 'float32x4',
+offset: 1328,
+shaderLocation: 10,
+}, {
+format: 'uint8x4',
+offset: 152,
+shaderLocation: 14,
+}, {
+format: 'sint16x4',
+offset: 1376,
+shaderLocation: 15,
+}, {
+format: 'sint32',
+offset: 1256,
+shaderLocation: 19,
+}, {
+format: 'sint32x4',
+offset: 592,
+shaderLocation: 8,
+}, {
+format: 'sint16x4',
+offset: 980,
+shaderLocation: 16,
+}, {
+format: 'unorm8x4',
+offset: 1012,
+shaderLocation: 3,
+}, {
+format: 'snorm16x2',
+offset: 1012,
+shaderLocation: 11,
+}, {
+format: 'snorm8x4',
+offset: 24,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 6532,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 3436,
+shaderLocation: 0,
+}, {
+format: 'snorm8x4',
+offset: 2124,
+shaderLocation: 9,
+}, {
+format: 'snorm8x4',
+offset: 5604,
+shaderLocation: 18,
+}, {
+format: 'float16x2',
+offset: 212,
+shaderLocation: 1,
+}],
+}
+]
+},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let img3 = await imageWithData(11, 70, '#d0ba2374', '#1e86ba42');
+let commandEncoder24 = device1.createCommandEncoder();
+let texture25 = device1.createTexture({
+label: '\u7223\ube5e\ua49a\u0bf9\ufd99\u01c8\u704a\uf321\u{1f702}\u02bb\u430e',
+size: [7664, 192, 1],
+mipLevelCount: 3,
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView24 = texture19.createView({label: '\u{1f8ec}\u{1f74b}\u9853\u7bb8\uce12\u069d\ue10c\u9cd8\u0683\u137d\u09db'});
+let videoFrame4 = new VideoFrame(videoFrame1, {timestamp: 0});
+pseudoSubmit(device0, commandEncoder9);
+try {
+commandEncoder21.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 1,
+  origin: { x: 530, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 520, y: 4, z: 0 },
+  aspect: 'all',
+}, {width: 505, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder23.resolveQuerySet(querySet0, 75, 640, buffer2, 1536);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 50432, new Float32Array(58569), 32493, 668);
+} catch {}
+let pipeline13 = await device0.createComputePipelineAsync({
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+});
+let pipeline14 = device0.createRenderPipeline({
+label: '\u0422\u0a1d\uf247\ud447\u0e28\u91f8',
+layout: pipelineLayout0,
+fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rgba16sint'}]},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater',
+depthFailOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2452,
+stencilWriteMask: 1484,
+depthBiasSlopeScale: 13,
+depthBiasClamp: 93,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 11996,
+shaderLocation: 11,
+}, {
+format: 'snorm8x2',
+offset: 7526,
+shaderLocation: 6,
+}, {
+format: 'uint32',
+offset: 8828,
+shaderLocation: 7,
+}, {
+format: 'float32x3',
+offset: 5628,
+shaderLocation: 18,
+}],
+},
+{
+arrayStride: 11868,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x4',
+offset: 500,
+shaderLocation: 15,
+}, {
+format: 'snorm8x2',
+offset: 3506,
+shaderLocation: 9,
+}, {
+format: 'sint32x2',
+offset: 5572,
+shaderLocation: 8,
+}, {
+format: 'uint8x4',
+offset: 3308,
+shaderLocation: 17,
+}, {
+format: 'uint8x4',
+offset: 10908,
+shaderLocation: 14,
+}, {
+format: 'unorm16x4',
+offset: 8040,
+shaderLocation: 2,
+}, {
+format: 'float16x2',
+offset: 1704,
+shaderLocation: 0,
+}, {
+format: 'uint32x3',
+offset: 1760,
+shaderLocation: 5,
+}, {
+format: 'float16x2',
+offset: 10396,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 5700,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x2',
+offset: 4576,
+shaderLocation: 16,
+}, {
+format: 'uint32x2',
+offset: 4144,
+shaderLocation: 13,
+}, {
+format: 'sint16x4',
+offset: 1760,
+shaderLocation: 19,
+}, {
+format: 'float32x2',
+offset: 3860,
+shaderLocation: 12,
+}, {
+format: 'float16x4',
+offset: 2348,
+shaderLocation: 1,
+}, {
+format: 'float32',
+offset: 3408,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 7984,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x2',
+offset: 56,
+shaderLocation: 10,
+}],
+}
+]
+},
+});
+let videoFrame5 = new VideoFrame(canvas0, {timestamp: 0});
+let buffer9 = device0.createBuffer({label: '\ua383\ud302\u839c\u82f9', size: 6632, usage: GPUBufferUsage.MAP_READ});
+let arrayBuffer6 = buffer6.getMappedRange();
+let promise5 = device0.queue.onSubmittedWorkDone();
+gc();
+let canvas2 = document.createElement('canvas');
+let bindGroupLayout3 = device0.createBindGroupLayout({
+label: '\ucf15\u{1fccf}\u032d\u757b\u7e9c\u77cf\u{1fbe6}\u4b28\ub027',
+entries: [{
+binding: 5542,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+let commandEncoder25 = device0.createCommandEncoder();
+let texture26 = device0.createTexture({
+label: '\u{1f8d1}\u02bc\u058f\u{1f68a}\ubef8',
+size: [144, 3, 7],
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let pipeline15 = await device0.createComputePipelineAsync({
+label: '\u60ef\u26e5\ufadf\u9445\uf41e\ub569',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+});
+let gpuCanvasContext2 = canvas2.getContext('webgpu');
+let imageBitmap4 = await createImageBitmap(imageData0);
+let texture27 = device1.createTexture({
+label: '\uc8fb\u091b\u2d11\ub2c3\u2196\u{1f8d8}\u035c\u6dd3\u21ba\ua039',
+size: {width: 2800, height: 6, depthOrArrayLayers: 177},
+mipLevelCount: 11,
+format: 'astc-10x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x6-unorm-srgb', 'astc-10x6-unorm-srgb'],
+});
+let computePassEncoder10 = commandEncoder24.beginComputePass();
+let renderBundleEncoder14 = device1.createRenderBundleEncoder({
+  label: '\u1b2d\uf7b7\uee9b\u{1f6f2}\u0b76',
+  colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint']
+});
+let renderBundle24 = renderBundleEncoder14.finish({label: '\u06bd\u{1f9a5}\u6fc3\ud90f\ufca0\ue555'});
+try {
+  await promise4;
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(696, 148);
+let pipelineLayout3 = device1.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout2, bindGroupLayout2, bindGroupLayout2, bindGroupLayout2, bindGroupLayout2]
+});
+let texture28 = device1.createTexture({
+label: '\ub23d\u949f\udddf\u{1fbf2}\u80ca\u865e\u6e23',
+size: [48, 2, 1],
+dimension: '3d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let sampler13 = device1.createSampler({
+label: '\u00c5\ue0c3\u3a27\u0055\ub289\u1f61\u{1fa6a}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 78.511,
+lodMaxClamp: 93.644,
+});
+let externalTexture1 = device1.importExternalTexture({
+source: videoFrame5,
+colorSpace: 'display-p3',
+});
+try {
+gpuCanvasContext1.configure({
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 7, y: 129 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 12, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 30, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder({label: '\u{1f8a2}\uc341\u40d2\uacef\u021d\u{1fadc}\uda4f\ud70e\uec7e\u77b5\ue42f'});
+let textureView25 = texture5.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 1});
+let computePassEncoder11 = commandEncoder23.beginComputePass({label: '\u4871\u{1fdbc}\u9fc3\uf80b'});
+let renderBundle25 = renderBundleEncoder11.finish();
+try {
+renderBundleEncoder8.setVertexBuffer(7, buffer4);
+} catch {}
+try {
+buffer6.destroy();
+} catch {}
+try {
+commandEncoder26.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 1,
+  origin: { x: 70, y: 10, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 35488 */
+offset: 35488,
+buffer: buffer3,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer0,
+]);
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+let renderBundle26 = renderBundleEncoder9.finish({label: '\u132d\u2e70\u0dfc\u67d6\u{1f670}\u3633\u{1f659}\u2504\u93a0'});
+try {
+buffer7.unmap();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 17, y: 1, z: 0 },
+  aspect: 'all',
+}, new DataView(arrayBuffer4), /* required buffer size: 176 */
+{offset: 96}, {width: 20, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext3 = offscreenCanvas3.getContext('webgpu');
+gc();
+let bindGroupLayout4 = device0.createBindGroupLayout({
+label: '\u0e09\ua783\u8874\uccca\u{1f703}\u09a9\u40e3\u{1f9ee}\u05ad\u127e\u8210',
+entries: [{
+binding: 1816,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 5759,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+}],
+});
+let commandBuffer1 = commandEncoder17.finish({
+label: '\u{1f854}\u0c17\u{1fe97}\u3c10\u{1f630}\u41b6\ud4a9\ucc49\u099c',
+});
+let texture29 = device0.createTexture({
+label: '\uaba9\ud3a1\u{1fde2}\u0de1\u03a9\u02a6\u{1ff64}\u0e94\u{1fe54}\u{1fe1a}',
+size: {width: 735, height: 15, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r32sint', 'r32sint', 'r32sint'],
+});
+let textureView26 = texture23.createView({
+  label: '\u509b\u{1fd24}\u04c8\u{1f88b}\u1d51\u50e9',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  mipLevelCount: 1
+});
+let renderBundle27 = renderBundleEncoder9.finish({});
+try {
+gpuCanvasContext3.configure({
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb'],
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas2,
+  origin: { x: 157, y: 47 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 37, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule1 = device1.createShaderModule({
+label: '\u86f2\u5f9c\ue2f9\u297a\ud61d\ucb0a\u43d9\u5785\ufb10',
+code: `@group(1) @binding(704)
+var<storage, read_write> function0: array<u32>;
+@group(2) @binding(704)
+var<storage, read_write> type0: array<u32>;
+@group(3) @binding(1300)
+var<storage, read_write> i0: array<u32>;
+@group(3) @binding(704)
+var<storage, read_write> parameter1: array<u32>;
+@group(4) @binding(704)
+var<storage, read_write> local0: array<u32>;
+@group(0) @binding(1300)
+var<storage, read_write> i1: array<u32>;
+@group(4) @binding(1300)
+var<storage, read_write> type1: array<u32>;
+
+@compute @workgroup_size(4, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(5) f0: vec4<i32>,
+  @location(6) f1: vec3<f32>,
+  @location(3) f2: vec2<f32>,
+  @location(1) f3: vec4<u32>,
+  @builtin(frag_depth) f4: f32,
+  @location(4) f5: vec3<u32>,
+  @location(0) f6: vec3<f32>,
+  @location(2) f7: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S1 {
+  @location(8) f0: vec3<f32>,
+  @location(15) f1: vec3<i32>,
+  @location(25) f2: vec4<i32>,
+  @location(24) f3: vec2<u32>,
+  @location(2) f4: vec2<f16>,
+  @location(5) f5: vec4<i32>,
+  @location(21) f6: f16,
+  @location(20) f7: vec2<f32>,
+  @location(4) f8: f32,
+  @location(17) f9: vec4<u32>,
+  @location(7) f10: f32,
+  @builtin(vertex_index) f11: u32,
+  @location(12) f12: vec2<u32>,
+  @location(22) f13: u32,
+  @location(14) f14: vec2<u32>,
+  @location(26) f15: vec4<u32>,
+  @builtin(instance_index) f16: u32,
+  @location(1) f17: vec3<f16>,
+  @location(0) f18: f16
+}
+
+@vertex
+fn vertex0(@location(16) a0: vec4<i32>, @location(10) a1: vec2<u32>, @location(6) a2: vec2<f32>, @location(13) a3: vec4<i32>, a4: S1) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+pseudoSubmit(device1, commandEncoder24);
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 1,
+  origin: { x: 330, y: 0, z: 129 },
+  aspect: 'all',
+}, new ArrayBuffer(246), /* required buffer size: 246 */
+{offset: 246, bytesPerRow: 1288}, {width: 720, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 106 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 39, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline16 = device1.createRenderPipeline({
+label: '\ue7f6\u{1f85d}\u3bd5\u{1f767}\u03c2',
+layout: pipelineLayout3,
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'r32uint'}, {format: 'rg8sint'}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r32sint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'replace',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'always',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'zero',
+},
+stencilReadMask: 1598,
+stencilWriteMask: 860,
+depthBias: 22,
+depthBiasSlopeScale: 6,
+depthBiasClamp: 39,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 6148,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x2',
+offset: 1954,
+shaderLocation: 15,
+}, {
+format: 'uint16x2',
+offset: 2708,
+shaderLocation: 26,
+}, {
+format: 'uint32x4',
+offset: 1608,
+shaderLocation: 14,
+}, {
+format: 'unorm8x2',
+offset: 2600,
+shaderLocation: 21,
+}, {
+format: 'unorm16x4',
+offset: 3288,
+shaderLocation: 0,
+}, {
+format: 'uint32x3',
+offset: 2224,
+shaderLocation: 12,
+}, {
+format: 'sint8x2',
+offset: 5718,
+shaderLocation: 16,
+}, {
+format: 'sint32x3',
+offset: 4728,
+shaderLocation: 5,
+}, {
+format: 'snorm8x2',
+offset: 246,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 21560,
+attributes: [{
+format: 'snorm16x4',
+offset: 6928,
+shaderLocation: 2,
+}, {
+format: 'sint8x2',
+offset: 2734,
+shaderLocation: 25,
+}, {
+format: 'unorm16x4',
+offset: 16872,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x2',
+offset: 30930,
+shaderLocation: 8,
+}, {
+format: 'float32',
+offset: 24468,
+shaderLocation: 1,
+}, {
+format: 'uint32x4',
+offset: 3320,
+shaderLocation: 22,
+}, {
+format: 'snorm16x4',
+offset: 31376,
+shaderLocation: 20,
+}, {
+format: 'uint32',
+offset: 22920,
+shaderLocation: 24,
+}, {
+format: 'uint16x2',
+offset: 31328,
+shaderLocation: 10,
+}, {
+format: 'uint32x4',
+offset: 29784,
+shaderLocation: 17,
+}, {
+format: 'float16x2',
+offset: 30136,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 4440,
+attributes: [],
+},
+{
+arrayStride: 8412,
+attributes: [],
+},
+{
+arrayStride: 14876,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 25056,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x2',
+offset: 24832,
+shaderLocation: 13,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let imageBitmap5 = await createImageBitmap(offscreenCanvas0);
+let bindGroupLayout5 = pipeline16.getBindGroupLayout(0);
+let sampler14 = device1.createSampler({
+label: '\u8cc3\u1def\u00cd\u3b92\u4c47',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 87.160,
+compare: 'equal',
+maxAnisotropy: 1,
+});
+let videoFrame6 = new VideoFrame(imageBitmap2, {timestamp: 0});
+let buffer10 = device0.createBuffer({
+  label: '\u{1f6fc}\ud1ee',
+  size: 1191,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: false
+});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({
+  label: '\u19fd\u036b\ucca2\u09b6\u4831\u5b5e\u0875\u0f74\u{1f77c}\u{1f818}\u0c42',
+  colorFormats: ['rg8sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 50, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 15, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 21, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 1,
+  origin: { x: 200, y: 30, z: 12 },
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer2), /* required buffer size: 7054 */
+{offset: 477, bytesPerRow: 823}, {width: 510, height: 80, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline17 = await device0.createComputePipelineAsync({
+label: '\ufa75\u80b2\u15c7\u04eb\u5e21\u06fb',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+});
+try {
+  await promise5;
+} catch {}
+let texture30 = device1.createTexture({
+label: '\u0927\u00dd\u0f92\ue9ca\u88b4\u{1f8f1}\u09e0\ucc3e\u8be6\u{1f63f}',
+size: {width: 220, height: 42, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'astc-10x6-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x6-unorm', 'astc-10x6-unorm', 'astc-10x6-unorm-srgb'],
+});
+let textureView27 = texture28.createView({label: '\u{1f65e}\ueb09\u04e3\ufc0c\uf744\u0855\u151f\u35c5\u{1fff1}\u0742'});
+try {
+buffer8.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-6x6-unorm-srgb', 'rg16uint', 'rg11b10ufloat'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let texture31 = device0.createTexture({
+label: '\u8a4c\u0467\u{1f743}\u0a98\u54b1\u04e7\u0678',
+size: {width: 576, height: 12, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  label: '\u01ed\u4a9b\u{1fca0}\u{1f622}',
+  colorFormats: ['rgba8unorm-srgb', 'rg8uint', 'r32sint', undefined, 'rg8uint', 'rgba8uint', 'rg11b10ufloat', 'r32sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 1,
+  depthReadOnly: false
+});
+try {
+computePassEncoder1.setPipeline(pipeline15);
+} catch {}
+try {
+commandEncoder10.resolveQuerySet(querySet0, 862, 2821, buffer2, 5888);
+} catch {}
+try {
+  await promise6;
+} catch {}
+let video3 = await videoWithData();
+let bindGroupLayout6 = pipeline16.getBindGroupLayout(3);
+pseudoSubmit(device1, commandEncoder20);
+let sampler15 = device1.createSampler({
+label: '\u32c2\u483a\uf105\u62fc\u{1fc78}\u064c\u1bd9\uae76\u0da0',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 25.414,
+lodMaxClamp: 54.941,
+});
+let offscreenCanvas4 = new OffscreenCanvas(639, 892);
+let imageData8 = new ImageData(128, 156);
+let bindGroupLayout7 = pipeline9.getBindGroupLayout(2);
+let querySet18 = device0.createQuerySet({
+label: '\ud99c\u940c\u0b85\u46d3\u{1fb85}\u03f8\u0d64\uba31\u02dc\u025d',
+type: 'occlusion',
+count: 809,
+});
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder14.clearBuffer(buffer3, 27716, 24528);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let texture32 = device1.createTexture({
+label: '\u{1f6f6}\u{1fe19}\u0ea5',
+size: [48, 1, 26],
+mipLevelCount: 6,
+format: 'rg8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle28 = renderBundleEncoder9.finish({label: '\u94be\u0813\u{1fdec}'});
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer8, 5784, new DataView(new ArrayBuffer(49733)), 7350, 5484);
+} catch {}
+let gpuCanvasContext4 = offscreenCanvas4.getContext('webgpu');
+let commandBuffer2 = commandEncoder14.finish({
+label: '\u0299\u949c\uf91a\u05d2\u0d9d\ucff3\u8ba8\u0d55\ub91f\ufad2',
+});
+try {
+commandEncoder16.insertDebugMarker('\u589c');
+} catch {}
+let device2 = await adapter2.requestDevice({
+label: '\u0c7c\uf39e\u0515\u138b\u{1f707}\ub965\u{1fc32}',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 48,
+maxVertexBufferArrayStride: 47628,
+maxStorageTexturesPerShaderStage: 34,
+maxStorageBuffersPerShaderStage: 36,
+maxDynamicStorageBuffersPerPipelineLayout: 1946,
+maxBindingsPerBindGroup: 3079,
+maxTextureDimension1D: 12729,
+maxTextureDimension2D: 15478,
+maxVertexBuffers: 10,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 233911788,
+maxUniformBuffersPerShaderStage: 23,
+maxInterStageShaderVariables: 99,
+maxInterStageShaderComponents: 91,
+maxSamplersPerShaderStage: 19,
+},
+});
+let imageBitmap6 = await createImageBitmap(videoFrame6);
+let commandEncoder27 = device2.createCommandEncoder({label: '\uc433\u0abb\u785f\uf1e1\u0eff\u{1ffb4}\u12fa\u{1f612}'});
+let texture33 = device2.createTexture({
+label: '\u{1fde4}\u4a6a\uedc9\u{1f6b7}\udadc\uc0ec\u2fdf\ub28f\u007f\u06f4\u{1fb4e}',
+size: {width: 9776, height: 25, depthOrArrayLayers: 210},
+mipLevelCount: 5,
+dimension: '2d',
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x5-unorm-srgb', 'astc-8x5-unorm-srgb', 'astc-8x5-unorm'],
+});
+let textureView28 = texture33.createView({
+  label: '\u2a7a\u0043\ua34a\u000c\u6c43\u4f7b\u091a\u866e\u045b\uc4ca',
+  format: 'astc-8x5-unorm-srgb',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 21,
+  arrayLayerCount: 145
+});
+let imageBitmap7 = await createImageBitmap(imageData0);
+let imageData9 = new ImageData(112, 20);
+let commandEncoder28 = device0.createCommandEncoder({label: '\u4457\ub59e'});
+let textureView29 = texture0.createView({
+  label: '\u{1f7fd}\uc907\ua7c7\ude47\u0b1a\u45a6\ua1ff\u0b54\ub360\uafb0',
+  format: 'astc-5x5-unorm-srgb',
+  baseMipLevel: 6,
+  mipLevelCount: 3,
+  baseArrayLayer: 120,
+  arrayLayerCount: 66
+});
+let computePassEncoder12 = commandEncoder10.beginComputePass({});
+try {
+computePassEncoder5.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder28.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 7, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 155 widthInBlocks: 155 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 43619 */
+offset: 43208,
+bytesPerRow: 256,
+buffer: buffer3,
+}, {width: 155, height: 2, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+renderBundleEncoder15.insertDebugMarker('\u02f7');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 864, new DataView(new ArrayBuffer(46003)), 41500, 2768);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 1,
+  origin: { x: 228, y: 48, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 200 */
+{offset: 200, bytesPerRow: 153}, {width: 0, height: 60, depthOrArrayLayers: 0});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(224, 64);
+let video4 = await videoWithData();
+let commandEncoder29 = device2.createCommandEncoder({label: '\u4f25\u07a2\ua619\u0b56\u8015\uec37\u09a9\u{1f76a}'});
+try {
+commandEncoder27.insertDebugMarker('\u06c3');
+} catch {}
+try {
+commandEncoder28.resolveQuerySet(querySet18, 466, 272, buffer2, 3840);
+} catch {}
+try {
+computePassEncoder1.insertDebugMarker('\u{1f8c8}');
+} catch {}
+let pipeline18 = device0.createComputePipeline({
+label: '\u0988\ufaf0\ua635\uffe5\u2d0d\u06cc',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline19 = await device0.createRenderPipelineAsync({
+label: '\u{1ff22}\u{1f898}\u04af\u{1fe93}\u9d30\u{1faa0}\u2dad\u17c1\u4867\u{1f63d}\u83d7',
+layout: pipelineLayout0,
+fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rgba16sint'}]},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less-equal',
+depthFailOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 3292,
+stencilWriteMask: 2067,
+depthBias: 94,
+depthBiasSlopeScale: 11,
+depthBiasClamp: 44,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 6288,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 2212,
+shaderLocation: 19,
+}, {
+format: 'float32',
+offset: 2676,
+shaderLocation: 2,
+}, {
+format: 'unorm8x4',
+offset: 1576,
+shaderLocation: 1,
+}, {
+format: 'float32x3',
+offset: 220,
+shaderLocation: 9,
+}, {
+format: 'sint16x2',
+offset: 28,
+shaderLocation: 15,
+}, {
+format: 'float32x3',
+offset: 3108,
+shaderLocation: 10,
+}, {
+format: 'sint32x4',
+offset: 3576,
+shaderLocation: 16,
+}, {
+format: 'unorm16x2',
+offset: 3932,
+shaderLocation: 4,
+}, {
+format: 'sint16x4',
+offset: 280,
+shaderLocation: 8,
+}, {
+format: 'snorm16x2',
+offset: 6168,
+shaderLocation: 3,
+}, {
+format: 'uint8x2',
+offset: 2720,
+shaderLocation: 14,
+}, {
+format: 'uint32x3',
+offset: 4652,
+shaderLocation: 13,
+}, {
+format: 'float32x3',
+offset: 392,
+shaderLocation: 6,
+}, {
+format: 'unorm16x2',
+offset: 5584,
+shaderLocation: 0,
+}, {
+format: 'snorm8x2',
+offset: 4800,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 3156,
+shaderLocation: 5,
+}, {
+format: 'float32x2',
+offset: 3484,
+shaderLocation: 18,
+}, {
+format: 'uint8x4',
+offset: 744,
+shaderLocation: 7,
+}, {
+format: 'uint32x3',
+offset: 5916,
+shaderLocation: 17,
+}, {
+format: 'unorm10-10-10-2',
+offset: 544,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+cullMode: 'front',
+unclippedDepth: false,
+},
+});
+try {
+offscreenCanvas5.getContext('webgl2');
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder({label: '\u{1f743}\u{1f933}\ue518\u3303'});
+let querySet19 = device0.createQuerySet({
+label: '\u0993\u24cf\ud020\ub56b\u01b6\u1fec\u1306\u8856\udb84',
+type: 'occlusion',
+count: 407,
+});
+let texture34 = device0.createTexture({
+label: '\u4244\ua2c6\u04f6\u{1fb18}\u02b4\uf897\u0199\u0913',
+size: [56, 2, 87],
+mipLevelCount: 4,
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r16float', 'r16float'],
+});
+let sampler16 = device0.createSampler({
+label: '\u47b0\ub148\ub610\ubc06\u{1f9cb}\u0bfe\udb76\u9295\uf508\u0a53\u45b2',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 88.844,
+lodMaxClamp: 91.207,
+maxAnisotropy: 15,
+});
+try {
+computePassEncoder3.setPipeline(pipeline13);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 780, new Int16Array(27649), 25265, 60);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let img4 = await imageWithData(128, 54, '#8f8fddf9', '#4915edcb');
+let bindGroupLayout8 = device2.createBindGroupLayout({
+label: '\u8549\u643c\uf03c\u0cd1',
+entries: [{
+binding: 1847,
+visibility: 0,
+sampler: { type: 'filtering' },
+}, {
+binding: 958,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+try {
+  await buffer3.mapAsync(GPUMapMode.READ, 7272, 28800);
+} catch {}
+let buffer11 = device2.createBuffer({label: '\u23e2\u03bd\u4576\u095c\u02ca\u0428\udc3b\u0110', size: 50488, usage: GPUBufferUsage.INDEX});
+let texture35 = device2.createTexture({
+label: '\u9748\u0815\u8e81\u0573\u58dd',
+size: {width: 288, height: 48, depthOrArrayLayers: 237},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView30 = texture33.createView({format: 'astc-8x5-unorm-srgb', baseMipLevel: 3, baseArrayLayer: 192, arrayLayerCount: 9});
+let texture36 = device2.createTexture({
+size: {width: 160, height: 100, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'astc-10x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+});
+let bindGroupLayout9 = device2.createBindGroupLayout({
+label: '\u1848\u{1fdd5}',
+entries: [{
+binding: 1877,
+visibility: 0,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+}, {
+binding: 2892,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+}],
+});
+let commandEncoder31 = device2.createCommandEncoder();
+let texture37 = device2.createTexture({
+label: '\u0cf7\u0a0a\u2184',
+size: [3720, 210, 1],
+dimension: '2d',
+format: 'astc-10x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-10x6-unorm-srgb', 'astc-10x6-unorm'],
+});
+let textureView31 = texture35.createView({baseMipLevel: 2, arrayLayerCount: 1});
+document.body.prepend(canvas2);
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline20 = device1.createRenderPipeline({
+label: '\u0145\u{1f99e}\uc58e',
+layout: pipelineLayout3,
+multisample: {
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-constant'},
+alpha: {operation: 'subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'dst'},
+},
+  writeMask: 0
+}, {format: 'r32uint', writeMask: GPUColorWrite.RED}, {format: 'rg8sint'}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'one-minus-constant'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {format: 'r32uint', writeMask: 0}, {format: 'r32sint'}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'invert',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 1289,
+stencilWriteMask: 1060,
+depthBias: 69,
+depthBiasSlopeScale: 56,
+depthBiasClamp: 98,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+attributes: [{
+format: 'sint32',
+offset: 27776,
+shaderLocation: 15,
+}, {
+format: 'sint32x4',
+offset: 7272,
+shaderLocation: 13,
+}, {
+format: 'sint32x3',
+offset: 19680,
+shaderLocation: 16,
+}, {
+format: 'uint32x3',
+offset: 1476,
+shaderLocation: 24,
+}, {
+format: 'sint32x4',
+offset: 20452,
+shaderLocation: 25,
+}, {
+format: 'uint32x4',
+offset: 2652,
+shaderLocation: 17,
+}, {
+format: 'unorm16x2',
+offset: 15132,
+shaderLocation: 2,
+}, {
+format: 'snorm16x2',
+offset: 9968,
+shaderLocation: 1,
+}, {
+format: 'uint8x4',
+offset: 32284,
+shaderLocation: 22,
+}],
+},
+{
+arrayStride: 15040,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm16x2',
+offset: 11196,
+shaderLocation: 8,
+}, {
+format: 'uint32',
+offset: 664,
+shaderLocation: 14,
+}, {
+format: 'unorm16x4',
+offset: 13804,
+shaderLocation: 7,
+}, {
+format: 'uint32',
+offset: 1576,
+shaderLocation: 12,
+}, {
+format: 'snorm8x4',
+offset: 7428,
+shaderLocation: 6,
+}, {
+format: 'uint32x2',
+offset: 3204,
+shaderLocation: 10,
+}, {
+format: 'sint8x4',
+offset: 8120,
+shaderLocation: 5,
+}, {
+format: 'snorm8x4',
+offset: 2744,
+shaderLocation: 21,
+}, {
+format: 'uint32x4',
+offset: 5860,
+shaderLocation: 26,
+}, {
+format: 'unorm8x4',
+offset: 9332,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 29636,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 19782,
+shaderLocation: 20,
+}, {
+format: 'float32x2',
+offset: 3144,
+shaderLocation: 4,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let commandEncoder32 = device0.createCommandEncoder();
+try {
+commandEncoder25.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 10, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 48, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 35, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 1124, new DataView(new ArrayBuffer(61305)), 22959, 56);
+} catch {}
+let promise7 = device0.createComputePipelineAsync({
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipelineLayout4 = device2.createPipelineLayout({label: '\u{1ff03}\ua47a\u0509\u69d6\u06c0\u{1f784}\u{1fcdc}\u{1f737}\uecca', bindGroupLayouts: []});
+let querySet20 = device1.createQuerySet({
+type: 'occlusion',
+count: 1396,
+});
+let texture38 = device1.createTexture({
+size: [96, 1, 1],
+mipLevelCount: 4,
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba8unorm'],
+});
+try {
+commandEncoder15.copyTextureToBuffer({
+  texture: texture27,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 8 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 5424 */
+offset: 5424,
+bytesPerRow: 0,
+rowsPerImage: 94,
+buffer: buffer8,
+}, {width: 0, height: 0, depthOrArrayLayers: 166});
+dissociateBuffer(device1, buffer8);
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout({
+label: '\u45aa\u923b\u{1ffa4}\u02a4',
+entries: [{
+binding: 4290,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}, {
+binding: 5366,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+}, {
+binding: 6107,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}],
+});
+let commandBuffer3 = commandEncoder21.finish({
+label: '\u{1fca8}\u410f\u0554\u04a7\uec00\u522f\u0fe0\ua51c\u0de2\u38e8\u{1fbb3}',
+});
+let sampler17 = device0.createSampler({
+label: '\u09a6\u0db4\u184b\ud8ea\u{1f850}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+lodMinClamp: 53.051,
+lodMaxClamp: 53.062,
+compare: 'always',
+});
+let pipeline21 = device0.createRenderPipeline({
+label: '\ud587\u{1fa33}\ue21b\u0b93\u0f94\u0347\u05a0',
+layout: 'auto',
+multisample: {
+mask: 0x7a86ba35,
+},
+fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rgba16sint'}]},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 1149,
+stencilWriteMask: 3340,
+depthBias: 54,
+depthBiasSlopeScale: 41,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 14132,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 7992,
+shaderLocation: 3,
+}, {
+format: 'snorm8x2',
+offset: 2432,
+shaderLocation: 10,
+}, {
+format: 'sint8x4',
+offset: 9036,
+shaderLocation: 16,
+}, {
+format: 'uint32',
+offset: 2628,
+shaderLocation: 14,
+}, {
+format: 'snorm16x2',
+offset: 8132,
+shaderLocation: 11,
+}, {
+format: 'snorm8x2',
+offset: 11114,
+shaderLocation: 2,
+}, {
+format: 'float32x2',
+offset: 4504,
+shaderLocation: 12,
+}, {
+format: 'sint16x2',
+offset: 6988,
+shaderLocation: 8,
+}, {
+format: 'uint16x2',
+offset: 13268,
+shaderLocation: 7,
+}, {
+format: 'sint32x3',
+offset: 7272,
+shaderLocation: 19,
+}, {
+format: 'float32',
+offset: 10140,
+shaderLocation: 0,
+}, {
+format: 'uint32x3',
+offset: 9404,
+shaderLocation: 17,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x4',
+offset: 5572,
+shaderLocation: 15,
+}, {
+format: 'uint32x2',
+offset: 10636,
+shaderLocation: 13,
+}, {
+format: 'float16x2',
+offset: 8488,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 564,
+shaderLocation: 5,
+}, {
+format: 'snorm8x2',
+offset: 922,
+shaderLocation: 1,
+}, {
+format: 'unorm16x4',
+offset: 12352,
+shaderLocation: 6,
+}, {
+format: 'snorm8x2',
+offset: 8244,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 5656,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32',
+offset: 2836,
+shaderLocation: 18,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let buffer12 = device1.createBuffer({label: '\u6673\ue232\u0397\ud7e0\ue6e8', size: 1032, usage: GPUBufferUsage.INDEX, mappedAtCreation: true});
+let renderBundleEncoder17 = device1.createRenderBundleEncoder({
+  label: '\u0d0d\u0dbc',
+  colorFormats: ['r8unorm', 'r32uint', 'rg8sint', 'rg8unorm', 'r32uint', 'r32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1,
+  stencilReadOnly: false
+});
+let sampler18 = device1.createSampler({
+label: '\ucf3a\u08a4\u0909\u0b33\u{1fa6e}',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 12.677,
+maxAnisotropy: 9,
+});
+try {
+commandEncoder15.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 9,
+  origin: { x: 0, y: 0, z: 73 },
+  aspect: 'all',
+}, {
+  texture: texture27,
+  mipLevel: 1,
+  origin: { x: 1060, y: 6, z: 92 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 6});
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer8, 9392, 1476);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer8, 4420, new Int16Array(22555), 6517, 2172);
+} catch {}
+let pipeline22 = device1.createComputePipeline({
+label: '\u0de8\u66a0',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipelineLayout5 = device0.createPipelineLayout({
+  label: '\u08f7\ud609\u3a64\u0195\u971d\u{1f8cc}\u{1fa19}',
+  bindGroupLayouts: [bindGroupLayout4, bindGroupLayout7, bindGroupLayout1, bindGroupLayout0]
+});
+let buffer13 = device0.createBuffer({label: '\u2021\uaeab', size: 61068, usage: GPUBufferUsage.UNIFORM});
+let computePassEncoder13 = commandEncoder16.beginComputePass({label: '\u398a\u8316\u0798\u005d\u0136'});
+let externalTexture2 = device0.importExternalTexture({
+label: '\u{1ff1d}\ud820\u0c68\u{1fc2d}',
+source: video3,
+colorSpace: 'srgb',
+});
+try {
+commandEncoder32.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 2,
+  origin: { x: 90, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture16,
+  mipLevel: 6,
+  origin: { x: 5, y: 4, z: 1 },
+  aspect: 'all',
+}, {width: 35, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder30.resolveQuerySet(querySet18, 190, 97, buffer2, 2560);
+} catch {}
+video1.height = 294;
+let bindGroupLayout11 = device1.createBindGroupLayout({
+label: '\u5733\u28a2\u70f8\u2485\ud703\uffe9\u9152\u0833\u007c',
+entries: [{
+binding: 542,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+}],
+});
+let textureView32 = texture17.createView({dimension: '2d', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 60});
+let renderBundleEncoder18 = device1.createRenderBundleEncoder({
+  label: '\u0b50\u{1fb51}\u6435\u{1f7f5}\u{1fa5b}\u0804',
+  colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint'],
+  depthReadOnly: true
+});
+let renderBundle29 = renderBundleEncoder14.finish({label: '\u{1fa9f}\u01e1\u5131\u{1fda9}\u0e2e\u457f\u2913\u{1faa6}\u{1f826}\u5fc2'});
+let promise8 = buffer8.mapAsync(GPUMapMode.READ, 6664, 2504);
+try {
+computePassEncoder8.insertDebugMarker('\u04e8');
+} catch {}
+let commandEncoder33 = device1.createCommandEncoder();
+let textureView33 = texture25.createView({label: '\u8a84\ufb6d\u7996', format: 'astc-8x6-unorm', mipLevelCount: 2});
+let renderBundle30 = renderBundleEncoder18.finish();
+try {
+commandEncoder15.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 1,
+  origin: { x: 250, y: 0, z: 76 },
+  aspect: 'all',
+}, {
+  texture: texture27,
+  mipLevel: 6,
+  origin: { x: 10, y: 0, z: 12 },
+  aspect: 'all',
+}, {width: 10, height: 0, depthOrArrayLayers: 87});
+} catch {}
+let promise9 = device1.createRenderPipelineAsync({
+label: '\u7e26\u{1f716}\u069a\u{1fdc3}\u94c0\u0635\u0514\u0b18\ud2a5\u0f42',
+layout: pipelineLayout3,
+multisample: {
+mask: 0x7c90a4b5,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'src-alpha-saturated'},
+},
+  writeMask: 0
+}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'subtract', srcFactor: 'one', dstFactor: 'src-alpha'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less',
+failOp: 'keep',
+depthFailOp: 'decrement-wrap',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+},
+stencilReadMask: 1437,
+stencilWriteMask: 2003,
+depthBias: 37,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 19192,
+attributes: [{
+format: 'sint32x3',
+offset: 15348,
+shaderLocation: 15,
+}, {
+format: 'uint16x2',
+offset: 6160,
+shaderLocation: 24,
+}, {
+format: 'uint8x2',
+offset: 12252,
+shaderLocation: 10,
+}, {
+format: 'sint32x2',
+offset: 6420,
+shaderLocation: 25,
+}, {
+format: 'unorm16x2',
+offset: 7392,
+shaderLocation: 2,
+}, {
+format: 'sint16x4',
+offset: 10964,
+shaderLocation: 13,
+}, {
+format: 'float32x3',
+offset: 968,
+shaderLocation: 1,
+}, {
+format: 'float16x2',
+offset: 19068,
+shaderLocation: 8,
+}, {
+format: 'uint32',
+offset: 12556,
+shaderLocation: 26,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 14364,
+shaderLocation: 12,
+}, {
+format: 'snorm16x4',
+offset: 30240,
+shaderLocation: 4,
+}, {
+format: 'uint8x4',
+offset: 35144,
+shaderLocation: 14,
+}, {
+format: 'snorm8x2',
+offset: 7708,
+shaderLocation: 7,
+}, {
+format: 'unorm16x2',
+offset: 27148,
+shaderLocation: 21,
+}, {
+format: 'snorm8x4',
+offset: 9004,
+shaderLocation: 6,
+}, {
+format: 'sint8x2',
+offset: 22138,
+shaderLocation: 5,
+}, {
+format: 'uint8x4',
+offset: 22596,
+shaderLocation: 22,
+}, {
+format: 'sint32x3',
+offset: 336,
+shaderLocation: 16,
+}, {
+format: 'uint8x2',
+offset: 23656,
+shaderLocation: 17,
+}],
+},
+{
+arrayStride: 8476,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x2',
+offset: 7250,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 23088,
+attributes: [{
+format: 'float32x2',
+offset: 17548,
+shaderLocation: 20,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: false,
+},
+});
+let canvas3 = document.createElement('canvas');
+let offscreenCanvas6 = new OffscreenCanvas(300, 216);
+try {
+gpuCanvasContext0.configure({
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let buffer14 = device2.createBuffer({label: '\u{1f82a}\u{1f641}', size: 63543, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let querySet21 = device2.createQuerySet({
+label: '\ud463\u5cad\ud8f7\ub21d\u7a82',
+type: 'occlusion',
+count: 530,
+});
+let textureView34 = texture33.createView({dimension: '2d', baseMipLevel: 2, mipLevelCount: 2, baseArrayLayer: 41});
+let sampler19 = device2.createSampler({
+label: '\u6eda\ufc58\u27da\u8c49\u9069\u6086\u0871\u030f\u8c33\ufccc\ufc3a',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 71.163,
+});
+try {
+  await promise8;
+} catch {}
+let imageBitmap8 = await createImageBitmap(canvas1);
+let textureView35 = texture27.createView({
+  label: '\u6334\u{1f9d9}\u4293\u06b2',
+  dimension: '2d',
+  baseMipLevel: 4,
+  mipLevelCount: 3,
+  baseArrayLayer: 133,
+  arrayLayerCount: 1
+});
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas0,
+  origin: { x: 238, y: 91 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 25, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 13, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext5 = canvas3.getContext('webgpu');
+let canvas4 = document.createElement('canvas');
+let texture39 = device2.createTexture({
+label: '\u352c\u0d36\u{1ffe2}\u{1fe0f}\u2e61\u{1fae8}\u0e0c\u0462\u59f0',
+size: {width: 180, height: 10, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-12x10-unorm', 'astc-12x10-unorm-srgb', 'astc-12x10-unorm-srgb'],
+});
+try {
+commandEncoder31.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 1,
+  origin: { x: 63, y: 3, z: 70 },
+  aspect: 'all',
+}, {
+  texture: texture35,
+  mipLevel: 2,
+  origin: { x: 37, y: 5, z: 23 },
+  aspect: 'all',
+}, {width: 22, height: 4, depthOrArrayLayers: 23});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: { x: 1640, y: 150, z: 0 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 346 */
+{offset: 346}, {width: 2030, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let adapter3 = await navigator.gpu.requestAdapter({
+});
+let querySet22 = device1.createQuerySet({
+label: '\u0681\u63b4\u0aed\u{1faae}\ubdd9\u{1f88f}',
+type: 'occlusion',
+count: 2793,
+});
+let renderBundle31 = renderBundleEncoder9.finish();
+try {
+device1.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 1,
+  origin: { x: 28, y: 69, z: 187 },
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(56)), /* required buffer size: 116933 */
+{offset: 764, bytesPerRow: 53, rowsPerImage: 186}, {width: 23, height: 146, depthOrArrayLayers: 12});
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas1,
+  origin: { x: 64, y: 33 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 42, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let textureView36 = texture34.createView({
+  label: '\u09c4\u{1f66e}\u04b7\u{1f6e4}\uf887\u026a\ucfa4\u5362\u7e0a\u0d67',
+  baseMipLevel: 3,
+  baseArrayLayer: 86
+});
+try {
+renderBundleEncoder16.setVertexBuffer(8, buffer4, 9132, 9268);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 1,
+  origin: { x: 96, y: 2, z: 0 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 758 */
+{offset: 758, bytesPerRow: 1034}, {width: 238, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let pipeline23 = await device0.createComputePipelineAsync({
+label: '\u01b1\u2ab1\ud57e\u{1fae1}\u93ba\u8a38\u7d30\u8c56\u4f4a',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let commandEncoder34 = device0.createCommandEncoder({label: '\u0f80\u097f\u0ef7\ua806\u094f\u2bb4\ua4fb\u454f\u8877'});
+let texture40 = device0.createTexture({
+label: '\u0813\u07c5\uff25\u0be4\u{1fbfe}\u0dbe\uec0d\u1d89',
+size: [735],
+dimension: '1d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({
+  label: '\u9cfd\u05f8\u3976',
+  colorFormats: ['rg8sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let commandBuffer4 = commandEncoder33.finish();
+let textureView37 = texture23.createView({baseMipLevel: 3});
+try {
+renderBundleEncoder17.setVertexBuffer(36, undefined, 3190219956);
+} catch {}
+let pipeline24 = device1.createRenderPipeline({
+label: '\u85d4\uae42\u9d78\u01ee\u5649\uebcb\u0612\u0e10',
+layout: pipelineLayout3,
+multisample: {
+mask: 0x9272c6ec,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {format: 'r32uint'}, {format: 'rg8sint', writeMask: 0}, {format: 'rg8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'equal',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 1819,
+stencilWriteMask: 2891,
+depthBias: 50,
+depthBiasSlopeScale: 28,
+depthBiasClamp: 77,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 13792,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 754,
+shaderLocation: 17,
+}, {
+format: 'float32x4',
+offset: 7688,
+shaderLocation: 1,
+}, {
+format: 'sint16x2',
+offset: 7084,
+shaderLocation: 16,
+}, {
+format: 'uint32x2',
+offset: 12384,
+shaderLocation: 22,
+}, {
+format: 'unorm10-10-10-2',
+offset: 60,
+shaderLocation: 21,
+}, {
+format: 'sint32x3',
+offset: 13116,
+shaderLocation: 25,
+}, {
+format: 'sint8x4',
+offset: 13224,
+shaderLocation: 15,
+}, {
+format: 'snorm8x2',
+offset: 6150,
+shaderLocation: 6,
+}, {
+format: 'snorm16x2',
+offset: 2044,
+shaderLocation: 8,
+}, {
+format: 'sint32x2',
+offset: 7200,
+shaderLocation: 5,
+}, {
+format: 'uint32',
+offset: 9532,
+shaderLocation: 14,
+}, {
+format: 'uint32x3',
+offset: 4068,
+shaderLocation: 12,
+}, {
+format: 'float16x2',
+offset: 4832,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 20556,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm16x4',
+offset: 10068,
+shaderLocation: 20,
+}, {
+format: 'sint32',
+offset: 10592,
+shaderLocation: 13,
+}, {
+format: 'unorm8x4',
+offset: 14768,
+shaderLocation: 0,
+}, {
+format: 'uint32x4',
+offset: 6224,
+shaderLocation: 26,
+}, {
+format: 'uint32x4',
+offset: 8756,
+shaderLocation: 24,
+}, {
+format: 'unorm8x4',
+offset: 3692,
+shaderLocation: 4,
+}, {
+format: 'float32x3',
+offset: 17140,
+shaderLocation: 2,
+}, {
+format: 'uint32x2',
+offset: 2620,
+shaderLocation: 10,
+}],
+}
+]
+},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+pseudoSubmit(device2, commandEncoder29);
+let renderBundleEncoder20 = device2.createRenderBundleEncoder({
+  label: '\ueb03\u1985\u729d',
+  colorFormats: ['rgba32sint', 'r8unorm', 'rg8uint', undefined, undefined, 'rgba8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let video5 = await videoWithData();
+let querySet23 = device2.createQuerySet({
+type: 'occlusion',
+count: 3897,
+});
+let texture41 = device2.createTexture({
+label: '\u1d1c\u9b52\u{1fb82}\u{1fa46}\ue271\u019f\u6fb7',
+size: {width: 72, height: 12, depthOrArrayLayers: 216},
+mipLevelCount: 7,
+dimension: '2d',
+format: 'etc2-rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['etc2-rgba8unorm-srgb', 'etc2-rgba8unorm'],
+});
+let textureView38 = texture41.createView({dimension: '2d', aspect: 'all', baseMipLevel: 5, baseArrayLayer: 66});
+let renderBundleEncoder21 = device2.createRenderBundleEncoder({
+  label: '\u19f0\u7c6a\u0cf3\uba4d',
+  colorFormats: ['rgba32sint', 'r8unorm', 'rg8uint', undefined, undefined, 'rgba8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder21.setIndexBuffer(buffer11, 'uint16', 21822);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 1,
+  origin: { x: 3, y: 15, z: 13 },
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 2482919 */
+{offset: 299, bytesPerRow: 492, rowsPerImage: 71}, {width: 120, height: 5, depthOrArrayLayers: 72});
+} catch {}
+pseudoSubmit(device0, commandEncoder10);
+let texture42 = device0.createTexture({
+label: '\ucb77\ucc8f\ue6b8\u00ac',
+size: [1200, 4, 1],
+mipLevelCount: 10,
+format: 'astc-4x4-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-4x4-unorm-srgb', 'astc-4x4-unorm-srgb', 'astc-4x4-unorm'],
+});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({
+  label: '\ua9c4\u{1fa60}\u97c9\u3c59\u20d7',
+  colorFormats: ['rgb10a2unorm', 'rgba32uint', 'bgra8unorm-srgb'],
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let sampler20 = device0.createSampler({
+label: '\u0a2d\u04f9\u{1f956}\u337a',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 30.323,
+});
+try {
+computePassEncoder13.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(7, buffer4, 10696, 13661);
+} catch {}
+try {
+commandEncoder18.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 1,
+  origin: { x: 0, y: 10, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: { x: 140, y: 10, z: 0 },
+  aspect: 'all',
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder26.clearBuffer(buffer3, 58524, 1716);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 340, new DataView(new ArrayBuffer(11199)), 10737, 328);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(9, undefined, 2316541694);
+} catch {}
+try {
+renderBundleEncoder17.insertDebugMarker('\u5ede');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 149, y: 60 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 25, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 2, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder35 = device2.createCommandEncoder({label: '\ufaca\u7b75\ua71f\u13a3'});
+let querySet24 = device2.createQuerySet({
+label: '\u081e\u72e5\u{1fa23}\ua6e7\u00b4\ubf6a\u07e0\u0b92\uadbb\u3c6b',
+type: 'occlusion',
+count: 2768,
+});
+let renderBundleEncoder23 = device2.createRenderBundleEncoder({
+  label: '\u30c7\u5b53\u8466\u645e\u069c\uc19b\u09d1\u970b\u{1f733}\ufa22\u0d42',
+  colorFormats: ['rgba32sint', 'r8unorm', 'rg8uint', undefined, undefined, 'rgba8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+gc();
+let textureView39 = texture17.createView({
+  label: '\u075f\u09e0\u0509\u8660\uaff0\u{1fbb9}\ub036\u032d\u4f92\u04b5',
+  format: 'r16sint',
+  mipLevelCount: 2,
+  baseArrayLayer: 105,
+  arrayLayerCount: 69
+});
+try {
+renderBundleEncoder17.setPipeline(pipeline16);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 5,
+  origin: { x: 40, y: 6, z: 5 },
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 2648789 */
+{offset: 89, bytesPerRow: 75, rowsPerImage: 218}, {width: 20, height: 0, depthOrArrayLayers: 163});
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+/* bytesInLastRow: 3600 widthInBlocks: 225 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 33024 */
+offset: 33024,
+buffer: buffer14,
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: { x: 1110, y: 150, z: 0 },
+  aspect: 'all',
+}, {width: 2250, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer14);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: { x: 0, y: 90, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: { x: 110, y: 24, z: 1 },
+  aspect: 'all',
+}, {width: 3540, height: 18, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext6 = canvas4.getContext('webgpu');
+let textureView40 = texture2.createView({label: '\u7eb4\u8294\u3d8c\u{1fcae}', dimension: '2d', baseMipLevel: 3, mipLevelCount: 2, baseArrayLayer: 20});
+let sampler21 = device0.createSampler({
+label: '\ua94b\u{1ff97}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMaxClamp: 48.211,
+maxAnisotropy: 1,
+});
+try {
+computePassEncoder13.setPipeline(pipeline18);
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(querySet10, 983, 1094, buffer2, 23552);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 576, new Int16Array(54428), 5213, 184);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 755 */
+{offset: 755, bytesPerRow: 320}, {width: 68, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder24 = device1.createRenderBundleEncoder({
+  colorFormats: ['r8unorm', 'r32uint', 'rg8sint', 'rg8unorm', 'r32uint', 'r32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder17.setPipeline(pipeline24);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let device3 = await adapter3.requestDevice({
+label: '\u0384\u9e97\u7441\u00c7\u{1f852}\u{1ffb9}\ubf07\u06f4\u{1fa95}\u7b90\u6053',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 38,
+maxVertexAttributes: 26,
+maxVertexBufferArrayStride: 28734,
+maxStorageBuffersPerShaderStage: 30,
+maxDynamicStorageBuffersPerPipelineLayout: 4675,
+maxBindingsPerBindGroup: 8595,
+maxTextureDimension1D: 8433,
+maxTextureDimension2D: 14738,
+maxVertexBuffers: 11,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 156416686,
+maxUniformBuffersPerShaderStage: 26,
+maxInterStageShaderVariables: 83,
+maxInterStageShaderComponents: 100,
+maxSamplersPerShaderStage: 21,
+},
+});
+let commandBuffer5 = commandEncoder15.finish();
+try {
+renderBundleEncoder17.setPipeline(pipeline20);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new Int32Array(arrayBuffer2), /* required buffer size: 733 */
+{offset: 733, rowsPerImage: 159}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let querySet25 = device1.createQuerySet({
+label: '\u0ed2\u{1fb7a}\ub23a\u13f5\u{1fb53}\u{1ff67}\u{1f85d}\u{1fead}\u970f',
+type: 'occlusion',
+count: 2082,
+});
+let renderBundleEncoder25 = device1.createRenderBundleEncoder({
+  label: '\u0d3e\u09a2\u035e\u0e2c\u{1f878}\u{1f93e}\u349a\u5256',
+  colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let textureView41 = texture27.createView({label: '\u85ce\uedd0\u19f1\u{1fe98}', dimension: '2d', baseMipLevel: 4, mipLevelCount: 5, baseArrayLayer: 60});
+let buffer15 = device0.createBuffer({size: 12520, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: true});
+let querySet26 = device0.createQuerySet({
+label: '\u02bd\u057f\u7d7d\ub0c1\u0eab\u4ff8',
+type: 'occlusion',
+count: 2834,
+});
+let textureView42 = texture29.createView({label: '\u42c0\u050e\u0306\u7760\u1312\u0d2e\u{1f8cf}\u{1fcc6}\u0e9c', aspect: 'all', baseMipLevel: 3});
+try {
+  await buffer5.mapAsync(GPUMapMode.READ, 5688);
+} catch {}
+try {
+commandEncoder22.clearBuffer(buffer3, 40532, 19896);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 1,
+  origin: { x: 30, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 741 */
+{offset: 741}, {width: 50, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame7 = new VideoFrame(imageBitmap5, {timestamp: 0});
+let querySet27 = device1.createQuerySet({
+label: '\u47d5\u{1f6bb}\u2f96\u257e\u{1f79a}\u8efa\u0439\u0f6a\u{1ff8f}\u024c',
+type: 'occlusion',
+count: 120,
+});
+let renderBundleEncoder26 = device1.createRenderBundleEncoder({
+  label: '\u{1f9ec}\u0013\u6270\u0e73\u{1f73a}\u{1f8d3}\ud055\u52eb\u1c6e\u{1fc1b}\u7571',
+  colorFormats: ['r8unorm', 'r32uint', 'rg8sint', 'rg8unorm', 'r32uint', 'r32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+let sampler22 = device1.createSampler({
+label: '\u0a22\u{1fea0}\u378c\u0934\u30a3\u523e\u{1fb3c}\u{1f8dd}\uaff7\u6877\u1a4a',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 93.673,
+lodMaxClamp: 97.197,
+maxAnisotropy: 9,
+});
+let offscreenCanvas7 = new OffscreenCanvas(131, 199);
+let buffer16 = device0.createBuffer({label: '\u2bb2\u17be\u0b3c\u0ef7', size: 16606, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let texture43 = device0.createTexture({
+label: '\u4076\u2510\u{1f7a3}\u0d10\ud2a7\u0952\u0e98\u{1f8eb}\uac2e\u08c2',
+size: [2940, 1, 1],
+mipLevelCount: 9,
+dimension: '2d',
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView43 = texture40.createView({label: '\u{1fe06}\ub7db\udfc6'});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({
+  colorFormats: ['r8sint', 'rg16float', 'rgba16float'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+let sampler23 = device0.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 27.887,
+lodMaxClamp: 99.113,
+});
+try {
+renderBundleEncoder19.setVertexBuffer(3, buffer4, 5604, 9004);
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: { x: 74, y: 11, z: 10 },
+  aspect: 'all',
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: { x: 208, y: 1, z: 1 },
+  aspect: 'all',
+}, {width: 52, height: 14, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg8unorm'],
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let canvas5 = document.createElement('canvas');
+let texture44 = device3.createTexture({
+size: [1008, 120, 878],
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['r8uint', 'r8uint', 'r8uint'],
+});
+let textureView44 = texture44.createView({label: '\u3aeb\u0035\u488f\ub068\u73a7\u0512'});
+let adapter4 = await navigator.gpu.requestAdapter({
+});
+let texture45 = device1.createTexture({
+label: '\u0032\u9dc0\ufc43\u6e26\u07d8\u{1fe3c}\u{1f88f}\u038f\u8a64\u63af',
+size: [96, 1, 1],
+mipLevelCount: 7,
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderBundleEncoder17.draw(64, 40, 8, 56);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(32, 40);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(9, undefined, 3138964128, 489204560);
+} catch {}
+try {
+buffer12.destroy();
+} catch {}
+let commandEncoder36 = device2.createCommandEncoder({});
+let sampler24 = device2.createSampler({
+label: '\u0bf4\uc844\u069d',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+lodMinClamp: 42.943,
+lodMaxClamp: 57.732,
+});
+document.body.prepend(img3);
+try {
+renderBundleEncoder17.draw(32, 32, 0, 8);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 508, y: 121 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 11, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 37, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let querySet28 = device2.createQuerySet({
+label: '\uc652\u{1f70f}\u505c\u{1f714}\u56a3\u4f78\ud462\uaf0f\u23dd\u022b',
+type: 'occlusion',
+count: 1520,
+});
+let texture46 = device2.createTexture({
+label: '\u5e23\ud3b1\u{1f979}\uc221',
+size: [8052, 1, 1],
+mipLevelCount: 8,
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let computePassEncoder14 = commandEncoder35.beginComputePass({label: '\u80c0\u4091\u0c66'});
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+let texture47 = gpuCanvasContext2.getCurrentTexture();
+try {
+gpuCanvasContext6.configure({
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x10-unorm-srgb', 'depth32float-stencil8', 'astc-10x8-unorm-srgb', 'rgba8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let imageData10 = new ImageData(256, 112);
+let querySet29 = device3.createQuerySet({
+label: '\u0e2f\u03fb\uefcd\ud05d\u06df\u5abe\u7729',
+type: 'occlusion',
+count: 2834,
+});
+let texture48 = device3.createTexture({
+label: '\u3241\u0b1c\u0443\u80cb\u453a\u{1f9dc}\u{1fd2a}\u691a\u{1ff6e}\u{1fbc6}\u0380',
+size: {width: 240, height: 960, depthOrArrayLayers: 1},
+mipLevelCount: 10,
+format: 'astc-6x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-6x6-unorm'],
+});
+let renderBundleEncoder28 = device3.createRenderBundleEncoder({
+  colorFormats: ['r8uint', undefined, 'r32sint', 'rgba8uint', 'rg8unorm', 'rg8uint', 'rg32uint', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let sampler25 = device3.createSampler({
+label: '\u{1f659}\ueba5\u0322',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 47.141,
+lodMaxClamp: 83.304,
+});
+try {
+await device3.popErrorScope();
+} catch {}
+let textureView45 = texture4.createView({
+  label: '\u88f8\u3789\u3b98\u7699\ua705',
+  dimension: '2d',
+  baseMipLevel: 3,
+  mipLevelCount: 2,
+  baseArrayLayer: 29,
+  arrayLayerCount: 1
+});
+try {
+computePassEncoder11.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(1, buffer4, 16316, 1806);
+} catch {}
+let arrayBuffer7 = buffer3.getMappedRange(27888, 5756);
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 10,
+  origin: { x: 4, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture11,
+  mipLevel: 6,
+  origin: { x: 28, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let adapter5 = await navigator.gpu.requestAdapter({
+});
+try {
+canvas5.getContext('webgl2');
+} catch {}
+pseudoSubmit(device2, commandEncoder35);
+let texture49 = device2.createTexture({
+label: '\u05a8\ufae1\u1cc9',
+size: [8750, 168, 173],
+mipLevelCount: 7,
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView46 = texture46.createView({dimension: '2d-array', baseMipLevel: 6, mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder15 = commandEncoder27.beginComputePass({label: '\u60f9\ue158'});
+let renderBundleEncoder29 = device2.createRenderBundleEncoder({
+  colorFormats: ['rgba32sint', 'r8unorm', 'rg8uint', undefined, undefined, 'rgba8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler26 = device2.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 61.873,
+lodMaxClamp: 79.091,
+});
+try {
+renderBundleEncoder23.setIndexBuffer(buffer11, 'uint16', 28266, 2489);
+} catch {}
+let querySet30 = device2.createQuerySet({
+label: '\u0107\u4558\u0f38\u6691\u0ca7\u0d34\u9cb5\u7aca\u0d4a',
+type: 'occlusion',
+count: 2962,
+});
+pseudoSubmit(device2, commandEncoder36);
+try {
+device2.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: { x: 320, y: 36, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 21637 */
+{offset: 667, bytesPerRow: 5246}, {width: 3270, height: 24, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(canvas3);
+let commandEncoder37 = device2.createCommandEncoder({label: '\ub412\uc15c\u5c7e\u019b\u8031'});
+let querySet31 = device2.createQuerySet({
+label: '\uaf79\ud472\u{1fc4f}\u{1fdf4}\u0875\u{1feba}',
+type: 'occlusion',
+count: 2343,
+});
+let promise10 = device2.queue.onSubmittedWorkDone();
+try {
+offscreenCanvas7.getContext('2d');
+} catch {}
+let pipelineLayout6 = device2.createPipelineLayout({label: '\u0474\u6ccc\u6da9\u3d24\u454e\u2488', bindGroupLayouts: [bindGroupLayout9, bindGroupLayout8]});
+let renderBundleEncoder30 = device2.createRenderBundleEncoder({
+  label: '\u02b6\u{1fb58}\u791e\u7188\u1b54',
+  colorFormats: ['rgba32sint', 'r8unorm', 'rg8uint', undefined, undefined, 'rgba8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+let sampler27 = device2.createSampler({
+label: '\u3e49\u{1f66d}\uead5\u{1fadb}\uc7ef',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 93.225,
+lodMaxClamp: 95.827,
+});
+try {
+device2.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 2,
+  origin: { x: 6, y: 5, z: 3 },
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 1904676 */
+{offset: 778, bytesPerRow: 445, rowsPerImage: 186}, {width: 47, height: 1, depthOrArrayLayers: 24});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(957, 2);
+try {
+offscreenCanvas8.getContext('webgl2');
+} catch {}
+let texture50 = device2.createTexture({
+size: [576, 96, 231],
+mipLevelCount: 9,
+sampleCount: 1,
+format: 'etc2-rgb8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['etc2-rgb8unorm-srgb', 'etc2-rgb8unorm-srgb', 'etc2-rgb8unorm'],
+});
+let textureView47 = texture39.createView({
+  label: '\u25d8\u{1ff84}\u01a5\u{1feb7}\u{1fb8d}\u85c6\ua728\u4082\u6911\ub99b\u0051',
+  aspect: 'all',
+  format: 'astc-12x10-unorm-srgb',
+  baseMipLevel: 3,
+  arrayLayerCount: 1
+});
+try {
+renderBundleEncoder29.pushDebugGroup('\u8cb3');
+} catch {}
+try {
+renderBundleEncoder29.popDebugGroup();
+} catch {}
+let commandEncoder38 = device0.createCommandEncoder({label: '\ue220\u{1f94d}\u4ce5\u0a6d'});
+let commandBuffer6 = commandEncoder26.finish({
+label: '\u08b7\u03c9\u002b\ufb3e\u{1fc9f}\u9117\u59b6\u003c\u0709\ue04b\u3ea9',
+});
+let sampler28 = device0.createSampler({
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 34.907,
+lodMaxClamp: 40.361,
+});
+try {
+device0.queue.submit([
+commandBuffer2,
+commandBuffer6,
+]);
+} catch {}
+try {
+renderBundleEncoder17.draw(8);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['bgra8unorm', 'bgra8unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder39 = device1.createCommandEncoder({label: '\u{1fafd}\u042a\u045f\u25f8\uf300\ud4bd\ufde3\u0430\u0986\uea98\u0540'});
+let querySet32 = device1.createQuerySet({
+label: '\uf2cf\u4ebb\u03dc\ue06d\u9916\u{1fea0}\u{1ff6a}\u9861\ua8e7\u0531',
+type: 'occlusion',
+count: 2126,
+});
+let renderBundleEncoder31 = device1.createRenderBundleEncoder({
+  colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder17.drawIndexed(8, 0, 16, 752, 64);
+} catch {}
+try {
+commandEncoder39.clearBuffer(buffer8, 5040, 688);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 5, y: 7 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 11, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 23, height: 2, depthOrArrayLayers: 1});
+} catch {}
+let pipeline25 = device1.createComputePipeline({
+label: '\ub331\u{1fd8c}\ud5e0\u023e\u66d2\u0fd9\ucbbd\u5a7c\u0e9b',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let commandEncoder40 = device1.createCommandEncoder({label: '\u8c6e\u5211\u0963\ubbad\u0949\u{1f672}\u{1fa06}\u0f45'});
+let texture51 = device1.createTexture({
+size: {width: 108, height: 768, depthOrArrayLayers: 176},
+mipLevelCount: 2,
+format: 'astc-4x4-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-4x4-unorm-srgb', 'astc-4x4-unorm-srgb', 'astc-4x4-unorm'],
+});
+let textureView48 = texture45.createView({label: '\ucaac\ub085\uf90f\u0db9\u2516\u520a\u{1ff7b}\u5747\u0a44', format: 'r32sint', baseMipLevel: 6});
+try {
+renderBundleEncoder17.draw(64);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(80, 32, 16);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: video1,
+  origin: { x: 5, y: 8 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 6, y: 2, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let bindGroupLayout12 = device0.createBindGroupLayout({
+label: '\u{1fa6a}\u{1fea3}\ud2b2\u62df',
+entries: [],
+});
+let buffer17 = device0.createBuffer({
+  label: '\u0200\u{1fe41}',
+  size: 26628,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM
+});
+let shaderModule2 = device1.createShaderModule({
+code: `@group(3) @binding(704)
+var<storage, read_write> local1: array<u32>;
+@group(0) @binding(1300)
+var<storage, read_write> type2: array<u32>;
+@group(4) @binding(1300)
+var<storage, read_write> field0: array<u32>;
+@group(3) @binding(1300)
+var<storage, read_write> field1: array<u32>;
+@group(2) @binding(1300)
+var<storage, read_write> i2: array<u32>;
+@group(1) @binding(1300)
+var<storage, read_write> local2: array<u32>;
+@group(1) @binding(704)
+var<storage, read_write> local3: array<u32>;
+@group(4) @binding(704)
+var<storage, read_write> local4: array<u32>;
+@group(2) @binding(704)
+var<storage, read_write> parameter2: array<u32>;
+
+@compute @workgroup_size(4, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<i32>,
+  @location(0) f1: vec4<i32>,
+  @location(4) f2: vec2<f32>,
+  @location(2) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S2 {
+  @location(9) f0: vec3<u32>,
+  @location(14) f1: vec4<i32>,
+  @location(12) f2: vec3<f16>,
+  @location(20) f3: vec2<u32>,
+  @location(7) f4: vec3<i32>,
+  @location(16) f5: vec3<f32>,
+  @location(4) f6: f32,
+  @location(21) f7: vec2<u32>,
+  @location(13) f8: f32,
+  @location(1) f9: vec2<u32>,
+  @location(2) f10: vec2<u32>,
+  @location(26) f11: vec3<f32>,
+  @location(19) f12: vec3<f16>,
+  @location(3) f13: vec2<u32>,
+  @location(10) f14: vec3<i32>,
+  @location(11) f15: vec2<u32>,
+  @location(0) f16: vec3<f16>,
+  @location(22) f17: vec2<i32>,
+  @location(6) f18: vec3<u32>,
+  @location(23) f19: vec2<f16>,
+  @location(5) f20: u32,
+  @location(25) f21: vec4<i32>,
+  @location(8) f22: vec4<u32>,
+  @builtin(vertex_index) f23: u32
+}
+
+@vertex
+fn vertex0(@location(18) a0: f16, @location(17) a1: vec2<i32>, @location(15) a2: vec4<f32>, @location(24) a3: vec4<f32>, a4: S2, @builtin(instance_index) a5: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let buffer18 = device1.createBuffer({size: 55321, usage: GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let renderBundleEncoder32 = device1.createRenderBundleEncoder({
+  label: '\u0d87\uc61f\u086c\u0d3c\u2790\u383d\u{1fbab}\u0ec2',
+  colorFormats: ['rgba32sint', 'rg8sint', 'rgba32uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder17.draw(56, 24, 56);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(7, buffer18, 44212);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: video3,
+  origin: { x: 2, y: 7 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 19, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 13, height: 2, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas9 = new OffscreenCanvas(358, 24);
+let img5 = await imageWithData(27, 89, '#fcbf870f', '#9c55cd8f');
+let commandEncoder41 = device2.createCommandEncoder({label: '\u0112\u{1fb3b}\uf81b\u2b6c\ue878\u039b\u001e\u317c'});
+pseudoSubmit(device2, commandEncoder37);
+let canvas6 = document.createElement('canvas');
+let sampler29 = device3.createSampler({
+label: '\uf92e\u0092\u{1f9ab}\u0044',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 71.766,
+lodMaxClamp: 77.356,
+maxAnisotropy: 18,
+});
+try {
+renderBundleEncoder28.setVertexBuffer(84, undefined, 3091826145, 763781219);
+} catch {}
+let bindGroupLayout13 = device0.createBindGroupLayout({
+label: '\u53f5\u5f46\u0af8\u0510',
+entries: [{
+binding: 2828,
+visibility: 0,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}, {
+binding: 869,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+let commandEncoder42 = device0.createCommandEncoder({label: '\uc73f\u0eee\u8677\u0d61\ud74b'});
+let texture52 = gpuCanvasContext0.getCurrentTexture();
+try {
+commandEncoder32.clearBuffer(buffer10, 372, 684);
+dissociateBuffer(device0, buffer10);
+} catch {}
+let pipeline26 = await device0.createRenderPipelineAsync({
+label: '\u095a\u0e1c\u0ee6\u09d8\u948f\u{1fbc1}\ud349\ub878\u{1fec5}\u{1f752}',
+layout: pipelineLayout0,
+multisample: {
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16sint', writeMask: GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 544,
+depthBiasSlopeScale: 84,
+depthBiasClamp: 30,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 13888,
+attributes: [{
+format: 'snorm8x4',
+offset: 9284,
+shaderLocation: 6,
+}, {
+format: 'snorm16x4',
+offset: 1512,
+shaderLocation: 0,
+}, {
+format: 'unorm16x2',
+offset: 10420,
+shaderLocation: 11,
+}, {
+format: 'sint32x3',
+offset: 9116,
+shaderLocation: 15,
+}, {
+format: 'uint32',
+offset: 4688,
+shaderLocation: 13,
+}, {
+format: 'float16x2',
+offset: 7128,
+shaderLocation: 2,
+}, {
+format: 'snorm16x4',
+offset: 7464,
+shaderLocation: 18,
+}, {
+format: 'snorm8x4',
+offset: 8364,
+shaderLocation: 9,
+}, {
+format: 'uint32x3',
+offset: 1968,
+shaderLocation: 7,
+}, {
+format: 'uint16x4',
+offset: 4600,
+shaderLocation: 17,
+}, {
+format: 'uint32x2',
+offset: 12012,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 12712,
+attributes: [{
+format: 'float32x3',
+offset: 11320,
+shaderLocation: 4,
+}, {
+format: 'unorm10-10-10-2',
+offset: 3012,
+shaderLocation: 3,
+}, {
+format: 'sint8x4',
+offset: 11832,
+shaderLocation: 19,
+}, {
+format: 'unorm8x4',
+offset: 3892,
+shaderLocation: 12,
+}, {
+format: 'snorm8x4',
+offset: 4232,
+shaderLocation: 1,
+}, {
+format: 'float32x4',
+offset: 3088,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 7048,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x4',
+offset: 584,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 456,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x2',
+offset: 100,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 10992,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32',
+offset: 10116,
+shaderLocation: 16,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+offscreenCanvas6.getContext('webgl2');
+} catch {}
+let shaderModule3 = device1.createShaderModule({
+code: `@group(0) @binding(1300)
+var<storage, read_write> global2: array<u32>;
+@group(0) @binding(704)
+var<storage, read_write> local5: array<u32>;
+@group(3) @binding(1300)
+var<storage, read_write> function1: array<u32>;
+@group(4) @binding(704)
+var<storage, read_write> field2: array<u32>;
+@group(2) @binding(704)
+var<storage, read_write> parameter3: array<u32>;
+@group(1) @binding(1300)
+var<storage, read_write> type3: array<u32>;
+
+@compute @workgroup_size(2, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S4 {
+  @builtin(sample_index) f0: u32,
+  @location(32) f1: vec2<f16>,
+  @location(39) f2: vec4<f16>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @location(2) f1: vec3<i32>,
+  @location(3) f2: vec2<f32>,
+  @location(4) f3: vec3<u32>,
+  @location(0) f4: vec3<f32>,
+  @location(5) f5: i32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @location(17) a1: vec3<u32>, @location(1) a2: vec3<i32>, a3: S4, @location(24) a4: vec2<f16>, @location(11) a5: vec2<i32>, @location(49) a6: vec2<u32>, @location(28) a7: vec4<i32>, @location(5) a8: vec3<i32>, @location(8) a9: vec3<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S3 {
+  @location(1) f0: vec3<u32>,
+  @location(3) f1: vec3<f32>,
+  @location(24) f2: vec3<f32>,
+  @location(15) f3: vec3<u32>,
+  @location(8) f4: u32,
+  @location(25) f5: vec3<f32>,
+  @location(20) f6: vec3<f16>,
+  @location(23) f7: vec4<u32>,
+  @location(9) f8: vec4<i32>,
+  @location(4) f9: vec4<u32>,
+  @location(11) f10: f16,
+  @location(12) f11: vec2<i32>,
+  @location(2) f12: vec3<u32>,
+  @location(0) f13: vec4<f16>
+}
+struct VertexOutput0 {
+  @location(25) f29: vec3<i32>,
+  @location(34) f30: f16,
+  @location(17) f31: vec3<u32>,
+  @location(27) f32: vec2<u32>,
+  @location(24) f33: vec2<f16>,
+  @location(46) f34: vec2<u32>,
+  @location(8) f35: vec3<u32>,
+  @location(1) f36: vec3<i32>,
+  @location(2) f37: f32,
+  @location(14) f38: vec3<f16>,
+  @location(13) f39: u32,
+  @location(6) f40: f16,
+  @location(5) f41: vec3<i32>,
+  @location(16) f42: vec3<u32>,
+  @location(15) f43: f32,
+  @location(47) f44: vec2<f16>,
+  @location(45) f45: vec3<f32>,
+  @location(37) f46: f16,
+  @location(0) f47: vec4<f16>,
+  @location(18) f48: vec2<f32>,
+  @location(40) f49: vec3<f16>,
+  @location(30) f50: vec4<i32>,
+  @location(29) f51: vec2<f16>,
+  @location(28) f52: vec4<i32>,
+  @location(35) f53: vec4<f32>,
+  @location(42) f54: vec2<u32>,
+  @location(23) f55: f16,
+  @location(7) f56: f32,
+  @location(22) f57: vec2<f32>,
+  @location(33) f58: vec2<u32>,
+  @location(38) f59: f16,
+  @builtin(position) f60: vec4<f32>,
+  @location(39) f61: vec4<f16>,
+  @location(49) f62: vec2<u32>,
+  @location(3) f63: vec4<f32>,
+  @location(32) f64: vec2<f16>,
+  @location(11) f65: vec2<i32>,
+  @location(36) f66: vec2<f32>,
+  @location(19) f67: vec4<u32>,
+  @location(44) f68: u32
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(22) a1: vec2<i32>, @location(6) a2: vec4<f32>, @location(17) a3: f32, @builtin(instance_index) a4: u32, @location(10) a5: vec3<i32>, a6: S3, @location(18) a7: vec3<f32>, @location(16) a8: vec4<f32>, @location(26) a9: vec4<i32>, @location(7) a10: vec2<i32>, @location(19) a11: vec3<f16>, @location(14) a12: f32, @location(13) a13: vec3<f32>, @location(5) a14: vec2<i32>, @location(21) a15: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroupLayout14 = device1.createBindGroupLayout({
+label: '\u{1fc8d}\u{1fa51}\ue8cb\u6719\ubf72\u3927\u4cc5\u{1f726}',
+entries: [{
+binding: 1723,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}],
+});
+let pipelineLayout7 = device1.createPipelineLayout({
+  label: '\u03d8\u19da\u{1f653}\u{1f988}\u61cb\u1ffd',
+  bindGroupLayouts: [bindGroupLayout11, bindGroupLayout6, bindGroupLayout14]
+});
+let texture53 = gpuCanvasContext0.getCurrentTexture();
+let textureView49 = texture27.createView({
+  label: '\ub1ae\u5f3c\ua0e7\u3d6f\ue566',
+  dimension: '2d',
+  baseMipLevel: 4,
+  mipLevelCount: 4,
+  baseArrayLayer: 87
+});
+let sampler30 = device1.createSampler({
+label: '\u{1ff77}\ub2c1\u455c\uf49b',
+addressModeU: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 5.350,
+lodMaxClamp: 59.220,
+maxAnisotropy: 20,
+});
+try {
+renderBundleEncoder17.drawIndexed(80, 48, 80, 136, 32);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(3, buffer18, 2280, 24328);
+} catch {}
+try {
+commandEncoder40.clearBuffer(buffer8, 9544, 1404);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+video5.height = 135;
+let bindGroup0 = device0.createBindGroup({
+layout: bindGroupLayout4,
+entries: [{
+binding: 5759,
+resource: externalTexture2
+}, {
+binding: 1816,
+resource: externalTexture2
+}],
+});
+let commandEncoder43 = device0.createCommandEncoder();
+let texture54 = device0.createTexture({
+label: '\uf70f\uc508\u209f\ub9b4\u03fb\u6b88\ucefb\u{1f688}\u{1f9fa}',
+size: [4800, 16, 1],
+dimension: '2d',
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x8-unorm', 'astc-10x8-unorm-srgb'],
+});
+let renderBundleEncoder33 = device0.createRenderBundleEncoder({
+  label: '\u0992\u001c',
+  colorFormats: ['r8unorm', 'rgba16sint', 'rg8sint', 'rgba32float', 'r32uint', undefined],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle32 = renderBundleEncoder7.finish({label: '\u3d38\u{1fe85}\ufecb\u542e\u47b6\u2b27'});
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder38.clearBuffer(buffer10, 864, 292);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer1,
+commandBuffer3,
+]);
+} catch {}
+let imageData11 = new ImageData(120, 76);
+let bindGroupLayout15 = device2.createBindGroupLayout({
+label: '\u0d96\u533d',
+entries: [],
+});
+let sampler31 = device2.createSampler({
+label: '\u{1f6ef}\u0480\u0d3e\u2d83\u070f\u{1feb4}\u01de\u0a78\u52e2\ube40',
+addressModeU: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 51.328,
+lodMaxClamp: 93.927,
+maxAnisotropy: 18,
+});
+try {
+commandEncoder31.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 3296 */
+offset: 3296,
+buffer: buffer14,
+}, {
+  texture: texture39,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer14);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let texture55 = device0.createTexture({
+label: '\u6c21\ueb90\u0ad5\u{1fd34}\u07be\u{1fde7}\u0d78\u{1fc59}',
+size: [1200, 4, 1],
+mipLevelCount: 9,
+format: 'rg32uint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rg32uint', 'rg32uint', 'rg32uint'],
+});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2unorm', 'r16float', 'rg8uint', 'r8uint'],
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder0.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(3, buffer4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 1,
+  origin: { x: 28, y: 0, z: 0 },
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer4), /* required buffer size: 1231 */
+{offset: 919, bytesPerRow: 470}, {width: 156, height: 4, depthOrArrayLayers: 1});
+} catch {}
+let pipeline27 = device0.createComputePipeline({
+layout: pipelineLayout5,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline28 = device0.createRenderPipeline({
+label: '\u04a4\uf631\uea82\udce3\u5519\u4cec\u4acc',
+layout: pipelineLayout2,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 1803,
+stencilWriteMask: 303,
+depthBias: 29,
+depthBiasSlopeScale: 10,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 456,
+attributes: [{
+format: 'uint16x2',
+offset: 272,
+shaderLocation: 5,
+}, {
+format: 'uint16x4',
+offset: 12,
+shaderLocation: 13,
+}, {
+format: 'float32',
+offset: 124,
+shaderLocation: 4,
+}, {
+format: 'snorm8x4',
+offset: 428,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 1332,
+attributes: [{
+format: 'snorm16x2',
+offset: 692,
+shaderLocation: 9,
+}, {
+format: 'sint32x4',
+offset: 568,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 8924,
+attributes: [{
+format: 'unorm8x2',
+offset: 8268,
+shaderLocation: 1,
+}, {
+format: 'uint16x4',
+offset: 1272,
+shaderLocation: 17,
+}, {
+format: 'snorm8x4',
+offset: 5488,
+shaderLocation: 3,
+}, {
+format: 'uint8x2',
+offset: 6274,
+shaderLocation: 14,
+}, {
+format: 'uint32',
+offset: 6040,
+shaderLocation: 7,
+}, {
+format: 'sint16x4',
+offset: 304,
+shaderLocation: 19,
+}, {
+format: 'snorm16x4',
+offset: 3508,
+shaderLocation: 2,
+}, {
+format: 'sint32x4',
+offset: 1160,
+shaderLocation: 16,
+}, {
+format: 'unorm8x4',
+offset: 3392,
+shaderLocation: 12,
+}, {
+format: 'unorm10-10-10-2',
+offset: 5936,
+shaderLocation: 0,
+}, {
+format: 'unorm16x2',
+offset: 3328,
+shaderLocation: 18,
+}, {
+format: 'float32x2',
+offset: 3520,
+shaderLocation: 6,
+}, {
+format: 'sint32',
+offset: 3464,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 5900,
+attributes: [],
+},
+{
+arrayStride: 3644,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 11028,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 5532,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 5364,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 12496,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 5184,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+try {
+  await promise10;
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas3,
+  origin: { x: 246, y: 68 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 6, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 39, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline29 = await device1.createComputePipelineAsync({
+label: '\u{1f795}\u0d9a\uc375\ude22\u7ec3\u15d7\u33e3',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let buffer19 = device3.createBuffer({
+  label: '\u{1fe46}\u0158\u633c\u01cc\uaceb\u0bfa\u2fa8',
+  size: 14797,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM
+});
+let renderBundle33 = renderBundleEncoder28.finish({label: '\u7ee7\u7118\ubb42\u0442\u3f2a\u299b\uc4ad'});
+document.body.prepend(img1);
+try {
+buffer19.destroy();
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext7 = offscreenCanvas9.getContext('webgpu');
+let commandEncoder44 = device3.createCommandEncoder({});
+let querySet33 = device3.createQuerySet({
+label: '\u09b2\uf59d\u08b7',
+type: 'occlusion',
+count: 2165,
+});
+try {
+buffer19.destroy();
+} catch {}
+try {
+gpuCanvasContext4.configure({
+device: device3,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+});
+} catch {}
+let commandEncoder45 = device3.createCommandEncoder({label: '\u{1f978}\u1413\u0a61'});
+let commandBuffer7 = commandEncoder44.finish({
+label: '\u{1fa92}\u0331',
+});
+pseudoSubmit(device3, commandEncoder45);
+let renderBundle34 = renderBundleEncoder28.finish({label: '\u017d\u01c5\ub551\u9b6c\u072c\u054e\u{1ffe2}'});
+let querySet34 = device3.createQuerySet({
+label: '\u4cd5\u344b\u3f62\u{1fd80}\u0091\u0bd0',
+type: 'occlusion',
+count: 1574,
+});
+let texture56 = device3.createTexture({
+label: '\uffb6\u0b78\u{1fed6}\u{1f64d}\u2b29\u{1f6c1}\u{1f815}\u4182\u6363\u058c\u314a',
+size: {width: 504, height: 60, depthOrArrayLayers: 193},
+mipLevelCount: 4,
+format: 'astc-6x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder32.setVertexBuffer(7, buffer18);
+} catch {}
+let pipeline30 = device1.createComputePipeline({
+label: '\u{1f916}\u1bb3\ud5d4\u2ecf\u4b18',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+},
+});
+let pipeline31 = device1.createRenderPipeline({
+label: '\u84f9\u3352\u58a0\u781b\ud2aa\ud692\u0bbf\u0fdc\u036f',
+layout: pipelineLayout7,
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {format: 'r32uint'}, {format: 'rg8sint', writeMask: 0}, {format: 'rg8unorm'}, {
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {format: 'r32sint'}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+},
+depthBias: 25,
+depthBiasSlopeScale: 13,
+depthBiasClamp: 19,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1996,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 13064,
+attributes: [{
+format: 'float16x2',
+offset: 8488,
+shaderLocation: 2,
+}, {
+format: 'sint8x2',
+offset: 8890,
+shaderLocation: 15,
+}, {
+format: 'uint32x2',
+offset: 1552,
+shaderLocation: 22,
+}, {
+format: 'unorm16x2',
+offset: 4036,
+shaderLocation: 21,
+}, {
+format: 'uint32',
+offset: 10432,
+shaderLocation: 12,
+}, {
+format: 'snorm8x4',
+offset: 5584,
+shaderLocation: 20,
+}, {
+format: 'sint32',
+offset: 4480,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 10412,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x3',
+offset: 1388,
+shaderLocation: 10,
+}, {
+format: 'snorm16x2',
+offset: 4952,
+shaderLocation: 6,
+}, {
+format: 'uint32x2',
+offset: 8784,
+shaderLocation: 26,
+}, {
+format: 'sint32',
+offset: 6836,
+shaderLocation: 16,
+}, {
+format: 'sint32',
+offset: 5360,
+shaderLocation: 25,
+}, {
+format: 'uint8x4',
+offset: 6512,
+shaderLocation: 17,
+}, {
+format: 'unorm8x2',
+offset: 6698,
+shaderLocation: 7,
+}, {
+format: 'float32x4',
+offset: 9244,
+shaderLocation: 8,
+}, {
+format: 'sint32x4',
+offset: 5196,
+shaderLocation: 5,
+}, {
+format: 'uint32',
+offset: 6952,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 5016,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x4',
+offset: 1500,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 1844,
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x2',
+offset: 11700,
+shaderLocation: 24,
+}],
+},
+{
+arrayStride: 11632,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 11288,
+shaderLocation: 0,
+}, {
+format: 'snorm16x4',
+offset: 7568,
+shaderLocation: 1,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+},
+});
+let bindGroup1 = device0.createBindGroup({
+label: '\u1001\u0707\ucb97',
+layout: bindGroupLayout13,
+entries: [{
+binding: 2828,
+resource: {
+buffer: buffer13,
+offset: 43808,
+size: 17076,
+}
+}, {
+binding: 869,
+resource: externalTexture2
+}],
+});
+let commandEncoder46 = device0.createCommandEncoder({label: '\u{1fdfe}\uf206\u8b93\u0c14\u9205'});
+let querySet35 = device0.createQuerySet({
+type: 'occlusion',
+count: 1386,
+});
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({
+  label: '\u321d\u9197\ua07e\u05b9\u08c1\u0e83\u{1f93b}\u03ca\ucf2f',
+  colorFormats: ['rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder3.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer3, 54036, 6092);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 308, new BigUint64Array(55676), 48230, 36);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 55, y: 1, z: 0 },
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer6), /* required buffer size: 14952252 */
+{offset: 111, bytesPerRow: 3681, rowsPerImage: 290}, {width: 225, height: 2, depthOrArrayLayers: 15});
+} catch {}
+let pipeline32 = device0.createComputePipeline({
+label: '\u0489\u7a06\u38a9\u07d3\u7c62',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let offscreenCanvas10 = new OffscreenCanvas(792, 590);
+let commandEncoder47 = device2.createCommandEncoder({label: '\u07ba\u8b15\u6339\u{1fa45}\ucd96\u0546\ue2c5\u7423\ua14e'});
+let promise11 = device2.queue.onSubmittedWorkDone();
+gc();
+let commandEncoder48 = device3.createCommandEncoder();
+let textureView50 = texture47.createView({dimension: '2d-array', format: 'astc-6x6-unorm-srgb'});
+let sampler32 = device3.createSampler({
+label: '\uaba8\ua806',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 47.632,
+lodMaxClamp: 84.322,
+});
+try {
+commandEncoder48.clearBuffer(buffer19, 5624, 8016);
+dissociateBuffer(device3, buffer19);
+} catch {}
+let videoFrame8 = new VideoFrame(canvas5, {timestamp: 0});
+let textureView51 = texture37.createView({label: '\u2640\uceda'});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let img6 = await imageWithData(130, 23, '#4bb77525', '#7adaec30');
+let buffer20 = device1.createBuffer({
+  label: '\u{1f9df}\u0752\u034f\udb0b\u4bd5\u0b1a\u{1fc20}\u{1ff4f}\ue780\ude9c\u0e07',
+  size: 1261,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC
+});
+let textureView52 = texture27.createView({
+  label: '\u06e5\u708d\ubbdc\u05d5\uad90\u9f21\u0e5e\u0376\u8214',
+  format: 'astc-10x6-unorm-srgb',
+  baseMipLevel: 5,
+  mipLevelCount: 5,
+  baseArrayLayer: 168,
+  arrayLayerCount: 5
+});
+try {
+renderBundleEncoder17.drawIndexed(16, 8, 64);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 28, y: 0, z: 0 },
+  aspect: 'all',
+}, new DataView(arrayBuffer2), /* required buffer size: 1058 */
+{offset: 722, bytesPerRow: 284, rowsPerImage: 268}, {width: 13, height: 2, depthOrArrayLayers: 1});
+} catch {}
+let pipeline33 = await device1.createComputePipelineAsync({
+layout: 'auto',
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline34 = device1.createRenderPipeline({
+label: '\u466d\u5c39\u0eab\u{1fd33}',
+layout: pipelineLayout3,
+multisample: {
+mask: 0x20ea4d18,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-src'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r32uint'}, {format: 'r32sint', writeMask: GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-clamp',
+},
+stencilReadMask: 2415,
+stencilWriteMask: 2320,
+depthBias: 26,
+depthBiasSlopeScale: 24,
+depthBiasClamp: 74,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 31444,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 8144,
+shaderLocation: 21,
+}, {
+format: 'float32x4',
+offset: 1720,
+shaderLocation: 6,
+}, {
+format: 'float32x3',
+offset: 6628,
+shaderLocation: 4,
+}, {
+format: 'uint32',
+offset: 26764,
+shaderLocation: 22,
+}, {
+format: 'uint8x4',
+offset: 29280,
+shaderLocation: 17,
+}, {
+format: 'uint16x4',
+offset: 5328,
+shaderLocation: 14,
+}, {
+format: 'sint32',
+offset: 4388,
+shaderLocation: 16,
+}, {
+format: 'uint8x2',
+offset: 27680,
+shaderLocation: 10,
+}, {
+format: 'sint16x4',
+offset: 8736,
+shaderLocation: 5,
+}, {
+format: 'snorm16x4',
+offset: 19592,
+shaderLocation: 1,
+}, {
+format: 'unorm16x4',
+offset: 7900,
+shaderLocation: 2,
+}, {
+format: 'sint32x2',
+offset: 28504,
+shaderLocation: 13,
+}, {
+format: 'uint32',
+offset: 5236,
+shaderLocation: 12,
+}, {
+format: 'snorm8x4',
+offset: 4760,
+shaderLocation: 20,
+}, {
+format: 'uint16x2',
+offset: 368,
+shaderLocation: 24,
+}, {
+format: 'unorm8x4',
+offset: 10420,
+shaderLocation: 8,
+}, {
+format: 'snorm16x2',
+offset: 24584,
+shaderLocation: 7,
+}, {
+format: 'sint16x4',
+offset: 8660,
+shaderLocation: 25,
+}, {
+format: 'uint8x4',
+offset: 9192,
+shaderLocation: 26,
+}],
+},
+{
+arrayStride: 10044,
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint16x2',
+offset: 14392,
+shaderLocation: 15,
+}, {
+format: 'snorm8x4',
+offset: 29028,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let shaderModule4 = device2.createShaderModule({
+label: '\u711b\u{1fa25}\u78b3\u{1f90c}',
+code: `@group(1) @binding(1847)
+var<storage, read_write> local6: array<u32>;
+@group(0) @binding(2892)
+var<storage, read_write> local7: array<u32>;
+@group(1) @binding(958)
+var<storage, read_write> parameter4: array<u32>;
+
+@compute @workgroup_size(1, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S6 {
+  @location(83) f0: vec3<f16>,
+  @location(21) f1: vec3<f32>,
+  @location(32) f2: vec4<u32>,
+  @builtin(front_facing) f3: bool,
+  @location(10) f4: vec2<i32>,
+  @location(49) f5: vec4<f32>,
+  @location(38) f6: vec2<u32>,
+  @location(91) f7: vec3<u32>,
+  @location(42) f8: vec2<i32>
+}
+struct FragmentOutput0 {
+  @location(5) f0: vec4<u32>,
+  @location(2) f1: vec3<u32>,
+  @location(1) f2: vec2<f32>,
+  @location(3) f3: u32,
+  @location(6) f4: f32,
+  @location(0) f5: vec4<i32>,
+  @builtin(frag_depth) f6: f32
+}
+
+@fragment
+fn fragment0(a0: S6, @location(89) a1: vec3<f32>, @location(2) a2: vec2<u32>, @location(69) a3: vec3<f16>, @location(77) a4: f16, @location(65) a5: vec3<f16>, @location(5) a6: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S5 {
+  @builtin(vertex_index) f0: u32,
+  @builtin(instance_index) f1: u32,
+  @location(12) f2: vec2<f16>,
+  @location(13) f3: vec2<i32>,
+  @location(8) f4: vec3<f32>,
+  @location(1) f5: i32,
+  @location(7) f6: vec4<f32>,
+  @location(15) f7: u32,
+  @location(6) f8: vec4<u32>,
+  @location(5) f9: vec4<i32>,
+  @location(14) f10: vec3<u32>,
+  @location(2) f11: i32,
+  @location(9) f12: vec3<i32>,
+  @location(10) f13: vec3<i32>,
+  @location(3) f14: vec2<i32>
+}
+struct VertexOutput0 {
+  @location(91) f69: vec3<u32>,
+  @location(49) f70: vec4<f32>,
+  @builtin(position) f71: vec4<f32>,
+  @location(32) f72: vec4<u32>,
+  @location(38) f73: vec2<u32>,
+  @location(42) f74: vec2<i32>,
+  @location(21) f75: vec3<f32>,
+  @location(10) f76: vec2<i32>,
+  @location(77) f77: f16,
+  @location(83) f78: vec3<f16>,
+  @location(65) f79: vec3<f16>,
+  @location(69) f80: vec3<f16>,
+  @location(89) f81: vec3<f32>,
+  @location(5) f82: vec4<f32>,
+  @location(2) f83: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(0) a0: vec4<f32>, a1: S5, @location(11) a2: f16, @location(4) a3: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let gpuCanvasContext8 = offscreenCanvas10.getContext('webgpu');
+let commandEncoder49 = device0.createCommandEncoder();
+let pipeline35 = device0.createComputePipeline({
+label: '\u09b8\u10bf',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let canvas7 = document.createElement('canvas');
+let bindGroupLayout16 = device2.createBindGroupLayout({
+label: '\u5311\u8a20',
+entries: [],
+});
+let computePassEncoder16 = commandEncoder47.beginComputePass();
+try {
+device2.pushErrorScope('out-of-memory');
+} catch {}
+try {
+buffer11.destroy();
+} catch {}
+try {
+commandEncoder31.copyBufferToTexture({
+/* bytesInLastRow: 304 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 48624 */
+offset: 48624,
+bytesPerRow: 512,
+buffer: buffer14,
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: { x: 1560, y: 96, z: 1 },
+  aspect: 'all',
+}, {width: 190, height: 102, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer14);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 5,
+  origin: { x: 4, y: 0, z: 30 },
+  aspect: 'all',
+}, new ArrayBuffer(827498), /* required buffer size: 827498 */
+{offset: 938, bytesPerRow: 246, rowsPerImage: 168}, {width: 4, height: 0, depthOrArrayLayers: 21});
+} catch {}
+let pipeline36 = await device2.createRenderPipelineAsync({
+label: '\u{1ff0d}\u{1fff3}\uc925\u0060\u19a5\u6c0d\u12d4\udfbb',
+layout: pipelineLayout6,
+fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: 0}, {format: 'r8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rg8uint'}, undefined, undefined, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'keep',
+depthFailOp: 'decrement-clamp',
+passOp: 'keep',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2196,
+stencilWriteMask: 2135,
+depthBias: 62,
+depthBiasClamp: 32,
+},
+vertex: {
+  module: shaderModule4,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 37892,
+attributes: [{
+format: 'sint32',
+offset: 6412,
+shaderLocation: 10,
+}, {
+format: 'float32x2',
+offset: 21108,
+shaderLocation: 4,
+}, {
+format: 'sint32x4',
+offset: 24316,
+shaderLocation: 13,
+}, {
+format: 'float32',
+offset: 27528,
+shaderLocation: 11,
+}, {
+format: 'sint32x3',
+offset: 27788,
+shaderLocation: 3,
+}, {
+format: 'unorm10-10-10-2',
+offset: 30572,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 14692,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 10868,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 5796,
+shaderLocation: 6,
+}, {
+format: 'sint32x3',
+offset: 1904,
+shaderLocation: 1,
+}, {
+format: 'sint32',
+offset: 4976,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 29628,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x4',
+offset: 8044,
+shaderLocation: 0,
+}, {
+format: 'uint32x2',
+offset: 8888,
+shaderLocation: 14,
+}, {
+format: 'snorm16x4',
+offset: 14300,
+shaderLocation: 8,
+}, {
+format: 'sint32x2',
+offset: 21144,
+shaderLocation: 5,
+}, {
+format: 'sint8x2',
+offset: 16988,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 26160,
+attributes: [{
+format: 'snorm8x2',
+offset: 5010,
+shaderLocation: 7,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+},
+});
+try {
+device2.destroy();
+} catch {}
+let gpuCanvasContext9 = canvas7.getContext('webgpu');
+let texture57 = device0.createTexture({
+label: '\u06a4\u{1f94a}\u8aef\u{1fddb}\u6efb\u5945\u344d',
+size: {width: 4800, height: 16, depthOrArrayLayers: 1},
+mipLevelCount: 12,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let computePassEncoder17 = commandEncoder43.beginComputePass({});
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({
+  label: '\u0825\u{1f9ac}\u0035\u0c7a\u6931\u0620\u1645\ucc22\u097b\u5bdf\u0f36',
+  colorFormats: ['rgb10a2unorm', 'r16float', 'rg8uint', 'r8uint'],
+  depthReadOnly: true
+});
+try {
+computePassEncoder2.setPipeline(pipeline1);
+} catch {}
+try {
+texture3.destroy();
+} catch {}
+let pipeline37 = await device0.createComputePipelineAsync({
+label: '\u03bb\u1c1c\u050d\u56ec\u02af\ua199\u{1f658}\u8474',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let video6 = await videoWithData();
+let texture58 = device3.createTexture({
+label: '\u0f65\u8cd8\u6ed5\ud218\u{1f7fe}',
+size: {width: 4032, height: 480, depthOrArrayLayers: 193},
+mipLevelCount: 2,
+format: 'astc-12x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x10-unorm'],
+});
+let computePassEncoder18 = commandEncoder48.beginComputePass({label: '\u{1f789}\u0141\u3c0f\u88ee\u{1fb27}\u0c73\u690e\u5973\u89a5'});
+try {
+computePassEncoder18.pushDebugGroup('\u6c4e');
+} catch {}
+let textureView53 = texture44.createView({mipLevelCount: 1});
+let renderBundle35 = renderBundleEncoder28.finish({label: '\ua39a\u1ae4\u{1f819}\u3d5a\u1a79\u0bc6\u06a2\u011e'});
+try {
+gpuCanvasContext1.configure({
+device: device3,
+format: 'rgba16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise11;
+} catch {}
+canvas3.width = 886;
+let textureView54 = texture0.createView({format: 'astc-5x5-unorm-srgb', baseMipLevel: 2, mipLevelCount: 2, baseArrayLayer: 27, arrayLayerCount: 162});
+let renderBundle36 = renderBundleEncoder3.finish();
+try {
+renderBundleEncoder27.setVertexBuffer(6, buffer4, 8860, 13866);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 664, new Int16Array(60950), 30882, 244);
+} catch {}
+let video7 = await videoWithData();
+try {
+canvas6.getContext('bitmaprenderer');
+} catch {}
+let computePassEncoder19 = commandEncoder42.beginComputePass({label: '\ue88d\u3c10\u3a48\uc1af\u86e5\udd76\u22e3\u{1f9ff}'});
+let imageBitmap9 = await createImageBitmap(videoFrame3);
+let querySet36 = device3.createQuerySet({
+label: '\ua46f\u73b5\u{1fbb0}\u9e89\uea74\u{1fc0f}',
+type: 'occlusion',
+count: 1546,
+});
+try {
+gpuCanvasContext1.configure({
+device: device3,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'stencil8', 'rgba16float', 'rgba16float'],
+});
+} catch {}
+document.body.prepend(img1);
+video1.height = 111;
+let texture59 = device3.createTexture({
+label: '\u{1fbfc}\u7df9\u{1ffda}',
+size: {width: 60, height: 240, depthOrArrayLayers: 227},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8snorm', 'rgba8snorm'],
+});
+let renderBundle37 = renderBundleEncoder28.finish({label: '\u{1fba7}\u9fe0\u{1f675}\u06a6\ufeaa\ue976\u1dcb\ub91c\u4a6a'});
+try {
+device2.label = '\u0f89\u{1fdf8}\u0f34';
+} catch {}
+let shaderModule5 = device1.createShaderModule({
+label: '\ue905\u0519\u02d3\uc9d9\u{1fb44}\u0437\u593c\ud382\u0e74',
+code: `@group(1) @binding(704)
+var<storage, read_write> local8: array<u32>;
+@group(1) @binding(1300)
+var<storage, read_write> global3: array<u32>;
+
+@compute @workgroup_size(7, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S7 {
+  @location(44) f0: vec4<f32>,
+  @location(17) f1: u32,
+  @location(38) f2: vec4<f16>
+}
+struct FragmentOutput0 {
+  @location(4) f0: vec4<u32>,
+  @location(2) f1: vec4<i32>,
+  @builtin(sample_mask) f2: u32,
+  @location(0) f3: vec3<f32>,
+  @location(1) f4: vec2<u32>,
+  @location(5) f5: vec3<i32>,
+  @location(3) f6: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(8) a0: vec2<i32>, @location(39) a1: f32, @location(33) a2: u32, @location(1) a3: vec2<f32>, a4: S7, @location(15) a5: vec4<f32>, @location(14) a6: vec4<f32>, @location(24) a7: vec2<f32>, @location(31) a8: vec4<u32>, @builtin(position) a9: vec4<f32>, @location(37) a10: vec2<i32>, @location(20) a11: f16, @location(9) a12: vec2<f16>, @location(46) a13: vec4<u32>, @location(16) a14: vec3<i32>, @location(49) a15: u32, @location(5) a16: i32, @location(6) a17: vec2<u32>, @location(29) a18: vec3<f16>, @location(21) a19: vec3<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(44) f84: vec4<f32>,
+  @location(5) f85: i32,
+  @location(21) f86: vec3<f16>,
+  @location(20) f87: f16,
+  @location(16) f88: vec3<i32>,
+  @location(15) f89: vec4<f32>,
+  @location(39) f90: f32,
+  @builtin(position) f91: vec4<f32>,
+  @location(33) f92: u32,
+  @location(8) f93: vec2<i32>,
+  @location(17) f94: u32,
+  @location(49) f95: u32,
+  @location(24) f96: vec2<f32>,
+  @location(14) f97: vec4<f32>,
+  @location(9) f98: vec2<f16>,
+  @location(38) f99: vec4<f16>,
+  @location(1) f100: vec2<f32>,
+  @location(29) f101: vec3<f16>,
+  @location(6) f102: vec2<u32>,
+  @location(37) f103: vec2<i32>,
+  @location(31) f104: vec4<u32>,
+  @location(46) f105: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec3<u32>, @location(6) a1: vec4<f16>, @location(22) a2: vec3<i32>, @builtin(vertex_index) a3: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder50 = device1.createCommandEncoder({label: '\u0083\uaf75\u{1fae2}\u{1f7e0}\u5d26\u043b\u{1fadb}\u043d\u0c4c\u0df6'});
+let commandBuffer8 = commandEncoder39.finish({
+});
+let computePassEncoder20 = commandEncoder40.beginComputePass({});
+try {
+renderBundleEncoder32.setVertexBuffer(6, buffer18, 23428, 30271);
+} catch {}
+try {
+commandEncoder50.copyBufferToBuffer(buffer20, 1080, buffer8, 11200, 80);
+dissociateBuffer(device1, buffer20);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 136, new BigUint64Array(45884), 44010, 100);
+} catch {}
+let promise12 = device1.createComputePipelineAsync({
+label: '\u{1fac1}\u{1fd8c}\uaa35\udc82\u{1fe8c}\u{1ff11}\uf8c8\udb59',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let promise13 = device1.createRenderPipelineAsync({
+label: '\u02d2\u951a\u07d3\u20e4\u3e3c\u7801\u{1fe60}\u064d\u06c7',
+layout: pipelineLayout3,
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'never',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'replace',
+passOp: 'invert',
+},
+stencilReadMask: 916,
+stencilWriteMask: 1116,
+depthBias: 54,
+depthBiasSlopeScale: 75,
+depthBiasClamp: 34,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 2268,
+attributes: [],
+},
+{
+arrayStride: 8204,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 5168,
+shaderLocation: 0,
+}, {
+format: 'snorm8x2',
+offset: 4940,
+shaderLocation: 26,
+}, {
+format: 'uint16x2',
+offset: 1192,
+shaderLocation: 6,
+}, {
+format: 'float32x2',
+offset: 2704,
+shaderLocation: 16,
+}, {
+format: 'sint16x4',
+offset: 2032,
+shaderLocation: 17,
+}, {
+format: 'uint8x4',
+offset: 5360,
+shaderLocation: 20,
+}, {
+format: 'uint32',
+offset: 404,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 27248,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x2',
+offset: 21348,
+shaderLocation: 3,
+}, {
+format: 'sint16x4',
+offset: 19316,
+shaderLocation: 22,
+}, {
+format: 'sint32x3',
+offset: 25896,
+shaderLocation: 14,
+}, {
+format: 'snorm16x2',
+offset: 4588,
+shaderLocation: 12,
+}, {
+format: 'snorm8x4',
+offset: 22100,
+shaderLocation: 4,
+}, {
+format: 'float16x4',
+offset: 96,
+shaderLocation: 23,
+}, {
+format: 'float32x3',
+offset: 7772,
+shaderLocation: 13,
+}, {
+format: 'float32x2',
+offset: 3136,
+shaderLocation: 18,
+}, {
+format: 'sint8x2',
+offset: 7860,
+shaderLocation: 25,
+}, {
+format: 'uint32x4',
+offset: 28,
+shaderLocation: 21,
+}, {
+format: 'float16x2',
+offset: 14532,
+shaderLocation: 24,
+}, {
+format: 'uint32x3',
+offset: 17044,
+shaderLocation: 5,
+}, {
+format: 'uint32x4',
+offset: 24056,
+shaderLocation: 1,
+}, {
+format: 'uint32x4',
+offset: 16748,
+shaderLocation: 8,
+}, {
+format: 'uint32',
+offset: 14108,
+shaderLocation: 11,
+}, {
+format: 'sint32x2',
+offset: 19912,
+shaderLocation: 7,
+}, {
+format: 'uint16x2',
+offset: 23612,
+shaderLocation: 9,
+}, {
+format: 'sint16x4',
+offset: 11812,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 25748,
+attributes: [],
+},
+{
+arrayStride: 5548,
+attributes: [{
+format: 'float16x4',
+offset: 272,
+shaderLocation: 15,
+}, {
+format: 'unorm10-10-10-2',
+offset: 5448,
+shaderLocation: 19,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+let buffer21 = device1.createBuffer({
+  label: '\u310f\uf07d\u021e',
+  size: 22472,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true
+});
+let computePassEncoder21 = commandEncoder50.beginComputePass({});
+let renderBundleEncoder37 = device1.createRenderBundleEncoder({
+  colorFormats: ['r8unorm', 'r32uint', 'rg8sint', 'rg8unorm', 'r32uint', 'r32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+try {
+buffer18.destroy();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas8,
+  origin: { x: 305, y: 1 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 21, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 6, height: 0, depthOrArrayLayers: 1});
+} catch {}
+gc();
+try {
+sampler12.label = '\u{1ffdc}\u0a99\u05c0\u0c37\u057b\u1896\u1677\u{1f881}\u{1f87a}\ud7a0';
+} catch {}
+let shaderModule6 = device1.createShaderModule({
+label: '\u3a71\u8c9a\u59db\u043e\u0341',
+code: `@group(2) @binding(1723)
+var<storage, read_write> global4: array<u32>;
+@group(1) @binding(704)
+var<storage, read_write> local9: array<u32>;
+@group(0) @binding(542)
+var<storage, read_write> type4: array<u32>;
+@group(1) @binding(1300)
+var<storage, read_write> field3: array<u32>;
+
+@compute @workgroup_size(5, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<i32>,
+  @location(1) f1: f32,
+  @location(0) f2: vec3<f32>,
+  @location(2) f3: vec2<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S8 {
+  @location(9) f0: vec3<u32>,
+  @location(12) f1: vec2<f32>,
+  @location(3) f2: vec3<u32>,
+  @location(22) f3: vec2<f16>,
+  @location(14) f4: f16,
+  @location(5) f5: vec2<f32>,
+  @location(6) f6: vec4<f16>,
+  @location(21) f7: u32,
+  @location(19) f8: f32
+}
+
+@vertex
+fn vertex0(@location(8) a0: f32, @location(23) a1: vec4<i32>, @builtin(instance_index) a2: u32, @location(1) a3: vec4<f32>, @location(11) a4: vec2<f16>, @location(24) a5: vec4<i32>, @location(0) a6: vec3<i32>, @location(13) a7: vec3<f16>, @location(7) a8: vec3<i32>, @location(26) a9: vec2<f32>, @location(10) a10: f16, @location(4) a11: f32, @location(17) a12: f32, @location(20) a13: vec2<f32>, @location(16) a14: f32, @location(25) a15: i32, @location(15) a16: vec2<u32>, @location(2) a17: u32, @location(18) a18: vec4<i32>, a19: S8, @builtin(vertex_index) a20: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+try {
+computePassEncoder20.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(8);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 56, y: 173, z: 38 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer7), /* required buffer size: 365178 */
+{offset: 426, bytesPerRow: 296, rowsPerImage: 689}, {width: 40, height: 544, depthOrArrayLayers: 2});
+} catch {}
+let video8 = await videoWithData();
+let videoFrame9 = new VideoFrame(imageBitmap9, {timestamp: 0});
+let promise14 = adapter1.requestAdapterInfo();
+let querySet37 = device0.createQuerySet({
+type: 'occlusion',
+count: 3587,
+});
+let commandBuffer9 = commandEncoder32.finish();
+let renderBundleEncoder38 = device0.createRenderBundleEncoder({
+  label: '\u0cea\u0200\ufe5c\u0c4b\u{1ff1f}\ua6e0\u95a4\u{1f968}\u0cdf\u06db',
+  colorFormats: ['rgba16uint', undefined, 'r8sint', 'rg16sint', 'rgba16sint', 'rgba16float', 'rg32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+let renderBundle38 = renderBundleEncoder36.finish({label: '\u23da\u06d8\u0d5f\u{1f72d}\u{1f947}\u4742\u{1ff0a}\u0dd1\u0a8e\u1716\u8ba3'});
+try {
+  await buffer1.mapAsync(GPUMapMode.READ, 0, 7460);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm', 'depth32float', 'r8sint'],
+alphaMode: 'opaque',
+});
+} catch {}
+let buffer22 = device0.createBuffer({
+  label: '\u08ca\u3a67\ud79c\u{1f73b}\u2e7c',
+  size: 32580,
+  usage: GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true
+});
+let renderBundleEncoder39 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rg8uint', 'r32sint', undefined, 'rg8uint', 'rgba8uint', 'rg11b10ufloat', 'r32sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+let sampler33 = device0.createSampler({
+label: '\u986d\ub70b',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 47.856,
+lodMaxClamp: 75.179,
+maxAnisotropy: 11,
+});
+try {
+computePassEncoder13.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder25.copyBufferToBuffer(buffer15, 6512, buffer3, 10980, 5460);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder30.resolveQuerySet(querySet5, 1540, 57, buffer2, 28416);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let canvas8 = document.createElement('canvas');
+try {
+canvas8.getContext('webgl2');
+} catch {}
+try {
+device3.queue.submit([
+]);
+} catch {}
+let renderBundle39 = renderBundleEncoder31.finish({label: '\u9665\u{1f8b9}\ud426\u0f8e\u{1f97a}\u2062\u0aa5'});
+try {
+renderBundleEncoder17.setVertexBuffer(20, undefined, 3837774951, 451065409);
+} catch {}
+let promise15 = device1.queue.onSubmittedWorkDone();
+let adapter6 = await navigator.gpu.requestAdapter();
+let commandEncoder51 = device3.createCommandEncoder();
+let textureView55 = texture59.createView({baseMipLevel: 1, mipLevelCount: 1, arrayLayerCount: 1});
+let renderBundleEncoder40 = device3.createRenderBundleEncoder({label: '\u256f\u0a9d\u05e7', colorFormats: ['rg32sint'], depthReadOnly: true});
+try {
+buffer19.unmap();
+} catch {}
+try {
+commandEncoder51.clearBuffer(buffer19, 11856, 1740);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+  await promise15;
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.prepend(canvas3);
+let offscreenCanvas11 = new OffscreenCanvas(369, 672);
+let computePassEncoder22 = commandEncoder28.beginComputePass({label: '\ua118\uef20\u0d20\u0447\u{1f7ec}\u{1f918}\u02cb\u0741\ufe1f\ub12b'});
+let renderBundle40 = renderBundleEncoder4.finish({label: '\u4897\ub51f\ub265\u{1fbde}\ua9b5\ua58e\ub8e1\u0cc6\u{1fdb2}\uaaa8'});
+let sampler34 = device0.createSampler({
+label: '\u{1fa46}\u5ba8\u3d73\u0032\u0f7a\u6075\u0bd1\u820f\uc4d6',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 45.992,
+maxAnisotropy: 18,
+});
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline15);
+} catch {}
+try {
+commandEncoder38.resolveQuerySet(querySet13, 582, 696, buffer2, 19968);
+} catch {}
+let pipeline38 = await device0.createRenderPipelineAsync({
+label: '\u0968\u0c70\u21f1\ub814\u0303',
+layout: pipelineLayout1,
+fragment: {module: shaderModule0, entryPoint: 'fragment0', targets: [{format: 'rgba16sint'}]},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'zero',
+passOp: 'replace',
+},
+stencilReadMask: 3781,
+depthBias: 38,
+depthBiasSlopeScale: 16,
+depthBiasClamp: 19,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 2848,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 1476,
+shaderLocation: 5,
+}, {
+format: 'uint8x2',
+offset: 1246,
+shaderLocation: 17,
+}, {
+format: 'unorm8x2',
+offset: 568,
+shaderLocation: 9,
+}, {
+format: 'float32x2',
+offset: 2328,
+shaderLocation: 11,
+}, {
+format: 'uint16x4',
+offset: 2212,
+shaderLocation: 13,
+}, {
+format: 'float32x2',
+offset: 2336,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 5336,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm16x4',
+offset: 2552,
+shaderLocation: 12,
+}, {
+format: 'uint32',
+offset: 3704,
+shaderLocation: 7,
+}, {
+format: 'unorm8x2',
+offset: 2486,
+shaderLocation: 0,
+}, {
+format: 'float32x2',
+offset: 3272,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 2896,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 1268,
+shaderLocation: 4,
+}, {
+format: 'float16x2',
+offset: 244,
+shaderLocation: 18,
+}, {
+format: 'sint32x4',
+offset: 936,
+shaderLocation: 16,
+}, {
+format: 'uint16x4',
+offset: 1584,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 10212,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x2',
+offset: 916,
+shaderLocation: 8,
+}, {
+format: 'unorm16x4',
+offset: 8992,
+shaderLocation: 1,
+}, {
+format: 'sint32x3',
+offset: 8580,
+shaderLocation: 19,
+}, {
+format: 'snorm16x4',
+offset: 2932,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 4488,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 8612,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32',
+offset: 6896,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 780,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+offscreenCanvas11.getContext('webgl');
+} catch {}
+try {
+window.someLabel = device2.queue.label;
+} catch {}
+try {
+  await promise14;
+} catch {}
+let buffer23 = device0.createBuffer({
+  label: '\u{1fc9f}\u0c22\uc284\u0b3c\u5072\u4362\u5441\u0a47',
+  size: 25276,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let textureView56 = texture2.createView({
+  label: '\u{1fa33}\u331f',
+  dimension: '2d',
+  format: 'eac-rg11snorm',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+  baseArrayLayer: 12
+});
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 2,
+  origin: { x: 84, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(999), /* required buffer size: 999 */
+{offset: 239, bytesPerRow: 424}, {width: 252, height: 24, depthOrArrayLayers: 1});
+} catch {}
+let shaderModule7 = device0.createShaderModule({
+label: '\u6551\u{1fce8}\u6fc3\ub8c1\ua4e1\u7d88\u81bf\ucef1\u7844\u052b',
+code: `@group(1) @binding(4710)
+var<storage, read_write> type5: array<u32>;
+@group(0) @binding(5759)
+var<storage, read_write> parameter5: array<u32>;
+
+@compute @workgroup_size(6, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<i32>,
+  @location(1) f1: vec4<i32>,
+  @location(0) f2: vec4<f32>,
+  @location(4) f3: vec2<u32>,
+  @builtin(sample_mask) f4: u32,
+  @location(3) f5: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(36) a0: vec3<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S9 {
+  @builtin(vertex_index) f0: u32,
+  @location(2) f1: vec3<u32>,
+  @location(14) f2: vec4<f32>,
+  @location(6) f3: vec3<i32>,
+  @location(13) f4: vec2<f32>,
+  @location(19) f5: vec3<f16>,
+  @builtin(instance_index) f6: u32,
+  @location(1) f7: vec4<f32>,
+  @location(18) f8: i32,
+  @location(8) f9: vec3<f32>,
+  @location(9) f10: vec2<f16>
+}
+struct VertexOutput0 {
+  @location(47) f106: vec3<u32>,
+  @location(55) f107: vec2<i32>,
+  @location(60) f108: vec2<i32>,
+  @location(28) f109: vec4<f16>,
+  @location(19) f110: vec4<i32>,
+  @location(0) f111: vec2<i32>,
+  @location(32) f112: vec3<i32>,
+  @location(73) f113: vec3<i32>,
+  @location(34) f114: u32,
+  @location(7) f115: i32,
+  @location(67) f116: u32,
+  @location(71) f117: vec4<u32>,
+  @location(49) f118: vec2<f32>,
+  @location(37) f119: u32,
+  @location(38) f120: vec4<f32>,
+  @location(20) f121: vec3<f32>,
+  @location(15) f122: vec3<f16>,
+  @location(33) f123: vec2<f16>,
+  @location(12) f124: vec2<f32>,
+  @location(21) f125: vec4<i32>,
+  @location(68) f126: f32,
+  @location(22) f127: f16,
+  @location(50) f128: f16,
+  @builtin(position) f129: vec4<f32>,
+  @location(58) f130: vec4<f16>,
+  @location(25) f131: vec4<u32>,
+  @location(2) f132: vec4<f16>,
+  @location(11) f133: u32,
+  @location(43) f134: vec3<f16>,
+  @location(18) f135: vec3<u32>,
+  @location(77) f136: vec4<i32>,
+  @location(13) f137: vec3<f32>,
+  @location(52) f138: u32,
+  @location(3) f139: vec2<u32>,
+  @location(82) f140: vec2<f32>,
+  @location(17) f141: vec3<f32>,
+  @location(9) f142: vec3<i32>,
+  @location(51) f143: vec2<f32>,
+  @location(53) f144: f32,
+  @location(16) f145: vec4<f16>,
+  @location(39) f146: vec4<i32>,
+  @location(81) f147: i32,
+  @location(45) f148: i32,
+  @location(36) f149: vec3<f32>,
+  @location(72) f150: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: u32, a1: S9, @location(7) a2: u32, @location(4) a3: vec2<u32>, @location(10) a4: vec3<i32>, @location(5) a5: vec2<i32>, @location(3) a6: vec2<f32>, @location(17) a7: vec2<f16>, @location(16) a8: vec3<u32>, @location(0) a9: vec3<f32>, @location(15) a10: vec2<f32>, @location(12) a11: f16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+});
+let texture60 = device0.createTexture({
+size: {width: 1200, height: 4, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'etc2-rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['etc2-rgba8unorm'],
+});
+let renderBundleEncoder41 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba16uint', undefined, 'r8sint', 'rg16sint', 'rgba16sint', 'rgba16float', 'rg32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder27.setVertexBuffer(7, buffer4);
+} catch {}
+try {
+commandEncoder0.copyBufferToBuffer(buffer15, 2200, buffer3, 27628, 7408);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder25.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 8,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(308), /* required buffer size: 308 */
+{offset: 308}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline39 = await device0.createRenderPipelineAsync({
+label: '\ucefc\u{1faad}\ub84e\u{1fc3a}\u363c\uf013\uae1d\u09f2',
+layout: pipelineLayout5,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 543,
+stencilWriteMask: 2219,
+depthBias: 87,
+depthBiasSlopeScale: 61,
+depthBiasClamp: 5,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 6264,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 176,
+shaderLocation: 9,
+}, {
+format: 'snorm8x4',
+offset: 5556,
+shaderLocation: 10,
+}, {
+format: 'uint16x4',
+offset: 5836,
+shaderLocation: 17,
+}, {
+format: 'sint16x2',
+offset: 4712,
+shaderLocation: 16,
+}, {
+format: 'float16x2',
+offset: 5076,
+shaderLocation: 1,
+}, {
+format: 'snorm8x2',
+offset: 4612,
+shaderLocation: 0,
+}, {
+format: 'uint32x4',
+offset: 3000,
+shaderLocation: 5,
+}, {
+format: 'sint8x4',
+offset: 1276,
+shaderLocation: 15,
+}, {
+format: 'float32x4',
+offset: 4104,
+shaderLocation: 3,
+}, {
+format: 'snorm16x2',
+offset: 5044,
+shaderLocation: 11,
+}, {
+format: 'sint32',
+offset: 4828,
+shaderLocation: 19,
+}, {
+format: 'uint32x4',
+offset: 776,
+shaderLocation: 14,
+}, {
+format: 'unorm16x2',
+offset: 4916,
+shaderLocation: 6,
+}, {
+format: 'unorm8x4',
+offset: 1236,
+shaderLocation: 2,
+}, {
+format: 'uint32x3',
+offset: 2580,
+shaderLocation: 13,
+}, {
+format: 'float16x4',
+offset: 2628,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 12576,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x3',
+offset: 10464,
+shaderLocation: 8,
+}, {
+format: 'snorm16x2',
+offset: 4920,
+shaderLocation: 4,
+}, {
+format: 'uint32x4',
+offset: 3952,
+shaderLocation: 7,
+}, {
+format: 'unorm8x2',
+offset: 2594,
+shaderLocation: 18,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+let textureView57 = texture11.createView({
+  label: '\u2f74\u1517\u0627\u3142\u00b8\u{1f81e}\u{1f7ef}\u8b75\ub639',
+  dimension: '2d-array',
+  baseMipLevel: 4,
+  mipLevelCount: 4
+});
+let renderBundle41 = renderBundleEncoder0.finish();
+try {
+renderBundleEncoder22.setVertexBuffer(3, buffer4, 14432, 5287);
+} catch {}
+try {
+commandEncoder46.clearBuffer(buffer10, 732, 440);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+renderBundleEncoder15.insertDebugMarker('\u{1fbfb}');
+} catch {}
+document.body.prepend(img5);
+let texture61 = device3.createTexture({
+size: [1008, 120, 193],
+mipLevelCount: 9,
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['r8uint'],
+});
+let textureView58 = texture56.createView({
+  label: '\u{1fbb2}\u01ca\ueef4\ue426\u0642\u0b44\u9f98\u{1fb85}',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 176,
+  arrayLayerCount: 14
+});
+let renderBundle42 = renderBundleEncoder28.finish();
+try {
+commandEncoder51.copyTextureToTexture({
+  texture: texture48,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture48,
+  mipLevel: 2,
+  origin: { x: 30, y: 156, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder52 = device3.createCommandEncoder();
+let texture62 = device3.createTexture({
+label: '\u1aa3\uc530\u0def\udc10\uaf90\u126f\uab84',
+size: [32, 60, 45],
+mipLevelCount: 3,
+format: 'astc-4x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+try {
+commandEncoder51.clearBuffer(buffer19, 2364, 11620);
+dissociateBuffer(device3, buffer19);
+} catch {}
+let promise16 = device3.queue.onSubmittedWorkDone();
+let renderBundleEncoder42 = device1.createRenderBundleEncoder({colorFormats: ['rgba32sint', 'rg8sint', 'rgba32uint'], sampleCount: 4, stencilReadOnly: true});
+let renderBundle43 = renderBundleEncoder26.finish({label: '\uddf5\u0ad3\u0a7e'});
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 1,
+  origin: { x: 530, y: 0, z: 113 },
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(40)), /* required buffer size: 5136720 */
+{offset: 820, bytesPerRow: 805, rowsPerImage: 110}, {width: 370, height: 0, depthOrArrayLayers: 59});
+} catch {}
+let pipeline40 = await device1.createComputePipelineAsync({
+label: '\u0ffa\u{1f94d}\u{1f6b6}\u{1fc72}\u9b10',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+},
+});
+document.body.prepend(video3);
+gc();
+try {
+  await promise16;
+} catch {}
+gc();
+let canvas9 = document.createElement('canvas');
+let bindGroup2 = device0.createBindGroup({
+label: '\u2c27\u{1f666}\u1994',
+layout: bindGroupLayout13,
+entries: [{
+binding: 869,
+resource: externalTexture2
+}, {
+binding: 2828,
+resource: {
+buffer: buffer13,
+offset: 6144,
+size: 45416,
+}
+}],
+});
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder0.clearBuffer(buffer3, 22872, 6396);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder38.resolveQuerySet(querySet6, 545, 283, buffer2, 6400);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 916, new Float32Array(2135), 1562, 36);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 2,
+  origin: { x: 4, y: 0, z: 63 },
+  aspect: 'all',
+}, new Float32Array(arrayBuffer4), /* required buffer size: 640349 */
+{offset: 299, bytesPerRow: 251, rowsPerImage: 170}, {width: 3, height: 0, depthOrArrayLayers: 16});
+} catch {}
+let commandEncoder53 = device0.createCommandEncoder({label: '\u093f\ua1c3\ue307\uc084\uaa09\u0387\u0ec7\u01c9\u0e7a\ue8fa'});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup1, [18112]);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(4, bindGroup1, [17760]);
+} catch {}
+let arrayBuffer8 = buffer1.getMappedRange(0, 3664);
+try {
+commandEncoder22.resolveQuerySet(querySet11, 357, 1170, buffer2, 15104);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 9,
+  origin: { x: 6, y: 1, z: 1 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 35 */
+{offset: 35, bytesPerRow: 219}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(2, bindGroup1, [32128]);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(5, buffer4);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let querySet38 = device3.createQuerySet({
+label: '\ua79e\u893e\u4d4f\u0122\udaf6\u0e5c\u{1f924}',
+type: 'occlusion',
+count: 2210,
+});
+let textureView59 = texture62.createView({label: '\uaa47\ue895\uefb2', dimension: '2d', baseMipLevel: 1, baseArrayLayer: 7});
+try {
+device3.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 1,
+  origin: { x: 5, y: 16, z: 70 },
+  aspect: 'all',
+}, new Float32Array(arrayBuffer7), /* required buffer size: 1990526 */
+{offset: 426, bytesPerRow: 398, rowsPerImage: 160}, {width: 25, height: 41, depthOrArrayLayers: 32});
+} catch {}
+document.body.prepend(video4);
+let renderBundle44 = renderBundleEncoder42.finish({label: '\u706f\ue22f'});
+try {
+device1.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 1,
+  origin: { x: 24, y: 0, z: 1 },
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer5), /* required buffer size: 435 */
+{offset: 435}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+canvas9.getContext('webgl2');
+} catch {}
+let offscreenCanvas12 = new OffscreenCanvas(7, 954);
+let commandEncoder54 = device1.createCommandEncoder({label: '\u0e8f\u0cd8'});
+try {
+renderBundleEncoder17.setVertexBuffer(28, undefined, 2514210788, 218179234);
+} catch {}
+try {
+commandEncoder54.clearBuffer(buffer8, 9676, 1792);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+computePassEncoder21.insertDebugMarker('\u2811');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: video6,
+  origin: { x: 8, y: 10 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 17, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise17 = device1.createRenderPipelineAsync({
+label: '\ud2b8\u0ac5\uf2f8\u88b1\uffed\ue8ce',
+layout: pipelineLayout3,
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32float', writeMask: 0}, {
+  format: 'r16float',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-dst'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {format: 'r16uint', writeMask: 0}, {format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r8uint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 1518,
+depthBias: 74,
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 12856,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x3',
+offset: 4880,
+shaderLocation: 11,
+}, {
+format: 'snorm16x4',
+offset: 9988,
+shaderLocation: 22,
+}, {
+format: 'float32',
+offset: 11532,
+shaderLocation: 4,
+}, {
+format: 'uint16x2',
+offset: 8744,
+shaderLocation: 9,
+}, {
+format: 'float32x2',
+offset: 5224,
+shaderLocation: 16,
+}, {
+format: 'sint16x2',
+offset: 12840,
+shaderLocation: 0,
+}, {
+format: 'float16x2',
+offset: 3424,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 29592,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 14544,
+shaderLocation: 1,
+}, {
+format: 'unorm16x4',
+offset: 3936,
+shaderLocation: 17,
+}, {
+format: 'float16x4',
+offset: 28208,
+shaderLocation: 14,
+}, {
+format: 'unorm16x2',
+offset: 7384,
+shaderLocation: 26,
+}, {
+format: 'uint32',
+offset: 27124,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 17632,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x4',
+offset: 3632,
+shaderLocation: 20,
+}, {
+format: 'unorm16x4',
+offset: 8532,
+shaderLocation: 13,
+}, {
+format: 'uint32x2',
+offset: 1504,
+shaderLocation: 3,
+}, {
+format: 'float32x4',
+offset: 13724,
+shaderLocation: 10,
+}, {
+format: 'sint8x4',
+offset: 9360,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 28100,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint16x2',
+offset: 12168,
+shaderLocation: 24,
+}, {
+format: 'sint8x4',
+offset: 17196,
+shaderLocation: 18,
+}, {
+format: 'float32x4',
+offset: 632,
+shaderLocation: 8,
+}, {
+format: 'float32x4',
+offset: 7276,
+shaderLocation: 12,
+}, {
+format: 'uint32x4',
+offset: 11992,
+shaderLocation: 21,
+}],
+},
+{
+arrayStride: 3168,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x2',
+offset: 20,
+shaderLocation: 5,
+}, {
+format: 'float16x2',
+offset: 960,
+shaderLocation: 19,
+}],
+},
+{
+arrayStride: 16928,
+attributes: [{
+format: 'sint32',
+offset: 9236,
+shaderLocation: 23,
+}, {
+format: 'sint16x4',
+offset: 988,
+shaderLocation: 25,
+}],
+},
+{
+arrayStride: 21448,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x3',
+offset: 9432,
+shaderLocation: 2,
+}],
+}
+]
+},
+});
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let commandEncoder55 = device1.createCommandEncoder({label: '\ufaf9\u9476\uc07e\ufb84\u0e50\u0c50\ufdc9'});
+let texture63 = device1.createTexture({
+label: '\u0e76\u06a2\u036c\u0e7d\u{1f8a7}\u08ff\u4280',
+size: {width: 384, height: 16, depthOrArrayLayers: 187},
+sampleCount: 1,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x8-unorm', 'astc-8x8-unorm', 'astc-8x8-unorm'],
+});
+try {
+renderBundleEncoder17.draw(40, 24, 72);
+} catch {}
+try {
+commandEncoder55.clearBuffer(buffer21);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+computePassEncoder21.insertDebugMarker('\ucf73');
+} catch {}
+let gpuCanvasContext10 = offscreenCanvas12.getContext('webgpu');
+document.body.prepend(video5);
+try {
+renderBundleEncoder15.setVertexBuffer(6, buffer4);
+} catch {}
+try {
+commandEncoder11.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 6,
+  origin: { x: 12, y: 0, z: 33 },
+  aspect: 'all',
+}, {
+  texture: texture8,
+  mipLevel: 6,
+  origin: { x: 4, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 4, height: 4, depthOrArrayLayers: 32});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 2,
+  origin: { x: 70, y: 40, z: 22 },
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 325165 */
+{offset: 941, bytesPerRow: 247, rowsPerImage: 32}, {width: 100, height: 10, depthOrArrayLayers: 42});
+} catch {}
+try {
+buffer19.destroy();
+} catch {}
+try {
+computePassEncoder18.insertDebugMarker('\u42fd');
+} catch {}
+canvas5.width = 470;
+canvas4.width = 7;
+let img7 = await imageWithData(235, 30, '#ff4a4e4d', '#42e4f65a');
+let querySet39 = device1.createQuerySet({
+type: 'occlusion',
+count: 2910,
+});
+let texture64 = device1.createTexture({
+size: {width: 384, height: 16, depthOrArrayLayers: 103},
+mipLevelCount: 3,
+format: 'etc2-rgb8a1unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['etc2-rgb8a1unorm', 'etc2-rgb8a1unorm-srgb'],
+});
+let computePassEncoder23 = commandEncoder54.beginComputePass({label: '\u0bce\u6c5b\u3aa4\ua3b7\ubedf\u0f25\u{1ff2c}'});
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 61, y: 129 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 40, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline41 = device1.createRenderPipeline({
+label: '\ue963\u2e38\u0354\ucd07\uf240\uac5d\u{1ff74}\uf16f\ue8ad',
+layout: pipelineLayout7,
+multisample: {
+count: 4,
+mask: 0xafb85aeb,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rg8sint', writeMask: GPUColorWrite.GREEN}, {format: 'rg8unorm', writeMask: 0}, {format: 'r32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+failOp: 'invert',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'keep',
+},
+stencilReadMask: 1450,
+stencilWriteMask: 1313,
+depthBiasSlopeScale: 65,
+depthBiasClamp: 74,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 22664,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x2',
+offset: 20268,
+shaderLocation: 13,
+}, {
+format: 'snorm16x4',
+offset: 220,
+shaderLocation: 4,
+}, {
+format: 'uint8x2',
+offset: 9186,
+shaderLocation: 24,
+}, {
+format: 'uint16x4',
+offset: 18536,
+shaderLocation: 14,
+}, {
+format: 'uint16x2',
+offset: 7564,
+shaderLocation: 26,
+}, {
+format: 'sint32x2',
+offset: 10936,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 30748,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 7472,
+shaderLocation: 22,
+}, {
+format: 'sint16x4',
+offset: 11636,
+shaderLocation: 5,
+}, {
+format: 'unorm10-10-10-2',
+offset: 16448,
+shaderLocation: 1,
+}, {
+format: 'uint16x2',
+offset: 21584,
+shaderLocation: 17,
+}, {
+format: 'float16x2',
+offset: 24328,
+shaderLocation: 7,
+}, {
+format: 'snorm8x4',
+offset: 6252,
+shaderLocation: 8,
+}, {
+format: 'unorm16x2',
+offset: 15412,
+shaderLocation: 0,
+}, {
+format: 'unorm10-10-10-2',
+offset: 27272,
+shaderLocation: 21,
+}, {
+format: 'sint16x4',
+offset: 14108,
+shaderLocation: 25,
+}, {
+format: 'unorm16x2',
+offset: 26660,
+shaderLocation: 6,
+}, {
+format: 'uint8x2',
+offset: 25356,
+shaderLocation: 12,
+}, {
+format: 'float32',
+offset: 20220,
+shaderLocation: 20,
+}, {
+format: 'uint8x4',
+offset: 1700,
+shaderLocation: 10,
+}, {
+format: 'unorm16x2',
+offset: 5836,
+shaderLocation: 2,
+}, {
+format: 'sint32x4',
+offset: 22624,
+shaderLocation: 16,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let bindGroupLayout17 = device0.createBindGroupLayout({
+label: '\u0879\u055f\u7766\u{1f999}\uaa8b\u0646\ub077\u43cc',
+entries: [],
+});
+let commandEncoder56 = device0.createCommandEncoder();
+let texture65 = device0.createTexture({
+label: '\u26cf\u5997\u0d31\u56c1\u8131\uef19\u{1fb2b}\uef93\uf7b0\u{1fc03}\u0c75',
+size: {width: 735, height: 1, depthOrArrayLayers: 20},
+sampleCount: 1,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView60 = texture55.createView({
+  label: '\u4f21\u{1f977}\u{1f983}\u47d5\u{1fc95}\ud9ab\u6d1b\u0c0f\u9ae0\u0927',
+  aspect: 'all',
+  format: 'rg32uint',
+  baseMipLevel: 7
+});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup1, [17280]);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(8, buffer4, 7192, 14878);
+} catch {}
+try {
+commandEncoder18.copyBufferToTexture({
+/* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 17836 */
+offset: 14232,
+bytesPerRow: 256,
+buffer: buffer23,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: { x: 264, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 5, height: 15, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer23);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba16float'],
+});
+} catch {}
+let bindGroup3 = device0.createBindGroup({
+layout: bindGroupLayout4,
+entries: [{
+binding: 5759,
+resource: externalTexture2
+}, {
+binding: 1816,
+resource: externalTexture2
+}],
+});
+let querySet40 = device0.createQuerySet({
+label: '\u0672\udfa7\u6315\u{1f6aa}\u77ab\ua264\u0df9\ub30b\u71de',
+type: 'occlusion',
+count: 3254,
+});
+let texture66 = gpuCanvasContext2.getCurrentTexture();
+let textureView61 = texture20.createView({
+  label: '\u9b26\u003a\u3244\uf812\u711b\u{1ffe6}',
+  baseMipLevel: 3,
+  mipLevelCount: 2,
+  baseArrayLayer: 6,
+  arrayLayerCount: 80
+});
+let renderBundleEncoder43 = device0.createRenderBundleEncoder({
+  label: '\u{1f831}\ua8be\u{1f767}\uf15d',
+  colorFormats: ['rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let renderBundle45 = renderBundleEncoder35.finish({});
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(0, buffer4, 6504, 5961);
+} catch {}
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 7, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 20, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 16, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(querySet17, 2791, 106, buffer2, 35072);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer9,
+]);
+} catch {}
+let imageData12 = new ImageData(40, 208);
+let querySet41 = device0.createQuerySet({
+type: 'occlusion',
+count: 3258,
+});
+let texture67 = device0.createTexture({
+label: '\ub489\u0ee7\u0382\u8386\u06ef\u0374',
+size: {width: 576, height: 12, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['eac-rg11snorm', 'eac-rg11snorm', 'eac-rg11snorm'],
+});
+let sampler35 = device0.createSampler({
+label: '\u{1f728}\u42ce\uc6d8\u6ca2\u4855\u0987\u702e',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 27.503,
+compare: 'greater',
+});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup3, new Uint32Array(3441), 2570, 0);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup3);
+} catch {}
+let promise18 = buffer23.mapAsync(GPUMapMode.WRITE, 24608, 208);
+try {
+commandEncoder46.copyBufferToBuffer(buffer15, 7432, buffer3, 29272, 492);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer3);
+} catch {}
+video0.height = 258;
+let texture68 = device0.createTexture({
+size: {width: 720, height: 120, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x8-unorm', 'astc-8x8-unorm'],
+});
+let renderBundleEncoder44 = device0.createRenderBundleEncoder({
+  label: '\u3d02\u{1fffc}\u{1fe48}\u7e01\u00a5\uc1d8',
+  colorFormats: ['r8unorm', 'rgba16sint', 'rg8sint', 'rgba32float', 'r32uint', undefined],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let promise19 = device0.queue.onSubmittedWorkDone();
+canvas4.height = 221;
+let videoFrame10 = new VideoFrame(imageBitmap7, {timestamp: 0});
+let computePassEncoder24 = commandEncoder52.beginComputePass({label: '\u3532\ueca6\u00bd\u0065\u{1f8a0}'});
+let renderBundle46 = renderBundleEncoder40.finish();
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+pseudoSubmit(device1, commandEncoder50);
+let renderBundleEncoder45 = device1.createRenderBundleEncoder({
+  colorFormats: ['rgba32sint', 'rg8sint', 'rgba32uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder23.setPipeline(pipeline22);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer2), /* required buffer size: 495 */
+{offset: 495, bytesPerRow: 136}, {width: 8, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+label: '\u0556\u7b80\u9656\u0c9d',
+code: `@group(3) @binding(4710)
+var<storage, read_write> function2: array<u32>;
+@group(1) @binding(4710)
+var<storage, read_write> parameter6: array<u32>;
+@group(4) @binding(4710)
+var<storage, read_write> i3: array<u32>;
+
+@compute @workgroup_size(5, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S11 {
+  @location(39) f0: vec3<f32>,
+  @location(65) f1: i32,
+  @location(57) f2: vec4<f32>,
+  @location(41) f3: f16,
+  @location(27) f4: vec4<f32>,
+  @location(71) f5: vec3<f32>,
+  @location(63) f6: i32,
+  @location(32) f7: vec4<f16>,
+  @location(20) f8: vec4<f32>,
+  @location(24) f9: vec2<f16>,
+  @location(33) f10: vec4<f32>,
+  @location(13) f11: vec2<u32>,
+  @location(67) f12: f16,
+  @location(2) f13: f32,
+  @location(11) f14: vec4<i32>,
+  @location(73) f15: vec4<u32>,
+  @location(79) f16: vec2<f16>,
+  @location(9) f17: vec4<f32>,
+  @location(31) f18: vec2<f16>,
+  @location(25) f19: vec4<f16>,
+  @location(38) f20: vec2<f32>,
+  @location(82) f21: u32,
+  @location(1) f22: vec4<f16>,
+  @location(7) f23: vec2<i32>,
+  @location(0) f24: vec4<u32>,
+  @builtin(sample_index) f25: u32,
+  @location(43) f26: vec3<f32>,
+  @location(74) f27: vec4<f32>,
+  @location(75) f28: vec3<f16>,
+  @location(17) f29: f16,
+  @location(35) f30: vec3<f16>,
+  @location(59) f31: vec3<f32>,
+  @location(5) f32: f32,
+  @location(45) f33: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(1) f1: vec4<u32>,
+  @builtin(sample_mask) f2: u32,
+  @location(2) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(36) a0: vec4<u32>, @location(46) a1: vec4<f32>, @location(28) a2: vec3<i32>, a3: S11, @builtin(front_facing) a4: bool, @location(12) a5: vec2<f32>, @location(72) a6: i32, @location(50) a7: vec2<f16>, @location(22) a8: vec3<f16>, @location(54) a9: f32, @builtin(sample_mask) a10: u32, @builtin(position) a11: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S10 {
+  @location(18) f0: i32,
+  @location(6) f1: vec2<u32>,
+  @location(19) f2: vec2<f32>,
+  @location(1) f3: vec2<f16>,
+  @location(11) f4: f16,
+  @location(14) f5: vec2<u32>,
+  @location(4) f6: i32,
+  @location(16) f7: vec4<f16>,
+  @location(9) f8: vec2<f16>,
+  @location(10) f9: vec4<f32>,
+  @location(3) f10: vec4<u32>,
+  @location(0) f11: vec4<i32>
+}
+struct VertexOutput0 {
+  @location(11) f151: vec4<i32>,
+  @location(74) f152: vec4<f32>,
+  @location(57) f153: vec4<f32>,
+  @location(79) f154: vec2<f16>,
+  @location(73) f155: vec4<u32>,
+  @location(0) f156: vec4<u32>,
+  @location(41) f157: f16,
+  @location(71) f158: vec3<f32>,
+  @location(32) f159: vec4<f16>,
+  @location(38) f160: vec2<f32>,
+  @location(75) f161: vec3<f16>,
+  @location(22) f162: vec3<f16>,
+  @location(43) f163: vec3<f32>,
+  @location(33) f164: vec4<f32>,
+  @location(25) f165: vec4<f16>,
+  @location(50) f166: vec2<f16>,
+  @location(24) f167: vec2<f16>,
+  @location(82) f168: u32,
+  @location(39) f169: vec3<f32>,
+  @builtin(position) f170: vec4<f32>,
+  @location(63) f171: i32,
+  @location(12) f172: vec2<f32>,
+  @location(17) f173: f16,
+  @location(35) f174: vec3<f16>,
+  @location(67) f175: f16,
+  @location(27) f176: vec4<f32>,
+  @location(28) f177: vec3<i32>,
+  @location(1) f178: vec4<f16>,
+  @location(72) f179: i32,
+  @location(13) f180: vec2<u32>,
+  @location(36) f181: vec4<u32>,
+  @location(31) f182: vec2<f16>,
+  @location(7) f183: vec2<i32>,
+  @location(54) f184: f32,
+  @location(65) f185: i32,
+  @location(20) f186: vec4<f32>,
+  @location(45) f187: vec4<f32>,
+  @location(46) f188: vec4<f32>,
+  @location(9) f189: vec4<f32>,
+  @location(5) f190: f32,
+  @location(59) f191: vec3<f32>,
+  @location(2) f192: f32
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec2<f16>, @location(2) a1: u32, @location(7) a2: vec4<i32>, a3: S10, @location(13) a4: vec2<f32>, @location(5) a5: vec4<f16>, @location(12) a6: u32, @location(17) a7: vec2<u32>, @location(15) a8: vec3<i32>, @builtin(vertex_index) a9: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let renderBundle47 = renderBundleEncoder15.finish();
+try {
+buffer6.unmap();
+} catch {}
+let querySet42 = device3.createQuerySet({
+label: '\u{1f6b9}\u0554\u0bc9\u{1f83b}',
+type: 'occlusion',
+count: 3538,
+});
+let texture69 = device3.createTexture({
+label: '\u9c37\u{1faed}\uaa6a\u004e\u060b\uecaa',
+size: {width: 30},
+sampleCount: 1,
+dimension: '1d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+});
+let textureView62 = texture47.createView({label: '\u86e8\udbb2', baseMipLevel: 0});
+let computePassEncoder25 = commandEncoder51.beginComputePass({label: '\udfd8\u24a1\u0219'});
+let renderBundle48 = renderBundleEncoder40.finish({label: '\u79f4\u060c\u0f7e\u{1fc6f}\ud8ae\u0de3\u0f3c'});
+let sampler36 = device3.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 54.162,
+lodMaxClamp: 71.866,
+compare: 'less-equal',
+maxAnisotropy: 11,
+});
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let videoFrame11 = new VideoFrame(img6, {timestamp: 0});
+let computePassEncoder26 = commandEncoder55.beginComputePass({label: '\u{1fa6b}\ud2e4\u0069\u9615\ued8d'});
+try {
+renderBundleEncoder17.draw(40, 16, 0, 8);
+} catch {}
+try {
+buffer8.destroy();
+} catch {}
+try {
+  await promise18;
+} catch {}
+let device4 = await adapter6.requestDevice({
+label: '\u2b7c\u765f\udd19\u{1f967}\udb3f\uecc7\u{1fdf5}\ued54\u8d17\u{1f60c}\u3d1a',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxColorAttachmentBytesPerSample: 39,
+maxVertexAttributes: 19,
+maxVertexBufferArrayStride: 19567,
+maxStorageTexturesPerShaderStage: 15,
+maxStorageBuffersPerShaderStage: 16,
+maxDynamicStorageBuffersPerPipelineLayout: 54670,
+maxBindingsPerBindGroup: 2341,
+maxTextureDimension1D: 9883,
+maxTextureDimension2D: 15366,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 256,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 178727275,
+maxUniformBuffersPerShaderStage: 37,
+maxInterStageShaderVariables: 55,
+maxInterStageShaderComponents: 108,
+maxSamplersPerShaderStage: 18,
+},
+});
+try {
+adapter5.label = '\u2752\u18e2\ud805\ub832\ua672';
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let commandEncoder57 = device3.createCommandEncoder({label: '\uf8c9\u562c'});
+try {
+texture48.destroy();
+} catch {}
+let querySet43 = device1.createQuerySet({
+label: '\uaf0b\u425a\u2907\u{1fb55}\u67e2\u{1fd4f}\u039d\u4bda\u{1fc5f}\u{1fe53}\u7159',
+type: 'occlusion',
+count: 3622,
+});
+let renderBundleEncoder46 = device1.createRenderBundleEncoder({label: '\u4f83\u77f3\u087a', colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint']});
+try {
+renderBundleEncoder17.setPipeline(pipeline34);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 772, new BigUint64Array(15992), 2392, 56);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let video9 = await videoWithData();
+let buffer24 = device3.createBuffer({
+  label: '\u027c\u0ea8\u{1fff9}\u{1fb03}\u03c7',
+  size: 9579,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE
+});
+let texture70 = gpuCanvasContext0.getCurrentTexture();
+try {
+buffer19.unmap();
+} catch {}
+try {
+commandEncoder57.clearBuffer(buffer19, 11624, 2544);
+dissociateBuffer(device3, buffer19);
+} catch {}
+let canvas10 = document.createElement('canvas');
+let commandEncoder58 = device3.createCommandEncoder({label: '\u{1fb75}\ucafe\u06b6\u{1f97a}\u0076\ueb94\u0586\u9da2'});
+let computePassEncoder27 = commandEncoder58.beginComputePass({label: '\u0501\u9840\u9daa\u01c6\ua1a8\u{1f80b}'});
+let renderBundle49 = renderBundleEncoder28.finish({label: '\u27fa\u{1f838}\u8ec9\u0005\u{1f60e}'});
+try {
+device3.queue.writeBuffer(buffer24, 7052, new DataView(new ArrayBuffer(13280)), 6812, 2116);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+canvas10.getContext('webgl');
+} catch {}
+let pipelineLayout8 = device1.createPipelineLayout({label: '\ua538\u41f3\u018b\u{1ffbc}', bindGroupLayouts: [bindGroupLayout11, bindGroupLayout14]});
+let renderBundle50 = renderBundleEncoder31.finish({label: '\u1bc4\u17e0\u{1faf6}\u2512\ubb2b\u8890\u0fe1\ueca9\u6a82'});
+let sampler37 = device1.createSampler({
+label: '\uadc7\uad37\u5d48\u{1fbce}\u85a3\u1eb1',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 44.403,
+lodMaxClamp: 70.097,
+});
+try {
+renderBundleEncoder17.draw(48, 16, 16, 8);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 22, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 816 */
+{offset: 816, bytesPerRow: 310}, {width: 21, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder59 = device1.createCommandEncoder({label: '\u{1fd9d}\u06a9\u{1fb35}\u8cdb\u11c0\u0e89\u7edf\u18e0\uf37a\u{1f9a6}\u61ee'});
+let textureView63 = texture25.createView({label: '\u{1fcf0}\u098c\uc2af\u{1f716}\u8d10\u0e92\ucb21\u{1f914}\u9cb4\ub981\u0db6', baseMipLevel: 2});
+try {
+renderBundleEncoder17.draw(0, 24, 80);
+} catch {}
+let video10 = await videoWithData();
+let querySet44 = device1.createQuerySet({
+label: '\u{1f883}\u1c36\u{1fa36}\u5171\u979e',
+type: 'occlusion',
+count: 2506,
+});
+try {
+renderBundleEncoder17.draw(8, 72, 80, 0);
+} catch {}
+let arrayBuffer9 = buffer21.getMappedRange();
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture45,
+  mipLevel: 1,
+  origin: { x: 29, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: { x: 75, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 8, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderBundleEncoder37.pushDebugGroup('\u0e07');
+} catch {}
+let pipeline42 = device1.createRenderPipeline({
+label: '\u0328\u5be0\u6981\u6a16\u6c3f\u1acd\u3bcb\uda39',
+layout: pipelineLayout8,
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32float', writeMask: 0}, {format: 'r16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r16uint', writeMask: 0}, {format: 'r16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8uint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilReadMask: 1213,
+depthBias: 5,
+depthBiasSlopeScale: 41,
+depthBiasClamp: 17,
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x4',
+offset: 13484,
+shaderLocation: 23,
+}, {
+format: 'sint16x4',
+offset: 28012,
+shaderLocation: 18,
+}, {
+format: 'unorm16x4',
+offset: 23028,
+shaderLocation: 6,
+}, {
+format: 'float16x4',
+offset: 28656,
+shaderLocation: 13,
+}, {
+format: 'sint32',
+offset: 2948,
+shaderLocation: 25,
+}, {
+format: 'uint32x3',
+offset: 22700,
+shaderLocation: 2,
+}, {
+format: 'snorm8x2',
+offset: 11394,
+shaderLocation: 11,
+}, {
+format: 'snorm16x4',
+offset: 35132,
+shaderLocation: 12,
+}, {
+format: 'unorm8x2',
+offset: 2072,
+shaderLocation: 4,
+}, {
+format: 'sint8x4',
+offset: 4068,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 2424,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x4',
+offset: 1192,
+shaderLocation: 14,
+}, {
+format: 'unorm10-10-10-2',
+offset: 1572,
+shaderLocation: 17,
+}, {
+format: 'unorm8x2',
+offset: 2180,
+shaderLocation: 1,
+}, {
+format: 'unorm8x2',
+offset: 1380,
+shaderLocation: 8,
+}, {
+format: 'uint16x4',
+offset: 2276,
+shaderLocation: 3,
+}, {
+format: 'snorm8x4',
+offset: 2148,
+shaderLocation: 20,
+}, {
+format: 'unorm8x4',
+offset: 620,
+shaderLocation: 5,
+}, {
+format: 'float16x4',
+offset: 1816,
+shaderLocation: 19,
+}, {
+format: 'uint16x4',
+offset: 736,
+shaderLocation: 9,
+}, {
+format: 'float32x3',
+offset: 280,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 27632,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x2',
+offset: 10500,
+shaderLocation: 21,
+}, {
+format: 'sint16x4',
+offset: 16920,
+shaderLocation: 7,
+}, {
+format: 'snorm16x4',
+offset: 10544,
+shaderLocation: 22,
+}, {
+format: 'sint8x2',
+offset: 236,
+shaderLocation: 24,
+}, {
+format: 'uint16x2',
+offset: 25632,
+shaderLocation: 15,
+}, {
+format: 'float32x4',
+offset: 20728,
+shaderLocation: 26,
+}, {
+format: 'unorm16x4',
+offset: 9092,
+shaderLocation: 16,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'none',
+},
+});
+let texture71 = device4.createTexture({
+label: '\u23c8\u{1fee8}\u082b',
+size: [2020, 1, 220],
+mipLevelCount: 8,
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+});
+let textureView64 = texture71.createView({label: '\u1d52\u8167', dimension: '2d', baseMipLevel: 3, baseArrayLayer: 194});
+try {
+  await promise19;
+} catch {}
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+let bindGroupLayout18 = device0.createBindGroupLayout({
+label: '\u03e3\u086a\ue06c\ue9c2\u{1f914}\u{1f7e6}',
+entries: [{
+binding: 5556,
+visibility: 0,
+storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '2d' },
+}, {
+binding: 1953,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}],
+});
+try {
+computePassEncoder3.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(3, buffer4, 20508);
+} catch {}
+try {
+commandEncoder49.clearBuffer(buffer3, 43352, 12972);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let renderBundleEncoder47 = device0.createRenderBundleEncoder({
+  label: '\u7e67\u{1fc87}',
+  colorFormats: ['rgba16uint', undefined, 'r8sint', 'rg16sint', 'rgba16sint', 'rgba16float', 'rg32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+let renderBundle51 = renderBundleEncoder16.finish({});
+try {
+computePassEncoder4.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(3, bindGroup0, new Uint32Array(3749), 3649, 0);
+} catch {}
+try {
+commandEncoder53.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 2,
+  origin: { x: 290, y: 4, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture16,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 75, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder11.clearBuffer(buffer3, 26096, 1552);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder49.resolveQuerySet(querySet41, 3156, 28, buffer2, 8960);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 384, new BigUint64Array(46502), 1041, 24);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 18, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData12,
+  origin: { x: 38, y: 34 },
+  flipY: false,
+}, {
+  texture: texture57,
+  mipLevel: 8,
+  origin: { x: 8, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline43 = device0.createComputePipeline({
+label: '\ufb26\u0cf1\u251d\u091c\ua776\u0d25\ue5bc',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+},
+});
+document.body.prepend(canvas6);
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap10 = await createImageBitmap(offscreenCanvas6);
+let pipelineLayout9 = device0.createPipelineLayout({
+  label: '\u55ac\u9425\u95d0\ue4df\u{1f643}',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout4, bindGroupLayout12, bindGroupLayout7, bindGroupLayout3]
+});
+let buffer25 = device0.createBuffer({label: '\u0fc9\udf2b', size: 5734, usage: GPUBufferUsage.QUERY_RESOLVE});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup2, new Uint32Array(2711), 1456, 1);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+try {
+commandEncoder22.clearBuffer(buffer3, 16884, 42632);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder16.resolveQuerySet(querySet41, 1248, 346, buffer2, 9216);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video9,
+  origin: { x: 1, y: 3 },
+  flipY: true,
+}, {
+  texture: texture57,
+  mipLevel: 11,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout19 = device4.createBindGroupLayout({
+label: '\u8008\u{1f9b9}\u7854',
+entries: [{
+binding: 115,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+}, {
+binding: 1245,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+}, {
+binding: 1223,
+visibility: 0,
+sampler: { type: 'non-filtering' },
+}],
+});
+let texture72 = device4.createTexture({
+size: {width: 4740, height: 1, depthOrArrayLayers: 240},
+mipLevelCount: 2,
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgb10a2uint', 'rgb10a2uint', 'rgb10a2uint'],
+});
+let renderBundleEncoder48 = device4.createRenderBundleEncoder({
+  label: '\u{1ff5f}\u25a7\uf826\u4b73\u734d\u08dc\u1684\u0855\u85d3\ue039',
+  colorFormats: ['r32uint', undefined, 'rgba32float', 'rg16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+document.body.prepend(img2);
+let bindGroupLayout20 = device0.createBindGroupLayout({
+entries: [{
+binding: 4281,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+}, {
+binding: 3997,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}, {
+binding: 1641,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+}],
+});
+let commandEncoder60 = device0.createCommandEncoder({});
+let querySet45 = device0.createQuerySet({
+label: '\ub7f9\u{1f89b}\u2f4b\u{1fdbd}\u0523\u1eff\u5bc4\u0e06\u0264\u0a41\u7b8e',
+type: 'occlusion',
+count: 4078,
+});
+let computePassEncoder28 = commandEncoder53.beginComputePass({label: '\u0fff\u7879\u{1f96a}\u0a47\u43e4\u0403\ua9f5\u0f69\u{1f9af}\u0f82\u0217'});
+try {
+renderBundleEncoder27.setBindGroup(0, bindGroup1, [35264]);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(3, bindGroup3, new Uint32Array(2607), 1190, 0);
+} catch {}
+try {
+commandEncoder25.copyBufferToBuffer(buffer15, 3676, buffer10, 912, 196);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder30.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder34.resolveQuerySet(querySet35, 633, 406, buffer25, 2304);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video7,
+  origin: { x: 6, y: 0 },
+  flipY: true,
+}, {
+  texture: texture57,
+  mipLevel: 4,
+  origin: { x: 232, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let video11 = await videoWithData();
+let commandEncoder61 = device3.createCommandEncoder({label: '\u0b2d\u{1feec}\u0d27\u0ce0\u{1feb3}\u9f54\u4424\u{1ff20}\u{1f758}\u{1ff82}'});
+let computePassEncoder29 = commandEncoder61.beginComputePass({label: '\u{1ff09}\u{1f6d3}\u{1f88d}\u2794\u51ea\u3c85'});
+try {
+device3.queue.writeBuffer(buffer24, 4168, new Float32Array(4109), 203, 616);
+} catch {}
+let querySet46 = device4.createQuerySet({
+label: '\u0fba\u5cb8\u{1fe56}\u13af\u0112\u4d5f\u95a8\u35ab',
+type: 'occlusion',
+count: 528,
+});
+let texture73 = device4.createTexture({
+label: '\u{1fb53}\u0c55\u87f0',
+size: [160, 320, 1],
+mipLevelCount: 7,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-5x5-unorm-srgb', 'astc-5x5-unorm-srgb'],
+});
+let sampler38 = device4.createSampler({
+label: '\u000f\ucb5d\u{1ff20}\u7a5f\uecfa\u{1fbf2}\ub729\u055f\u0b9e\u{1feb4}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 43.763,
+lodMaxClamp: 74.934,
+});
+let buffer26 = device4.createBuffer({label: '\u003c\uc0f3\u{1f90a}', size: 54936, usage: GPUBufferUsage.INDIRECT, mappedAtCreation: true});
+let commandEncoder62 = device4.createCommandEncoder();
+let texture74 = device4.createTexture({
+label: '\u0327\u73d0\u02fd\u0738\u16ac\ub058',
+size: {width: 160, height: 320, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+sampleCount: 1,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x8-unorm-srgb'],
+});
+let texture75 = gpuCanvasContext2.getCurrentTexture();
+let textureView65 = texture74.createView({
+  label: '\u0e2d\ufd06\u67ea\u4014',
+  aspect: 'all',
+  format: 'astc-8x8-unorm-srgb',
+  baseMipLevel: 1,
+  mipLevelCount: 1
+});
+try {
+device4.destroy();
+} catch {}
+let querySet47 = device1.createQuerySet({
+type: 'occlusion',
+count: 3517,
+});
+let renderBundleEncoder49 = device1.createRenderBundleEncoder({
+  label: '\u4b83\uddae\u2e10\u0aa1\u01dd',
+  colorFormats: [undefined, 'rg8sint', 'rgba8uint', 'bgra8unorm-srgb', 'rg16sint', 'rg16float', 'rg8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+try {
+computePassEncoder23.end();
+} catch {}
+try {
+renderBundleEncoder17.draw(16, 24);
+} catch {}
+try {
+renderBundleEncoder46.setIndexBuffer(buffer7, 'uint16', 19500, 5825);
+} catch {}
+try {
+commandEncoder54.copyTextureToTexture({
+  texture: texture45,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture45,
+  mipLevel: 4,
+  origin: { x: 3, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder54.clearBuffer(buffer21);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 85, y: 99 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 30, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 17, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame12 = new VideoFrame(video2, {timestamp: 0});
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let texture76 = device0.createTexture({
+size: [180, 30, 1],
+format: 'astc-10x6-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView66 = texture43.createView({
+  label: '\u7af2\u3791\u{1f780}\ufb48\u04f3\u255e',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseMipLevel: 6,
+  mipLevelCount: 3
+});
+try {
+computePassEncoder19.setBindGroup(4, bindGroup2, new Uint32Array(9149), 822, 1);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(4, buffer4, 23932, 644);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 352, new BigUint64Array(54955), 51022, 88);
+} catch {}
+let img8 = await imageWithData(54, 142, '#dd2d3567', '#bb7317af');
+let sampler39 = device1.createSampler({
+label: '\ue836\u5fb2\u{1f7a4}',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 6.290,
+lodMaxClamp: 60.933,
+compare: 'not-equal',
+maxAnisotropy: 9,
+});
+try {
+renderBundleEncoder17.draw(8, 64, 56, 56);
+} catch {}
+try {
+renderBundleEncoder37.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let commandEncoder63 = device3.createCommandEncoder();
+let querySet48 = device3.createQuerySet({
+label: '\ue9bd\u00e6\u{1fcdf}\u{1fc54}\u0666\u0cb8\ub7e1\u4528\u{1fe07}\u2046',
+type: 'occlusion',
+count: 424,
+});
+let sampler40 = device3.createSampler({
+label: '\ub578\uc2ba\u085b\u33db\u{1f723}\u0a2d\u2c4e\u1aad\u04ac',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 49.289,
+lodMaxClamp: 93.929,
+});
+try {
+device3.queue.submit([
+]);
+} catch {}
+let img9 = await imageWithData(69, 188, '#851227b3', '#db9ce1f0');
+let promise20 = adapter3.requestAdapterInfo();
+let texture77 = device3.createTexture({
+label: '\u31e0\u654d\u300a',
+size: [912, 20, 163],
+mipLevelCount: 8,
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x10-unorm', 'astc-12x10-unorm', 'astc-12x10-unorm-srgb'],
+});
+let computePassEncoder30 = commandEncoder63.beginComputePass();
+try {
+device3.queue.submit([
+commandBuffer7,
+]);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 1,
+  origin: { x: 0, y: 25, z: 62 },
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 1716688 */
+{offset: 838, bytesPerRow: 837, rowsPerImage: 50}, {width: 210, height: 0, depthOrArrayLayers: 42});
+} catch {}
+let commandEncoder64 = device0.createCommandEncoder({label: '\u0690\ub036\u2592\u0ecf\ub257\u{1f997}'});
+let texture78 = device0.createTexture({
+label: '\u587b\u{1f659}\u0f21\uf11c\u09eb\u55fd\u06dc',
+size: [360, 60, 200],
+mipLevelCount: 9,
+format: 'astc-4x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-4x4-unorm', 'astc-4x4-unorm-srgb'],
+});
+let renderBundle52 = renderBundleEncoder6.finish({label: '\u{1feb8}\u24f8'});
+try {
+renderBundleEncoder22.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 4,
+  origin: { x: 20, y: 0, z: 0 },
+  aspect: 'all',
+}, new DataView(arrayBuffer1), /* required buffer size: 13 */
+{offset: 13}, {width: 128, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture79 = device3.createTexture({
+label: '\u0a53\u7e7d\u6710\ua5b1\u0dcd\u2f86',
+size: {width: 60, height: 240, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder31 = commandEncoder57.beginComputePass({label: '\uf9a6\u{1fa97}\u0c50\u4d29\uebd7\u9d61'});
+let sampler41 = device3.createSampler({
+label: '\u{1f978}\ubacf\u5bc6',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 68.497,
+lodMaxClamp: 72.893,
+});
+offscreenCanvas3.height = 730;
+let canvas11 = document.createElement('canvas');
+let renderBundleEncoder50 = device3.createRenderBundleEncoder({
+  label: '\u089e\u8968\u0a46\u0f01\ubcb2\u{1f926}\u765f\u0abf\u6fcd\u56e9',
+  colorFormats: ['rg32sint'],
+  stencilReadOnly: true
+});
+let renderBundle53 = renderBundleEncoder50.finish({label: '\u{1fc40}\ue886'});
+let shaderModule9 = device0.createShaderModule({
+label: '\u8e66\ucbf8\u07ff\u448f',
+code: `@group(0) @binding(5759)
+var<storage, read_write> local10: array<u32>;
+@group(3) @binding(4710)
+var<storage, read_write> global5: array<u32>;
+
+@compute @workgroup_size(7, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: f32,
+  @location(2) f1: vec2<u32>,
+  @location(3) f2: u32,
+  @location(0) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool, @builtin(sample_mask) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S12 {
+  @location(16) f0: vec2<i32>,
+  @location(10) f1: f16,
+  @location(18) f2: vec4<i32>,
+  @location(4) f3: i32,
+  @location(6) f4: vec2<f32>,
+  @location(3) f5: vec4<i32>,
+  @location(14) f6: vec2<f16>,
+  @location(19) f7: vec4<u32>,
+  @location(5) f8: vec3<i32>,
+  @location(12) f9: vec4<f16>,
+  @location(11) f10: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec4<f16>, @location(8) a1: f16, @builtin(vertex_index) a2: u32, @location(1) a3: u32, @location(7) a4: vec4<u32>, @location(13) a5: vec4<f16>, @builtin(instance_index) a6: u32, @location(0) a7: i32, @location(9) a8: vec4<i32>, @location(17) a9: vec2<f32>, a10: S12, @location(2) a11: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder65 = device0.createCommandEncoder();
+let querySet49 = device0.createQuerySet({
+label: '\u{1f652}\u{1f8fa}\u0740\u9652\u0f5b\ube06\u07ab\u{1fee2}',
+type: 'occlusion',
+count: 1464,
+});
+let renderBundleEncoder51 = device0.createRenderBundleEncoder({
+  label: '\u0fdb\u3b7c\u{1fe94}\u026a\u1370\u0223\u{1fe20}\u{1fe2d}',
+  colorFormats: ['r8sint', 'rg16float', 'rgba16float'],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+let sampler42 = device0.createSampler({
+label: '\uef30\u0d85\uf37f\ua175\u{1febd}\u0e86\u390d\u{1fb71}\u073e\u0ae2\u0a0f',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 73.945,
+lodMaxClamp: 97.370,
+maxAnisotropy: 8,
+});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup3, new Uint32Array(3189), 654, 0);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline27);
+} catch {}
+try {
+commandEncoder34.copyBufferToBuffer(buffer23, 1828, buffer3, 46752, 12760);
+dissociateBuffer(device0, buffer23);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder0.clearBuffer(buffer3, 6516, 9284);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 219, y: 2, z: 1 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 414017 */
+{offset: 968, bytesPerRow: 1003, rowsPerImage: 82}, {width: 51, height: 2, depthOrArrayLayers: 6});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let querySet50 = device3.createQuerySet({
+label: '\u0a9b\u{1fb1d}\u0e63\u0c02\u7da4\u0950\u{1fc67}',
+type: 'occlusion',
+count: 3974,
+});
+let textureView67 = texture77.createView({label: '\u0f5b\ua544\ud602', baseMipLevel: 5, mipLevelCount: 2, baseArrayLayer: 98, arrayLayerCount: 8});
+let sampler43 = device3.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 63.184,
+lodMaxClamp: 93.476,
+});
+try {
+canvas11.getContext('bitmaprenderer');
+} catch {}
+let img10 = await imageWithData(104, 275, '#088358bb', '#ffdf3b9b');
+try {
+window.someLabel = device4.label;
+} catch {}
+let renderBundle54 = renderBundleEncoder43.finish({label: '\ud681\u0d68\udec2\ueeec'});
+try {
+renderBundleEncoder12.setBindGroup(3, bindGroup0, new Uint32Array(6845), 376, 0);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(7, buffer4, 7220, 7816);
+} catch {}
+let promise21 = device0.createComputePipelineAsync({
+label: '\u07b2\u004b\u4503',
+layout: 'auto',
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+  await promise20;
+} catch {}
+let textureView68 = texture58.createView({label: '\u9977\ue4cf\u{1f97f}', baseMipLevel: 1, baseArrayLayer: 24, arrayLayerCount: 91});
+let sampler44 = device3.createSampler({
+label: '\u09c8\uc537\u1ec6\u{1f661}',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMaxClamp: 50.495,
+});
+try {
+device3.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 3,
+  origin: { x: 12, y: 5, z: 4 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 2949205 */
+{offset: 190, bytesPerRow: 235, rowsPerImage: 267}, {width: 24, height: 0, depthOrArrayLayers: 48});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+gc();
+let buffer27 = device1.createBuffer({size: 20756, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let querySet51 = device1.createQuerySet({
+label: '\u8db7\u8763\u0e36\u{1fa02}\u6691\ue15f\u62d3\u0b06\u07e8',
+type: 'occlusion',
+count: 3274,
+});
+let textureView69 = texture64.createView({
+  label: '\ue51b\uc1b1\u93f3\ud072\u{1fd9c}\u{1faa5}\u4759\u3fd0\u0e61\ue37c\u3ba6',
+  format: 'etc2-rgb8a1unorm',
+  mipLevelCount: 2,
+  baseArrayLayer: 71,
+  arrayLayerCount: 11
+});
+let renderBundle55 = renderBundleEncoder24.finish();
+try {
+renderBundleEncoder49.setVertexBuffer(72, undefined, 2332263278, 1260032284);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer27, 19336, new Int16Array(31330), 23825, 56);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData5,
+  origin: { x: 147, y: 104 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 45, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let bindGroupLayout21 = device1.createBindGroupLayout({
+label: '\u0461\u{1fca7}\u0796',
+entries: [{
+binding: 3399,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}, {
+binding: 1145,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '3d' },
+}, {
+binding: 3240,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}],
+});
+let bindGroup4 = device1.createBindGroup({
+label: '\uf5f8\u049d\ud89a\uf83b\u7b3c\u{1f7e9}\u{1faa3}',
+layout: bindGroupLayout14,
+entries: [{
+binding: 1723,
+resource: sampler22
+}],
+});
+let renderBundle56 = renderBundleEncoder9.finish({label: '\u0122\u601f\u7579\u30fc\u{1fd85}\u{1fcd8}\u1dbe\u0cd3'});
+let sampler45 = device1.createSampler({
+label: '\u898c\ucbf5\u{1fff3}\u{1fa53}\ubcbc\ud255\u4cc6',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 65.488,
+lodMaxClamp: 93.194,
+maxAnisotropy: 15,
+});
+try {
+renderBundleEncoder25.setVertexBuffer(23, undefined, 1690392923, 1421406778);
+} catch {}
+try {
+computePassEncoder21.insertDebugMarker('\u0fdb');
+} catch {}
+let canvas12 = document.createElement('canvas');
+let offscreenCanvas13 = new OffscreenCanvas(331, 539);
+let textureView70 = texture31.createView({label: '\u{1fcee}\u{1f714}\uf822\u{1fd8e}\u0033', dimension: '2d-array', mipLevelCount: 3});
+let computePassEncoder32 = commandEncoder65.beginComputePass({label: '\u68c3\u7f38\u{1fdac}\u0882\u0f3a\u{1f609}'});
+let renderBundle57 = renderBundleEncoder7.finish({label: '\u0f63\u29f8\u0693\ufee3\u7bac\u1f67\u{1ffaa}\u{1fc3d}\u0b28\u{1f87f}\u{1ff77}'});
+try {
+commandEncoder34.copyBufferToBuffer(buffer23, 3044, buffer10, 1104, 72);
+dissociateBuffer(device0, buffer23);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video4,
+  origin: { x: 5, y: 14 },
+  flipY: false,
+}, {
+  texture: texture57,
+  mipLevel: 4,
+  origin: { x: 228, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline44 = await promise7;
+try {
+computePassEncoder5.setPipeline(pipeline37);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 4,
+  origin: { x: 30, y: 0, z: 4 },
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 892401 */
+{offset: 373, bytesPerRow: 311, rowsPerImage: 47}, {width: 50, height: 20, depthOrArrayLayers: 62});
+} catch {}
+let pipeline45 = await promise21;
+let gpuCanvasContext11 = canvas12.getContext('webgpu');
+let img11 = await imageWithData(50, 103, '#01e5a3e1', '#562fb65b');
+let querySet52 = device0.createQuerySet({
+label: '\u{1f911}\u0edb\u2396\u9413\u0970\u8fa8',
+type: 'occlusion',
+count: 2414,
+});
+let computePassEncoder33 = commandEncoder64.beginComputePass({});
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 75, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas6,
+  origin: { x: 53, y: 89 },
+  flipY: false,
+}, {
+  texture: texture57,
+  mipLevel: 6,
+  origin: { x: 33, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 18, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline46 = await device0.createComputePipelineAsync({
+layout: pipelineLayout5,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let videoFrame13 = videoFrame2.clone();
+let bindGroup5 = device0.createBindGroup({
+label: '\u0fbf\u00d8\ua9b5\u0d4a',
+layout: bindGroupLayout13,
+entries: [{
+binding: 2828,
+resource: {
+buffer: buffer13,
+offset: 31040,
+size: 10860,
+}
+}, {
+binding: 869,
+resource: externalTexture2
+}],
+});
+let buffer28 = device0.createBuffer({
+  label: '\udee5\uaacc',
+  size: 48792,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX
+});
+let querySet53 = device0.createQuerySet({
+label: '\u{1ff29}\ua179\u0628\uf727\u04c4\u0502',
+type: 'occlusion',
+count: 1029,
+});
+try {
+renderBundleEncoder39.setBindGroup(2, bindGroup5, new Uint32Array(5503), 4008, 1);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(3, buffer28, 28708, 6516);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+alphaMode: 'premultiplied',
+});
+} catch {}
+let videoFrame14 = new VideoFrame(video3, {timestamp: 0});
+let querySet54 = device2.createQuerySet({
+label: '\uc7a6\u64d1',
+type: 'occlusion',
+count: 1100,
+});
+let computePassEncoder34 = commandEncoder31.beginComputePass();
+let renderBundle58 = renderBundleEncoder30.finish({label: '\u9802\u{1fd02}\ub092\uc073\u126d\u053b\u677c\u{1ff67}\u{1f800}\u0740'});
+try {
+renderBundleEncoder21.setVertexBuffer(22, undefined, 3047368825, 1106745983);
+} catch {}
+let offscreenCanvas14 = new OffscreenCanvas(961, 658);
+document.body.prepend(video3);
+let textureView71 = texture12.createView({label: '\u086c\u11fe\ua0f5\u4ba4\u4312\u{1f824}\u0e66'});
+try {
+commandEncoder22.copyBufferToBuffer(buffer23, 15516, buffer6, 1300, 3600);
+dissociateBuffer(device0, buffer23);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let gpuCanvasContext12 = offscreenCanvas13.getContext('webgpu');
+let canvas13 = document.createElement('canvas');
+try {
+offscreenCanvas14.getContext('webgl2');
+} catch {}
+document.body.prepend(img11);
+let img12 = await imageWithData(3, 196, '#7a8e74ba', '#4ebd7861');
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+video6.height = 226;
+let promise22 = adapter5.requestDevice({
+});
+let querySet55 = device0.createQuerySet({
+type: 'occlusion',
+count: 1853,
+});
+let textureView72 = texture57.createView({dimension: '2d-array', baseMipLevel: 4, mipLevelCount: 4});
+let computePassEncoder35 = commandEncoder49.beginComputePass({label: '\ubd81\ud121'});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup3, new Uint32Array(3384), 1291, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 940, new Int16Array(14604), 4522, 84);
+} catch {}
+let imageBitmap11 = await createImageBitmap(canvas2);
+let imageData13 = new ImageData(124, 240);
+let commandEncoder66 = device3.createCommandEncoder({});
+try {
+window.someLabel = sampler29.label;
+} catch {}
+let bindGroupLayout22 = device3.createBindGroupLayout({
+label: '\ub376\u{1f6ac}\uc8ce\u06da\u0be3\u{1fc34}\u8c11\u09d0\ua967\u{1fbc9}',
+entries: [],
+});
+let pipelineLayout10 = device3.createPipelineLayout({label: '\u025c\u{1fdb4}\u{1f73a}\u1e60\ufb6b\u0dda\u0292', bindGroupLayouts: []});
+let commandEncoder67 = device3.createCommandEncoder({label: '\u582a\u2cb4\ud470\ubf7a'});
+let renderBundleEncoder52 = device3.createRenderBundleEncoder({
+  label: '\u{1f878}\u63d2\uc7ea\uf395\uf16c\u026c\u3360\u0ba7',
+  colorFormats: ['rg32sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler46 = device3.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 45.088,
+lodMaxClamp: 64.438,
+compare: 'equal',
+});
+let externalTexture3 = device3.importExternalTexture({
+label: '\u{1ffdc}\u0296\u{1f6aa}\u24d2\u2db9\u0afa\uf4e1\u08d0',
+source: video2,
+colorSpace: 'srgb',
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let shaderModule10 = device0.createShaderModule({
+code: `@group(3) @binding(4710)
+var<storage, read_write> parameter7: array<u32>;
+@group(4) @binding(4710)
+var<storage, read_write> local11: array<u32>;
+@group(0) @binding(4710)
+var<storage, read_write> type6: array<u32>;
+@group(2) @binding(4710)
+var<storage, read_write> type7: array<u32>;
+@group(1) @binding(4710)
+var<storage, read_write> global6: array<u32>;
+
+@compute @workgroup_size(6, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S13 {
+  @location(11) f0: vec2<u32>,
+  @builtin(sample_mask) f1: u32,
+  @location(65) f2: vec3<f16>,
+  @location(1) f3: f32,
+  @location(57) f4: vec3<f16>,
+  @location(6) f5: vec2<f32>,
+  @location(62) f6: u32,
+  @builtin(sample_index) f7: u32,
+  @location(18) f8: vec2<u32>
+}
+struct FragmentOutput0 {
+  @builtin(frag_depth) f0: f32,
+  @builtin(sample_mask) f1: u32,
+  @location(0) f2: u32,
+  @location(5) f3: i32
+}
+
+@fragment
+fn fragment0(a0: S13, @location(12) a1: vec3<f32>, @builtin(position) a2: vec4<f32>, @location(44) a3: f16, @location(8) a4: vec2<f32>, @location(66) a5: f32, @location(82) a6: i32, @location(72) a7: vec3<f32>, @location(46) a8: i32, @location(64) a9: u32, @location(16) a10: vec2<i32>, @location(17) a11: vec3<i32>, @location(48) a12: vec4<i32>, @location(60) a13: f32, @location(73) a14: vec2<i32>, @location(67) a15: f32, @location(28) a16: vec2<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(46) f193: i32,
+  @location(64) f194: u32,
+  @location(3) f195: vec4<i32>,
+  @location(48) f196: vec4<i32>,
+  @location(28) f197: vec2<i32>,
+  @location(29) f198: vec3<f32>,
+  @location(62) f199: u32,
+  @location(82) f200: i32,
+  @location(65) f201: vec3<f16>,
+  @location(76) f202: vec2<f32>,
+  @location(72) f203: vec3<f32>,
+  @location(1) f204: f32,
+  @location(18) f205: vec2<u32>,
+  @location(12) f206: vec3<f32>,
+  @location(6) f207: vec2<f32>,
+  @location(11) f208: vec2<u32>,
+  @location(67) f209: f32,
+  @location(60) f210: f32,
+  @location(10) f211: vec4<u32>,
+  @location(57) f212: vec3<f16>,
+  @location(66) f213: f32,
+  @builtin(position) f214: vec4<f32>,
+  @location(44) f215: f16,
+  @location(8) f216: vec2<f32>,
+  @location(23) f217: vec4<f16>,
+  @location(73) f218: vec2<i32>,
+  @location(16) f219: vec2<i32>,
+  @location(17) f220: vec3<i32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroupLayout23 = device0.createBindGroupLayout({
+label: '\u1730\u{1f73e}\u4c49\u0089',
+entries: [],
+});
+let renderBundleEncoder53 = device0.createRenderBundleEncoder({label: '\u2811\u0b95', colorFormats: ['rgb10a2unorm', 'r16float', 'rg8uint', 'r8uint']});
+let renderBundle59 = renderBundleEncoder0.finish();
+try {
+computePassEncoder32.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(0, buffer28);
+} catch {}
+try {
+  await buffer9.mapAsync(GPUMapMode.READ, 0, 340);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 344, new Float32Array(15832), 12383, 156);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 2,
+  origin: { x: 12, y: 0, z: 11 },
+  aspect: 'all',
+}, new Int16Array(arrayBuffer6), /* required buffer size: 1279435 */
+{offset: 157, bytesPerRow: 142, rowsPerImage: 143}, {width: 0, height: 1, depthOrArrayLayers: 64});
+} catch {}
+let bindGroupLayout24 = device3.createBindGroupLayout({
+entries: [],
+});
+let buffer29 = device3.createBuffer({label: '\u0fbb\u8fef', size: 4288, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let commandEncoder68 = device3.createCommandEncoder({label: '\u{1fb69}\u97ee\ubb79\u0dde\u9b2d'});
+let texture80 = device3.createTexture({
+label: '\ub7f4\u0fad\u{1feba}\u{1faf1}\ucd75',
+size: {width: 64, height: 120, depthOrArrayLayers: 94},
+mipLevelCount: 4,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let renderBundleEncoder54 = device3.createRenderBundleEncoder({colorFormats: ['rg32sint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundleEncoder55 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba16uint', undefined, 'r8sint', 'rg16sint', 'rgba16sint', 'rgba16float', 'rg32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true
+});
+let sampler47 = device0.createSampler({
+label: '\u8b43\u0b4c\uba32\ud032\u{1ffef}\ub79f',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 1.311,
+lodMaxClamp: 56.673,
+maxAnisotropy: 6,
+});
+try {
+commandEncoder30.clearBuffer(buffer10, 604, 208);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder34.resolveQuerySet(querySet7, 312, 32, buffer25, 512);
+} catch {}
+try {
+commandEncoder34.insertDebugMarker('\u5b36');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4800, height: 16, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 114, y: 9 },
+  flipY: false,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: { x: 1558, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 80, height: 14, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext13 = canvas13.getContext('webgpu');
+document.body.prepend(video6);
+let bindGroup6 = device3.createBindGroup({
+layout: bindGroupLayout24,
+entries: [],
+});
+let pipelineLayout11 = device3.createPipelineLayout({
+  label: '\u434c\uc5d4\u{1f71d}\u0906\u3584\u8508\u4eb7\u56d9',
+  bindGroupLayouts: [bindGroupLayout24, bindGroupLayout24, bindGroupLayout22, bindGroupLayout22, bindGroupLayout22]
+});
+let querySet56 = device3.createQuerySet({
+label: '\udb1e\u{1f991}\u{1fe25}\uf2d3\u{1ffd1}\u07d2\ud88d\ub090\u0693',
+type: 'occlusion',
+count: 1982,
+});
+let computePassEncoder36 = commandEncoder67.beginComputePass({label: '\u0c06\u0f72\u0feb\u0d87'});
+let renderBundleEncoder56 = device3.createRenderBundleEncoder({
+  label: '\u6918\u9ad2\u9f72\u4f47',
+  colorFormats: ['r8uint', undefined, 'r32sint', 'rgba8uint', 'rg8unorm', 'rg8uint', 'rg32uint', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+commandEncoder68.copyTextureToTexture({
+  texture: texture80,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 14 },
+  aspect: 'all',
+}, {
+  texture: texture80,
+  mipLevel: 1,
+  origin: { x: 0, y: 32, z: 13 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 73});
+} catch {}
+try {
+device3.queue.writeBuffer(buffer24, 8644, new Int16Array(32954), 18717, 64);
+} catch {}
+try {
+device1.queue.label = '\u01e0\u17c5\ud932\u{1fb8e}\u0708\ufeeb\u0317\u0420\u0d3a\u0c4a';
+} catch {}
+let texture81 = gpuCanvasContext6.getCurrentTexture();
+let renderBundleEncoder57 = device1.createRenderBundleEncoder({colorFormats: ['rgba32sint', 'rg8sint', 'rgba32uint'], sampleCount: 4, stencilReadOnly: true});
+try {
+computePassEncoder26.setBindGroup(3, bindGroup4, new Uint32Array(7567), 1997, 0);
+} catch {}
+try {
+renderBundleEncoder17.draw(8, 80, 48, 64);
+} catch {}
+try {
+commandEncoder54.copyBufferToBuffer(buffer20, 876, buffer8, 10480, 28);
+dissociateBuffer(device1, buffer20);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder54.clearBuffer(buffer20, 1060, 168);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 23, y: 71 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 12, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 32, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.label = '\u38fe\u747a\ue402';
+} catch {}
+let textureView73 = texture25.createView({label: '\uf68a\u86c2\ubcb0\u1297\u{1f73d}\u0f88\u2ab7\u83b7', dimension: '2d-array', baseMipLevel: 2});
+let renderBundle60 = renderBundleEncoder9.finish({});
+try {
+renderBundleEncoder17.draw(16, 80);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(72, 32);
+} catch {}
+let pipeline47 = await device1.createRenderPipelineAsync({
+label: '\u0eb6\u074b\u0f74',
+layout: pipelineLayout3,
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3617,
+stencilWriteMask: 3684,
+depthBiasSlopeScale: 83,
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 10548,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 8652,
+shaderLocation: 19,
+}, {
+format: 'uint32',
+offset: 412,
+shaderLocation: 21,
+}, {
+format: 'snorm16x2',
+offset: 912,
+shaderLocation: 20,
+}, {
+format: 'snorm8x4',
+offset: 4324,
+shaderLocation: 11,
+}, {
+format: 'uint16x2',
+offset: 9172,
+shaderLocation: 9,
+}, {
+format: 'float32x4',
+offset: 9732,
+shaderLocation: 26,
+}, {
+format: 'uint16x2',
+offset: 6848,
+shaderLocation: 3,
+}, {
+format: 'sint16x4',
+offset: 3484,
+shaderLocation: 7,
+}, {
+format: 'snorm8x4',
+offset: 6904,
+shaderLocation: 14,
+}, {
+format: 'unorm10-10-10-2',
+offset: 6212,
+shaderLocation: 4,
+}, {
+format: 'sint16x2',
+offset: 9816,
+shaderLocation: 23,
+}, {
+format: 'sint32x2',
+offset: 7044,
+shaderLocation: 25,
+}, {
+format: 'snorm16x4',
+offset: 5408,
+shaderLocation: 5,
+}, {
+format: 'sint16x2',
+offset: 7644,
+shaderLocation: 18,
+}, {
+format: 'snorm16x4',
+offset: 5372,
+shaderLocation: 12,
+}, {
+format: 'snorm16x2',
+offset: 10244,
+shaderLocation: 22,
+}, {
+format: 'sint16x4',
+offset: 2516,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 12960,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm16x2',
+offset: 1724,
+shaderLocation: 17,
+}, {
+format: 'unorm8x4',
+offset: 1748,
+shaderLocation: 8,
+}, {
+format: 'float16x4',
+offset: 808,
+shaderLocation: 13,
+}, {
+format: 'snorm16x2',
+offset: 7396,
+shaderLocation: 1,
+}, {
+format: 'uint8x4',
+offset: 8080,
+shaderLocation: 15,
+}, {
+format: 'float32x2',
+offset: 12228,
+shaderLocation: 16,
+}, {
+format: 'unorm8x4',
+offset: 7380,
+shaderLocation: 6,
+}, {
+format: 'uint32x4',
+offset: 6616,
+shaderLocation: 2,
+}, {
+format: 'sint8x4',
+offset: 4936,
+shaderLocation: 24,
+}, {
+format: 'float16x2',
+offset: 6624,
+shaderLocation: 10,
+}],
+}
+]
+},
+});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let bindGroupLayout25 = device1.createBindGroupLayout({
+entries: [],
+});
+let buffer30 = device1.createBuffer({
+  label: '\uc9b5\u44e7\u94eb\u4d15\u{1f8c1}\uf9bd\u0efb\u6443\u{1fc2e}\u{1febf}\ueaea',
+  size: 46974,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let querySet57 = device1.createQuerySet({
+label: '\uc169\ueeaf\u96e4\u63e9\u3c42\ud88a\u5fd7\u0822\uaee1\u2e91',
+type: 'occlusion',
+count: 1994,
+});
+let commandBuffer10 = commandEncoder54.finish({
+label: '\ueb4c\u0285\u0840\u9c32\u0d57\u0982',
+});
+let textureView74 = texture19.createView({label: '\u682d\udcb9\ub4bc\u03f1\u{1fdb3}\u4faf', dimension: '2d-array'});
+let sampler48 = device1.createSampler({
+label: '\u6248\u1071\ucc2a\ufc12\u3100\ucca9',
+addressModeU: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 54.763,
+lodMaxClamp: 62.559,
+});
+try {
+device1.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 1,
+  origin: { x: 24, y: 86, z: 95 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer6), /* required buffer size: 647 */
+{offset: 647, bytesPerRow: 295}, {width: 23, height: 167, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData13,
+  origin: { x: 94, y: 207 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 19, y: 2, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 13, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline48 = device1.createComputePipeline({
+label: '\u{1ffa1}\u25c7\u{1f815}\u00dc\ua9ef\u99d3',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+renderBundleEncoder17.draw(40);
+} catch {}
+try {
+commandEncoder59.copyBufferToBuffer(buffer20, 896, buffer27, 16712, 84);
+dissociateBuffer(device1, buffer20);
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 2,
+  origin: { x: 2, y: 0, z: 51 },
+  aspect: 'all',
+}, {
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 49, y: 623, z: 157 },
+  aspect: 'all',
+}, {width: 23, height: 5, depthOrArrayLayers: 38});
+} catch {}
+let pipeline49 = device1.createRenderPipeline({
+layout: pipelineLayout8,
+fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg8sint'}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-constant'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-src-alpha'},
+},
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r32uint'}, {
+  format: 'r32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater',
+failOp: 'keep',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-wrap',
+depthFailOp: 'invert',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 3250,
+stencilWriteMask: 1730,
+depthBias: 89,
+depthBiasSlopeScale: 31,
+depthBiasClamp: 34,
+},
+vertex: {
+  module: shaderModule5,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 26772,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 1896,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 22376,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 32196,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x2',
+offset: 29876,
+shaderLocation: 6,
+}, {
+format: 'sint8x2',
+offset: 29118,
+shaderLocation: 22,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+video11.width = 188;
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageBitmap12 = await createImageBitmap(imageBitmap3);
+canvas2.height = 900;
+let video12 = await videoWithData();
+let img13 = await imageWithData(100, 183, '#01982809', '#05505431');
+let imageData14 = new ImageData(28, 232);
+let commandBuffer11 = commandEncoder11.finish();
+let renderBundleEncoder58 = device0.createRenderBundleEncoder({
+  label: '\u2551\ue57f\ud343\ud658\u{1fe37}\ue33e\u37bf\u406c\u0fff\u0e3e\ud69b',
+  colorFormats: ['r8unorm', 'rgba16sint', 'rg8sint', 'rgba32float', 'r32uint', undefined],
+  sampleCount: 4
+});
+try {
+renderBundleEncoder22.setBindGroup(3, bindGroup5, new Uint32Array(2075), 1840, 1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 600, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: video4,
+  origin: { x: 3, y: 4 },
+  flipY: false,
+}, {
+  texture: texture57,
+  mipLevel: 3,
+  origin: { x: 460, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let pipelineLayout12 = device1.createPipelineLayout({
+  label: '\u789e\ub72a\uc979\u4375\ub9b3\u185b\u4278\u02c9\u81eb',
+  bindGroupLayouts: [bindGroupLayout5, bindGroupLayout2, bindGroupLayout21, bindGroupLayout6, bindGroupLayout21, bindGroupLayout2, bindGroupLayout25]
+});
+let buffer31 = device1.createBuffer({label: '\u1bdb\u0661\u{1fda2}\u154f\ueec2', size: 28513, usage: GPUBufferUsage.MAP_READ});
+let querySet58 = device1.createQuerySet({
+type: 'occlusion',
+count: 2382,
+});
+let texture82 = device1.createTexture({
+label: '\u{1fd8c}\u1bb6\ue316\u{1f861}\u{1f788}\uea1e',
+size: {width: 27, height: 192, depthOrArrayLayers: 141},
+dimension: '2d',
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['depth16unorm', 'depth16unorm', 'depth16unorm'],
+});
+try {
+renderBundleEncoder17.drawIndexed(56, 40, 56, 24, 8);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 2,
+  origin: { x: 0, y: 6, z: 106 },
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 171385 */
+{offset: 556, bytesPerRow: 275, rowsPerImage: 457}, {width: 27, height: 165, depthOrArrayLayers: 2});
+} catch {}
+let texture83 = device3.createTexture({
+label: '\u8e8c\uad34\u0875\ucea1',
+size: [4032, 480, 193],
+mipLevelCount: 10,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x8-unorm', 'astc-8x8-unorm-srgb', 'astc-8x8-unorm-srgb'],
+});
+let textureView75 = texture77.createView({mipLevelCount: 4, baseArrayLayer: 53, arrayLayerCount: 30});
+let renderBundle61 = renderBundleEncoder40.finish({});
+try {
+device3.queue.writeBuffer(buffer24, 9204, new BigUint64Array(36709), 9812, 16);
+} catch {}
+let bindGroup7 = device1.createBindGroup({
+label: '\u3ee7\u41fb\ue80b\uf323\u13cd\u4825\u{1fb3c}\ud4e9\uf8d7\ue67e\uec90',
+layout: bindGroupLayout14,
+entries: [{
+binding: 1723,
+resource: sampler30
+}],
+});
+let pipelineLayout13 = device1.createPipelineLayout({label: '\uc8ad\u47bb\udd5b\u0c8c\u{1f9c4}\u3b83', bindGroupLayouts: [bindGroupLayout2]});
+try {
+renderBundleEncoder45.setVertexBuffer(85, undefined, 808455806, 1852397215);
+} catch {}
+let promise23 = device1.popErrorScope();
+try {
+device1.queue.writeBuffer(buffer30, 36488, new Float32Array(57234), 3015, 308);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline50 = await device1.createRenderPipelineAsync({
+label: '\u{1f968}\u{1f80a}',
+layout: pipelineLayout3,
+multisample: {
+mask: 0x3abeffce,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'r32uint'}, {format: 'rg8sint'}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-dst-alpha'},
+alpha: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-dst-alpha'},
+},
+  writeMask: GPUColorWrite.GREEN
+}, {
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilWriteMask: 993,
+depthBias: 10,
+depthBiasSlopeScale: 42,
+depthBiasClamp: 19,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 17296,
+attributes: [{
+format: 'uint16x2',
+offset: 9924,
+shaderLocation: 10,
+}, {
+format: 'float32x3',
+offset: 14160,
+shaderLocation: 4,
+}, {
+format: 'uint32x2',
+offset: 8660,
+shaderLocation: 26,
+}, {
+format: 'float32x3',
+offset: 10912,
+shaderLocation: 20,
+}, {
+format: 'sint16x2',
+offset: 10988,
+shaderLocation: 16,
+}, {
+format: 'unorm8x2',
+offset: 13754,
+shaderLocation: 0,
+}, {
+format: 'sint32',
+offset: 13392,
+shaderLocation: 5,
+}, {
+format: 'float32x3',
+offset: 848,
+shaderLocation: 21,
+}, {
+format: 'float32',
+offset: 10996,
+shaderLocation: 6,
+}, {
+format: 'uint32x3',
+offset: 13916,
+shaderLocation: 24,
+}, {
+format: 'unorm8x4',
+offset: 5960,
+shaderLocation: 7,
+}, {
+format: 'sint8x2',
+offset: 4638,
+shaderLocation: 25,
+}, {
+format: 'sint32x3',
+offset: 416,
+shaderLocation: 13,
+}, {
+format: 'uint8x4',
+offset: 13792,
+shaderLocation: 22,
+}, {
+format: 'uint16x4',
+offset: 7396,
+shaderLocation: 14,
+}, {
+format: 'unorm8x2',
+offset: 15230,
+shaderLocation: 1,
+}, {
+format: 'uint16x2',
+offset: 16260,
+shaderLocation: 12,
+}, {
+format: 'sint32x4',
+offset: 14124,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 31400,
+attributes: [{
+format: 'float16x2',
+offset: 12688,
+shaderLocation: 8,
+}, {
+format: 'uint16x2',
+offset: 22416,
+shaderLocation: 17,
+}, {
+format: 'snorm8x2',
+offset: 28690,
+shaderLocation: 2,
+}],
+}
+]
+},
+});
+let bindGroupLayout26 = device3.createBindGroupLayout({
+label: '\u08e3\u094a\uecc5\u{1f71a}\u0796\ufffa',
+entries: [{
+binding: 846,
+visibility: 0,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}],
+});
+let renderBundle62 = renderBundleEncoder50.finish({});
+try {
+computePassEncoder27.setBindGroup(4, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(9, buffer29, 2448, 1333);
+} catch {}
+try {
+commandEncoder66.copyTextureToTexture({
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 20, y: 24, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture79,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 711 */
+{offset: 711}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame15 = new VideoFrame(video1, {timestamp: 0});
+try {
+computePassEncoder30.setBindGroup(7, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder56.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(7, bindGroup6, new Uint32Array(4410), 2833, 0);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(video12);
+let canvas14 = document.createElement('canvas');
+let gpuCanvasContext14 = canvas14.getContext('webgpu');
+let bindGroup8 = device3.createBindGroup({
+label: '\u4852\u046c\u993a\u0c77\u8ee2\ucb49\uc0ce\u{1feb1}\u06d7\u{1f78f}\u02c4',
+layout: bindGroupLayout22,
+entries: [],
+});
+let texture84 = device3.createTexture({
+label: '\u087a\u414d\u0e86\u6112',
+size: {width: 240, height: 960, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+dimension: '2d',
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder37 = commandEncoder68.beginComputePass();
+try {
+renderBundleEncoder54.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer24, 2440, new BigUint64Array(54946), 40038, 48);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture80,
+  mipLevel: 2,
+  origin: { x: 8, y: 8, z: 57 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer7), /* required buffer size: 1955550 */
+{offset: 735, bytesPerRow: 285, rowsPerImage: 254}, {width: 0, height: 16, depthOrArrayLayers: 28});
+} catch {}
+let video13 = await videoWithData();
+document.body.prepend(img2);
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let bindGroupLayout27 = device3.createBindGroupLayout({
+label: '\u5ac4\u{1fb01}\uff43\u2f0d',
+entries: [{
+binding: 7747,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '1d' },
+}, {
+binding: 2070,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}],
+});
+let bindGroup9 = device3.createBindGroup({
+label: '\u{1fd8f}\ubdaa\uca4f\u01b3\u08f1\u{1fdba}\u09e8\ua59b\u08d3',
+layout: bindGroupLayout24,
+entries: [],
+});
+try {
+renderBundleEncoder56.setVertexBuffer(3, buffer29, 36, 1418);
+} catch {}
+try {
+commandEncoder66.clearBuffer(buffer19, 9356, 3752);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+renderBundleEncoder54.insertDebugMarker('\u{1fd41}');
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 1,
+  origin: { x: 42, y: 5, z: 96 },
+  aspect: 'all',
+}, new Int32Array(arrayBuffer0), /* required buffer size: 5656192 */
+{offset: 32, bytesPerRow: 429, rowsPerImage: 269}, {width: 84, height: 20, depthOrArrayLayers: 50});
+} catch {}
+let textureView76 = texture69.createView({label: '\uf836\u{1fe7d}\u3cf6\ue1b4\ufcbb\u3e1c\u2c35\u0b28\u17dc', format: 'rgba8unorm-srgb'});
+let sampler49 = device3.createSampler({
+label: '\u{1f9c6}\u7443\u7216',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 82.254,
+lodMaxClamp: 90.901,
+});
+try {
+computePassEncoder29.setBindGroup(5, bindGroup9, []);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(5, buffer29, 2132, 583);
+} catch {}
+try {
+commandEncoder66.clearBuffer(buffer19, 11092, 912);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 3,
+  origin: { x: 0, y: 8, z: 1 },
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 197 */
+{offset: 197, bytesPerRow: 102}, {width: 0, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = commandEncoder52.label;
+} catch {}
+let computePassEncoder38 = commandEncoder66.beginComputePass();
+let renderBundleEncoder59 = device1.createRenderBundleEncoder({
+  label: '\ua247\u0c6b\u99f7\u{1fa36}\u2671\u6deb\u{1f684}\u8c01\ucfc3\u{1fdb8}',
+  colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint'],
+  depthReadOnly: true
+});
+try {
+computePassEncoder26.setBindGroup(3, bindGroup4, []);
+} catch {}
+let promise24 = device1.queue.onSubmittedWorkDone();
+document.body.prepend(img13);
+let shaderModule11 = device0.createShaderModule({
+label: '\ua806\u3cc7\u{1fb18}',
+code: `@group(2) @binding(4710)
+var<storage, read_write> i4: array<u32>;
+@group(4) @binding(4710)
+var<storage, read_write> field4: array<u32>;
+@group(3) @binding(4710)
+var<storage, read_write> i5: array<u32>;
+@group(1) @binding(4710)
+var<storage, read_write> type8: array<u32>;
+@group(0) @binding(4710)
+var<storage, read_write> type9: array<u32>;
+
+@compute @workgroup_size(3, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S15 {
+  @builtin(sample_mask) f0: u32,
+  @location(38) f1: vec2<u32>,
+  @location(57) f2: vec3<i32>,
+  @location(50) f3: vec4<f16>,
+  @location(31) f4: vec2<i32>,
+  @location(63) f5: vec2<i32>,
+  @builtin(position) f6: vec4<f32>,
+  @builtin(sample_index) f7: u32,
+  @location(49) f8: vec2<u32>,
+  @location(83) f9: vec2<f16>,
+  @location(29) f10: vec4<f16>,
+  @location(54) f11: vec4<u32>,
+  @location(33) f12: vec4<f32>,
+  @location(80) f13: vec3<f32>,
+  @location(28) f14: vec4<f16>,
+  @location(55) f15: vec3<u32>,
+  @location(40) f16: vec4<i32>,
+  @location(62) f17: vec3<f16>,
+  @location(20) f18: i32,
+  @location(52) f19: u32,
+  @location(41) f20: u32,
+  @location(71) f21: vec2<u32>,
+  @builtin(front_facing) f22: bool,
+  @location(0) f23: f16,
+  @location(34) f24: i32,
+  @location(77) f25: vec3<f16>,
+  @location(44) f26: f32,
+  @location(68) f27: vec2<i32>,
+  @location(66) f28: f32,
+  @location(56) f29: vec3<f32>,
+  @location(46) f30: vec2<u32>,
+  @location(60) f31: f32,
+  @location(61) f32: vec3<f32>,
+  @location(1) f33: vec3<f32>,
+  @location(22) f34: vec4<u32>,
+  @location(65) f35: f32,
+  @location(17) f36: vec2<f16>,
+  @location(79) f37: vec3<u32>,
+  @location(51) f38: vec4<f16>,
+  @location(18) f39: vec3<i32>,
+  @location(7) f40: vec3<i32>,
+  @location(3) f41: vec3<f16>,
+  @location(53) f42: u32
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec3<u32>,
+  @builtin(frag_depth) f1: f32
+}
+
+@fragment
+fn fragment0(@location(70) a0: f16, @location(45) a1: i32, @location(67) a2: vec2<i32>, @location(47) a3: f32, @location(19) a4: vec2<i32>, a5: S15, @location(9) a6: i32, @location(48) a7: vec4<f32>, @location(24) a8: vec2<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S14 {
+  @location(18) f0: vec4<f32>,
+  @location(0) f1: vec2<u32>,
+  @location(1) f2: i32,
+  @location(6) f3: vec2<f32>,
+  @location(2) f4: vec3<i32>,
+  @location(10) f5: vec2<u32>,
+  @location(5) f6: vec4<u32>,
+  @location(13) f7: vec4<f32>,
+  @location(8) f8: vec3<i32>,
+  @location(19) f9: vec4<f16>,
+  @location(15) f10: i32,
+  @location(11) f11: vec3<f32>,
+  @location(4) f12: vec2<f32>,
+  @location(7) f13: vec3<f16>,
+  @location(12) f14: f32,
+  @location(3) f15: i32
+}
+struct VertexOutput0 {
+  @location(17) f221: vec2<f16>,
+  @location(41) f222: u32,
+  @location(62) f223: vec3<f16>,
+  @location(51) f224: vec4<f16>,
+  @location(24) f225: vec2<f32>,
+  @location(66) f226: f32,
+  @location(63) f227: vec2<i32>,
+  @location(47) f228: f32,
+  @location(49) f229: vec2<u32>,
+  @location(28) f230: vec4<f16>,
+  @location(31) f231: vec2<i32>,
+  @location(52) f232: u32,
+  @location(45) f233: i32,
+  @location(18) f234: vec3<i32>,
+  @location(40) f235: vec4<i32>,
+  @location(44) f236: f32,
+  @location(55) f237: vec3<u32>,
+  @builtin(position) f238: vec4<f32>,
+  @location(29) f239: vec4<f16>,
+  @location(50) f240: vec4<f16>,
+  @location(0) f241: f16,
+  @location(53) f242: u32,
+  @location(56) f243: vec3<f32>,
+  @location(48) f244: vec4<f32>,
+  @location(79) f245: vec3<u32>,
+  @location(60) f246: f32,
+  @location(22) f247: vec4<u32>,
+  @location(9) f248: i32,
+  @location(70) f249: f16,
+  @location(80) f250: vec3<f32>,
+  @location(83) f251: vec2<f16>,
+  @location(67) f252: vec2<i32>,
+  @location(33) f253: vec4<f32>,
+  @location(7) f254: vec3<i32>,
+  @location(34) f255: i32,
+  @location(54) f256: vec4<u32>,
+  @location(38) f257: vec2<u32>,
+  @location(65) f258: f32,
+  @location(61) f259: vec3<f32>,
+  @location(77) f260: vec3<f16>,
+  @location(57) f261: vec3<i32>,
+  @location(20) f262: i32,
+  @location(71) f263: vec2<u32>,
+  @location(1) f264: vec3<f32>,
+  @location(3) f265: vec3<f16>,
+  @location(19) f266: vec2<i32>,
+  @location(46) f267: vec2<u32>,
+  @location(68) f268: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec4<u32>, a1: S14, @location(14) a2: vec3<f32>, @location(16) a3: vec2<u32>, @location(17) a4: vec4<u32>, @builtin(instance_index) a5: u32, @builtin(vertex_index) a6: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandBuffer12 = commandEncoder25.finish({
+});
+try {
+renderBundleEncoder22.setVertexBuffer(0, buffer4, 1116, 8287);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 524, new DataView(new ArrayBuffer(60830)), 31812, 232);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: { x: 789, y: 0, z: 0 },
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(72)), /* required buffer size: 7758 */
+{offset: 534}, {width: 1806, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 18, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img8,
+  origin: { x: 35, y: 30 },
+  flipY: true,
+}, {
+  texture: texture57,
+  mipLevel: 8,
+  origin: { x: 7, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+try {
+window.someLabel = renderBundleEncoder26.label;
+} catch {}
+let commandEncoder69 = device1.createCommandEncoder();
+let renderBundle63 = renderBundleEncoder14.finish();
+try {
+renderBundleEncoder17.draw(32, 80);
+} catch {}
+let pipeline51 = device1.createComputePipeline({
+label: '\u23a6\u8d2b',
+layout: pipelineLayout12,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroup10 = device0.createBindGroup({
+layout: bindGroupLayout12,
+entries: [],
+});
+let commandBuffer13 = commandEncoder34.finish({
+label: '\u1286\u0868\u4eea\ud109\u0337\u3a04',
+});
+let textureView77 = texture31.createView({
+  label: '\u{1fa10}\u0982\u0a20\u01ac\u05be\uf5a5\u0dc6\u0e19\u61f4\u015f',
+  baseMipLevel: 3,
+  baseArrayLayer: 0
+});
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+commandEncoder18.copyBufferToTexture({
+/* bytesInLastRow: 1744 widthInBlocks: 436 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 25680 */
+offset: 25680,
+buffer: buffer28,
+}, {
+  texture: texture7,
+  mipLevel: 1,
+  origin: { x: 1559, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 436, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer28);
+} catch {}
+try {
+device0.destroy();
+} catch {}
+gc();
+let video14 = await videoWithData();
+let canvas15 = document.createElement('canvas');
+let bindGroup11 = device3.createBindGroup({
+layout: bindGroupLayout24,
+entries: [],
+});
+let externalTexture4 = device3.importExternalTexture({
+label: '\u8f57\ua56f\u{1f7a8}\ud30c\u{1f8e9}\ud0cf\u440c\u4716',
+source: video11,
+colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder54.pushDebugGroup('\u{1fac5}');
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let texture85 = device3.createTexture({
+label: '\u{1f6b2}\u1f50\u0288\ua43f\u0de6\u0762\u9e89\u65e0',
+size: {width: 504, height: 60, depthOrArrayLayers: 193},
+mipLevelCount: 7,
+format: 'astc-6x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView78 = texture59.createView({label: '\u49d3\u18a5\u01f9\u7fbc\ufa4a\ubb71\u12fa\u00fb', aspect: 'all', mipLevelCount: 2});
+let renderBundle64 = renderBundleEncoder52.finish({});
+try {
+device3.queue.writeBuffer(buffer24, 668, new DataView(new ArrayBuffer(20654)), 10640, 3176);
+} catch {}
+gc();
+let commandEncoder70 = device1.createCommandEncoder();
+let textureView79 = texture30.createView({
+  label: '\u09ec\u{1fc4a}\ua7ba\uf5e2\u{1f909}\u3222\u19cf\ub5ea\u55fd\u0f51\uf407',
+  dimension: '2d-array',
+  mipLevelCount: 1
+});
+let sampler50 = device1.createSampler({
+label: '\u{1f6d0}\uae38\u490d\u{1fb93}\u08a1\u0747\u{1fa3f}\u0199\u005d',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 30.285,
+lodMaxClamp: 57.535,
+compare: 'greater-equal',
+});
+let externalTexture5 = device1.importExternalTexture({
+label: '\u256d\u000e\ud6b9\u0f3a\u0d3b',
+source: videoFrame14,
+colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder45.setVertexBuffer(46, undefined, 1752803767);
+} catch {}
+let pipeline52 = await device1.createComputePipelineAsync({
+layout: pipelineLayout13,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let imageBitmap13 = await createImageBitmap(offscreenCanvas7);
+try {
+canvas15.getContext('webgl');
+} catch {}
+let commandEncoder71 = device1.createCommandEncoder({label: '\ua240\u508b\u41d7\u0a21\ub070'});
+let textureView80 = texture38.createView({
+  label: '\ufeaa\u0856\u{1fa53}\u3a91',
+  format: 'rgba8unorm',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  arrayLayerCount: 1
+});
+let computePassEncoder39 = commandEncoder59.beginComputePass({label: '\u3a68\u4732\u7514'});
+let sampler51 = device1.createSampler({
+label: '\uc4fd\ufc8c\ub90c\u0b86\u0b35\u{1f666}\uf516\u60c6\ud88d\u06bb',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMaxClamp: 97.947,
+});
+try {
+renderBundleEncoder46.setVertexBuffer(0, undefined, 2058900679, 1639589443);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'r32float', 'astc-8x8-unorm-srgb', 'rgba16float'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let canvas16 = document.createElement('canvas');
+let offscreenCanvas15 = new OffscreenCanvas(835, 269);
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+  await promise23;
+} catch {}
+let adapter7 = await navigator.gpu.requestAdapter({
+});
+let img14 = await imageWithData(70, 116, '#cb015cdd', '#89414115');
+let pipelineLayout14 = device3.createPipelineLayout({
+  label: '\u0a95\u5b93\uf254\uc694\u00d3\u08ac\u5552\ub256',
+  bindGroupLayouts: [bindGroupLayout26, bindGroupLayout24, bindGroupLayout22, bindGroupLayout22, bindGroupLayout26, bindGroupLayout22, bindGroupLayout22]
+});
+let querySet59 = device3.createQuerySet({
+label: '\u{1fe8e}\u3b1f\u{1fe65}\u0e63\u{1f7c9}\u0ccd\ue103\u57e9\u0fe1\u8a10',
+type: 'occlusion',
+count: 1025,
+});
+let renderBundle65 = renderBundleEncoder50.finish({});
+try {
+computePassEncoder31.setBindGroup(8, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(7, buffer29);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 2,
+  origin: { x: 1, y: 27, z: 14 },
+  aspect: 'all',
+}, new Float32Array(arrayBuffer4), /* required buffer size: 285079 */
+{offset: 837, bytesPerRow: 134, rowsPerImage: 141}, {width: 7, height: 7, depthOrArrayLayers: 16});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+canvas16.getContext('webgl2');
+} catch {}
+let querySet60 = device3.createQuerySet({
+type: 'occlusion',
+count: 544,
+});
+let buffer32 = device1.createBuffer({
+  label: '\u0662\u02ae\u{1f98c}\u1fb7\uc627\u0715\u483b\ub92d\ubd70\ub62c\u9afd',
+  size: 16206,
+  usage: GPUBufferUsage.INDEX
+});
+let commandEncoder72 = device1.createCommandEncoder({label: '\u0a87\u0dd0\udb18\u{1fec5}\u0ff3\u9594\u{1ff53}\u18d1\uf27b\ua572'});
+let querySet61 = device1.createQuerySet({
+label: '\u304b\uea8a\u5684\u3c58\u72c0\u{1f887}\u{1f76a}\uf418\u0aa1',
+type: 'occlusion',
+count: 1864,
+});
+try {
+renderBundleEncoder45.setBindGroup(4, bindGroup4, new Uint32Array(3366), 880, 0);
+} catch {}
+try {
+commandEncoder69.copyBufferToBuffer(buffer20, 372, buffer27, 1892, 496);
+dissociateBuffer(device1, buffer20);
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+commandEncoder71.clearBuffer(buffer30, 5264, 8564);
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer5,
+commandBuffer10,
+]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 10,
+  origin: { x: 0, y: 6, z: 83 },
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 1169411 */
+{offset: 803, bytesPerRow: 282, rowsPerImage: 112}, {width: 0, height: 0, depthOrArrayLayers: 38});
+} catch {}
+let pipeline53 = device1.createRenderPipeline({
+label: '\u{1f8f9}\u0937\u{1fe02}\u{1fbc5}\u5389\u6f1f\u0039\u{1f675}\u0420\u0e90',
+layout: pipelineLayout12,
+fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'r32uint'}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rg8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32sint'}]
+},
+vertex: {
+  module: shaderModule5,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 27644,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 18312,
+shaderLocation: 22,
+}, {
+format: 'snorm16x4',
+offset: 21028,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 7116,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 18788,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x3',
+offset: 4872,
+shaderLocation: 8,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'back',
+},
+});
+try {
+  await promise24;
+} catch {}
+let imageBitmap14 = await createImageBitmap(imageData14);
+let sampler52 = device3.createSampler({
+label: '\u0057\ua201\u{1feac}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 88.403,
+lodMaxClamp: 92.355,
+});
+try {
+renderBundleEncoder56.setBindGroup(4, bindGroup11);
+} catch {}
+let shaderModule12 = device3.createShaderModule({
+label: '\u{1f9ad}\u82f5\udbcf\u033c\u87a7',
+code: `@group(0) @binding(846)
+var<storage, read_write> parameter8: array<u32>;
+@group(4) @binding(846)
+var<storage, read_write> local12: array<u32>;
+
+@compute @workgroup_size(5, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<f32>,
+  @location(1) f1: vec4<f32>,
+  @location(0) f2: vec4<f32>,
+  @location(2) f3: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(34) a0: vec4<f16>, @location(2) a1: vec4<f16>, @location(54) a2: vec3<f16>, @location(8) a3: vec3<f32>, @location(75) a4: f32, @builtin(sample_index) a5: u32, @location(48) a6: vec2<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S16 {
+  @location(25) f0: vec4<i32>,
+  @builtin(instance_index) f1: u32,
+  @location(7) f2: vec4<i32>,
+  @location(24) f3: vec4<u32>,
+  @location(22) f4: vec3<f32>,
+  @location(16) f5: vec2<f16>,
+  @location(18) f6: vec3<f16>,
+  @location(8) f7: vec4<f32>,
+  @location(1) f8: vec3<i32>,
+  @location(13) f9: vec2<u32>,
+  @location(21) f10: vec3<f32>,
+  @location(17) f11: vec3<f32>,
+  @location(15) f12: vec3<f32>,
+  @location(12) f13: vec4<u32>,
+  @location(9) f14: vec4<f16>,
+  @location(3) f15: vec2<f16>
+}
+struct VertexOutput0 {
+  @location(24) f269: vec4<u32>,
+  @location(63) f270: vec3<f32>,
+  @location(37) f271: vec3<f16>,
+  @location(29) f272: f16,
+  @location(60) f273: vec2<f16>,
+  @location(0) f274: i32,
+  @location(77) f275: u32,
+  @location(11) f276: vec4<f32>,
+  @builtin(position) f277: vec4<f32>,
+  @location(1) f278: vec4<i32>,
+  @location(19) f279: vec3<f32>,
+  @location(73) f280: vec4<f16>,
+  @location(8) f281: vec3<f32>,
+  @location(5) f282: vec4<i32>,
+  @location(48) f283: vec2<f16>,
+  @location(4) f284: vec2<u32>,
+  @location(23) f285: vec4<f16>,
+  @location(13) f286: vec3<f32>,
+  @location(54) f287: vec3<f16>,
+  @location(71) f288: vec2<f16>,
+  @location(21) f289: vec4<u32>,
+  @location(75) f290: f32,
+  @location(76) f291: f16,
+  @location(17) f292: vec4<u32>,
+  @location(7) f293: i32,
+  @location(6) f294: vec2<i32>,
+  @location(34) f295: vec4<f16>,
+  @location(32) f296: vec4<u32>,
+  @location(65) f297: f32,
+  @location(58) f298: f16,
+  @location(51) f299: vec4<i32>,
+  @location(74) f300: vec4<u32>,
+  @location(38) f301: f16,
+  @location(41) f302: f16,
+  @location(16) f303: vec2<i32>,
+  @location(12) f304: vec2<f16>,
+  @location(2) f305: vec4<f16>,
+  @location(56) f306: vec2<u32>,
+  @location(42) f307: vec4<i32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(20) a1: vec3<u32>, @location(4) a2: vec4<u32>, @location(5) a3: vec2<f32>, @location(10) a4: vec2<f16>, @location(0) a5: vec3<f32>, a6: S16, @location(14) a7: vec4<u32>, @location(19) a8: vec2<f16>, @location(11) a9: vec4<i32>, @location(23) a10: vec2<f16>, @location(6) a11: vec2<i32>, @location(2) a12: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder73 = device3.createCommandEncoder({label: '\u0f15\u305a\u7cc2\u628b'});
+let querySet62 = device3.createQuerySet({
+label: '\u2afa\ud24d\u51dc\u01ad\u{1f67a}\uc280',
+type: 'occlusion',
+count: 2179,
+});
+let sampler53 = device3.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 79.907,
+lodMaxClamp: 83.222,
+});
+gc();
+let canvas17 = document.createElement('canvas');
+try {
+canvas17.getContext('bitmaprenderer');
+} catch {}
+let bindGroupLayout28 = device3.createBindGroupLayout({
+label: '\u0abd\u{1f700}',
+entries: [],
+});
+let commandEncoder74 = device3.createCommandEncoder({label: '\u{1f918}\u{1fd23}\u04be\u9d25\u7a1e\u3dd0\u289c'});
+let pipeline54 = device3.createComputePipeline({
+label: '\u{1fc33}\ud579\ueb32\u54ab\u{1f8c4}\u1c41\u0c1e\ub764\ue8b3',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+gc();
+let videoFrame16 = new VideoFrame(video8, {timestamp: 0});
+let gpuCanvasContext15 = offscreenCanvas15.getContext('webgpu');
+let texture86 = device3.createTexture({
+label: '\u7c0c\ucd2f\u2185\u26dd\u04b4\u110f',
+size: [2016],
+dimension: '1d',
+format: 'r32float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r32float'],
+});
+try {
+renderBundleEncoder54.setBindGroup(9, bindGroup8, new Uint32Array(6384), 4932, 0);
+} catch {}
+let pipeline55 = await device3.createComputePipelineAsync({
+label: '\u0a98\u081b\u{1fbac}\u022d\uaa4e\u0ba0\u007e\u1b89\u02ed\u{1f725}\uab16',
+layout: 'auto',
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let bindGroup12 = device1.createBindGroup({
+label: '\u{1fa04}\u{1f8ef}\u{1fe9e}\u5c68\u0f90\u0e03\ua9e0\u0f81',
+layout: bindGroupLayout25,
+entries: [],
+});
+let renderBundle66 = renderBundleEncoder24.finish({label: '\u0863\u0053\u0678\u7f3f'});
+try {
+  await buffer31.mapAsync(GPUMapMode.READ, 0, 5676);
+} catch {}
+try {
+renderBundleEncoder46.insertDebugMarker('\u0d0c');
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16sint', 'rg8sint', 'rgba8unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline56 = device1.createRenderPipeline({
+label: '\u0da6\uce01\u2722\uf23e\u{1fe12}\u383a\u{1f955}',
+layout: pipelineLayout3,
+multisample: {
+count: 4,
+mask: 0x5a0313bc,
+},
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32float'}, {format: 'r16float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r16uint', writeMask: 0}, {format: 'r16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r8uint', writeMask: 0}]
+},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilReadMask: 96,
+stencilWriteMask: 100,
+depthBias: 82,
+depthBiasSlopeScale: 93,
+depthBiasClamp: 97,
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 13240,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x2',
+offset: 6124,
+shaderLocation: 7,
+}, {
+format: 'float16x4',
+offset: 12724,
+shaderLocation: 10,
+}, {
+format: 'float32x2',
+offset: 4244,
+shaderLocation: 13,
+}, {
+format: 'unorm8x4',
+offset: 11344,
+shaderLocation: 26,
+}, {
+format: 'float32x3',
+offset: 13092,
+shaderLocation: 20,
+}, {
+format: 'unorm16x4',
+offset: 7308,
+shaderLocation: 1,
+}, {
+format: 'snorm8x4',
+offset: 11744,
+shaderLocation: 6,
+}, {
+format: 'snorm16x4',
+offset: 3572,
+shaderLocation: 17,
+}, {
+format: 'sint32x2',
+offset: 10596,
+shaderLocation: 25,
+}, {
+format: 'snorm8x2',
+offset: 12376,
+shaderLocation: 16,
+}, {
+format: 'uint16x4',
+offset: 11408,
+shaderLocation: 9,
+}, {
+format: 'uint8x2',
+offset: 9036,
+shaderLocation: 3,
+}, {
+format: 'float32x4',
+offset: 3656,
+shaderLocation: 19,
+}, {
+format: 'uint32x2',
+offset: 7636,
+shaderLocation: 21,
+}, {
+format: 'float32x2',
+offset: 2868,
+shaderLocation: 22,
+}, {
+format: 'uint16x4',
+offset: 12132,
+shaderLocation: 15,
+}, {
+format: 'float16x2',
+offset: 2376,
+shaderLocation: 11,
+}, {
+format: 'sint16x2',
+offset: 12060,
+shaderLocation: 0,
+}, {
+format: 'unorm16x4',
+offset: 9896,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x3',
+offset: 5764,
+shaderLocation: 18,
+}, {
+format: 'unorm8x4',
+offset: 4428,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 27360,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 17224,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 17116,
+shaderLocation: 14,
+}, {
+format: 'snorm8x4',
+offset: 10496,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 3836,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 28396,
+attributes: [{
+format: 'uint16x4',
+offset: 260,
+shaderLocation: 2,
+}, {
+format: 'sint8x4',
+offset: 14476,
+shaderLocation: 24,
+}, {
+format: 'sint8x4',
+offset: 20168,
+shaderLocation: 23,
+}],
+},
+{
+arrayStride: 0,
+attributes: [],
+},
+{
+arrayStride: 30220,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 19372,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 23888,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 7196,
+shaderLocation: 8,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+unclippedDepth: true,
+},
+});
+let buffer33 = device3.createBuffer({
+  label: '\u{1fd53}\u06a4\u0092\u0a2e\u{1f937}\u0df3\u0ec5\u{1f969}',
+  size: 40275,
+  usage: GPUBufferUsage.QUERY_RESOLVE
+});
+try {
+renderBundleEncoder54.setVertexBuffer(1, buffer29, 1688, 2456);
+} catch {}
+let img15 = await imageWithData(91, 146, '#562babac', '#925ab510');
+let querySet63 = device1.createQuerySet({
+label: '\u77f9\u2aa2\u{1f9e4}\u0a17',
+type: 'occlusion',
+count: 875,
+});
+let texture87 = device1.createTexture({
+size: [205, 100, 1],
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-5x5-unorm-srgb'],
+});
+let pipeline57 = await device1.createRenderPipelineAsync({
+label: '\u0d23\u68a1\u6cb3\u0bf3',
+layout: pipelineLayout3,
+multisample: {
+count: 4,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'r32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+}
+}, {format: 'r32uint'}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'invert',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilWriteMask: 2196,
+depthBias: 31,
+depthBiasSlopeScale: 36,
+depthBiasClamp: 20,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 18904,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32',
+offset: 12616,
+shaderLocation: 21,
+}, {
+format: 'uint16x4',
+offset: 1948,
+shaderLocation: 26,
+}, {
+format: 'uint8x4',
+offset: 544,
+shaderLocation: 14,
+}, {
+format: 'uint16x2',
+offset: 14800,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 16972,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 10928,
+shaderLocation: 20,
+}, {
+format: 'snorm16x2',
+offset: 14804,
+shaderLocation: 4,
+}, {
+format: 'uint32x2',
+offset: 14488,
+shaderLocation: 24,
+}],
+},
+{
+arrayStride: 2500,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 160,
+shaderLocation: 7,
+}, {
+format: 'uint32',
+offset: 2156,
+shaderLocation: 22,
+}, {
+format: 'snorm16x2',
+offset: 848,
+shaderLocation: 0,
+}, {
+format: 'unorm16x4',
+offset: 1432,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 11668,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x2',
+offset: 2336,
+shaderLocation: 16,
+}, {
+format: 'uint16x2',
+offset: 10884,
+shaderLocation: 17,
+}, {
+format: 'sint32x2',
+offset: 6196,
+shaderLocation: 15,
+}, {
+format: 'sint16x4',
+offset: 6348,
+shaderLocation: 13,
+}, {
+format: 'unorm16x4',
+offset: 8736,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 11280,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 9032,
+shaderLocation: 25,
+}, {
+format: 'snorm16x2',
+offset: 7520,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 27900,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 5632,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 12340,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 3872,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 3636,
+attributes: [{
+format: 'sint8x4',
+offset: 2208,
+shaderLocation: 5,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+offscreenCanvas0.height = 904;
+let img16 = await imageWithData(278, 118, '#cbb8cd74', '#a539470e');
+let commandEncoder75 = device3.createCommandEncoder({label: '\uf3f6\u{1f760}\u2351\uac13\u1c31\u9c30'});
+let commandBuffer14 = commandEncoder73.finish({
+label: '\udd6f\u0f50\u0e07\u{1f70d}\u9343\u2e5f\uf13e',
+});
+let computePassEncoder40 = commandEncoder75.beginComputePass({label: '\uc4f2\u0b48\u{1fdfd}'});
+let renderBundle67 = renderBundleEncoder28.finish({label: '\ua1df\ub1f2\uf37e\uac53\u0c32\u01de\u0b44\u28c3\u8272\ubbff'});
+try {
+renderBundleEncoder56.setVertexBuffer(9, buffer29);
+} catch {}
+try {
+commandEncoder74.clearBuffer(buffer19, 4892, 7784);
+dissociateBuffer(device3, buffer19);
+} catch {}
+let promise25 = device3.queue.onSubmittedWorkDone();
+offscreenCanvas10.width = 649;
+gc();
+let canvas18 = document.createElement('canvas');
+let promise26 = adapter3.requestAdapterInfo();
+try {
+renderBundleEncoder56.setVertexBuffer(5, buffer29, 212, 232);
+} catch {}
+try {
+commandEncoder74.copyTextureToBuffer({
+  texture: texture84,
+  mipLevel: 2,
+  origin: { x: 16, y: 24, z: 1 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 7040 */
+offset: 7040,
+bytesPerRow: 256,
+buffer: buffer19,
+}, {width: 40, height: 204, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+commandEncoder74.clearBuffer(buffer24, 2040, 2124);
+dissociateBuffer(device3, buffer24);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer24, 4056, new Float32Array(23550), 259, 404);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: { x: 186, y: 15, z: 30 },
+  aspect: 'all',
+}, new Int8Array(arrayBuffer2), /* required buffer size: 8069391 */
+{offset: 767, bytesPerRow: 272, rowsPerImage: 223}, {width: 6, height: 30, depthOrArrayLayers: 134});
+} catch {}
+try {
+adapter5.label = '\ufc81\udfff\u{1f74b}\u1637\ub460\ub00f\u02bf';
+} catch {}
+try {
+  await promise25;
+} catch {}
+let querySet64 = device1.createQuerySet({
+label: '\u{1ff0c}\ubaeb',
+type: 'occlusion',
+count: 1084,
+});
+let computePassEncoder41 = commandEncoder72.beginComputePass({label: '\u{1f647}\u{1fbbe}\u39d4\u6dd2\u6fa7\u04d3\u46a5\u{1fd7c}\u3c46\u09f5'});
+try {
+computePassEncoder20.setPipeline(pipeline30);
+} catch {}
+try {
+renderBundleEncoder57.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder17.draw(16, 48, 40, 8);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(24, 8, 72, 728, 0);
+} catch {}
+try {
+commandEncoder70.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 2,
+  origin: { x: 23, y: 35, z: 44 },
+  aspect: 'all',
+}, {
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 92, y: 146, z: 12 },
+  aspect: 'all',
+}, {width: 3, height: 10, depthOrArrayLayers: 178});
+} catch {}
+try {
+commandEncoder70.clearBuffer(buffer30, 612, 40092);
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba8unorm-srgb', 'rgba8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer8,
+]);
+} catch {}
+let pipeline58 = device1.createComputePipeline({
+label: '\u{1fad3}\u940b\u{1f6a5}\u343d\u{1ffe2}\u4ccc\u70e2\u0a91\ub170',
+layout: pipelineLayout13,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let videoFrame17 = new VideoFrame(videoFrame12, {timestamp: 0});
+let bindGroupLayout29 = pipeline55.getBindGroupLayout(3);
+let querySet65 = device3.createQuerySet({
+label: '\u37fa\u543f\u0aae\u{1f907}\u503f\u{1fd27}\u{1fd1a}\uc0c0\u00cf',
+type: 'occlusion',
+count: 850,
+});
+try {
+renderBundleEncoder56.setVertexBuffer(10, buffer29, 3744, 49);
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(buffer29, 3604, buffer24, 6192, 324);
+dissociateBuffer(device3, buffer29);
+dissociateBuffer(device3, buffer24);
+} catch {}
+let imageData15 = new ImageData(112, 116);
+let gpuCanvasContext16 = canvas18.getContext('webgpu');
+canvas6.width = 888;
+gc();
+try {
+window.someLabel = externalTexture5.label;
+} catch {}
+let bindGroup13 = device1.createBindGroup({
+label: '\u1496\ubb0d',
+layout: bindGroupLayout14,
+entries: [{
+binding: 1723,
+resource: sampler12
+}],
+});
+let buffer34 = device1.createBuffer({
+  label: '\uc18f\u02ba\u38ec',
+  size: 23246,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM
+});
+let commandEncoder76 = device1.createCommandEncoder({});
+pseudoSubmit(device1, commandEncoder70);
+let texture88 = device1.createTexture({
+label: '\u0b47\u{1fc84}\u{1fa71}\u050d\u6390\u0e1a\u0b56\u4755\u{1fdfc}\u{1f69d}',
+size: {width: 384, height: 5, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+dimension: '2d',
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView81 = texture63.createView({label: '\u0f9b\u66f5\u031d\ucb52\ue4fd', dimension: '2d', baseArrayLayer: 162});
+let computePassEncoder42 = commandEncoder71.beginComputePass({label: '\u703e\uc272\u0c3f'});
+let renderBundle68 = renderBundleEncoder32.finish({});
+try {
+computePassEncoder39.setPipeline(pipeline30);
+} catch {}
+try {
+renderBundleEncoder17.draw(80, 56, 72);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(16);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline49);
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer4,
+]);
+} catch {}
+let pipeline59 = await promise12;
+let offscreenCanvas16 = new OffscreenCanvas(103, 560);
+let imageData16 = new ImageData(36, 256);
+let videoFrame18 = new VideoFrame(offscreenCanvas13, {timestamp: 0});
+let commandEncoder77 = device3.createCommandEncoder({label: '\ud18e\uf8a9\uabbf'});
+let texture89 = device3.createTexture({
+label: '\u0a6b\u0038\u08fc\u6f5a\u617c',
+size: [504, 60, 193],
+mipLevelCount: 9,
+sampleCount: 1,
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16sint', 'rg16sint', 'rg16sint'],
+});
+let computePassEncoder43 = commandEncoder74.beginComputePass({label: '\u0c27\u5248\u061e'});
+let sampler54 = device3.createSampler({
+label: '\ue231\u0eb4',
+addressModeU: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 11.572,
+lodMaxClamp: 82.223,
+maxAnisotropy: 16,
+});
+try {
+computePassEncoder24.setPipeline(pipeline54);
+} catch {}
+let renderBundle69 = renderBundleEncoder46.finish({label: '\u{1fb3d}\udff0\ub249\u{1ff0e}\ua507\u0e05\u0edb'});
+try {
+renderBundleEncoder17.drawIndexed(40, 72, 72, 400, 0);
+} catch {}
+try {
+  await buffer27.mapAsync(GPUMapMode.READ);
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let offscreenCanvas17 = new OffscreenCanvas(90, 457);
+let bindGroup14 = device3.createBindGroup({
+label: '\u{1ff66}\u{1f9b6}\u8321\u0951\ubd5c\u07bb\u0745\u661e',
+layout: bindGroupLayout22,
+entries: [],
+});
+let renderBundleEncoder60 = device3.createRenderBundleEncoder({colorFormats: ['rg32sint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderBundleEncoder56.setVertexBuffer(10, buffer29);
+} catch {}
+try {
+commandEncoder77.clearBuffer(buffer19, 3536, 6428);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+offscreenCanvas17.getContext('webgpu');
+} catch {}
+let computePassEncoder44 = commandEncoder77.beginComputePass({label: '\u01d9\u0655\u0973\u4fd8\u81de'});
+let renderBundle70 = renderBundleEncoder28.finish({label: '\u08d3\u713a\ua500\u9113\u0607\u{1faba}'});
+try {
+computePassEncoder25.setBindGroup(8, bindGroup11, new Uint32Array(9924), 4619, 0);
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline54);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(6, buffer29);
+} catch {}
+try {
+device3.queue.submit([
+]);
+} catch {}
+try {
+  await promise26;
+} catch {}
+canvas13.height = 496;
+try {
+commandEncoder76.clearBuffer(buffer20, 120, 412);
+dissociateBuffer(device1, buffer20);
+} catch {}
+document.body.prepend(video9);
+try {
+offscreenCanvas16.getContext('webgl');
+} catch {}
+let texture90 = device1.createTexture({
+label: '\u{1ffd8}\u935a\ua8a3\u{1fbb7}\u{1f703}\ufb43\u0cf6\u09fb\ua9ad',
+size: {width: 108, height: 768, depthOrArrayLayers: 1321},
+mipLevelCount: 7,
+sampleCount: 1,
+dimension: '3d',
+format: 'rg8uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg8uint', 'rg8uint', 'rg8uint'],
+});
+try {
+computePassEncoder26.setBindGroup(2, bindGroup13, new Uint32Array(1983), 1632, 0);
+} catch {}
+try {
+commandEncoder69.clearBuffer(buffer21, 5792);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 363 */
+{offset: 363}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise27 = device1.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let offscreenCanvas18 = new OffscreenCanvas(95, 237);
+let querySet66 = device3.createQuerySet({
+label: '\u89a2\u09f1\u0080\u0d5a\uf875',
+type: 'occlusion',
+count: 353,
+});
+try {
+  await promise27;
+} catch {}
+let offscreenCanvas19 = new OffscreenCanvas(52, 72);
+let computePassEncoder45 = commandEncoder62.beginComputePass({label: '\u0fce\u1c14\u0358\u89d4\u1066\u927b\u7f11\u80e2\ub6ec\u919b\u0c56'});
+document.body.prepend(canvas16);
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let offscreenCanvas20 = new OffscreenCanvas(76, 179);
+let adapter8 = await navigator.gpu.requestAdapter({
+});
+let offscreenCanvas21 = new OffscreenCanvas(729, 905);
+let video15 = await videoWithData();
+let imageBitmap15 = await createImageBitmap(imageBitmap6);
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let videoFrame19 = new VideoFrame(canvas13, {timestamp: 0});
+try {
+renderBundle48.label = '\u0e42\u076b\udea8\u{1f724}\u46d8\uf970\u{1f89f}\u51ea\u667d\u3b41';
+} catch {}
+let textureView82 = texture85.createView({baseMipLevel: 0, mipLevelCount: 6, baseArrayLayer: 9, arrayLayerCount: 18});
+let renderBundleEncoder61 = device3.createRenderBundleEncoder({label: '\u0ed3\u{1fa07}\u04fb\u08a5\u{1f746}\ue6eb\u0967', colorFormats: ['r16uint', 'rg16uint']});
+let sampler55 = device3.createSampler({
+label: '\u3078\u{1fd08}\u4999\u0eb3\u6587\u9aa7\ue417\u{1fa95}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 9.472,
+lodMaxClamp: 50.989,
+maxAnisotropy: 12,
+});
+try {
+renderBundleEncoder54.setBindGroup(8, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder56.setBindGroup(2, bindGroup6, new Uint32Array(363), 54, 0);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer24, 8028, new BigUint64Array(49562), 18503, 128);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: { x: 30, y: 104, z: 95 },
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 1685809 */
+{offset: 437, bytesPerRow: 164, rowsPerImage: 283}, {width: 27, height: 89, depthOrArrayLayers: 37});
+} catch {}
+let adapter9 = await navigator.gpu.requestAdapter({
+});
+try {
+offscreenCanvas21.getContext('2d');
+} catch {}
+let texture91 = device3.createTexture({
+label: '\u9d1c\u1bed',
+size: [1024],
+dimension: '1d',
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundle71 = renderBundleEncoder40.finish({});
+let sampler56 = device3.createSampler({
+label: '\uec6f\u{1f6d5}\u06a9\u6411\u1723\u09f7\u8053\ue7f8\u2f05\u37e9',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 36.607,
+lodMaxClamp: 38.306,
+maxAnisotropy: 6,
+});
+try {
+renderBundleEncoder60.setVertexBuffer(6, buffer29, 24);
+} catch {}
+let imageBitmap16 = await createImageBitmap(canvas2);
+let imageData17 = new ImageData(24, 156);
+document.body.prepend(canvas2);
+let buffer35 = device3.createBuffer({
+  label: '\u04f6\u0100',
+  size: 54882,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM
+});
+let texture92 = device3.createTexture({
+size: {width: 456},
+dimension: '1d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8uint'],
+});
+let renderBundleEncoder62 = device3.createRenderBundleEncoder({
+  label: '\u{1fe8f}\u17c5\u{1f88c}\uc981\u0560\u7e90\u0149\u{1fa49}\u0718\u3d52',
+  colorFormats: ['r8uint', undefined, 'r32sint', 'rgba8uint', 'rg8unorm', 'rg8uint', 'rg32uint', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+try {
+renderBundleEncoder62.setVertexBuffer(10, buffer29, 512, 1161);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer24, 3740, new BigUint64Array(19812), 18496, 440);
+} catch {}
+let promise28 = device3.createComputePipelineAsync({
+label: '\u7cea\u33dc\u77be\u01c7\u{1ff94}\u0678\u0ec0',
+layout: pipelineLayout14,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+},
+});
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let bindGroup15 = device3.createBindGroup({
+layout: bindGroupLayout22,
+entries: [],
+});
+let texture93 = device3.createTexture({
+label: '\u442f\u1a16\u23b9\uaa1b',
+size: [1024, 12, 13],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba32float'],
+});
+let renderBundle72 = renderBundleEncoder28.finish({});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(3, buffer29, 180);
+} catch {}
+try {
+buffer35.unmap();
+} catch {}
+try {
+renderBundleEncoder54.popDebugGroup();
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 0,
+  origin: { x: 424, y: 264, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(21530), /* required buffer size: 21530 */
+{offset: 730, bytesPerRow: 4172}, {width: 2056, height: 40, depthOrArrayLayers: 1});
+} catch {}
+let pipeline60 = await device3.createRenderPipelineAsync({
+label: '\u4fc1\u05f6\u815e\u2626',
+layout: pipelineLayout10,
+fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r32sint', writeMask: 0}, {
+  format: 'bgra8unorm-srgb',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilWriteMask: 509,
+depthBias: 48,
+depthBiasSlopeScale: 38,
+depthBiasClamp: 22,
+},
+vertex: {
+  module: shaderModule12,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 5988,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32',
+offset: 2764,
+shaderLocation: 20,
+}, {
+format: 'float16x2',
+offset: 2872,
+shaderLocation: 15,
+}, {
+format: 'unorm8x4',
+offset: 1956,
+shaderLocation: 22,
+}, {
+format: 'uint32x2',
+offset: 648,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 3684,
+shaderLocation: 14,
+}, {
+format: 'snorm8x2',
+offset: 5648,
+shaderLocation: 8,
+}, {
+format: 'unorm16x2',
+offset: 4320,
+shaderLocation: 19,
+}, {
+format: 'sint16x2',
+offset: 3048,
+shaderLocation: 7,
+}, {
+format: 'unorm16x4',
+offset: 3552,
+shaderLocation: 0,
+}, {
+format: 'uint32x4',
+offset: 5796,
+shaderLocation: 24,
+}, {
+format: 'sint32',
+offset: 916,
+shaderLocation: 6,
+}, {
+format: 'float32x2',
+offset: 5680,
+shaderLocation: 17,
+}, {
+format: 'snorm16x4',
+offset: 2896,
+shaderLocation: 5,
+}, {
+format: 'uint32x4',
+offset: 4216,
+shaderLocation: 4,
+}, {
+format: 'float32x2',
+offset: 2140,
+shaderLocation: 18,
+}, {
+format: 'sint16x2',
+offset: 3052,
+shaderLocation: 1,
+}, {
+format: 'uint8x4',
+offset: 3616,
+shaderLocation: 2,
+}, {
+format: 'unorm8x2',
+offset: 5888,
+shaderLocation: 23,
+}, {
+format: 'float32x2',
+offset: 2944,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 22844,
+attributes: [],
+},
+{
+arrayStride: 12164,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 12108,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint16x2',
+offset: 3464,
+shaderLocation: 25,
+}, {
+format: 'unorm10-10-10-2',
+offset: 25200,
+shaderLocation: 10,
+}, {
+format: 'unorm16x4',
+offset: 18704,
+shaderLocation: 21,
+}, {
+format: 'uint32',
+offset: 26132,
+shaderLocation: 13,
+}, {
+format: 'snorm8x4',
+offset: 2832,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 22836,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x2',
+offset: 158,
+shaderLocation: 16,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let img17 = await imageWithData(43, 126, '#bc5cb327', '#e0b41d34');
+try {
+offscreenCanvas18.getContext('2d');
+} catch {}
+try {
+offscreenCanvas20.getContext('bitmaprenderer');
+} catch {}
+let texture94 = device1.createTexture({
+size: [96, 1, 318],
+mipLevelCount: 8,
+dimension: '3d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderBundleEncoder17.drawIndexed(8, 64, 40, 784, 72);
+} catch {}
+let arrayBuffer10 = buffer31.getMappedRange(4336, 96);
+try {
+commandEncoder76.copyBufferToBuffer(buffer34, 17652, buffer30, 32564, 636);
+dissociateBuffer(device1, buffer34);
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+commandEncoder76.resolveQuerySet(querySet44, 475, 1184, buffer34, 9472);
+} catch {}
+let promise29 = device1.queue.onSubmittedWorkDone();
+let bindGroupLayout30 = device1.createBindGroupLayout({
+label: '\u6cd5\udc4a\u0022\u2fe2\u296c\u01ff\u{1f974}',
+entries: [{
+binding: 3524,
+visibility: 0,
+buffer: { type: 'uniform', minBindingSize: 558476, hasDynamicOffset: true },
+}],
+});
+let buffer36 = device1.createBuffer({
+  label: '\u{1fa67}\u0adb\u737a\ua35a\u5d9e\u5007',
+  size: 34627,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let querySet67 = device1.createQuerySet({
+label: '\u80d2\u{1f93a}\u{1f845}\uc3eb',
+type: 'occlusion',
+count: 1547,
+});
+let texture95 = device1.createTexture({
+size: [384],
+dimension: '1d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST,
+});
+try {
+renderBundleEncoder49.setBindGroup(8, bindGroup12);
+} catch {}
+try {
+  await buffer36.mapAsync(GPUMapMode.WRITE, 12744, 12452);
+} catch {}
+try {
+commandEncoder69.clearBuffer(buffer21, 7052);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture88,
+  mipLevel: 1,
+  origin: { x: 24, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 105 */
+{offset: 105}, {width: 72, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext17 = offscreenCanvas19.getContext('webgpu');
+let renderBundleEncoder63 = device1.createRenderBundleEncoder({
+  label: '\u{1fad5}\udcc7\u{1faad}',
+  colorFormats: [undefined, 'rg8sint', 'rgba8uint', 'bgra8unorm-srgb', 'rg16sint', 'rg16float', 'rg8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle73 = renderBundleEncoder17.finish({});
+try {
+computePassEncoder26.end();
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline59);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(6, bindGroup4);
+} catch {}
+try {
+commandEncoder76.copyBufferToBuffer(buffer20, 108, buffer27, 15832, 452);
+dissociateBuffer(device1, buffer20);
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+device: device1,
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgb10a2unorm', 'astc-5x4-unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame19,
+  origin: { x: 8, y: 69 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 13, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 32, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let video16 = await videoWithData();
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let renderBundleEncoder64 = device3.createRenderBundleEncoder({
+  label: '\u4fe4\u{1fc64}',
+  colorFormats: ['r8uint', undefined, 'r32sint', 'rgba8uint', 'rg8unorm', 'rg8uint', 'rg32uint', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder56.setVertexBuffer(10, buffer29, 2752, 1403);
+} catch {}
+let offscreenCanvas22 = new OffscreenCanvas(544, 320);
+let video17 = await videoWithData();
+let imageBitmap17 = await createImageBitmap(offscreenCanvas17);
+let commandEncoder78 = device3.createCommandEncoder({label: '\u0fd3\u{1f946}\ua246'});
+let textureView83 = texture89.createView({
+  label: '\u066a\ufa19\u{1fa5e}\u69c4\u{1fa0e}\u{1f7f8}\u7d6b\u{1f925}',
+  dimension: '2d',
+  baseMipLevel: 7,
+  mipLevelCount: 1,
+  baseArrayLayer: 121
+});
+try {
+computePassEncoder38.setPipeline(pipeline54);
+} catch {}
+try {
+renderBundleEncoder62.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+commandEncoder78.copyBufferToTexture({
+/* bytesInLastRow: 528 widthInBlocks: 33 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 33872 */
+offset: 33872,
+bytesPerRow: 768,
+buffer: buffer35,
+}, {
+  texture: texture48,
+  mipLevel: 0,
+  origin: { x: 18, y: 288, z: 0 },
+  aspect: 'all',
+}, {width: 198, height: 294, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer35);
+} catch {}
+let gpuCanvasContext18 = offscreenCanvas22.getContext('webgpu');
+let adapter10 = await navigator.gpu.requestAdapter({
+});
+let renderBundleEncoder65 = device3.createRenderBundleEncoder({
+  label: '\u08fc\uaa6f\u99cb\u78e6\uaecd\u0653\udb24\ue06b\u0ef0\u301c\ua63b',
+  colorFormats: ['rg8unorm'],
+  sampleCount: 1,
+  stencilReadOnly: false
+});
+try {
+commandEncoder78.clearBuffer(buffer24, 3572, 4992);
+dissociateBuffer(device3, buffer24);
+} catch {}
+try {
+  await promise29;
+} catch {}
+let adapter11 = await navigator.gpu.requestAdapter();
+let video18 = await videoWithData();
+let imageData18 = new ImageData(136, 232);
+try {
+renderBundleEncoder63.setVertexBuffer(41, undefined, 1617249828, 145364569);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer34, 22768, new DataView(new ArrayBuffer(37481)), 18976, 188);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas13,
+  origin: { x: 181, y: 440 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 41, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let promise30 = adapter11.requestAdapterInfo();
+let commandEncoder79 = device1.createCommandEncoder({label: '\uf84e\uc770\u{1f9a8}'});
+let commandBuffer15 = commandEncoder55.finish({
+label: '\u5c14\u{1fbb7}\uc8fb\ue2bc\u7a74\u65b5',
+});
+let texture96 = device1.createTexture({
+size: {width: 192, height: 8, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['etc2-rgb8unorm-srgb', 'etc2-rgb8unorm-srgb'],
+});
+let computePassEncoder46 = commandEncoder69.beginComputePass({label: '\uef83\u{1fc00}\u{1f621}\u{1fc96}'});
+try {
+computePassEncoder41.setPipeline(pipeline22);
+} catch {}
+try {
+commandEncoder79.copyBufferToBuffer(buffer34, 13904, buffer20, 188, 632);
+dissociateBuffer(device1, buffer34);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+  await promise30;
+} catch {}
+let img18 = await imageWithData(220, 166, '#7ec73c67', '#1cbe589c');
+let imageData19 = new ImageData(176, 224);
+canvas11.height = 455;
+let img19 = await imageWithData(103, 213, '#01fafc84', '#cbf180cb');
+let shaderModule13 = device1.createShaderModule({
+label: '\u0ba9\ueae2\u752d\u469c\u0d06\u7fe9\u08ee\u{1fcb6}\u{1f6ad}\u07cc\u08cb',
+code: `@group(0) @binding(542)
+var<storage, read_write> type10: array<u32>;
+@group(1) @binding(1723)
+var<storage, read_write> type11: array<u32>;
+
+@compute @workgroup_size(3, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec2<i32>,
+  @location(0) f1: vec3<f32>,
+  @location(4) f2: vec3<u32>,
+  @location(1) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4<f32>, @builtin(sample_mask) a2: u32, @builtin(sample_index) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S17 {
+  @location(23) f0: vec4<u32>,
+  @location(13) f1: vec4<i32>,
+  @location(4) f2: u32,
+  @location(15) f3: f16,
+  @location(2) f4: vec4<i32>,
+  @location(3) f5: vec4<f16>,
+  @location(0) f6: vec3<i32>,
+  @location(25) f7: vec4<f16>,
+  @location(11) f8: i32,
+  @location(19) f9: u32,
+  @location(6) f10: f16,
+  @location(1) f11: vec3<u32>,
+  @location(24) f12: f32,
+  @location(22) f13: vec4<u32>
+}
+
+@vertex
+fn vertex0(a0: S17, @location(20) a1: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+let renderBundle74 = renderBundleEncoder46.finish({});
+let externalTexture6 = device1.importExternalTexture({
+label: '\u0c13\ua860\u0320\u{1faf8}\u9a79\ue8b0\ud509',
+source: videoFrame5,
+colorSpace: 'srgb',
+});
+try {
+computePassEncoder20.setBindGroup(5, bindGroup12, new Uint32Array(9327), 1649, 0);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline52);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(5, bindGroup4);
+} catch {}
+try {
+commandEncoder76.clearBuffer(buffer21);
+dissociateBuffer(device1, buffer21);
+} catch {}
+let promise31 = device1.createComputePipelineAsync({
+label: '\u04f7\u06e2\u9db1\u{1fcd9}\u{1febc}',
+layout: 'auto',
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let commandEncoder80 = device1.createCommandEncoder({label: '\uf4b8\u0280\u6028\u1c5c\u07ed\u1282\u0785\ud62b\ue627'});
+let textureView84 = texture32.createView({baseMipLevel: 3, mipLevelCount: 2, baseArrayLayer: 7, arrayLayerCount: 13});
+let renderBundle75 = renderBundleEncoder26.finish({});
+try {
+computePassEncoder39.end();
+} catch {}
+try {
+commandEncoder76.clearBuffer(buffer34, 9532, 6320);
+dissociateBuffer(device1, buffer34);
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(querySet25, 1512, 121, buffer34, 3840);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 576, new BigUint64Array(42271), 3712, 68);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: video11,
+  origin: { x: 4, y: 6 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 33, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let adapter12 = await navigator.gpu.requestAdapter({
+});
+canvas12.height = 644;
+let img20 = await imageWithData(55, 83, '#553664a0', '#8b160ec9');
+try {
+renderBundle29.label = '\u58d6\u7a98';
+} catch {}
+pseudoSubmit(device1, commandEncoder69);
+let texture97 = device1.createTexture({
+size: {width: 48, height: 2, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder41.setPipeline(pipeline40);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(1, bindGroup13, new Uint32Array(3896), 1804, 0);
+} catch {}
+try {
+commandEncoder80.resolveQuerySet(querySet25, 272, 1297, buffer34, 7936);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 1,
+  origin: { x: 36, y: 4, z: 0 },
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 389 */
+{offset: 389}, {width: 4, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline61 = device1.createComputePipeline({
+label: '\u6304\u{1f86d}\u27c5',
+layout: 'auto',
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let querySet68 = device1.createQuerySet({
+label: '\u075b\u0e60\u1d92\u97a4\uf4a0\u{1fe9d}\u115a\u0eb6',
+type: 'occlusion',
+count: 1927,
+});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+computePassEncoder42.setBindGroup(8, bindGroup4, new Uint32Array(1069), 1033, 0);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline22);
+} catch {}
+try {
+commandEncoder76.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 9,
+  origin: { x: 0, y: 6, z: 127 },
+  aspect: 'all',
+}, {
+  texture: texture27,
+  mipLevel: 10,
+  origin: { x: 0, y: 0, z: 123 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 21});
+} catch {}
+try {
+commandEncoder79.resolveQuerySet(querySet39, 2401, 207, buffer34, 12288);
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer15,
+]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture88,
+  mipLevel: 4,
+  origin: { x: 8, y: 5, z: 1 },
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer1), /* required buffer size: 127 */
+{offset: 127}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout15 = device1.createPipelineLayout({
+  label: '\uacce\uffe7\ud685',
+  bindGroupLayouts: [bindGroupLayout11, bindGroupLayout30, bindGroupLayout2, bindGroupLayout25, bindGroupLayout6, bindGroupLayout6, bindGroupLayout21, bindGroupLayout11, bindGroupLayout14, bindGroupLayout21, bindGroupLayout21]
+});
+let texture98 = device1.createTexture({
+label: '\u7469\u4179\u{1f720}\u71de\u02c9\u1d6b\u9ad3\u07a1\u00c5\u065a\u6e1a',
+size: [96, 4, 2],
+mipLevelCount: 3,
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [],
+});
+let renderBundleEncoder66 = device1.createRenderBundleEncoder({
+  label: '\u884d\u1455\u3fac\u7612\u{1fda6}\ua0d1\u9b22',
+  colorFormats: [undefined, 'rg8sint', 'rgba8uint', 'bgra8unorm-srgb', 'rg16sint', 'rg16float', 'rg8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: false
+});
+try {
+computePassEncoder41.setBindGroup(5, bindGroup12, new Uint32Array(1653), 375, 0);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline30);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(62, undefined, 1392713464, 1571660599);
+} catch {}
+let arrayBuffer11 = buffer31.getMappedRange(4432, 580);
+try {
+commandEncoder76.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 10,
+  origin: { x: 0, y: 0, z: 41 },
+  aspect: 'all',
+}, {
+  texture: texture27,
+  mipLevel: 10,
+  origin: { x: 0, y: 0, z: 110 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 60});
+} catch {}
+try {
+gpuCanvasContext7.configure({
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['r8uint'],
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: img19,
+  origin: { x: 2, y: 35 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 5, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 35, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline62 = device1.createComputePipeline({
+label: '\u7720\u{1fd74}',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let video19 = await videoWithData();
+let renderBundleEncoder67 = device3.createRenderBundleEncoder({label: '\u{1f95b}\u7b0d\u{1f7a6}', colorFormats: ['rg8unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder40.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder64.setVertexBuffer(8, buffer29, 3704, 107);
+} catch {}
+let promise32 = device3.createRenderPipelineAsync({
+label: '\u308d\uf238\u{1fbb5}',
+layout: 'auto',
+fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'one-minus-dst-alpha'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r32sint', writeMask: 0}, {format: 'bgra8unorm-srgb'}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 2614,
+stencilWriteMask: 3105,
+depthBiasSlopeScale: 33,
+depthBiasClamp: 29,
+},
+vertex: {
+  module: shaderModule12,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1588,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x2',
+offset: 856,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 28524,
+attributes: [{
+format: 'sint16x2',
+offset: 28288,
+shaderLocation: 1,
+}, {
+format: 'sint16x4',
+offset: 12220,
+shaderLocation: 6,
+}, {
+format: 'unorm10-10-10-2',
+offset: 468,
+shaderLocation: 22,
+}, {
+format: 'float16x4',
+offset: 21012,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 11184,
+attributes: [{
+format: 'uint32',
+offset: 9964,
+shaderLocation: 24,
+}, {
+format: 'sint16x4',
+offset: 9920,
+shaderLocation: 7,
+}, {
+format: 'float32x2',
+offset: 6312,
+shaderLocation: 21,
+}, {
+format: 'float32x4',
+offset: 10200,
+shaderLocation: 9,
+}, {
+format: 'float16x4',
+offset: 9732,
+shaderLocation: 5,
+}, {
+format: 'float32x4',
+offset: 9448,
+shaderLocation: 19,
+}, {
+format: 'snorm16x4',
+offset: 508,
+shaderLocation: 8,
+}, {
+format: 'uint8x4',
+offset: 3224,
+shaderLocation: 12,
+}, {
+format: 'uint16x2',
+offset: 7360,
+shaderLocation: 14,
+}, {
+format: 'uint32x3',
+offset: 10092,
+shaderLocation: 13,
+}, {
+format: 'unorm8x2',
+offset: 6466,
+shaderLocation: 23,
+}, {
+format: 'uint8x4',
+offset: 9048,
+shaderLocation: 20,
+}, {
+format: 'uint16x4',
+offset: 188,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 10064,
+attributes: [{
+format: 'snorm16x4',
+offset: 3920,
+shaderLocation: 17,
+}],
+},
+{
+arrayStride: 7064,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x2',
+offset: 2188,
+shaderLocation: 16,
+}, {
+format: 'unorm16x4',
+offset: 4900,
+shaderLocation: 18,
+}, {
+format: 'sint32x3',
+offset: 4928,
+shaderLocation: 25,
+}, {
+format: 'float16x4',
+offset: 6388,
+shaderLocation: 0,
+}, {
+format: 'snorm16x4',
+offset: 5104,
+shaderLocation: 15,
+}, {
+format: 'uint16x2',
+offset: 6844,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 14168,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 6728,
+attributes: [],
+},
+{
+arrayStride: 0,
+attributes: [],
+},
+{
+arrayStride: 15572,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 1472,
+shaderLocation: 10,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+},
+});
+gc();
+let canvas19 = document.createElement('canvas');
+let imageData20 = new ImageData(132, 12);
+let bindGroup16 = device3.createBindGroup({
+label: '\u058d\u{1fa58}\u0d90\u2756\u0652\u{1f8a3}\u05cc\u050a',
+layout: bindGroupLayout29,
+entries: [],
+});
+let texture99 = device3.createTexture({
+label: '\u6dca\ub32d\u40b5\u{1fb6e}\uf9ae\u00a6\ue830\u6f01\u2943',
+size: [512],
+dimension: '1d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16float', 'rg16float', 'rg16float'],
+});
+let textureView85 = texture56.createView({label: '\uff91\u{1fabd}', dimension: '2d', aspect: 'all', baseMipLevel: 2, baseArrayLayer: 15});
+let computePassEncoder47 = commandEncoder78.beginComputePass({label: '\u8f6d\u0b42'});
+let renderBundleEncoder68 = device3.createRenderBundleEncoder({label: '\u0e75\u0d04\u0f6e', colorFormats: ['rg32sint'], depthReadOnly: true, stencilReadOnly: true});
+let sampler57 = device3.createSampler({
+label: '\u06ea\u4378\u39af\u{1f605}\u934d\u7573\u35d6\u5d8c',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 50.308,
+lodMaxClamp: 74.036,
+compare: 'equal',
+maxAnisotropy: 8,
+});
+try {
+device3.queue.writeBuffer(buffer24, 1124, new Int16Array(5759), 1211, 1556);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 9,
+  origin: { x: 0, y: 0, z: 81 },
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 96235 */
+{offset: 867, bytesPerRow: 131, rowsPerImage: 8}, {width: 0, height: 0, depthOrArrayLayers: 92});
+} catch {}
+offscreenCanvas11.width = 439;
+try {
+await adapter6.requestAdapterInfo();
+} catch {}
+try {
+computePassEncoder20.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer32, 'uint16', 15418);
+} catch {}
+try {
+commandEncoder76.copyTextureToTexture({
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 145, y: 20, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 140, y: 5, z: 0 },
+  aspect: 'all',
+}, {width: 5, height: 20, depthOrArrayLayers: 0});
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext19 = canvas19.getContext('webgpu');
+document.body.prepend(canvas5);
+try {
+window.someLabel = texture75.label;
+} catch {}
+let imageData21 = new ImageData(188, 228);
+let adapter13 = await navigator.gpu.requestAdapter({
+});
+let commandEncoder81 = device3.createCommandEncoder();
+let texture100 = device3.createTexture({
+label: '\udba1\u041f\u3e37\u{1fd2f}\u0216\uc110\u048e\u8a2b\u{1fa16}\uaab4',
+size: {width: 504, height: 60, depthOrArrayLayers: 193},
+mipLevelCount: 7,
+format: 'eac-rg11unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView86 = texture47.createView({
+  label: '\u0883\u0135\u0703\u8cef\uf904\u4385\u0eb2\uf9a2',
+  format: 'astc-6x6-unorm-srgb',
+  baseMipLevel: 0
+});
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+commandEncoder81.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 45808 */
+offset: 45808,
+bytesPerRow: 0,
+rowsPerImage: 227,
+buffer: buffer35,
+}, {
+  texture: texture85,
+  mipLevel: 6,
+  origin: { x: 6, y: 0, z: 73 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 38});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder81.resolveQuerySet(querySet48, 202, 94, buffer33, 18688);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer24, 2748, new DataView(new ArrayBuffer(33008)), 20049, 2044);
+} catch {}
+let bindGroupLayout31 = device3.createBindGroupLayout({
+entries: [{
+binding: 2662,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+}, {
+binding: 6976,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'filtering' },
+}],
+});
+let commandBuffer16 = commandEncoder81.finish();
+try {
+renderBundleEncoder65.setBindGroup(9, bindGroup14, []);
+} catch {}
+try {
+renderBundleEncoder67.setVertexBuffer(6, buffer29, 428, 1690);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 348, y: 20, z: 122 },
+  aspect: 'all',
+}, new ArrayBuffer(195035), /* required buffer size: 195035 */
+{offset: 905, bytesPerRow: 454, rowsPerImage: 84}, {width: 102, height: 40, depthOrArrayLayers: 6});
+} catch {}
+let imageBitmap18 = await createImageBitmap(video12);
+pseudoSubmit(device1, commandEncoder40);
+let textureView87 = texture63.createView({dimension: '2d', format: 'astc-8x8-unorm', baseArrayLayer: 4});
+let sampler58 = device1.createSampler({
+label: '\u2077\u0b0c\u3d5a\uadcf\uab45\u1fd8\u1943\u9005\uc08e',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 82.894,
+lodMaxClamp: 84.448,
+maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder66.setBindGroup(0, bindGroup12, []);
+} catch {}
+try {
+  await buffer30.mapAsync(GPUMapMode.READ, 21208, 3216);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC,
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 95 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 442301 */
+{offset: 43, bytesPerRow: 119, rowsPerImage: 235}, {width: 27, height: 192, depthOrArrayLayers: 16});
+} catch {}
+let pipeline63 = device1.createRenderPipeline({
+label: '\u0f81\u{1f63b}\u0b43\u01e8\u{1fd60}\u1308',
+layout: pipelineLayout3,
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'constant'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rg8sint', writeMask: 0}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one', dstFactor: 'one-minus-src'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.RED
+}, {format: 'r32uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r32sint'}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilWriteMask: 1799,
+depthBias: 51,
+depthBiasSlopeScale: 3,
+depthBiasClamp: 23,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 20128,
+attributes: [{
+format: 'unorm8x4',
+offset: 12692,
+shaderLocation: 2,
+}, {
+format: 'sint32',
+offset: 2936,
+shaderLocation: 16,
+}, {
+format: 'uint8x2',
+offset: 4246,
+shaderLocation: 17,
+}, {
+format: 'unorm16x4',
+offset: 9896,
+shaderLocation: 4,
+}, {
+format: 'float16x4',
+offset: 17864,
+shaderLocation: 0,
+}, {
+format: 'uint16x2',
+offset: 4740,
+shaderLocation: 12,
+}, {
+format: 'float16x4',
+offset: 13424,
+shaderLocation: 20,
+}, {
+format: 'uint8x4',
+offset: 4696,
+shaderLocation: 14,
+}, {
+format: 'uint16x4',
+offset: 1456,
+shaderLocation: 22,
+}, {
+format: 'unorm16x4',
+offset: 7664,
+shaderLocation: 1,
+}, {
+format: 'sint32x3',
+offset: 5420,
+shaderLocation: 25,
+}, {
+format: 'uint16x2',
+offset: 2388,
+shaderLocation: 26,
+}, {
+format: 'uint32x3',
+offset: 5772,
+shaderLocation: 10,
+}, {
+format: 'sint8x4',
+offset: 3040,
+shaderLocation: 5,
+}, {
+format: 'float32x4',
+offset: 18012,
+shaderLocation: 21,
+}, {
+format: 'sint16x4',
+offset: 18184,
+shaderLocation: 13,
+}, {
+format: 'float16x4',
+offset: 14068,
+shaderLocation: 6,
+}, {
+format: 'snorm8x2',
+offset: 476,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 34044,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 5324,
+shaderLocation: 7,
+}, {
+format: 'sint16x2',
+offset: 13320,
+shaderLocation: 15,
+}, {
+format: 'uint32x4',
+offset: 17588,
+shaderLocation: 24,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let img21 = await imageWithData(142, 252, '#57835747', '#cda85e9a');
+let videoFrame20 = new VideoFrame(canvas7, {timestamp: 0});
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let offscreenCanvas23 = new OffscreenCanvas(412, 161);
+let sampler59 = device3.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMaxClamp: 67.204,
+});
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(video6);
+try {
+device3.label = '\u{1fc41}\u028f\uf5f5\ud213\u30ad\u517f\u{1fc3b}\ud0e3\uebdf\u1299';
+} catch {}
+let bindGroupLayout32 = device3.createBindGroupLayout({
+label: '\u{1f75d}\u0828\ufc75\u28c3\u062f\u034d\u07f1',
+entries: [],
+});
+try {
+renderBundleEncoder64.setVertexBuffer(9, buffer29, 3740, 215);
+} catch {}
+let pipeline64 = await promise32;
+let canvas20 = document.createElement('canvas');
+let renderBundleEncoder69 = device1.createRenderBundleEncoder({
+  label: '\ue92b\u{1f63f}\u1954\u0bb0',
+  colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+try {
+renderBundleEncoder63.setIndexBuffer(buffer32, 'uint16');
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(querySet39, 1947, 272, buffer34, 20736);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 24, y: 176, z: 70 },
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(80)), /* required buffer size: 750002 */
+{offset: 30, bytesPerRow: 286, rowsPerImage: 289}, {width: 20, height: 88, depthOrArrayLayers: 10});
+} catch {}
+let promise33 = device1.queue.onSubmittedWorkDone();
+let imageData22 = new ImageData(228, 208);
+try {
+canvas20.getContext('webgl2');
+} catch {}
+try {
+offscreenCanvas23.getContext('webgl2');
+} catch {}
+offscreenCanvas11.width = 782;
+let offscreenCanvas24 = new OffscreenCanvas(343, 632);
+let gpuCanvasContext20 = offscreenCanvas24.getContext('webgpu');
+gc();
+let imageBitmap19 = await createImageBitmap(img19);
+let videoFrame21 = new VideoFrame(canvas17, {timestamp: 0});
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+try {
+  await promise33;
+} catch {}
+let renderBundle76 = renderBundleEncoder28.finish({label: '\u28a8\ub213\ue55c\uc1ce\uc1be\u{1fa1c}'});
+try {
+computePassEncoder37.setBindGroup(9, bindGroup16, new Uint32Array(6429), 1681, 0);
+} catch {}
+try {
+renderBundleEncoder67.setVertexBuffer(2, buffer29, 860, 2599);
+} catch {}
+let pipeline65 = device3.createComputePipeline({
+layout: 'auto',
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+document.body.prepend(canvas4);
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let querySet69 = device1.createQuerySet({
+label: '\ud02a\u9b63\u4317\u{1fdaf}\u0748\u0fe2\u0d42\u0896',
+type: 'occlusion',
+count: 4058,
+});
+let texture101 = device1.createTexture({
+size: [192, 8, 5],
+mipLevelCount: 8,
+dimension: '3d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba16uint', 'rgba16uint'],
+});
+let textureView88 = texture95.createView({label: '\ufb0e\udbaf', baseMipLevel: 0});
+try {
+computePassEncoder41.end();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: { x: 0, y: 30, z: 81 },
+  aspect: 'depth-only',
+}, arrayBuffer2, /* required buffer size: 1521146 */
+{offset: 821, bytesPerRow: 233, rowsPerImage: 145}, {width: 27, height: 0, depthOrArrayLayers: 46});
+} catch {}
+let texture102 = device2.createTexture({
+size: {width: 576, height: 96, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'eac-r11unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['eac-r11unorm', 'eac-r11unorm'],
+});
+let textureView89 = texture35.createView({label: '\u8845\u3aca\u3b68\uc797\ua2b4\u3762', mipLevelCount: 2});
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 2,
+  origin: { x: 16, y: 6, z: 16 },
+  aspect: 'all',
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 106, y: 41, z: 105 },
+  aspect: 'all',
+}, {width: 41, height: 3, depthOrArrayLayers: 10});
+} catch {}
+document.body.prepend(img11);
+let renderBundleEncoder70 = device1.createRenderBundleEncoder({
+  label: '\ua10e\u811d\u0fb0\uf9c9\u02dc\u04f1\u8598\u0b96\u{1ffe0}\u{1fad7}\u505e',
+  colorFormats: ['rg8sint', 'r16uint', 'r32sint', 'rg16sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder66.setBindGroup(8, bindGroup4);
+} catch {}
+let arrayBuffer12 = buffer27.getMappedRange(0, 8632);
+try {
+device1.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: { x: 0, y: 4, z: 41 },
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 2973485 */
+{offset: 863, bytesPerRow: 599, rowsPerImage: 121}, {width: 192, height: 8, depthOrArrayLayers: 42});
+} catch {}
+let promise34 = device1.createComputePipelineAsync({
+layout: pipelineLayout7,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let adapter14 = await navigator.gpu.requestAdapter();
+let buffer37 = device3.createBuffer({
+  label: '\u47b8\u{1fa3e}\u6bad\ub389\u9292\ube99\udacf\u{1f9f9}\ufef5\u0c21',
+  size: 41660,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let commandEncoder82 = device3.createCommandEncoder();
+let computePassEncoder48 = commandEncoder82.beginComputePass({label: '\u760a\u{1fc33}\u090a\u{1fbd4}\u04f8\u6ea7\u52c3\u0b2c'});
+try {
+renderBundleEncoder64.setBindGroup(2, bindGroup11);
+} catch {}
+let pipeline66 = await device3.createComputePipelineAsync({
+label: '\u{1ff13}\u0e1a',
+layout: 'auto',
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+window.someLabel = commandBuffer5.label;
+} catch {}
+let textureView90 = texture95.createView({label: '\ue1d5\u0713\ufdd8\u{1f732}\ubefc\ued04', aspect: 'all', mipLevelCount: 1});
+let computePassEncoder49 = commandEncoder79.beginComputePass();
+try {
+computePassEncoder42.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(35, undefined, 503102045, 1586376843);
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+try {
+commandEncoder72.resolveQuerySet(querySet16, 843, 51, buffer34, 4352);
+} catch {}
+try {
+renderBundleEncoder59.insertDebugMarker('\ub1b7');
+} catch {}
+let pipeline67 = await device1.createRenderPipelineAsync({
+label: '\u{1f8c6}\u0ba6\ub943\u{1ffcd}\u00c7',
+layout: pipelineLayout3,
+multisample: {
+count: 4,
+},
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg32float'}, {
+  format: 'r16float',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'zero'},
+}
+}, {format: 'r16uint', writeMask: 0}, {format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r8uint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'equal',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 3692,
+depthBias: 5,
+depthBiasSlopeScale: 29,
+depthBiasClamp: 19,
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 21068,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 21736,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 15750,
+shaderLocation: 5,
+}, {
+format: 'unorm8x2',
+offset: 962,
+shaderLocation: 13,
+}, {
+format: 'sint8x2',
+offset: 15480,
+shaderLocation: 7,
+}, {
+format: 'unorm16x2',
+offset: 7004,
+shaderLocation: 4,
+}, {
+format: 'uint8x4',
+offset: 18584,
+shaderLocation: 15,
+}, {
+format: 'unorm8x2',
+offset: 2594,
+shaderLocation: 19,
+}, {
+format: 'uint32',
+offset: 17984,
+shaderLocation: 2,
+}, {
+format: 'float32',
+offset: 21156,
+shaderLocation: 6,
+}, {
+format: 'unorm16x4',
+offset: 17852,
+shaderLocation: 10,
+}, {
+format: 'sint8x4',
+offset: 2260,
+shaderLocation: 23,
+}, {
+format: 'unorm16x4',
+offset: 20376,
+shaderLocation: 22,
+}, {
+format: 'sint32x4',
+offset: 6636,
+shaderLocation: 25,
+}, {
+format: 'float32x2',
+offset: 17020,
+shaderLocation: 16,
+}, {
+format: 'unorm10-10-10-2',
+offset: 10936,
+shaderLocation: 8,
+}, {
+format: 'float16x2',
+offset: 12916,
+shaderLocation: 1,
+}, {
+format: 'uint8x4',
+offset: 1932,
+shaderLocation: 3,
+}, {
+format: 'uint16x4',
+offset: 16228,
+shaderLocation: 21,
+}, {
+format: 'sint8x2',
+offset: 12902,
+shaderLocation: 0,
+}, {
+format: 'float16x2',
+offset: 7948,
+shaderLocation: 20,
+}, {
+format: 'uint8x2',
+offset: 6590,
+shaderLocation: 9,
+}, {
+format: 'sint32x4',
+offset: 11976,
+shaderLocation: 18,
+}, {
+format: 'float32',
+offset: 2260,
+shaderLocation: 17,
+}, {
+format: 'sint8x4',
+offset: 8180,
+shaderLocation: 24,
+}, {
+format: 'float16x4',
+offset: 4832,
+shaderLocation: 12,
+}, {
+format: 'snorm8x4',
+offset: 3084,
+shaderLocation: 26,
+}, {
+format: 'snorm8x4',
+offset: 10272,
+shaderLocation: 11,
+}, {
+format: 'unorm16x4',
+offset: 8304,
+shaderLocation: 14,
+}],
+}
+]
+},
+});
+gc();
+let imageBitmap20 = await createImageBitmap(video16);
+let querySet70 = device3.createQuerySet({
+label: '\u008a\u3eca\u0637',
+type: 'occlusion',
+count: 1792,
+});
+let sampler60 = device3.createSampler({
+label: '\u{1ff76}\ub858\ua99b\u{1f78c}\u0463\u16ef\u037a',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 43.724,
+maxAnisotropy: 15,
+});
+try {
+computePassEncoder27.end();
+} catch {}
+try {
+renderBundleEncoder68.setVertexBuffer(0, buffer29, 684);
+} catch {}
+try {
+commandEncoder58.copyTextureToBuffer({
+  texture: texture58,
+  mipLevel: 0,
+  origin: { x: 168, y: 170, z: 15 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 4304 widthInBlocks: 269 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 10016 */
+offset: 10016,
+bytesPerRow: 4608,
+buffer: buffer19,
+}, {width: 3228, height: 30, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer19);
+} catch {}
+let pipeline68 = await device3.createRenderPipelineAsync({
+label: '\u{1fec4}\u1048\u03a7\u{1f758}\u7fed\u09db',
+layout: pipelineLayout14,
+fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one', dstFactor: 'dst'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+vertex: {
+  module: shaderModule12,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 20788,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 4032,
+shaderLocation: 25,
+}, {
+format: 'float32x3',
+offset: 18132,
+shaderLocation: 19,
+}, {
+format: 'sint16x4',
+offset: 14160,
+shaderLocation: 1,
+}, {
+format: 'sint16x2',
+offset: 17416,
+shaderLocation: 11,
+}, {
+format: 'unorm10-10-10-2',
+offset: 1500,
+shaderLocation: 3,
+}, {
+format: 'snorm8x4',
+offset: 9024,
+shaderLocation: 10,
+}, {
+format: 'uint16x4',
+offset: 13660,
+shaderLocation: 20,
+}, {
+format: 'uint8x2',
+offset: 15222,
+shaderLocation: 2,
+}, {
+format: 'snorm16x4',
+offset: 4224,
+shaderLocation: 5,
+}, {
+format: 'unorm16x4',
+offset: 15440,
+shaderLocation: 17,
+}, {
+format: 'sint32',
+offset: 948,
+shaderLocation: 6,
+}, {
+format: 'float16x2',
+offset: 11172,
+shaderLocation: 8,
+}, {
+format: 'uint32x2',
+offset: 2688,
+shaderLocation: 13,
+}, {
+format: 'sint32x4',
+offset: 9900,
+shaderLocation: 7,
+}, {
+format: 'uint8x4',
+offset: 7912,
+shaderLocation: 4,
+}, {
+format: 'snorm8x2',
+offset: 6546,
+shaderLocation: 21,
+}, {
+format: 'uint32x4',
+offset: 7516,
+shaderLocation: 24,
+}, {
+format: 'float32x3',
+offset: 16908,
+shaderLocation: 22,
+}, {
+format: 'uint8x2',
+offset: 6204,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 10904,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 9688,
+attributes: [{
+format: 'unorm16x4',
+offset: 8712,
+shaderLocation: 0,
+}, {
+format: 'float32x4',
+offset: 3128,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 25168,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 1612,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 15936,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 14252,
+shaderLocation: 18,
+}, {
+format: 'unorm8x2',
+offset: 13458,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 25732,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 26924,
+attributes: [],
+},
+{
+arrayStride: 22880,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 22652,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 18320,
+shaderLocation: 23,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let canvas21 = document.createElement('canvas');
+let shaderModule14 = device3.createShaderModule({
+label: '\ufc76\uf7c8\u3e51\u{1fe9f}\u5d87\u26f9\u0884\u234c\u7bc0\ud027',
+code: `@group(0) @binding(846)
+var<storage, read_write> field5: array<u32>;
+
+@compute @workgroup_size(3, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S19 {
+  @builtin(sample_index) f0: u32,
+  @builtin(position) f1: vec4<f32>,
+  @location(24) f2: f16,
+  @location(33) f3: vec4<i32>,
+  @location(12) f4: vec3<f16>,
+  @location(58) f5: vec4<u32>,
+  @location(73) f6: u32,
+  @location(40) f7: vec4<u32>,
+  @location(15) f8: f16,
+  @location(37) f9: vec4<f16>,
+  @location(42) f10: vec3<i32>,
+  @location(44) f11: u32,
+  @location(81) f12: f32,
+  @location(74) f13: vec3<f32>,
+  @location(2) f14: f16,
+  @location(3) f15: vec4<i32>,
+  @location(79) f16: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: i32,
+  @location(0) f1: vec2<u32>,
+  @location(5) f2: vec3<u32>,
+  @location(3) f3: vec4<u32>,
+  @location(6) f4: vec3<u32>,
+  @location(4) f5: vec2<f32>,
+  @location(7) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(59) a0: vec2<f32>, @location(66) a1: vec2<u32>, @location(56) a2: vec4<f32>, @location(7) a3: vec4<f16>, @builtin(front_facing) a4: bool, @location(80) a5: vec3<f32>, @location(43) a6: f16, @location(11) a7: f32, @location(28) a8: vec2<f32>, @builtin(sample_mask) a9: u32, @location(0) a10: vec4<f16>, @location(27) a11: vec3<u32>, @location(16) a12: vec3<f16>, @location(60) a13: f32, a14: S19, @location(52) a15: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S18 {
+  @location(14) f0: f16,
+  @location(11) f1: i32,
+  @location(7) f2: vec3<u32>,
+  @location(4) f3: f32,
+  @location(18) f4: vec4<f16>,
+  @location(0) f5: vec2<f32>,
+  @location(19) f6: vec2<u32>
+}
+struct VertexOutput0 {
+  @location(12) f308: vec3<f16>,
+  @location(37) f309: vec4<f16>,
+  @location(59) f310: vec2<f32>,
+  @location(80) f311: vec3<f32>,
+  @builtin(position) f312: vec4<f32>,
+  @location(11) f313: f32,
+  @location(44) f314: u32,
+  @location(56) f315: vec4<f32>,
+  @location(3) f316: vec4<i32>,
+  @location(27) f317: vec3<u32>,
+  @location(40) f318: vec4<u32>,
+  @location(79) f319: vec4<f32>,
+  @location(2) f320: f16,
+  @location(58) f321: vec4<u32>,
+  @location(24) f322: f16,
+  @location(74) f323: vec3<f32>,
+  @location(66) f324: vec2<u32>,
+  @location(52) f325: u32,
+  @location(33) f326: vec4<i32>,
+  @location(28) f327: vec2<f32>,
+  @location(0) f328: vec4<f16>,
+  @location(81) f329: f32,
+  @location(73) f330: u32,
+  @location(60) f331: f32,
+  @location(16) f332: vec3<f16>,
+  @location(7) f333: vec4<f16>,
+  @location(43) f334: f16,
+  @location(15) f335: f16,
+  @location(42) f336: vec3<i32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @builtin(instance_index) a1: u32, a2: S18, @location(25) a3: vec2<f16>, @location(21) a4: vec3<i32>, @location(3) a5: vec4<f32>, @location(20) a6: vec2<u32>, @location(17) a7: vec3<f32>, @location(13) a8: vec2<u32>, @location(23) a9: vec4<i32>, @location(15) a10: vec2<f32>, @location(12) a11: vec2<f16>, @location(9) a12: u32, @location(8) a13: vec4<f32>, @location(22) a14: i32, @location(1) a15: i32, @location(10) a16: vec2<u32>, @location(24) a17: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+});
+let bindGroup17 = device3.createBindGroup({
+label: '\u{1fc3c}\ub79a\u02d6\uee5a\u0852\u039f\ue263\uea40\u072d',
+layout: bindGroupLayout22,
+entries: [],
+});
+let texture103 = device3.createTexture({
+label: '\u000f\u085c\u7099',
+size: {width: 1824},
+sampleCount: 1,
+dimension: '1d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['bgra8unorm'],
+});
+let computePassEncoder50 = commandEncoder58.beginComputePass({label: '\u0cb8\udb80\u5543\u{1fd90}\ucab4\uf36c\u{1fedc}\u{1f83c}\u12e8\u7a67\u0c76'});
+let renderBundleEncoder71 = device3.createRenderBundleEncoder({
+  label: '\u0cf7\u1c9b\ub429\u9375\u3f1c\u2fa3\u8401\u2fe2\u0a0c\u{1fe94}\ufd05',
+  colorFormats: ['rg32sint'],
+  stencilReadOnly: true
+});
+let renderBundle77 = renderBundleEncoder61.finish();
+let externalTexture7 = device3.importExternalTexture({
+label: '\u4d32\u258d\u0c58\ufa94\u{1f8d5}\u07f6\u{1f716}\ub83c\u0241',
+source: videoFrame16,
+});
+try {
+buffer19.unmap();
+} catch {}
+try {
+device3.queue.writeBuffer(buffer24, 2132, new Float32Array(60630), 55866, 452);
+} catch {}
+let pipeline69 = await device3.createRenderPipelineAsync({
+label: '\u6d5f\u0d4b\u{1ff44}\u33b8',
+layout: pipelineLayout11,
+fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: GPUColorWrite.ALPHA}, undefined, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8uint', writeMask: 0}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rg8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rg32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgb10a2unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'src-alpha'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.RED
+}]
+},
+vertex: {
+  module: shaderModule14,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 14616,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x4',
+offset: 8544,
+shaderLocation: 15,
+}, {
+format: 'unorm8x2',
+offset: 10502,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 14844,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 10856,
+shaderLocation: 7,
+}, {
+format: 'snorm16x4',
+offset: 3360,
+shaderLocation: 17,
+}, {
+format: 'uint16x2',
+offset: 7692,
+shaderLocation: 9,
+}, {
+format: 'sint16x4',
+offset: 2240,
+shaderLocation: 1,
+}, {
+format: 'float32x4',
+offset: 6316,
+shaderLocation: 14,
+}, {
+format: 'uint8x4',
+offset: 4176,
+shaderLocation: 10,
+}, {
+format: 'unorm10-10-10-2',
+offset: 13304,
+shaderLocation: 18,
+}, {
+format: 'sint16x4',
+offset: 4264,
+shaderLocation: 11,
+}, {
+format: 'sint16x4',
+offset: 6000,
+shaderLocation: 21,
+}, {
+format: 'float32x3',
+offset: 4784,
+shaderLocation: 3,
+}, {
+format: 'uint16x2',
+offset: 9128,
+shaderLocation: 19,
+}, {
+format: 'sint16x4',
+offset: 14280,
+shaderLocation: 22,
+}, {
+format: 'float32',
+offset: 4060,
+shaderLocation: 25,
+}, {
+format: 'uint16x4',
+offset: 1496,
+shaderLocation: 20,
+}, {
+format: 'unorm8x4',
+offset: 13548,
+shaderLocation: 4,
+}, {
+format: 'sint8x4',
+offset: 14444,
+shaderLocation: 23,
+}, {
+format: 'snorm16x2',
+offset: 8672,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 19536,
+attributes: [{
+format: 'uint32x3',
+offset: 6412,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 21828,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 13728,
+attributes: [{
+format: 'float32',
+offset: 1660,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 720,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 10196,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 23876,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 4360,
+attributes: [{
+format: 'sint16x4',
+offset: 2844,
+shaderLocation: 24,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+let offscreenCanvas25 = new OffscreenCanvas(89, 393);
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let adapter15 = await navigator.gpu.requestAdapter();
+let gpuCanvasContext21 = canvas21.getContext('webgpu');
+let canvas22 = document.createElement('canvas');
+let textureView91 = texture97.createView({label: '\u00e4\u44da\u0342\u{1f759}\ub23e\u0ca9\u3990\u3e95\u{1fb8b}\u1cda'});
+let renderBundleEncoder72 = device1.createRenderBundleEncoder({
+  label: '\uc733\u0365\u3439\u6415\u0ccb\u{1f7e8}\ua7e6\u{1fd81}\ufc3e\u0440',
+  colorFormats: ['r8unorm', 'r32uint', 'rg8sint', 'rg8unorm', 'r32uint', 'r32sint'],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+let renderBundle78 = renderBundleEncoder45.finish();
+try {
+computePassEncoder42.setPipeline(pipeline58);
+} catch {}
+gc();
+pseudoSubmit(device3, commandEncoder67);
+let texture104 = device3.createTexture({
+label: '\u8e76\u043c\u{1f6fd}\ua59b',
+size: {width: 120, height: 480, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'astc-10x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-10x6-unorm-srgb'],
+});
+try {
+computePassEncoder18.setBindGroup(5, bindGroup15, new Uint32Array(9563), 1229, 0);
+} catch {}
+try {
+device3.queue.submit([
+commandBuffer16,
+commandBuffer14,
+]);
+} catch {}
+document.body.prepend(canvas0);
+let adapter16 = await navigator.gpu.requestAdapter({
+});
+let offscreenCanvas26 = new OffscreenCanvas(962, 609);
+let video20 = await videoWithData();
+let texture105 = device3.createTexture({
+label: '\uca46\u0982\u{1fb31}\u0c27\u2b60\u9968\u{1f885}',
+size: [60, 240, 173],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rg16uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView92 = texture86.createView({label: '\u5215\u07b9\u0289\u0756\u074f\u{1fb9f}\u1650', aspect: 'all'});
+try {
+computePassEncoder18.setBindGroup(6, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder71.setIndexBuffer(buffer35, 'uint32', 9896);
+} catch {}
+let pipeline70 = await device3.createRenderPipelineAsync({
+label: '\u2c36\u04c5',
+layout: pipelineLayout14,
+multisample: {
+},
+fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined, {format: 'r32sint', writeMask: GPUColorWrite.BLUE}, {format: 'rgba8uint', writeMask: 0}, {format: 'rg8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg8uint'}, {format: 'rg32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rgb10a2unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'one-minus-src'},
+alpha: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-dst'},
+},
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED
+}]
+},
+vertex: {
+  module: shaderModule14,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 22820,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 20188,
+shaderLocation: 17,
+}, {
+format: 'snorm16x2',
+offset: 11996,
+shaderLocation: 14,
+}, {
+format: 'sint32x4',
+offset: 19532,
+shaderLocation: 21,
+}, {
+format: 'sint8x2',
+offset: 2858,
+shaderLocation: 24,
+}, {
+format: 'float32x3',
+offset: 6504,
+shaderLocation: 15,
+}, {
+format: 'snorm8x4',
+offset: 22228,
+shaderLocation: 18,
+}, {
+format: 'uint16x2',
+offset: 2592,
+shaderLocation: 20,
+}, {
+format: 'unorm10-10-10-2',
+offset: 14652,
+shaderLocation: 0,
+}, {
+format: 'float32x3',
+offset: 632,
+shaderLocation: 4,
+}, {
+format: 'float32x2',
+offset: 7348,
+shaderLocation: 3,
+}, {
+format: 'sint8x2',
+offset: 20790,
+shaderLocation: 11,
+}, {
+format: 'uint32x2',
+offset: 10776,
+shaderLocation: 10,
+}, {
+format: 'sint16x2',
+offset: 10160,
+shaderLocation: 23,
+}, {
+format: 'uint32x3',
+offset: 15452,
+shaderLocation: 7,
+}, {
+format: 'uint32x2',
+offset: 4248,
+shaderLocation: 19,
+}],
+},
+{
+arrayStride: 12696,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 12596,
+shaderLocation: 13,
+}, {
+format: 'sint32x3',
+offset: 3596,
+shaderLocation: 22,
+}, {
+format: 'uint16x2',
+offset: 5700,
+shaderLocation: 9,
+}, {
+format: 'sint8x4',
+offset: 12200,
+shaderLocation: 1,
+}, {
+format: 'unorm10-10-10-2',
+offset: 3736,
+shaderLocation: 12,
+}, {
+format: 'unorm10-10-10-2',
+offset: 3576,
+shaderLocation: 25,
+}, {
+format: 'float32x3',
+offset: 8824,
+shaderLocation: 8,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let imageData23 = new ImageData(124, 220);
+let querySet71 = device1.createQuerySet({
+type: 'occlusion',
+count: 1936,
+});
+let textureView93 = texture82.createView({label: '\u08e0\u{1f92e}\u{1f8d7}\u0fcc\u{1feee}\u1e7d', baseArrayLayer: 103, arrayLayerCount: 33});
+try {
+computePassEncoder49.setBindGroup(7, bindGroup13);
+} catch {}
+try {
+computePassEncoder49.setBindGroup(0, bindGroup12, new Uint32Array(6198), 3277, 0);
+} catch {}
+try {
+commandEncoder76.copyBufferToBuffer(buffer36, 10560, buffer21, 20744, 684);
+dissociateBuffer(device1, buffer36);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 2,
+  origin: { x: 5, y: 29, z: 59 },
+  aspect: 'all',
+}, {
+  texture: texture17,
+  mipLevel: 2,
+  origin: { x: 2, y: 14, z: 156 },
+  aspect: 'all',
+}, {width: 18, height: 32, depthOrArrayLayers: 2});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 380, new Int16Array(40779), 15830, 324);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame18,
+  origin: { x: 157, y: 307 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 31, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline71 = await device1.createRenderPipelineAsync({
+label: '\ubee7\u2829\u{1f657}\ub88b\u02ff',
+layout: pipelineLayout7,
+multisample: {
+mask: 0x32eec057,
+},
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'rg8sint'}, {format: 'rgba32uint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'invert',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 1043,
+stencilWriteMask: 2828,
+depthBias: 67,
+depthBiasSlopeScale: 16,
+depthBiasClamp: 19,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 11460,
+attributes: [{
+format: 'sint16x2',
+offset: 4336,
+shaderLocation: 22,
+}, {
+format: 'float32x4',
+offset: 3324,
+shaderLocation: 16,
+}, {
+format: 'float16x2',
+offset: 120,
+shaderLocation: 18,
+}, {
+format: 'snorm16x4',
+offset: 9316,
+shaderLocation: 4,
+}, {
+format: 'uint16x4',
+offset: 3464,
+shaderLocation: 3,
+}, {
+format: 'uint32x3',
+offset: 7296,
+shaderLocation: 8,
+}, {
+format: 'unorm8x2',
+offset: 11016,
+shaderLocation: 13,
+}, {
+format: 'unorm16x4',
+offset: 8292,
+shaderLocation: 24,
+}, {
+format: 'snorm16x2',
+offset: 2992,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 8248,
+shaderLocation: 20,
+}, {
+format: 'sint16x4',
+offset: 7580,
+shaderLocation: 10,
+}, {
+format: 'sint16x4',
+offset: 5400,
+shaderLocation: 7,
+}, {
+format: 'float32x2',
+offset: 7664,
+shaderLocation: 19,
+}, {
+format: 'sint32x4',
+offset: 10636,
+shaderLocation: 14,
+}, {
+format: 'unorm8x2',
+offset: 9714,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 0,
+attributes: [{
+format: 'sint32x3',
+offset: 19716,
+shaderLocation: 25,
+}, {
+format: 'uint8x4',
+offset: 9448,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 34316,
+attributes: [{
+format: 'unorm16x2',
+offset: 22464,
+shaderLocation: 23,
+}, {
+format: 'uint32x2',
+offset: 30800,
+shaderLocation: 6,
+}, {
+format: 'uint32',
+offset: 21444,
+shaderLocation: 5,
+}, {
+format: 'uint8x4',
+offset: 4860,
+shaderLocation: 2,
+}, {
+format: 'snorm8x4',
+offset: 19396,
+shaderLocation: 15,
+}, {
+format: 'sint8x4',
+offset: 14484,
+shaderLocation: 17,
+}],
+},
+{
+arrayStride: 16408,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 4728,
+shaderLocation: 26,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x2',
+offset: 15116,
+shaderLocation: 1,
+}, {
+format: 'uint8x4',
+offset: 20296,
+shaderLocation: 21,
+}],
+},
+{
+arrayStride: 6608,
+attributes: [],
+},
+{
+arrayStride: 35784,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 22640,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x2',
+offset: 16592,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let gpuCanvasContext22 = canvas22.getContext('webgpu');
+let video21 = await videoWithData();
+let imageBitmap21 = await createImageBitmap(offscreenCanvas7);
+gc();
+try {
+adapter2.label = '\uae9b\u0feb\u25d0\u{1f721}\ufcf9';
+} catch {}
+let offscreenCanvas27 = new OffscreenCanvas(283, 291);
+try {
+offscreenCanvas26.getContext('webgl2');
+} catch {}
+try {
+device2.queue.label = '\u0611\uff55\u095d\u{1f851}\u0087\u4bd0';
+} catch {}
+let renderBundle79 = renderBundleEncoder45.finish({label: '\u46b1\u1eb5\u29f3\u348e\u{1fcce}\u2c9c\u0456\u{1fe13}\u045a'});
+try {
+computePassEncoder42.setBindGroup(10, bindGroup7, new Uint32Array(1524), 831, 0);
+} catch {}
+try {
+renderBundleEncoder72.setBindGroup(1, bindGroup4, new Uint32Array(1731), 1434, 0);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let imageData24 = new ImageData(164, 24);
+let querySet72 = device4.createQuerySet({
+type: 'occlusion',
+count: 1086,
+});
+let textureView94 = texture74.createView({label: '\u{1f8ee}\u0d35', arrayLayerCount: 1});
+let canvas23 = document.createElement('canvas');
+let video22 = await videoWithData();
+let imageBitmap22 = await createImageBitmap(videoFrame15);
+try {
+offscreenCanvas27.getContext('webgl2');
+} catch {}
+let pipelineLayout16 = device3.createPipelineLayout({
+  label: '\u0acf\ueb73',
+  bindGroupLayouts: [bindGroupLayout32, bindGroupLayout24, bindGroupLayout28, bindGroupLayout32, bindGroupLayout31, bindGroupLayout22, bindGroupLayout31, bindGroupLayout28, bindGroupLayout27]
+});
+try {
+computePassEncoder38.setPipeline(pipeline55);
+} catch {}
+try {
+renderBundleEncoder68.setVertexBuffer(10, buffer29);
+} catch {}
+let video23 = await videoWithData();
+let buffer38 = device1.createBuffer({
+  label: '\u1a7f\u1a65\u8217\u23e4\ucdcb\u{1fe19}\u8cf0\u{1fb0a}\ue852\u{1ffec}\u53fd',
+  size: 2691,
+  usage: GPUBufferUsage.UNIFORM
+});
+let commandEncoder83 = device1.createCommandEncoder({});
+let renderBundle80 = renderBundleEncoder69.finish();
+try {
+renderBundleEncoder59.setVertexBuffer(88, undefined, 1220253945, 2659901091);
+} catch {}
+try {
+commandEncoder80.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 1,
+  origin: { x: 26, y: 4, z: 96 },
+  aspect: 'all',
+}, {
+  texture: texture17,
+  mipLevel: 1,
+  origin: { x: 36, y: 74, z: 146 },
+  aspect: 'all',
+}, {width: 18, height: 274, depthOrArrayLayers: 5});
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(querySet58, 1960, 322, buffer34, 5888);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer34, 5548, new BigUint64Array(34066), 17094, 24);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 84, y: 260, z: 31 },
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer10), /* required buffer size: 8030704 */
+{offset: 8, bytesPerRow: 243, rowsPerImage: 273}, {width: 8, height: 64, depthOrArrayLayers: 122});
+} catch {}
+try {
+offscreenCanvas25.getContext('webgpu');
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+offscreenCanvas6.height = 440;
+let offscreenCanvas28 = new OffscreenCanvas(404, 356);
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+gc();
+let commandEncoder84 = device3.createCommandEncoder({label: '\u8ebf\u041e\ubc92\u0629\u0c12\ub1ac\u0e79\u0695\u1bd6'});
+let texture106 = device3.createTexture({
+label: '\u{1fa41}\ubbb0\u3b76\u9442\u{1faa5}\u7985\u{1fbf9}\ue7e0',
+size: {width: 1024, height: 12, depthOrArrayLayers: 13},
+mipLevelCount: 9,
+sampleCount: 1,
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let renderBundleEncoder73 = device3.createRenderBundleEncoder({
+  label: '\ue309\u{1fb44}\u5ae6\ued4f',
+  colorFormats: ['rg32sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+commandEncoder84.copyBufferToBuffer(buffer29, 676, buffer37, 2260, 1092);
+dissociateBuffer(device3, buffer29);
+dissociateBuffer(device3, buffer37);
+} catch {}
+try {
+commandEncoder84.resolveQuerySet(querySet33, 2051, 69, buffer33, 4608);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline72 = await device3.createComputePipelineAsync({
+label: '\u{1f6ea}\u8ea1\u08c9\u638a\uc484\u9d14\ueeaf\ue949\ubd8a\u07c6',
+layout: pipelineLayout10,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+},
+});
+let buffer39 = device1.createBuffer({
+  label: '\u0029\u{1f918}\u490a\u0e95\ue4c2\u0e93\ucba6\ucfcb\u{1f650}',
+  size: 63080,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let querySet73 = device1.createQuerySet({
+label: '\u56b8\u{1fc65}\ua3ac\u{1fc30}',
+type: 'occlusion',
+count: 1726,
+});
+let sampler61 = device1.createSampler({
+label: '\ueae0\u0a12\u0ead\u0e88\u{1f969}\u0c2a\u92be\u5c92\u{1f721}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMaxClamp: 88.112,
+compare: 'less',
+});
+try {
+renderBundleEncoder37.setIndexBuffer(buffer12, 'uint16', 450, 282);
+} catch {}
+try {
+commandEncoder59.copyTextureToBuffer({
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 65, y: 10, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 336 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 55120 */
+offset: 50176,
+bytesPerRow: 512,
+buffer: buffer39,
+}, {width: 105, height: 50, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 2,
+  origin: { x: 4, y: 28, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture17,
+  mipLevel: 1,
+  origin: { x: 35, y: 134, z: 1 },
+  aspect: 'all',
+}, {width: 4, height: 113, depthOrArrayLayers: 221});
+} catch {}
+try {
+computePassEncoder10.insertDebugMarker('\u1caa');
+} catch {}
+let promise35 = device1.createComputePipelineAsync({
+layout: pipelineLayout12,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let buffer40 = device3.createBuffer({
+  label: '\u6df0\u{1fd85}\u24c9\u7178\ua4ac\u7515\u02ee\u{1ff1c}\u{1fe14}',
+  size: 40563,
+  usage: GPUBufferUsage.COPY_DST
+});
+let texture107 = device3.createTexture({
+label: '\u{1fe62}\u{1f952}\u0002\u2d43',
+size: [228],
+dimension: '1d',
+format: 'r32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture108 = gpuCanvasContext6.getCurrentTexture();
+try {
+commandEncoder84.clearBuffer(buffer19, 9488, 420);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+commandEncoder84.resolveQuerySet(querySet70, 458, 35, buffer33, 4864);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline73 = await promise28;
+let promise36 = device3.createRenderPipelineAsync({
+label: '\u{1fafc}\u77ad',
+layout: pipelineLayout10,
+fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, undefined, {format: 'r32sint'}, {format: 'rgba8uint', writeMask: 0}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'dst-alpha'},
+},
+  writeMask: GPUColorWrite.GREEN
+}, {format: 'rg8uint', writeMask: 0}, {format: 'rg32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+vertex: {
+  module: shaderModule14,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 3884,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 2214,
+shaderLocation: 23,
+}, {
+format: 'uint16x4',
+offset: 1224,
+shaderLocation: 9,
+}, {
+format: 'float32x2',
+offset: 1384,
+shaderLocation: 25,
+}],
+},
+{
+arrayStride: 4968,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 438,
+shaderLocation: 10,
+}, {
+format: 'snorm8x2',
+offset: 1442,
+shaderLocation: 4,
+}, {
+format: 'snorm16x2',
+offset: 3036,
+shaderLocation: 3,
+}, {
+format: 'float32x2',
+offset: 2612,
+shaderLocation: 17,
+}, {
+format: 'sint32x2',
+offset: 568,
+shaderLocation: 21,
+}, {
+format: 'snorm8x4',
+offset: 3160,
+shaderLocation: 12,
+}, {
+format: 'unorm16x2',
+offset: 4220,
+shaderLocation: 18,
+}, {
+format: 'sint32x3',
+offset: 1856,
+shaderLocation: 24,
+}, {
+format: 'uint8x4',
+offset: 3124,
+shaderLocation: 13,
+}, {
+format: 'sint8x2',
+offset: 2262,
+shaderLocation: 22,
+}, {
+format: 'unorm8x4',
+offset: 1848,
+shaderLocation: 15,
+}, {
+format: 'float32x4',
+offset: 2684,
+shaderLocation: 8,
+}, {
+format: 'sint16x4',
+offset: 2708,
+shaderLocation: 1,
+}, {
+format: 'float32x4',
+offset: 4384,
+shaderLocation: 0,
+}, {
+format: 'sint16x2',
+offset: 368,
+shaderLocation: 11,
+}, {
+format: 'uint32x2',
+offset: 2712,
+shaderLocation: 20,
+}, {
+format: 'float32',
+offset: 4608,
+shaderLocation: 14,
+}, {
+format: 'uint8x4',
+offset: 2076,
+shaderLocation: 19,
+}],
+},
+{
+arrayStride: 3056,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x3',
+offset: 7204,
+shaderLocation: 7,
+}],
+}
+]
+},
+});
+try {
+externalTexture2.label = '\u03bd\ucae6';
+} catch {}
+let adapter17 = await navigator.gpu.requestAdapter({
+});
+try {
+computePassEncoder44.setBindGroup(7, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder68.setBindGroup(4, bindGroup6);
+} catch {}
+try {
+commandEncoder84.copyTextureToBuffer({
+  texture: texture99,
+  mipLevel: 0,
+  origin: { x: 234, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 388 widthInBlocks: 97 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 3068 */
+offset: 2680,
+buffer: buffer19,
+}, {width: 97, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+canvas23.getContext('webgl2');
+} catch {}
+let commandEncoder85 = device3.createCommandEncoder({label: '\u{1fc8d}\u7ce2\ud9f8\u01c9\u009a'});
+let computePassEncoder51 = commandEncoder85.beginComputePass({label: '\u064b\u03fe\u0d5e\u8c32\u0b58\u{1feb9}\u18ae\u0dff\u0b68\u7490'});
+let renderBundleEncoder74 = device3.createRenderBundleEncoder({
+  label: '\u{1ff0c}\u{1f99d}\u55be',
+  colorFormats: ['r8uint', undefined, 'r32sint', 'rgba8uint', 'rg8unorm', 'rg8uint', 'rg32uint', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+try {
+computePassEncoder18.popDebugGroup();
+} catch {}
+try {
+device3.queue.writeBuffer(buffer40, 22528, new Int16Array(65522), 65117, 204);
+} catch {}
+let pipeline74 = await device3.createComputePipelineAsync({
+label: '\u050e\u{1fefb}\uf8f5\u05d2\ua628\u06f2\u{1f9e9}',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let videoFrame22 = new VideoFrame(videoFrame9, {timestamp: 0});
+try {
+offscreenCanvas28.getContext('bitmaprenderer');
+} catch {}
+let bindGroupLayout33 = device1.createBindGroupLayout({
+label: '\u085f\udfed\u754c\u1681\u{1fd30}\u{1fefe}\u8a7a\u8651',
+entries: [{
+binding: 1265,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+let commandEncoder86 = device1.createCommandEncoder({label: '\u007d\u0a41\ub4ca\u2ae2\u{1f7fc}\ub946\u{1ffb6}\u{1fda0}\u0ae0\u8945\u20be'});
+let textureView95 = texture87.createView({label: '\u06d3\ub571\ub139\u{1fc57}', dimension: '2d-array', format: 'astc-5x5-unorm-srgb'});
+let renderBundleEncoder75 = device1.createRenderBundleEncoder({
+  label: '\uf67c\ucb8b\ua9bd',
+  colorFormats: ['r8uint', 'r16float', 'rg32sint', 'rgba16sint', 'rgba32uint'],
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder49.end();
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 102, y: 850 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 11, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 36, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame23 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let bindGroupLayout34 = pipeline64.getBindGroupLayout(2);
+let commandEncoder87 = device3.createCommandEncoder();
+let renderBundleEncoder76 = device3.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle81 = renderBundleEncoder60.finish({label: '\u{1fae2}\u87b9\u0c81\u0e0c\udc2d\ue9eb\u0950\u0c43'});
+try {
+computePassEncoder50.setPipeline(pipeline55);
+} catch {}
+let pipelineLayout17 = device1.createPipelineLayout({
+  label: '\u91eb\u0bff\u0520\u0717\u0e90\u{1fe8a}\ueffa\u{1f61a}\u0f86\u{1f6d8}',
+  bindGroupLayouts: [bindGroupLayout21, bindGroupLayout11]
+});
+let textureView96 = texture95.createView({mipLevelCount: 1});
+let renderBundle82 = renderBundleEncoder17.finish();
+try {
+texture97.destroy();
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+commandEncoder72.copyBufferToBuffer(buffer34, 16996, buffer8, 3684, 2012);
+dissociateBuffer(device1, buffer34);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder86.resolveQuerySet(querySet51, 578, 1863, buffer34, 1792);
+} catch {}
+let canvas24 = document.createElement('canvas');
+try {
+canvas24.getContext('webgpu');
+} catch {}
+let imageBitmap23 = await createImageBitmap(img11);
+let buffer41 = device3.createBuffer({
+  label: '\u51b9\u282f\u0c98\ua371',
+  size: 8177,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE
+});
+let querySet74 = device3.createQuerySet({
+label: '\ucfc2\u{1f817}\u3bef\u{1fe9d}\uace6\u{1f983}\u{1fe72}\u044a',
+type: 'occlusion',
+count: 3491,
+});
+let texture109 = device3.createTexture({
+label: '\u1963\u0f67\ubf4c\u01a3\u932e\u1d98',
+size: {width: 1824, height: 40, depthOrArrayLayers: 1264},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['r8snorm'],
+});
+let computePassEncoder52 = commandEncoder84.beginComputePass({label: '\u0bce\u0977\u{1fe31}\u48cc\u8244\u0f12\ud7b0\ub08a\u9a6d\u00bb\u91e8'});
+let renderBundle83 = renderBundleEncoder40.finish({label: '\u{1fc2a}\u0e07\u{1f78d}\u11da\u063d\ua4f3\u2f3e\u{1fdd6}\u06b0'});
+try {
+commandEncoder87.clearBuffer(buffer24, 1388, 3976);
+dissociateBuffer(device3, buffer24);
+} catch {}
+let imageData25 = new ImageData(184, 220);
+let computePassEncoder53 = commandEncoder87.beginComputePass({label: '\u03e5\ufcbb\u{1f71b}\u41b0\u6792\u{1f902}\u0039\u0275'});
+let renderBundle84 = renderBundleEncoder60.finish({label: '\u066d\u1602\u4178\u{1f86f}\u014e\u183d\u6c94\u436c\u374f'});
+try {
+computePassEncoder24.setBindGroup(8, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder67.setBindGroup(8, bindGroup14);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let imageData26 = new ImageData(48, 144);
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let offscreenCanvas29 = new OffscreenCanvas(582, 572);
+video0.height = 85;
+let buffer42 = device3.createBuffer({
+  label: '\u1520\u62ea\u0673\u33c1\u09e0\u0e9c\u147b\ud527\u02dc\u0793',
+  size: 3858,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+pseudoSubmit(device3, commandEncoder66);
+try {
+renderBundleEncoder64.setBindGroup(8, bindGroup9, []);
+} catch {}
+let pipeline75 = await device3.createComputePipelineAsync({
+label: '\u04e4\u{1fd07}\u{1f6da}',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline76 = device3.createRenderPipeline({
+label: '\ua9e9\u0066\ue061',
+layout: pipelineLayout11,
+multisample: {
+count: 4,
+mask: 0x53992fa9,
+},
+fragment: {
+  module: shaderModule12,
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'src'},
+},
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'r32sint', writeMask: GPUColorWrite.RED}, {format: 'bgra8unorm-srgb'}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'keep',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilBack: {
+failOp: 'replace',
+passOp: 'replace',
+},
+stencilReadMask: 3560,
+depthBias: 92,
+depthBiasSlopeScale: 63,
+depthBiasClamp: 15,
+},
+vertex: {
+  module: shaderModule12,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 14760,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 12616,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x3',
+offset: 8812,
+shaderLocation: 14,
+}, {
+format: 'unorm8x2',
+offset: 6650,
+shaderLocation: 16,
+}, {
+format: 'unorm8x4',
+offset: 3044,
+shaderLocation: 17,
+}, {
+format: 'sint32x3',
+offset: 10628,
+shaderLocation: 7,
+}, {
+format: 'uint32x4',
+offset: 11172,
+shaderLocation: 13,
+}, {
+format: 'sint8x4',
+offset: 12076,
+shaderLocation: 6,
+}, {
+format: 'unorm8x2',
+offset: 10362,
+shaderLocation: 8,
+}, {
+format: 'unorm8x4',
+offset: 4228,
+shaderLocation: 3,
+}, {
+format: 'uint16x4',
+offset: 2300,
+shaderLocation: 4,
+}, {
+format: 'uint32x2',
+offset: 1292,
+shaderLocation: 20,
+}, {
+format: 'snorm8x4',
+offset: 8312,
+shaderLocation: 5,
+}, {
+format: 'float32x4',
+offset: 11588,
+shaderLocation: 21,
+}, {
+format: 'float32x4',
+offset: 7388,
+shaderLocation: 10,
+}, {
+format: 'snorm8x4',
+offset: 4096,
+shaderLocation: 9,
+}, {
+format: 'float16x2',
+offset: 5428,
+shaderLocation: 22,
+}, {
+format: 'uint16x2',
+offset: 6000,
+shaderLocation: 24,
+}, {
+format: 'float32x3',
+offset: 8932,
+shaderLocation: 0,
+}, {
+format: 'snorm16x4',
+offset: 1880,
+shaderLocation: 19,
+}, {
+format: 'unorm8x4',
+offset: 1816,
+shaderLocation: 23,
+}, {
+format: 'uint32x4',
+offset: 10112,
+shaderLocation: 12,
+}, {
+format: 'float32',
+offset: 10052,
+shaderLocation: 18,
+}],
+},
+{
+arrayStride: 13496,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 11020,
+shaderLocation: 15,
+}, {
+format: 'sint32',
+offset: 7020,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 9480,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 14188,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+attributes: [],
+},
+{
+arrayStride: 28588,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x4',
+offset: 13048,
+shaderLocation: 2,
+}, {
+format: 'sint32x4',
+offset: 22144,
+shaderLocation: 25,
+}, {
+format: 'sint8x2',
+offset: 10080,
+shaderLocation: 1,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let adapter18 = await navigator.gpu.requestAdapter({
+});
+try {
+offscreenCanvas29.getContext('webgl2');
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let promise37 = navigator.gpu.requestAdapter();
+let sampler62 = device3.createSampler({
+label: '\u6584\u094e\u05b1\u{1fb89}\u73a4\u{1f79d}\uec75',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 31.547,
+lodMaxClamp: 91.351,
+});
+try {
+renderBundleEncoder65.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture106,
+  mipLevel: 7,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(867), /* required buffer size: 867 */
+{offset: 867}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas26.height = 93;
+let img22 = await imageWithData(209, 100, '#2deb1b58', '#6e349a58');
+let img23 = await imageWithData(294, 250, '#3dea45be', '#d3e5aa15');
+offscreenCanvas16.height = 230;
+let imageBitmap24 = await createImageBitmap(offscreenCanvas13);
+let videoFrame24 = new VideoFrame(videoFrame23, {timestamp: 0});
+let promise38 = adapter15.requestAdapterInfo();
+let querySet75 = device3.createQuerySet({
+label: '\u8cf4\u{1fb19}\u{1f725}\uc861\u3501\u0561\u{1faa9}\u{1fcf0}',
+type: 'occlusion',
+count: 3269,
+});
+try {
+renderBundleEncoder65.setVertexBuffer(5, buffer29, 64, 139);
+} catch {}
+let commandEncoder88 = device1.createCommandEncoder({label: '\u14dd\u02ac\u6c02\ua95b\u0bcf\ue59c\u40c4\u0cf8\u6988\u18fd'});
+let querySet76 = device1.createQuerySet({
+type: 'occlusion',
+count: 208,
+});
+let renderBundle85 = renderBundleEncoder18.finish();
+try {
+renderBundleEncoder49.setBindGroup(6, bindGroup13);
+} catch {}
+try {
+commandEncoder59.copyTextureToBuffer({
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 80, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 96 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 53968 */
+offset: 53968,
+bytesPerRow: 256,
+buffer: buffer39,
+}, {width: 30, height: 65, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer39);
+} catch {}
+let buffer43 = device1.createBuffer({
+  label: '\u74ac\u03cb\u{1fb61}\uf210\u{1fb36}\u549d\u71d4\ufd76\u{1fcc5}\ua55b\u{1fab7}',
+  size: 42626,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM
+});
+let computePassEncoder54 = commandEncoder83.beginComputePass({});
+try {
+computePassEncoder42.setPipeline(pipeline51);
+} catch {}
+try {
+renderBundleEncoder66.pushDebugGroup('\u08a1');
+} catch {}
+document.body.prepend(video2);
+let shaderModule15 = device1.createShaderModule({
+code: `@group(1) @binding(1300)
+var<storage, read_write> parameter9: array<u32>;
+@group(2) @binding(1723)
+var<storage, read_write> i6: array<u32>;
+
+@compute @workgroup_size(7, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S20 {
+  @location(4) f0: vec2<f32>,
+  @location(47) f1: f32,
+  @location(8) f2: i32,
+  @location(35) f3: vec2<i32>,
+  @location(23) f4: vec2<f32>,
+  @location(20) f5: vec4<u32>,
+  @location(13) f6: vec3<f16>,
+  @location(43) f7: i32,
+  @location(45) f8: vec3<u32>,
+  @builtin(position) f9: vec4<f32>,
+  @location(46) f10: u32,
+  @location(41) f11: vec3<u32>,
+  @location(32) f12: vec4<u32>,
+  @location(10) f13: vec2<f16>,
+  @location(44) f14: f16,
+  @location(9) f15: vec3<u32>,
+  @location(27) f16: u32,
+  @location(1) f17: vec4<u32>,
+  @location(11) f18: u32,
+  @location(5) f19: vec2<f16>,
+  @location(30) f20: u32,
+  @location(31) f21: f16,
+  @location(0) f22: u32,
+  @location(38) f23: f16,
+  @location(29) f24: vec3<f32>,
+  @builtin(sample_index) f25: u32,
+  @location(6) f26: i32,
+  @builtin(front_facing) f27: bool,
+  @location(17) f28: vec2<i32>,
+  @location(40) f29: vec4<u32>,
+  @builtin(sample_mask) f30: u32,
+  @location(49) f31: u32,
+  @location(19) f32: vec4<f16>,
+  @location(12) f33: vec4<i32>,
+  @location(36) f34: u32,
+  @location(26) f35: f16,
+  @location(28) f36: vec3<f16>,
+  @location(33) f37: vec3<u32>,
+  @location(48) f38: vec3<f32>,
+  @location(2) f39: vec3<f16>,
+  @location(37) f40: vec4<i32>,
+  @location(22) f41: f32
+}
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(1) f1: vec4<i32>,
+  @location(6) f2: vec4<u32>,
+  @location(2) f3: vec4<u32>,
+  @location(4) f4: vec4<i32>,
+  @builtin(frag_depth) f5: f32,
+  @location(5) f6: vec2<f32>,
+  @location(3) f7: vec4<f32>
+}
+
+@fragment
+fn fragment0(a0: S20, @location(16) a1: vec4<i32>, @location(24) a2: i32, @location(25) a3: vec3<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(36) f337: u32,
+  @location(38) f338: f16,
+  @location(0) f339: u32,
+  @location(35) f340: vec2<i32>,
+  @location(47) f341: f32,
+  @location(37) f342: vec4<i32>,
+  @location(32) f343: vec4<u32>,
+  @location(11) f344: u32,
+  @location(43) f345: i32,
+  @location(25) f346: vec3<i32>,
+  @location(23) f347: vec2<f32>,
+  @location(49) f348: u32,
+  @location(30) f349: u32,
+  @location(31) f350: f16,
+  @location(44) f351: f16,
+  @location(16) f352: vec4<i32>,
+  @location(4) f353: vec2<f32>,
+  @location(5) f354: vec2<f16>,
+  @location(45) f355: vec3<u32>,
+  @location(20) f356: vec4<u32>,
+  @location(27) f357: u32,
+  @location(2) f358: vec3<f16>,
+  @location(17) f359: vec2<i32>,
+  @location(8) f360: i32,
+  @location(28) f361: vec3<f16>,
+  @location(6) f362: i32,
+  @location(22) f363: f32,
+  @location(19) f364: vec4<f16>,
+  @location(29) f365: vec3<f32>,
+  @location(48) f366: vec3<f32>,
+  @location(9) f367: vec3<u32>,
+  @location(33) f368: vec3<u32>,
+  @location(26) f369: f16,
+  @location(13) f370: vec3<f16>,
+  @location(12) f371: vec4<i32>,
+  @location(40) f372: vec4<u32>,
+  @location(24) f373: i32,
+  @builtin(position) f374: vec4<f32>,
+  @location(46) f375: u32,
+  @location(10) f376: vec2<f16>,
+  @location(1) f377: vec4<u32>,
+  @location(41) f378: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(26) a0: i32, @location(18) a1: vec3<u32>, @location(15) a2: vec2<f16>, @location(9) a3: vec3<u32>, @location(24) a4: f16, @location(23) a5: vec2<f32>, @location(5) a6: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let querySet77 = device1.createQuerySet({
+type: 'occlusion',
+count: 3641,
+});
+let texture110 = device1.createTexture({
+size: {width: 384, height: 5, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x5-unorm', 'astc-8x5-unorm'],
+});
+let textureView97 = texture87.createView({dimension: '2d-array', format: 'astc-5x5-unorm-srgb'});
+let renderBundleEncoder77 = device1.createRenderBundleEncoder({
+  label: '\u154f\u075f\u48d7\u0c38\u{1fbce}\uea05',
+  colorFormats: ['r8unorm', 'r32uint', 'rg8sint', 'rg8unorm', 'r32uint', 'r32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1
+});
+try {
+computePassEncoder54.setBindGroup(10, bindGroup13);
+} catch {}
+let pipeline77 = device1.createComputePipeline({
+label: '\u2a0a\u7b81\u{1f671}\u4093\u84bd\u{1ff01}\u8739\u{1fd4c}\u0f58',
+layout: pipelineLayout17,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let imageBitmap25 = await createImageBitmap(videoFrame2);
+let promise39 = navigator.gpu.requestAdapter({
+});
+try {
+computePassEncoder24.setPipeline(pipeline75);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer37, 15496, new Int16Array(7904));
+} catch {}
+let shaderModule16 = device1.createShaderModule({
+label: '\u0733\u0b2e\u3a58\ua83b\u0863',
+code: `@group(0) @binding(542)
+var<storage, read_write> parameter10: array<u32>;
+@group(5) @binding(704)
+var<storage, read_write> local13: array<u32>;
+@group(6) @binding(1145)
+var<storage, read_write> i7: array<u32>;
+@group(9) @binding(1145)
+var<storage, read_write> local14: array<u32>;
+@group(2) @binding(704)
+var<storage, read_write> type12: array<u32>;
+@group(1) @binding(3524)
+var<storage, read_write> field6: array<u32>;
+@group(6) @binding(3399)
+var<storage, read_write> field7: array<u32>;
+@group(10) @binding(1145)
+var<storage, read_write> function3: array<u32>;
+@group(10) @binding(3399)
+var<storage, read_write> field8: array<u32>;
+@group(10) @binding(3240)
+var<storage, read_write> i8: array<u32>;
+@group(2) @binding(1300)
+var<storage, read_write> field9: array<u32>;
+@group(8) @binding(1723)
+var<storage, read_write> local15: array<u32>;
+@group(9) @binding(3240)
+var<storage, read_write> type13: array<u32>;
+@group(4) @binding(704)
+var<storage, read_write> i9: array<u32>;
+@group(4) @binding(1300)
+var<storage, read_write> parameter11: array<u32>;
+@group(5) @binding(1300)
+var<storage, read_write> i10: array<u32>;
+
+@compute @workgroup_size(1, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec3<i32>,
+  @location(3) f1: vec3<i32>,
+  @location(1) f2: vec2<u32>,
+  @builtin(sample_mask) f3: u32,
+  @location(0) f4: vec4<i32>,
+  @builtin(frag_depth) f5: f32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(front_facing) a2: bool, @builtin(sample_mask) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S21 {
+  @location(21) f0: u32,
+  @location(12) f1: vec4<i32>,
+  @location(4) f2: vec2<f16>,
+  @location(20) f3: vec3<f32>,
+  @location(24) f4: vec4<u32>,
+  @location(1) f5: vec4<f32>,
+  @location(9) f6: vec4<i32>,
+  @location(11) f7: vec3<u32>,
+  @location(7) f8: u32,
+  @location(16) f9: vec3<f32>,
+  @location(22) f10: vec2<u32>,
+  @location(15) f11: vec3<i32>,
+  @location(3) f12: vec3<f16>,
+  @location(5) f13: vec3<f16>,
+  @location(26) f14: i32,
+  @location(19) f15: vec2<u32>,
+  @location(8) f16: vec2<f16>,
+  @location(23) f17: vec3<f16>
+}
+
+@vertex
+fn vertex0(a0: S21, @location(18) a1: f16, @location(0) a2: vec3<u32>, @location(2) a3: f32, @location(6) a4: vec4<u32>, @location(13) a5: vec3<i32>, @location(17) a6: vec3<f16>, @location(10) a7: vec3<i32>, @location(14) a8: vec4<i32>, @location(25) a9: vec4<i32>, @builtin(vertex_index) a10: u32, @builtin(instance_index) a11: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+try {
+computePassEncoder8.insertDebugMarker('\ubde7');
+} catch {}
+let pipeline78 = await promise17;
+let bindGroupLayout35 = pipeline3.getBindGroupLayout(4);
+let commandEncoder89 = device0.createCommandEncoder({label: '\ueba4\u8761\u4525\u{1f9be}\u{1fcbb}'});
+let renderBundle86 = renderBundleEncoder36.finish({label: '\uaf66\u0c4c\u0b68\u70e5\u0f2f\uc951\u7b10'});
+let externalTexture8 = device0.importExternalTexture({
+label: '\uffa9\u0544\u{1f798}',
+source: video15,
+colorSpace: 'srgb',
+});
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: { x: 36, y: 4, z: 1 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 772 */
+{offset: 772, bytesPerRow: 451}, {width: 208, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 150, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 116, y: 23 },
+  flipY: true,
+}, {
+  texture: texture57,
+  mipLevel: 5,
+  origin: { x: 82, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 14, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline79 = await device0.createComputePipelineAsync({
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+});
+let bindGroup18 = device3.createBindGroup({
+label: '\u677b\u0e61\u{1fe37}\uf4e4\ub97e',
+layout: bindGroupLayout34,
+entries: [],
+});
+let buffer44 = device3.createBuffer({
+  label: '\u{1f70b}\u{1fe89}\u497d\u8be5\u0e4f\uec5e\u0f63\u3d9c\u833b\u0a39\ub09a',
+  size: 62797,
+  usage: GPUBufferUsage.VERTEX
+});
+let texture111 = device3.createTexture({
+label: '\u{1fe94}\u04a6\u1c79\u59a1\u{1fe15}\u8f24\u05ec',
+size: {width: 60, height: 240, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView98 = texture59.createView({baseArrayLayer: 0});
+let renderBundle87 = renderBundleEncoder65.finish({});
+try {
+gpuCanvasContext11.configure({
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let pipeline80 = device3.createRenderPipeline({
+layout: pipelineLayout14,
+multisample: {
+count: 4,
+mask: 0x743108f5,
+},
+fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, undefined, {format: 'r32sint'}, {format: 'rgba8uint', writeMask: 0}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'zero', dstFactor: 'zero'},
+alpha: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'src-alpha'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {
+  format: 'rg8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rg32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgb10a2unorm', writeMask: 0}]
+},
+vertex: {
+  module: shaderModule14,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 5584,
+shaderLocation: 23,
+}, {
+format: 'float32x3',
+offset: 5708,
+shaderLocation: 0,
+}, {
+format: 'unorm16x4',
+offset: 5956,
+shaderLocation: 4,
+}, {
+format: 'sint16x2',
+offset: 5172,
+shaderLocation: 22,
+}, {
+format: 'unorm10-10-10-2',
+offset: 24568,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 14388,
+shaderLocation: 19,
+}, {
+format: 'unorm8x2',
+offset: 19012,
+shaderLocation: 14,
+}, {
+format: 'float32',
+offset: 14280,
+shaderLocation: 3,
+}, {
+format: 'sint8x4',
+offset: 10568,
+shaderLocation: 21,
+}, {
+format: 'sint32x4',
+offset: 1376,
+shaderLocation: 24,
+}, {
+format: 'unorm16x2',
+offset: 10328,
+shaderLocation: 15,
+}, {
+format: 'sint16x2',
+offset: 17700,
+shaderLocation: 1,
+}, {
+format: 'uint16x2',
+offset: 8304,
+shaderLocation: 7,
+}, {
+format: 'uint16x2',
+offset: 9336,
+shaderLocation: 13,
+}, {
+format: 'float16x2',
+offset: 6848,
+shaderLocation: 17,
+}, {
+format: 'sint32x4',
+offset: 22752,
+shaderLocation: 11,
+}, {
+format: 'uint32x4',
+offset: 12592,
+shaderLocation: 10,
+}, {
+format: 'uint8x2',
+offset: 17524,
+shaderLocation: 9,
+}, {
+format: 'float32',
+offset: 23816,
+shaderLocation: 18,
+}, {
+format: 'float32x4',
+offset: 27720,
+shaderLocation: 8,
+}, {
+format: 'unorm16x2',
+offset: 5224,
+shaderLocation: 25,
+}],
+},
+{
+arrayStride: 8324,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 6136,
+attributes: [{
+format: 'uint8x4',
+offset: 2084,
+shaderLocation: 20,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+try {
+  await promise38;
+} catch {}
+canvas0.width = 968;
+let videoFrame25 = new VideoFrame(offscreenCanvas5, {timestamp: 0});
+let canvas25 = document.createElement('canvas');
+let video24 = await videoWithData();
+let imageBitmap26 = await createImageBitmap(videoFrame11);
+let commandEncoder90 = device1.createCommandEncoder({});
+try {
+computePassEncoder54.setPipeline(pipeline52);
+} catch {}
+try {
+renderBundleEncoder70.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder57.setVertexBuffer(1, undefined, 1370987002, 890272743);
+} catch {}
+try {
+commandEncoder72.clearBuffer(buffer34, 16488, 3220);
+dissociateBuffer(device1, buffer34);
+} catch {}
+let pipeline81 = await device1.createRenderPipelineAsync({
+label: '\u0bee\u050a\u0fcf\u88c6\uc9a7\u0380\u8afd\u{1ff52}\uef50',
+layout: pipelineLayout13,
+multisample: {
+count: 4,
+mask: 0x93b11935,
+},
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {format: 'rgba32uint', writeMask: 0}]
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 24852,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x4',
+offset: 4288,
+shaderLocation: 7,
+}, {
+format: 'snorm8x4',
+offset: 10368,
+shaderLocation: 0,
+}, {
+format: 'sint32',
+offset: 15328,
+shaderLocation: 10,
+}, {
+format: 'uint16x2',
+offset: 7340,
+shaderLocation: 9,
+}, {
+format: 'sint32',
+offset: 18868,
+shaderLocation: 14,
+}, {
+format: 'uint32x2',
+offset: 17920,
+shaderLocation: 5,
+}, {
+format: 'uint32',
+offset: 4788,
+shaderLocation: 2,
+}, {
+format: 'unorm8x2',
+offset: 7990,
+shaderLocation: 13,
+}, {
+format: 'uint32',
+offset: 16152,
+shaderLocation: 8,
+}, {
+format: 'unorm8x4',
+offset: 5052,
+shaderLocation: 18,
+}, {
+format: 'uint32x4',
+offset: 17224,
+shaderLocation: 3,
+}, {
+format: 'uint32x4',
+offset: 19436,
+shaderLocation: 20,
+}, {
+format: 'sint8x4',
+offset: 21096,
+shaderLocation: 25,
+}, {
+format: 'uint32x3',
+offset: 19152,
+shaderLocation: 21,
+}, {
+format: 'float32x2',
+offset: 11080,
+shaderLocation: 4,
+}, {
+format: 'sint32',
+offset: 17148,
+shaderLocation: 22,
+}, {
+format: 'snorm8x4',
+offset: 20448,
+shaderLocation: 24,
+}, {
+format: 'float32x2',
+offset: 14460,
+shaderLocation: 12,
+}, {
+format: 'float32x3',
+offset: 22448,
+shaderLocation: 16,
+}, {
+format: 'uint8x4',
+offset: 9472,
+shaderLocation: 1,
+}, {
+format: 'snorm16x2',
+offset: 892,
+shaderLocation: 19,
+}, {
+format: 'float32x4',
+offset: 4980,
+shaderLocation: 23,
+}, {
+format: 'uint32x3',
+offset: 22748,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 14616,
+attributes: [{
+format: 'unorm8x4',
+offset: 1832,
+shaderLocation: 26,
+}, {
+format: 'unorm8x4',
+offset: 480,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 524,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 26608,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x4',
+offset: 15032,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 7340,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 460,
+attributes: [{
+format: 'sint32',
+offset: 344,
+shaderLocation: 17,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let imageBitmap27 = await createImageBitmap(canvas3);
+let buffer45 = device2.createBuffer({
+  label: '\u{1f819}\u46db\u5cc2\u0d42\u027d',
+  size: 62642,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let sampler63 = device2.createSampler({
+label: '\u092f\u{1fd6c}\u02f6',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 81.856,
+lodMaxClamp: 97.823,
+maxAnisotropy: 2,
+});
+let bindGroup19 = device1.createBindGroup({
+label: '\u059d\u{1fa49}\u{1f837}\u{1fcac}\u{1fbf3}\u05f6\u{1f785}',
+layout: bindGroupLayout11,
+entries: [{
+binding: 542,
+resource: textureView91
+}],
+});
+pseudoSubmit(device1, commandEncoder71);
+let textureView99 = texture97.createView({
+  label: '\uf9f3\u5cb0\u07bc\ub044\u4152\u01c0\u457a\u07bd\u1ff5\ucdf7\ube99',
+  baseMipLevel: 1,
+  mipLevelCount: 1
+});
+try {
+commandEncoder90.copyBufferToBuffer(buffer20, 12, buffer27, 1224, 16);
+dissociateBuffer(device1, buffer20);
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+commandEncoder88.copyTextureToBuffer({
+  texture: texture53,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 59712 */
+offset: 59712,
+buffer: buffer39,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+commandEncoder88.clearBuffer(buffer34, 7236, 900);
+dissociateBuffer(device1, buffer34);
+} catch {}
+try {
+gpuCanvasContext21.configure({
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+});
+} catch {}
+let video25 = await videoWithData();
+try {
+canvas25.getContext('2d');
+} catch {}
+let shaderModule17 = device1.createShaderModule({
+label: '\ubbec\u0ef2\u0ec0\u7fe4\ubb49\ub2f9\u5ce2',
+code: `@group(8) @binding(1723)
+var<storage, read_write> type14: array<u32>;
+@group(9) @binding(1145)
+var<storage, read_write> parameter12: array<u32>;
+@group(6) @binding(3399)
+var<storage, read_write> type15: array<u32>;
+@group(0) @binding(542)
+var<storage, read_write> type16: array<u32>;
+@group(9) @binding(3240)
+var<storage, read_write> parameter13: array<u32>;
+@group(4) @binding(704)
+var<storage, read_write> function4: array<u32>;
+@group(4) @binding(1300)
+var<storage, read_write> function5: array<u32>;
+@group(2) @binding(704)
+var<storage, read_write> type17: array<u32>;
+@group(9) @binding(3399)
+var<storage, read_write> type18: array<u32>;
+@group(6) @binding(3240)
+var<storage, read_write> field10: array<u32>;
+@group(1) @binding(3524)
+var<storage, read_write> global7: array<u32>;
+@group(7) @binding(542)
+var<storage, read_write> i11: array<u32>;
+@group(10) @binding(3399)
+var<storage, read_write> type19: array<u32>;
+@group(5) @binding(1300)
+var<storage, read_write> global8: array<u32>;
+@group(6) @binding(1145)
+var<storage, read_write> type20: array<u32>;
+@group(10) @binding(3240)
+var<storage, read_write> parameter14: array<u32>;
+@group(10) @binding(1145)
+var<storage, read_write> function6: array<u32>;
+
+@compute @workgroup_size(1, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S22 {
+  @location(44) f0: vec4<f32>,
+  @location(37) f1: u32,
+  @location(14) f2: vec4<f32>,
+  @location(43) f3: vec2<f16>,
+  @builtin(position) f4: vec4<f32>,
+  @location(20) f5: vec2<i32>,
+  @location(13) f6: vec2<u32>,
+  @location(28) f7: f16,
+  @location(34) f8: vec4<f16>,
+  @location(47) f9: vec3<i32>,
+  @location(42) f10: vec2<f16>,
+  @location(32) f11: vec2<i32>,
+  @location(25) f12: vec2<f32>,
+  @location(21) f13: f16,
+  @location(27) f14: vec2<f32>
+}
+struct FragmentOutput0 {
+  @location(5) f0: vec4<i32>,
+  @location(1) f1: vec3<u32>,
+  @location(2) f2: vec3<i32>,
+  @location(3) f3: vec3<f32>,
+  @location(4) f4: u32,
+  @location(0) f5: vec3<f32>,
+  @builtin(sample_mask) f6: u32
+}
+
+@fragment
+fn fragment0(a0: S22, @location(41) a1: vec2<f16>, @location(12) a2: vec2<f32>, @location(48) a3: vec2<f32>, @location(6) a4: vec2<u32>, @builtin(sample_mask) a5: u32, @location(40) a6: i32, @location(46) a7: vec3<f16>, @location(23) a8: f16, @location(16) a9: vec2<i32>, @location(39) a10: vec3<i32>, @location(49) a11: i32, @location(19) a12: vec2<f32>, @location(4) a13: i32, @location(5) a14: vec4<u32>, @location(35) a15: f16, @location(2) a16: vec2<f32>, @location(15) a17: vec2<i32>, @location(8) a18: vec3<f16>, @location(26) a19: u32, @location(33) a20: i32, @location(18) a21: vec2<u32>, @location(29) a22: vec4<i32>, @location(1) a23: vec2<i32>, @location(31) a24: vec4<f32>, @location(38) a25: vec4<f32>, @location(22) a26: vec3<u32>, @location(9) a27: vec3<u32>, @builtin(front_facing) a28: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(40) f379: i32,
+  @location(22) f380: vec3<u32>,
+  @location(42) f381: vec2<f16>,
+  @location(48) f382: vec2<f32>,
+  @location(21) f383: f16,
+  @location(39) f384: vec3<i32>,
+  @location(12) f385: vec2<f32>,
+  @location(25) f386: vec2<f32>,
+  @location(6) f387: vec2<u32>,
+  @location(2) f388: vec2<f32>,
+  @location(19) f389: vec2<f32>,
+  @location(33) f390: i32,
+  @location(13) f391: vec2<u32>,
+  @location(27) f392: vec2<f32>,
+  @location(43) f393: vec2<f16>,
+  @location(41) f394: vec2<f16>,
+  @location(20) f395: vec2<i32>,
+  @location(15) f396: vec2<i32>,
+  @location(9) f397: vec3<u32>,
+  @location(14) f398: vec4<f32>,
+  @location(16) f399: vec2<i32>,
+  @location(47) f400: vec3<i32>,
+  @location(46) f401: vec3<f16>,
+  @location(31) f402: vec4<f32>,
+  @location(1) f403: vec2<i32>,
+  @location(18) f404: vec2<u32>,
+  @location(44) f405: vec4<f32>,
+  @location(23) f406: f16,
+  @location(4) f407: i32,
+  @location(8) f408: vec3<f16>,
+  @location(5) f409: vec4<u32>,
+  @location(38) f410: vec4<f32>,
+  @location(35) f411: f16,
+  @location(32) f412: vec2<i32>,
+  @location(37) f413: u32,
+  @location(34) f414: vec4<f16>,
+  @location(28) f415: f16,
+  @location(49) f416: i32,
+  @location(29) f417: vec4<i32>,
+  @builtin(position) f418: vec4<f32>,
+  @location(26) f419: u32
+}
+
+@vertex
+fn vertex0(@location(23) a0: f16, @location(1) a1: vec4<u32>, @location(19) a2: vec3<u32>, @location(8) a3: vec3<f32>, @location(22) a4: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let renderBundle88 = renderBundleEncoder14.finish();
+try {
+computePassEncoder54.setPipeline(pipeline61);
+} catch {}
+try {
+renderBundleEncoder70.setBindGroup(6, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder49.setVertexBuffer(44, undefined, 877063511);
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(querySet43, 1029, 966, buffer34, 3328);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 1148, new BigUint64Array(25723), 14370, 8);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: video6,
+  origin: { x: 3, y: 13 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 15, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline82 = device1.createRenderPipeline({
+label: '\u2029\u{1fda0}\u{1fe5c}\u72c4\u{1fbfd}\u6802\uea32\u0832\u4ffe',
+layout: pipelineLayout15,
+fragment: {
+  module: shaderModule13,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32float'}, {format: 'r16float', writeMask: GPUColorWrite.ALL}, {format: 'r16uint', writeMask: 0}, {format: 'r16sint', writeMask: 0}, {format: 'r8uint', writeMask: 0}]
+},
+vertex: {
+  module: shaderModule13,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 5756,
+attributes: [],
+},
+{
+arrayStride: 26812,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x2',
+offset: 13962,
+shaderLocation: 24,
+}, {
+format: 'uint8x4',
+offset: 16288,
+shaderLocation: 22,
+}, {
+format: 'uint32x2',
+offset: 7632,
+shaderLocation: 1,
+}, {
+format: 'sint32',
+offset: 3700,
+shaderLocation: 0,
+}, {
+format: 'uint8x2',
+offset: 19156,
+shaderLocation: 4,
+}, {
+format: 'snorm8x2',
+offset: 22262,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 32968,
+attributes: [{
+format: 'uint16x2',
+offset: 28500,
+shaderLocation: 19,
+}, {
+format: 'sint16x2',
+offset: 3272,
+shaderLocation: 2,
+}, {
+format: 'snorm16x2',
+offset: 19296,
+shaderLocation: 15,
+}, {
+format: 'uint8x2',
+offset: 14402,
+shaderLocation: 23,
+}, {
+format: 'float16x2',
+offset: 4240,
+shaderLocation: 6,
+}, {
+format: 'sint16x2',
+offset: 20180,
+shaderLocation: 20,
+}, {
+format: 'sint8x4',
+offset: 32080,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 25220,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 5708,
+shaderLocation: 13,
+}, {
+format: 'snorm16x2',
+offset: 18836,
+shaderLocation: 25,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+unclippedDepth: true,
+},
+});
+let imageBitmap28 = await createImageBitmap(videoFrame19);
+let textureView100 = texture87.createView({
+  label: '\u{1fd58}\u88c9\u{1f8a2}\u2937\ubc0e\u0922\u0b16\ue080',
+  dimension: '2d-array',
+  format: 'astc-5x5-unorm-srgb'
+});
+let computePassEncoder55 = commandEncoder80.beginComputePass();
+let sampler64 = device1.createSampler({
+label: '\udda4\u786f\u{1ff13}\u{1fa42}\u0ee5\u7dc5\udca0\uc1fc\u{1fd5d}\u073b\u8f5b',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 5.143,
+lodMaxClamp: 72.836,
+});
+try {
+renderBundleEncoder77.setBindGroup(8, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder77.setVertexBuffer(37, undefined, 577394612);
+} catch {}
+try {
+commandEncoder88.clearBuffer(buffer39);
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas13,
+  origin: { x: 152, y: 208 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 23, y: 2, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let texture112 = device3.createTexture({
+label: '\u{1f746}\u0beb\u0346\u1e7e\u2dd6\u{1fa9f}',
+size: [1008, 120, 193],
+mipLevelCount: 10,
+format: 'astc-4x4-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-4x4-unorm-srgb', 'astc-4x4-unorm-srgb'],
+});
+let textureView101 = texture86.createView({label: '\u1ba5\u0d78\u08ac\u0917\u7b0a\u{1f7ec}'});
+try {
+renderBundleEncoder74.setBindGroup(2, bindGroup6);
+} catch {}
+document.body.prepend(video13);
+let canvas26 = document.createElement('canvas');
+try {
+window.someLabel = device4.queue.label;
+} catch {}
+try {
+texture74.label = '\u0c8c\ue5ec\u0c8b\ud455\u0997\u01a4\u5ace\udc67\u8654\u95e2';
+} catch {}
+let offscreenCanvas30 = new OffscreenCanvas(135, 624);
+try {
+canvas26.getContext('webgpu');
+} catch {}
+let textureView102 = texture82.createView({label: '\uf540\u0221', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 123});
+try {
+computePassEncoder55.setBindGroup(9, bindGroup4, new Uint32Array(2321), 442, 0);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+let adapter19 = await promise39;
+let imageData27 = new ImageData(200, 12);
+let canvas27 = document.createElement('canvas');
+let video26 = await videoWithData();
+let bindGroupLayout36 = device3.createBindGroupLayout({
+label: '\u{1fd75}\u0f88',
+entries: [{
+binding: 1662,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+}],
+});
+try {
+renderBundleEncoder56.setBindGroup(3, bindGroup16, []);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let pipeline83 = await device3.createComputePipelineAsync({
+label: '\uf124\u0d20',
+layout: 'auto',
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let gpuCanvasContext23 = offscreenCanvas30.getContext('webgpu');
+let gpuCanvasContext24 = canvas27.getContext('webgpu');
+try {
+gpuCanvasContext21.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let renderBundle89 = renderBundleEncoder63.finish({label: '\u0ad2\u0c81\u{1ffe3}\ud58f\u3e34\uba6d'});
+let sampler65 = device1.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 76.583,
+lodMaxClamp: 90.894,
+});
+try {
+device1.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 63 },
+  aspect: 'depth-only',
+}, new Uint32Array(new ArrayBuffer(8)), /* required buffer size: 652194 */
+{offset: 104, bytesPerRow: 308, rowsPerImage: 321}, {width: 27, height: 192, depthOrArrayLayers: 7});
+} catch {}
+let promise40 = device1.queue.onSubmittedWorkDone();
+gc();
+try {
+  await promise40;
+} catch {}
+let bindGroupLayout37 = device3.createBindGroupLayout({
+label: '\ubc70\u0fad',
+entries: [{
+binding: 3821,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}, {
+binding: 416,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+}, {
+binding: 7473,
+visibility: 0,
+externalTexture: {},
+}],
+});
+let renderBundle90 = renderBundleEncoder68.finish({label: '\ub53e\u1922\u45a6\u0081\u{1f9d0}\u012f\u1bc5\u{1fcd2}\u0ac8\uf033'});
+try {
+renderBundleEncoder56.setVertexBuffer(5, buffer29, 2716, 790);
+} catch {}
+offscreenCanvas0.width = 453;
+let offscreenCanvas31 = new OffscreenCanvas(219, 938);
+let commandEncoder91 = device3.createCommandEncoder({label: '\ud289\u{1fb1d}\u{1f6be}\u4102\u0819\ue54d'});
+let texture113 = device3.createTexture({
+size: {width: 120, height: 480, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView103 = texture62.createView({aspect: 'all', baseMipLevel: 1, baseArrayLayer: 9, arrayLayerCount: 28});
+let renderBundleEncoder78 = device3.createRenderBundleEncoder({
+  colorFormats: ['r32float', 'rgb10a2uint', 'r32uint', 'rg8unorm', 'rg8sint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle91 = renderBundleEncoder40.finish({});
+try {
+commandEncoder91.clearBuffer(buffer37);
+dissociateBuffer(device3, buffer37);
+} catch {}
+let promise41 = device3.queue.onSubmittedWorkDone();
+let pipelineLayout18 = device4.createPipelineLayout({
+  label: '\u{1f6e4}\u{1fb08}\uac18',
+  bindGroupLayouts: [bindGroupLayout19, bindGroupLayout19, bindGroupLayout19, bindGroupLayout19]
+});
+let buffer46 = device4.createBuffer({label: '\u3aa8\u9fe2\u2b92\u{1fd61}\u{1fd11}', size: 51578, usage: GPUBufferUsage.MAP_READ});
+let commandEncoder92 = device4.createCommandEncoder({label: '\u2ffb\ud14e\u{1faed}\u3ffa\u019c\u0ddb\u8a12'});
+let commandBuffer17 = commandEncoder92.finish({
+});
+let renderBundle92 = renderBundleEncoder48.finish({label: '\u00a5\u0d19\u2f63'});
+let adapter20 = await navigator.gpu.requestAdapter({
+});
+let commandEncoder93 = device1.createCommandEncoder({label: '\ud4be\ub629\u0256\u0559\u0cf0\ua43d\u6dd4\u0d6f\u621e'});
+let texture114 = device1.createTexture({
+label: '\u06c7\u{1ff95}\u56ea\u{1ff8f}\u{1fe71}\ub461\u{1f94d}\u5504\uff36\u{1fb3f}\u3b82',
+size: [192],
+dimension: '1d',
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+let computePassEncoder56 = commandEncoder90.beginComputePass({label: '\ud525\ufe00\u{1fef1}\u06fa\u09c2\u1530\u{1fb42}'});
+let renderBundle93 = renderBundleEncoder69.finish({label: '\u01b1\ufb40\u063c\u{1f6c8}\uc374\u{1f7b2}\u0468\u0f8a\u34ff\u3106\uaca1'});
+let sampler66 = device1.createSampler({
+label: '\ubb29\u0d34\ua64e\u056c\u4d79',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMaxClamp: 68.570,
+});
+try {
+renderBundleEncoder66.popDebugGroup();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: video9,
+  origin: { x: 2, y: 12 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 15, y: 2, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+let texture115 = device3.createTexture({
+label: '\u7e0e\ucfef',
+size: [30, 120, 1],
+format: 'astc-10x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView104 = texture105.createView({label: '\u9e5a\u4cff', dimension: '3d', baseMipLevel: 3});
+try {
+renderBundleEncoder71.setBindGroup(4, bindGroup18);
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(3, bindGroup18, new Uint32Array(9386), 5892, 0);
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+commandEncoder91.copyTextureToTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: { x: 12, y: 98, z: 158 },
+  aspect: 'all',
+}, {
+  texture: texture59,
+  mipLevel: 1,
+  origin: { x: 1, y: 14, z: 25 },
+  aspect: 'all',
+}, {width: 28, height: 65, depthOrArrayLayers: 36});
+} catch {}
+try {
+commandEncoder91.clearBuffer(buffer24, 2956, 4928);
+dissociateBuffer(device3, buffer24);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline84 = await device3.createComputePipelineAsync({
+label: '\u087b\u0799\u229a',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+video22.height = 121;
+let canvas28 = document.createElement('canvas');
+let bindGroupLayout38 = device3.createBindGroupLayout({
+label: '\u{1f7c5}\u0893\u0712\u{1f607}\u07fd\u0f66\u0565\u{1f652}',
+entries: [],
+});
+let commandEncoder94 = device3.createCommandEncoder();
+try {
+computePassEncoder50.end();
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline83);
+} catch {}
+try {
+renderBundleEncoder64.setIndexBuffer(buffer35, 'uint32', 41048, 12232);
+} catch {}
+let adapter21 = await promise37;
+document.body.prepend(img0);
+let gpuCanvasContext25 = canvas28.getContext('webgpu');
+let buffer47 = device1.createBuffer({size: 31468, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let textureView105 = texture30.createView({
+  label: '\u056d\ua0a7\u348f\uc4ba\u{1fc5c}\u8617\u{1fc37}\u{1f788}',
+  dimension: '2d-array',
+  baseMipLevel: 1
+});
+let computePassEncoder57 = commandEncoder76.beginComputePass({label: '\uf5d4\u{1ff87}\u54ea\u{1f6c9}\u8c44\u03bc\u0daf\u{1f851}\u{1fb11}\u6372\u253e'});
+try {
+buffer47.unmap();
+} catch {}
+try {
+commandEncoder86.copyBufferToBuffer(buffer34, 11392, buffer39, 45880, 3692);
+dissociateBuffer(device1, buffer34);
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer39, 23556, new Int16Array(9402), 6738);
+} catch {}
+let commandEncoder95 = device0.createCommandEncoder({label: '\u6cea\ud168\uad17\u5059\ua9d2\u5b82\ua961'});
+let computePassEncoder58 = commandEncoder0.beginComputePass({label: '\u9d68\u16ce\ue5c0\u062a'});
+let sampler67 = device0.createSampler({
+label: '\u0320\u73ca\u1939\u{1f93b}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 50.178,
+lodMaxClamp: 65.833,
+});
+try {
+renderBundleEncoder34.setBindGroup(0, bindGroup2, [3744]);
+} catch {}
+try {
+commandEncoder56.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 20, new Float32Array(43228), 15701, 192);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise42 = device0.createComputePipelineAsync({
+label: '\u0a46\u7157',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let textureView106 = texture79.createView({
+  label: '\uef85\u{1fb4b}\u416a\u{1f741}\u{1f6ca}\u0618\u{1fe94}\u0347\u2195\u72e0\u{1f77c}',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+  mipLevelCount: 4,
+  arrayLayerCount: 1
+});
+let sampler68 = device3.createSampler({
+label: '\uca14\u00c3\u070e\u{1fdf2}\u{1fffb}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 88.295,
+lodMaxClamp: 96.666,
+maxAnisotropy: 1,
+});
+try {
+commandEncoder58.clearBuffer(buffer37);
+dissociateBuffer(device3, buffer37);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer37, 6584, new Float32Array(16036), 11778);
+} catch {}
+let promise43 = device3.queue.onSubmittedWorkDone();
+let pipeline85 = device3.createComputePipeline({
+label: '\ufea9\u0111\u8cd9\u95c7\u{1f8f2}\u8d93',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let imageData28 = new ImageData(128, 36);
+try {
+renderBundleEncoder66.setVertexBuffer(83, undefined, 3085687169, 290474724);
+} catch {}
+try {
+commandEncoder93.copyTextureToTexture({
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 30, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 10, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 170, height: 65, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder93.clearBuffer(buffer8, 1832, 9060);
+dissociateBuffer(device1, buffer8);
+} catch {}
+let gpuCanvasContext26 = offscreenCanvas31.getContext('webgpu');
+let canvas29 = document.createElement('canvas');
+try {
+canvas29.getContext('2d');
+} catch {}
+let renderBundle94 = renderBundleEncoder72.finish({label: '\u00f3\uae90\u9401\u97e7'});
+try {
+computePassEncoder55.setBindGroup(6, bindGroup12, new Uint32Array(3639), 667, 0);
+} catch {}
+try {
+renderBundleEncoder77.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer12, 'uint32', 988, 44);
+} catch {}
+try {
+commandEncoder88.clearBuffer(buffer39);
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture98,
+  mipLevel: 0,
+  origin: { x: 59, y: 3, z: 0 },
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer3), /* required buffer size: 41 */
+{offset: 41}, {width: 10, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline86 = device1.createRenderPipeline({
+label: '\uedaf\u1ff1\ub187\u9620',
+layout: pipelineLayout15,
+fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'dst-alpha'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {format: 'rg8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'never',
+depthFailOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 158,
+depthBiasClamp: 65,
+},
+vertex: {
+  module: shaderModule5,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 15032,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x2',
+offset: 12502,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 13752,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 7272,
+shaderLocation: 22,
+}],
+},
+{
+arrayStride: 26964,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 14196,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x4',
+offset: 6984,
+shaderLocation: 8,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let canvas30 = document.createElement('canvas');
+let img24 = await imageWithData(206, 226, '#3b78c91f', '#a5ebd30a');
+try {
+adapter5.label = '\u97d1\u{1f6a8}\u0b0c\u262e\ua0e4\u5d1d\u8217\u{1fd6d}\u0a27';
+} catch {}
+let commandEncoder96 = device3.createCommandEncoder({});
+let computePassEncoder59 = commandEncoder58.beginComputePass({label: '\u6430\u0aef\u91a1\u{1fbe9}'});
+let renderBundle95 = renderBundleEncoder74.finish({label: '\u{1fa0b}\u0916\u{1ff4a}\ub292\u05a2\u0d62\u6054'});
+try {
+computePassEncoder53.setPipeline(pipeline75);
+} catch {}
+try {
+renderBundleEncoder62.setBindGroup(3, bindGroup17, new Uint32Array(3902), 3098, 0);
+} catch {}
+try {
+commandEncoder94.resolveQuerySet(querySet62, 1563, 282, buffer33, 22272);
+} catch {}
+let pipeline87 = await promise36;
+let textureView107 = texture23.createView({label: '\u0885\uc1e2', dimension: '2d-array', baseMipLevel: 2});
+let renderBundle96 = renderBundleEncoder45.finish({label: '\u07e5\u{1f980}\ud51f\u77a5\u0a6d\u0f9d\u0c9c\u01e6\u422f'});
+try {
+computePassEncoder57.setPipeline(pipeline59);
+} catch {}
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture45,
+  mipLevel: 5,
+  origin: { x: 1, y: 1, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: { x: 14, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder59.clearBuffer(buffer20, 588, 596);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 1,
+  origin: { x: 840, y: 0, z: 50 },
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer7), /* required buffer size: 797122 */
+{offset: 650, bytesPerRow: 808, rowsPerImage: 197}, {width: 370, height: 6, depthOrArrayLayers: 6});
+} catch {}
+try {
+  await promise43;
+} catch {}
+let bindGroup20 = device1.createBindGroup({
+label: '\u{1f931}\u062e',
+layout: bindGroupLayout11,
+entries: [{
+binding: 542,
+resource: textureView99
+}],
+});
+let commandEncoder97 = device1.createCommandEncoder({label: '\ue48e\uafe1\u6c36\u412d'});
+let querySet78 = device1.createQuerySet({
+label: '\u9201\u8b6a\u0709\u052e\u{1fd0c}\ubcea',
+type: 'occlusion',
+count: 2139,
+});
+let texture116 = device1.createTexture({
+label: '\u21f9\u{1fc01}\u02dd\u1164\ud6a3\u01ad\ub96a',
+size: {width: 48, height: 1, depthOrArrayLayers: 220},
+mipLevelCount: 6,
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['r8unorm', 'r8unorm'],
+});
+let textureView108 = texture101.createView({label: '\u0663\u0aab\ubf41', baseMipLevel: 6, mipLevelCount: 1});
+let computePassEncoder60 = commandEncoder59.beginComputePass({label: '\u7e93\u5259'});
+try {
+computePassEncoder60.setPipeline(pipeline59);
+} catch {}
+try {
+renderBundleEncoder57.setBindGroup(0, bindGroup4, new Uint32Array(7563), 3817, 0);
+} catch {}
+try {
+commandEncoder79.resolveQuerySet(querySet77, 3585, 16, buffer34, 18432);
+} catch {}
+let pipeline88 = device1.createComputePipeline({
+label: '\uf7dc\u2d72\u562b\u{1fbf2}',
+layout: pipelineLayout12,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+let img25 = await imageWithData(213, 58, '#3709908c', '#401670ee');
+let imageData29 = new ImageData(120, 72);
+gc();
+let img26 = await imageWithData(98, 49, '#9dadeb65', '#d87ec13c');
+let video27 = await videoWithData();
+let pipelineLayout19 = device1.createPipelineLayout({
+  label: '\uc1db\u093f\u7d04\u0074\u054f\u{1fcd7}\u09f1\u789c\u9dfc\u10d1',
+  bindGroupLayouts: [bindGroupLayout30, bindGroupLayout30, bindGroupLayout14, bindGroupLayout11, bindGroupLayout11, bindGroupLayout11, bindGroupLayout11]
+});
+let texture117 = device1.createTexture({
+label: '\u7421\u09b2\uc1ec\u3847\u24a1\u{1f66a}',
+size: [120, 115, 1],
+format: 'astc-10x5-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder59.setPipeline(pipeline82);
+} catch {}
+try {
+renderBundleEncoder57.setVertexBuffer(12, undefined, 14815892, 1516561928);
+} catch {}
+try {
+commandEncoder93.copyTextureToTexture({
+  texture: texture45,
+  mipLevel: 4,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture45,
+  mipLevel: 2,
+  origin: { x: 17, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap23,
+  origin: { x: 15, y: 52 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 33, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 2, depthOrArrayLayers: 1});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let canvas31 = document.createElement('canvas');
+try {
+renderBundle82.label = '\ub880\u0ec6\u{1ffd0}\u31fd\ua6f4\u0b0d\u07df';
+} catch {}
+let querySet79 = device1.createQuerySet({
+label: '\u{1fb36}\u{1f6ce}\u167c',
+type: 'occlusion',
+count: 578,
+});
+let computePassEncoder61 = commandEncoder72.beginComputePass({});
+try {
+renderBundleEncoder25.setBindGroup(8, bindGroup12, new Uint32Array(2017), 2002, 0);
+} catch {}
+try {
+renderBundleEncoder59.draw(16);
+} catch {}
+try {
+renderBundleEncoder37.setPipeline(pipeline31);
+} catch {}
+try {
+commandEncoder88.copyTextureToBuffer({
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 80, y: 5, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 176 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 51872 */
+offset: 50928,
+bytesPerRow: 256,
+buffer: buffer39,
+}, {width: 55, height: 20, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+commandEncoder79.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 1,
+  origin: { x: 9, y: 2, z: 109 },
+  aspect: 'all',
+}, {
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 16, y: 321, z: 90 },
+  aspect: 'all',
+}, {width: 36, height: 379, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder97.clearBuffer(buffer27);
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: video14,
+  origin: { x: 10, y: 4 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 35, y: 2, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.label = '\u0292\u3f71\u6df5\u0845\u94ed\udcdd\u{1f65b}\u1a08\ud062\u2fbd';
+} catch {}
+let videoFrame26 = new VideoFrame(imageBitmap25, {timestamp: 0});
+try {
+canvas31.getContext('2d');
+} catch {}
+let imageBitmap29 = await createImageBitmap(canvas31);
+try {
+  await promise41;
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+video8.height = 158;
+let adapter22 = await navigator.gpu.requestAdapter({
+});
+try {
+window.someLabel = device3.queue.label;
+} catch {}
+try {
+computePassEncoder30.setBindGroup(3, bindGroup16, new Uint32Array(4423), 4288, 0);
+} catch {}
+try {
+renderBundleEncoder71.setVertexBuffer(1, buffer29, 1692, 687);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: { x: 119, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 322 */
+{offset: 322, bytesPerRow: 1591, rowsPerImage: 192}, {width: 389, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let videoFrame27 = new VideoFrame(offscreenCanvas27, {timestamp: 0});
+try {
+canvas30.getContext('webgpu');
+} catch {}
+let textureView109 = texture99.createView({label: '\u5701\ub232'});
+let renderBundleEncoder79 = device3.createRenderBundleEncoder({
+  label: '\u05ed\u0547\ub2c8\u2e05\u{1f662}\u{1fcaa}\u{1f727}\u596f\u{1f64d}\u{1febb}\uf5ad',
+  colorFormats: ['rg32sint'],
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder62.setVertexBuffer(7, buffer29, 3660);
+} catch {}
+try {
+buffer35.unmap();
+} catch {}
+try {
+commandEncoder91.copyBufferToBuffer(buffer35, 44736, buffer19, 4568, 2572);
+dissociateBuffer(device3, buffer35);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+device: device3,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [],
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder98 = device3.createCommandEncoder();
+let querySet80 = device3.createQuerySet({
+label: '\uce57\u0c88',
+type: 'occlusion',
+count: 179,
+});
+let textureView110 = texture93.createView({label: '\u4623\u{1fadc}\ub1b1\u{1fb9e}\uffc7\u0cc6\u0e8b', mipLevelCount: 4, arrayLayerCount: 1});
+let computePassEncoder62 = commandEncoder96.beginComputePass({label: '\u554f\u{1f9b4}\ubc2b\u{1fcf9}\u0700\u1a41'});
+let renderBundle97 = renderBundleEncoder52.finish({label: '\u01ba\udf90\u{1fa8a}\ubbc0'});
+try {
+renderBundleEncoder54.setVertexBuffer(6, buffer29);
+} catch {}
+try {
+commandEncoder98.resolveQuerySet(querySet59, 549, 87, buffer41, 1792);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 5,
+  origin: { x: 0, y: 8, z: 86 },
+  aspect: 'all',
+}, arrayBuffer8, /* required buffer size: 3778212 */
+{offset: 438, bytesPerRow: 481, rowsPerImage: 187}, {width: 120, height: 0, depthOrArrayLayers: 43});
+} catch {}
+document.body.prepend(video19);
+document.body.prepend(canvas20);
+let commandEncoder99 = device1.createCommandEncoder({});
+let commandBuffer18 = commandEncoder86.finish({
+label: '\ud217\u{1f6fb}\u745a\u85c4\u3578\u{1fe88}\ue9d6\u{1f76f}\u0544\ub770',
+});
+let textureView111 = texture51.createView({
+  label: '\u5d58\u{1f7c2}\u678e\u0ed6\u{1fe4e}\u{1fcda}\u{1fc83}\ucdcd\ua00b\udd66\u19cb',
+  format: 'astc-4x4-unorm-srgb',
+  baseMipLevel: 1,
+  baseArrayLayer: 117,
+  arrayLayerCount: 44
+});
+try {
+renderBundleEncoder37.drawIndexed(80);
+} catch {}
+try {
+commandEncoder99.clearBuffer(buffer21);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: { x: 140, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(72), /* required buffer size: 2542711 */
+{offset: 303, bytesPerRow: 268, rowsPerImage: 279}, {width: 80, height: 4, depthOrArrayLayers: 35});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: img15,
+  origin: { x: 35, y: 63 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 5, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 41, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let imageBitmap30 = await createImageBitmap(video13);
+let texture118 = device3.createTexture({
+size: [1008, 120, 193],
+mipLevelCount: 9,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8unorm', 'etc2-rgb8unorm-srgb', 'etc2-rgb8unorm-srgb'],
+});
+let textureView112 = texture105.createView({baseMipLevel: 1, mipLevelCount: 1});
+try {
+renderBundleEncoder62.setIndexBuffer(buffer35, 'uint32', 11196, 27916);
+} catch {}
+try {
+renderBundleEncoder64.setVertexBuffer(7, buffer44, 28728);
+} catch {}
+try {
+commandEncoder91.clearBuffer(buffer37, 21400);
+dissociateBuffer(device3, buffer37);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(16)), /* required buffer size: 543 */
+{offset: 543, rowsPerImage: 118}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise44 = device3.queue.onSubmittedWorkDone();
+let pipeline89 = device3.createComputePipeline({
+label: '\u0f6a\u4232\u2c3d\u0fef\u{1ff36}\u{1fe9c}',
+layout: 'auto',
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+  await promise44;
+} catch {}
+let video28 = await videoWithData();
+let imageData30 = new ImageData(100, 56);
+let canvas32 = document.createElement('canvas');
+let texture119 = device2.createTexture({
+label: '\u088f\u0d37',
+size: [576, 96, 1],
+mipLevelCount: 3,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundleEncoder80 = device2.createRenderBundleEncoder({
+  colorFormats: ['rgba32sint', 'r8unorm', 'rg8uint', undefined, undefined, 'rgba8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+try {
+renderBundleEncoder21.setVertexBuffer(46, undefined, 1787199359, 1455784410);
+} catch {}
+let computePassEncoder63 = commandEncoder79.beginComputePass({label: '\u0c56\u6137\u{1fc43}\u7303'});
+try {
+renderBundleEncoder70.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder37.drawIndexed(8);
+} catch {}
+try {
+renderBundleEncoder49.setIndexBuffer(buffer47, 'uint16');
+} catch {}
+let arrayBuffer13 = buffer36.getMappedRange(24888, 256);
+try {
+device1.queue.writeBuffer(buffer20, 556, new Float32Array(32022), 14444, 28);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture116,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 10 },
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer4), /* required buffer size: 22226 */
+{offset: 449, bytesPerRow: 17, rowsPerImage: 61}, {width: 0, height: 1, depthOrArrayLayers: 22});
+} catch {}
+let pipeline90 = await promise34;
+let shaderModule18 = device1.createShaderModule({
+label: '\u076c\u{1f6c2}\u0035\u1f10\u{1f63a}',
+code: `@group(4) @binding(542)
+var<storage, read_write> global9: array<u32>;
+@group(3) @binding(542)
+var<storage, read_write> type21: array<u32>;
+@group(0) @binding(3524)
+var<storage, read_write> field11: array<u32>;
+@group(5) @binding(542)
+var<storage, read_write> global10: array<u32>;
+@group(2) @binding(1723)
+var<storage, read_write> global11: array<u32>;
+@group(6) @binding(542)
+var<storage, read_write> parameter15: array<u32>;
+
+@compute @workgroup_size(5, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(7) f0: vec2<u32>,
+  @location(0) f1: vec2<u32>,
+  @location(4) f2: vec4<u32>,
+  @location(3) f3: vec4<i32>,
+  @location(2) f4: vec2<i32>,
+  @location(1) f5: vec3<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S23 {
+  @location(18) f0: vec2<f16>,
+  @location(10) f1: vec3<i32>,
+  @location(26) f2: i32,
+  @location(21) f3: vec3<u32>,
+  @location(11) f4: vec4<i32>,
+  @location(13) f5: vec2<f16>,
+  @location(0) f6: vec2<f16>,
+  @location(23) f7: f16,
+  @location(3) f8: i32,
+  @location(19) f9: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: u32, @location(22) a1: vec2<u32>, @location(8) a2: vec4<u32>, @location(6) a3: u32, @location(25) a4: f16, @location(20) a5: vec4<f16>, @location(17) a6: f16, @location(2) a7: vec4<f16>, @location(24) a8: vec4<u32>, @location(15) a9: vec4<u32>, @location(14) a10: vec4<f32>, @location(7) a11: vec3<u32>, a12: S23, @location(4) a13: vec4<f16>, @location(16) a14: u32, @location(12) a15: vec4<u32>, @location(1) a16: vec2<u32>, @builtin(instance_index) a17: u32, @location(5) a18: vec4<u32>, @builtin(vertex_index) a19: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let textureView113 = texture94.createView({label: '\u070a\u04d2\ufc29', baseMipLevel: 5, mipLevelCount: 1, arrayLayerCount: 1});
+let renderBundleEncoder81 = device1.createRenderBundleEncoder({
+  label: '\u57c4\uff0d\u511e\u{1fd97}\u21ab\u{1fcb4}\u01a1\u{1f7e2}\u5595',
+  colorFormats: ['rgba32sint', 'rg8sint', 'rgba32uint'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle98 = renderBundleEncoder81.finish({});
+try {
+renderBundleEncoder77.setBindGroup(4, bindGroup4);
+} catch {}
+try {
+await device1.popErrorScope();
+} catch {}
+try {
+commandEncoder97.copyBufferToBuffer(buffer36, 8264, buffer20, 280, 284);
+dissociateBuffer(device1, buffer36);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas24,
+  origin: { x: 156, y: 136 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 10, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 38, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+document.body.prepend(img12);
+try {
+computePassEncoder44.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+computePassEncoder25.dispatchWorkgroupsIndirect(buffer41, 1272);
+} catch {}
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+commandEncoder94.copyBufferToBuffer(buffer29, 3528, buffer24, 9572, 0);
+dissociateBuffer(device3, buffer29);
+dissociateBuffer(device3, buffer24);
+} catch {}
+try {
+commandEncoder91.copyTextureToTexture({
+  texture: texture89,
+  mipLevel: 5,
+  origin: { x: 14, y: 0, z: 82 },
+  aspect: 'all',
+}, {
+  texture: texture89,
+  mipLevel: 2,
+  origin: { x: 90, y: 8, z: 36 },
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 62});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['bgra8unorm', 'rg11b10ufloat'],
+alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.prepend(video25);
+let canvas33 = document.createElement('canvas');
+let videoFrame28 = new VideoFrame(videoFrame6, {timestamp: 0});
+let videoFrame29 = new VideoFrame(img3, {timestamp: 0});
+let commandEncoder100 = device1.createCommandEncoder();
+let querySet81 = device1.createQuerySet({
+label: '\u1699\u08df\u5c12\u3669\u0d62\u{1fd63}\u039d\u00d0\u{1f858}',
+type: 'occlusion',
+count: 3462,
+});
+let computePassEncoder64 = commandEncoder99.beginComputePass();
+let sampler69 = device1.createSampler({
+label: '\u0594\u3c7d\u43c2\u055f\u0aa2\ubb2d\u7a74\u0163\u{1f892}\ub1c1',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 68.516,
+lodMaxClamp: 71.680,
+});
+try {
+renderBundleEncoder77.setIndexBuffer(buffer43, 'uint32', 38936, 1131);
+} catch {}
+try {
+commandEncoder97.copyBufferToBuffer(buffer34, 20340, buffer8, 456, 628);
+dissociateBuffer(device1, buffer34);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder93.copyBufferToTexture({
+/* bytesInLastRow: 96 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 672 */
+offset: 672,
+buffer: buffer34,
+}, {
+  texture: texture88,
+  mipLevel: 2,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 48, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer34);
+} catch {}
+try {
+commandEncoder88.copyTextureToBuffer({
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 37, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 44 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 3832 */
+offset: 3532,
+bytesPerRow: 256,
+rowsPerImage: 141,
+buffer: buffer39,
+}, {width: 11, height: 2, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+commandEncoder88.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 2,
+  origin: { x: 270, y: 0, z: 3 },
+  aspect: 'all',
+}, {
+  texture: texture27,
+  mipLevel: 6,
+  origin: { x: 10, y: 0, z: 19 },
+  aspect: 'all',
+}, {width: 20, height: 0, depthOrArrayLayers: 126});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 1, y: 8 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 40, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let imageData31 = new ImageData(168, 60);
+let canvas34 = document.createElement('canvas');
+let video29 = await videoWithData();
+let textureView114 = texture36.createView({label: '\u07f2\ufc5f\u05c3\u94ff', dimension: '2d-array', baseMipLevel: 5});
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+commandEncoder27.clearBuffer(buffer45, 49740, 8168);
+dissociateBuffer(device2, buffer45);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer45, 31900, new Float32Array(51781), 25220, 1512);
+} catch {}
+let pipeline91 = await device2.createRenderPipelineAsync({
+label: '\u{1f98e}\u2cdc\ubd48\uda59\ua8f1\u1d36\ub3b8\u0c8a',
+layout: pipelineLayout6,
+fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: 0}, {format: 'r8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg8uint', writeMask: GPUColorWrite.BLUE}, undefined, undefined, {format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'invert',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 3764,
+stencilWriteMask: 1963,
+depthBiasSlopeScale: 47,
+depthBiasClamp: 49,
+},
+vertex: {
+  module: shaderModule4,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 28152,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x4',
+offset: 16632,
+shaderLocation: 3,
+}, {
+format: 'uint32',
+offset: 3304,
+shaderLocation: 14,
+}, {
+format: 'float16x2',
+offset: 24268,
+shaderLocation: 11,
+}, {
+format: 'sint32x4',
+offset: 19004,
+shaderLocation: 13,
+}, {
+format: 'sint32',
+offset: 6444,
+shaderLocation: 5,
+}, {
+format: 'sint16x2',
+offset: 18484,
+shaderLocation: 10,
+}, {
+format: 'sint32',
+offset: 12416,
+shaderLocation: 1,
+}, {
+format: 'uint8x4',
+offset: 22132,
+shaderLocation: 6,
+}, {
+format: 'unorm8x4',
+offset: 23628,
+shaderLocation: 8,
+}, {
+format: 'uint8x4',
+offset: 9504,
+shaderLocation: 15,
+}, {
+format: 'snorm8x4',
+offset: 11664,
+shaderLocation: 12,
+}, {
+format: 'float32x3',
+offset: 21448,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 21884,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 13218,
+shaderLocation: 4,
+}, {
+format: 'sint32x4',
+offset: 19692,
+shaderLocation: 9,
+}, {
+format: 'float32x3',
+offset: 15728,
+shaderLocation: 7,
+}, {
+format: 'sint16x4',
+offset: 11108,
+shaderLocation: 2,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let commandEncoder101 = device3.createCommandEncoder({label: '\u0beb\uf9a8\u3e11\ue04e\u0e1f\u7847\u57ab\u0e31'});
+let texture120 = device3.createTexture({
+label: '\ua4db\u060e',
+size: {width: 30, height: 120, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rg32sint'],
+});
+let textureView115 = texture59.createView({
+  label: '\uf456\ud07c\u7f2b\u{1f933}\u076d\u{1fec1}\u0929\u8848\ufbd1\ud62f',
+  baseMipLevel: 1,
+  mipLevelCount: 1
+});
+let sampler70 = device3.createSampler({
+label: '\u9b83\u006d\u0fe5\u1faf',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 70.616,
+maxAnisotropy: 12,
+});
+try {
+commandEncoder91.copyBufferToTexture({
+/* bytesInLastRow: 192 widthInBlocks: 24 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 33832 */
+offset: 33832,
+bytesPerRow: 256,
+buffer: buffer35,
+}, {
+  texture: texture120,
+  mipLevel: 0,
+  origin: { x: 5, y: 17, z: 1 },
+  aspect: 'all',
+}, {width: 24, height: 99, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder91.copyTextureToTexture({
+  texture: texture59,
+  mipLevel: 1,
+  origin: { x: 10, y: 50, z: 53 },
+  aspect: 'all',
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: { x: 7, y: 133, z: 104 },
+  aspect: 'all',
+}, {width: 14, height: 51, depthOrArrayLayers: 45});
+} catch {}
+let pipeline92 = await device3.createRenderPipelineAsync({
+label: '\ue3e7\u{1fa61}\u{1fe6b}\u{1f6fa}\uf779\u7393\u04e3\udbf0\u7fa3\u16b1',
+layout: pipelineLayout10,
+fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALPHA}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one', dstFactor: 'one-minus-constant'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALPHA
+}]
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'never',
+failOp: 'keep',
+depthFailOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+depthBias: 11,
+depthBiasSlopeScale: 82,
+},
+vertex: {
+  module: shaderModule12,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 15720,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 14306,
+shaderLocation: 0,
+}, {
+format: 'uint32x3',
+offset: 8676,
+shaderLocation: 4,
+}, {
+format: 'unorm10-10-10-2',
+offset: 1044,
+shaderLocation: 19,
+}, {
+format: 'uint32',
+offset: 13900,
+shaderLocation: 20,
+}, {
+format: 'unorm8x2',
+offset: 2184,
+shaderLocation: 18,
+}, {
+format: 'float32',
+offset: 12332,
+shaderLocation: 9,
+}, {
+format: 'uint32x3',
+offset: 13412,
+shaderLocation: 14,
+}, {
+format: 'sint16x4',
+offset: 4464,
+shaderLocation: 1,
+}, {
+format: 'uint32x3',
+offset: 664,
+shaderLocation: 24,
+}, {
+format: 'unorm16x2',
+offset: 12236,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 27088,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 13772,
+shaderLocation: 17,
+}, {
+format: 'snorm8x4',
+offset: 8952,
+shaderLocation: 23,
+}, {
+format: 'unorm16x2',
+offset: 25500,
+shaderLocation: 21,
+}, {
+format: 'sint32x3',
+offset: 26788,
+shaderLocation: 6,
+}, {
+format: 'float16x2',
+offset: 12556,
+shaderLocation: 16,
+}, {
+format: 'sint8x4',
+offset: 14280,
+shaderLocation: 11,
+}, {
+format: 'unorm8x2',
+offset: 13348,
+shaderLocation: 22,
+}],
+},
+{
+arrayStride: 23004,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 18760,
+shaderLocation: 10,
+}, {
+format: 'uint16x4',
+offset: 4832,
+shaderLocation: 12,
+}, {
+format: 'float16x2',
+offset: 4976,
+shaderLocation: 15,
+}, {
+format: 'uint32x3',
+offset: 21708,
+shaderLocation: 2,
+}, {
+format: 'snorm16x2',
+offset: 20432,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 25788,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 16240,
+shaderLocation: 7,
+}, {
+format: 'sint8x4',
+offset: 10332,
+shaderLocation: 25,
+}, {
+format: 'uint16x4',
+offset: 4916,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 7768,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 20832,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x2',
+offset: 8156,
+shaderLocation: 8,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+},
+});
+let texture121 = device3.createTexture({
+label: '\u19b8\u{1fb86}\u{1fadd}\ucc60\u4d23\ue806\u{1f72b}\u{1fb38}\u0fb5',
+size: {width: 240, height: 960, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+sampleCount: 1,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder65 = commandEncoder91.beginComputePass({label: '\u1343\u0280\ufd9b\u{1f6bd}'});
+let renderBundle99 = renderBundleEncoder64.finish({});
+try {
+renderBundleEncoder78.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder79.setBindGroup(7, bindGroup15, new Uint32Array(2359), 2268, 0);
+} catch {}
+try {
+renderBundleEncoder76.setVertexBuffer(9, buffer44, 35384);
+} catch {}
+try {
+commandEncoder101.clearBuffer(buffer24, 3340, 2564);
+dissociateBuffer(device3, buffer24);
+} catch {}
+try {
+commandEncoder101.insertDebugMarker('\u2962');
+} catch {}
+let texture122 = device3.createTexture({
+label: '\u3d1d\u077d\u59a4\u08e2\u0765\u5b59\uc7df\u091f\ua9de\u0d8d',
+size: [256, 480, 1],
+mipLevelCount: 1,
+sampleCount: 1,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8unorm-srgb', 'etc2-rgb8unorm-srgb', 'etc2-rgb8unorm-srgb'],
+});
+let renderBundle100 = renderBundleEncoder60.finish();
+try {
+renderBundleEncoder56.setVertexBuffer(3, buffer44, 24708, 23584);
+} catch {}
+let pipeline93 = device3.createComputePipeline({
+label: '\u0f14\u0eac',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let renderBundleEncoder82 = device3.createRenderBundleEncoder({
+  label: '\ua1c6\u02b5\u03f1\u96e5\u0402\u{1f63d}\u{1fe37}\u390f\u03cb',
+  colorFormats: ['r32float', 'rgb10a2uint', 'r32uint', 'rg8unorm', 'rg8sint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+try {
+computePassEncoder37.end();
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(7, buffer29, 1208);
+} catch {}
+try {
+commandEncoder101.copyBufferToBuffer(buffer35, 17284, buffer24, 2088, 2252);
+dissociateBuffer(device3, buffer35);
+dissociateBuffer(device3, buffer24);
+} catch {}
+try {
+commandEncoder94.resolveQuerySet(querySet38, 1328, 15, buffer41, 3584);
+} catch {}
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+let imageData32 = new ImageData(84, 20);
+let commandEncoder102 = device1.createCommandEncoder();
+let querySet82 = device1.createQuerySet({
+label: '\uda21\u1f41\u{1fbb3}\ua944\u{1f92c}\u4e33',
+type: 'occlusion',
+count: 103,
+});
+try {
+renderBundleEncoder37.setBindGroup(10, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder37.draw(32, 48, 32, 32);
+} catch {}
+try {
+renderBundleEncoder70.setIndexBuffer(buffer18, 'uint32', 45624, 6102);
+} catch {}
+try {
+commandEncoder100.clearBuffer(buffer21, 20360);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture95,
+  mipLevel: 0,
+  origin: { x: 102, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(190), /* required buffer size: 190 */
+{offset: 25, rowsPerImage: 152}, {width: 165, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let offscreenCanvas32 = new OffscreenCanvas(448, 375);
+let device5 = await promise22;
+let commandEncoder103 = device5.createCommandEncoder({label: '\u930f\u0443\u0728\u09d6\u91eb'});
+try {
+gpuCanvasContext8.configure({
+device: device5,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth24plus'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let promise45 = device5.queue.onSubmittedWorkDone();
+let offscreenCanvas33 = new OffscreenCanvas(174, 873);
+let commandEncoder104 = device5.createCommandEncoder({label: '\u{1f62a}\u{1ff02}\u71f8\u943b\u0243\u0812\u095f\u{1f973}\u5a4b\u02a5\u0d3c'});
+let texture123 = device5.createTexture({
+size: {width: 624, height: 2, depthOrArrayLayers: 1723},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rgb10a2unorm', 'rgb10a2unorm'],
+});
+let computePassEncoder66 = commandEncoder103.beginComputePass();
+let sampler71 = device5.createSampler({
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 15.145,
+lodMaxClamp: 58.163,
+});
+let gpuCanvasContext27 = canvas32.getContext('webgpu');
+canvas21.width = 992;
+pseudoSubmit(device5, commandEncoder104);
+let renderBundleEncoder83 = device5.createRenderBundleEncoder({label: '\u8ecc\u{1fdbd}\u00a8\u08e6', colorFormats: ['rg16uint'], sampleCount: 4, depthReadOnly: true});
+let sampler72 = device5.createSampler({
+label: '\ua09f\u{1f9c2}',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 38.069,
+lodMaxClamp: 71.256,
+compare: 'less-equal',
+maxAnisotropy: 3,
+});
+try {
+device5.queue.writeTexture({
+  texture: texture123,
+  mipLevel: 1,
+  origin: { x: 4, y: 0, z: 34 },
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer4), /* required buffer size: 21560870 */
+{offset: 732, bytesPerRow: 862, rowsPerImage: 63}, {width: 164, height: 1, depthOrArrayLayers: 398});
+} catch {}
+let texture124 = device3.createTexture({
+label: '\u0d1a\u49b4\u7ade\u3e40\u7ecc',
+size: [120, 480, 1],
+mipLevelCount: 5,
+format: 'astc-6x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let sampler73 = device3.createSampler({
+label: '\u0349\uc971',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 57.405,
+lodMaxClamp: 91.881,
+});
+let promise46 = device3.popErrorScope();
+let pipeline94 = device3.createComputePipeline({
+label: '\u9cd8\u{1fb14}',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline95 = device3.createRenderPipeline({
+label: '\u08d8\u0404\ud4ed\u996f\u2369\uf6aa\ub5fa\u2bf5\u{1f75f}\u0f75\ua1be',
+layout: pipelineLayout14,
+fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-constant'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'src-alpha'},
+}
+}, {format: 'r32sint'}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'dst'},
+alpha: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-dst-alpha'},
+},
+  writeMask: GPUColorWrite.ALPHA
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 30,
+stencilWriteMask: 2867,
+depthBias: 20,
+depthBiasSlopeScale: 14,
+depthBiasClamp: 13,
+},
+vertex: {
+  module: shaderModule12,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 19340,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 11740,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint16x4',
+offset: 13720,
+shaderLocation: 7,
+}, {
+format: 'uint32x2',
+offset: 24852,
+shaderLocation: 2,
+}, {
+format: 'float32x2',
+offset: 1896,
+shaderLocation: 21,
+}, {
+format: 'unorm10-10-10-2',
+offset: 22512,
+shaderLocation: 17,
+}, {
+format: 'uint8x4',
+offset: 25896,
+shaderLocation: 20,
+}, {
+format: 'uint32x3',
+offset: 11360,
+shaderLocation: 13,
+}, {
+format: 'float16x4',
+offset: 5844,
+shaderLocation: 22,
+}, {
+format: 'snorm16x4',
+offset: 24452,
+shaderLocation: 18,
+}, {
+format: 'snorm8x2',
+offset: 6436,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 0,
+attributes: [{
+format: 'float32x3',
+offset: 1944,
+shaderLocation: 0,
+}, {
+format: 'float32x4',
+offset: 15292,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 19812,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x4',
+offset: 17192,
+shaderLocation: 15,
+}, {
+format: 'uint32x3',
+offset: 17368,
+shaderLocation: 12,
+}, {
+format: 'snorm16x2',
+offset: 1364,
+shaderLocation: 23,
+}, {
+format: 'sint32x2',
+offset: 16852,
+shaderLocation: 11,
+}, {
+format: 'float32x3',
+offset: 2964,
+shaderLocation: 8,
+}, {
+format: 'sint32x2',
+offset: 9752,
+shaderLocation: 25,
+}, {
+format: 'uint32x4',
+offset: 11680,
+shaderLocation: 4,
+}, {
+format: 'unorm16x4',
+offset: 7624,
+shaderLocation: 9,
+}, {
+format: 'sint32',
+offset: 5364,
+shaderLocation: 6,
+}, {
+format: 'snorm8x2',
+offset: 2092,
+shaderLocation: 19,
+}, {
+format: 'snorm8x2',
+offset: 8598,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 9020,
+attributes: [],
+},
+{
+arrayStride: 6072,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 28208,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x3',
+offset: 28180,
+shaderLocation: 14,
+}, {
+format: 'uint16x2',
+offset: 11720,
+shaderLocation: 24,
+}],
+},
+{
+arrayStride: 23896,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x2',
+offset: 15504,
+shaderLocation: 5,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+try {
+  await promise45;
+} catch {}
+let commandEncoder105 = device5.createCommandEncoder({label: '\ua50b\u0f71\u{1f9c2}\u587f\u3a58\uf67c\u0f23\ubb56\u10a7'});
+let querySet83 = device5.createQuerySet({
+label: '\u08eb\ua811\u20c3\u3916\ufc48\uba0c\u40c6\u0140',
+type: 'occlusion',
+count: 2415,
+});
+let commandBuffer19 = commandEncoder105.finish({
+label: '\u{1ff2e}\u32c1\uc7d5\ub695',
+});
+let renderBundle101 = renderBundleEncoder83.finish({label: '\ue4b6\u7317'});
+try {
+device5.queue.writeTexture({
+  texture: texture123,
+  mipLevel: 1,
+  origin: { x: 15, y: 0, z: 182 },
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer5), /* required buffer size: 33507332 */
+{offset: 288, bytesPerRow: 1385, rowsPerImage: 192}, {width: 281, height: 1, depthOrArrayLayers: 127});
+} catch {}
+canvas16.width = 429;
+let canvas35 = document.createElement('canvas');
+let img27 = await imageWithData(285, 54, '#e8568f35', '#dbf8368c');
+let promise47 = adapter13.requestAdapterInfo();
+let bindGroupLayout39 = device5.createBindGroupLayout({
+label: '\u84f0\u{1f916}',
+entries: [],
+});
+try {
+device5.addEventListener('uncapturederror', e => { log('device5.uncapturederror'); log(e); e.label = device5.label; });
+} catch {}
+let videoFrame30 = new VideoFrame(video29, {timestamp: 0});
+let texture125 = device1.createTexture({
+label: '\u0481\u1039\u076d\u0601',
+size: {width: 384, height: 5, depthOrArrayLayers: 113},
+format: 'astc-6x5-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder67 = commandEncoder100.beginComputePass({label: '\ub1e4\u5345'});
+try {
+renderBundleEncoder77.setBindGroup(9, bindGroup19, new Uint32Array(7870), 4783, 0);
+} catch {}
+try {
+renderBundleEncoder37.draw(8, 24, 24, 56);
+} catch {}
+try {
+commandEncoder88.resolveQuerySet(querySet39, 795, 957, buffer34, 14848);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer34, 20892, new DataView(new ArrayBuffer(2573)), 459, 1804);
+} catch {}
+let pipeline96 = device1.createComputePipeline({
+label: '\u4fa5\u97f6\u2fa8\u0d0f\u7635\uc73f\u05ea\u5a73\uce52\u0a61',
+layout: pipelineLayout12,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+  await promise46;
+} catch {}
+let textureView116 = texture123.createView({label: '\u0444\u0852\u4f4d\u64dd\u{1fb0d}\u701a\u89c9\uc840\u064e\u01e1', baseMipLevel: 1});
+let img28 = await imageWithData(280, 12, '#cbf75d42', '#b41f6082');
+let imageBitmap31 = await createImageBitmap(video0);
+let video30 = await videoWithData();
+try {
+  await promise47;
+} catch {}
+let img29 = await imageWithData(280, 277, '#6d958065', '#e5e56c48');
+let bindGroupLayout40 = device1.createBindGroupLayout({
+entries: [],
+});
+let querySet84 = device1.createQuerySet({
+label: '\uf691\ub85a',
+type: 'occlusion',
+count: 612,
+});
+try {
+renderBundleEncoder70.setBindGroup(5, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder59.setBindGroup(5, bindGroup7, new Uint32Array(816), 561, 0);
+} catch {}
+try {
+commandEncoder88.insertDebugMarker('\ufa06');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap27,
+  origin: { x: 404, y: 97 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 46, y: 2, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline97 = device1.createComputePipeline({
+label: '\u23dc\u{1f763}\ude1e\u{1fad5}\uc549\u066d\u2d64\u8226\u7d5c',
+layout: pipelineLayout8,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let gpuCanvasContext28 = canvas33.getContext('webgpu');
+let bindGroup21 = device5.createBindGroup({
+layout: bindGroupLayout39,
+entries: [],
+});
+let querySet85 = device5.createQuerySet({
+label: '\u{1feb0}\u0f47\u8beb\uf1ca\u844b\u8377\u0660\uf02b',
+type: 'occlusion',
+count: 1086,
+});
+let textureView117 = texture123.createView({label: '\u0cb3\ue8a7\u0d3f', mipLevelCount: 1});
+let renderBundleEncoder84 = device5.createRenderBundleEncoder({
+  label: '\u916b\u0f9a\u8297\u9591\u02ea\u0e89\u{1f62b}',
+  colorFormats: ['rg16uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let externalTexture9 = device5.importExternalTexture({
+label: '\ub358\u45c8\u{1febb}\u03f8\uf56f\u036d\u5584\u{1fc53}\uf9a5',
+source: videoFrame5,
+colorSpace: 'display-p3',
+});
+try {
+gpuCanvasContext8.configure({
+device: device5,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let promise48 = device5.queue.onSubmittedWorkDone();
+let img30 = await imageWithData(207, 274, '#8b04ccea', '#7da75b1c');
+try {
+canvas35.getContext('2d');
+} catch {}
+try {
+  await promise48;
+} catch {}
+let img31 = await imageWithData(146, 208, '#676ba080', '#1b130991');
+try {
+querySet1.label = '\u4873\u509f\u6f81\u076a\u{1f801}\u0934\udd4b\u0775\u{1fdc8}\u{1fc9c}\u886c';
+} catch {}
+try {
+renderBundleEncoder84.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+device5.queue.writeTexture({
+  texture: texture123,
+  mipLevel: 1,
+  origin: { x: 268, y: 1, z: 753 },
+  aspect: 'all',
+}, arrayBuffer12, /* required buffer size: 860081 */
+{offset: 697, bytesPerRow: 136, rowsPerImage: 71}, {width: 19, height: 0, depthOrArrayLayers: 90});
+} catch {}
+canvas17.width = 553;
+let renderBundle102 = renderBundleEncoder83.finish({label: '\ub9b0\u{1f8fe}\u15fe\u0bb3\u{1f8c3}\u07ba\u2b01\u5848\u6ec1\ue897\u9f77'});
+gc();
+let canvas36 = document.createElement('canvas');
+let imageData33 = new ImageData(248, 156);
+let renderBundle103 = renderBundleEncoder61.finish({label: '\u{1f99b}\u{1f822}\u8581\u{1f892}\u{1f8c9}\u11b1\uce47\u{1f97a}\u06a2\u9e70'});
+try {
+renderBundleEncoder56.setBindGroup(3, bindGroup14, new Uint32Array(6442), 2689, 0);
+} catch {}
+try {
+adapter11.label = '\u{1fd5e}\u1fd3\u1cd9\u19e1';
+} catch {}
+let device6 = await adapter4.requestDevice({
+label: '\uff4f\uabf4\u1ff3\u07a8\u{1f886}\u41c8\u6601',
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 35,
+maxVertexAttributes: 25,
+maxVertexBufferArrayStride: 31411,
+maxStorageTexturesPerShaderStage: 41,
+maxStorageBuffersPerShaderStage: 17,
+maxDynamicStorageBuffersPerPipelineLayout: 26203,
+maxBindingsPerBindGroup: 4663,
+maxTextureDimension1D: 9364,
+maxTextureDimension2D: 13488,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 40444181,
+maxUniformBuffersPerShaderStage: 14,
+maxInterStageShaderVariables: 38,
+maxInterStageShaderComponents: 62,
+maxSamplersPerShaderStage: 20,
+},
+});
+let computePassEncoder68 = commandEncoder94.beginComputePass({label: '\u3b1c\u817f\u7e46\u012e\u7f0e\uce2d\ud008\udc95\u0164\u6c8c\u{1f69e}'});
+let sampler74 = device3.createSampler({
+label: '\u548d\u{1feb3}',
+addressModeU: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 93.471,
+lodMaxClamp: 98.619,
+maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder79.setBindGroup(7, bindGroup8, new Uint32Array(9229), 6449, 0);
+} catch {}
+let pipeline98 = await device3.createComputePipelineAsync({
+label: '\u37de\u6795\ufcd9\u1a8e',
+layout: pipelineLayout10,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+},
+});
+let device7 = await adapter14.requestDevice({
+label: '\u{1fcd1}\ud0fc\u06aa\u9e40\u48fe\u85e0\u068a',
+requiredFeatures: [
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 6,
+maxColorAttachmentBytesPerSample: 52,
+maxVertexBufferArrayStride: 60076,
+maxStorageTexturesPerShaderStage: 26,
+maxStorageBuffersPerShaderStage: 25,
+maxDynamicStorageBuffersPerPipelineLayout: 39249,
+maxBindingsPerBindGroup: 8484,
+maxTextureDimension1D: 13922,
+maxTextureDimension2D: 10957,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 195871878,
+maxUniformBuffersPerShaderStage: 19,
+maxInterStageShaderVariables: 102,
+maxInterStageShaderComponents: 92,
+},
+});
+let imageBitmap32 = await createImageBitmap(img6);
+let texture126 = device1.createTexture({
+size: {width: 384, height: 16, depthOrArrayLayers: 243},
+mipLevelCount: 5,
+dimension: '2d',
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundleEncoder85 = device1.createRenderBundleEncoder({
+  label: '\ua26b\u8141\u79d1\u417a\u8a45\u{1f891}\u0b6e',
+  colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint']
+});
+try {
+renderBundleEncoder37.draw(72, 56, 72);
+} catch {}
+try {
+renderBundleEncoder59.drawIndexed(16, 40, 16);
+} catch {}
+try {
+renderBundleEncoder66.setIndexBuffer(buffer47, 'uint32', 15684, 9527);
+} catch {}
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+try {
+adapter3.label = '\ud696\udcb1\u02b7\u51bd\u0463\u{1fcc2}';
+} catch {}
+let device8 = await adapter8.requestDevice({
+label: '\uf393\u9cf4\u{1f869}\u{1fa62}\u1b7b\u2bbe',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 6,
+maxColorAttachmentBytesPerSample: 45,
+maxVertexAttributes: 17,
+maxVertexBufferArrayStride: 5510,
+maxStorageTexturesPerShaderStage: 39,
+maxStorageBuffersPerShaderStage: 39,
+maxDynamicStorageBuffersPerPipelineLayout: 26188,
+maxBindingsPerBindGroup: 4184,
+maxTextureDimension1D: 15929,
+maxTextureDimension2D: 13179,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 147110740,
+maxUniformBuffersPerShaderStage: 17,
+maxInterStageShaderVariables: 98,
+maxInterStageShaderComponents: 67,
+maxSamplersPerShaderStage: 17,
+},
+});
+let video31 = await videoWithData();
+try {
+gpuCanvasContext8.configure({
+device: device8,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16float', 'rg32float', 'rgba16float', 'rgba16float'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let offscreenCanvas34 = new OffscreenCanvas(655, 704);
+let sampler75 = device8.createSampler({
+label: '\u64e0\u{1fb19}\u{1f791}\u1252\u3d50',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 42.634,
+maxAnisotropy: 9,
+});
+try {
+gpuCanvasContext25.unconfigure();
+} catch {}
+let bindGroup22 = device1.createBindGroup({
+label: '\u89ca\u0014\ua3ee\udbcc\u{1fcf1}\u{1fb34}\u1890\u{1fea6}\u00be\u4e09\u7381',
+layout: bindGroupLayout25,
+entries: [],
+});
+let textureView118 = texture17.createView({label: '\u94c5\ua735\u0e44\u04d0\u6529', dimension: '2d', baseMipLevel: 2, baseArrayLayer: 200});
+try {
+device1.pushErrorScope('internal');
+} catch {}
+let pipeline99 = device1.createRenderPipeline({
+layout: pipelineLayout7,
+multisample: {
+mask: 0x6b45d840,
+},
+fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'r32uint', writeMask: GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'rg8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r32uint'}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'always',
+failOp: 'replace',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2703,
+depthBiasSlopeScale: 35,
+},
+vertex: {
+  module: shaderModule3,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 6104,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x4',
+offset: 4256,
+shaderLocation: 15,
+}, {
+format: 'sint16x4',
+offset: 3980,
+shaderLocation: 7,
+}, {
+format: 'sint32x3',
+offset: 140,
+shaderLocation: 10,
+}, {
+format: 'snorm8x4',
+offset: 3380,
+shaderLocation: 20,
+}, {
+format: 'uint32x2',
+offset: 1412,
+shaderLocation: 4,
+}, {
+format: 'uint16x4',
+offset: 920,
+shaderLocation: 2,
+}, {
+format: 'float32',
+offset: 3012,
+shaderLocation: 14,
+}, {
+format: 'sint16x4',
+offset: 1220,
+shaderLocation: 9,
+}, {
+format: 'unorm8x2',
+offset: 686,
+shaderLocation: 19,
+}, {
+format: 'unorm16x4',
+offset: 5036,
+shaderLocation: 18,
+}, {
+format: 'sint8x4',
+offset: 5724,
+shaderLocation: 5,
+}, {
+format: 'uint32x4',
+offset: 5532,
+shaderLocation: 23,
+}, {
+format: 'sint8x4',
+offset: 3908,
+shaderLocation: 26,
+}, {
+format: 'sint16x2',
+offset: 5184,
+shaderLocation: 22,
+}, {
+format: 'snorm8x2',
+offset: 366,
+shaderLocation: 16,
+}, {
+format: 'snorm16x2',
+offset: 3164,
+shaderLocation: 13,
+}, {
+format: 'snorm16x4',
+offset: 2636,
+shaderLocation: 17,
+}],
+},
+{
+arrayStride: 9888,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 5478,
+shaderLocation: 1,
+}, {
+format: 'sint8x2',
+offset: 7774,
+shaderLocation: 21,
+}, {
+format: 'uint32x3',
+offset: 8976,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 10152,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 31608,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 2098,
+shaderLocation: 0,
+}, {
+format: 'sint32x4',
+offset: 10460,
+shaderLocation: 12,
+}, {
+format: 'float16x4',
+offset: 23716,
+shaderLocation: 3,
+}, {
+format: 'float32x3',
+offset: 26992,
+shaderLocation: 24,
+}, {
+format: 'unorm8x4',
+offset: 2472,
+shaderLocation: 25,
+}],
+},
+{
+arrayStride: 15468,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 33628,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x4',
+offset: 23068,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 216,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 12,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let gpuCanvasContext29 = offscreenCanvas32.getContext('webgpu');
+document.body.prepend(video26);
+let offscreenCanvas35 = new OffscreenCanvas(641, 692);
+let querySet86 = device1.createQuerySet({
+label: '\u023c\u0cec\u{1f661}',
+type: 'occlusion',
+count: 3173,
+});
+pseudoSubmit(device1, commandEncoder90);
+let renderBundleEncoder86 = device1.createRenderBundleEncoder({
+  label: '\ue976\u094d\u0829\u0ddf\u795e\u6180\u9aca\ud573',
+  colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint'],
+  sampleCount: 1,
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+let sampler76 = device1.createSampler({
+label: '\u{1ffa0}\uef86\uae07',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 16.581,
+lodMaxClamp: 67.948,
+compare: 'always',
+});
+try {
+renderBundleEncoder37.drawIndexed(0, 72, 48, 376, 32);
+} catch {}
+try {
+renderBundleEncoder57.setPipeline(pipeline81);
+} catch {}
+try {
+commandEncoder93.copyBufferToBuffer(buffer47, 31104, buffer21, 8672, 324);
+dissociateBuffer(device1, buffer47);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+commandEncoder102.copyTextureToTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 8, y: 344, z: 41 },
+  aspect: 'all',
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: { x: 4, y: 32, z: 17 },
+  aspect: 'all',
+}, {width: 36, height: 244, depthOrArrayLayers: 4});
+} catch {}
+try {
+commandEncoder97.resolveQuerySet(querySet69, 2354, 1334, buffer34, 8448);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 936, new DataView(new ArrayBuffer(65467)), 38851, 28);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: { x: 0, y: 184, z: 60 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 525934 */
+{offset: 332, bytesPerRow: 74, rowsPerImage: 106}, {width: 27, height: 1, depthOrArrayLayers: 68});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas19,
+  origin: { x: 105, y: 82 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 7, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 40, height: 2, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let renderBundleEncoder87 = device6.createRenderBundleEncoder({
+  label: '\uc010\u{1f96b}\uc8ef\ub2b9\u{1f692}\ud033\u0d18\u4d57\u{1f83f}\ufad0',
+  colorFormats: ['r8uint', 'rg16uint', 'r32float', 'rgba8uint', 'rgba16float', 'rgb10a2unorm'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+document.body.prepend(img0);
+let textureView119 = texture123.createView({
+  label: '\u{1fab0}\u{1fdad}\u0375\ued00\u{1fa7e}\u9507\u0e8b\u068e\ubb98\u{1f667}\udc37',
+  mipLevelCount: 1
+});
+let renderBundleEncoder88 = device5.createRenderBundleEncoder({
+  label: '\u{1ff51}\u6ab2\u3cab\u0864\ud2d1\udff8\u88d3\ucf0e',
+  colorFormats: ['rg16uint'],
+  sampleCount: 4,
+  depthReadOnly: false
+});
+let computePassEncoder69 = commandEncoder93.beginComputePass();
+try {
+computePassEncoder67.setBindGroup(6, bindGroup4, []);
+} catch {}
+try {
+renderBundleEncoder77.setIndexBuffer(buffer43, 'uint16', 15544);
+} catch {}
+try {
+texture126.destroy();
+} catch {}
+try {
+buffer47.unmap();
+} catch {}
+try {
+commandEncoder97.copyBufferToBuffer(buffer34, 21984, buffer8, 6604, 832);
+dissociateBuffer(device1, buffer34);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder97.clearBuffer(buffer8, 5708, 5840);
+dissociateBuffer(device1, buffer8);
+} catch {}
+let video32 = await videoWithData();
+try {
+device5.label = '\u1878\u{1fc3a}\u005a\uaa23\uc993\u0101\ufddb\u916b\u0366';
+} catch {}
+let pipelineLayout20 = device5.createPipelineLayout({label: '\u0812\u{1fc92}\u{1f7db}', bindGroupLayouts: [bindGroupLayout39, bindGroupLayout39]});
+let renderBundleEncoder89 = device5.createRenderBundleEncoder({
+  label: '\ue2c8\ue67c\uc311\ua9eb\u9d34\u{1fd6d}\u{1fa02}\ub688\u06f5',
+  colorFormats: ['rg16uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+let renderBundle104 = renderBundleEncoder83.finish({label: '\u13f6\u0ed4\uec3c\u17e1\u8801\u09b7'});
+let sampler77 = device5.createSampler({
+label: '\u0416\u0d6f\ua86b\u047e\u4eb8\u4e99\uc507\u04ce\u1d4a',
+addressModeU: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 94.467,
+lodMaxClamp: 95.636,
+});
+try {
+renderBundleEncoder84.setBindGroup(2, bindGroup21);
+} catch {}
+let bindGroupLayout41 = device8.createBindGroupLayout({
+entries: [{
+binding: 4129,
+visibility: 0,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+}, {
+binding: 1813,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}],
+});
+let pipelineLayout21 = device8.createPipelineLayout({label: '\uc20b\u0887\u026b\u{1f642}\u0d7a\u0b47', bindGroupLayouts: []});
+let renderBundleEncoder90 = device8.createRenderBundleEncoder({label: '\ubdab\u473b', colorFormats: ['rg16sint'], sampleCount: 4, depthReadOnly: true});
+try {
+gpuCanvasContext28.configure({
+device: device8,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'depth24plus-stencil8'],
+alphaMode: 'premultiplied',
+});
+} catch {}
+let imageBitmap33 = await createImageBitmap(videoFrame14);
+let commandEncoder106 = device1.createCommandEncoder({label: '\u{1fd9d}\u24b2\u584c\u3849\u97c8\ue366\u051a\u021e\ud505\u24df\u307e'});
+let texture127 = device1.createTexture({
+label: '\u{1f740}\ueddd\u6604',
+size: {width: 192, height: 8, depthOrArrayLayers: 5},
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let sampler78 = device1.createSampler({
+label: '\u78d8\uc3bd\u146e\u385e\u33e9\u0589',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 73.534,
+lodMaxClamp: 85.891,
+maxAnisotropy: 12,
+});
+try {
+computePassEncoder63.setBindGroup(6, bindGroup12);
+} catch {}
+try {
+commandEncoder88.clearBuffer(buffer39);
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+device1.queue.submit([
+]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer39, 32856, new DataView(new ArrayBuffer(24032)));
+} catch {}
+let querySet87 = device7.createQuerySet({
+label: '\u5fc0\u02db',
+type: 'occlusion',
+count: 3175,
+});
+let texture128 = device7.createTexture({
+label: '\u{1ffdf}\u07e3\u4d29\u{1f775}\ub6ee',
+size: {width: 149, height: 2, depthOrArrayLayers: 47},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rg16sint', 'rg16sint'],
+});
+try {
+device7.queue.writeTexture({
+  texture: texture128,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 2 },
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 229 */
+{offset: 229}, {width: 9, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let img32 = await imageWithData(277, 150, '#bb7c3108', '#86461a73');
+let querySet88 = device5.createQuerySet({
+type: 'occlusion',
+count: 2643,
+});
+let texture129 = device5.createTexture({
+size: {width: 312, height: 1, depthOrArrayLayers: 244},
+mipLevelCount: 8,
+sampleCount: 1,
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundleEncoder91 = device5.createRenderBundleEncoder({label: '\ubf35\ude44\u{1ff94}\u3d12\u{1f627}\udce5', colorFormats: ['rg16uint'], sampleCount: 4});
+try {
+computePassEncoder66.setBindGroup(2, bindGroup21, new Uint32Array(3249), 2042, 0);
+} catch {}
+let imageBitmap34 = await createImageBitmap(canvas17);
+let renderBundleEncoder92 = device8.createRenderBundleEncoder({label: '\u5b68\uba41\u5712\u{1f804}', colorFormats: ['rg16sint'], sampleCount: 4});
+try {
+await device8.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundleEncoder93 = device6.createRenderBundleEncoder({
+  colorFormats: ['r8uint', 'rg16uint', 'r32float', 'rgba8uint', 'rgba16float', 'rgb10a2unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+let bindGroup23 = device1.createBindGroup({
+label: '\u{1f9be}\u5369\uc109\u3c84\u{1feae}\ufb1d\u2d12',
+layout: bindGroupLayout33,
+entries: [{
+binding: 1265,
+resource: externalTexture6
+}],
+});
+let commandEncoder107 = device1.createCommandEncoder({label: '\u{1f94d}\u{1fcc1}\uadd1'});
+let commandBuffer20 = commandEncoder106.finish({
+label: '\u{1ff2f}\u{1f608}\u01cc\u3cb7\u632e\uebfd\u{1f604}\u{1ffec}\u470a\u20c6',
+});
+try {
+renderBundleEncoder59.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+commandEncoder107.copyBufferToBuffer(buffer20, 660, buffer8, 1884, 508);
+dissociateBuffer(device1, buffer20);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder102.resolveQuerySet(querySet39, 2455, 199, buffer34, 3072);
+} catch {}
+try {
+commandEncoder107.insertDebugMarker('\u{1f8b0}');
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer20,
+commandBuffer18,
+]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 852, new DataView(new ArrayBuffer(49517)), 2042, 160);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 2,
+  origin: { x: 1, y: 16, z: 7 },
+  aspect: 'all',
+}, new DataView(arrayBuffer10), /* required buffer size: 18174504 */
+{offset: 736, bytesPerRow: 247, rowsPerImage: 373}, {width: 1, height: 98, depthOrArrayLayers: 198});
+} catch {}
+let pipeline100 = await device1.createComputePipelineAsync({
+label: '\u04b3\ud29a',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+},
+});
+let videoFrame31 = new VideoFrame(imageBitmap17, {timestamp: 0});
+let buffer48 = device7.createBuffer({
+  label: '\u{1f7ce}\u4105\u{1ff0e}\u{1f741}\ufa97',
+  size: 9948,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true
+});
+let texture130 = device7.createTexture({
+label: '\u0806\u198f\u65cd\u84e3\u{1fb2f}\u0bdf',
+size: [4858, 1, 174],
+mipLevelCount: 5,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['bgra8unorm-srgb'],
+});
+let textureView120 = texture128.createView({baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 0});
+let sampler79 = device7.createSampler({
+label: '\u{1fdea}\uaf23\u09a8\uf711\u0f23\uc986\u6cba\u0c31\u06cc',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 87.483,
+maxAnisotropy: 17,
+});
+let arrayBuffer14 = buffer48.getMappedRange(0, 9444);
+try {
+renderBundleEncoder87.setVertexBuffer(98, undefined, 110944318);
+} catch {}
+let gpuCanvasContext30 = offscreenCanvas35.getContext('webgpu');
+let offscreenCanvas36 = new OffscreenCanvas(346, 803);
+let imageBitmap35 = await createImageBitmap(imageData31);
+let commandEncoder108 = device5.createCommandEncoder({label: '\u7241\ub3eb\u{1f817}\u08c1\u063f\u{1ff5e}\ub70e\u{1fed8}\uf075\u0c1d'});
+let texture131 = device5.createTexture({
+label: '\ud487\u08d5\u2285\u8e96\u09e0',
+size: {width: 1248},
+dimension: '1d',
+format: 'rg32float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rg32float'],
+});
+let computePassEncoder70 = commandEncoder108.beginComputePass({});
+let promise49 = navigator.gpu.requestAdapter({
+});
+let imageData34 = new ImageData(16, 64);
+let videoFrame32 = new VideoFrame(video2, {timestamp: 0});
+let canvas37 = document.createElement('canvas');
+let gpuCanvasContext31 = canvas37.getContext('webgpu');
+let img33 = await imageWithData(156, 283, '#3a202db3', '#b225f877');
+let commandEncoder109 = device8.createCommandEncoder({});
+let texture132 = device8.createTexture({
+label: '\u010a\u029e\u{1fd71}\u0f2f\u323e\u0834\ub054\u62f4\u9b89',
+size: {width: 320, height: 24, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'r8snorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8snorm', 'r8snorm'],
+});
+try {
+renderBundleEncoder92.setVertexBuffer(22, undefined, 1724164326, 2202998771);
+} catch {}
+let texture133 = device6.createTexture({
+label: '\u781a\ucedb\ue4dd',
+size: {width: 140},
+dimension: '1d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView121 = texture133.createView({format: 'rgba8uint'});
+let renderBundleEncoder94 = device6.createRenderBundleEncoder({
+  label: '\u6016\u0a63\u09c5\uc83f\u0c12\u2352',
+  colorFormats: ['r8uint', 'rg16uint', 'r32float', 'rgba8uint', 'rgba16float', 'rgb10a2unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler80 = device6.createSampler({
+label: '\u4d0a\u{1f876}\ud73f\u0a9b\u64c5\uccff\u465c\u048d\u6600\u3e57\ue057',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 3.979,
+lodMaxClamp: 36.812,
+});
+try {
+gpuCanvasContext6.configure({
+device: device6,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['depth32float', 'r32float'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+gc();
+try {
+offscreenCanvas34.getContext('bitmaprenderer');
+} catch {}
+let textureView122 = texture51.createView({
+  label: '\u7ea6\u0847\u32d3\u{1fd9a}\u13b5\u9ab8\u0d64',
+  format: 'astc-4x4-unorm-srgb',
+  baseMipLevel: 1,
+  baseArrayLayer: 159,
+  arrayLayerCount: 8
+});
+try {
+computePassEncoder55.setBindGroup(1, bindGroup7, new Uint32Array(4184), 3952, 0);
+} catch {}
+try {
+renderBundleEncoder59.draw(32, 32, 80);
+} catch {}
+try {
+renderBundleEncoder59.drawIndexed(40);
+} catch {}
+try {
+renderBundleEncoder86.setPipeline(pipeline82);
+} catch {}
+try {
+buffer18.destroy();
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+try {
+commandEncoder88.copyBufferToTexture({
+/* bytesInLastRow: 112 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 23536 */
+offset: 23536,
+buffer: buffer47,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: { x: 4, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 28, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer47);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 48, new DataView(new ArrayBuffer(30751)), 18272, 332);
+} catch {}
+video23.width = 112;
+let commandBuffer21 = commandEncoder109.finish({
+label: '\ucc65\u09f6\u0329\u60ba\ufc70\u86e4\u{1fce6}',
+});
+let renderBundle105 = renderBundleEncoder92.finish({label: '\u421c\u6181\u06fa\u0e4a\u0bc5\udd7d'});
+let sampler81 = device8.createSampler({
+label: '\u0e11\u83cf\ubeab\u5a61\u{1fd81}\u6d46',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 32.612,
+compare: 'greater-equal',
+maxAnisotropy: 4,
+});
+try {
+await device8.queue.onSubmittedWorkDone();
+} catch {}
+let textureView123 = texture133.createView({label: '\u2ab1\u0614'});
+let buffer49 = device1.createBuffer({size: 3265, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let renderBundle106 = renderBundleEncoder14.finish();
+try {
+renderBundleEncoder66.setBindGroup(7, bindGroup4, new Uint32Array(9105), 7242, 0);
+} catch {}
+try {
+commandEncoder97.copyTextureToBuffer({
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 3, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 124 widthInBlocks: 31 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 592 */
+offset: 468,
+bytesPerRow: 256,
+rowsPerImage: 298,
+buffer: buffer39,
+}, {width: 31, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+gpuCanvasContext25.configure({
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float'],
+alphaMode: 'opaque',
+});
+} catch {}
+let pipeline101 = await device1.createComputePipelineAsync({
+label: '\u57da\u{1fc69}\u0a9a\u52db\u46e5\u7a9b\u4b9c\u0201',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let offscreenCanvas37 = new OffscreenCanvas(472, 299);
+try {
+adapter15.label = '\ud5f0\ue49e\u{1fa04}\u7bee\ua597\u{1f761}\u0195\u3808\u{1fe0d}\u6cd7\u0e9f';
+} catch {}
+let adapter23 = await promise49;
+let device9 = await adapter9.requestDevice({
+label: '\u5aa7\u4926\u8141\u085a\u32ed\u{1f70c}\uc8cd\u{1ffe4}\uf193',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 52,
+maxVertexAttributes: 29,
+maxVertexBufferArrayStride: 3582,
+maxStorageTexturesPerShaderStage: 17,
+maxStorageBuffersPerShaderStage: 43,
+maxDynamicStorageBuffersPerPipelineLayout: 45254,
+maxBindingsPerBindGroup: 1047,
+maxTextureDimension1D: 10333,
+maxTextureDimension2D: 12740,
+minStorageBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 78782145,
+maxUniformBuffersPerShaderStage: 19,
+maxInterStageShaderVariables: 30,
+maxInterStageShaderComponents: 65,
+maxSamplersPerShaderStage: 19,
+},
+});
+let commandEncoder110 = device3.createCommandEncoder({label: '\u0ba0\ua1e7\u3e76\u72a5\u0c01\u011a\u7fce\u3638\u61f5\u81e6'});
+let querySet89 = device3.createQuerySet({
+label: '\u{1fda9}\u1361\u{1fe57}\u{1f629}',
+type: 'occlusion',
+count: 3368,
+});
+try {
+renderBundleEncoder54.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder62.setVertexBuffer(3, buffer29, 3676, 538);
+} catch {}
+try {
+commandEncoder110.resolveQuerySet(querySet33, 861, 616, buffer33, 5632);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer37, 17808, new Int16Array(7572));
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture120,
+  mipLevel: 1,
+  origin: { x: 3, y: 3, z: 1 },
+  aspect: 'all',
+}, new DataView(arrayBuffer2), /* required buffer size: 285 */
+{offset: 285, bytesPerRow: 295}, {width: 5, height: 57, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder111 = device8.createCommandEncoder({label: '\u431b\u02a6\u{1fe34}\u5477\u8c04\u2d68\u701a\u85b9\u040c'});
+pseudoSubmit(device8, commandEncoder111);
+let texture134 = device8.createTexture({
+label: '\uc144\u4f8e\u07cb\u7e80\u08dd',
+size: [320, 24, 1],
+mipLevelCount: 6,
+format: 'etc2-rgb8a1unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8a1unorm'],
+});
+let textureView124 = texture132.createView({label: '\u{1f767}\u{1f983}\u6524\u{1fb4a}\u9544\u{1f7a6}\u6ee6', baseMipLevel: 3, mipLevelCount: 2});
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas37.getContext('webgl');
+} catch {}
+let renderBundleEncoder95 = device6.createRenderBundleEncoder({
+  label: '\u0f1d\udd97\uc340\u0ed4\u{1fb01}',
+  colorFormats: ['r8uint', 'rg16uint', 'r32float', 'rgba8uint', 'rgba16float', 'rgb10a2unorm'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder95.insertDebugMarker('\u869c');
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture133,
+  mipLevel: 0,
+  origin: { x: 78, y: 1, z: 1 },
+  aspect: 'all',
+}, arrayBuffer12, /* required buffer size: 357 */
+{offset: 357}, {width: 59, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas38 = new OffscreenCanvas(459, 88);
+let videoFrame33 = new VideoFrame(videoFrame28, {timestamp: 0});
+let buffer50 = device7.createBuffer({size: 54781, usage: GPUBufferUsage.INDEX});
+let commandEncoder112 = device7.createCommandEncoder({label: '\u{1f7e0}\u06c4\u7ba5\ue13c\u{1fa57}\uf70a'});
+let renderBundleEncoder96 = device7.createRenderBundleEncoder({
+  label: '\ufd5a\ud629\u5289\u02a9\u0876',
+  colorFormats: ['rgba16sint', 'rgba32sint', 'rgba32sint', 'rg16float', 'r16uint', undefined]
+});
+try {
+gpuCanvasContext31.configure({
+device: device7,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm', 'bgra8unorm', 'depth24plus-stencil8'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageData35 = new ImageData(76, 228);
+let gpuCanvasContext32 = offscreenCanvas33.getContext('webgpu');
+canvas3.width = 415;
+let img34 = await imageWithData(86, 265, '#b0c1807e', '#42beed73');
+let commandEncoder113 = device6.createCommandEncoder();
+let renderBundleEncoder97 = device6.createRenderBundleEncoder({
+  label: '\u{1fb46}\uef9c',
+  colorFormats: ['r8uint', 'rg16uint', 'r32float', 'rgba8uint', 'rgba16float', 'rgb10a2unorm'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder94.setVertexBuffer(44, undefined, 1563203222);
+} catch {}
+pseudoSubmit(device1, commandEncoder83);
+let sampler82 = device1.createSampler({
+label: '\uf868\u10b7\uddd8\ufb69\u2101\u5fa4\u0221\ucf54\u328d',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 63.872,
+lodMaxClamp: 75.938,
+});
+try {
+renderBundleEncoder57.drawIndexed(72);
+} catch {}
+try {
+renderBundleEncoder59.setVertexBuffer(47, undefined, 3919681797, 184618806);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: video14,
+  origin: { x: 1, y: 2 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 22, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas38 = document.createElement('canvas');
+let offscreenCanvas39 = new OffscreenCanvas(913, 886);
+let img35 = await imageWithData(162, 214, '#ef8d5ffa', '#7ef507b3');
+let bindGroupLayout42 = device1.createBindGroupLayout({
+entries: [{
+binding: 2984,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '1d' },
+}, {
+binding: 516,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}],
+});
+let texture135 = device1.createTexture({
+label: '\ufe66\ua339',
+size: {width: 96, height: 4, depthOrArrayLayers: 234},
+mipLevelCount: 3,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['etc2-rgb8unorm', 'etc2-rgb8unorm-srgb'],
+});
+let textureView125 = texture135.createView({dimension: '2d', format: 'etc2-rgb8unorm', mipLevelCount: 1, baseArrayLayer: 68});
+let renderBundleEncoder98 = device1.createRenderBundleEncoder({
+  colorFormats: ['r32float', 'rgb10a2unorm', 'rg16sint', 'r32float'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder59.drawIndexed(16, 80, 8, 448);
+} catch {}
+try {
+commandEncoder107.resolveQuerySet(querySet57, 261, 533, buffer34, 15616);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer39, 37356, new DataView(new ArrayBuffer(25328)));
+} catch {}
+let commandEncoder114 = device8.createCommandEncoder({label: '\u9e7d\u0a04\u0fd8'});
+let renderBundle107 = renderBundleEncoder90.finish({label: '\uc76d\uaccb\u{1f60d}\u068c\u40be'});
+let sampler83 = device8.createSampler({
+label: '\u{1f69d}\uba0a\u2ffc\ubca4',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 74.998,
+maxAnisotropy: 15,
+});
+try {
+gpuCanvasContext29.configure({
+device: device8,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba8sint', 'rgba8unorm'],
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+gc();
+let img36 = await imageWithData(293, 131, '#935bea14', '#fd8c2002');
+let buffer51 = device6.createBuffer({label: '\u7a69\u6e3e\u6c7c\ucdfc\u2d5d', size: 48001, usage: GPUBufferUsage.COPY_SRC});
+let querySet90 = device9.createQuerySet({
+label: '\u50cf\ucc9c\u7bba',
+type: 'occlusion',
+count: 1815,
+});
+let renderBundleEncoder99 = device9.createRenderBundleEncoder({
+  label: '\u0d0d\u769b\u{1f71a}\u1959\u0dc7\udfec\u05c6\u52a9',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2unorm', 'rg32float', 'rgba8unorm', 'r8uint', 'rgba8unorm-srgb', 'rg8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle108 = renderBundleEncoder99.finish();
+let sampler84 = device9.createSampler({
+label: '\u9d30\u{1fdde}\ub546\u{1fad5}\u0e06\u{1f99c}\u0393',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 50.227,
+lodMaxClamp: 85.156,
+compare: 'greater',
+});
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+let video33 = await videoWithData();
+let renderBundle109 = renderBundleEncoder77.finish({label: '\ud248\uba4f\u057d\uc676\u038a\u9b13\u{1fd73}\u{1f787}\u09ad\u4ec0\u02f6'});
+let sampler85 = device1.createSampler({
+label: '\u0561\u2b8c\udb7d\u{1fd27}\u05dc\u94b8',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 99.716,
+lodMaxClamp: 99.840,
+});
+try {
+renderBundleEncoder25.setVertexBuffer(78, undefined, 1091144514, 1322593844);
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let videoFrame34 = new VideoFrame(img13, {timestamp: 0});
+let sampler86 = device1.createSampler({
+label: '\u5a74\u6e2a\u45de\u095f\u5f2e\u{1f8b1}\uee8b\u4a10\u3ec8\u2c29\u{1fa26}',
+addressModeU: 'mirror-repeat',
+magFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMaxClamp: 96.214,
+compare: 'not-equal',
+});
+try {
+renderBundleEncoder70.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder59.drawIndexed(24);
+} catch {}
+try {
+computePassEncoder60.pushDebugGroup('\u4cb5');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas10,
+  origin: { x: 171, y: 464 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 10, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 14, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video14);
+let buffer52 = device3.createBuffer({
+  label: '\u{1fb6e}\u0020\u0d61\u018b\u0354\u03f6\ub5b5\u292f\u0ee3\u071c',
+  size: 39369,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: false
+});
+let texture136 = device3.createTexture({
+label: '\u8be0\u9637\u372d\ud88e\u0696\uac06',
+size: [128, 240, 244],
+mipLevelCount: 7,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder51.setBindGroup(0, bindGroup9, new Uint32Array(6862), 4536, 0);
+} catch {}
+try {
+renderBundleEncoder79.setIndexBuffer(buffer35, 'uint16', 6126, 102);
+} catch {}
+try {
+commandEncoder110.copyBufferToBuffer(buffer35, 28928, buffer19, 10712, 2040);
+dissociateBuffer(device3, buffer35);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+commandEncoder110.clearBuffer(buffer37);
+dissociateBuffer(device3, buffer37);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 367 */
+{offset: 367}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline102 = device3.createRenderPipeline({
+layout: pipelineLayout11,
+multisample: {
+mask: 0x282d5a7a,
+},
+fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint'}, undefined, {format: 'r32sint', writeMask: GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: 0}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'src-alpha-saturated'},
+},
+  writeMask: GPUColorWrite.GREEN
+}, {format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rg32uint'}, {
+  format: 'rgb10a2unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 912,
+stencilWriteMask: 3536,
+depthBias: 87,
+depthBiasSlopeScale: 92,
+depthBiasClamp: 90,
+},
+vertex: {
+  module: shaderModule14,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 5988,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x3',
+offset: 2644,
+shaderLocation: 10,
+}, {
+format: 'float16x2',
+offset: 4768,
+shaderLocation: 25,
+}, {
+format: 'unorm16x2',
+offset: 2544,
+shaderLocation: 3,
+}, {
+format: 'uint8x2',
+offset: 2978,
+shaderLocation: 20,
+}, {
+format: 'snorm8x4',
+offset: 3096,
+shaderLocation: 12,
+}, {
+format: 'float16x2',
+offset: 1228,
+shaderLocation: 14,
+}, {
+format: 'unorm16x2',
+offset: 2344,
+shaderLocation: 18,
+}, {
+format: 'sint8x4',
+offset: 588,
+shaderLocation: 21,
+}, {
+format: 'sint16x2',
+offset: 1296,
+shaderLocation: 24,
+}, {
+format: 'unorm8x4',
+offset: 2508,
+shaderLocation: 17,
+}, {
+format: 'uint16x2',
+offset: 4440,
+shaderLocation: 19,
+}, {
+format: 'float32x2',
+offset: 3904,
+shaderLocation: 8,
+}, {
+format: 'sint16x4',
+offset: 5308,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 13084,
+attributes: [{
+format: 'snorm8x4',
+offset: 9696,
+shaderLocation: 4,
+}, {
+format: 'uint8x4',
+offset: 5796,
+shaderLocation: 9,
+}, {
+format: 'sint32x2',
+offset: 4540,
+shaderLocation: 22,
+}, {
+format: 'sint8x4',
+offset: 5824,
+shaderLocation: 23,
+}, {
+format: 'unorm16x4',
+offset: 11852,
+shaderLocation: 15,
+}, {
+format: 'uint32',
+offset: 1696,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 27420,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 3614,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 5784,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 10716,
+attributes: [{
+format: 'sint32x4',
+offset: 2500,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 14780,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 13408,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x2',
+offset: 10572,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+frontFace: 'cw',
+cullMode: 'back',
+},
+});
+let canvas39 = document.createElement('canvas');
+let sampler87 = device5.createSampler({
+label: '\u1685\u0bac\ufd49',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 23.006,
+});
+try {
+gpuCanvasContext8.configure({
+device: device5,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16float', 'rg8unorm', 'rgba8unorm'],
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let renderBundle110 = renderBundleEncoder92.finish({label: '\u02f1\u{1fc0e}\ufbcc\u{1ffaa}\u{1fffb}\u375a\u0680'});
+let sampler88 = device8.createSampler({
+label: '\ud47a\u0a8b\u021d\u06dd\u09a3\u{1ffa6}\ua78f\uef65',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMaxClamp: 94.311,
+});
+gc();
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandBuffer22 = commandEncoder114.finish({
+label: '\u547c\uc877\u5ea0\u1a1d',
+});
+let textureView126 = texture134.createView({label: '\u{1fd55}\u7c17\u{1fe3f}\u4bbf\u{1fe9a}\u0611\u08a2\uae66', baseMipLevel: 5});
+let sampler89 = device8.createSampler({
+label: '\u096d\uf487\uc2a3\uead6\ud76f\u5488\ube0b\u26c3',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 42.591,
+maxAnisotropy: 15,
+});
+let commandEncoder115 = device6.createCommandEncoder({});
+let computePassEncoder71 = commandEncoder115.beginComputePass({label: '\u0fd9\u348e'});
+let video34 = await videoWithData();
+let textureView127 = texture59.createView({baseMipLevel: 1});
+try {
+computePassEncoder51.setPipeline(pipeline84);
+} catch {}
+try {
+renderBundleEncoder71.setBindGroup(4, bindGroup14);
+} catch {}
+try {
+commandEncoder110.copyBufferToBuffer(buffer29, 68, buffer37, 9592, 1716);
+dissociateBuffer(device3, buffer29);
+dissociateBuffer(device3, buffer37);
+} catch {}
+let device10 = await adapter18.requestDevice({
+label: '\u{1fd44}\uab11\u{1f661}\u03fb',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 45,
+maxVertexAttributes: 27,
+maxVertexBufferArrayStride: 40432,
+maxStorageTexturesPerShaderStage: 18,
+maxStorageBuffersPerShaderStage: 19,
+maxDynamicStorageBuffersPerPipelineLayout: 12639,
+maxBindingsPerBindGroup: 7151,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 10393,
+maxTextureDimension2D: 12458,
+maxVertexBuffers: 12,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 156446444,
+maxUniformBuffersPerShaderStage: 38,
+maxInterStageShaderVariables: 85,
+maxInterStageShaderComponents: 90,
+},
+});
+try {
+gpuCanvasContext8.configure({
+device: device10,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+});
+} catch {}
+let device11 = await adapter13.requestDevice({
+label: '\u03d4\u752c\uc20d\u{1fc2b}',
+requiredFeatures: [
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 9,
+maxColorAttachmentBytesPerSample: 37,
+maxVertexAttributes: 27,
+maxVertexBufferArrayStride: 35717,
+maxStorageTexturesPerShaderStage: 8,
+maxStorageBuffersPerShaderStage: 23,
+maxDynamicStorageBuffersPerPipelineLayout: 9293,
+maxBindingsPerBindGroup: 6970,
+maxTextureDimension1D: 12367,
+maxTextureDimension2D: 16359,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 162668265,
+maxUniformBuffersPerShaderStage: 34,
+maxInterStageShaderVariables: 114,
+maxInterStageShaderComponents: 105,
+},
+});
+let offscreenCanvas40 = new OffscreenCanvas(403, 114);
+let imageBitmap36 = await createImageBitmap(imageBitmap15);
+let commandEncoder116 = device9.createCommandEncoder();
+let renderBundleEncoder100 = device9.createRenderBundleEncoder({
+  label: '\u0220\u{1fb89}\u0ef9\u0983\u0e24\ub5db',
+  colorFormats: ['r16float', 'r8sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+let renderBundle111 = renderBundleEncoder100.finish();
+let textureView128 = texture133.createView({label: '\u5ada\u020d\u4446\u8b9d\u0281\u2cf5\u0dbb\u023e'});
+let renderBundle112 = renderBundleEncoder93.finish({label: '\u472f\ue862'});
+try {
+computePassEncoder71.insertDebugMarker('\ufaf7');
+} catch {}
+let pipelineLayout22 = device3.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout27, bindGroupLayout22, bindGroupLayout32, bindGroupLayout32, bindGroupLayout34, bindGroupLayout32]
+});
+let querySet91 = device3.createQuerySet({
+label: '\udd90\u5e30\ufe1b\u06c5\u{1fbd1}\u{1f95c}\u055f',
+type: 'occlusion',
+count: 3589,
+});
+try {
+computePassEncoder53.setBindGroup(8, bindGroup14, new Uint32Array(5458), 36, 0);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer40, 5212, new DataView(new ArrayBuffer(7341)), 5803, 1256);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 0, y: 24, z: 1 },
+  aspect: 'all',
+}, new Int16Array(arrayBuffer8), /* required buffer size: 707 */
+{offset: 707, bytesPerRow: 292, rowsPerImage: 195}, {width: 20, height: 64, depthOrArrayLayers: 0});
+} catch {}
+let promise50 = navigator.gpu.requestAdapter();
+let commandEncoder117 = device10.createCommandEncoder();
+let computePassEncoder72 = commandEncoder117.beginComputePass();
+try {
+await adapter19.requestAdapterInfo();
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let texture137 = device6.createTexture({
+size: {width: 140, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['bgra8unorm-srgb'],
+});
+let renderBundleEncoder101 = device6.createRenderBundleEncoder({
+  label: '\u0dd3\u0746\u09a2',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler90 = device6.createSampler({
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 38.530,
+lodMaxClamp: 39.529,
+});
+try {
+gpuCanvasContext23.configure({
+device: device6,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba8unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroupLayout43 = device11.createBindGroupLayout({
+label: '\u2e0b\ue339\ua58d\u8f30\u817c\u0db6\u54d1\u0d71\u0de0',
+entries: [{
+binding: 4677,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}, {
+binding: 772,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 5512,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '1d' },
+}],
+});
+let texture138 = device10.createTexture({
+size: [240, 80, 254],
+mipLevelCount: 3,
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x8-unorm-srgb'],
+});
+let renderBundleEncoder102 = device10.createRenderBundleEncoder({
+  label: '\u6a4d\u06b5\u{1f713}\u0dde\u29d1\u123d\u5f29\u3e34\u853c',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle113 = renderBundleEncoder102.finish();
+try {
+texture138.destroy();
+} catch {}
+try {
+await device10.queue.onSubmittedWorkDone();
+} catch {}
+let video35 = await videoWithData();
+try {
+canvas36.getContext('webgpu');
+} catch {}
+let imageBitmap37 = await createImageBitmap(videoFrame6);
+try {
+device9.queue.label = '\u{1fa50}\u{1fc06}\u{1f9d6}\u1652\u1349\u0a0c\u5580\ub6fa\ue5d9\u{1fa4e}';
+} catch {}
+let texture139 = device9.createTexture({
+label: '\u0ce6\u996f\ua25b\u{1fcc8}\ufd44\u8470\u431b\u{1ff43}',
+size: {width: 1633, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16uint'],
+});
+let textureView129 = texture139.createView({dimension: '2d-array', baseMipLevel: 1});
+let renderBundle114 = renderBundleEncoder99.finish({});
+try {
+gpuCanvasContext32.unconfigure();
+} catch {}
+document.body.prepend(canvas8);
+let querySet92 = device7.createQuerySet({
+label: '\ud61f\u0c81',
+type: 'occlusion',
+count: 2298,
+});
+let renderBundleEncoder103 = device7.createRenderBundleEncoder({
+  label: '\u0837\u{1fb9d}\u5daa\u7905\ue800\u0f8e\u7edf',
+  colorFormats: ['rgba16sint', 'rgba32sint', 'rgba32sint', 'rg16float', 'r16uint', undefined]
+});
+let renderBundle115 = renderBundleEncoder96.finish({label: '\u79e5\u401a\u{1f94b}\uc022\u576e\u2032\ued60\ue756\u0388\u0313'});
+try {
+buffer48.unmap();
+} catch {}
+let textureView130 = texture130.createView({
+  label: '\u32ec\u0a02',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 130,
+  arrayLayerCount: 43
+});
+let renderBundle116 = renderBundleEncoder103.finish({label: '\u{1fd95}\u59e3'});
+let promise51 = device7.queue.onSubmittedWorkDone();
+let promise52 = navigator.gpu.requestAdapter({
+});
+let texture140 = device1.createTexture({
+label: '\ud957\u4c18\ufd73\u007b\u0866\u{1f768}',
+size: [140, 10, 161],
+mipLevelCount: 7,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+renderBundleEncoder37.draw(64, 16);
+} catch {}
+try {
+renderBundleEncoder59.setIndexBuffer(buffer18, 'uint32', 7276, 46066);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+try {
+commandEncoder97.copyBufferToBuffer(buffer49, 904, buffer39, 25748, 1676);
+dissociateBuffer(device1, buffer49);
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+commandEncoder107.clearBuffer(buffer21);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap27,
+  origin: { x: 412, y: 131 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 10, y: 2, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 33, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline103 = await device1.createComputePipelineAsync({
+label: '\u0261\u{1f865}\u{1f6a7}\u1967\u{1f957}\u02b9\u0e31\u{1fc47}\uc6c6\u751d\u5cae',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let videoFrame35 = new VideoFrame(video23, {timestamp: 0});
+let renderBundleEncoder104 = device5.createRenderBundleEncoder({
+  label: '\u7e0f\u{1fbfa}\u686f\uadd1\u33f5\u{1fa5b}\u{1fea1}\u05cc',
+  colorFormats: ['rg32float', 'r8sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+try {
+computePassEncoder66.setBindGroup(2, bindGroup21);
+} catch {}
+let promise53 = buffer48.mapAsync(GPUMapMode.READ, 3768, 4568);
+let gpuCanvasContext33 = offscreenCanvas40.getContext('webgpu');
+let gpuCanvasContext34 = offscreenCanvas39.getContext('webgpu');
+offscreenCanvas35.width = 407;
+let bindGroup24 = device5.createBindGroup({
+layout: bindGroupLayout39,
+entries: [],
+});
+let commandEncoder118 = device5.createCommandEncoder({label: '\u05c5\u0e5c\u9607\u5786\u{1f8fd}\u022f\u0235\u{1f665}\u01fa\u{1fcab}'});
+let texture141 = device5.createTexture({
+label: '\u1266\uc0d5\u4176',
+size: {width: 1248},
+dimension: '1d',
+format: 'rgba16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float'],
+});
+let sampler91 = device5.createSampler({
+label: '\u811c\u0257\u060e\u{1fe08}\u{1f6c8}\u{1fff8}\u65ab',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 32.059,
+lodMaxClamp: 77.499,
+compare: 'greater-equal',
+});
+let bindGroupLayout44 = device5.createBindGroupLayout({
+label: '\u{1fd3e}\u{1f7be}\u293e\ue651\u{1fd71}\u{1f70b}',
+entries: [{
+binding: 180,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}, {
+binding: 101,
+visibility: 0,
+storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '2d' },
+}, {
+binding: 251,
+visibility: 0,
+sampler: { type: 'comparison' },
+}],
+});
+let renderBundleEncoder105 = device5.createRenderBundleEncoder({
+  label: '\uee4e\u{1f8d1}\u0a3f\ube54\udfeb\ue9c1\u{1facc}\u{1f6d6}\uddff\u036b',
+  colorFormats: ['r32float', 'r8sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle117 = renderBundleEncoder84.finish({});
+let promise54 = device5.queue.onSubmittedWorkDone();
+try {
+  await promise53;
+} catch {}
+let gpuCanvasContext35 = canvas38.getContext('webgpu');
+try {
+  await promise54;
+} catch {}
+let img37 = await imageWithData(271, 183, '#a54da85f', '#54bbe7fc');
+let bindGroupLayout45 = device1.createBindGroupLayout({
+label: '\u0858\udb5e',
+entries: [{
+binding: 3389,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '1d' },
+}, {
+binding: 1057,
+visibility: 0,
+buffer: { type: 'uniform', minBindingSize: 859088, hasDynamicOffset: false },
+}, {
+binding: 2074,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+}],
+});
+let pipelineLayout23 = device1.createPipelineLayout({
+  label: '\u0f25\u0f60\u253e\u047a\u0dcc\u1421\u28a8\u02c6\uf7e7\u{1fa49}',
+  bindGroupLayouts: [bindGroupLayout11, bindGroupLayout21, bindGroupLayout6, bindGroupLayout45, bindGroupLayout2, bindGroupLayout2, bindGroupLayout25, bindGroupLayout6]
+});
+let buffer53 = device1.createBuffer({
+  label: '\u5d60\u4a46\u381e\u{1ff5d}\u04d2\u0a70\u04f1\u{1fe00}\u{1facb}',
+  size: 9228,
+  usage: GPUBufferUsage.STORAGE,
+  mappedAtCreation: false
+});
+let texture142 = device1.createTexture({
+label: '\u5ae8\u0fd0',
+size: [108, 768, 1],
+mipLevelCount: 5,
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.COPY_DST,
+});
+let textureView131 = texture140.createView({label: '\u0b48\uea70\u6ad1', baseMipLevel: 4, mipLevelCount: 2, baseArrayLayer: 39, arrayLayerCount: 29});
+try {
+renderBundleEncoder37.draw(24, 24, 80, 48);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer43, 'uint16');
+} catch {}
+let promise55 = buffer49.mapAsync(GPUMapMode.WRITE, 0, 3088);
+try {
+commandEncoder88.resolveQuerySet(querySet32, 983, 1000, buffer34, 5120);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture88,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer14, /* required buffer size: 613 */
+{offset: 613, bytesPerRow: 162}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline104 = device1.createRenderPipeline({
+label: '\ud9da\u{1fce6}\u9b12\u1853\u{1fdb6}',
+layout: pipelineLayout8,
+multisample: {
+count: 4,
+mask: 0xd2b430f7,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'r32uint', writeMask: 0}, {format: 'rg8sint', writeMask: 0}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'constant', dstFactor: 'one-minus-src'},
+alpha: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-constant'},
+},
+  writeMask: 0
+}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32sint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 256,
+stencilWriteMask: 1953,
+depthBiasSlopeScale: 52,
+depthBiasClamp: 61,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x2',
+offset: 30340,
+shaderLocation: 15,
+}, {
+format: 'unorm8x2',
+offset: 30388,
+shaderLocation: 6,
+}, {
+format: 'float32x4',
+offset: 9668,
+shaderLocation: 20,
+}, {
+format: 'sint8x2',
+offset: 12728,
+shaderLocation: 16,
+}, {
+format: 'uint32',
+offset: 24940,
+shaderLocation: 14,
+}, {
+format: 'sint16x4',
+offset: 12200,
+shaderLocation: 13,
+}, {
+format: 'snorm8x2',
+offset: 13692,
+shaderLocation: 1,
+}, {
+format: 'float32x2',
+offset: 18284,
+shaderLocation: 8,
+}, {
+format: 'uint16x2',
+offset: 21548,
+shaderLocation: 10,
+}, {
+format: 'uint32x4',
+offset: 456,
+shaderLocation: 22,
+}, {
+format: 'snorm8x2',
+offset: 16040,
+shaderLocation: 0,
+}, {
+format: 'float32x2',
+offset: 26220,
+shaderLocation: 7,
+}, {
+format: 'uint8x4',
+offset: 5736,
+shaderLocation: 24,
+}, {
+format: 'uint8x4',
+offset: 4060,
+shaderLocation: 12,
+}, {
+format: 'sint8x2',
+offset: 15996,
+shaderLocation: 5,
+}, {
+format: 'uint32x4',
+offset: 23492,
+shaderLocation: 26,
+}, {
+format: 'snorm8x2',
+offset: 32996,
+shaderLocation: 2,
+}, {
+format: 'sint16x2',
+offset: 22116,
+shaderLocation: 25,
+}],
+},
+{
+arrayStride: 16604,
+attributes: [{
+format: 'uint32x4',
+offset: 844,
+shaderLocation: 17,
+}, {
+format: 'unorm8x2',
+offset: 13168,
+shaderLocation: 4,
+}, {
+format: 'unorm16x4',
+offset: 2984,
+shaderLocation: 21,
+}],
+}
+]
+},
+});
+let buffer54 = device3.createBuffer({
+  label: '\uafc1\u0285\u733a\u3883\u1bcb\u{1f83a}',
+  size: 11482,
+  usage: GPUBufferUsage.VERTEX,
+  mappedAtCreation: false
+});
+try {
+renderBundleEncoder82.setBindGroup(5, bindGroup15, new Uint32Array(2014), 405, 0);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST,
+colorSpace: 'display-p3',
+});
+} catch {}
+let offscreenCanvas41 = new OffscreenCanvas(154, 947);
+let shaderModule19 = device1.createShaderModule({
+code: `@group(0) @binding(542)
+var<storage, read_write> parameter16: array<u32>;
+@group(8) @binding(1723)
+var<storage, read_write> parameter17: array<u32>;
+@group(5) @binding(1300)
+var<storage, read_write> global12: array<u32>;
+@group(10) @binding(3399)
+var<storage, read_write> function7: array<u32>;
+@group(10) @binding(3240)
+var<storage, read_write> local16: array<u32>;
+@group(6) @binding(3399)
+var<storage, read_write> type22: array<u32>;
+@group(5) @binding(704)
+var<storage, read_write> parameter18: array<u32>;
+@group(9) @binding(1145)
+var<storage, read_write> parameter19: array<u32>;
+@group(1) @binding(3524)
+var<storage, read_write> parameter20: array<u32>;
+@group(4) @binding(704)
+var<storage, read_write> global13: array<u32>;
+@group(7) @binding(542)
+var<storage, read_write> local17: array<u32>;
+@group(10) @binding(1145)
+var<storage, read_write> local18: array<u32>;
+@group(9) @binding(3399)
+var<storage, read_write> type23: array<u32>;
+@group(6) @binding(3240)
+var<storage, read_write> function8: array<u32>;
+
+@compute @workgroup_size(1, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S25 {
+  @location(24) f0: vec4<i32>,
+  @location(31) f1: vec2<i32>,
+  @location(38) f2: vec4<f32>,
+  @location(29) f3: vec2<f32>,
+  @location(28) f4: vec2<f16>,
+  @location(2) f5: vec3<f32>,
+  @location(6) f6: f32,
+  @location(18) f7: vec4<i32>,
+  @builtin(sample_index) f8: u32,
+  @location(1) f9: vec4<f16>,
+  @location(45) f10: i32,
+  @location(3) f11: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @location(1) f1: vec4<i32>,
+  @location(2) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(16) a0: vec3<u32>, @location(40) a1: vec4<u32>, @location(4) a2: vec4<f32>, @location(33) a3: u32, @location(36) a4: vec2<u32>, @location(30) a5: vec3<f16>, a6: S25, @location(13) a7: vec3<i32>, @location(7) a8: vec2<i32>, @location(5) a9: i32, @builtin(position) a10: vec4<f32>, @builtin(front_facing) a11: bool, @builtin(sample_mask) a12: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S24 {
+  @location(7) f0: vec4<i32>,
+  @location(3) f1: vec4<u32>,
+  @location(22) f2: f32,
+  @location(21) f3: f32,
+  @location(13) f4: vec3<f16>,
+  @builtin(vertex_index) f5: u32,
+  @builtin(instance_index) f6: u32,
+  @location(26) f7: vec4<f32>,
+  @location(5) f8: vec2<f16>,
+  @location(4) f9: vec4<i32>,
+  @location(20) f10: vec3<u32>,
+  @location(1) f11: vec3<i32>,
+  @location(15) f12: f16
+}
+struct VertexOutput0 {
+  @location(24) f420: vec4<i32>,
+  @location(3) f421: vec4<f32>,
+  @location(13) f422: vec3<i32>,
+  @location(33) f423: u32,
+  @location(36) f424: vec2<u32>,
+  @builtin(position) f425: vec4<f32>,
+  @location(28) f426: vec2<f16>,
+  @location(29) f427: vec2<f32>,
+  @location(31) f428: vec2<i32>,
+  @location(6) f429: f32,
+  @location(4) f430: vec4<f32>,
+  @location(30) f431: vec3<f16>,
+  @location(2) f432: vec3<f32>,
+  @location(16) f433: vec3<u32>,
+  @location(1) f434: vec4<f16>,
+  @location(5) f435: i32,
+  @location(7) f436: vec2<i32>,
+  @location(18) f437: vec4<i32>,
+  @location(45) f438: i32,
+  @location(40) f439: vec4<u32>,
+  @location(38) f440: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(25) a0: vec3<u32>, @location(11) a1: vec2<u32>, @location(24) a2: vec3<i32>, @location(10) a3: i32, @location(19) a4: f32, @location(18) a5: vec4<i32>, @location(9) a6: vec4<f16>, @location(2) a7: vec4<f16>, @location(16) a8: vec4<i32>, @location(17) a9: vec3<i32>, @location(23) a10: i32, @location(0) a11: i32, @location(12) a12: f16, @location(6) a13: f16, @location(8) a14: vec4<u32>, @location(14) a15: vec2<u32>, a16: S24) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+});
+let bindGroupLayout46 = device1.createBindGroupLayout({
+label: '\ub81d\uddf2\u4428\u0d03\u77ab\u3593\uf3fa\u{1f64c}',
+entries: [],
+});
+let querySet93 = device1.createQuerySet({
+label: '\u{1ff67}\u{1fb07}\u{1fb3f}\u6d36',
+type: 'occlusion',
+count: 1067,
+});
+let textureView132 = texture142.createView({label: '\u0923\u84b9\udb3a\u{1fbe1}', dimension: '2d-array', baseMipLevel: 1});
+try {
+renderBundleEncoder57.draw(8, 64);
+} catch {}
+try {
+commandEncoder97.copyBufferToBuffer(buffer36, 364, buffer20, 580, 132);
+dissociateBuffer(device1, buffer36);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame29,
+  origin: { x: 0, y: 50 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 39, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let imageData36 = new ImageData(192, 64);
+let videoFrame36 = new VideoFrame(offscreenCanvas23, {timestamp: 0});
+let texture143 = device1.createTexture({
+label: '\u02d8\u8b85\u5a9d\u0fc6\u0e86\u{1f7af}\uadb7',
+size: {width: 384, height: 5, depthOrArrayLayers: 1},
+format: 'astc-6x5-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+renderBundleEncoder57.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+commandEncoder88.copyBufferToBuffer(buffer20, 776, buffer8, 1176, 476);
+dissociateBuffer(device1, buffer20);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder97.clearBuffer(buffer27);
+dissociateBuffer(device1, buffer27);
+} catch {}
+let imageData37 = new ImageData(148, 104);
+let gpuCanvasContext36 = offscreenCanvas38.getContext('webgpu');
+gc();
+let videoFrame37 = new VideoFrame(img2, {timestamp: 0});
+let commandEncoder119 = device11.createCommandEncoder({label: '\u096a\u0db9'});
+let texture144 = device11.createTexture({
+label: '\u00c6\u35e2\u08e6\ucec2\u047d\u00f7\ufdb8\uf938',
+size: [1024],
+dimension: '1d',
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['r32sint', 'r32sint'],
+});
+let computePassEncoder73 = commandEncoder119.beginComputePass({label: '\u{1fd76}\u4448\u655f\u0fca\u433c\ue0fc\u0be6'});
+let promise56 = device11.queue.onSubmittedWorkDone();
+try {
+  await promise51;
+} catch {}
+let shaderModule20 = device3.createShaderModule({
+label: '\u737c\u{1fc0d}\ub5b6\u0fee\u2847\ucee0\u{1f62c}\u08aa\u985f\u{1fee3}',
+code: `@group(4) @binding(6976)
+var<storage, read_write> i12: array<u32>;
+@group(8) @binding(7747)
+var<storage, read_write> i13: array<u32>;
+@group(8) @binding(2070)
+var<storage, read_write> i14: array<u32>;
+@group(6) @binding(2662)
+var<storage, read_write> local19: array<u32>;
+
+@compute @workgroup_size(2, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(frag_depth) f0: f32,
+  @location(2) f1: vec4<u32>,
+  @location(7) f2: vec2<u32>,
+  @location(0) f3: vec2<f32>,
+  @location(3) f4: vec2<f32>,
+  @location(5) f5: vec4<u32>,
+  @location(1) f6: vec4<u32>,
+  @location(4) f7: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S26 {
+  @location(4) f0: vec3<u32>,
+  @builtin(instance_index) f1: u32,
+  @location(5) f2: i32,
+  @location(8) f3: vec4<f16>,
+  @location(9) f4: f32,
+  @builtin(vertex_index) f5: u32,
+  @location(13) f6: vec3<i32>,
+  @location(10) f7: u32,
+  @location(21) f8: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(16) a0: vec4<u32>, @location(3) a1: f16, @location(20) a2: vec4<u32>, a3: S26, @location(7) a4: vec2<f32>, @location(19) a5: u32, @location(0) a6: vec2<f32>, @location(24) a7: vec4<u32>, @location(12) a8: vec2<f16>, @location(6) a9: vec4<i32>, @location(11) a10: vec4<i32>, @location(18) a11: vec3<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+});
+let texture145 = device3.createTexture({
+label: '\u9cd4\u01e8\u09e9\u01ba\ud450\u7cd1\u0167\u{1fc83}',
+size: [60, 240, 1],
+mipLevelCount: 7,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+computePassEncoder52.insertDebugMarker('\u{1f95e}');
+} catch {}
+try {
+  await promise55;
+} catch {}
+let bindGroup25 = device3.createBindGroup({
+label: '\u0d27\u{1f9d6}\ue6d4\u2e93\u0466\u{1fcde}\u022c\u0e92\uf73f',
+layout: bindGroupLayout38,
+entries: [],
+});
+try {
+renderBundleEncoder82.setBindGroup(4, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder79.setVertexBuffer(0, buffer44, 47164, 2774);
+} catch {}
+try {
+commandEncoder51.clearBuffer(buffer37);
+dissociateBuffer(device3, buffer37);
+} catch {}
+try {
+gpuCanvasContext25.configure({
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['bgra8unorm', 'rgba8unorm'],
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device3.queue.writeBuffer(buffer37, 5204, new Float32Array(1085));
+} catch {}
+let textureView133 = texture61.createView({
+  label: '\u51b2\u315a\u{1fab2}\u0570\u{1f932}\ub4bd\u04bc\uca82\u0d55\u58d4',
+  dimension: '2d',
+  baseMipLevel: 3,
+  mipLevelCount: 4,
+  baseArrayLayer: 8
+});
+let renderBundle118 = renderBundleEncoder40.finish({label: '\u81d7\ufc57\u3a18'});
+try {
+computePassEncoder52.setBindGroup(3, bindGroup25, new Uint32Array(3709), 2522, 0);
+} catch {}
+try {
+commandEncoder68.copyBufferToTexture({
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 30036 */
+offset: 30036,
+bytesPerRow: 256,
+buffer: buffer35,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder98.clearBuffer(buffer40, 6708, 8768);
+dissociateBuffer(device3, buffer40);
+} catch {}
+try {
+commandEncoder101.resolveQuerySet(querySet42, 3006, 133, buffer41, 4096);
+} catch {}
+pseudoSubmit(device11, commandEncoder119);
+let texture146 = device11.createTexture({
+label: '\u0891\u0f95\u0dbb',
+size: [1024],
+dimension: '1d',
+format: 'rg32float',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rg32float'],
+});
+let sampler92 = device3.createSampler({
+label: '\ufaac\u263b',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 97.040,
+maxAnisotropy: 5,
+});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup9, new Uint32Array(1915), 1736, 0);
+} catch {}
+let pipeline105 = device3.createComputePipeline({
+layout: pipelineLayout16,
+compute: {
+module: shaderModule20,
+entryPoint: 'compute0',
+},
+});
+let texture147 = device11.createTexture({
+label: '\u8bcc\ua6e6\u0b25\u0f5c\ud9f5\u1468\u08c3\ue7b4',
+size: [1024, 1, 1],
+mipLevelCount: 2,
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [],
+});
+let sampler93 = device11.createSampler({
+label: '\u{1fe8a}\u1fc8\u{1ffeb}\uf274\ua289\u9d25\u2561',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+lodMinClamp: 40.847,
+lodMaxClamp: 96.817,
+});
+let imageBitmap38 = await createImageBitmap(video18);
+let buffer55 = device8.createBuffer({
+  label: '\u0b09\ue76a\u83c5\u{1f793}\u1452\u1a6e\u{1fd76}\u6665\u3e41',
+  size: 16070,
+  usage: GPUBufferUsage.INDIRECT
+});
+let commandEncoder120 = device8.createCommandEncoder({label: '\u{1ff7e}\u0e18\uf73c\u22ce\u0c72'});
+let commandBuffer23 = commandEncoder120.finish({
+});
+let renderBundleEncoder106 = device8.createRenderBundleEncoder({label: '\u2dc3\u0289', colorFormats: ['rg16sint'], sampleCount: 4, depthReadOnly: true});
+let renderBundle119 = renderBundleEncoder90.finish({});
+let sampler94 = device8.createSampler({
+label: '\u871d\u{1fe70}\ufa5c',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 47.488,
+lodMaxClamp: 68.235,
+});
+try {
+renderBundleEncoder106.setVertexBuffer(67, undefined);
+} catch {}
+canvas7.width = 126;
+let renderBundleEncoder107 = device3.createRenderBundleEncoder({
+  label: '\u07c9\u097b\u{1fd97}\u06bc\ub125\u6fbf\u234c\ua2a1\uce10\ub5b8\uf3e0',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+try {
+computePassEncoder24.setBindGroup(6, bindGroup18, new Uint32Array(9793), 9737, 0);
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline94);
+} catch {}
+try {
+commandEncoder110.copyBufferToBuffer(buffer35, 33764, buffer37, 24332, 16396);
+dissociateBuffer(device3, buffer35);
+dissociateBuffer(device3, buffer37);
+} catch {}
+try {
+commandEncoder110.resolveQuerySet(querySet38, 1136, 569, buffer33, 17152);
+} catch {}
+let promise57 = device3.createComputePipelineAsync({
+label: '\u{1ff31}\ubeae\u{1fe7b}\u66cb\ub9aa\u7a92\u0631',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+offscreenCanvas36.getContext('bitmaprenderer');
+} catch {}
+pseudoSubmit(device1, commandEncoder102);
+let texture148 = device1.createTexture({
+label: '\ue719\u2f5c\u530e\u04f2\u{1fe98}\u099a\u{1f627}\u0b2c\u0960\u06e6\u54ce',
+size: [384, 5, 1275],
+dimension: '3d',
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler95 = device1.createSampler({
+label: '\u{1ff5f}\u1d58\ucb16\u9d34\u08af\u0717\u0b5e\u0074\ue469',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 95.181,
+lodMaxClamp: 99.136,
+});
+try {
+renderBundleEncoder59.draw(0, 56);
+} catch {}
+try {
+renderBundleEncoder59.setPipeline(pipeline82);
+} catch {}
+try {
+commandEncoder107.copyBufferToBuffer(buffer36, 5120, buffer27, 15848, 1116);
+dissociateBuffer(device1, buffer36);
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+commandEncoder107.copyTextureToTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 92, y: 328, z: 61 },
+  aspect: 'all',
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: { x: 16, y: 4, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 308, depthOrArrayLayers: 108});
+} catch {}
+try {
+commandEncoder107.clearBuffer(buffer8, 9508, 92);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder97.resolveQuerySet(querySet86, 790, 1800, buffer34, 3072);
+} catch {}
+try {
+computePassEncoder60.popDebugGroup();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture96,
+  mipLevel: 7,
+  origin: { x: 4, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer13, /* required buffer size: 390 */
+{offset: 390}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline106 = device1.createComputePipeline({
+layout: pipelineLayout15,
+compute: {
+module: shaderModule18,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+gpuCanvasContext28.unconfigure();
+} catch {}
+pseudoSubmit(device7, commandEncoder112);
+let texture149 = device7.createTexture({
+size: [240, 24, 1],
+mipLevelCount: 8,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-8x8-unorm'],
+});
+try {
+buffer48.unmap();
+} catch {}
+let canvas40 = document.createElement('canvas');
+try {
+  await promise56;
+} catch {}
+let device12 = await adapter19.requestDevice({
+label: '\u{1fc86}\uc104\ua33b',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxColorAttachmentBytesPerSample: 36,
+maxVertexAttributes: 21,
+maxVertexBufferArrayStride: 50053,
+maxStorageTexturesPerShaderStage: 36,
+maxStorageBuffersPerShaderStage: 36,
+maxDynamicStorageBuffersPerPipelineLayout: 63758,
+maxBindingsPerBindGroup: 3448,
+maxTextureDimension1D: 8424,
+maxTextureDimension2D: 15232,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 75117908,
+maxUniformBuffersPerShaderStage: 21,
+maxInterStageShaderVariables: 122,
+maxInterStageShaderComponents: 95,
+maxSamplersPerShaderStage: 19,
+},
+});
+let commandEncoder121 = device9.createCommandEncoder({label: '\u{1fe66}\ud0ab\u{1fea5}\u0297\u{1f8ea}'});
+let computePassEncoder74 = commandEncoder121.beginComputePass({label: '\ub788\u284f\u1ec8\u0b18'});
+let renderBundle120 = renderBundleEncoder99.finish({label: '\ufbdc\u015a\u{1fa93}\u{1f982}\u{1fc26}\udba6\u{1fd03}\u1aaf\udce8\ub28f'});
+let videoFrame38 = new VideoFrame(imageBitmap2, {timestamp: 0});
+let pipelineLayout24 = device11.createPipelineLayout({
+  label: '\u100f\u4b95\u9ed2\ufd2f\u00e1\u{1fa15}\u{1fbd0}\u02b2\u038e\u0cab\u4bdb',
+  bindGroupLayouts: [bindGroupLayout43, bindGroupLayout43, bindGroupLayout43, bindGroupLayout43, bindGroupLayout43, bindGroupLayout43, bindGroupLayout43, bindGroupLayout43]
+});
+let texture150 = device11.createTexture({
+label: '\u{1fc9a}\ua3cf\u{1fa76}\u{1f8c4}\u771a\ud932\u05fa\u3335',
+size: {width: 2550, height: 8, depthOrArrayLayers: 1},
+mipLevelCount: 9,
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-10x8-unorm-srgb'],
+});
+try {
+gpuCanvasContext34.configure({
+device: device11,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba32float', 'rgba16float'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let promise58 = device11.queue.onSubmittedWorkDone();
+let commandEncoder122 = device8.createCommandEncoder({});
+let querySet94 = device8.createQuerySet({
+label: '\u{1fc5f}\u2aa0',
+type: 'occlusion',
+count: 3158,
+});
+let externalTexture10 = device8.importExternalTexture({
+source: video13,
+colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder96.label = '\u0510\u6c09\u0663\u0441\u0ff5\u{1fee1}\u0638';
+} catch {}
+let textureView134 = texture130.createView({
+  label: '\u{1ff45}\u00e2\u{1f7f4}\uad4a\u00bc',
+  format: 'bgra8unorm-srgb',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 22,
+  arrayLayerCount: 138
+});
+let sampler96 = device7.createSampler({
+label: '\ud062\u0241\ua8ab\u0580\u0263',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 2.324,
+lodMaxClamp: 70.782,
+});
+try {
+texture130.destroy();
+} catch {}
+try {
+device7.queue.writeBuffer(buffer48, 4444, new Float32Array(58009), 30704, 980);
+} catch {}
+gc();
+try {
+  await promise58;
+} catch {}
+let commandEncoder123 = device12.createCommandEncoder();
+let sampler97 = device12.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 6.922,
+lodMaxClamp: 99.044,
+maxAnisotropy: 15,
+});
+let promise59 = adapter9.requestAdapterInfo();
+let commandEncoder124 = device10.createCommandEncoder({label: '\u{1fcce}\u094e\u76cd\u5db8\u0258\u0bca\ucf01\u0604\u{1fc3f}\u74bb'});
+let renderBundleEncoder108 = device10.createRenderBundleEncoder({
+  label: '\ua26c\ua884\u{1fc8a}\u8485\u{1ff68}',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+try {
+renderBundleEncoder108.setVertexBuffer(97, undefined);
+} catch {}
+let gpuCanvasContext37 = canvas34.getContext('webgpu');
+let commandEncoder125 = device12.createCommandEncoder({label: '\u22b2\uaa8b'});
+let texture151 = device12.createTexture({
+label: '\u518d\u25be\u0c07\u0765\u8f38\ub829\u6713',
+size: [176, 112, 1],
+mipLevelCount: 4,
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['eac-r11snorm'],
+});
+let shaderModule21 = device11.createShaderModule({
+label: '\u0dae\u71ce\u4f7f\u5e76\u035a\u7493\ua6e7\u5fc0\u{1fa00}\u029b',
+code: `@group(2) @binding(4677)
+var<storage, read_write> type24: array<u32>;
+@group(5) @binding(4677)
+var<storage, read_write> parameter21: array<u32>;
+@group(3) @binding(5512)
+var<storage, read_write> global14: array<u32>;
+@group(1) @binding(772)
+var<storage, read_write> parameter22: array<u32>;
+@group(4) @binding(772)
+var<storage, read_write> type25: array<u32>;
+@group(6) @binding(5512)
+var<storage, read_write> i15: array<u32>;
+@group(3) @binding(4677)
+var<storage, read_write> global15: array<u32>;
+@group(3) @binding(772)
+var<storage, read_write> parameter23: array<u32>;
+@group(5) @binding(5512)
+var<storage, read_write> local20: array<u32>;
+@group(7) @binding(4677)
+var<storage, read_write> local21: array<u32>;
+@group(4) @binding(4677)
+var<storage, read_write> local22: array<u32>;
+@group(7) @binding(772)
+var<storage, read_write> type26: array<u32>;
+@group(5) @binding(772)
+var<storage, read_write> local23: array<u32>;
+@group(0) @binding(772)
+var<storage, read_write> i16: array<u32>;
+@group(2) @binding(772)
+var<storage, read_write> type27: array<u32>;
+@group(7) @binding(5512)
+var<storage, read_write> parameter24: array<u32>;
+@group(1) @binding(4677)
+var<storage, read_write> local24: array<u32>;
+@group(6) @binding(772)
+var<storage, read_write> function9: array<u32>;
+@group(0) @binding(4677)
+var<storage, read_write> global16: array<u32>;
+@group(0) @binding(5512)
+var<storage, read_write> i17: array<u32>;
+
+@compute @workgroup_size(6, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S28 {
+  @location(30) f0: vec2<u32>,
+  @location(10) f1: vec2<f32>,
+  @location(77) f2: vec2<f16>,
+  @location(66) f3: vec3<i32>,
+  @location(76) f4: vec3<i32>,
+  @location(39) f5: vec2<f16>,
+  @location(22) f6: vec4<f16>,
+  @location(19) f7: vec3<u32>,
+  @location(32) f8: i32,
+  @location(101) f9: f32,
+  @location(27) f10: u32,
+  @location(82) f11: vec3<u32>,
+  @location(8) f12: vec3<f16>,
+  @location(20) f13: vec4<i32>,
+  @location(54) f14: vec2<f16>,
+  @location(69) f15: f16,
+  @builtin(front_facing) f16: bool,
+  @location(111) f17: vec2<f32>,
+  @location(49) f18: i32,
+  @location(97) f19: vec4<f32>,
+  @builtin(position) f20: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec3<u32>,
+  @location(7) f1: vec3<u32>,
+  @location(2) f2: vec4<u32>,
+  @location(0) f3: i32,
+  @location(5) f4: f32,
+  @location(3) f5: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(68) a0: vec4<f16>, @location(55) a1: vec4<u32>, @location(35) a2: vec2<u32>, @location(107) a3: f32, @location(40) a4: f16, @location(4) a5: vec2<i32>, @location(87) a6: vec4<u32>, @location(45) a7: i32, @location(89) a8: f16, @location(5) a9: vec4<f32>, @location(53) a10: u32, @location(88) a11: vec3<i32>, @location(104) a12: i32, @location(99) a13: vec3<f16>, @location(84) a14: vec3<u32>, @location(75) a15: vec3<f16>, @location(37) a16: vec4<f32>, @location(0) a17: f32, @location(92) a18: vec2<f16>, @location(94) a19: i32, @location(93) a20: i32, @location(33) a21: vec4<u32>, @location(65) a22: vec2<f16>, @location(23) a23: vec2<f32>, @builtin(sample_index) a24: u32, @location(110) a25: f16, @location(15) a26: vec2<i32>, @location(62) a27: vec3<i32>, a28: S28, @builtin(sample_mask) a29: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S27 {
+  @location(0) f0: f16,
+  @location(21) f1: vec3<f32>,
+  @location(4) f2: vec2<f16>,
+  @location(7) f3: vec2<i32>,
+  @location(5) f4: vec2<f32>,
+  @location(8) f5: vec2<u32>,
+  @location(22) f6: f16,
+  @location(2) f7: vec2<u32>,
+  @location(1) f8: i32,
+  @location(19) f9: f16,
+  @location(15) f10: vec2<i32>,
+  @location(13) f11: vec4<f16>
+}
+struct VertexOutput0 {
+  @location(65) f441: vec2<f16>,
+  @location(104) f442: i32,
+  @location(22) f443: vec4<f16>,
+  @location(111) f444: vec2<f32>,
+  @location(20) f445: vec4<i32>,
+  @location(87) f446: vec4<u32>,
+  @location(10) f447: vec2<f32>,
+  @location(45) f448: i32,
+  @location(53) f449: u32,
+  @location(94) f450: i32,
+  @location(89) f451: f16,
+  @location(35) f452: vec2<u32>,
+  @location(30) f453: vec2<u32>,
+  @location(82) f454: vec3<u32>,
+  @location(54) f455: vec2<f16>,
+  @location(23) f456: vec2<f32>,
+  @location(5) f457: vec4<f32>,
+  @location(15) f458: vec2<i32>,
+  @builtin(position) f459: vec4<f32>,
+  @location(0) f460: f32,
+  @location(37) f461: vec4<f32>,
+  @location(4) f462: vec2<i32>,
+  @location(62) f463: vec3<i32>,
+  @location(88) f464: vec3<i32>,
+  @location(49) f465: i32,
+  @location(97) f466: vec4<f32>,
+  @location(32) f467: i32,
+  @location(19) f468: vec3<u32>,
+  @location(39) f469: vec2<f16>,
+  @location(55) f470: vec4<u32>,
+  @location(101) f471: f32,
+  @location(75) f472: vec3<f16>,
+  @location(68) f473: vec4<f16>,
+  @location(76) f474: vec3<i32>,
+  @location(27) f475: u32,
+  @location(69) f476: f16,
+  @location(110) f477: f16,
+  @location(93) f478: i32,
+  @location(40) f479: f16,
+  @location(84) f480: vec3<u32>,
+  @location(8) f481: vec3<f16>,
+  @location(92) f482: vec2<f16>,
+  @location(33) f483: vec4<u32>,
+  @location(77) f484: vec2<f16>,
+  @location(107) f485: f32,
+  @location(66) f486: vec3<i32>,
+  @location(99) f487: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(24) a0: vec3<f32>, @location(17) a1: vec4<f16>, @builtin(vertex_index) a2: u32, @location(16) a3: i32, @location(10) a4: vec2<f32>, @location(9) a5: vec2<f32>, @location(14) a6: f32, @builtin(instance_index) a7: u32, @location(23) a8: vec4<f16>, @location(20) a9: vec4<f16>, @location(26) a10: vec4<u32>, @location(6) a11: vec2<u32>, a12: S27, @location(12) a13: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let textureView135 = texture146.createView({label: '\u3df1\u1e0d\ua087\u3b8f\u07a0\u38a5\u224e'});
+let sampler98 = device11.createSampler({
+addressModeV: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 58.707,
+lodMaxClamp: 78.570,
+});
+let pipeline107 = await device11.createRenderPipelineAsync({
+layout: pipelineLayout24,
+multisample: {
+},
+fragment: {
+  module: shaderModule21,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16sint'}, {format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgb10a2uint'}, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}]
+},
+vertex: {
+  module: shaderModule21,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 19872,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x4',
+offset: 2008,
+shaderLocation: 7,
+}, {
+format: 'float32x3',
+offset: 15372,
+shaderLocation: 21,
+}, {
+format: 'float32x2',
+offset: 15508,
+shaderLocation: 13,
+}, {
+format: 'unorm8x2',
+offset: 17982,
+shaderLocation: 19,
+}, {
+format: 'float32x4',
+offset: 3932,
+shaderLocation: 9,
+}, {
+format: 'unorm8x4',
+offset: 17548,
+shaderLocation: 17,
+}, {
+format: 'unorm10-10-10-2',
+offset: 3800,
+shaderLocation: 5,
+}, {
+format: 'sint16x2',
+offset: 5060,
+shaderLocation: 16,
+}, {
+format: 'float16x4',
+offset: 8768,
+shaderLocation: 4,
+}, {
+format: 'sint32x2',
+offset: 14568,
+shaderLocation: 1,
+}, {
+format: 'float32',
+offset: 5360,
+shaderLocation: 10,
+}, {
+format: 'uint32x3',
+offset: 4332,
+shaderLocation: 2,
+}, {
+format: 'float16x4',
+offset: 8012,
+shaderLocation: 14,
+}, {
+format: 'unorm10-10-10-2',
+offset: 852,
+shaderLocation: 22,
+}, {
+format: 'unorm8x2',
+offset: 3920,
+shaderLocation: 0,
+}, {
+format: 'snorm16x4',
+offset: 11952,
+shaderLocation: 24,
+}, {
+format: 'uint8x4',
+offset: 13104,
+shaderLocation: 26,
+}, {
+format: 'sint8x4',
+offset: 7928,
+shaderLocation: 15,
+}, {
+format: 'snorm8x4',
+offset: 6244,
+shaderLocation: 20,
+}, {
+format: 'float16x4',
+offset: 1744,
+shaderLocation: 12,
+}, {
+format: 'snorm16x4',
+offset: 7316,
+shaderLocation: 23,
+}, {
+format: 'uint8x2',
+offset: 11242,
+shaderLocation: 8,
+}, {
+format: 'uint16x2',
+offset: 5248,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+unclippedDepth: true,
+},
+});
+let texture152 = device6.createTexture({
+label: '\u8c43\u0abd\u8cc7\u0e5d',
+size: {width: 280},
+dimension: '1d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8snorm', 'r8snorm'],
+});
+let computePassEncoder75 = commandEncoder113.beginComputePass({label: '\u{1f6fc}\uad87\u0f33\u4f31\u06d7\uc586\u0aa6\u0ea4'});
+let renderBundle121 = renderBundleEncoder87.finish();
+try {
+device6.queue.writeTexture({
+  texture: texture133,
+  mipLevel: 0,
+  origin: { x: 8, y: 1, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 780 */
+{offset: 780}, {width: 108, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 4, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas24,
+  origin: { x: 133, y: 562 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 5,
+  origin: { x: 3, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+shaderModule17.label = '\u{1f856}\ue10d\u0482\u0252\uf528\u384d';
+} catch {}
+let buffer56 = device1.createBuffer({label: '\u1bd1\u665a', size: 57613, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC});
+let querySet95 = device1.createQuerySet({
+label: '\u{1f9cc}\ud38a',
+type: 'occlusion',
+count: 369,
+});
+pseudoSubmit(device1, commandEncoder72);
+let sampler99 = device1.createSampler({
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'linear',
+lodMinClamp: 66.301,
+lodMaxClamp: 72.350,
+});
+try {
+computePassEncoder64.setPipeline(pipeline77);
+} catch {}
+try {
+renderBundleEncoder66.setIndexBuffer(buffer32, 'uint32', 3944, 7267);
+} catch {}
+try {
+commandEncoder107.copyBufferToTexture({
+/* bytesInLastRow: 256 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 37584 */
+offset: 37584,
+bytesPerRow: 256,
+buffer: buffer56,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 55, y: 75, z: 1 },
+  aspect: 'all',
+}, {width: 80, height: 15, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer56);
+} catch {}
+try {
+commandEncoder97.resolveQuerySet(querySet81, 3446, 0, buffer34, 14336);
+} catch {}
+try {
+  await promise59;
+} catch {}
+let commandEncoder126 = device12.createCommandEncoder({label: '\ue8d2\u9f43\u0ad7\u4aca\u093b\u8e0d\u{1f9a0}\u{1fa9d}\u{1fb62}\ua5bc'});
+let gpuCanvasContext38 = canvas40.getContext('webgpu');
+try {
+offscreenCanvas41.getContext('bitmaprenderer');
+} catch {}
+let bindGroupLayout47 = device11.createBindGroupLayout({
+label: '\u5c1a\u{1f6b1}\u6035\u{1f94f}\u{1f621}\ue76a\u{1fd3c}',
+entries: [],
+});
+try {
+device11.queue.writeTexture({
+  texture: texture144,
+  mipLevel: 0,
+  origin: { x: 110, y: 1, z: 0 },
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer1), /* required buffer size: 296 */
+{offset: 296, bytesPerRow: 2091}, {width: 460, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise60 = device11.queue.onSubmittedWorkDone();
+try {
+  await promise60;
+} catch {}
+let imageData38 = new ImageData(220, 248);
+let querySet96 = device7.createQuerySet({
+label: '\u06bc\u269e\u{1f989}\ue4ac\u122f\u{1fa9c}\u0c65\u2f4d',
+type: 'occlusion',
+count: 3076,
+});
+try {
+canvas39.getContext('2d');
+} catch {}
+let computePassEncoder76 = commandEncoder116.beginComputePass({label: '\u{1f8a4}\u0d34\u0350\u8967\ub530\ud0f1\u0173\uae49\u03df\u{1f64c}\u{1fd59}'});
+let renderBundle122 = renderBundleEncoder99.finish({});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageBitmap39 = await createImageBitmap(canvas34);
+pseudoSubmit(device6, commandEncoder113);
+let texture153 = device6.createTexture({
+label: '\ufc18\u0ebc\u0ccd\u{1fb17}',
+size: [1035, 1, 1],
+mipLevelCount: 11,
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rg8uint', 'rg8uint'],
+});
+let renderBundleEncoder109 = device6.createRenderBundleEncoder({
+  label: '\u495c\u4547\u2320\ue474\u0574\u{1feb0}\u0551\ub801\ue600\u2e82',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 17, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas30,
+  origin: { x: 265, y: 71 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 9, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let renderBundle123 = renderBundleEncoder100.finish();
+try {
+gpuCanvasContext10.configure({
+device: device9,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let texture154 = device1.createTexture({
+label: '\u8e01\ua642\u01fc\u08b7\u0f98\u6d43\u013c\u{1faf9}\uad8e\uc003',
+size: [7740, 10, 1],
+mipLevelCount: 5,
+sampleCount: 1,
+dimension: '2d',
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x10-unorm', 'astc-12x10-unorm-srgb'],
+});
+let textureView136 = texture143.createView({label: '\u0a37\u0f8f\uefe3\ud18f\u066b\u0b25\u0cb8\u453f\u138d\u09f9\u5a79'});
+let renderBundle124 = renderBundleEncoder18.finish({label: '\u079d\u0722\u5f8d'});
+try {
+  await buffer27.mapAsync(GPUMapMode.READ, 19544, 336);
+} catch {}
+try {
+commandEncoder107.copyBufferToBuffer(buffer47, 7736, buffer39, 53120, 9820);
+dissociateBuffer(device1, buffer47);
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+commandEncoder97.copyBufferToTexture({
+/* bytesInLastRow: 108 widthInBlocks: 27 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 23388 */
+offset: 23388,
+bytesPerRow: 256,
+buffer: buffer56,
+}, {
+  texture: texture45,
+  mipLevel: 1,
+  origin: { x: 14, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 27, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer56);
+} catch {}
+try {
+commandEncoder88.copyTextureToBuffer({
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 23, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 504 */
+offset: 504,
+bytesPerRow: 256,
+buffer: buffer8,
+}, {width: 2, height: 2, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder107.resolveQuerySet(querySet82, 102, 0, buffer34, 8448);
+} catch {}
+let pipeline108 = await device1.createRenderPipelineAsync({
+label: '\u0624\u0925\u0af4\u0071\ubfcc\u03c1\ueebe\u030e',
+layout: pipelineLayout7,
+multisample: {
+},
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32float'}, {
+  format: 'r16float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r16uint', writeMask: 0}, {format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r8uint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'invert',
+depthFailOp: 'keep',
+passOp: 'increment-clamp',
+},
+stencilWriteMask: 3076,
+depthBiasSlopeScale: 58,
+depthBiasClamp: 68,
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x2',
+offset: 29832,
+shaderLocation: 22,
+}, {
+format: 'uint32x3',
+offset: 21664,
+shaderLocation: 21,
+}, {
+format: 'unorm10-10-10-2',
+offset: 20020,
+shaderLocation: 17,
+}, {
+format: 'sint16x2',
+offset: 15460,
+shaderLocation: 25,
+}, {
+format: 'unorm16x4',
+offset: 23324,
+shaderLocation: 8,
+}, {
+format: 'snorm16x2',
+offset: 1768,
+shaderLocation: 12,
+}, {
+format: 'float32x4',
+offset: 1420,
+shaderLocation: 16,
+}, {
+format: 'unorm16x2',
+offset: 33584,
+shaderLocation: 20,
+}, {
+format: 'float32x4',
+offset: 11788,
+shaderLocation: 4,
+}, {
+format: 'snorm8x2',
+offset: 6796,
+shaderLocation: 5,
+}, {
+format: 'snorm16x2',
+offset: 10320,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 5548,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 4812,
+shaderLocation: 14,
+}, {
+format: 'uint16x2',
+offset: 3876,
+shaderLocation: 3,
+}, {
+format: 'sint16x2',
+offset: 5192,
+shaderLocation: 23,
+}, {
+format: 'sint8x4',
+offset: 868,
+shaderLocation: 0,
+}, {
+format: 'unorm16x2',
+offset: 3948,
+shaderLocation: 1,
+}, {
+format: 'float16x2',
+offset: 5308,
+shaderLocation: 26,
+}, {
+format: 'sint16x2',
+offset: 3948,
+shaderLocation: 18,
+}, {
+format: 'uint16x4',
+offset: 692,
+shaderLocation: 15,
+}, {
+format: 'uint32x2',
+offset: 1572,
+shaderLocation: 2,
+}, {
+format: 'unorm10-10-10-2',
+offset: 1904,
+shaderLocation: 10,
+}, {
+format: 'sint32x4',
+offset: 236,
+shaderLocation: 24,
+}, {
+format: 'uint32',
+offset: 3672,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 6392,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 3696,
+shaderLocation: 13,
+}, {
+format: 'float32x3',
+offset: 6040,
+shaderLocation: 19,
+}, {
+format: 'sint32',
+offset: 480,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 27100,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1196,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 30836,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 15096,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 19668,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 4600,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 6036,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 2832,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let img38 = await imageWithData(271, 277, '#5f6b48c0', '#961a98c1');
+let textureView137 = texture151.createView({label: '\u6c89\u53d0\u0d14\ucd19\u0cdb\u1ec4\uab68\u0cf2\u06e8', baseMipLevel: 2});
+try {
+gpuCanvasContext23.unconfigure();
+} catch {}
+let adapter24 = await promise52;
+let renderBundleEncoder110 = device1.createRenderBundleEncoder({
+  label: '\u0f52\u{1ff61}\u0833\u09f9\u{1f6d6}\u0596\u8f21\u{1f626}\u28d4\u022c',
+  colorFormats: ['rg8sint', 'r16uint', 'r32sint', 'rg16sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let sampler100 = device1.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 12.945,
+lodMaxClamp: 52.841,
+});
+try {
+renderBundleEncoder59.draw(72, 24, 24, 32);
+} catch {}
+try {
+renderBundleEncoder59.drawIndexed(72, 80, 8, 768);
+} catch {}
+try {
+commandEncoder97.copyBufferToBuffer(buffer56, 17748, buffer30, 14516, 14084);
+dissociateBuffer(device1, buffer56);
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+commandEncoder107.clearBuffer(buffer39);
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+commandEncoder88.resolveQuerySet(querySet43, 3213, 172, buffer34, 8704);
+} catch {}
+let commandEncoder127 = device10.createCommandEncoder();
+let texture155 = device10.createTexture({
+label: '\uc589\ua16b\u{1f65f}\u7ec3\u03cc',
+size: {width: 120, height: 40, depthOrArrayLayers: 254},
+mipLevelCount: 2,
+format: 'astc-5x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-5x4-unorm-srgb', 'astc-5x4-unorm', 'astc-5x4-unorm'],
+});
+let renderBundle125 = renderBundleEncoder102.finish({});
+let sampler101 = device10.createSampler({
+label: '\u{1fbdf}\u{1fa0f}\u0216\uc965\u0eed\u0481\u2747',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 37.039,
+lodMaxClamp: 50.901,
+});
+try {
+renderBundleEncoder108.insertDebugMarker('\u098b');
+} catch {}
+try {
+gpuCanvasContext37.unconfigure();
+} catch {}
+let adapter25 = await navigator.gpu.requestAdapter();
+let computePassEncoder77 = commandEncoder118.beginComputePass({});
+try {
+computePassEncoder66.pushDebugGroup('\u04e3');
+} catch {}
+try {
+device5.queue.writeTexture({
+  texture: texture131,
+  mipLevel: 0,
+  origin: { x: 319, y: 0, z: 1 },
+  aspect: 'all',
+}, new Uint16Array(new ArrayBuffer(32)), /* required buffer size: 86 */
+{offset: 86, bytesPerRow: 7422, rowsPerImage: 143}, {width: 901, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture156 = device6.createTexture({
+label: '\u5eab\u0d3b\u0a8f\u{1f6ca}\u017a\u5193\u{1f727}\u6d48\u04be',
+size: [640, 480, 1],
+mipLevelCount: 8,
+sampleCount: 1,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth32float', 'depth32float'],
+});
+try {
+renderBundleEncoder94.pushDebugGroup('\u9b40');
+} catch {}
+let imageData39 = new ImageData(236, 176);
+pseudoSubmit(device10, commandEncoder127);
+let renderBundleEncoder111 = device10.createRenderBundleEncoder({
+  label: '\u{1f814}\u9bc9\u{1ff9a}\u9d94\u463d\ub938\u6f85\u68cc',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle126 = renderBundleEncoder108.finish({});
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let promise61 = navigator.gpu.requestAdapter();
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend(video20);
+let sampler102 = device9.createSampler({
+label: '\u3273\u4bcf',
+addressModeU: 'repeat',
+addressModeW: 'mirror-repeat',
+lodMinClamp: 78.127,
+lodMaxClamp: 85.277,
+});
+let textureView138 = texture132.createView({
+  label: '\u154b\u0104\u0dec\u3953\u640b\u8a5b\ua08f\u2a29\ub74b\u55d2\u{1f935}',
+  dimension: '2d-array',
+  baseMipLevel: 5
+});
+try {
+renderBundleEncoder106.setVertexBuffer(5, undefined, 1278777758, 3011786311);
+} catch {}
+try {
+commandEncoder122.copyTextureToTexture({
+  texture: texture134,
+  mipLevel: 2,
+  origin: { x: 32, y: 4, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture134,
+  mipLevel: 5,
+  origin: { x: 4, y: 4, z: 1 },
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device8.queue.writeTexture({
+  texture: texture134,
+  mipLevel: 3,
+  origin: { x: 12, y: 0, z: 0 },
+  aspect: 'all',
+}, new Int8Array(arrayBuffer3), /* required buffer size: 44 */
+{offset: 44, rowsPerImage: 109}, {width: 24, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let texture157 = device3.createTexture({
+label: '\u6c88\udb03\uc708\u{1f6e4}\u0989\u{1fa5c}\u022d',
+size: {width: 2048, height: 24, depthOrArrayLayers: 1},
+mipLevelCount: 11,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder112 = device3.createRenderBundleEncoder({
+  label: '\u7173\u{1f9a2}\u{1ff5c}\u{1f96d}\u33c9\ub80c\u{1fb4b}\u50a1',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'r32sint', 'bgra8unorm-srgb'],
+  stencilReadOnly: false
+});
+let renderBundle127 = renderBundleEncoder56.finish({});
+let sampler103 = device3.createSampler({
+label: '\u1c78\ue178\u6eb9\u0e00\u{1fd46}\u094e\u{1fe1b}\u2c13\u5b4b\u0695',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 6.486,
+lodMaxClamp: 93.868,
+compare: 'not-equal',
+});
+try {
+renderBundleEncoder82.setIndexBuffer(buffer35, 'uint32');
+} catch {}
+let imageData40 = new ImageData(92, 28);
+let bindGroup26 = device11.createBindGroup({
+layout: bindGroupLayout47,
+entries: [],
+});
+let texture158 = gpuCanvasContext29.getCurrentTexture();
+gc();
+let canvas41 = document.createElement('canvas');
+try {
+device6.queue.writeTexture({
+  texture: texture153,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 98 */
+{offset: 98}, {width: 32, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise62 = adapter12.requestAdapterInfo();
+let commandEncoder128 = device10.createCommandEncoder({label: '\u0d20\u4136\uda18\ud3e3\uf924\u15f5\u{1fe7e}\u6c75\u0ff7\u4de1\u0d72'});
+let querySet97 = device10.createQuerySet({
+label: '\u0cfb\u9664\u53de\u9021\u{1fc67}\u0ba5\u426a\u9f17\u97be\u537b\u6bd3',
+type: 'occlusion',
+count: 3091,
+});
+let renderBundleEncoder113 = device10.createRenderBundleEncoder({
+  label: '\u7132\u{1fd6d}\u2322\u5fbb\u00e2\u4df7\u1578',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let commandEncoder129 = device11.createCommandEncoder();
+let renderBundleEncoder114 = device11.createRenderBundleEncoder({
+  colorFormats: ['r16sint', 'rg16uint', 'rgb10a2uint', 'rg32float'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler104 = device11.createSampler({
+label: '\u90f8\u{1fe85}\u{1f6e6}\u3463\u7947\u{1f9ff}\u{1f895}\u04ca',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMaxClamp: 95.743,
+});
+let textureView139 = texture75.createView({format: 'rg11b10ufloat'});
+let renderBundle128 = renderBundleEncoder48.finish({});
+try {
+pipeline70.label = '\u{1fc00}\u{1f6e4}\u{1f707}\u4035\u0188\u5040\u2033';
+} catch {}
+let bindGroup27 = device3.createBindGroup({
+layout: bindGroupLayout34,
+entries: [],
+});
+let computePassEncoder78 = commandEncoder98.beginComputePass({label: '\uf9d7\u589c\u02a9\u{1f785}\u{1f9e9}\u5477\u2d0a'});
+let renderBundleEncoder115 = device3.createRenderBundleEncoder({
+  label: '\u0cb9\ub8c2\u0f10\ufc70\ub072\uc679\uce21\u{1fe69}',
+  colorFormats: ['r16uint', 'rg16uint'],
+  sampleCount: 1,
+  stencilReadOnly: true
+});
+try {
+commandEncoder68.copyTextureToBuffer({
+  texture: texture44,
+  mipLevel: 0,
+  origin: { x: 641, y: 10, z: 682 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 335 widthInBlocks: 335 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 9300 */
+offset: 9300,
+bytesPerRow: 768,
+buffer: buffer19,
+}, {width: 335, height: 103, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+commandEncoder51.copyTextureToTexture({
+  texture: texture79,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture79,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise63 = device3.createComputePipelineAsync({
+layout: pipelineLayout16,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+canvas41.getContext('webgl');
+} catch {}
+let texture159 = device1.createTexture({
+label: '\u0a67\u0c64\u7293\ue2e7\u9697\u0dc2\u059b\uf5a3\uf795\u0437\u{1fe13}',
+size: {width: 96, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['depth24plus-stencil8'],
+});
+let textureView140 = texture117.createView({});
+try {
+gpuCanvasContext27.unconfigure();
+} catch {}
+let imageBitmap40 = await createImageBitmap(video21);
+let commandEncoder130 = device5.createCommandEncoder({label: '\u{1fe96}\u{1f9ed}\u250e\ub921\u0bbd\u0810\ub16a\ud37b'});
+let querySet98 = device5.createQuerySet({
+type: 'occlusion',
+count: 200,
+});
+let texture160 = device5.createTexture({
+label: '\u20e5\u0f8a\u156f\u2f85',
+size: {width: 624},
+mipLevelCount: 1,
+dimension: '1d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle129 = renderBundleEncoder104.finish();
+let externalTexture11 = device5.importExternalTexture({
+label: '\u146f\u031f\ufa79\ub45f\u5f3d\u059a\u080d\u5dcb',
+source: video15,
+colorSpace: 'display-p3',
+});
+try {
+computePassEncoder66.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+gpuCanvasContext20.configure({
+device: device5,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device5.queue.writeTexture({
+  texture: texture131,
+  mipLevel: 0,
+  origin: { x: 64, y: 1, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(225), /* required buffer size: 225 */
+{offset: 225}, {width: 1165, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device9.queue.label = '\u{1fe06}\uac70\uda41';
+} catch {}
+let texture161 = device9.createTexture({
+label: '\u7fa9\u0adf\u{1f859}\ua67c\u053d\ud073\u89f6\u52a7',
+size: {width: 2000, height: 480, depthOrArrayLayers: 172},
+mipLevelCount: 11,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x6-unorm-srgb', 'astc-8x6-unorm', 'astc-8x6-unorm-srgb'],
+});
+let sampler105 = device9.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 17.774,
+lodMaxClamp: 70.247,
+});
+let videoFrame39 = new VideoFrame(img21, {timestamp: 0});
+let bindGroupLayout48 = device11.createBindGroupLayout({
+entries: [{
+binding: 5789,
+visibility: GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}, {
+binding: 6176,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+}, {
+binding: 2668,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '1d' },
+}],
+});
+let pipelineLayout25 = device11.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout43, bindGroupLayout43, bindGroupLayout47, bindGroupLayout48, bindGroupLayout48, bindGroupLayout47, bindGroupLayout48, bindGroupLayout43]
+});
+let buffer57 = device11.createBuffer({
+  label: '\u0aab\u0926\u03ab\uc00a\uef99\ud7bd\u6148\u9399\u5ff4',
+  size: 14772,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let texture162 = device11.createTexture({
+label: '\ub553\u7432\u{1f6c4}\u{1fab1}\u{1f8db}',
+size: {width: 768, height: 12, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-4x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundle130 = renderBundleEncoder114.finish({label: '\u0d5f\uc3f0\u9a35\u2929\uc0fb\u09a6\u{1ff72}\u{1fd48}\u0034\udc4e\ua14a'});
+let promise64 = buffer57.mapAsync(GPUMapMode.WRITE, 3864, 1400);
+let shaderModule22 = device1.createShaderModule({
+label: '\u00ae\uc388\u0f47\u{1ffcf}',
+code: `@group(0) @binding(1300)
+var<storage, read_write> type28: array<u32>;
+@group(0) @binding(704)
+var<storage, read_write> field12: array<u32>;
+
+@compute @workgroup_size(3, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<i32>,
+  @location(1) f1: vec4<f32>,
+  @location(0) f2: vec2<f32>,
+  @location(3) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(19) a1: vec4<u32>, @location(21) a2: vec4<f16>, @location(4) a3: vec4<f32>, @location(3) a4: i32, @location(1) a5: vec3<f16>, @location(26) a6: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroup28 = device1.createBindGroup({
+label: '\u0fb2\u3a94',
+layout: bindGroupLayout25,
+entries: [],
+});
+let renderBundle131 = renderBundleEncoder98.finish({label: '\uc29e\uad3b\u5f32\ud9e9\u2d12\u035d'});
+let sampler106 = device1.createSampler({
+label: '\u3955\u0941\uf2f9\u{1ffaf}\u{1f7b0}\u{1fef9}\u6b3c\u326a\u0304\u060e',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 77.757,
+lodMaxClamp: 87.011,
+maxAnisotropy: 5,
+});
+try {
+renderBundleEncoder110.setVertexBuffer(6, undefined);
+} catch {}
+try {
+commandEncoder107.clearBuffer(buffer20, 452, 360);
+dissociateBuffer(device1, buffer20);
+} catch {}
+let img39 = await imageWithData(290, 251, '#161cb870', '#d0b8cf33');
+let commandBuffer24 = commandEncoder97.finish({
+label: '\u5a1b\u51ac\u168c\u3aec\u099b\u064a\u4ca3',
+});
+let texture163 = device1.createTexture({
+label: '\u0438\u369b\ubc76\u1d2f\u0bb2\uc5af\u70b0',
+size: {width: 192, height: 8, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+try {
+computePassEncoder67.setBindGroup(10, bindGroup28, new Uint32Array(2276), 1789, 0);
+} catch {}
+try {
+buffer43.destroy();
+} catch {}
+try {
+renderBundleEncoder49.insertDebugMarker('\ua014');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData17,
+  origin: { x: 3, y: 60 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 27, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet99 = device6.createQuerySet({
+type: 'occlusion',
+count: 3799,
+});
+try {
+renderBundleEncoder109.setVertexBuffer(96, undefined, 302323412, 1917246157);
+} catch {}
+let video36 = await videoWithData();
+let imageBitmap41 = await createImageBitmap(img30);
+let commandEncoder131 = device8.createCommandEncoder({label: '\u3db8\ua93d\u9942\u{1f76f}\uec94\ub200\u4782\u28b0\ub10c'});
+let querySet100 = device8.createQuerySet({
+label: '\u{1fbce}\ue255\u025d',
+type: 'occlusion',
+count: 3641,
+});
+let textureView141 = texture134.createView({label: '\u8966\ufbd3', dimension: '2d-array', format: 'etc2-rgb8a1unorm', baseMipLevel: 2, mipLevelCount: 3});
+try {
+device8.queue.writeTexture({
+  texture: texture134,
+  mipLevel: 1,
+  origin: { x: 72, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 1180 */
+{offset: 814, bytesPerRow: 206}, {width: 80, height: 8, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder132 = device7.createCommandEncoder({label: '\u{1f6a1}\u{1f8b9}\u0496\u2314\u{1f78a}\u1b2a\u00d6'});
+let texture164 = device7.createTexture({
+label: '\u01cb\u6cb1',
+size: {width: 1740, height: 131, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rgb9e5ufloat', 'rgb9e5ufloat', 'rgb9e5ufloat'],
+});
+try {
+commandEncoder132.clearBuffer(buffer48);
+dissociateBuffer(device7, buffer48);
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture164,
+  mipLevel: 1,
+  origin: { x: 8, y: 49, z: 0 },
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 59 */
+{offset: 59, bytesPerRow: 3417}, {width: 784, height: 9, depthOrArrayLayers: 0});
+} catch {}
+let video37 = await videoWithData();
+let querySet101 = device1.createQuerySet({
+label: '\u070a\ub292\u11be\ua374\u52df\u{1fffd}',
+type: 'occlusion',
+count: 883,
+});
+let texture165 = device1.createTexture({
+label: '\uaad5\u{1fed2}\uc6be\u0851\u6d95\uf0f6\uf687\u0adf\u0af2\u6a5e',
+size: {width: 108, height: 768, depthOrArrayLayers: 20},
+mipLevelCount: 5,
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let textureView142 = texture28.createView({label: '\u24b1\u5e87\u1299\u0f62\u{1f667}\u{1f8c2}\ucaa1\ud391\u3f2a\uc666'});
+let renderBundle132 = renderBundleEncoder57.finish({label: '\u0019\ufdd7\u5e04\u4dcb\u{1f601}\u{1f928}\ueeca'});
+try {
+computePassEncoder63.setPipeline(pipeline106);
+} catch {}
+try {
+renderBundleEncoder59.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder59.draw(56);
+} catch {}
+try {
+renderBundleEncoder86.drawIndexed(40, 80);
+} catch {}
+try {
+commandEncoder107.copyBufferToBuffer(buffer56, 51280, buffer8, 9516, 1092);
+dissociateBuffer(device1, buffer56);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+renderBundleEncoder54.setIndexBuffer(buffer35, 'uint16', 18560, 7695);
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+try {
+commandEncoder51.copyBufferToBuffer(buffer35, 9544, buffer37, 4056, 9208);
+dissociateBuffer(device3, buffer35);
+dissociateBuffer(device3, buffer37);
+} catch {}
+try {
+commandEncoder110.clearBuffer(buffer24, 4984, 3896);
+dissociateBuffer(device3, buffer24);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let buffer58 = device1.createBuffer({label: '\u557c\u4d13\u0e2b\ud793\u1200', size: 1230, usage: GPUBufferUsage.COPY_SRC});
+let renderBundle133 = renderBundleEncoder85.finish({label: '\u7d5a\u070d\u54ad\u6a32'});
+try {
+computePassEncoder60.setPipeline(pipeline25);
+} catch {}
+try {
+renderBundleEncoder70.setBindGroup(3, bindGroup12, []);
+} catch {}
+try {
+renderBundleEncoder37.drawIndexed(32);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(56, undefined, 1268510883, 1333941604);
+} catch {}
+try {
+commandEncoder107.resolveQuerySet(querySet95, 235, 55, buffer34, 17920);
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer24,
+]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture98,
+  mipLevel: 0,
+  origin: { x: 53, y: 2, z: 0 },
+  aspect: 'all',
+}, arrayBuffer12, /* required buffer size: 948 */
+{offset: 948, bytesPerRow: 28}, {width: 23, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend(video12);
+let adapter26 = await promise50;
+let offscreenCanvas42 = new OffscreenCanvas(281, 167);
+try {
+gpuCanvasContext18.configure({
+device: device9,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth24plus', 'bgra8unorm-srgb', 'bgra8unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let videoFrame40 = new VideoFrame(video3, {timestamp: 0});
+let bindGroup29 = device5.createBindGroup({
+label: '\u74c3\u2eff\u0096\ud4d6\u0ff5\udab2\uc9e0',
+layout: bindGroupLayout39,
+entries: [],
+});
+let texture166 = device5.createTexture({
+label: '\u240a\u519d\u2aef\u89d8\u8c48\u{1f7e2}',
+size: {width: 312, height: 1, depthOrArrayLayers: 244},
+mipLevelCount: 7,
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgb10a2unorm', 'rgb10a2unorm', 'rgb10a2unorm'],
+});
+try {
+  await promise62;
+} catch {}
+let videoFrame41 = new VideoFrame(img36, {timestamp: 0});
+offscreenCanvas28.width = 81;
+let imageData41 = new ImageData(4, 128);
+let videoFrame42 = new VideoFrame(canvas4, {timestamp: 0});
+let texture167 = device9.createTexture({
+label: '\uf2f0\ue08c\ucb5c\uc897\u042b\ucc45',
+size: {width: 11616, height: 160, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+dimension: '2d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r16sint'],
+});
+let renderBundleEncoder116 = device9.createRenderBundleEncoder({
+  label: '\ua3b4\u8def\u5245\ub854\u{1fff8}\u0bf5\u0742\u9b10\u0fae\u0e97\u0092',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2unorm', 'rg32float', 'rgba8unorm', 'r8uint', 'rgba8unorm-srgb', 'rg8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+let texture168 = device5.createTexture({
+label: '\u13fa\u{1f834}\u{1f7eb}\u0ee2\u{1f607}\u64b1\u0e3f\u{1fea0}',
+size: [312],
+dimension: '1d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_SRC,
+});
+let renderBundle134 = renderBundleEncoder89.finish({label: '\u0296\u0b91\u54e6\u18b4\u2763\u0256\u7b2d\u{1fcd9}'});
+try {
+renderBundleEncoder105.setVertexBuffer(74, undefined);
+} catch {}
+let gpuCanvasContext39 = offscreenCanvas42.getContext('webgpu');
+let texture169 = device5.createTexture({
+label: '\u0fa4\u07fe\ua34c\u653b\u7458\u{1fb08}',
+size: {width: 156, height: 1, depthOrArrayLayers: 1011},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8uint'],
+});
+let imageData42 = new ImageData(64, 152);
+let commandEncoder133 = device1.createCommandEncoder({label: '\u{1f9d2}\u2038\ud8bc'});
+try {
+commandEncoder88.clearBuffer(buffer30, 2516, 14700);
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+gpuCanvasContext39.configure({
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm', 'rgba8unorm', 'rgba8unorm-srgb'],
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 36, y: 484, z: 22 },
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(40)), /* required buffer size: 461261 */
+{offset: 718, bytesPerRow: 479, rowsPerImage: 115}, {width: 56, height: 168, depthOrArrayLayers: 9});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame11,
+  origin: { x: 84, y: 9 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 0, y: 2, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 45, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise64;
+} catch {}
+let videoFrame43 = new VideoFrame(videoFrame13, {timestamp: 0});
+pseudoSubmit(device10, commandEncoder117);
+let querySet102 = device3.createQuerySet({
+label: '\u{1fc33}\u3b38\u1aab\udee0\u0d9d\u8fdc',
+type: 'occlusion',
+count: 1402,
+});
+let texture170 = device3.createTexture({
+label: '\ud50e\u07a7\u02ba\u0438\uf1db\u44fa\u{1fb5c}\u1969\ufa0d',
+size: {width: 32, height: 60, depthOrArrayLayers: 179},
+mipLevelCount: 6,
+sampleCount: 1,
+format: 'r32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['r32float'],
+});
+let computePassEncoder79 = commandEncoder101.beginComputePass();
+let sampler107 = device3.createSampler({
+label: '\u{1fb20}\u{1fd1c}\u38af\u7b97\u169c\u0841\u0760\u76e9\ud072\u5c2d\u{1fc30}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 65.666,
+lodMaxClamp: 98.093,
+compare: 'always',
+maxAnisotropy: 1,
+});
+try {
+computePassEncoder68.setBindGroup(6, bindGroup27, new Uint32Array(9939), 125, 0);
+} catch {}
+try {
+commandEncoder51.copyTextureToTexture({
+  texture: texture79,
+  mipLevel: 7,
+  origin: { x: 10, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture79,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder110.resolveQuerySet(querySet29, 1847, 965, buffer33, 14336);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline109 = device3.createComputePipeline({
+layout: pipelineLayout11,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let textureView143 = texture151.createView({label: '\u3edf\u1374\u2461\u0508\ub9ed', dimension: '2d-array', baseMipLevel: 3});
+let renderBundleEncoder117 = device12.createRenderBundleEncoder({
+  label: '\u0e94\u{1fb30}\u{1fc5a}\u7145',
+  colorFormats: ['rg16uint', 'rg16sint'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle135 = renderBundleEncoder117.finish({label: '\u496c\ufb94\u996e'});
+try {
+gpuCanvasContext34.configure({
+device: device12,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['eac-r11snorm', 'etc2-rgb8a1unorm', 'bgra8unorm-srgb', 'rgba8unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+gc();
+let commandEncoder134 = device3.createCommandEncoder({label: '\u4dde\u{1fe56}\u3e03\u6fe5\u67b0\u0a48\u561c\u035c'});
+let renderBundleEncoder118 = device3.createRenderBundleEncoder({label: '\u5a6b\u205e\uf42c\u08e8', colorFormats: ['rg32sint'], stencilReadOnly: true});
+try {
+computePassEncoder78.setPipeline(pipeline109);
+} catch {}
+try {
+renderBundleEncoder107.setVertexBuffer(8, buffer54);
+} catch {}
+let promise65 = buffer37.mapAsync(GPUMapMode.READ, 0, 12056);
+try {
+commandEncoder68.copyTextureToTexture({
+  texture: texture145,
+  mipLevel: 3,
+  origin: { x: 0, y: 25, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture145,
+  mipLevel: 4,
+  origin: { x: 0, y: 5, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder134.resolveQuerySet(querySet74, 2631, 446, buffer41, 3840);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 8, height: 15, depthOrArrayLayers: 179}
+*/
+{
+  source: imageData4,
+  origin: { x: 85, y: 69 },
+  flipY: true,
+}, {
+  texture: texture170,
+  mipLevel: 2,
+  origin: { x: 1, y: 4, z: 40 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder135 = device9.createCommandEncoder({label: '\u1ad1\u826b\u{1fa7a}\u1bbf\ua785'});
+let textureView144 = texture161.createView({
+  label: '\u{1fc46}\uf90f\uc7b8\ua170\u0bf0\uf9e8\u3665\u0112\u0bb4\u7a07',
+  dimension: '2d',
+  baseMipLevel: 7,
+  mipLevelCount: 1,
+  baseArrayLayer: 17
+});
+let renderBundle136 = renderBundleEncoder99.finish({label: '\u0427\u{1fa5f}\u050a\uae36\u3e5e\u7d51\u439c'});
+try {
+renderBundleEncoder116.setVertexBuffer(70, undefined, 3266289223, 687296722);
+} catch {}
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let commandEncoder136 = device1.createCommandEncoder({});
+let sampler108 = device1.createSampler({
+label: '\uaef6\u20ef',
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 95.845,
+lodMaxClamp: 98.352,
+maxAnisotropy: 14,
+});
+try {
+renderBundleEncoder37.drawIndexed(16);
+} catch {}
+try {
+renderBundleEncoder86.setPipeline(pipeline82);
+} catch {}
+try {
+commandEncoder88.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 17672 */
+offset: 17672,
+bytesPerRow: 0,
+buffer: buffer47,
+}, {
+  texture: texture142,
+  mipLevel: 2,
+  origin: { x: 4, y: 16, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 152, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer47);
+} catch {}
+try {
+commandEncoder107.clearBuffer(buffer27);
+dissociateBuffer(device1, buffer27);
+} catch {}
+let promise66 = device1.queue.onSubmittedWorkDone();
+document.body.prepend(img32);
+let textureView145 = texture167.createView({
+  label: '\u3f61\u{1fa85}\u{1f728}\u4dad\u24bb\u4aa2\u4f6f\ubceb\u0d80\u009f\u0b5b',
+  format: 'r16sint',
+  baseMipLevel: 2,
+  mipLevelCount: 3
+});
+let sampler109 = device9.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 79.624,
+lodMaxClamp: 90.200,
+compare: 'less-equal',
+});
+try {
+device9.addEventListener('uncapturederror', e => { log('device9.uncapturederror'); log(e); e.label = device9.label; });
+} catch {}
+offscreenCanvas3.height = 682;
+let imageData43 = new ImageData(184, 32);
+let textureView146 = texture130.createView({label: '\ueb3c\u{1f6d0}\u664a', dimension: '2d', baseMipLevel: 3, baseArrayLayer: 170});
+let computePassEncoder80 = commandEncoder132.beginComputePass({label: '\u{1fa3d}\u0e8a\u{1ffbd}\u3b80\u{1ff07}'});
+try {
+device7.queue.writeTexture({
+  texture: texture128,
+  mipLevel: 2,
+  origin: { x: 21, y: 0, z: 0 },
+  aspect: 'all',
+}, new Float32Array(arrayBuffer14), /* required buffer size: 459280 */
+{offset: 280, bytesPerRow: 300, rowsPerImage: 153}, {width: 8, height: 0, depthOrArrayLayers: 11});
+} catch {}
+let canvas42 = document.createElement('canvas');
+let computePassEncoder81 = commandEncoder88.beginComputePass();
+let renderBundle137 = renderBundleEncoder42.finish({label: '\u0975\u0bfb'});
+try {
+computePassEncoder60.setPipeline(pipeline106);
+} catch {}
+try {
+commandEncoder136.copyTextureToTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 32, y: 468, z: 34 },
+  aspect: 'all',
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: { x: 20, y: 32, z: 49 },
+  aspect: 'all',
+}, {width: 36, height: 276, depthOrArrayLayers: 9});
+} catch {}
+try {
+commandEncoder136.resolveQuerySet(querySet27, 84, 0, buffer34, 512);
+} catch {}
+try {
+renderBundleEncoder94.popDebugGroup();
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture137,
+  mipLevel: 5,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 213 */
+{offset: 205}, {width: 2, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let imageBitmap42 = await createImageBitmap(canvas24);
+try {
+await adapter11.requestAdapterInfo();
+} catch {}
+try {
+canvas42.getContext('webgpu');
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture152,
+  mipLevel: 0,
+  origin: { x: 12, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 384 */
+{offset: 384, rowsPerImage: 234}, {width: 266, height: 1, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas36.height = 901;
+let texture171 = device9.createTexture({
+label: '\u4eca\u{1f725}\u33bf\u0d7e\u{1fe06}\u713e\u{1f77e}\ua19a\u0f9b\u5795\u9551',
+size: {width: 2688, height: 1, depthOrArrayLayers: 63},
+mipLevelCount: 3,
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+});
+let sampler110 = device9.createSampler({
+label: '\u0d62\u06e1\u0c6a',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 18.703,
+lodMaxClamp: 73.505,
+maxAnisotropy: 3,
+});
+try {
+renderBundleEncoder116.setVertexBuffer(6, undefined, 1101574973, 3150808641);
+} catch {}
+let texture172 = device10.createTexture({
+label: '\u467f\u73cd\u9b42\u48ca\u0075',
+size: [180, 204, 1],
+mipLevelCount: 7,
+format: 'astc-12x12-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-12x12-unorm', 'astc-12x12-unorm-srgb', 'astc-12x12-unorm'],
+});
+try {
+await device10.popErrorScope();
+} catch {}
+try {
+gpuCanvasContext32.unconfigure();
+} catch {}
+let offscreenCanvas43 = new OffscreenCanvas(247, 424);
+let video38 = await videoWithData();
+try {
+  await promise65;
+} catch {}
+let sampler111 = device6.createSampler({
+label: '\u{1f7fb}\u{1f63d}\uac37\u27d8\u9829\u4bb8\u04d7\u03ed',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 96.898,
+lodMaxClamp: 99.044,
+});
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 4, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap30,
+  origin: { x: 10, y: 11 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+offscreenCanvas43.getContext('webgpu');
+} catch {}
+let querySet103 = device1.createQuerySet({
+label: '\u{1f9ad}\u0bdd\u{1fef4}',
+type: 'occlusion',
+count: 641,
+});
+let textureView147 = texture30.createView({
+  label: '\udeea\u0d7c\u{1f7dc}\u330c\u764f\u7da1\ua699\u07d4\u6a96\ue983\u99a7',
+  dimension: '2d-array',
+  baseMipLevel: 1
+});
+let renderBundle138 = renderBundleEncoder37.finish({});
+try {
+computePassEncoder55.setPipeline(pipeline101);
+} catch {}
+try {
+renderBundleEncoder59.draw(72, 32, 48, 48);
+} catch {}
+try {
+commandEncoder107.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 1,
+  origin: { x: 3, y: 82, z: 6 },
+  aspect: 'all',
+}, {
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 29, y: 229, z: 30 },
+  aspect: 'all',
+}, {width: 48, height: 302, depthOrArrayLayers: 2});
+} catch {}
+try {
+commandEncoder136.insertDebugMarker('\u09c8');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture163,
+  mipLevel: 1,
+  origin: { x: 8, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 300 */
+{offset: 300, bytesPerRow: 335}, {width: 88, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let pipeline110 = device1.createComputePipeline({
+label: '\u{1fba1}\u954d\u58ae',
+layout: pipelineLayout13,
+compute: {
+module: shaderModule18,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+computePassEncoder48.setPipeline(pipeline98);
+} catch {}
+try {
+renderBundleEncoder76.setBindGroup(0, bindGroup25, []);
+} catch {}
+try {
+computePassEncoder51.insertDebugMarker('\u{1fec2}');
+} catch {}
+try {
+adapter22.label = '\u480c\u0f19\u01d3';
+} catch {}
+let bindGroup30 = device3.createBindGroup({
+label: '\u1c8d\u0ee5\u9188\u6d25\ub6e8',
+layout: bindGroupLayout32,
+entries: [],
+});
+let texture173 = device3.createTexture({
+label: '\u7133\u08cd\u1321\u00b9',
+size: {width: 240, height: 960, depthOrArrayLayers: 1455},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rg32sint'],
+});
+try {
+renderBundleEncoder78.setBindGroup(4, bindGroup27);
+} catch {}
+try {
+renderBundleEncoder79.setIndexBuffer(buffer35, 'uint32', 19648, 24844);
+} catch {}
+try {
+renderBundleEncoder78.setVertexBuffer(6, buffer54, 9996, 1479);
+} catch {}
+try {
+  await buffer42.mapAsync(GPUMapMode.WRITE, 1752, 896);
+} catch {}
+let adapter27 = await navigator.gpu.requestAdapter();
+let textureView148 = texture138.createView({
+  label: '\ua265\ud9a6\u0365\u{1ff09}\u{1fc2e}\u9997',
+  format: 'astc-10x8-unorm-srgb',
+  baseMipLevel: 1,
+  baseArrayLayer: 5,
+  arrayLayerCount: 163
+});
+try {
+renderBundleEncoder111.setVertexBuffer(58, undefined);
+} catch {}
+try {
+  await promise66;
+} catch {}
+let device13 = await adapter25.requestDevice({
+label: '\uca0a\ub7c3\u9fbf\ue63d\u{1ffd0}\u0c62\ue3cf\uab76',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 8,
+maxColorAttachmentBytesPerSample: 40,
+maxVertexAttributes: 25,
+maxVertexBufferArrayStride: 19828,
+maxStorageTexturesPerShaderStage: 26,
+maxStorageBuffersPerShaderStage: 43,
+maxDynamicStorageBuffersPerPipelineLayout: 9379,
+maxBindingsPerBindGroup: 4932,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 13804,
+maxTextureDimension2D: 14509,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 113391366,
+maxUniformBuffersPerShaderStage: 33,
+maxInterStageShaderVariables: 97,
+maxInterStageShaderComponents: 70,
+maxSamplersPerShaderStage: 22,
+},
+});
+let commandEncoder137 = device8.createCommandEncoder({label: '\u{1fc85}\u0655\u069e'});
+try {
+commandEncoder131.copyTextureToTexture({
+  texture: texture134,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture134,
+  mipLevel: 1,
+  origin: { x: 0, y: 4, z: 0 },
+  aspect: 'all',
+}, {width: 156, height: 8, depthOrArrayLayers: 0});
+} catch {}
+canvas3.width = 278;
+let computePassEncoder82 = commandEncoder125.beginComputePass({label: '\u{1fb9a}\u0d2b\ue58a\ub92e\u94e7\u0c92\u0d4e\u0de8\u{1ffb1}'});
+let renderBundle139 = renderBundleEncoder117.finish({label: '\u{1fdc7}\u{1f728}\u0fe9\u0650\u05ff\u026b\u{1f7d1}\u{1f6fe}\u6982\u05b9\u0c61'});
+document.body.prepend(canvas33);
+let imageData44 = new ImageData(88, 176);
+try {
+adapter18.label = '\u0f13\uf666';
+} catch {}
+let buffer59 = device7.createBuffer({
+  label: '\u{1f962}\u05d0\u3176\u{1fcde}\u1d8c\u6159',
+  size: 65359,
+  usage: GPUBufferUsage.MAP_READ,
+  mappedAtCreation: false
+});
+let textureView149 = texture164.createView({label: '\ua058\u866f\u5d8c\u38c5\u0541\uab0f\u2ae9\u8397\uf75f', baseMipLevel: 1, mipLevelCount: 2});
+try {
+computePassEncoder80.end();
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture149,
+  mipLevel: 3,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer9), /* required buffer size: 906 */
+{offset: 906}, {width: 16, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let img40 = await imageWithData(216, 225, '#138a02b5', '#7425111b');
+let promise67 = adapter3.requestAdapterInfo();
+document.body.prepend(canvas20);
+let renderBundle140 = renderBundleEncoder26.finish();
+try {
+computePassEncoder81.setBindGroup(5, bindGroup23, []);
+} catch {}
+try {
+computePassEncoder63.setBindGroup(0, bindGroup20, new Uint32Array(2579), 58, 0);
+} catch {}
+try {
+computePassEncoder81.end();
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline29);
+} catch {}
+try {
+commandEncoder136.copyBufferToBuffer(buffer58, 688, buffer20, 1144, 64);
+dissociateBuffer(device1, buffer58);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder107.clearBuffer(buffer27, 16676);
+dissociateBuffer(device1, buffer27);
+} catch {}
+let promise68 = device1.createRenderPipelineAsync({
+layout: pipelineLayout12,
+fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'r32uint', writeMask: GPUColorWrite.ALL}, {format: 'rg8sint', writeMask: GPUColorWrite.BLUE}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'dst-alpha'},
+}
+}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}]
+},
+vertex: {
+  module: shaderModule3,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 9228,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 8516,
+shaderLocation: 19,
+}, {
+format: 'float16x2',
+offset: 4908,
+shaderLocation: 3,
+}, {
+format: 'unorm16x4',
+offset: 2432,
+shaderLocation: 6,
+}, {
+format: 'uint32x3',
+offset: 3720,
+shaderLocation: 23,
+}],
+},
+{
+arrayStride: 13508,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 6780,
+shaderLocation: 22,
+}, {
+format: 'float16x4',
+offset: 4684,
+shaderLocation: 14,
+}, {
+format: 'uint16x2',
+offset: 8968,
+shaderLocation: 2,
+}, {
+format: 'uint32',
+offset: 11216,
+shaderLocation: 15,
+}, {
+format: 'float32x4',
+offset: 600,
+shaderLocation: 18,
+}, {
+format: 'uint32x4',
+offset: 13408,
+shaderLocation: 8,
+}, {
+format: 'sint8x4',
+offset: 4616,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 9432,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x4',
+offset: 4848,
+shaderLocation: 26,
+}, {
+format: 'sint8x4',
+offset: 6592,
+shaderLocation: 5,
+}, {
+format: 'snorm8x2',
+offset: 1638,
+shaderLocation: 13,
+}, {
+format: 'unorm10-10-10-2',
+offset: 1260,
+shaderLocation: 25,
+}, {
+format: 'float32x4',
+offset: 8812,
+shaderLocation: 0,
+}, {
+format: 'sint8x4',
+offset: 9100,
+shaderLocation: 9,
+}, {
+format: 'sint32x4',
+offset: 8080,
+shaderLocation: 12,
+}, {
+format: 'float32',
+offset: 2240,
+shaderLocation: 11,
+}, {
+format: 'float32x4',
+offset: 6232,
+shaderLocation: 16,
+}, {
+format: 'snorm16x4',
+offset: 2592,
+shaderLocation: 20,
+}],
+},
+{
+arrayStride: 27564,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 22096,
+shaderLocation: 17,
+}, {
+format: 'uint32',
+offset: 15764,
+shaderLocation: 4,
+}, {
+format: 'snorm8x4',
+offset: 9812,
+shaderLocation: 24,
+}, {
+format: 'sint16x4',
+offset: 4476,
+shaderLocation: 10,
+}, {
+format: 'uint8x2',
+offset: 4828,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 33696,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1500,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 1160,
+shaderLocation: 21,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let bindGroupLayout49 = device3.createBindGroupLayout({
+entries: [],
+});
+let commandEncoder138 = device3.createCommandEncoder({label: '\u{1fe05}\u6da2\u97dd\u{1f747}\ub7f8\u0c64\u{1ff2a}\u{1f847}\u8ea2'});
+let querySet104 = device3.createQuerySet({
+label: '\uf331\ue663',
+type: 'occlusion',
+count: 2137,
+});
+try {
+commandEncoder134.copyBufferToBuffer(buffer35, 30492, buffer24, 5036, 2136);
+dissociateBuffer(device3, buffer35);
+dissociateBuffer(device3, buffer24);
+} catch {}
+try {
+commandEncoder51.copyTextureToBuffer({
+  texture: texture79,
+  mipLevel: 4,
+  origin: { x: 10, y: 8, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 33488 */
+offset: 33488,
+buffer: buffer40,
+}, {width: 0, height: 8, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer40);
+} catch {}
+try {
+commandEncoder138.resolveQuerySet(querySet74, 1350, 837, buffer33, 33024);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 179}
+*/
+{
+  source: img27,
+  origin: { x: 56, y: 54 },
+  flipY: false,
+}, {
+  texture: texture170,
+  mipLevel: 5,
+  origin: { x: 0, y: 1, z: 94 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let bindGroupLayout50 = device12.createBindGroupLayout({
+label: '\u04a0\uefa5',
+entries: [],
+});
+let bindGroup31 = device12.createBindGroup({
+layout: bindGroupLayout50,
+entries: [],
+});
+let pipelineLayout26 = device12.createPipelineLayout({label: '\u9e0a\u47f7\u9957', bindGroupLayouts: [bindGroupLayout50]});
+let commandEncoder139 = device12.createCommandEncoder();
+let querySet105 = device12.createQuerySet({
+label: '\u{1feac}\u1e17\u057a\u1c30',
+type: 'occlusion',
+count: 3724,
+});
+let renderBundleEncoder119 = device12.createRenderBundleEncoder({
+  colorFormats: [undefined, 'rgba8uint', 'rgba16float', 'rgba16sint', 'bgra8unorm', 'rgba16sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder119.setBindGroup(2, bindGroup31);
+} catch {}
+try {
+renderBundleEncoder119.setVertexBuffer(39, undefined, 1521196456, 1576214910);
+} catch {}
+document.body.prepend(img4);
+let texture174 = device13.createTexture({
+label: '\uc20c\u02f4\u0337\uaae4',
+size: {width: 450, height: 5, depthOrArrayLayers: 66},
+format: 'astc-10x5-unorm',
+usage: GPUTextureUsage.COPY_DST,
+});
+let textureView150 = texture174.createView({baseArrayLayer: 13, arrayLayerCount: 17});
+let renderBundleEncoder120 = device13.createRenderBundleEncoder({
+  label: '\u8815\u{1f871}\u043a\ua944\u0690',
+  colorFormats: ['rgba32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: false
+});
+let canvas43 = document.createElement('canvas');
+let shaderModule23 = device4.createShaderModule({
+label: '\ue775\u3b5c\ud873\u{1fd99}\u7948\ua33e',
+code: `@group(2) @binding(1245)
+var<storage, read_write> parameter25: array<u32>;
+@group(0) @binding(115)
+var<storage, read_write> global17: array<u32>;
+@group(3) @binding(115)
+var<storage, read_write> local25: array<u32>;
+@group(0) @binding(1223)
+var<storage, read_write> field13: array<u32>;
+@group(0) @binding(1245)
+var<storage, read_write> function10: array<u32>;
+@group(3) @binding(1223)
+var<storage, read_write> type29: array<u32>;
+@group(1) @binding(1245)
+var<storage, read_write> parameter26: array<u32>;
+@group(1) @binding(1223)
+var<storage, read_write> local26: array<u32>;
+
+@compute @workgroup_size(3, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S30 {
+  @builtin(position) f0: vec4<f32>,
+  @builtin(front_facing) f1: bool,
+  @builtin(sample_mask) f2: u32
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @builtin(frag_depth) f1: f32,
+  @location(0) f2: vec4<u32>,
+  @location(4) f3: u32,
+  @location(3) f4: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, a1: S30) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S29 {
+  @location(7) f0: vec2<f32>,
+  @location(15) f1: vec3<f32>,
+  @location(3) f2: vec4<f32>,
+  @location(12) f3: vec2<f16>,
+  @location(1) f4: vec3<f16>,
+  @location(0) f5: vec2<f32>,
+  @location(18) f6: vec3<i32>,
+  @location(2) f7: vec3<f32>,
+  @location(17) f8: i32,
+  @builtin(instance_index) f9: u32
+}
+
+@vertex
+fn vertex0(@location(11) a0: i32, @location(14) a1: vec4<f16>, @location(16) a2: vec3<i32>, @location(5) a3: vec2<i32>, a4: S29, @location(9) a5: vec4<u32>, @location(10) a6: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+let arrayBuffer15 = buffer26.getMappedRange(17824);
+let pipeline111 = await device4.createRenderPipelineAsync({
+layout: 'auto',
+multisample: {
+mask: 0xe842e253,
+},
+fragment: {
+  module: shaderModule23,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined, {format: 'rgba32float'}, {format: 'rg16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 1896,
+stencilWriteMask: 3397,
+depthBias: 60,
+depthBiasSlopeScale: 75,
+depthBiasClamp: 89,
+},
+vertex: {
+  module: shaderModule23,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 9208,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 7896,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 6040,
+shaderLocation: 1,
+}, {
+format: 'unorm16x2',
+offset: 1472,
+shaderLocation: 7,
+}, {
+format: 'sint16x2',
+offset: 3560,
+shaderLocation: 5,
+}, {
+format: 'sint8x4',
+offset: 2304,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 15172,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 1316,
+shaderLocation: 12,
+}, {
+format: 'unorm16x4',
+offset: 14272,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 11144,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 7656,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 1412,
+attributes: [{
+format: 'float32x3',
+offset: 152,
+shaderLocation: 14,
+}, {
+format: 'unorm16x2',
+offset: 788,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 0,
+attributes: [{
+format: 'sint32x4',
+offset: 15576,
+shaderLocation: 18,
+}, {
+format: 'uint8x2',
+offset: 19284,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 5748,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x4',
+offset: 1728,
+shaderLocation: 15,
+}, {
+format: 'uint32x2',
+offset: 1324,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 17832,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x2',
+offset: 2222,
+shaderLocation: 17,
+}],
+},
+{
+arrayStride: 4460,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x2',
+offset: 1112,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let promise69 = adapter13.requestAdapterInfo();
+let texture175 = gpuCanvasContext10.getCurrentTexture();
+try {
+commandEncoder122.copyTextureToTexture({
+  texture: texture175,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture175,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext40 = canvas43.getContext('webgpu');
+let commandEncoder140 = device12.createCommandEncoder({});
+let renderBundleEncoder121 = device10.createRenderBundleEncoder({
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler112 = device10.createSampler({
+label: '\u3ce4\u5362\u64cb\ucffd\uaa80',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 88.269,
+lodMaxClamp: 93.083,
+});
+try {
+device10.queue.writeTexture({
+  texture: texture172,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer14, /* required buffer size: 138 */
+{offset: 138, bytesPerRow: 280}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise70 = device10.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let imageData45 = new ImageData(180, 192);
+let videoFrame44 = new VideoFrame(canvas23, {timestamp: 0});
+let sampler113 = device4.createSampler({
+label: '\ue083\u443a\u{1ff75}',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 94.605,
+lodMaxClamp: 96.826,
+compare: 'always',
+});
+let video39 = await videoWithData();
+let imageBitmap43 = await createImageBitmap(img26);
+let videoFrame45 = new VideoFrame(imageBitmap24, {timestamp: 0});
+let offscreenCanvas44 = new OffscreenCanvas(985, 456);
+let querySet106 = device3.createQuerySet({
+label: '\u8829\u70ce',
+type: 'occlusion',
+count: 1274,
+});
+let textureView151 = texture92.createView({label: '\uf31d\ud42f\u2670', aspect: 'all'});
+let renderBundleEncoder122 = device3.createRenderBundleEncoder({
+  label: '\u{1f86a}\u2a0b\ubca7\u0b52\u0741\u{1f94b}\u0e2f\u{1fd45}\u2be3\u0ea9\u07c6',
+  colorFormats: ['bgra8unorm-srgb', 'rg32uint', 'rg32sint', 'rgb10a2unorm', undefined, 'rgba8uint']
+});
+try {
+renderBundleEncoder118.setVertexBuffer(0, buffer44);
+} catch {}
+try {
+commandEncoder138.copyTextureToTexture({
+  texture: texture69,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture106,
+  mipLevel: 5,
+  origin: { x: 2, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 30, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder110.clearBuffer(buffer40, 13472, 2952);
+dissociateBuffer(device3, buffer40);
+} catch {}
+try {
+commandEncoder68.resolveQuerySet(querySet91, 2178, 774, buffer41, 1280);
+} catch {}
+let offscreenCanvas45 = new OffscreenCanvas(465, 514);
+let gpuCanvasContext41 = offscreenCanvas44.getContext('webgpu');
+try {
+  await promise70;
+} catch {}
+let imageData46 = new ImageData(136, 96);
+let textureView152 = texture134.createView({format: 'etc2-rgb8a1unorm', baseMipLevel: 5});
+let renderBundle141 = renderBundleEncoder90.finish({label: '\u8119\u6038\ufbbe\u2208\ue077\u0f91\ude40'});
+let sampler114 = device8.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 19.705,
+lodMaxClamp: 40.554,
+});
+try {
+commandEncoder88.clearBuffer(buffer39);
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+commandEncoder133.resolveQuerySet(querySet67, 1354, 11, buffer34, 22272);
+} catch {}
+let commandEncoder141 = device1.createCommandEncoder({label: '\u{1f63a}\u0f65\u0680\u0a01\ucc0a\uc2ee\u0089\u014d'});
+let querySet107 = device1.createQuerySet({
+label: '\u{1f7a1}\u5802\u75f2\ucecb\u4710\u4d4f\u{1fa64}\uc763\udcf7\ua6a9',
+type: 'occlusion',
+count: 3435,
+});
+let computePassEncoder83 = commandEncoder141.beginComputePass({label: '\u3656\uf0c9\u63b3\u781c\ufab6\u{1f7f6}'});
+try {
+commandEncoder133.resolveQuerySet(querySet73, 760, 241, buffer34, 10752);
+} catch {}
+let bindGroup32 = device1.createBindGroup({
+label: '\u0f31\u{1fd1f}\ub3fe',
+layout: bindGroupLayout11,
+entries: [{
+binding: 542,
+resource: textureView99
+}],
+});
+let texture176 = device1.createTexture({
+label: '\u{1fb92}\u17b0\u0882\u2722\uace9\u6246\u{1f916}\ufc24\ua477\u0c32',
+size: [13, 96, 165],
+mipLevelCount: 3,
+dimension: '3d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['r16float', 'r16float', 'r16float'],
+});
+let texture177 = gpuCanvasContext34.getCurrentTexture();
+try {
+commandEncoder133.copyBufferToTexture({
+/* bytesInLastRow: 96 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 4720 */
+offset: 4720,
+buffer: buffer34,
+}, {
+  texture: texture154,
+  mipLevel: 3,
+  origin: { x: 576, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 72, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer34);
+} catch {}
+try {
+commandEncoder136.copyTextureToTexture({
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 100, y: 40, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 55, y: 70, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext42 = offscreenCanvas45.getContext('webgpu');
+let img41 = await imageWithData(271, 107, '#05fa5602', '#5f63cc6b');
+let imageBitmap44 = await createImageBitmap(img7);
+let bindGroup33 = device12.createBindGroup({
+layout: bindGroupLayout50,
+entries: [],
+});
+let commandEncoder142 = device12.createCommandEncoder({label: '\u8ad7\u{1fe8e}\u{1fcde}'});
+let renderBundle142 = renderBundleEncoder117.finish({label: '\uffd4\uec99\u821d\u042c\u8d30\ub50a\u{1f982}\u09e8\u9ff5\u008e\u{1f9aa}'});
+let externalTexture12 = device12.importExternalTexture({
+source: videoFrame27,
+colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder119.setBindGroup(2, bindGroup33, new Uint32Array(175), 76, 0);
+} catch {}
+let canvas44 = document.createElement('canvas');
+let video40 = await videoWithData();
+try {
+computePassEncoder47.setBindGroup(8, bindGroup9, new Uint32Array(2069), 694, 0);
+} catch {}
+try {
+renderBundleEncoder73.insertDebugMarker('\u{1fbe8}');
+} catch {}
+try {
+device3.queue.writeBuffer(buffer40, 6220, new Int16Array(42071), 29228, 4016);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: { x: 4, y: 1, z: 1 },
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer15), /* required buffer size: 670 */
+{offset: 670}, {width: 501, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline112 = device3.createComputePipeline({
+label: '\u666c\u0ac9\u{1f75d}\u{1fcc5}\u09a6\u{1fdbe}\udb22\u{1fc43}\u09f6',
+layout: pipelineLayout10,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let canvas45 = document.createElement('canvas');
+let offscreenCanvas46 = new OffscreenCanvas(36, 932);
+let shaderModule24 = device3.createShaderModule({
+label: '\u7de4\u0328\u0a12\u5b56\u{1fe15}\u573d\u68a7\u06f8\u409b\uc0e2',
+code: `@group(0) @binding(846)
+var<storage, read_write> parameter27: array<u32>;
+@group(4) @binding(846)
+var<storage, read_write> function11: array<u32>;
+
+@compute @workgroup_size(8, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(5) f0: vec4<u32>,
+  @location(1) f1: vec4<u32>,
+  @location(0) f2: f32,
+  @location(2) f3: u32,
+  @location(4) f4: vec2<i32>,
+  @location(3) f5: vec4<f32>,
+  @builtin(sample_mask) f6: u32
+}
+
+@fragment
+fn fragment0(@location(57) a0: i32, @location(78) a1: vec4<i32>, @location(72) a2: vec4<f32>, @location(34) a3: vec4<u32>, @location(55) a4: vec3<f32>, @location(81) a5: f16, @location(60) a6: vec3<f16>, @location(38) a7: vec3<f32>, @location(54) a8: vec2<f32>, @location(40) a9: vec3<f16>, @location(62) a10: u32, @location(46) a11: vec2<u32>, @location(26) a12: vec2<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(70) f488: f32,
+  @location(53) f489: vec2<u32>,
+  @location(78) f490: vec4<i32>,
+  @location(50) f491: u32,
+  @location(18) f492: vec4<f16>,
+  @location(49) f493: f16,
+  @location(48) f494: vec4<f16>,
+  @location(21) f495: i32,
+  @location(34) f496: vec4<u32>,
+  @location(81) f497: f16,
+  @location(12) f498: vec2<i32>,
+  @location(68) f499: vec2<i32>,
+  @location(22) f500: vec2<u32>,
+  @location(80) f501: f32,
+  @builtin(position) f502: vec4<f32>,
+  @location(75) f503: vec2<f32>,
+  @location(2) f504: vec4<f16>,
+  @location(40) f505: vec3<f16>,
+  @location(60) f506: vec3<f16>,
+  @location(38) f507: vec3<f32>,
+  @location(67) f508: vec3<f16>,
+  @location(57) f509: i32,
+  @location(82) f510: vec3<f16>,
+  @location(43) f511: vec4<f32>,
+  @location(46) f512: vec2<u32>,
+  @location(76) f513: i32,
+  @location(32) f514: vec2<f32>,
+  @location(59) f515: vec4<u32>,
+  @location(31) f516: u32,
+  @location(54) f517: vec2<f32>,
+  @location(77) f518: u32,
+  @location(10) f519: vec2<i32>,
+  @location(69) f520: i32,
+  @location(62) f521: u32,
+  @location(72) f522: vec4<f32>,
+  @location(23) f523: vec2<i32>,
+  @location(17) f524: f16,
+  @location(26) f525: vec2<i32>,
+  @location(36) f526: vec4<f32>,
+  @location(65) f527: u32,
+  @location(55) f528: vec3<f32>,
+  @location(41) f529: u32,
+  @location(5) f530: vec4<f16>,
+  @location(8) f531: f16,
+  @location(7) f532: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(23) a0: vec4<f16>, @location(21) a1: vec3<f32>, @location(9) a2: f32, @location(11) a3: vec3<u32>, @location(22) a4: vec4<f32>, @location(7) a5: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder143 = device3.createCommandEncoder({label: '\u98c9\u076d\u{1f66e}\u0ee9\u0c17\u0f40'});
+let texture178 = device3.createTexture({
+label: '\ubda1\u{1f7af}\u46b0\u272b\uc864\u0315\u3f1b\u1de1\u{1fa1d}',
+size: {width: 30, height: 120, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+sampleCount: 1,
+format: 'astc-6x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-6x6-unorm-srgb', 'astc-6x6-unorm-srgb', 'astc-6x6-unorm'],
+});
+let renderBundle143 = renderBundleEncoder65.finish({label: '\u0283\u{1faea}\uf0e6'});
+try {
+computePassEncoder48.dispatchWorkgroups(2, 1);
+} catch {}
+try {
+renderBundleEncoder54.setVertexBuffer(0, buffer29, 1600, 1819);
+} catch {}
+try {
+commandEncoder68.copyTextureToTexture({
+  texture: texture157,
+  mipLevel: 5,
+  origin: { x: 5, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture157,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'depth-only',
+}, {width: 8, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder134.clearBuffer(buffer37);
+dissociateBuffer(device3, buffer37);
+} catch {}
+let gpuCanvasContext43 = canvas45.getContext('webgpu');
+let videoFrame46 = new VideoFrame(img21, {timestamp: 0});
+let computePassEncoder84 = commandEncoder132.beginComputePass();
+let renderBundleEncoder123 = device7.createRenderBundleEncoder({
+  label: '\uc377\u0931\u0ce3\u0ba0\u4af6',
+  colorFormats: ['rgba16sint', 'rgba32sint', 'rgba32sint', 'rg16float', 'r16uint', undefined],
+  stencilReadOnly: true
+});
+let sampler115 = device7.createSampler({
+label: '\u{1f62e}\uf8db\u63c4',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 81.457,
+lodMaxClamp: 93.220,
+maxAnisotropy: 6,
+});
+let buffer60 = device6.createBuffer({
+  label: '\ufcc2\u7bd2\u3406\u1612\u{1fc2d}\u{1fb63}\u4594\ue5b8',
+  size: 14163,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT
+});
+let querySet108 = device6.createQuerySet({
+label: '\u05a6\u21f5\u{1fb99}\u08fe\u4d5c\u0f79\ub10c',
+type: 'occlusion',
+count: 555,
+});
+let sampler116 = device6.createSampler({
+label: '\u5255\u{1f6ed}\u0f2e\u59d6\u{1f8bf}\u0f03\u{1fec6}\ubee2\u8b8a\ub61d\u0048',
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 75.006,
+lodMaxClamp: 75.599,
+maxAnisotropy: 12,
+});
+try {
+renderBundleEncoder109.insertDebugMarker('\ud1f6');
+} catch {}
+canvas25.height = 49;
+let offscreenCanvas47 = new OffscreenCanvas(508, 705);
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+document.body.prepend(canvas16);
+let gpuCanvasContext44 = offscreenCanvas47.getContext('webgpu');
+let bindGroupLayout51 = device3.createBindGroupLayout({
+label: '\u56b7\ud3ed\ucca0\u036f\uee9b\ub6cd\u0ce8\ud41d\u1d84\uf7f5',
+entries: [],
+});
+let renderBundleEncoder124 = device3.createRenderBundleEncoder({label: '\u{1fa83}\u06f9\u0420\u1de9\u1077\ubeb3\u348a', colorFormats: ['rg8unorm'], depthReadOnly: true});
+let renderBundle144 = renderBundleEncoder65.finish({label: '\ubd6e\u091f'});
+try {
+commandEncoder68.copyTextureToTexture({
+  texture: texture59,
+  mipLevel: 1,
+  origin: { x: 3, y: 32, z: 40 },
+  aspect: 'all',
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: { x: 1, y: 116, z: 188 },
+  aspect: 'all',
+}, {width: 5, height: 60, depthOrArrayLayers: 0});
+} catch {}
+let texture179 = device8.createTexture({
+label: '\u1844\ua14d\ub2aa\uf7a8\u5e60\u0409\ud3a2\u00c8\ubf09\u7b1e\u7528',
+size: {width: 320},
+dimension: '1d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba32float', 'rgba32float'],
+});
+try {
+commandEncoder137.copyTextureToTexture({
+  texture: texture175,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture175,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device8.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video38,
+  origin: { x: 13, y: 6 },
+  flipY: false,
+}, {
+  texture: texture175,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img42 = await imageWithData(83, 240, '#c718a3a4', '#c2870904');
+let video41 = await videoWithData();
+let commandEncoder144 = device3.createCommandEncoder();
+let textureView153 = texture44.createView({label: '\u35c8\u4d6c\u2374\u7e1a\u802c\u5d54\u3656\u5168\u6932', baseArrayLayer: 0});
+let computePassEncoder85 = commandEncoder134.beginComputePass();
+try {
+renderBundleEncoder78.setBindGroup(0, bindGroup15, new Uint32Array(14), 7, 0);
+} catch {}
+let pipeline113 = device3.createComputePipeline({
+label: '\u0026\u0421\u0442\u0789',
+layout: pipelineLayout14,
+compute: {
+module: shaderModule24,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+gc();
+let commandEncoder145 = device7.createCommandEncoder({label: '\u{1fb11}\u{1fe29}\u02a1\u{1ff7a}\u05f4\uf203\u0d24\u99c7'});
+let renderBundle145 = renderBundleEncoder103.finish({label: '\u09b2\ub9bc\u11a2\u01d1\u01a8\u2472'});
+gc();
+let commandEncoder146 = device10.createCommandEncoder({label: '\uc106\u0ab6\u011b\uf50a\u6994\u065d\ua9b3\u2b02\u84fc'});
+let querySet109 = device10.createQuerySet({
+label: '\u235f\u4bec\u{1fe86}\u{1f695}\u7e65\u7b65\u0353\u8b83\udec5\u0ca7',
+type: 'occlusion',
+count: 681,
+});
+let textureView154 = texture138.createView({
+  label: '\u0324\u{1f9df}\uc49a\u{1fa4a}\udb33\ueff8\u8629\ucf6b',
+  dimension: '2d',
+  baseMipLevel: 2,
+  baseArrayLayer: 240
+});
+let renderBundleEncoder125 = device10.createRenderBundleEncoder({
+  label: '\u3d41\u{1fd2c}\u04d9\u099a\u{1f845}\u09a0\u0103\u114c\u0ceb\u145f\u6b31',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let sampler117 = device10.createSampler({
+label: '\u6091\u{1ffc0}\u{1fa66}\u0f98\u786e',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+lodMaxClamp: 98.338,
+});
+try {
+  await promise67;
+} catch {}
+try {
+adapter12.label = '\ufb3e\u6399\u01cc\u04f4\u2501\u2c7f\u0aa0\u9316\ubf5a';
+} catch {}
+let texture180 = device6.createTexture({
+label: '\u{1f8af}\u2c24\u{1f62c}\u{1fa52}\u8f0b\u6efa\u53c6',
+size: [140, 1, 1],
+sampleCount: 4,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundleEncoder126 = device6.createRenderBundleEncoder({
+  label: '\u9d2e\u{1f79f}\uf26d',
+  colorFormats: ['r8uint', 'rg16uint', 'r32float', 'rgba8uint', 'rgba16float', 'rgb10a2unorm'],
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+computePassEncoder71.end();
+} catch {}
+try {
+commandEncoder115.copyTextureToTexture({
+  texture: texture180,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture156,
+  mipLevel: 0,
+  origin: { x: 47, y: 279, z: 0 },
+  aspect: 'depth-only',
+}, {width: 140, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder115.insertDebugMarker('\u2db1');
+} catch {}
+let offscreenCanvas48 = new OffscreenCanvas(327, 77);
+try {
+textureView150.label = '\u31f4\u309d\ud863\ub3a5\u{1f897}\u93e3';
+} catch {}
+let texture181 = gpuCanvasContext20.getCurrentTexture();
+video29.width = 259;
+let commandEncoder147 = device7.createCommandEncoder({});
+let texture182 = device7.createTexture({
+label: '\u286b\u171e\u020c\u9831\uca43\u3b3b\u0dd4\u08cd\u0e11\ue2b2\u{1f85a}',
+size: {width: 591, height: 1, depthOrArrayLayers: 1458},
+mipLevelCount: 8,
+dimension: '3d',
+format: 'r8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle146 = renderBundleEncoder96.finish({label: '\uc94e\u0ad8\u0355'});
+let sampler118 = device7.createSampler({
+label: '\u{1f664}\u2eca\u0dcd\u{1f9d9}\uf281\u4a7f\u0fa0',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 89.521,
+});
+try {
+renderBundleEncoder123.setVertexBuffer(94, undefined, 1298893487, 500963130);
+} catch {}
+let bindGroupLayout52 = device4.createBindGroupLayout({
+label: '\u0502\uc155\u5fea\uae36\u{1fd97}\u{1ffdd}\uade0\u0f11\u{1f949}\u0200',
+entries: [],
+});
+let textureView155 = texture73.createView({
+  label: '\u0705\u0b79\uccf9\u05c7\ud5c8\ud235\u0d50\ua326\u7612\udff5',
+  dimension: '2d-array',
+  format: 'astc-5x5-unorm-srgb',
+  baseMipLevel: 4,
+  mipLevelCount: 1
+});
+try {
+device4.queue.submit([
+]);
+} catch {}
+try {
+  await promise69;
+} catch {}
+let videoFrame47 = videoFrame33.clone();
+let bindGroupLayout53 = device8.createBindGroupLayout({
+label: '\u07e4\u9638\u12a7\u529d\uca45\u{1f985}\ud50b\u001d',
+entries: [{
+binding: 3148,
+visibility: 0,
+externalTexture: {},
+}, {
+binding: 603,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}, {
+binding: 4171,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}],
+});
+let querySet110 = device8.createQuerySet({
+label: '\ufbf7\u0656\u053d\uf7d1\u2e54',
+type: 'occlusion',
+count: 142,
+});
+try {
+device8.queue.submit([
+commandBuffer22,
+commandBuffer23,
+]);
+} catch {}
+let offscreenCanvas49 = new OffscreenCanvas(163, 351);
+let textureView156 = texture172.createView({
+  label: '\u0c33\u3c91\u{1fb19}\u4e5b\u1025\u870e\u8ed2\u4787\u3f1c\u0e94',
+  format: 'astc-12x12-unorm-srgb',
+  baseMipLevel: 3,
+  mipLevelCount: 1
+});
+let sampler119 = device10.createSampler({
+label: '\ub527\ub3cd\ufc83\u017f\u0fe7\u{1fdea}\u{1fbbf}\u6093',
+addressModeU: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMaxClamp: 74.194,
+});
+let bindGroupLayout54 = device10.createBindGroupLayout({
+label: '\u859a\u0d17\u{1f640}\u3684\u8567',
+entries: [{
+binding: 4499,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 424236, hasDynamicOffset: true },
+}, {
+binding: 2163,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}, {
+binding: 3588,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+}],
+});
+let querySet111 = device10.createQuerySet({
+label: '\u{1f797}\uf402\u76b9\u{1fe11}\u2d78',
+type: 'occlusion',
+count: 3276,
+});
+try {
+device10.queue.writeTexture({
+  texture: texture172,
+  mipLevel: 0,
+  origin: { x: 24, y: 96, z: 0 },
+  aspect: 'all',
+}, arrayBuffer8, /* required buffer size: 951 */
+{offset: 919}, {width: 24, height: 12, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup34 = device12.createBindGroup({
+label: '\u564d\u0296\uad4b\u097c\ua0ef\u{1f67e}\u04e8\u{1fc4e}\u06d8\u{1fc3a}\u0da6',
+layout: bindGroupLayout50,
+entries: [],
+});
+let shaderModule25 = device11.createShaderModule({
+label: '\ue987\uf088\u7e8b',
+code: `@group(1) @binding(5512)
+var<storage, read_write> field14: array<u32>;
+@group(1) @binding(4677)
+var<storage, read_write> i18: array<u32>;
+@group(3) @binding(5789)
+var<storage, read_write> local27: array<u32>;
+@group(4) @binding(5789)
+var<storage, read_write> i19: array<u32>;
+@group(7) @binding(4677)
+var<storage, read_write> i20: array<u32>;
+@group(0) @binding(772)
+var<storage, read_write> global18: array<u32>;
+@group(0) @binding(5512)
+var<storage, read_write> global19: array<u32>;
+@group(4) @binding(6176)
+var<storage, read_write> parameter28: array<u32>;
+@group(3) @binding(6176)
+var<storage, read_write> global20: array<u32>;
+@group(0) @binding(4677)
+var<storage, read_write> parameter29: array<u32>;
+@group(6) @binding(5789)
+var<storage, read_write> i21: array<u32>;
+@group(3) @binding(2668)
+var<storage, read_write> field15: array<u32>;
+@group(7) @binding(5512)
+var<storage, read_write> global21: array<u32>;
+@group(7) @binding(772)
+var<storage, read_write> field16: array<u32>;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S32 {
+  @location(37) f0: vec3<f32>,
+  @location(97) f1: i32,
+  @location(72) f2: vec4<u32>,
+  @location(86) f3: vec2<i32>,
+  @location(4) f4: vec4<i32>,
+  @location(112) f5: u32,
+  @location(12) f6: vec3<f32>,
+  @location(58) f7: vec3<f32>,
+  @location(78) f8: vec3<f32>,
+  @location(55) f9: f16,
+  @location(76) f10: u32,
+  @builtin(position) f11: vec4<f32>,
+  @location(0) f12: u32,
+  @location(19) f13: vec2<u32>,
+  @location(106) f14: f16
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @location(2) f1: vec4<u32>,
+  @location(3) f2: vec2<f32>,
+  @location(0) f3: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(61) a0: vec2<u32>, a1: S32, @location(47) a2: vec3<f16>, @location(50) a3: vec3<f32>, @builtin(sample_mask) a4: u32, @location(63) a5: vec4<f16>, @location(54) a6: vec2<f32>, @location(96) a7: f16, @location(49) a8: vec2<f32>, @location(91) a9: vec4<f16>, @location(21) a10: vec3<u32>, @location(44) a11: vec4<f32>, @location(34) a12: vec4<u32>, @location(40) a13: f16, @location(77) a14: f16, @location(39) a15: vec3<i32>, @location(105) a16: vec3<u32>, @location(59) a17: vec4<i32>, @location(7) a18: vec3<i32>, @location(113) a19: vec2<u32>, @builtin(front_facing) a20: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S31 {
+  @location(8) f0: vec4<f32>,
+  @location(24) f1: f16,
+  @location(21) f2: f32,
+  @location(12) f3: vec3<u32>,
+  @location(25) f4: vec3<f16>,
+  @location(22) f5: vec2<f16>,
+  @location(5) f6: vec4<f16>,
+  @location(10) f7: u32,
+  @location(15) f8: vec2<u32>,
+  @location(6) f9: u32,
+  @location(2) f10: vec2<f16>,
+  @location(0) f11: vec3<f32>,
+  @location(26) f12: vec2<u32>,
+  @location(3) f13: u32,
+  @builtin(vertex_index) f14: u32
+}
+struct VertexOutput0 {
+  @location(59) f533: vec4<i32>,
+  @location(34) f534: vec4<u32>,
+  @location(76) f535: u32,
+  @location(55) f536: f16,
+  @location(93) f537: i32,
+  @location(49) f538: vec2<f32>,
+  @location(106) f539: f16,
+  @builtin(position) f540: vec4<f32>,
+  @location(7) f541: vec3<i32>,
+  @location(58) f542: vec3<f32>,
+  @location(105) f543: vec3<u32>,
+  @location(19) f544: vec2<u32>,
+  @location(47) f545: vec3<f16>,
+  @location(44) f546: vec4<f32>,
+  @location(78) f547: vec3<f32>,
+  @location(80) f548: vec4<f16>,
+  @location(50) f549: vec3<f32>,
+  @location(37) f550: vec3<f32>,
+  @location(86) f551: vec2<i32>,
+  @location(0) f552: u32,
+  @location(97) f553: i32,
+  @location(17) f554: i32,
+  @location(77) f555: f16,
+  @location(11) f556: vec3<f16>,
+  @location(43) f557: u32,
+  @location(5) f558: vec4<i32>,
+  @location(21) f559: vec3<u32>,
+  @location(40) f560: f16,
+  @location(36) f561: i32,
+  @location(16) f562: vec3<f32>,
+  @location(4) f563: vec4<i32>,
+  @location(113) f564: vec2<u32>,
+  @location(39) f565: vec3<i32>,
+  @location(72) f566: vec4<u32>,
+  @location(54) f567: vec2<f32>,
+  @location(2) f568: vec3<f16>,
+  @location(112) f569: u32,
+  @location(61) f570: vec2<u32>,
+  @location(63) f571: vec4<f16>,
+  @location(12) f572: vec3<f32>,
+  @location(73) f573: f32,
+  @location(103) f574: vec4<i32>,
+  @location(96) f575: f16,
+  @location(91) f576: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(14) a0: i32, @location(16) a1: vec4<u32>, @location(11) a2: vec3<i32>, @location(13) a3: u32, @location(4) a4: vec4<f32>, @location(20) a5: vec2<i32>, @location(19) a6: vec3<f32>, @location(1) a7: vec3<f16>, a8: S31, @location(23) a9: f32, @location(7) a10: vec2<i32>, @location(18) a11: vec4<i32>, @location(9) a12: vec3<u32>, @location(17) a13: vec3<f32>, @builtin(instance_index) a14: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+});
+let commandEncoder148 = device11.createCommandEncoder({label: '\u1001\u{1fcbd}\u45b6\u3467\u1d82\u0442\ub375'});
+let textureView157 = texture158.createView({format: 'rgba8unorm', baseMipLevel: 0});
+let renderBundleEncoder127 = device11.createRenderBundleEncoder({
+  label: '\ud4d0\u9f14\ub059\u0073\u6c56\u4f57\u{1f7f7}\u1f71',
+  colorFormats: ['r16sint', 'rg16uint', 'rgb10a2uint', 'rg32float'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let texture183 = device5.createTexture({
+size: {width: 312, height: 1, depthOrArrayLayers: 222},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+});
+let renderBundle147 = renderBundleEncoder104.finish({label: '\u162c\u7dc0\u0659\u6aee\u1662\u9b71'});
+try {
+device5.destroy();
+} catch {}
+let video42 = await videoWithData();
+let gpuCanvasContext45 = canvas44.getContext('webgpu');
+try {
+offscreenCanvas46.getContext('webgl2');
+} catch {}
+let gpuCanvasContext46 = offscreenCanvas48.getContext('webgpu');
+try {
+offscreenCanvas49.getContext('webgpu');
+} catch {}
+let commandEncoder149 = device9.createCommandEncoder({label: '\u019c\u{1f96c}\u59f6\uefeb'});
+let querySet112 = device9.createQuerySet({
+label: '\u0b9e\u05c6\uf496\u848f\u{1fb16}\u{1fa6d}\ud496\u{1fe2e}',
+type: 'occlusion',
+count: 2221,
+});
+let texture184 = device9.createTexture({
+label: '\u{1fc05}\ud542\u2dc5\uaa3a\u05bf\ub410\u3a3a\u5e48\u0286\u889b',
+size: {width: 1452, height: 20, depthOrArrayLayers: 1},
+mipLevelCount: 10,
+format: 'astc-6x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView158 = texture161.createView({
+  label: '\u{1faa9}\u0455\u27e2\ub2d6\u5959\u{1ff3d}',
+  dimension: '2d',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  baseArrayLayer: 93
+});
+let renderBundleEncoder128 = device9.createRenderBundleEncoder({
+  label: '\ub4c0\u531f\u{1fbb8}\u8fff\u{1fbb8}\u{1ffdc}',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2unorm', 'rg32float', 'rgba8unorm', 'r8uint', 'rgba8unorm-srgb', 'rg8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundle135.label = '\u0588\u{1fd6b}\u277d\uab1f\u1e91';
+} catch {}
+let commandEncoder150 = device12.createCommandEncoder({label: '\u{1fda7}\u{1f908}\uc30f'});
+let querySet113 = device12.createQuerySet({
+type: 'occlusion',
+count: 4095,
+});
+let texture185 = device12.createTexture({
+label: '\uf6ef\u0aeb\u265e\uc7ee\ub14b\u30ed\u39a4\uc5f5',
+size: [9368, 152, 179],
+mipLevelCount: 11,
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg32sint', 'rg32sint', 'rg32sint'],
+});
+let promise71 = navigator.gpu.requestAdapter();
+let imageData47 = new ImageData(112, 132);
+let canvas46 = document.createElement('canvas');
+let bindGroupLayout55 = device3.createBindGroupLayout({
+label: '\u8f5b\uca05',
+entries: [{
+binding: 688,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+}, {
+binding: 7759,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '1d' },
+}, {
+binding: 3049,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+}],
+});
+let computePassEncoder86 = commandEncoder138.beginComputePass();
+let renderBundleEncoder129 = device3.createRenderBundleEncoder({
+  label: '\u0d1d\u0450',
+  colorFormats: ['r32float', 'rgb10a2uint', 'r32uint', 'rg8unorm', 'rg8sint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let renderBundle148 = renderBundleEncoder68.finish({label: '\ub225\ub6dd\u3eff\u0d77\u{1faf8}\u0871\u01a8'});
+let sampler120 = device3.createSampler({
+label: '\u898b\u5394\ufc45\u6378\u4fdf',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 99.674,
+compare: 'greater-equal',
+});
+try {
+commandEncoder144.copyBufferToBuffer(buffer29, 3628, buffer19, 12176, 420);
+dissociateBuffer(device3, buffer29);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+commandEncoder68.resolveQuerySet(querySet106, 642, 505, buffer33, 12800);
+} catch {}
+let gpuCanvasContext47 = canvas46.getContext('webgpu');
+let commandEncoder151 = device9.createCommandEncoder({});
+let sampler121 = device9.createSampler({
+label: '\uebd9\ud991\u8a83\u4bb7\ub8dc\ud729\u{1fd74}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 80.486,
+lodMaxClamp: 95.118,
+});
+try {
+await adapter13.requestAdapterInfo();
+} catch {}
+try {
+adapter13.label = '\u0f60\u{1fe6d}\u351d\u4d2a';
+} catch {}
+try {
+window.someLabel = externalTexture10.label;
+} catch {}
+let renderBundle149 = renderBundleEncoder106.finish({label: '\ue0d4\u34bb\u0f82\u0531\u{1ffa1}\u2307\u04ae\u01d7\u{1fe37}\u0067\u{1fc3a}'});
+let sampler122 = device8.createSampler({
+label: '\uaa82\u70c9\u06f5\u0d35\u{1f7d5}\u01b5\u0364',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 21.835,
+compare: 'never',
+});
+let adapter28 = await navigator.gpu.requestAdapter({
+});
+try {
+gpuCanvasContext24.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let computePassEncoder87 = commandEncoder147.beginComputePass({label: '\u240e\u0cb2\u{1f7a7}\u0da1\u63b5\u352d\u7b38\ueb7f\u6fb2\u92fe\u0883'});
+try {
+  await buffer48.mapAsync(GPUMapMode.READ, 2480, 3924);
+} catch {}
+try {
+commandEncoder145.copyTextureToTexture({
+  texture: texture130,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 8 },
+  aspect: 'all',
+}, {
+  texture: texture130,
+  mipLevel: 3,
+  origin: { x: 175, y: 0, z: 24 },
+  aspect: 'all',
+}, {width: 258, height: 1, depthOrArrayLayers: 134});
+} catch {}
+try {
+gpuCanvasContext23.configure({
+device: device7,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float', 'rgb10a2unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let canvas47 = document.createElement('canvas');
+let img43 = await imageWithData(200, 59, '#16540b6e', '#6d78f799');
+let bindGroupLayout56 = device6.createBindGroupLayout({
+label: '\u{1fee5}\ucbf6\uc4c8\ue57f\u562b\u6e47\u2567\u0486\u80ef\uc47d\uf6fa',
+entries: [],
+});
+let pipelineLayout27 = device6.createPipelineLayout({
+  label: '\uf35a\u0f5e\u61e5\u6ea3\u72fb\u05ce\u5352\u{1fa01}\u{1ffda}',
+  bindGroupLayouts: [bindGroupLayout56, bindGroupLayout56, bindGroupLayout56, bindGroupLayout56]
+});
+pseudoSubmit(device6, commandEncoder115);
+let textureView159 = texture133.createView({label: '\u{1f950}\u{1fb49}\u74b8\u03ad\u{1f98a}\ucddd\u5a14\u0324'});
+try {
+device6.queue.writeBuffer(buffer60, 10596, new Float32Array(51651), 42782, 460);
+} catch {}
+let imageData48 = new ImageData(120, 256);
+let renderBundleEncoder130 = device11.createRenderBundleEncoder({
+  label: '\ue5f4\uba5e\ufb19\u6afe\uc545\u{1f8bc}\u5105\u0c77',
+  colorFormats: ['r16sint', 'rg16uint', 'rgb10a2uint', 'rg32float'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder127.setBindGroup(2, bindGroup26, new Uint32Array(1728), 1565, 0);
+} catch {}
+try {
+renderBundleEncoder130.pushDebugGroup('\uf2ee');
+} catch {}
+let pipeline114 = await device11.createRenderPipelineAsync({
+label: '\ube7b\u0a20\u0005\u056d\u0127\u{1f850}',
+layout: pipelineLayout24,
+fragment: {
+  module: shaderModule25,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rg32float'}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'not-equal',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2721,
+stencilWriteMask: 1039,
+depthBiasSlopeScale: 83,
+depthBiasClamp: 60,
+},
+vertex: {
+  module: shaderModule25,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 14012,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 31816,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32',
+offset: 5664,
+shaderLocation: 11,
+}, {
+format: 'snorm16x4',
+offset: 11052,
+shaderLocation: 25,
+}, {
+format: 'float16x2',
+offset: 3428,
+shaderLocation: 21,
+}, {
+format: 'float32',
+offset: 3468,
+shaderLocation: 4,
+}, {
+format: 'uint32x4',
+offset: 21624,
+shaderLocation: 12,
+}, {
+format: 'unorm8x4',
+offset: 4708,
+shaderLocation: 19,
+}, {
+format: 'snorm16x2',
+offset: 25172,
+shaderLocation: 1,
+}, {
+format: 'snorm16x2',
+offset: 12364,
+shaderLocation: 5,
+}, {
+format: 'uint32x4',
+offset: 16044,
+shaderLocation: 26,
+}, {
+format: 'uint32x4',
+offset: 8500,
+shaderLocation: 16,
+}, {
+format: 'float32x3',
+offset: 7452,
+shaderLocation: 23,
+}, {
+format: 'sint32',
+offset: 184,
+shaderLocation: 18,
+}, {
+format: 'uint16x2',
+offset: 26420,
+shaderLocation: 10,
+}, {
+format: 'uint16x4',
+offset: 3968,
+shaderLocation: 9,
+}, {
+format: 'sint8x2',
+offset: 23948,
+shaderLocation: 14,
+}, {
+format: 'float16x4',
+offset: 1224,
+shaderLocation: 22,
+}],
+},
+{
+arrayStride: 28004,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x3',
+offset: 8648,
+shaderLocation: 20,
+}, {
+format: 'uint8x4',
+offset: 21584,
+shaderLocation: 3,
+}, {
+format: 'unorm16x4',
+offset: 21868,
+shaderLocation: 17,
+}, {
+format: 'uint32x2',
+offset: 7408,
+shaderLocation: 6,
+}, {
+format: 'uint32x4',
+offset: 1880,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 19324,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 4176,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 31232,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x2',
+offset: 12208,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 29308,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 22732,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 20656,
+shaderLocation: 7,
+}, {
+format: 'unorm16x2',
+offset: 21964,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 25288,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 4036,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 30596,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x4',
+offset: 29344,
+shaderLocation: 24,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+window.someLabel = externalTexture8.label;
+} catch {}
+let offscreenCanvas50 = new OffscreenCanvas(500, 277);
+try {
+canvas47.getContext('webgl2');
+} catch {}
+let renderBundle150 = renderBundleEncoder95.finish({label: '\u{1fa77}\u0522\ud40d\u0ee2\u5673\ua16e\udd6f\u0d90'});
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 140, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img27,
+  origin: { x: 104, y: 44 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: { x: 37, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 80, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext25.unconfigure();
+} catch {}
+document.body.prepend(img12);
+canvas2.width = 754;
+let textureView160 = texture167.createView({
+  label: '\ub41b\u{1fed6}\ufac4\uc4bb',
+  dimension: '2d-array',
+  aspect: 'all',
+  baseMipLevel: 3,
+  mipLevelCount: 4
+});
+let sampler123 = device9.createSampler({
+label: '\u2502\u22de\uedd2\uc1e6',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 45.265,
+lodMaxClamp: 58.877,
+compare: 'less-equal',
+maxAnisotropy: 12,
+});
+try {
+computePassEncoder74.end();
+} catch {}
+try {
+renderBundleEncoder116.pushDebugGroup('\u{1faba}');
+} catch {}
+let bindGroupLayout57 = device6.createBindGroupLayout({
+label: '\u217f\u1ca1\ub266\u767b',
+entries: [{
+binding: 3160,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+}],
+});
+let commandEncoder152 = device6.createCommandEncoder({label: '\u0df0\u9ede\u0c84\u5200\u{1f651}\uf6f2\u1090\uf4d6\u8eef\ue5d4'});
+let computePassEncoder88 = commandEncoder152.beginComputePass({label: '\u0e6d\u4864\u05ff\u0a58\u078a\u{1f691}'});
+let renderBundle151 = renderBundleEncoder87.finish();
+try {
+renderBundleEncoder109.setVertexBuffer(90, undefined, 172136510, 3329050169);
+} catch {}
+document.body.prepend(canvas31);
+let textureView161 = texture180.createView({});
+try {
+renderBundleEncoder126.setVertexBuffer(19, undefined, 1255532346, 385676205);
+} catch {}
+try {
+gpuCanvasContext22.configure({
+device: device6,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8sint', 'bgra8unorm-srgb', 'r32sint'],
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device6.queue.writeBuffer(buffer60, 6156, new Float32Array(37269), 268, 384);
+} catch {}
+let gpuCanvasContext48 = offscreenCanvas50.getContext('webgpu');
+let commandEncoder153 = device7.createCommandEncoder({label: '\u4137\u0384\u4c9e\u5651'});
+try {
+computePassEncoder87.end();
+} catch {}
+try {
+await adapter2.requestAdapterInfo();
+} catch {}
+try {
+renderBundle3.label = '\u0053\u{1f775}\ua2d1\ub338\u0fb8\u203b\ue690\uf0a8';
+} catch {}
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+video23.width = 54;
+let commandEncoder154 = device1.createCommandEncoder({});
+let texture186 = device1.createTexture({
+label: '\ua337\u9c6b\u44e8\u{1fb6b}\uc77f\u7523\ud024\u04a4\u0865',
+size: [384, 16, 1],
+mipLevelCount: 9,
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder131 = device1.createRenderBundleEncoder({
+  label: '\u1228\u07a9\u664e\u3423\u3913\ufd04',
+  colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+let externalTexture13 = device1.importExternalTexture({
+label: '\u1e51\u095d\u25b2\u1338\u0683\u63d2\u2022\u012e\u9bfc\u5286',
+source: video22,
+colorSpace: 'display-p3',
+});
+let arrayBuffer16 = buffer21.getMappedRange(22472, 0);
+try {
+commandEncoder88.copyBufferToTexture({
+/* bytesInLastRow: 416 widthInBlocks: 26 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 18208 */
+offset: 18208,
+bytesPerRow: 512,
+buffer: buffer47,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 55, y: 45, z: 0 },
+  aspect: 'all',
+}, {width: 130, height: 35, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer47);
+} catch {}
+try {
+commandEncoder107.clearBuffer(buffer20, 1148, 0);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 1248, new Float32Array(32399), 10171, 0);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let promise72 = device1.createRenderPipelineAsync({
+label: '\ub8e3\u0421\u99b3\u3399',
+layout: pipelineLayout3,
+vertex: {
+  module: shaderModule22,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 2056,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 1692,
+shaderLocation: 26,
+}, {
+format: 'float16x2',
+offset: 60,
+shaderLocation: 4,
+}, {
+format: 'unorm10-10-10-2',
+offset: 72,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 1872,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 29028,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 21244,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 20116,
+shaderLocation: 3,
+}, {
+format: 'uint16x2',
+offset: 18700,
+shaderLocation: 19,
+}],
+},
+{
+arrayStride: 1288,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 8916,
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 14392,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 29740,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 13296,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 9620,
+shaderLocation: 21,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55) };
+} catch {}
+let adapter29 = await promise71;
+let renderBundle152 = renderBundleEncoder103.finish({label: '\u0ada\ubda8\uc648\u0034\u{1ff1d}\u7055'});
+let promise73 = adapter12.requestDevice({
+requiredLimits: {
+maxBindGroups: 8,
+maxColorAttachmentBytesPerSample: 47,
+maxVertexAttributes: 24,
+maxVertexBufferArrayStride: 41744,
+maxStorageTexturesPerShaderStage: 8,
+maxStorageBuffersPerShaderStage: 22,
+maxDynamicStorageBuffersPerPipelineLayout: 7299,
+maxBindingsPerBindGroup: 8089,
+maxTextureDimension1D: 9886,
+maxTextureDimension2D: 8673,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 50508974,
+maxUniformBuffersPerShaderStage: 38,
+maxInterStageShaderVariables: 50,
+maxInterStageShaderComponents: 77,
+},
+});
+let bindGroupLayout58 = device9.createBindGroupLayout({
+entries: [{
+binding: 291,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}, {
+binding: 979,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}],
+});
+let commandEncoder155 = device9.createCommandEncoder({});
+let textureView162 = texture139.createView({label: '\u0647\u6c77\u8041\ue253\u0e53\u8f1e', baseMipLevel: 6, mipLevelCount: 1, baseArrayLayer: 0});
+try {
+device9.pushErrorScope('internal');
+} catch {}
+let commandEncoder156 = device10.createCommandEncoder({label: '\ucede\ubc56\u{1f6aa}\u0e97'});
+let texture187 = device10.createTexture({
+label: '\u0685\u806b\u{1faa2}\u{1ff4e}',
+size: [408],
+dimension: '1d',
+format: 'rgba32uint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba32uint', 'rgba32uint', 'rgba32uint'],
+});
+let textureView163 = texture138.createView({aspect: 'all', mipLevelCount: 1, baseArrayLayer: 57, arrayLayerCount: 128});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let pipelineLayout28 = device3.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout38, bindGroupLayout55, bindGroupLayout51, bindGroupLayout27, bindGroupLayout32, bindGroupLayout26]
+});
+let texture188 = device3.createTexture({
+label: '\u6d5c\u{1f9b5}\u066d\u{1fdde}\u0d57\ud3c7',
+size: [1824, 40, 91],
+mipLevelCount: 11,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+});
+try {
+computePassEncoder48.dispatchWorkgroupsIndirect(buffer35, 32696);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(806), /* required buffer size: 806 */
+{offset: 806, bytesPerRow: 109}, {width: 0, height: 16, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder89 = commandEncoder137.beginComputePass({label: '\u8e51\u0c85\u363a'});
+let renderBundle153 = renderBundleEncoder90.finish({label: '\u4c1f\u{1fb89}\u550b\u115b\ub39b\u8f85\u2648\u53ff\u13b9'});
+try {
+commandEncoder131.copyTextureToTexture({
+  texture: texture134,
+  mipLevel: 1,
+  origin: { x: 32, y: 4, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture134,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 40, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device8.queue.onSubmittedWorkDone();
+} catch {}
+let video43 = await videoWithData();
+let querySet114 = device6.createQuerySet({
+label: '\u{1fdb9}\u025a\u{1fb07}\u{1f87d}\u47a2\u2f65\u91a4\u20a4\u9655\u2da9\u{1fb80}',
+type: 'occlusion',
+count: 3857,
+});
+let renderBundle154 = renderBundleEncoder95.finish({label: '\u{1ffca}\ua2aa\u982d\u0c0f'});
+try {
+texture181.destroy();
+} catch {}
+let videoFrame48 = new VideoFrame(offscreenCanvas20, {timestamp: 0});
+let pipelineLayout29 = device10.createPipelineLayout({label: '\ub38b\u04c8', bindGroupLayouts: [bindGroupLayout54, bindGroupLayout54, bindGroupLayout54]});
+let textureView164 = texture187.createView({label: '\u{1fa56}\udfc2\u0c70\u{1f9ab}'});
+let renderBundle155 = renderBundleEncoder113.finish({label: '\uf065\ud606\u{1f88d}\u0014\uee56\u{1ff82}\u{1fac9}\u01de\u5aba\uab79\u{1f6b7}'});
+let sampler124 = device10.createSampler({
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 67.932,
+lodMaxClamp: 92.338,
+});
+let promise74 = navigator.gpu.requestAdapter({
+});
+let imageBitmap45 = await createImageBitmap(canvas39);
+let commandEncoder157 = device6.createCommandEncoder({label: '\u0e1b\udad3\uf579\u0a5a\u201c'});
+try {
+gpuCanvasContext48.configure({
+device: device6,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rgba16float', 'rgba16float'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 17, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video11,
+  origin: { x: 3, y: 4 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 3,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 9, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let textureView165 = texture133.createView({label: '\u{1fcc2}\u6dad\u{1fe16}\u4892\ub991'});
+let sampler125 = device6.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'linear',
+lodMinClamp: 82.018,
+lodMaxClamp: 90.217,
+});
+try {
+commandEncoder157.copyBufferToTexture({
+/* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 30336 */
+offset: 30336,
+buffer: buffer51,
+}, {
+  texture: texture133,
+  mipLevel: 0,
+  origin: { x: 127, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device6, buffer51);
+} catch {}
+try {
+commandEncoder157.clearBuffer(buffer60, 13216, 260);
+dissociateBuffer(device6, buffer60);
+} catch {}
+try {
+device6.queue.writeBuffer(buffer60, 12900, new DataView(new ArrayBuffer(24295)), 17354, 832);
+} catch {}
+let bindGroupLayout59 = device9.createBindGroupLayout({
+label: '\u0f3a\u{1faf9}\ubd10\ueb1f\u{1fe97}\u058f\u{1f860}',
+entries: [],
+});
+let bindGroupLayout60 = device13.createBindGroupLayout({
+label: '\u{1fb26}\ufd50\u{1fab6}',
+entries: [],
+});
+let buffer61 = device13.createBuffer({size: 11507, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let offscreenCanvas51 = new OffscreenCanvas(696, 698);
+let gpuCanvasContext49 = offscreenCanvas51.getContext('webgpu');
+let commandEncoder158 = device12.createCommandEncoder({label: '\uc3d6\u4a96\u{1f8a0}\u040b\u003b\u0fb1\u45a3\u{1fb1b}\u{1f795}'});
+let renderBundle156 = renderBundleEncoder117.finish({label: '\u0440\uecec\u0a03\u1663\u06c6\uc237\u{1f6da}\u8599'});
+try {
+computePassEncoder82.setBindGroup(3, bindGroup31);
+} catch {}
+try {
+computePassEncoder82.end();
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame40.close();
+videoFrame41.close();
+videoFrame42.close();
+videoFrame43.close();
+videoFrame44.close();
+videoFrame45.close();
+videoFrame46.close();
+videoFrame47.close();
+videoFrame48.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -3680,6 +3680,9 @@ bool Texture::validateLinearTextureData(const WGPUTextureDataLayout& layout, uin
 
 bool Texture::previouslyCleared(uint32_t mipLevel, uint32_t slice) const
 {
+    if (isDestroyed())
+        return true;
+
     if (auto it = m_clearedToZero.find(mipLevel); it != m_clearedToZero.end())
         return it->value.contains(slice);
 


### PR DESCRIPTION
#### a4646567a5dadda7de0b64cdc57e6e4ab6fb2e4a
<pre>
[WebGPU] no need to clear destroyed textures
<a href="https://bugs.webkit.org/show_bug.cgi?id=273570">https://bugs.webkit.org/show_bug.cgi?id=273570</a>
&lt;radar://127364747&gt;

Reviewed by Cameron McCormack.

Destroyed textures act like valid objects but no operations
including clearing should occur on them.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-273570-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-273570.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::previouslyCleared const):

Canonical link: <a href="https://commits.webkit.org/278337@main">https://commits.webkit.org/278337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45d095e43da36bd8f87416bc783e0103100d6c64

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53486 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/917 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/539 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22085 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/24610 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/475 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8605 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/536 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55071 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25323 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48381 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/26584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43411 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47409 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11016 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27448 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/26316 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->