### PR TITLE
[UnifiedPDF] Snapshots don't get the correct scroll offset

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -783,7 +783,15 @@ void UnifiedPDFPlugin::paint(GraphicsContext& context, const IntRect&)
     context.translate(-m_scrollOffset.width(), -m_scrollOffset.height());
 
     FloatRect clipRect { FloatPoint(m_scrollOffset), size() };
+
     context.clip(clipRect);
+    context.fillRect(clipRect, WebCore::roundAndClampToSRGBALossy([WebCore::CocoaColor grayColor].CGColor));
+    context.scale(m_scaleFactor);
+
+    auto paddingForCentering = centeringOffset();
+    context.translate(paddingForCentering.width(), paddingForCentering.height());
+
+    clipRect.scale(1.0f / m_scaleFactor);
 
     paintPDFContent(context, clipRect);
 }


### PR DESCRIPTION
#### 8cf954d346bc1cc6b549e8a60cb95bda9c7d15f1
<pre>
[UnifiedPDF] Snapshots don&apos;t get the correct scroll offset
<a href="https://bugs.webkit.org/show_bug.cgi?id=273565">https://bugs.webkit.org/show_bug.cgi?id=273565</a>
<a href="https://rdar.apple.com/126945237">rdar://126945237</a>

Reviewed by Simon Fraser and Abrar Rahman Protyasha.

In order to make the snapshots appear correct in the tab preview we
need to make a few related changes.

The first change we need to make is to take into consideration the page
scale. This is the main factor that is driving the incorrect scroll
offset in the snapshots. However, we must also recenter the document
by adding in the padding that is used to center it. Finally, we must
also make sure that we paint the grey background that is shown on the
page itself.

One other related change we need to make is to factor out the page scale
in the clip rect we pass to paintPDFContent. This is because we will
pass in the rect to pageCoverageForRect, which seems to expect that the
passed in rect is in document space, in order to determine which pages
need to get painted. With the page scale factored into the rect we
can get into a state where we scroll to a new page in the document but
not have that page appear in the snapshot.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::paint):

Canonical link: <a href="https://commits.webkit.org/278244@main">https://commits.webkit.org/278244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4c8116ac0d4e65ad4e8d13f71a1a7cc430011b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2192 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53154 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/588 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/157 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40723 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42946 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21849 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24217 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8281 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46314 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/217 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54735 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25005 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/164 "Found 2 new test failures: imported/w3c/web-platform-tests/web-locks/query.tentative.https.any.worker.html, imported/w3c/web-platform-tests/workers/nested_worker_close_from_parent_worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48112 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26262 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43136 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47166 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10958 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27124 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25992 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->