### PR TITLE
[WebGPU] Destroyed depth stencil textures should have a depth stencil format

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2103,6 +2103,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-126711484.html [ Pass Failure ]
 [ Debug ] fast/webgpu/fuzz-273505.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-273505.html [ Pass Failure ]
+[ Debug ] fast/webgpu/fuzz-273566.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-273566.html [ Pass Failure ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2107,6 +2107,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-273566.html [ Pass Failure ]
 [ Debug ] fast/webgpu/fuzz-273570.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-273570.html [ Pass Failure ]
+[ Debug ] fast/webgpu/fuzz-273573.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-273573.html [ Pass Failure ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2105,6 +2105,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-273505.html [ Pass Failure ]
 [ Debug ] fast/webgpu/fuzz-273566.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-273566.html [ Pass Failure ]
+[ Debug ] fast/webgpu/fuzz-273570.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-273570.html [ Pass Failure ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2101,6 +2101,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-273023.html [ Pass Failure ]
 [ Debug ] fast/webgpu/fuzz-126711484.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-126711484.html [ Pass Failure ]
+[ Debug ] fast/webgpu/fuzz-273505.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-273505.html [ Pass Failure ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-273505-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-273505-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-273505.html
+++ b/LayoutTests/fast/webgpu/fuzz-273505.html
@@ -1,0 +1,29130 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter();
+let device0 = await adapter0.requestDevice({
+label: '\u{1f72f}\u09af\u{1f7eb}\u630d\ua242\u{1f647}\uf8e1\u270c',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+});
+let imageData0 = new ImageData(224, 204);
+let img0 = await imageWithData(205, 53, '#88ed8d73', '#e69d72a4');
+try {
+adapter0.label = '\u0003\ub500\u132e\uf8a2\u0a4a';
+} catch {}
+let texture0 = device0.createTexture({
+label: '\uef19\ud022\ub361\ueb18\u{1fbb7}',
+size: [1320, 96, 1],
+mipLevelCount: 9,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let textureView0 = texture0.createView({label: '\u4f00\u073e\uccc1\u7893', dimension: '2d-array', baseMipLevel: 6});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\u2a1a\ub342\u{1fc5c}\u06cb\u4748\u09d2\u200d',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 224, y: 8, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(1150), /* required buffer size: 1150 */
+{offset: 230, bytesPerRow: 396}, {width: 64, height: 24, depthOrArrayLayers: 1});
+} catch {}
+let imageBitmap0 = await createImageBitmap(img0);
+let commandEncoder0 = device0.createCommandEncoder({label: '\u0187\u075c\u0529\u27c3\u{1fec5}\u82f0\u784e\u{1f666}\ub2ac'});
+let textureView1 = texture0.createView({label: '\ue09a\u526d\ua2b3\u8890\u8365', dimension: '2d', mipLevelCount: 5, baseArrayLayer: 0});
+try {
+renderBundleEncoder0.setVertexBuffer(85, undefined, 2085082217, 642100254);
+} catch {}
+let bindGroupLayout0 = device0.createBindGroupLayout({
+label: '\u05ac\u109e\ub2e7\ucd4b\u291f\ub9f2\u3bc7\u8e17',
+entries: [{
+binding: 561,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}],
+});
+let commandEncoder1 = device0.createCommandEncoder();
+let querySet0 = device0.createQuerySet({
+label: '\ufcfb\u094f\uf163\u8d70\u5f08\u0b7b\ua583',
+type: 'occlusion',
+count: 2099,
+});
+let textureView2 = texture0.createView({aspect: 'all', baseMipLevel: 5, mipLevelCount: 2});
+let renderBundle0 = renderBundleEncoder0.finish();
+document.body.prepend(img0);
+let video0 = await videoWithData();
+let pipelineLayout0 = device0.createPipelineLayout({label: '\uc999\u055f\u4eb1\u6498\u{1f95c}\u3d64\u4b09', bindGroupLayouts: [bindGroupLayout0]});
+let commandBuffer0 = commandEncoder1.finish({
+label: '\u672c\ud0b7\u663c\u{1f612}',
+});
+let texture1 = device0.createTexture({
+size: {width: 64},
+dimension: '1d',
+format: 'rgba8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8sint', 'rgba8sint'],
+});
+let shaderModule0 = device0.createShaderModule({
+label: '\udd56\u0333\u04e2',
+code: `@group(0) @binding(561)
+var<storage, read_write> global0: array<u32>;
+
+@compute @workgroup_size(4, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec4<f32>,
+  @location(3) f1: vec3<f32>,
+  @builtin(frag_depth) f2: f32,
+  @location(0) f3: vec2<u32>,
+  @location(1) f4: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(sample_mask) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(4) a1: vec2<i32>, @location(6) a2: vec3<i32>, @location(5) a3: vec4<f32>, @location(14) a4: vec4<f32>, @builtin(instance_index) a5: u32, @location(12) a6: vec2<u32>, @location(8) a7: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let renderBundle1 = renderBundleEncoder0.finish({label: '\u{1f7d1}\uf502\u6533\uafa8\u922c\u0895\u2b67\u0b1c\u1b9e\u67a3\uc9b2'});
+let pipeline0 = await device0.createRenderPipelineAsync({
+label: '\u2883\u0bb0\u022d\u988a\u22a6\u079d\u3881',
+layout: pipelineLayout0,
+multisample: {
+count: 4,
+mask: 0xb3c55fc5,
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'bgra8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'keep',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 557,
+stencilWriteMask: 1586,
+depthBias: 31,
+depthBiasSlopeScale: 85,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 668,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 520,
+shaderLocation: 5,
+}, {
+format: 'float32',
+offset: 336,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 1544,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x2',
+offset: 1124,
+shaderLocation: 12,
+}, {
+format: 'sint32x4',
+offset: 212,
+shaderLocation: 4,
+}, {
+format: 'sint8x4',
+offset: 1056,
+shaderLocation: 6,
+}, {
+format: 'unorm16x4',
+offset: 680,
+shaderLocation: 8,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let canvas0 = document.createElement('canvas');
+let sampler0 = device0.createSampler({
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMaxClamp: 99.270,
+});
+let shaderModule1 = device0.createShaderModule({
+code: `@group(0) @binding(561)
+var<storage, read_write> function0: array<u32>;
+
+@compute @workgroup_size(1, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec3<i32>,
+  @builtin(frag_depth) f1: f32,
+  @location(2) f2: vec4<i32>,
+  @location(3) f3: vec4<f32>,
+  @builtin(sample_mask) f4: u32,
+  @location(0) f5: vec3<u32>,
+  @location(4) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(0) a0: vec4<f32>, @builtin(instance_index) a1: u32, @location(15) a2: vec2<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroupLayout1 = device0.createBindGroupLayout({
+entries: [{
+binding: 257,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+}, {
+binding: 43,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+}],
+});
+let commandEncoder2 = device0.createCommandEncoder({});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(1000), /* required buffer size: 1000 */
+{offset: 1000}, {width: 15, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise0 = device0.createRenderPipelineAsync({
+label: '\u0b11\u05a6\u{1f6de}\u06b5\ucaf1\u567a',
+layout: pipelineLayout0,
+multisample: {
+mask: 0xef01c96b,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.GREEN}, {format: 'rg8sint', writeMask: GPUColorWrite.GREEN}, undefined, {
+  format: 'rg32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'src-alpha', dstFactor: 'dst'},
+alpha: {operation: 'add', srcFactor: 'one', dstFactor: 'src-alpha'},
+},
+  writeMask: GPUColorWrite.BLUE
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'invert',
+depthFailOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2545,
+stencilWriteMask: 1132,
+depthBiasClamp: 86,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 1960,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 112,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1760,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1524,
+attributes: [{
+format: 'sint16x4',
+offset: 428,
+shaderLocation: 15,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'none',
+unclippedDepth: true,
+},
+});
+let img1 = await imageWithData(142, 183, '#b4fe5da4', '#1a694126');
+let buffer0 = device0.createBuffer({
+  label: '\ue726\uba9c\u0d18\ubdbd\ubeaf\u2f07\u5b4d\u0cbd\ub75e\u59b5',
+  size: 37235,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX
+});
+let texture2 = device0.createTexture({
+label: '\ua1c2\ud2d2\u44a1\u0048\u333f\uc844\u7075\u{1fdc7}\u{1fe48}',
+size: [1320, 96, 1],
+mipLevelCount: 7,
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x6-unorm-srgb', 'astc-8x6-unorm-srgb'],
+});
+let pipeline1 = await device0.createRenderPipelineAsync({
+label: '\u{1fa9d}\u7ce1',
+layout: 'auto',
+multisample: {
+mask: 0x8f273e41,
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rg8sint'}, undefined, {format: 'rg32float'}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'src'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'zero'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+depthBias: 16,
+depthBiasSlopeScale: 83,
+depthBiasClamp: 87,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 528,
+attributes: [{
+format: 'unorm8x4',
+offset: 260,
+shaderLocation: 14,
+}, {
+format: 'uint8x2',
+offset: 350,
+shaderLocation: 12,
+}, {
+format: 'float32x3',
+offset: 276,
+shaderLocation: 8,
+}, {
+format: 'float32x3',
+offset: 484,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 1684,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x4',
+offset: 1088,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 1392,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1408,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1816,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 1696,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let commandEncoder3 = device0.createCommandEncoder({label: '\ua9b9\u0397\ue09d\u0229\u{1f818}\u31fd\ua4e9\u02b0'});
+let texture3 = device0.createTexture({
+label: '\ue0d2\u7826\u2857\u{1fd61}\ufcc1\u66db\u0375\u2ca4',
+size: {width: 438, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+sampleCount: 1,
+dimension: '2d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  label: '\u5179\u6bd4\u0b5a',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+let sampler1 = device0.createSampler({
+label: '\u94dc\ucf23\u9187\u{1f9c7}\uf71b\u05b6\u2fb3\u28cc\u0b67',
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 68.277,
+lodMaxClamp: 82.874,
+});
+try {
+renderBundleEncoder1.setIndexBuffer(buffer0, 'uint16', 8562, 5073);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(4, buffer0, 1432, 26980);
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+let pipeline2 = device0.createComputePipeline({
+label: '\u261e\u{1f6cd}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+let bindGroupLayout2 = device0.createBindGroupLayout({
+label: '\u05fa\u{1fad7}\u077d\u{1fc25}',
+entries: [{
+binding: 788,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+}, {
+binding: 803,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+}],
+});
+let querySet1 = device0.createQuerySet({
+label: '\ue520\u46a5\u569c\u0b86\uc683\u056f\u{1fee1}\u6200\u{1faf2}',
+type: 'occlusion',
+count: 2461,
+});
+pseudoSubmit(device0, commandEncoder0);
+let texture4 = device0.createTexture({
+label: '\u0f3f\u{1fb9c}',
+size: {width: 438},
+dimension: '1d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+commandEncoder2.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 56, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 5, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer1 = device0.createBuffer({
+  label: '\u0fbd\u{1fffe}\ud603\u{1f6fa}\u077a\u33ea\u0513',
+  size: 59133,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE
+});
+try {
+renderBundleEncoder1.setVertexBuffer(5, buffer0);
+} catch {}
+try {
+commandEncoder2.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 250, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 448 widthInBlocks: 112 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 33380 */
+offset: 32932,
+buffer: buffer1,
+}, {width: 112, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 7, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 336, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 35, height: 1, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let imageData1 = new ImageData(8, 140);
+let querySet2 = device0.createQuerySet({
+label: '\u6d8c\u7a8d\u0c6e\u89d0\u0223\u{1fad4}\u5f0a\u074c\u3461\u01f8\u{1fdb3}',
+type: 'occlusion',
+count: 992,
+});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  label: '\u1525\uc306\uc408\ue853\u0af4',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder3.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 1,
+  origin: { x: 0, y: 32, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 1296 widthInBlocks: 81 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 52368 */
+offset: 51072,
+bytesPerRow: 1536,
+buffer: buffer1,
+}, {width: 648, height: 8, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 1,
+  origin: { x: 464, y: 32, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 3,
+  origin: { x: 32, y: 16, z: 1 },
+  aspect: 'all',
+}, {width: 136, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(222, 788);
+let buffer2 = device0.createBuffer({
+  label: '\u0948\ufd84\u0d91\u{1febf}\u095f\ud13b\uf129\u{1f746}',
+  size: 1403,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let querySet3 = device0.createQuerySet({
+label: '\uc393\u09dd',
+type: 'occlusion',
+count: 350,
+});
+let texture5 = gpuCanvasContext0.getCurrentTexture();
+try {
+commandEncoder2.copyBufferToBuffer(buffer2, 240, buffer1, 12800, 20);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.clearBuffer(buffer1, 7696, 41192);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({
+label: '\ub79c\uceb9\u04f0\u{1f77e}\ua603\u0345',
+entries: [],
+});
+let commandEncoder4 = device0.createCommandEncoder();
+let computePassEncoder0 = commandEncoder4.beginComputePass({label: '\u{1f839}\ue733\u0cc4\u0e48\ufc1b\u08fb'});
+let sampler2 = device0.createSampler({
+label: '\u8556\u0b25',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 99.146,
+lodMaxClamp: 99.754,
+maxAnisotropy: 4,
+});
+try {
+computePassEncoder0.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder1.setIndexBuffer(buffer0, 'uint32', 18308, 12598);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(5, buffer0, 17108);
+} catch {}
+try {
+  await buffer2.mapAsync(GPUMapMode.WRITE, 1024, 136);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 22700, new Int16Array(16815), 2035, 13044);
+} catch {}
+offscreenCanvas0.height = 125;
+let bindGroupLayout4 = device0.createBindGroupLayout({
+entries: [],
+});
+let texture6 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderBundleEncoder2.setVertexBuffer(3, buffer0, 35684, 1035);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 4204, new Int16Array(3267), 2321, 504);
+} catch {}
+let pipeline3 = device0.createComputePipeline({
+label: '\u0841\u2904\u0739\u04d9\ue8c4\u187d\ud781',
+layout: 'auto',
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+});
+let pipeline4 = device0.createRenderPipeline({
+label: '\ua8da\u{1fb7d}\u344b\u{1fd66}\u095c\u{1f874}\u{1f79c}\u1ea1\u0286\uea3d',
+layout: pipelineLayout0,
+multisample: {
+mask: 0x7702147,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.BLUE}, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 1287,
+stencilWriteMask: 3725,
+depthBias: 91,
+depthBiasClamp: 70,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1588,
+attributes: [{
+format: 'sint32x4',
+offset: 176,
+shaderLocation: 15,
+}, {
+format: 'float32',
+offset: 1308,
+shaderLocation: 0,
+}],
+}
+]
+},
+});
+let texture7 = device0.createTexture({
+label: '\u5e59\ub6b1\uc7fc\ucd77\u51e0\u0926\u3a2a\ud0c9\u0cc3',
+size: {width: 64, height: 90, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-8x5-unorm', 'astc-8x5-unorm'],
+});
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder({label: '\u{1fee5}\u{1f695}\u070f'});
+let renderBundle2 = renderBundleEncoder0.finish({label: '\u{1fbe2}\u0677\u03e1\u{1ff4e}\u03da\u032b\u0885\u{1f880}\udfca\uc0a1\u0729'});
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(17, undefined, 1883029151);
+} catch {}
+try {
+commandEncoder5.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 7,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 32304 */
+offset: 32304,
+rowsPerImage: 125,
+buffer: buffer1,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder5.clearBuffer(buffer1, 45760, 1040);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 24916, new DataView(new ArrayBuffer(29352)), 11279, 15724);
+} catch {}
+canvas0.height = 625;
+let computePassEncoder1 = commandEncoder4.beginComputePass({});
+let renderBundle3 = renderBundleEncoder2.finish({});
+try {
+renderBundleEncoder1.setVertexBuffer(2, buffer0, 10496, 4888);
+} catch {}
+try {
+commandEncoder5.copyBufferToTexture({
+/* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 9764 */
+offset: 9764,
+buffer: buffer0,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 30, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder2.insertDebugMarker('\u0e03');
+} catch {}
+let pipeline5 = await device0.createComputePipelineAsync({
+label: '\u973b\u{1f691}\ub081\ub8c2\u5a37\u0374\u{1f651}\u{1ff01}\u6542\u99fc\u0574',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+offscreenCanvas0.getContext('bitmaprenderer');
+} catch {}
+let textureView3 = texture0.createView({
+  label: '\u{1f628}\u0f14\u008b\u0b9c\ubccb\u29ac\u0e89\u{1f9c0}',
+  dimension: '2d-array',
+  aspect: 'all',
+  format: 'astc-8x8-unorm',
+  baseMipLevel: 8
+});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\u{1ff55}\u7120\u5d3d\u0081\uf019',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+try {
+computePassEncoder1.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(buffer2, 240, buffer1, 22276, 168);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 39616, new Int16Array(46263), 4521, 2216);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let canvas1 = document.createElement('canvas');
+let offscreenCanvas1 = new OffscreenCanvas(254, 633);
+let pipelineLayout1 = device0.createPipelineLayout({label: '\u{1fc2f}\u{1f681}\ua573', bindGroupLayouts: []});
+let commandEncoder6 = device0.createCommandEncoder({});
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 163, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 15, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 237, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['etc2-rgb8unorm', 'astc-5x5-unorm'],
+colorSpace: 'srgb',
+});
+} catch {}
+let texture8 = device0.createTexture({
+label: '\u{1f8f3}\u0df6\u9227',
+size: {width: 128, height: 180, depthOrArrayLayers: 1029},
+mipLevelCount: 10,
+dimension: '3d',
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rg16sint'],
+});
+let sampler3 = device0.createSampler({
+label: '\u{1f7a7}\u{1fd76}\u5cbd\ubc96\u{1fd7e}\u7983\ued3e',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+lodMinClamp: 28.012,
+lodMaxClamp: 47.400,
+compare: 'equal',
+});
+try {
+renderBundleEncoder3.setVertexBuffer(35, undefined);
+} catch {}
+try {
+commandEncoder6.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 5680 */
+offset: 5680,
+buffer: buffer0,
+}, {
+  texture: texture2,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder6.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 195, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 21, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 45, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let canvas2 = document.createElement('canvas');
+let texture9 = device0.createTexture({
+label: '\u8a87\ua8ee\u70ef\ua88d\u0c84\u0dcc\u0a8e\u5e16',
+size: {width: 876, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'rgba16uint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16uint'],
+});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\u{1f83c}\u846d\u850d\u067d\u{1f9a7}\u{1f7f6}\u{1f7d3}',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder3.setVertexBuffer(0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 53160, new Float32Array(2245), 869, 1180);
+} catch {}
+let pipeline6 = await device0.createRenderPipelineAsync({
+layout: pipelineLayout0,
+multisample: {
+count: 4,
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint', writeMask: 0}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, undefined, {format: 'rg32float', writeMask: 0}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'dst'},
+alpha: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'one-minus-src-alpha'},
+},
+  writeMask: 0
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3950,
+depthBias: 62,
+depthBiasSlopeScale: 24,
+depthBiasClamp: 14,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 196,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 12,
+shaderLocation: 12,
+}, {
+format: 'snorm16x2',
+offset: 20,
+shaderLocation: 5,
+}, {
+format: 'sint32x4',
+offset: 12,
+shaderLocation: 6,
+}, {
+format: 'sint32x4',
+offset: 120,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 148,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x2',
+offset: 40,
+shaderLocation: 8,
+}, {
+format: 'snorm16x4',
+offset: 28,
+shaderLocation: 14,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let videoFrame0 = new VideoFrame(video0, {timestamp: 0});
+let bindGroup0 = device0.createBindGroup({
+label: '\u0173\u0553\ua4e7\u3ac3\u85a1',
+layout: bindGroupLayout4,
+entries: [],
+});
+let commandBuffer1 = commandEncoder6.finish({
+label: '\u0362\u05ee',
+});
+let texture10 = device0.createTexture({
+size: {width: 660, height: 48, depthOrArrayLayers: 1},
+mipLevelCount: 9,
+format: 'r32sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r32sint', 'r32sint', 'r32sint'],
+});
+try {
+renderBundleEncoder3.setVertexBuffer(29, undefined);
+} catch {}
+try {
+commandEncoder3.copyBufferToBuffer(buffer0, 32992, buffer1, 40644, 0);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 42, y: 1, z: 0 },
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(24)), /* required buffer size: 97 */
+{offset: 97}, {width: 339, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder2 = commandEncoder3.beginComputePass({label: '\u1169\ufb22'});
+try {
+renderBundleEncoder3.setPipeline(pipeline6);
+} catch {}
+let video1 = await videoWithData();
+let imageData2 = new ImageData(76, 132);
+try {
+renderBundleEncoder3.drawIndexed(32);
+} catch {}
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 1,
+  origin: { x: 184, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 1,
+  origin: { x: 32, y: 8, z: 0 },
+  aspect: 'all',
+}, {width: 256, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder2.clearBuffer(buffer1, 11756, 7676);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+window.someLabel = renderBundleEncoder1.label;
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder3.draw(40, 64, 48, 24);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 110, y: 1, z: 0 },
+  aspect: 'all',
+}, new Uint16Array(new ArrayBuffer(8)), /* required buffer size: 22 */
+{offset: 22, rowsPerImage: 196}, {width: 196, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(487, 687);
+let videoFrame1 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+try {
+canvas1.getContext('webgl2');
+} catch {}
+let querySet4 = device0.createQuerySet({
+label: '\u012e\u0fde\u7b95\u2779\u{1f768}\u943a',
+type: 'occlusion',
+count: 624,
+});
+try {
+renderBundleEncoder3.drawIndexed(16, 80);
+} catch {}
+try {
+commandEncoder5.copyBufferToBuffer(buffer0, 1644, buffer1, 52016, 4076);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline7 = await promise0;
+let gpuCanvasContext1 = offscreenCanvas1.getContext('webgpu');
+let canvas3 = document.createElement('canvas');
+try {
+offscreenCanvas2.getContext('webgl');
+} catch {}
+let bindGroupLayout5 = device0.createBindGroupLayout({
+label: '\ub750\ue1bb\ubfb8\u{1fcb4}\ue546\u{1f909}',
+entries: [],
+});
+let bindGroupLayout6 = pipeline7.getBindGroupLayout(0);
+let querySet5 = device0.createQuerySet({
+label: '\u{1fa77}\u{1f84f}\u{1fdc2}\u57a2',
+type: 'occlusion',
+count: 2739,
+});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder3.draw(24, 72, 56, 8);
+} catch {}
+try {
+renderBundleEncoder3.drawIndexed(48, 56, 56);
+} catch {}
+try {
+commandEncoder4.copyBufferToBuffer(buffer0, 32480, buffer1, 24648, 2320);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 2, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 240 widthInBlocks: 60 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 46860 */
+offset: 46860,
+rowsPerImage: 277,
+buffer: buffer1,
+}, {width: 60, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.clearBuffer(buffer1, 16284, 37984);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 2,
+  origin: { x: 16, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 428 */
+{offset: 428, bytesPerRow: 638}, {width: 272, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+label: '\uf6f0\u0488',
+code: `@group(0) @binding(561)
+var<storage, read_write> function1: array<u32>;
+
+@compute @workgroup_size(6, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec4<f32>,
+  @location(3) f1: vec4<f32>,
+  @location(1) f2: vec4<i32>,
+  @builtin(frag_depth) f3: f32,
+  @location(0) f4: vec2<u32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_index) a1: u32, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S0 {
+  @location(4) f0: f32,
+  @location(2) f1: f16,
+  @location(6) f2: vec2<f16>,
+  @location(13) f3: vec4<f32>,
+  @location(3) f4: i32
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec3<f16>, @location(15) a1: vec2<u32>, @location(7) a2: vec3<i32>, @builtin(instance_index) a3: u32, @location(12) a4: vec4<f32>, a5: S0) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let buffer3 = device0.createBuffer({size: 62511, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let querySet6 = device0.createQuerySet({
+type: 'occlusion',
+count: 1560,
+});
+let textureView4 = texture3.createView({label: '\u{1feb9}\u01ad\u006d\u0599\uf62d\u0fb4\u3df9\uce15\u329c\u{1ffdb}', mipLevelCount: 2});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler4 = device0.createSampler({
+label: '\u{1fcf8}\u3236\u6bc6\u017b\u21ce\u2c6b\u03a3\ubfd0\u6003',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+lodMinClamp: 11.966,
+lodMaxClamp: 90.285,
+});
+try {
+renderBundleEncoder1.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder3.draw(40, 48, 48, 64);
+} catch {}
+try {
+  await buffer3.mapAsync(GPUMapMode.WRITE, 0, 34900);
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(buffer2, 868, buffer1, 23256, 72);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 118, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 608 widthInBlocks: 152 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 40468 */
+offset: 39860,
+buffer: buffer1,
+}, {width: 152, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline8 = device0.createComputePipeline({
+label: '\u{1fd5f}\uc759\u{1f85f}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let img2 = await imageWithData(17, 34, '#943b7bb8', '#930aea29');
+let querySet7 = device0.createQuerySet({
+label: '\u{1fff3}\u0aa1\u2556\uab91\u{1f6b7}\u5277\u0c00\u{1fd0f}\uaf03\u7ee3\u0f58',
+type: 'occlusion',
+count: 2633,
+});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u0405\u8660\u0cff\ue5dd\u{1fdbb}',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder3.drawIndexed(8, 16, 64, -152, 80);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(6, buffer0, 14616, 1009);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 20, y: 0, z: 0 },
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(24)), /* required buffer size: 632 */
+{offset: 632}, {width: 293, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline9 = await device0.createComputePipelineAsync({
+label: '\u83f6\u1261\u5883\u{1ff76}\u07c6\ud542\u5a67\u7ca2\u2118',
+layout: 'auto',
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline10 = device0.createRenderPipeline({
+label: '\u032b\u001c\u4175\ub307\u7e80\u{1fae0}\u04ee\u{1fa05}\u{1fc0c}\u{1fd9a}\u7887',
+layout: pipelineLayout1,
+multisample: {
+count: 4,
+mask: 0x2ceb7c5,
+},
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'zero',
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+stencilBack: {
+failOp: 'zero',
+depthFailOp: 'zero',
+},
+stencilReadMask: 2416,
+stencilWriteMask: 3552,
+depthBias: 39,
+depthBiasSlopeScale: 87,
+depthBiasClamp: 16,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 856,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 804,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x4',
+offset: 600,
+shaderLocation: 3,
+}, {
+format: 'float16x2',
+offset: 572,
+shaderLocation: 4,
+}, {
+format: 'uint8x2',
+offset: 692,
+shaderLocation: 15,
+}, {
+format: 'sint32x2',
+offset: 16,
+shaderLocation: 7,
+}, {
+format: 'float16x4',
+offset: 776,
+shaderLocation: 13,
+}, {
+format: 'unorm16x4',
+offset: 224,
+shaderLocation: 6,
+}, {
+format: 'float32',
+offset: 784,
+shaderLocation: 1,
+}, {
+format: 'snorm8x4',
+offset: 300,
+shaderLocation: 2,
+}, {
+format: 'float32x2',
+offset: 300,
+shaderLocation: 12,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+try {
+  await promise1;
+} catch {}
+let adapter1 = await navigator.gpu.requestAdapter();
+let bindGroup1 = device0.createBindGroup({
+label: '\u2df1\u{1fbe9}\u{1ff5f}\u{1f9ce}\u{1ff9b}\u00d0\u0e7d',
+layout: bindGroupLayout5,
+entries: [],
+});
+let commandEncoder7 = device0.createCommandEncoder({label: '\u{1f992}\u2f31\ua9d0\u00af\u{1fb45}\u0fd3\u{1fca4}\u3865\u0225\u{1fef2}'});
+let imageBitmap1 = await createImageBitmap(video1);
+let commandEncoder8 = device0.createCommandEncoder({label: '\u{1f77c}\u{1fc69}\u2d8d\u{1fa80}\u0c95\u{1f9a8}\u9b11'});
+let querySet8 = device0.createQuerySet({
+label: '\u0d1c\u0542\u03f8\u2007',
+type: 'occlusion',
+count: 1959,
+});
+try {
+renderBundleEncoder3.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer0, 'uint16', 36162);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(2, buffer0, 4580);
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout({
+  label: '\u7568\u6ea2\u9ab7\u076b',
+  bindGroupLayouts: [bindGroupLayout2, bindGroupLayout2, bindGroupLayout3, bindGroupLayout2]
+});
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint32', 24896, 2120);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(3, buffer0, 22200, 2969);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 4,
+  origin: { x: 0, y: 1, z: 3 },
+  aspect: 'all',
+}, new ArrayBuffer(40), /* required buffer size: 3910461 */
+{offset: 748, bytesPerRow: 301, rowsPerImage: 220}, {width: 6, height: 10, depthOrArrayLayers: 60});
+} catch {}
+let pipeline11 = await device0.createComputePipelineAsync({
+label: '\u0586\u0a96\u0b47\u0897\u{1fe3d}\ub913\u{1f66a}\u0685',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let renderBundle4 = renderBundleEncoder0.finish();
+try {
+renderBundleEncoder3.draw(32, 64, 16, 32);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(51, undefined, 2765062406, 561794035);
+} catch {}
+let arrayBuffer0 = buffer2.getMappedRange(1144, 12);
+try {
+device0.queue.submit([
+commandBuffer0,
+]);
+} catch {}
+let promise2 = navigator.gpu.requestAdapter({
+});
+let offscreenCanvas3 = new OffscreenCanvas(636, 815);
+let querySet9 = device0.createQuerySet({
+label: '\u623e\uc87f',
+type: 'occlusion',
+count: 1948,
+});
+pseudoSubmit(device0, commandEncoder3);
+let texture11 = device0.createTexture({
+label: '\u8de8\u9396\ucc05',
+size: [660, 48, 1],
+mipLevelCount: 7,
+format: 'astc-10x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder3 = commandEncoder4.beginComputePass();
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  label: '\u04f2\u{1fcde}\u{1f9bb}\u{1fb72}\u{1f9d0}\uac38\u09cc\u0212\u{1f795}\ua281',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder3.draw(40, 40);
+} catch {}
+try {
+renderBundleEncoder1.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 864, y: 88, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder7.clearBuffer(buffer1, 30856, 12808);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 673 */
+{offset: 673}, {width: 32, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+canvas2.getContext('webgl2');
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+layout: bindGroupLayout3,
+entries: [],
+});
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout3, bindGroupLayout1, bindGroupLayout5, bindGroupLayout5]});
+pseudoSubmit(device0, commandEncoder4);
+let texture12 = device0.createTexture({
+label: '\u0652\u{1fe1e}\u{1f74a}\u{1f927}\u0eab',
+size: {width: 32, height: 45, depthOrArrayLayers: 453},
+mipLevelCount: 8,
+sampleCount: 1,
+dimension: '3d',
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u80ea\ucade\u2ca3\u828a',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup1, new Uint32Array(4528), 1386, 0);
+} catch {}
+try {
+renderBundleEncoder1.draw(48, 8, 24, 16);
+} catch {}
+try {
+commandEncoder8.copyBufferToBuffer(buffer3, 49760, buffer1, 48840, 1424);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img3 = await imageWithData(12, 153, '#ca4ef2ca', '#4eb33394');
+let bindGroup3 = device0.createBindGroup({
+layout: bindGroupLayout3,
+entries: [],
+});
+let querySet10 = device0.createQuerySet({
+label: '\uca0d\u{1f64d}\u7cd5',
+type: 'occlusion',
+count: 3763,
+});
+let commandBuffer2 = commandEncoder5.finish();
+let computePassEncoder4 = commandEncoder7.beginComputePass({label: '\u5562\uc058\ue7be\u2857\u5087\u6b10'});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup1, new Uint32Array(8291), 2293, 0);
+} catch {}
+try {
+renderBundleEncoder3.draw(64, 24, 72, 0);
+} catch {}
+try {
+renderBundleEncoder1.drawIndexed(8, 80, 32, 568, 72);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['depth24plus', 'rgba16float', 'rgba16float'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 57200, new Float32Array(44402), 30362, 364);
+} catch {}
+let pipeline12 = await device0.createRenderPipelineAsync({
+layout: pipelineLayout2,
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rg8sint'}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'bgra8unorm', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'invert',
+passOp: 'replace',
+},
+stencilReadMask: 2192,
+stencilWriteMask: 2631,
+depthBias: 89,
+depthBiasSlopeScale: 21,
+depthBiasClamp: 26,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1012,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 1002,
+shaderLocation: 15,
+}, {
+format: 'float32x2',
+offset: 896,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 1364,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x4',
+offset: 632,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 1352,
+attributes: [{
+format: 'unorm16x2',
+offset: 52,
+shaderLocation: 12,
+}, {
+format: 'float16x4',
+offset: 316,
+shaderLocation: 4,
+}, {
+format: 'sint16x2',
+offset: 124,
+shaderLocation: 7,
+}, {
+format: 'snorm16x2',
+offset: 348,
+shaderLocation: 1,
+}, {
+format: 'float16x4',
+offset: 1304,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32',
+offset: 680,
+shaderLocation: 13,
+}],
+}
+]
+},
+});
+let shaderModule3 = device0.createShaderModule({
+label: '\u{1ff1c}\u91e5\u0b16\ua100\u5eab',
+code: `@group(1) @binding(43)
+var<storage, read_write> parameter0: array<u32>;
+@group(1) @binding(257)
+var<storage, read_write> parameter1: array<u32>;
+
+@compute @workgroup_size(3, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec2<f32>,
+  @location(3) f1: vec4<u32>,
+  @location(4) f2: vec4<f32>,
+  @location(1) f3: vec4<f32>,
+  @location(0) f4: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(4) a0: vec3<i32>, @location(1) a1: vec2<i32>, @location(10) a2: u32, @builtin(sample_mask) a3: u32, @builtin(sample_index) a4: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(10) f0: u32,
+  @location(4) f1: vec3<i32>,
+  @builtin(position) f2: vec4<f32>,
+  @location(1) f3: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec3<f16>, @location(2) a1: i32, @location(15) a2: vec4<u32>, @location(0) a3: f16, @builtin(vertex_index) a4: u32, @location(14) a5: vec3<u32>, @location(10) a6: f16, @location(7) a7: vec2<f16>, @location(4) a8: vec4<f16>, @location(13) a9: vec4<u32>, @location(3) a10: vec3<f16>, @location(5) a11: vec4<f16>, @location(6) a12: vec3<i32>, @location(9) a13: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+});
+let bindGroupLayout7 = device0.createBindGroupLayout({
+label: '\u5f42\u0456\u{1f9d1}\u8b44\u{1f871}\u84ef\u0bd8\u04df\u{1f65b}',
+entries: [{
+binding: 791,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d' },
+}],
+});
+try {
+computePassEncoder4.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer0, 'uint32', 19248, 1622);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(5, buffer0, 31080, 6101);
+} catch {}
+let pipeline13 = device0.createComputePipeline({
+label: '\uc626\u9af3',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+document.body.prepend(img2);
+let textureView5 = texture8.createView({label: '\u9457\uf5c9\u5026\u8b4a\ue094\u78cf', mipLevelCount: 6, arrayLayerCount: 1});
+let renderBundle5 = renderBundleEncoder2.finish({});
+try {
+renderBundleEncoder1.drawIndexed(64, 32, 0, 40, 16);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline14 = await device0.createRenderPipelineAsync({
+label: '\u0737\u01cb\u{1fa78}',
+layout: pipelineLayout1,
+multisample: {
+count: 4,
+mask: 0x7b6bb422,
+},
+fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'rgba8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one', dstFactor: 'src-alpha-saturated'},
+alpha: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'dst'},
+},
+  writeMask: GPUColorWrite.ALL
+}, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'one-minus-src'},
+alpha: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'constant'},
+},
+  writeMask: 0
+}, undefined, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'dst'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'dst-alpha'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE
+}]
+},
+vertex: {
+  module: shaderModule3,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 264,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 96,
+shaderLocation: 0,
+}, {
+format: 'sint8x4',
+offset: 140,
+shaderLocation: 6,
+}, {
+format: 'unorm16x4',
+offset: 208,
+shaderLocation: 3,
+}, {
+format: 'uint16x2',
+offset: 180,
+shaderLocation: 14,
+}, {
+format: 'unorm16x2',
+offset: 148,
+shaderLocation: 8,
+}, {
+format: 'float32x3',
+offset: 220,
+shaderLocation: 5,
+}, {
+format: 'sint32',
+offset: 148,
+shaderLocation: 2,
+}, {
+format: 'sint32',
+offset: 12,
+shaderLocation: 9,
+}, {
+format: 'snorm16x2',
+offset: 104,
+shaderLocation: 4,
+}, {
+format: 'unorm16x4',
+offset: 20,
+shaderLocation: 7,
+}, {
+format: 'uint16x2',
+offset: 172,
+shaderLocation: 13,
+}, {
+format: 'float32x3',
+offset: 216,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 1844,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x4',
+offset: 256,
+shaderLocation: 15,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let bindGroup4 = device0.createBindGroup({
+label: '\u{1fa55}\u2870\u02df\uc550\u971f\ueed3\u{1febe}\ue25c\ubb4f',
+layout: bindGroupLayout5,
+entries: [],
+});
+let buffer4 = device0.createBuffer({
+  label: '\u09de\u067e\ucfe5\u74e2\u{1f8c1}',
+  size: 11643,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX
+});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({label: '\u767a\u0680\u49ce\ue997', colorFormats: ['rg8uint', 'r16uint', 'rgba16uint', 'rgba16sint']});
+try {
+renderBundleEncoder1.setVertexBuffer(5, buffer0, 7088, 17903);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+alphaMode: 'premultiplied',
+});
+} catch {}
+let promise3 = device0.createRenderPipelineAsync({
+label: '\u079e\u{1fe31}\u0e7b',
+layout: pipelineLayout2,
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: 0}, {format: 'rg8sint', writeMask: GPUColorWrite.RED}, undefined, {format: 'rg32float', writeMask: 0}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'one'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+failOp: 'zero',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2962,
+stencilWriteMask: 632,
+depthBias: 27,
+depthBiasSlopeScale: 30,
+depthBiasClamp: 10,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x2',
+offset: 324,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 648,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1956,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1632,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 792,
+attributes: [],
+},
+{
+arrayStride: 1084,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1384,
+attributes: [],
+},
+{
+arrayStride: 28,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 0,
+shaderLocation: 15,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let gpuCanvasContext2 = canvas3.getContext('webgpu');
+document.body.prepend(img1);
+let buffer5 = device0.createBuffer({
+  label: '\u29b7\u1cae\u7683\uc637\ucdef\u6b63\u02b1',
+  size: 26760,
+  usage: GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true
+});
+let computePassEncoder5 = commandEncoder8.beginComputePass({label: '\u3039\u{1fc17}\u{1fa40}\u0543\u6c3f\u2cd4\u{1fca0}\u82cf'});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  label: '\ua25a\u{1f66c}\u09c4\u{1fc74}\u{1f81a}\u1ca4',
+  colorFormats: ['rg8uint', 'r16uint', 'rgba16uint', 'rgba16sint'],
+  sampleCount: 1
+});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder1.draw(8, 48, 64, 48);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(4, buffer0, 35352, 321);
+} catch {}
+try {
+commandEncoder2.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 28176 */
+offset: 28176,
+bytesPerRow: 0,
+rowsPerImage: 290,
+buffer: buffer0,
+}, {
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 8, y: 2, z: 36 },
+  aspect: 'all',
+}, {width: 0, height: 8, depthOrArrayLayers: 71});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let canvas4 = document.createElement('canvas');
+let bindGroupLayout8 = device0.createBindGroupLayout({
+label: '\u{1fef0}\u653e\u0994',
+entries: [{
+binding: 289,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}, {
+binding: 934,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}],
+});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(3, bindGroup4, new Uint32Array(1982), 830, 0);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(2, buffer0, 35804);
+} catch {}
+try {
+commandEncoder7.copyBufferToBuffer(buffer2, 1044, buffer1, 17504, 188);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 3,
+  origin: { x: 10, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 112 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 43600 */
+offset: 43600,
+buffer: buffer1,
+}, {width: 70, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-5x5-unorm', 'bgra8unorm', 'bgra8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline15 = device0.createComputePipeline({
+label: '\ue6a2\u0300\u{1ff73}\u214b\u{1ffc2}\u9368\u{1fb15}\ufc99',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let gpuCanvasContext3 = canvas4.getContext('webgpu');
+let bindGroupLayout9 = device0.createBindGroupLayout({
+label: '\ua831\u{1fd1c}\u{1fa9c}',
+entries: [{
+binding: 297,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+}, {
+binding: 794,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+}],
+});
+let textureView6 = texture2.createView({label: '\u095f\ueca9', dimension: '2d-array', baseMipLevel: 4, mipLevelCount: 1});
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup4);
+} catch {}
+let pipeline16 = await device0.createRenderPipelineAsync({
+label: '\u2739\u1219\u8194\uaab8\u{1fd49}',
+layout: pipelineLayout2,
+fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: 0}, {
+  format: 'rgba8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'dst'},
+alpha: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'dst'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED
+}, {format: 'rg16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'dst-alpha'},
+alpha: {operation: 'add', srcFactor: 'one-minus-src-alpha', dstFactor: 'dst-alpha'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED
+}]
+},
+vertex: {
+  module: shaderModule3,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 904,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 640,
+shaderLocation: 2,
+}, {
+format: 'uint32x4',
+offset: 92,
+shaderLocation: 15,
+}, {
+format: 'unorm16x4',
+offset: 324,
+shaderLocation: 5,
+}, {
+format: 'float32',
+offset: 492,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 1544,
+attributes: [{
+format: 'uint32x2',
+offset: 1368,
+shaderLocation: 14,
+}, {
+format: 'unorm8x4',
+offset: 504,
+shaderLocation: 0,
+}, {
+format: 'sint8x4',
+offset: 1340,
+shaderLocation: 9,
+}, {
+format: 'snorm8x2',
+offset: 58,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 48,
+attributes: [{
+format: 'unorm8x4',
+offset: 36,
+shaderLocation: 10,
+}, {
+format: 'unorm16x2',
+offset: 8,
+shaderLocation: 3,
+}, {
+format: 'sint32x3',
+offset: 16,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 64,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 76,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 356,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 976,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 320,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x2',
+offset: 708,
+shaderLocation: 13,
+}],
+}
+]
+},
+});
+document.body.prepend(video0);
+let offscreenCanvas4 = new OffscreenCanvas(40, 165);
+let commandEncoder9 = device0.createCommandEncoder({label: '\u{1ff9a}\u{1fde8}\u0fa3\u2c10\u0731\uf360\u{1fc9a}'});
+let sampler5 = device0.createSampler({
+label: '\u0e2c\u6da1\u0ee8\u285f\u6cd4\u395e\ub942',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 12.676,
+lodMaxClamp: 35.726,
+});
+try {
+renderBundleEncoder1.drawIndexed(32, 48, 0, 256);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(0, buffer0, 27620, 8981);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder9.copyBufferToBuffer(buffer2, 856, buffer1, 32048, 144);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let canvas5 = document.createElement('canvas');
+let commandEncoder10 = device0.createCommandEncoder({label: '\u0b3f\u2cc2\u{1fd98}\u9a64\u3fb0\u{1f956}\u{1f81d}\ud1c6\u{1fa0d}\u0a69'});
+pseudoSubmit(device0, commandEncoder9);
+let texture13 = device0.createTexture({
+label: '\u0b9b\uc213\u0122',
+size: {width: 120, height: 120, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'astc-10x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+renderBundleEncoder3.draw(64, 56);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(5, buffer0, 26464, 6705);
+} catch {}
+try {
+commandEncoder2.clearBuffer(buffer4, 88, 5056);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise4 = adapter1.requestDevice({
+label: '\u{1fd8b}\u6422\u07ee\u9800',
+});
+let pipelineLayout4 = device0.createPipelineLayout({label: '\u0e61\u0916\u009c\u8cbb\u2499\ud621', bindGroupLayouts: [bindGroupLayout9, bindGroupLayout1]});
+let commandEncoder11 = device0.createCommandEncoder({label: '\u{1f8e6}\u{1fc0d}\u{1fd0c}\u47b6\u459e\u{1fb0d}\u{1f900}\u081a'});
+let commandBuffer3 = commandEncoder11.finish({
+});
+let texture14 = device0.createTexture({
+size: [330, 24, 1],
+mipLevelCount: 6,
+format: 'astc-6x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView7 = texture9.createView({
+  label: '\u0353\ub180\u0944\u{1f6d1}\ud03c\u0cb9\u00f1\u04e1\u{1f721}\u6734',
+  dimension: '2d-array',
+  baseMipLevel: 0,
+  mipLevelCount: 4
+});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder1.draw(16, 56, 64, 0);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(5, buffer0, 28488, 4856);
+} catch {}
+try {
+commandEncoder10.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 2,
+  origin: { x: 20, y: 5, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture13,
+  mipLevel: 2,
+  origin: { x: 30, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 20, depthOrArrayLayers: 0});
+} catch {}
+let pipeline17 = await promise3;
+let buffer6 = device0.createBuffer({
+  label: '\u048e\u6f6c\u{1f81d}\u18ab\u15f2\u{1fba9}\u9df1\uaa7f\ud0bb',
+  size: 37096,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX
+});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder3.draw(24, 80, 32, 48);
+} catch {}
+try {
+commandEncoder7.copyBufferToBuffer(buffer2, 1308, buffer4, 11396, 0);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline18 = device0.createComputePipeline({
+label: '\ue4bf\uf43e\u02ae\u{1fe2a}\u{1ff43}\u04bd\ub482\u{1f742}\ub558\u{1fd23}\u0018',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+},
+});
+let computePassEncoder6 = commandEncoder7.beginComputePass();
+let renderBundle6 = renderBundleEncoder5.finish({label: '\ud86e\u54ba\ue060\u01e7\u0aea\u0564\u022f\u{1fea1}\u{1fcd4}\u0fbd'});
+try {
+renderBundleEncoder1.draw(40, 32);
+} catch {}
+try {
+renderBundleEncoder3.drawIndexed(0, 24, 8, 160, 24);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(6, buffer0, 11632, 2389);
+} catch {}
+try {
+commandEncoder10.copyBufferToBuffer(buffer3, 1368, buffer1, 45760, 7424);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({
+  label: '\u{1ff71}\u61c6\u00c2\u0cc4\ub9c9\u94fe\ud76b\u{1f764}\u0d3a',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true
+});
+let sampler6 = device0.createSampler({
+label: '\u0387\u0b55\u364c\u{1f773}\ufb75\ub0cd\ua895\u691b\u38b9\u9562\u5eaa',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMaxClamp: 52.359,
+});
+try {
+computePassEncoder6.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup2, new Uint32Array(6625), 2236, 0);
+} catch {}
+try {
+renderBundleEncoder1.draw(24, 80);
+} catch {}
+try {
+commandEncoder10.copyBufferToBuffer(buffer0, 1344, buffer1, 58372, 456);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder10.copyBufferToTexture({
+/* bytesInLastRow: 80 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 20408 */
+offset: 20408,
+buffer: buffer0,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 238, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 20, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 720, new BigUint64Array(64032), 46279, 6272);
+} catch {}
+let texture15 = device0.createTexture({
+size: [128, 180, 1],
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let computePassEncoder7 = commandEncoder10.beginComputePass({label: '\u15fc\ua395\u59b2\u0846\uffe6\u3d99\u0934\u0b27\u4d13\u1417\u{1f6bb}'});
+try {
+renderBundleEncoder11.setVertexBuffer(5, buffer6, 25220);
+} catch {}
+let promise5 = navigator.gpu.requestAdapter({
+});
+let imageBitmap2 = await createImageBitmap(canvas0);
+let buffer7 = device0.createBuffer({label: '\ub82c\uff68\u0844\u0acd\u{1f782}\uf43a', size: 42040, usage: GPUBufferUsage.MAP_READ});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({
+  label: '\ub3b0\u78f5\u{1fafc}\ua4ce\u1118',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler7 = device0.createSampler({
+label: '\u1a06\u04c9\u{1f945}\u7a22\u{1fdd5}\ued7c\u1b29\u{1f86d}\uc44f\u{1f819}\u0074',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 75.708,
+lodMaxClamp: 82.629,
+});
+try {
+renderBundleEncoder1.draw(40, 32, 16, 80);
+} catch {}
+try {
+renderBundleEncoder1.drawIndexed(0, 0, 8, -392, 40);
+} catch {}
+try {
+commandEncoder2.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let canvas6 = document.createElement('canvas');
+let commandBuffer4 = commandEncoder2.finish({
+label: '\u0ed7\u728e\u471b\uf776\u05b0\u0af9\u9a61\u051e\u7f12',
+});
+let texture16 = device0.createTexture({
+label: '\uf8b7\u9102\u9ebf\uccd2\u85b9\u01a6\u0e84\uf710\u9e6e\u856f\u028d',
+size: {width: 320, height: 2, depthOrArrayLayers: 222},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let querySet11 = device0.createQuerySet({
+label: '\u0152\ubeff\u7301\u{1f987}\u{1f6f7}',
+type: 'occlusion',
+count: 217,
+});
+let texture17 = device0.createTexture({
+label: '\ubc8f\u{1f93e}\u043a\uf402\u7278',
+size: {width: 4302, height: 40, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'astc-6x5-unorm',
+usage: GPUTextureUsage.COPY_DST,
+});
+let sampler8 = device0.createSampler({
+label: '\u1437\u424d\u{1fb7c}\u0788',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 25.696,
+lodMaxClamp: 97.178,
+compare: 'less-equal',
+});
+try {
+computePassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder3.draw(40, 16);
+} catch {}
+try {
+renderBundleEncoder1.setPipeline(pipeline10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 1, y: 0, z: 57 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 338094 */
+{offset: 926, bytesPerRow: 172, rowsPerImage: 245}, {width: 3, height: 1, depthOrArrayLayers: 9});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+offscreenCanvas4.getContext('webgl');
+} catch {}
+let textureView8 = texture11.createView({
+  label: '\u6dcf\u117e\u{1ff97}\u462f\u8fd0\u{1fdb6}\u08df\ub4c8\u05ff',
+  baseMipLevel: 5,
+  arrayLayerCount: 1
+});
+try {
+renderBundleEncoder3.setBindGroup(3, bindGroup0, new Uint32Array(4531), 3915, 0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer6, 'uint16', 1272, 26294);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline6);
+} catch {}
+let promise6 = device0.createRenderPipelineAsync({
+layout: pipelineLayout3,
+multisample: {
+count: 4,
+mask: 0x730bfc31,
+},
+fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {
+  format: 'rgba8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'constant', dstFactor: 'one-minus-dst'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'dst-alpha'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'rg16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, undefined, {format: 'rg16float'}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+},
+stencilReadMask: 3010,
+depthBias: 0,
+depthBiasSlopeScale: 17,
+depthBiasClamp: 43,
+},
+vertex: {
+  module: shaderModule3,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1228,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x2',
+offset: 808,
+shaderLocation: 14,
+}, {
+format: 'sint32',
+offset: 1068,
+shaderLocation: 2,
+}, {
+format: 'float32x3',
+offset: 1120,
+shaderLocation: 8,
+}, {
+format: 'snorm8x4',
+offset: 60,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x4',
+offset: 1464,
+shaderLocation: 13,
+}, {
+format: 'snorm16x4',
+offset: 420,
+shaderLocation: 0,
+}, {
+format: 'sint8x4',
+offset: 456,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 1132,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x4',
+offset: 944,
+shaderLocation: 10,
+}, {
+format: 'uint32x2',
+offset: 596,
+shaderLocation: 15,
+}, {
+format: 'unorm16x2',
+offset: 536,
+shaderLocation: 3,
+}, {
+format: 'unorm10-10-10-2',
+offset: 500,
+shaderLocation: 7,
+}, {
+format: 'sint16x2',
+offset: 836,
+shaderLocation: 6,
+}, {
+format: 'unorm16x4',
+offset: 132,
+shaderLocation: 5,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+unclippedDepth: false,
+},
+});
+pseudoSubmit(device0, commandEncoder8);
+let texture18 = device0.createTexture({
+label: '\u0719\u3a09\u0f69\ufc9e\uaace\u51e6\ucb20\u{1faff}\uad9d\u2a44',
+size: {width: 32, height: 45, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+dimension: '2d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm-srgb'],
+});
+let sampler9 = device0.createSampler({
+label: '\u07a6\u{1fe05}\u64a7\u{1f840}\ua591',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 37.936,
+lodMaxClamp: 40.610,
+});
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder3.draw(32);
+} catch {}
+try {
+commandEncoder10.copyBufferToTexture({
+/* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 6848 */
+offset: 6848,
+bytesPerRow: 256,
+buffer: buffer0,
+}, {
+  texture: texture13,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 50, height: 55, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame2 = new VideoFrame(imageBitmap1, {timestamp: 0});
+let renderBundle7 = renderBundleEncoder11.finish({label: '\u5f00\u0cb2\u6b3f'});
+try {
+renderBundleEncoder1.draw(80, 16, 40, 64);
+} catch {}
+try {
+  await buffer7.mapAsync(GPUMapMode.READ, 37496);
+} catch {}
+try {
+commandEncoder10.copyBufferToTexture({
+/* bytesInLastRow: 96 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 28208 */
+offset: 28208,
+buffer: buffer0,
+}, {
+  texture: texture2,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 48, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder10.clearBuffer(buffer1, 33216, 8300);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline19 = device0.createRenderPipeline({
+label: '\ue606\ue618\u0966\u0bad\u069c\u{1fcfa}\u0699\u{1fae7}\u{1f6c3}\u0330',
+layout: pipelineLayout1,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'zero', dstFactor: 'dst-alpha'},
+alpha: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'dst-alpha'},
+},
+  writeMask: GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'keep',
+passOp: 'zero',
+},
+stencilReadMask: 3512,
+depthBiasSlopeScale: 44,
+depthBiasClamp: 22,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 72,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x4',
+offset: 28,
+shaderLocation: 14,
+}, {
+format: 'unorm16x2',
+offset: 64,
+shaderLocation: 8,
+}, {
+format: 'sint32x3',
+offset: 32,
+shaderLocation: 4,
+}, {
+format: 'sint8x4',
+offset: 48,
+shaderLocation: 6,
+}, {
+format: 'uint16x4',
+offset: 20,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 1512,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 736,
+shaderLocation: 5,
+}],
+}
+]
+},
+});
+let img4 = await imageWithData(62, 128, '#26b57398', '#bf648230');
+let commandEncoder12 = device0.createCommandEncoder({label: '\u16ff\u00d8\ue3f0'});
+let querySet12 = device0.createQuerySet({
+label: '\u0fda\u0a4b\u476b',
+type: 'occlusion',
+count: 4050,
+});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  label: '\u{1f7ce}\u84e1\u7dbd\u9191\uee74\u{1f8c5}\u{1fe9a}',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8',
+  stencilReadOnly: false
+});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup2, new Uint32Array(8139), 6287, 0);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup3, []);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(8, 72, 32, 72);
+} catch {}
+try {
+commandEncoder12.clearBuffer(buffer1, 46168, 1528);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let texture19 = device0.createTexture({
+label: '\u92b9\u5618\u0170\u{1fa69}\u0a37\u0785',
+size: {width: 4134, height: 5, depthOrArrayLayers: 143},
+mipLevelCount: 6,
+sampleCount: 1,
+format: 'astc-6x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-6x5-unorm-srgb', 'astc-6x5-unorm', 'astc-6x5-unorm-srgb'],
+});
+let renderBundle8 = renderBundleEncoder1.finish({label: '\u{1f69f}\u8057\u72fb\ucb56\ub52f'});
+try {
+computePassEncoder6.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder3.draw(48, 16);
+} catch {}
+video0.height = 79;
+canvas6.height = 192;
+let canvas7 = document.createElement('canvas');
+let img5 = await imageWithData(153, 179, '#c2acf060', '#8c60d131');
+try {
+offscreenCanvas3.getContext('2d');
+} catch {}
+let commandEncoder13 = device0.createCommandEncoder();
+let computePassEncoder8 = commandEncoder12.beginComputePass({});
+try {
+commandEncoder10.clearBuffer(buffer4, 6428, 4444);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let canvas8 = document.createElement('canvas');
+let bindGroupLayout10 = device0.createBindGroupLayout({
+label: '\u{1ffe6}\u0429\u572d\uaed6\u0f4d\ue742\u0a9c\u3f3f\ub08f',
+entries: [{
+binding: 20,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}],
+});
+let querySet13 = device0.createQuerySet({
+label: '\u63d5\u{1fe77}\ue79b',
+type: 'occlusion',
+count: 1,
+});
+let computePassEncoder9 = commandEncoder10.beginComputePass();
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({
+  label: '\u2a16\u06d1\u770b\u0bff\u9d0d\ua35f\u36d5',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let sampler10 = device0.createSampler({
+label: '\u{1ffde}\u8433\u12e7\u7431\u0b83\u31d1\u0de7\u{1fee6}\u07e2\u{1ff7f}',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 12.103,
+lodMaxClamp: 83.330,
+compare: 'greater-equal',
+});
+let pipeline20 = await device0.createComputePipelineAsync({
+layout: pipelineLayout3,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let querySet14 = device0.createQuerySet({
+label: '\u2c1f\u6e93\u4585',
+type: 'occlusion',
+count: 2625,
+});
+let sampler11 = device0.createSampler({
+label: '\u46a6\ud622\u0aa6\uf051\uf6b7\u0bf5\uf1e1\u3d04\u095e\u395d',
+addressModeU: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMaxClamp: 97.553,
+});
+try {
+renderBundleEncoder8.draw(80, 32);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(16, 56, 48);
+} catch {}
+try {
+commandEncoder13.clearBuffer(buffer4, 9784, 336);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth24plus'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let pipeline21 = device0.createRenderPipeline({
+layout: pipelineLayout0,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: 0}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, undefined, {format: 'rg32float'}, {format: 'bgra8unorm', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'zero',
+depthFailOp: 'keep',
+passOp: 'decrement-clamp',
+},
+stencilWriteMask: 4085,
+depthBias: 34,
+depthBiasClamp: 89,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1504,
+attributes: [{
+format: 'snorm16x2',
+offset: 588,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 840,
+attributes: [{
+format: 'sint8x4',
+offset: 160,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 1400,
+attributes: [],
+},
+{
+arrayStride: 1576,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x2',
+offset: 500,
+shaderLocation: 12,
+}, {
+format: 'unorm8x2',
+offset: 1526,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 1856,
+attributes: [],
+},
+{
+arrayStride: 840,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32',
+offset: 484,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 912,
+shaderLocation: 14,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+let querySet15 = device0.createQuerySet({
+label: '\u6858\u7579\u2b82\u5992',
+type: 'occlusion',
+count: 106,
+});
+let textureView9 = texture11.createView({label: '\u0ea1\u7857', dimension: '2d', baseMipLevel: 3});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 424, new DataView(new ArrayBuffer(35965)), 28313, 1900);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 5,
+  origin: { x: 12, y: 0, z: 59 },
+  aspect: 'all',
+}, new Int16Array(arrayBuffer0), /* required buffer size: 3319043 */
+{offset: 806, bytesPerRow: 359, rowsPerImage: 237}, {width: 108, height: 0, depthOrArrayLayers: 40});
+} catch {}
+let pipeline22 = await device0.createComputePipelineAsync({
+label: '\u{1f807}\u{1fcbb}\u{1fa58}\ubad0\u0a60\u0172',
+layout: 'auto',
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let renderBundle9 = renderBundleEncoder3.finish();
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup2, new Uint32Array(8641), 7330, 0);
+} catch {}
+try {
+renderBundleEncoder8.draw(56, 0);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(80, 80, 32, 488, 40);
+} catch {}
+try {
+buffer1.destroy();
+} catch {}
+let pipeline23 = device0.createComputePipeline({
+label: '\u{1fc08}\ub421\u324d\u0f26\u{1fe40}\ucc54\ufa6e\ue5b1',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+document.body.prepend(canvas3);
+let shaderModule4 = device0.createShaderModule({
+label: '\u6a9a\ub697\uc1e5\ue614\u099d',
+code: `@group(1) @binding(257)
+var<storage, read_write> type0: array<u32>;
+@group(0) @binding(794)
+var<storage, read_write> field0: array<u32>;
+@group(0) @binding(297)
+var<storage, read_write> field1: array<u32>;
+@group(1) @binding(43)
+var<storage, read_write> parameter2: array<u32>;
+
+@compute @workgroup_size(5, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(3) f1: vec4<i32>,
+  @location(1) f2: vec4<u32>,
+  @location(2) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S1 {
+  @location(6) f0: vec2<f16>,
+  @location(1) f1: vec2<f32>,
+  @location(13) f2: f16,
+  @location(9) f3: vec2<u32>,
+  @location(11) f4: f16,
+  @location(7) f5: vec4<f16>,
+  @location(15) f6: vec2<f32>,
+  @location(4) f7: vec4<u32>,
+  @location(0) f8: i32,
+  @location(2) f9: vec3<f16>,
+  @location(12) f10: vec3<f32>,
+  @location(14) f11: f16
+}
+
+@vertex
+fn vertex0(a0: S1, @location(5) a1: vec3<i32>, @builtin(instance_index) a2: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let renderBundle10 = renderBundleEncoder0.finish({label: '\u{1fde0}\u{1f849}\u{1fdc9}\u0772\u{1fa34}\ud023\u8ef1\udb3f\u{1fe80}\ue80f'});
+try {
+renderBundleEncoder8.draw(32, 0, 0, 64);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 631 */
+{offset: 599, bytesPerRow: 117}, {width: 20, height: 8, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder({label: '\u0a6c\ubd4b\u057b\ueebe\u0dd5\u079a\u0618'});
+let querySet16 = device0.createQuerySet({
+label: '\ud1df\u0b2a\u{1fbff}\u80d3\u{1fbad}\u72a4\ubc43',
+type: 'occlusion',
+count: 2149,
+});
+let texture20 = device0.createTexture({
+label: '\u{1fd73}\u{1fe80}\u3a41\u57b0\u{1fda8}\u0aed\u0e8d\u{1f7b5}',
+size: {width: 32, height: 45, depthOrArrayLayers: 254},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm'],
+});
+let renderBundle11 = renderBundleEncoder7.finish({label: '\u690e\u4adc\uf0a0'});
+try {
+computePassEncoder6.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder8.draw(32, 40);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer0, 'uint32', 11116, 11276);
+} catch {}
+try {
+commandEncoder14.clearBuffer(buffer4, 5392, 1220);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer4,
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 9744, new BigUint64Array(39881), 26186, 84);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let bindGroupLayout11 = device0.createBindGroupLayout({
+label: '\ud78d\u{1f6bf}\ufc2a\u0285\u0e26\u806f\u26d5\u09bd',
+entries: [{
+binding: 297,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 823,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+}],
+});
+let pipelineLayout5 = device0.createPipelineLayout({label: '\u094e\u0304\u0b34\u8eb8\ucbb9\ua695\u03c3\ufe72\u0ab3\ua742', bindGroupLayouts: []});
+let computePassEncoder10 = commandEncoder13.beginComputePass();
+try {
+renderBundleEncoder8.draw(64, 16, 56, 24);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(32, 32, 16, 320, 56);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(4, buffer6);
+} catch {}
+let arrayBuffer1 = buffer5.getMappedRange();
+try {
+commandEncoder14.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 3,
+  origin: { x: 32, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 53504 */
+offset: 53504,
+bytesPerRow: 0,
+buffer: buffer1,
+}, {width: 0, height: 16, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let video2 = await videoWithData();
+try {
+adapter1.label = '\u{1fd2c}\u{1fef8}\u0024\u0527\u{1f998}\u0975\ub19e\u012f\u1699\ub32c';
+} catch {}
+let querySet17 = device0.createQuerySet({
+label: '\u0bfb\u077f',
+type: 'occlusion',
+count: 2662,
+});
+let texture21 = device0.createTexture({
+label: '\u{1fed2}\u0374\uaa26\ud409\u6ea0\u9f9c\u0fa4\u068b\uebab',
+size: [660],
+dimension: '1d',
+format: 'r32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+});
+try {
+renderBundleEncoder9.draw(72);
+} catch {}
+try {
+computePassEncoder10.insertDebugMarker('\u9dcf');
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer3,
+commandBuffer2,
+commandBuffer1,
+]);
+} catch {}
+document.body.prepend(img0);
+let bindGroupLayout12 = device0.createBindGroupLayout({
+label: '\u{1f9ad}\u5fd4\u1eb6\u0fc3\ue119\u8ced\u0e20\u0e42',
+entries: [],
+});
+try {
+renderBundleEncoder10.setIndexBuffer(buffer4, 'uint32', 5716, 1787);
+} catch {}
+try {
+commandEncoder14.copyBufferToBuffer(buffer2, 64, buffer1, 11048, 1060);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder14.copyBufferToTexture({
+/* bytesInLastRow: 2360 widthInBlocks: 590 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 34380 */
+offset: 34380,
+buffer: buffer0,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: { x: 13, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 590, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder14.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 3,
+  origin: { x: 96, y: 16, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderBundleEncoder9.pushDebugGroup('\u0e11');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 3,
+  origin: { x: 66, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(186), /* required buffer size: 186 */
+{offset: 186}, {width: 168, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder15 = device0.createCommandEncoder({label: '\ubce8\ue802\u0fb5\uf6d2\u5781\udbdb\u008e\u0ef2\ueecf\u07bf'});
+let computePassEncoder11 = commandEncoder14.beginComputePass({});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup1, new Uint32Array(3016), 1155, 0);
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder9.draw(32, 0, 72, 80);
+} catch {}
+let arrayBuffer2 = buffer3.getMappedRange(0, 12164);
+try {
+commandEncoder15.copyBufferToBuffer(buffer3, 38544, buffer4, 5964, 4464);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+renderBundleEncoder9.popDebugGroup();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.prepend(img1);
+gc();
+let externalTexture0 = device0.importExternalTexture({
+source: video2,
+colorSpace: 'srgb',
+});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(16, 0, 32, -400);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer4, 'uint16', 11484);
+} catch {}
+try {
+commandEncoder12.copyBufferToBuffer(buffer0, 13788, buffer1, 7980, 5984);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer1, 1584, 9776);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+canvas8.getContext('webgl');
+} catch {}
+let renderBundle12 = renderBundleEncoder14.finish({label: '\u{1fdd6}\u00f9\u4b4c\u5cf6\ue164'});
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(7, buffer0, 2888, 1093);
+} catch {}
+let promise8 = device0.createRenderPipelineAsync({
+label: '\u9724\u6bea\u0a26\u02bc',
+layout: pipelineLayout3,
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.GREEN}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'constant', dstFactor: 'one-minus-dst'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilWriteMask: 3062,
+depthBias: 76,
+depthBiasClamp: 11,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1892,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 1736,
+shaderLocation: 6,
+}, {
+format: 'snorm16x4',
+offset: 376,
+shaderLocation: 1,
+}, {
+format: 'float32x2',
+offset: 1532,
+shaderLocation: 2,
+}, {
+format: 'sint8x2',
+offset: 680,
+shaderLocation: 3,
+}, {
+format: 'float32x3',
+offset: 1344,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 2044,
+attributes: [{
+format: 'uint32x3',
+offset: 1736,
+shaderLocation: 15,
+}, {
+format: 'snorm8x4',
+offset: 112,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 1256,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 984,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 1540,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x2',
+offset: 424,
+shaderLocation: 7,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+},
+});
+let canvas9 = document.createElement('canvas');
+let imageBitmap3 = await createImageBitmap(canvas9);
+let textureView10 = texture3.createView({label: '\u7389\u1378\u{1f9c5}\u3d02\u0b0e\uef5f\u{1f890}\ufe97'});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup1, new Uint32Array(5074), 959, 0);
+} catch {}
+try {
+renderBundleEncoder8.draw(8);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(56, 32, 8, 752, 40);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer4, 'uint16', 888);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(3, buffer6, 26104, 5575);
+} catch {}
+try {
+commandEncoder12.copyBufferToTexture({
+/* bytesInLastRow: 9424 widthInBlocks: 589 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 30736 */
+offset: 30736,
+bytesPerRow: 9472,
+rowsPerImage: 283,
+buffer: buffer0,
+}, {
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 414, y: 10, z: 0 },
+  aspect: 'all',
+}, {width: 3534, height: 20, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline24 = await device0.createRenderPipelineAsync({
+label: '\ua852\ubbd6\u6955\u079a\ue9f9\u05ff\u5b62\u{1f808}',
+layout: pipelineLayout5,
+multisample: {
+count: 4,
+mask: 0x268b2af5,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, undefined, {format: 'rg32float'}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+}
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-wrap',
+},
+depthBias: 62,
+depthBiasSlopeScale: 62,
+depthBiasClamp: 30,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1140,
+attributes: [{
+format: 'unorm16x2',
+offset: 460,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 1284,
+attributes: [],
+},
+{
+arrayStride: 1936,
+attributes: [],
+},
+{
+arrayStride: 1320,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 1124,
+shaderLocation: 15,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: false,
+},
+});
+let gpuCanvasContext4 = canvas9.getContext('webgpu');
+let offscreenCanvas5 = new OffscreenCanvas(389, 700);
+try {
+canvas7.getContext('webgpu');
+} catch {}
+let buffer8 = device0.createBuffer({
+  label: '\u{1fe5c}\ubf05\u{1fac0}\u4015\u3419',
+  size: 15463,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let texture22 = device0.createTexture({
+label: '\u0c55\u{1fc75}\uf27a',
+size: {width: 128, height: 180, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'astc-4x4-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+commandEncoder12.clearBuffer(buffer8, 13800, 156);
+dissociateBuffer(device0, buffer8);
+} catch {}
+let pipeline25 = device0.createRenderPipeline({
+layout: pipelineLayout4,
+fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE}, {
+  format: 'rgba16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'rgba16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+failOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2788,
+stencilWriteMask: 1256,
+depthBias: 62,
+depthBiasSlopeScale: 56,
+depthBiasClamp: 97,
+},
+vertex: {
+  module: shaderModule4,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1124,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 1000,
+shaderLocation: 12,
+}, {
+format: 'float32x3',
+offset: 1084,
+shaderLocation: 11,
+}, {
+format: 'sint32x3',
+offset: 848,
+shaderLocation: 0,
+}, {
+format: 'unorm10-10-10-2',
+offset: 20,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 688,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 316,
+shaderLocation: 7,
+}, {
+format: 'float16x4',
+offset: 620,
+shaderLocation: 1,
+}, {
+format: 'uint32x2',
+offset: 228,
+shaderLocation: 4,
+}, {
+format: 'sint32x4',
+offset: 292,
+shaderLocation: 5,
+}, {
+format: 'float32x4',
+offset: 52,
+shaderLocation: 6,
+}, {
+format: 'uint32x3',
+offset: 136,
+shaderLocation: 9,
+}, {
+format: 'unorm16x2',
+offset: 316,
+shaderLocation: 14,
+}, {
+format: 'snorm8x2',
+offset: 172,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 748,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 28,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x2',
+offset: 6,
+shaderLocation: 2,
+}],
+}
+]
+},
+});
+gc();
+let img6 = await imageWithData(135, 166, '#ffda90ed', '#6247a69b');
+let shaderModule5 = device0.createShaderModule({
+code: `@group(1) @binding(257)
+var<storage, read_write> local0: array<u32>;
+@group(1) @binding(43)
+var<storage, read_write> function2: array<u32>;
+
+@compute @workgroup_size(7, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<u32>,
+  @location(0) f1: vec3<u32>,
+  @location(1) f2: u32,
+  @location(3) f3: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(12) a0: vec2<f32>, @location(9) a1: vec4<u32>, @builtin(position) a2: vec4<f32>, @builtin(sample_mask) a3: u32, @builtin(sample_index) a4: u32, @builtin(front_facing) a5: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(12) f4: vec2<f32>,
+  @builtin(position) f5: vec4<f32>,
+  @location(9) f6: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: i32, @location(6) a1: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroupLayout13 = device0.createBindGroupLayout({
+label: '\u063b\u0d74\ua7cc\u0a3e\u0e49\uda01\u{1ff01}\ueff7\uce37',
+entries: [{
+binding: 674,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}],
+});
+try {
+renderBundleEncoder9.drawIndexed(64);
+} catch {}
+try {
+commandEncoder12.copyBufferToBuffer(buffer2, 1144, buffer4, 4336, 68);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder12.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 1,
+  origin: { x: 0, y: 8, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 208 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 51824 */
+offset: 51824,
+bytesPerRow: 512,
+buffer: buffer1,
+}, {width: 52, height: 80, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+computePassEncoder2.pushDebugGroup('\u{1fb4c}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 20, y: 5, z: 48 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 6977582 */
+{offset: 692, bytesPerRow: 162, rowsPerImage: 210}, {width: 9, height: 18, depthOrArrayLayers: 206});
+} catch {}
+let pipeline26 = device0.createRenderPipeline({
+label: '\u0b3b\u0f90\uade1\u0a3b\ue547\u{1fef9}\u{1f7a7}\u0da0',
+layout: pipelineLayout4,
+multisample: {
+},
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'src'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'dst'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 550,
+stencilWriteMask: 3510,
+depthBias: 58,
+depthBiasSlopeScale: 31,
+depthBiasClamp: 24,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 428,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 70,
+shaderLocation: 1,
+}, {
+format: 'sint32x4',
+offset: 160,
+shaderLocation: 7,
+}, {
+format: 'unorm10-10-10-2',
+offset: 224,
+shaderLocation: 2,
+}, {
+format: 'uint32',
+offset: 168,
+shaderLocation: 15,
+}, {
+format: 'snorm8x4',
+offset: 392,
+shaderLocation: 4,
+}, {
+format: 'snorm8x2',
+offset: 404,
+shaderLocation: 13,
+}, {
+format: 'float32x3',
+offset: 368,
+shaderLocation: 6,
+}, {
+format: 'snorm8x2',
+offset: 362,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 1692,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1596,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x2',
+offset: 64,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let videoFrame3 = new VideoFrame(offscreenCanvas2, {timestamp: 0});
+let bindGroup5 = device0.createBindGroup({
+label: '\ub55f\u{1fdd9}\u7544\u080e\u{1fed7}\u009a',
+layout: bindGroupLayout1,
+entries: [{
+binding: 257,
+resource: externalTexture0
+}, {
+binding: 43,
+resource: externalTexture0
+}],
+});
+let querySet18 = device0.createQuerySet({
+label: '\u0da7\u002c\u{1f75c}\ufed3\u{1fd92}\u{1ff61}\u3639\u9387\u{1ff35}\u0145',
+type: 'occlusion',
+count: 3809,
+});
+let textureView11 = texture16.createView({label: '\ub19c\u8df6\u2259\u{1fb37}\u00e9\u{1f8b7}\u0a2b\u7397\u1067', baseMipLevel: 3, mipLevelCount: 3});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({
+  label: '\u72ba\u74d3\u9a2e\u{1fe4e}\u310f\u80c0\uc256\u025b\ub506',
+  colorFormats: ['rg8uint', 'r16uint', 'rgba16uint', 'rgba16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let arrayBuffer3 = buffer3.getMappedRange(12168, 4180);
+try {
+buffer6.unmap();
+} catch {}
+try {
+commandEncoder12.copyBufferToBuffer(buffer0, 15840, buffer4, 956, 9292);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer8, 9280, 340);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 2060, new BigUint64Array(51781), 41624, 728);
+} catch {}
+let pipeline27 = await device0.createRenderPipelineAsync({
+label: '\u0976\u{1feaa}\u1d13\u{1fb22}\ud643\u4eda\u0b6a\uc283\u02f7\u3195',
+layout: pipelineLayout3,
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg8sint'}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'bgra8unorm', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'invert',
+passOp: 'replace',
+},
+stencilReadMask: 3113,
+depthBias: 50,
+depthBiasSlopeScale: 81,
+depthBiasClamp: 33,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 704,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x2',
+offset: 120,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 424,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x2',
+offset: 12,
+shaderLocation: 15,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'none',
+unclippedDepth: true,
+},
+});
+let video3 = await videoWithData();
+let commandBuffer5 = commandEncoder12.finish({
+label: '\udde0\uc73c\u2d54\u5d1e\u{1fb3b}\u{1f924}\u08c8\u90af\ufbc4',
+});
+let texture23 = device0.createTexture({
+size: [32, 45, 1],
+mipLevelCount: 3,
+sampleCount: 1,
+dimension: '2d',
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+computePassEncoder6.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder9.draw(32, 40);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgba16float'],
+colorSpace: 'display-p3',
+});
+} catch {}
+let pipeline28 = device0.createComputePipeline({
+layout: pipelineLayout5,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let buffer9 = device0.createBuffer({label: '\u7262\u0a93\u01c3', size: 20488, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX});
+let textureView12 = texture23.createView({dimension: '2d-array', aspect: 'all', baseMipLevel: 1, mipLevelCount: 1});
+try {
+renderBundleEncoder8.drawIndexed(80, 24);
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView13 = texture7.createView({
+  label: '\u628b\uc931\uf088\ua475\u3cef\u0c18\u099e\u9f5a',
+  dimension: '2d-array',
+  format: 'astc-8x5-unorm',
+  baseMipLevel: 1,
+  mipLevelCount: 2
+});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({
+  label: '\ufd02\u7366\u{1f650}\u{1f9c6}',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+try {
+renderBundleEncoder8.drawIndexed(32, 32, 32, -144, 64);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(1, buffer0);
+} catch {}
+try {
+querySet17.destroy();
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer5,
+]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(974), /* required buffer size: 974 */
+{offset: 974, bytesPerRow: 267}, {width: 0, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+label: '\u{1ffb1}\u1528\u9946\u0e5b\u0be4\u{1fd89}',
+layout: bindGroupLayout4,
+entries: [],
+});
+let commandEncoder16 = device0.createCommandEncoder({});
+let textureView14 = texture10.createView({label: '\uffda\u02c7\u0550\u{1f74e}\u2400\u2f84\u0e57\u7d8f\ud462', baseMipLevel: 2, mipLevelCount: 3});
+let computePassEncoder12 = commandEncoder15.beginComputePass({});
+let renderBundle13 = renderBundleEncoder18.finish({label: '\u003e\u0971\u5382\u718c\u0d42\uf40b\u68aa\u080e\u619f'});
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+commandEncoder16.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 0,
+  origin: { x: 530, y: 8, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 55152 */
+offset: 55152,
+bytesPerRow: 0,
+buffer: buffer1,
+}, {width: 0, height: 32, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 8328, new Int16Array(36535), 30571, 444);
+} catch {}
+let gpuCanvasContext5 = canvas6.getContext('webgpu');
+try {
+  await promise7;
+} catch {}
+let imageBitmap4 = await createImageBitmap(canvas1);
+let pipelineLayout6 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout6, bindGroupLayout2, bindGroupLayout10, bindGroupLayout13]});
+let commandEncoder17 = device0.createCommandEncoder({label: '\u{1fb3f}\uc52a\u{1fcb5}\u28d1\u{1f9a1}\u87fb\u9c91\u{1fc58}\u2882'});
+let texture24 = device0.createTexture({
+size: {width: 1320, height: 96, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'etc2-rgba8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgba8unorm-srgb', 'etc2-rgba8unorm'],
+});
+let textureView15 = texture12.createView({baseMipLevel: 3, mipLevelCount: 2});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({
+  label: '\u2d43\u{1f653}\u6916\u{1f67b}\u3b39\u85e0\uf1e4\ue98c',
+  colorFormats: ['bgra8unorm-srgb', 'rgba16uint', 'r8uint', 'rg11b10ufloat', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler12 = device0.createSampler({
+label: '\u3eee\ufd56\u0e5a\uf371\u630b',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 92.193,
+lodMaxClamp: 96.378,
+maxAnisotropy: 14,
+});
+try {
+renderBundleEncoder9.drawIndexed(56, 32, 32, 408, 56);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer9, 'uint16', 17330, 93);
+} catch {}
+gc();
+let querySet19 = device0.createQuerySet({
+label: '\u8a12\u39c8\u{1fec5}\u{1fa45}\u0e37\uba2f\u1365\u61de\u{1ffdc}',
+type: 'occlusion',
+count: 3250,
+});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup6, new Uint32Array(9895), 5415, 0);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(8, 16, 48, -592);
+} catch {}
+try {
+querySet4.destroy();
+} catch {}
+let arrayBuffer4 = buffer5.getMappedRange(26760, 0);
+try {
+  await buffer8.mapAsync(GPUMapMode.READ, 0, 2876);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 2760, new BigUint64Array(27294), 6871, 36);
+} catch {}
+let bindGroupLayout14 = device0.createBindGroupLayout({
+label: '\u0f7b\ue21e\uf2c0\u035c\uf700\u08f7',
+entries: [],
+});
+let buffer10 = device0.createBuffer({
+  label: '\u0520\u34c4\u00fc\u{1ff66}',
+  size: 8122,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let querySet20 = device0.createQuerySet({
+label: '\u{1fc95}\u0307\u{1fef0}\u2668',
+type: 'occlusion',
+count: 3120,
+});
+let texture25 = device0.createTexture({
+label: '\u1954\u{1fbdf}\ud748\u{1f7a0}\u70ee\u761d\ucf14\u{1f631}\u{1fff9}\u{1fe2b}',
+size: {width: 160, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+sampleCount: 1,
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg8snorm', 'rg8snorm', 'rg8snorm'],
+});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({
+  label: '\u0990\u00f7\u{1fe85}\u33a6\u0892\ua383\u8bad\uc851',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8'
+});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup3, new Uint32Array(579), 231, 0);
+} catch {}
+try {
+commandEncoder16.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 56, y: 36, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 55136 */
+offset: 55136,
+bytesPerRow: 0,
+buffer: buffer1,
+}, {width: 0, height: 100, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+canvas5.getContext('webgl');
+} catch {}
+let texture26 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder13 = commandEncoder17.beginComputePass();
+try {
+computePassEncoder10.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(40);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer3, 55524, buffer1, 50560, 2424);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+offscreenCanvas5.getContext('webgl');
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+label: '\u7add\u084e\u0669\ue850\u{1f9e6}\ue19d\u6b78',
+code: `@group(1) @binding(43)
+var<storage, read_write> local1: array<u32>;
+@group(0) @binding(794)
+var<storage, read_write> parameter3: array<u32>;
+@group(1) @binding(257)
+var<storage, read_write> type1: array<u32>;
+
+@compute @workgroup_size(5, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S3 {
+  @location(14) f0: vec4<f32>,
+  @builtin(sample_index) f1: u32,
+  @location(8) f2: vec2<u32>,
+  @builtin(front_facing) f3: bool,
+  @location(2) f4: i32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec2<u32>,
+  @location(1) f1: vec3<i32>,
+  @location(3) f2: vec2<f32>,
+  @builtin(sample_mask) f3: u32,
+  @location(4) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(13) a0: vec2<f16>, @builtin(position) a1: vec4<f32>, @location(12) a2: vec4<f32>, a3: S3, @location(6) a4: vec3<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S2 {
+  @location(6) f0: vec2<f32>,
+  @location(3) f1: u32
+}
+struct VertexOutput0 {
+  @location(0) f7: f16,
+  @location(10) f8: vec4<f16>,
+  @location(14) f9: vec4<f32>,
+  @location(12) f10: vec4<f32>,
+  @location(15) f11: vec2<f16>,
+  @location(6) f12: vec3<f32>,
+  @location(2) f13: i32,
+  @location(13) f14: vec2<f16>,
+  @location(8) f15: vec2<u32>,
+  @builtin(position) f16: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec4<u32>, @location(5) a1: f16, a2: S2, @location(4) a3: vec2<i32>, @location(1) a4: i32, @location(7) a5: u32, @location(8) a6: f32, @location(10) a7: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+pseudoSubmit(device0, commandEncoder10);
+let texture27 = device0.createTexture({
+label: '\u4215\u0c60\ufe03\u0a0a\u09be\ub710\ua59a',
+size: [1320, 96, 1],
+mipLevelCount: 5,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x6-unorm'],
+});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({
+  label: '\u33c8\u0579\u55e2\u84d8\u{1fc3c}\u9ccb\u0681\uab72\u26cf\u3e8b\u0224',
+  colorFormats: ['bgra8unorm-srgb', 'rgba16uint', 'r8uint', 'rg11b10ufloat', 'r8uint'],
+  stencilReadOnly: true
+});
+let sampler13 = device0.createSampler({
+label: '\u06b4\ucc24\u{1f9df}\u000e\u198f\u{1fa20}\u8801\ue73c',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 51.659,
+lodMaxClamp: 69.568,
+});
+try {
+renderBundleEncoder6.setBindGroup(1, bindGroup0, []);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(24, 72, 48);
+} catch {}
+try {
+  await buffer10.mapAsync(GPUMapMode.READ, 0, 3092);
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer2, 1064, buffer10, 5608, 276);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+/* bytesInLastRow: 452 widthInBlocks: 113 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 12536 */
+offset: 12536,
+buffer: buffer0,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 98, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 113, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline29 = await device0.createComputePipelineAsync({
+layout: pipelineLayout4,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+},
+});
+let videoFrame4 = new VideoFrame(video1, {timestamp: 0});
+let textureView16 = texture11.createView({baseMipLevel: 3, mipLevelCount: 3});
+try {
+renderBundleEncoder17.drawIndexed(24);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(7, buffer0, 13656, 170);
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer0, 7024, buffer1, 19112, 3588);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let videoFrame5 = new VideoFrame(videoFrame3, {timestamp: 0});
+let shaderModule7 = device0.createShaderModule({
+label: '\ud05c\uf2f1\udd13\ufadb\u{1fc58}',
+code: `@group(1) @binding(43)
+var<storage, read_write> global1: array<u32>;
+@group(0) @binding(794)
+var<storage, read_write> i0: array<u32>;
+@group(1) @binding(257)
+var<storage, read_write> field2: array<u32>;
+@group(0) @binding(297)
+var<storage, read_write> function3: array<u32>;
+
+@compute @workgroup_size(8, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S5 {
+  @builtin(position) f0: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(3) f0: vec4<i32>,
+  @location(2) f1: vec4<u32>,
+  @location(1) f2: u32,
+  @location(0) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, a1: S5, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S4 {
+  @location(15) f0: vec4<u32>,
+  @builtin(vertex_index) f1: u32,
+  @builtin(instance_index) f2: u32,
+  @location(13) f3: vec4<u32>,
+  @location(2) f4: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec4<u32>, @location(1) a1: vec2<f16>, a2: S4, @location(0) a3: u32, @location(5) a4: vec3<u32>, @location(14) a5: vec4<f32>, @location(7) a6: f16, @location(12) a7: u32, @location(9) a8: vec4<u32>, @location(10) a9: vec4<u32>, @location(4) a10: f32, @location(6) a11: vec2<i32>, @location(8) a12: vec3<f16>, @location(11) a13: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let textureView17 = texture4.createView({});
+let computePassEncoder14 = commandEncoder16.beginComputePass({label: '\u2378\u2225\ucb2b\u5fba\u2b7f'});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(8, 72);
+} catch {}
+let arrayBuffer5 = buffer7.getMappedRange(40328, 544);
+try {
+computePassEncoder11.pushDebugGroup('\u3b1e');
+} catch {}
+let videoFrame6 = new VideoFrame(canvas7, {timestamp: 0});
+try {
+window.someLabel = commandEncoder10.label;
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+label: '\u6ebe\u{1f8f1}\u{1f6b3}',
+code: `@group(1) @binding(803)
+var<storage, read_write> field3: array<u32>;
+@group(0) @binding(803)
+var<storage, read_write> i1: array<u32>;
+@group(3) @binding(803)
+var<storage, read_write> type2: array<u32>;
+@group(0) @binding(788)
+var<storage, read_write> type3: array<u32>;
+@group(1) @binding(788)
+var<storage, read_write> type4: array<u32>;
+@group(3) @binding(788)
+var<storage, read_write> field4: array<u32>;
+
+@compute @workgroup_size(6, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(3) f1: vec2<f32>,
+  @location(1) f2: vec3<i32>,
+  @location(4) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(11) a0: vec4<u32>, @location(0) a1: vec3<i32>, @location(4) a2: vec2<i32>, @location(9) a3: f16, @location(13) a4: vec4<f16>, @builtin(front_facing) a5: bool, @location(14) a6: vec3<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S6 {
+  @location(2) f0: u32,
+  @location(7) f1: vec2<f16>,
+  @location(8) f2: vec3<f16>,
+  @location(10) f3: f32,
+  @location(12) f4: f32,
+  @location(0) f5: vec3<f32>,
+  @location(11) f6: vec3<u32>,
+  @location(15) f7: vec4<u32>
+}
+struct VertexOutput0 {
+  @location(0) f17: vec3<i32>,
+  @location(13) f18: vec4<f16>,
+  @location(4) f19: vec2<i32>,
+  @builtin(position) f20: vec4<f32>,
+  @location(11) f21: vec4<u32>,
+  @location(14) f22: vec3<i32>,
+  @location(9) f23: f16
+}
+
+@vertex
+fn vertex0(a0: S6, @location(3) a1: vec2<i32>, @location(6) a2: vec4<f32>, @location(9) a3: vec4<f16>, @location(1) a4: vec4<i32>, @location(13) a5: f16, @location(4) a6: vec2<f32>, @location(14) a7: vec3<f32>, @location(5) a8: i32, @builtin(vertex_index) a9: u32, @builtin(instance_index) a10: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let querySet21 = device0.createQuerySet({
+label: '\u0df9\u{1f835}\uead6\u{1fa08}\u2a47\u{1ff87}\u{1fedf}\u00d3\u0925\u0b56\u{1f80e}',
+type: 'occlusion',
+count: 1455,
+});
+let renderBundle14 = renderBundleEncoder4.finish();
+try {
+renderBundleEncoder17.setVertexBuffer(3, buffer0, 20588, 1350);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: { x: 49, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 665 */
+{offset: 665, bytesPerRow: 2563}, {width: 606, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline30 = device0.createRenderPipeline({
+layout: pipelineLayout0,
+multisample: {
+count: 4,
+mask: 0x49a273fd,
+},
+fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba16uint', writeMask: 0}, {format: 'rgba16sint', writeMask: GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 994,
+stencilWriteMask: 2578,
+depthBias: 74,
+},
+vertex: {
+  module: shaderModule7,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 208,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x4',
+offset: 132,
+shaderLocation: 7,
+}, {
+format: 'uint16x4',
+offset: 48,
+shaderLocation: 12,
+}, {
+format: 'uint32x4',
+offset: 68,
+shaderLocation: 11,
+}, {
+format: 'snorm8x4',
+offset: 28,
+shaderLocation: 4,
+}, {
+format: 'sint32',
+offset: 68,
+shaderLocation: 6,
+}, {
+format: 'uint8x4',
+offset: 24,
+shaderLocation: 0,
+}, {
+format: 'uint32',
+offset: 64,
+shaderLocation: 13,
+}, {
+format: 'uint32',
+offset: 60,
+shaderLocation: 2,
+}, {
+format: 'uint16x4',
+offset: 48,
+shaderLocation: 5,
+}, {
+format: 'uint32x3',
+offset: 152,
+shaderLocation: 15,
+}, {
+format: 'uint8x2',
+offset: 40,
+shaderLocation: 9,
+}, {
+format: 'unorm8x2',
+offset: 86,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 1084,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x2',
+offset: 496,
+shaderLocation: 8,
+}, {
+format: 'uint8x4',
+offset: 272,
+shaderLocation: 10,
+}, {
+format: 'unorm10-10-10-2',
+offset: 912,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 376,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 696,
+attributes: [{
+format: 'uint16x2',
+offset: 420,
+shaderLocation: 3,
+}],
+}
+]
+},
+});
+let shaderModule9 = device0.createShaderModule({
+label: '\u{1f886}\u{1fe6d}\u{1fbf8}\udefd\u{1fb79}\u{1fb03}\u6716\u{1fcfa}\uc94a\u30e8',
+code: `@group(1) @binding(788)
+var<storage, read_write> field5: array<u32>;
+@group(1) @binding(803)
+var<storage, read_write> local2: array<u32>;
+@group(0) @binding(561)
+var<storage, read_write> i2: array<u32>;
+@group(3) @binding(674)
+var<storage, read_write> field6: array<u32>;
+@group(2) @binding(20)
+var<storage, read_write> i3: array<u32>;
+
+@compute @workgroup_size(8, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @builtin(sample_mask) f1: u32,
+  @location(2) f2: vec4<u32>,
+  @location(0) f3: vec4<f32>,
+  @location(3) f4: vec3<f32>,
+  @location(4) f5: vec2<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(sample_mask) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(6) a0: vec4<f32>, @location(4) a1: vec4<i32>, @location(12) a2: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+pseudoSubmit(device0, commandEncoder7);
+let renderBundle15 = renderBundleEncoder7.finish({label: '\u02fb\u0ed4\u6671\udc89\u6017\u{1fccb}'});
+try {
+renderBundleEncoder9.drawIndexed(8, 40, 0);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let bindGroup7 = device0.createBindGroup({
+label: '\ubccc\u0b81',
+layout: bindGroupLayout3,
+entries: [],
+});
+try {
+computePassEncoder13.setPipeline(pipeline3);
+} catch {}
+let pipeline31 = device0.createComputePipeline({
+label: '\u{1f8dc}\u2352\u7666\u045e\u0143\u0b73\u3e04',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+canvas2.height = 144;
+let offscreenCanvas6 = new OffscreenCanvas(445, 934);
+let buffer11 = device0.createBuffer({
+  label: '\u9093\u{1f827}\u0774\uffe7\u060e\u{1fa3a}',
+  size: 62138,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+pseudoSubmit(device0, commandEncoder13);
+let texture28 = device0.createTexture({
+label: '\uf7d6\u0e66\ua6b6\u0351\ucb40\u13a6\u{1fe54}\u581d\ua574\u7446\u6b9f',
+size: [219],
+dimension: '1d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({
+  colorFormats: ['bgra8unorm-srgb', 'rgba16uint', 'r8uint', 'rg11b10ufloat', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle16 = renderBundleEncoder16.finish({label: '\u05d3\u{1fa51}'});
+let sampler14 = device0.createSampler({
+label: '\u8210\u91fe',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 69.932,
+lodMaxClamp: 91.988,
+compare: 'greater-equal',
+});
+try {
+renderBundleEncoder17.draw(48, 48);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 5252, new DataView(new ArrayBuffer(41623)), 5812, 14600);
+} catch {}
+canvas2.width = 730;
+let video4 = await videoWithData();
+let bindGroup8 = device0.createBindGroup({
+label: '\u6067\u6e71\udd6b\u0d18\ued40\u{1fff1}\u90e1\u4c2f',
+layout: bindGroupLayout1,
+entries: [{
+binding: 43,
+resource: externalTexture0
+}, {
+binding: 257,
+resource: externalTexture0
+}],
+});
+pseudoSubmit(device0, commandEncoder14);
+let texture29 = device0.createTexture({
+label: '\u7aa2\u{1f828}',
+size: [1670, 160, 1],
+mipLevelCount: 8,
+format: 'astc-10x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler15 = device0.createSampler({
+label: '\u89be\u0aef\u{1f9cb}\ud163',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 30.303,
+lodMaxClamp: 85.374,
+maxAnisotropy: 15,
+});
+try {
+renderBundleEncoder8.drawIndexed(48, 64);
+} catch {}
+try {
+computePassEncoder11.insertDebugMarker('\uc620');
+} catch {}
+let bindGroupLayout15 = device0.createBindGroupLayout({
+label: '\u882d\u0296\ud892\u2779\u{1faaa}\u0428\u{1fc82}\u0369\uaf8c\u450b',
+entries: [{
+binding: 432,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d' },
+}, {
+binding: 927,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+}, {
+binding: 151,
+visibility: 0,
+externalTexture: {},
+}],
+});
+let textureView18 = texture23.createView({label: '\u3640\u0696\u0ca5\u{1feca}\u{1f77e}\u{1fe5d}\u0421', dimension: '2d-array', mipLevelCount: 1});
+let renderBundle17 = renderBundleEncoder23.finish({label: '\u1cc6\u1375\u2a6d\u973c\u{1f90c}'});
+let sampler16 = device0.createSampler({
+label: '\u50cc\u66ee\u45e3\u{1faf4}\uee00\u{1fbb8}\u0f68\u{1fdd9}',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 95.715,
+maxAnisotropy: 19,
+});
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+commandEncoder15.copyBufferToTexture({
+/* bytesInLastRow: 2012 widthInBlocks: 503 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 5120 */
+offset: 3108,
+bytesPerRow: 2048,
+buffer: buffer0,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: { x: 141, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 503, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['astc-10x6-unorm-srgb', 'bgra8unorm', 'bgra8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let pipeline32 = await device0.createComputePipelineAsync({
+label: '\u3e4a\u303d\u3b53\u0e35\u7e45\ub9dc\u0fe0\uc367\u5205\u0e35\u{1fbe6}',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+offscreenCanvas0.height = 583;
+let commandEncoder18 = device0.createCommandEncoder({});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({
+  colorFormats: [undefined, 'r16uint', 'rg32uint', 'rg16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+let renderBundle18 = renderBundleEncoder0.finish({});
+try {
+renderBundleEncoder9.drawIndexed(48, 0, 72, -656);
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(buffer3, 7200, buffer10, 3172, 3752);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer10);
+} catch {}
+let canvas10 = document.createElement('canvas');
+let bindGroup9 = device0.createBindGroup({
+label: '\u8ba6\u8940\u227a\u132c\ucd46\u8941\u{1f6b7}',
+layout: bindGroupLayout1,
+entries: [{
+binding: 43,
+resource: externalTexture0
+}, {
+binding: 257,
+resource: externalTexture0
+}],
+});
+let commandEncoder19 = device0.createCommandEncoder();
+let textureView19 = texture1.createView({label: '\ueabf\u03ee\u9119\u845a'});
+let computePassEncoder15 = commandEncoder15.beginComputePass();
+let renderBundle19 = renderBundleEncoder19.finish({label: '\u{1ff0c}\u0d2e\u5a27\ud763\u{1fa30}\u5f6d\ue374\u05a1\u0c92'});
+let sampler17 = device0.createSampler({
+label: '\u03b3\ud6e9\u015c\u{1fd9b}\u44e4\uc991\u{1fb82}\u{1f8e8}\u0f6e',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 52.079,
+lodMaxClamp: 93.333,
+});
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(0, bindGroup1, new Uint32Array(4984), 4462, 0);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext5.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['eac-rg11snorm', 'rgba16float', 'r32float'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 2,
+  origin: { x: 5, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 283 */
+{offset: 251}, {width: 16, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let renderBundle20 = renderBundleEncoder7.finish({});
+try {
+renderBundleEncoder8.draw(32, 72);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(0, buffer6, 36332, 444);
+} catch {}
+let querySet22 = device0.createQuerySet({
+type: 'occlusion',
+count: 1645,
+});
+let sampler18 = device0.createSampler({
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 69.653,
+lodMaxClamp: 83.057,
+maxAnisotropy: 11,
+});
+try {
+renderBundleEncoder9.draw(16);
+} catch {}
+try {
+commandEncoder18.copyTextureToBuffer({
+  texture: texture14,
+  mipLevel: 2,
+  origin: { x: 30, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 36304 */
+offset: 36304,
+buffer: buffer1,
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline33 = device0.createRenderPipeline({
+label: '\u6801\u38db\u05a4\u3632',
+layout: pipelineLayout3,
+multisample: {
+count: 4,
+mask: 0xc9a632cc,
+},
+fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: 0}, {
+  format: 'rgba8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'dst'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'one-minus-src-alpha'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, undefined, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'dst'},
+alpha: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'constant'},
+},
+  writeMask: 0
+}]
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'replace',
+depthFailOp: 'decrement-wrap',
+passOp: 'invert',
+},
+stencilReadMask: 1628,
+stencilWriteMask: 1780,
+depthBias: 97,
+depthBiasClamp: 74,
+},
+vertex: {
+  module: shaderModule3,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 848,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 88,
+shaderLocation: 4,
+}, {
+format: 'uint32x3',
+offset: 756,
+shaderLocation: 14,
+}, {
+format: 'sint32x3',
+offset: 420,
+shaderLocation: 9,
+}, {
+format: 'float32x3',
+offset: 432,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 304,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 16,
+shaderLocation: 15,
+}, {
+format: 'unorm10-10-10-2',
+offset: 80,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 740,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x4',
+offset: 568,
+shaderLocation: 13,
+}, {
+format: 'snorm16x4',
+offset: 240,
+shaderLocation: 5,
+}, {
+format: 'snorm16x2',
+offset: 188,
+shaderLocation: 10,
+}, {
+format: 'sint8x2',
+offset: 554,
+shaderLocation: 6,
+}, {
+format: 'unorm10-10-10-2',
+offset: 100,
+shaderLocation: 8,
+}, {
+format: 'float16x2',
+offset: 56,
+shaderLocation: 3,
+}, {
+format: 'sint8x2',
+offset: 722,
+shaderLocation: 2,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+},
+});
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+gc();
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+commandEncoder19.copyBufferToBuffer(buffer2, 584, buffer11, 56192, 116);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer11);
+} catch {}
+let img7 = await imageWithData(294, 99, '#95f21c07', '#0aad8b56');
+let bindGroup10 = device0.createBindGroup({
+label: '\uf890\u{1fa15}\u43f5\u3636\u{1fbc5}\u0651\u{1fb4c}\u5758\u0a82',
+layout: bindGroupLayout1,
+entries: [{
+binding: 43,
+resource: externalTexture0
+}, {
+binding: 257,
+resource: externalTexture0
+}],
+});
+let computePassEncoder16 = commandEncoder18.beginComputePass({});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({
+  label: '\u{1fd49}\u65a2\u{1fef6}\ub03a\u{1ffcf}\u756e\u09bb\u0ab6\u{1ff3a}',
+  colorFormats: [undefined, 'r16uint', 'rg32uint', 'rg16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder8.draw(48);
+} catch {}
+try {
+renderBundleEncoder13.setPipeline(pipeline10);
+} catch {}
+gc();
+let canvas11 = document.createElement('canvas');
+try {
+offscreenCanvas6.getContext('bitmaprenderer');
+} catch {}
+let shaderModule10 = device0.createShaderModule({
+label: '\u6ad0\u08be\u0cd8\u0aa4\u792b\u03dd\u0d12\u6cc2\u8174',
+code: `@group(0) @binding(561)
+var<storage, read_write> global2: array<u32>;
+
+@compute @workgroup_size(6, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<i32>,
+  @location(0) f1: vec4<u32>,
+  @location(1) f2: vec4<u32>,
+  @location(2) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(13) a0: vec4<f32>, @location(8) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S7 {
+  @location(15) f0: vec2<u32>,
+  @location(2) f1: i32,
+  @location(7) f2: vec4<f32>,
+  @location(4) f3: f32
+}
+struct VertexOutput0 {
+  @location(14) f24: vec2<f16>,
+  @builtin(position) f25: vec4<f32>,
+  @location(8) f26: u32,
+  @location(11) f27: vec3<u32>,
+  @location(12) f28: u32,
+  @location(15) f29: u32,
+  @location(7) f30: f16,
+  @location(13) f31: vec4<f32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, a1: S7, @location(14) a2: vec4<u32>, @location(3) a3: vec4<u32>, @location(13) a4: i32, @location(1) a5: f16, @location(10) a6: vec3<f32>, @location(12) a7: vec2<f16>, @location(5) a8: vec4<f16>, @location(6) a9: vec2<f32>, @location(0) a10: i32, @location(9) a11: u32, @location(8) a12: vec4<f16>, @location(11) a13: vec3<f16>, @builtin(instance_index) a14: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let textureView20 = texture5.createView({dimension: '2d-array'});
+let computePassEncoder17 = commandEncoder19.beginComputePass({label: '\ubef4\u13f6\u{1f63a}\ufb45\u5b35\u608e\u5a6d\u{1f983}\u0176'});
+try {
+computePassEncoder16.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 5396, new Int16Array(35927), 10658, 1496);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(6, buffer6);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let pipeline34 = await device0.createComputePipelineAsync({
+label: '\u0706\ue10c\u04ea\u0720\u1501\u{1fd41}\u07e9\u{1fc11}\u0891\u0372\u0334',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline35 = await device0.createRenderPipelineAsync({
+label: '\u1926\u870a\u98c5\u{1f67e}\u4ced\u43aa',
+layout: pipelineLayout2,
+fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint'}, {format: 'rg8sint', writeMask: GPUColorWrite.GREEN}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'dst', dstFactor: 'constant'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}]
+},
+vertex: {
+  module: shaderModule8,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1204,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x4',
+offset: 232,
+shaderLocation: 7,
+}, {
+format: 'unorm16x4',
+offset: 580,
+shaderLocation: 14,
+}, {
+format: 'uint32x4',
+offset: 416,
+shaderLocation: 11,
+}, {
+format: 'unorm10-10-10-2',
+offset: 248,
+shaderLocation: 0,
+}, {
+format: 'snorm8x2',
+offset: 898,
+shaderLocation: 9,
+}, {
+format: 'uint32x2',
+offset: 208,
+shaderLocation: 2,
+}, {
+format: 'float32',
+offset: 368,
+shaderLocation: 6,
+}, {
+format: 'sint32x4',
+offset: 64,
+shaderLocation: 3,
+}, {
+format: 'sint32',
+offset: 68,
+shaderLocation: 1,
+}, {
+format: 'float16x4',
+offset: 760,
+shaderLocation: 10,
+}, {
+format: 'unorm16x2',
+offset: 56,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 1324,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 1036,
+shaderLocation: 8,
+}, {
+format: 'float32',
+offset: 132,
+shaderLocation: 13,
+}, {
+format: 'uint32x2',
+offset: 684,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 536,
+attributes: [{
+format: 'sint16x2',
+offset: 196,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 1140,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 872,
+shaderLocation: 12,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let adapter2 = await promise5;
+let buffer12 = device0.createBuffer({
+  label: '\uf577\uf1d3\u08e7\u{1f8fd}\u{1fd77}\u{1ff85}\u7e89\uab39\ue9e2',
+  size: 41068,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: true
+});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup3, new Uint32Array(2867), 383, 0);
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline13);
+} catch {}
+let pipeline36 = await promise8;
+let querySet23 = device0.createQuerySet({
+label: '\u0caf\u7f91\u5f5f\u9ebb\ua3fb',
+type: 'occlusion',
+count: 2213,
+});
+let sampler19 = device0.createSampler({
+label: '\u89f4\ued7c\u0505\u07c6\ub96f\ucec6\u0a9e\u0670\u{1fd52}\uc00b',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 80.146,
+lodMaxClamp: 91.791,
+});
+try {
+renderBundleEncoder17.draw(32, 72, 80, 40);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer6, 'uint16');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 19580, new DataView(new ArrayBuffer(7277)), 4569, 164);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 483 */
+{offset: 483, bytesPerRow: 34}, {width: 20, height: 10, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img2);
+let commandEncoder20 = device0.createCommandEncoder({label: '\ub8dc\u{1f87d}\ua972\u{1f7f1}\u2135'});
+let computePassEncoder18 = commandEncoder20.beginComputePass({});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({
+  label: '\ub523\u0738\u{1ff9e}\u04b0\u0c35',
+  colorFormats: ['bgra8unorm-srgb', 'rgba16uint', 'r8uint', 'rg11b10ufloat', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+try {
+gpuCanvasContext4.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['astc-10x5-unorm', 'astc-8x6-unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroupLayout16 = device0.createBindGroupLayout({
+entries: [],
+});
+let bindGroup11 = device0.createBindGroup({
+label: '\u3fd4\u{1f689}\u8053\u0710',
+layout: bindGroupLayout4,
+entries: [],
+});
+let buffer13 = device0.createBuffer({
+  label: '\u{1fd0f}\u{1fe25}\ub2b5\u0db3\u65e8\u4233\u0819\u05b4\u66e9',
+  size: 60176,
+  usage: GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true
+});
+let querySet24 = device0.createQuerySet({
+label: '\u873b\u00e6\u060f\ub470\u4421\u0a4c\u5969\ua431',
+type: 'occlusion',
+count: 2345,
+});
+try {
+computePassEncoder18.setPipeline(pipeline31);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 12200);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer0, 'uint32', 25324, 540);
+} catch {}
+let promise9 = adapter2.requestDevice({
+label: '\ufbc2\u18cc\ua107\u66f1\u{1fa58}\u037c\u{1f7f8}\u{1fae8}\u{1f72a}\uf5d7',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+});
+let buffer14 = device0.createBuffer({size: 14420, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let querySet25 = device0.createQuerySet({
+label: '\uc287\u{1fd1b}\uc1db\u0cd4\u{1f885}',
+type: 'occlusion',
+count: 932,
+});
+let texture30 = device0.createTexture({
+label: '\u5d9b\uf6a6\u7655\u08bd\u0c7e\u03a1',
+size: [64, 90, 1],
+mipLevelCount: 7,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({
+  label: '\u2392\u0aad',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8'
+});
+let renderBundle21 = renderBundleEncoder13.finish({label: '\u00cb\u9994\u0314\uf503\u4296\u0fc8\u59e0\u0c57'});
+let sampler20 = device0.createSampler({
+label: '\u0bc4\uf748\u{1f72c}\ua219\u01bd',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 77.003,
+lodMaxClamp: 92.916,
+maxAnisotropy: 1,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 1, y: 11, z: 71 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 2957067 */
+{offset: 507, bytesPerRow: 296, rowsPerImage: 120}, {width: 28, height: 29, depthOrArrayLayers: 84});
+} catch {}
+let pipeline37 = device0.createComputePipeline({
+label: '\u0870\u05a6\u3809\u{1fa08}\u0e0d\ubabf\ud6e5\u0723\u0bbb\u137f',
+layout: 'auto',
+compute: {
+module: shaderModule10,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let texture31 = device0.createTexture({
+label: '\u0164\u{1f8bb}\u0a03\u{1fcd8}\u{1feb5}\u{1f632}\u{1f7f6}\u7305',
+size: {width: 1320, height: 96, depthOrArrayLayers: 1},
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x6-unorm', 'astc-8x6-unorm-srgb', 'astc-8x6-unorm'],
+});
+try {
+computePassEncoder2.popDebugGroup();
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder({label: '\uc710\u0655\uc60f\ubacc\u6428\u{1fbe9}\u57bf\u0e72'});
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(40, 80, 48, -360);
+} catch {}
+try {
+commandEncoder17.copyBufferToBuffer(buffer3, 20872, buffer11, 44476, 4992);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder17.clearBuffer(buffer1, 46108, 2200);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(querySet15, 77, 5, buffer12, 38144);
+} catch {}
+let pipeline38 = device0.createRenderPipeline({
+label: '\ubf07\u0105\uc1de\u{1f6d0}\u3223\u0f75\u07fa\u{1fed0}\ud371\ucbcc\u2c46',
+layout: pipelineLayout6,
+fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r16uint', writeMask: 0}, {format: 'rgba16uint', writeMask: 0}, {format: 'rgba16sint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'greater-equal',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 2333,
+stencilWriteMask: 376,
+depthBiasSlopeScale: 53,
+depthBiasClamp: 89,
+},
+vertex: {
+  module: shaderModule4,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 936,
+attributes: [{
+format: 'unorm16x4',
+offset: 888,
+shaderLocation: 12,
+}, {
+format: 'snorm8x2',
+offset: 908,
+shaderLocation: 15,
+}, {
+format: 'uint8x2',
+offset: 678,
+shaderLocation: 9,
+}, {
+format: 'sint16x4',
+offset: 400,
+shaderLocation: 0,
+}, {
+format: 'uint32x3',
+offset: 884,
+shaderLocation: 4,
+}, {
+format: 'unorm10-10-10-2',
+offset: 48,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 920,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 308,
+shaderLocation: 5,
+}, {
+format: 'unorm8x4',
+offset: 236,
+shaderLocation: 2,
+}, {
+format: 'unorm16x2',
+offset: 708,
+shaderLocation: 13,
+}, {
+format: 'unorm8x4',
+offset: 840,
+shaderLocation: 14,
+}, {
+format: 'float32x4',
+offset: 440,
+shaderLocation: 11,
+}, {
+format: 'float32x4',
+offset: 348,
+shaderLocation: 1,
+}, {
+format: 'float16x2',
+offset: 584,
+shaderLocation: 6,
+}],
+}
+]
+},
+});
+let renderBundle22 = renderBundleEncoder24.finish({label: '\uaf20\u3922\u66b0\ud189\uc919\u6fef\ub961'});
+let sampler21 = device0.createSampler({
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 46.247,
+lodMaxClamp: 94.026,
+maxAnisotropy: 3,
+});
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer12, 408);
+} catch {}
+try {
+renderBundleEncoder8.drawIndirect(buffer12, 1240);
+} catch {}
+try {
+commandEncoder21.copyBufferToBuffer(buffer3, 55932, buffer9, 17004, 3048);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder21.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 68, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 1188 widthInBlocks: 297 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 21160 */
+offset: 21160,
+buffer: buffer1,
+}, {width: 297, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder17.clearBuffer(buffer8, 4752, 5944);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+canvas11.getContext('webgpu');
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(80, 16, 24, 584, 80);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer12, 22604);
+} catch {}
+try {
+commandEncoder21.resolveQuerySet(querySet24, 1289, 141, buffer12, 15104);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 8724, new Int16Array(5059), 922, 2164);
+} catch {}
+let canvas12 = document.createElement('canvas');
+let bindGroup12 = device0.createBindGroup({
+label: '\u050d\u{1f869}\u8a96\ufc9c',
+layout: bindGroupLayout16,
+entries: [],
+});
+let pipelineLayout7 = device0.createPipelineLayout({
+  label: '\uad98\u03ae\u0da8\u91d7\u06cc\u1f2e\u57a3',
+  bindGroupLayouts: [bindGroupLayout2, bindGroupLayout0, bindGroupLayout8, bindGroupLayout16]
+});
+let buffer15 = device0.createBuffer({size: 6209, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandBuffer6 = commandEncoder17.finish({
+label: '\u279d\u31ca',
+});
+let texture32 = device0.createTexture({
+label: '\u05bb\u774a\u064e\u{1f743}\u8960\u5e98\u0c0f\u0c38\ud0e1\u0723\u50df',
+size: {width: 40, height: 1, depthOrArrayLayers: 1},
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexedIndirect(buffer15, 5944);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer6, 'uint16', 4230);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let textureView21 = texture17.createView({
+  label: '\uaa5d\ub29e\u2aaa\u0666\u6c35\u86bc\u{1fef7}',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 3
+});
+try {
+computePassEncoder18.end();
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer0, 'uint16', 9024, 23290);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(6, buffer6, 24428);
+} catch {}
+let bindGroupLayout17 = device0.createBindGroupLayout({
+entries: [{
+binding: 274,
+visibility: 0,
+storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '2d' },
+}, {
+binding: 887,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'non-filtering' },
+}],
+});
+let bindGroup13 = device0.createBindGroup({
+label: '\u1c37\u09f8\u09ac\u2436\u050d\ua5a6',
+layout: bindGroupLayout11,
+entries: [{
+binding: 297,
+resource: externalTexture0
+}, {
+binding: 823,
+resource: textureView12
+}],
+});
+let buffer16 = device0.createBuffer({label: '\ucfdc\ub054\u085e\uae0c', size: 62825, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let querySet26 = device0.createQuerySet({
+label: '\u825f\u5cc7',
+type: 'occlusion',
+count: 248,
+});
+let textureView22 = texture3.createView({dimension: '2d-array', baseMipLevel: 1});
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer15, 5920);
+} catch {}
+try {
+querySet9.destroy();
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(buffer2, 848, buffer10, 7952, 80);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder21.copyTextureToBuffer({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 32716 */
+offset: 32716,
+bytesPerRow: 256,
+buffer: buffer1,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 33400, new BigUint64Array(63711), 24430, 1940);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 1,
+  origin: { x: 1530, y: 5, z: 0 },
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 1570 */
+{offset: 978, rowsPerImage: 203}, {width: 222, height: 5, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext6 = canvas10.getContext('webgpu');
+let commandEncoder22 = device0.createCommandEncoder();
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({
+  label: '\u20f1\uf7cf\u077e\uf978\u{1fef0}\u0f1b\u{1ff01}',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+renderBundleEncoder9.draw(80, 16, 48);
+} catch {}
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 4,
+  origin: { x: 0, y: 1, z: 15 },
+  aspect: 'all',
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 214, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder11.popDebugGroup();
+} catch {}
+try {
+commandEncoder21.insertDebugMarker('\u3d4f');
+} catch {}
+let pipeline39 = device0.createRenderPipeline({
+layout: pipelineLayout6,
+multisample: {
+count: 4,
+mask: 0xf4a8bf37,
+},
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'bgra8unorm', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'keep',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilWriteMask: 1056,
+depthBiasSlopeScale: 0,
+depthBiasClamp: 63,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1924,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1452,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 320,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x4',
+offset: 248,
+shaderLocation: 12,
+}, {
+format: 'sint32x2',
+offset: 300,
+shaderLocation: 3,
+}, {
+format: 'sint8x4',
+offset: 268,
+shaderLocation: 7,
+}, {
+format: 'unorm16x4',
+offset: 220,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 1140,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 120,
+shaderLocation: 1,
+}, {
+format: 'uint16x2',
+offset: 1128,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 44,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x2',
+offset: 32,
+shaderLocation: 2,
+}, {
+format: 'float16x4',
+offset: 24,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 452,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 700,
+attributes: [{
+format: 'float32x3',
+offset: 668,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+let commandBuffer7 = commandEncoder16.finish({
+label: '\u0db8\u0037\udcde\u23e7\u0b0f',
+});
+try {
+computePassEncoder16.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(2, bindGroup12, new Uint32Array(9099), 1224, 0);
+} catch {}
+try {
+renderBundleEncoder8.drawIndirect(buffer12, 29864);
+} catch {}
+try {
+commandEncoder22.copyBufferToBuffer(buffer2, 116, buffer16, 10116, 120);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder21.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 54, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 4,
+  origin: { x: 42, y: 0, z: 132 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer3), /* required buffer size: 369 */
+{offset: 369, bytesPerRow: 735}, {width: 192, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let pipeline40 = await device0.createComputePipelineAsync({
+label: '\u3725\u44f8\u90be\u2e3d\u{1ffa0}\u{1fdb3}\u0284\u5089',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let texture33 = device0.createTexture({
+size: {width: 128, height: 180, depthOrArrayLayers: 1},
+format: 'astc-4x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView23 = texture33.createView({label: '\u01c4\u{1fce8}\u7a7c\u03b5\u0323\u{1f70e}\u062f\uc23a\u6044\u{1fe83}\u{1fd3b}'});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({
+  label: '\uc01a\uca12\u3b5d\u1177\u85a9',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder8.drawIndexed(56, 40, 24);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer15, 2092);
+} catch {}
+try {
+commandEncoder21.copyBufferToTexture({
+/* bytesInLastRow: 128 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 32208 */
+offset: 32208,
+buffer: buffer0,
+}, {
+  texture: texture27,
+  mipLevel: 4,
+  origin: { x: 16, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 64, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 9892, new BigUint64Array(59229), 20521, 128);
+} catch {}
+let pipeline41 = device0.createComputePipeline({
+label: '\u04c3\uaf38\u7cb2\u2c16\u8c65\u23e7\u0506\u0e80\u85f1',
+layout: 'auto',
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline42 = device0.createRenderPipeline({
+label: '\u{1fe6f}\u23b9\u{1f779}',
+layout: pipelineLayout0,
+multisample: {
+mask: 0x105fe53f,
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 1892,
+depthBiasSlopeScale: 53,
+depthBiasClamp: 93,
+},
+vertex: {
+  module: shaderModule8,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 1776,
+shaderLocation: 9,
+}, {
+format: 'unorm16x2',
+offset: 980,
+shaderLocation: 14,
+}, {
+format: 'snorm8x4',
+offset: 8,
+shaderLocation: 10,
+}, {
+format: 'unorm16x2',
+offset: 92,
+shaderLocation: 8,
+}, {
+format: 'float16x4',
+offset: 1312,
+shaderLocation: 7,
+}, {
+format: 'uint8x4',
+offset: 1168,
+shaderLocation: 15,
+}, {
+format: 'sint32x3',
+offset: 208,
+shaderLocation: 5,
+}, {
+format: 'sint16x2',
+offset: 208,
+shaderLocation: 1,
+}, {
+format: 'float16x2',
+offset: 312,
+shaderLocation: 12,
+}, {
+format: 'uint16x4',
+offset: 688,
+shaderLocation: 11,
+}, {
+format: 'unorm10-10-10-2',
+offset: 852,
+shaderLocation: 13,
+}, {
+format: 'float32x2',
+offset: 708,
+shaderLocation: 4,
+}, {
+format: 'sint32x4',
+offset: 1276,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 1724,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 820,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 4,
+shaderLocation: 6,
+}, {
+format: 'uint32x3',
+offset: 340,
+shaderLocation: 2,
+}, {
+format: 'float32x3',
+offset: 364,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let pipelineLayout8 = device0.createPipelineLayout({
+  label: '\u08db\u6952\u6676\ufea0\u{1f7b9}\u31a4\uf725',
+  bindGroupLayouts: [bindGroupLayout10, bindGroupLayout1, bindGroupLayout5, bindGroupLayout6]
+});
+let textureView24 = texture26.createView({dimension: '2d-array', baseMipLevel: 0});
+let renderBundle23 = renderBundleEncoder25.finish({label: '\u{1ff8f}\u20b5\u0e09\uce71'});
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder17.draw(72, 80, 64, 40);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer15, 348);
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(buffer12, 15852, buffer4, 3088, 3320);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder21.clearBuffer(buffer10, 5656, 900);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 3968, new DataView(new ArrayBuffer(23074)), 21338, 520);
+} catch {}
+gc();
+let commandEncoder23 = device0.createCommandEncoder({label: '\u042b\u1fac'});
+let computePassEncoder19 = commandEncoder21.beginComputePass();
+let renderBundle24 = renderBundleEncoder13.finish();
+try {
+renderBundleEncoder8.drawIndexedIndirect(buffer12, 220);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer15, 1240);
+} catch {}
+try {
+commandEncoder23.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 54288 */
+offset: 54288,
+buffer: buffer11,
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer11);
+} catch {}
+let pipeline43 = device0.createComputePipeline({
+label: '\u{1fce4}\u9e5c\u{1fbb9}\ua112\uccdb\u2cb6\u0e76\u0977\uc364',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let gpuCanvasContext7 = canvas12.getContext('webgpu');
+let renderBundle25 = renderBundleEncoder15.finish({label: '\u0b9c\u{1f7e4}\u41e2\u{1fc8f}'});
+try {
+computePassEncoder16.dispatchWorkgroups(5, 2, 5);
+} catch {}
+try {
+computePassEncoder19.end();
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(0, 32, 32, 16, 16);
+} catch {}
+try {
+commandEncoder22.clearBuffer(buffer8, 13652, 468);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 6844, new DataView(new ArrayBuffer(24784)), 5706, 11300);
+} catch {}
+let texture34 = device0.createTexture({
+label: '\u06d5\u{1fe9c}\u0147\u05e2\u8613\u019d\u0fff\u496d\u708d\u{1fbd0}',
+size: [40, 1, 80],
+dimension: '3d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rg8sint', 'rg8sint'],
+});
+try {
+renderBundleEncoder17.drawIndexed(24, 16, 16, 744, 40);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexedIndirect(buffer15, 2208);
+} catch {}
+let arrayBuffer6 = buffer12.getMappedRange(0, 10964);
+try {
+commandEncoder20.copyTextureToBuffer({
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 16, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 20 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 1548 */
+offset: 1548,
+rowsPerImage: 117,
+buffer: buffer11,
+}, {width: 10, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder21.clearBuffer(buffer8, 4220, 712);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+device: device0,
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline44 = await device0.createComputePipelineAsync({
+layout: pipelineLayout0,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({
+  label: '\u{1f6b9}\uc077',
+  colorFormats: ['bgra8unorm-srgb', 'rgba16uint', 'r8uint', 'rg11b10ufloat', 'r8uint'],
+  depthReadOnly: true
+});
+let renderBundle26 = renderBundleEncoder11.finish({label: '\u{1fd2f}\ufede\u0252\uee2d\ud206\ub8a2\u46e6\u{1fc7b}\u{1fdb5}\u{1ffbe}'});
+let arrayBuffer7 = buffer10.getMappedRange(0, 1768);
+try {
+buffer11.unmap();
+} catch {}
+try {
+commandEncoder23.copyBufferToBuffer(buffer3, 19368, buffer14, 4556, 7980);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 3,
+  origin: { x: 32, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 554 */
+{offset: 554}, {width: 16, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout18 = device0.createBindGroupLayout({
+entries: [{
+binding: 109,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+}, {
+binding: 606,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+}, {
+binding: 218,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+}],
+});
+let buffer17 = device0.createBuffer({
+  label: '\u0b64\u0361\ua689\ub59a\u{1fb34}\u0284\u{1f910}\u081a\u0fea\u{1fac0}',
+  size: 19313,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let commandEncoder24 = device0.createCommandEncoder({label: '\u0062\u{1ff95}\ua49d\ue665\u{1f732}\u4eef\u1720\u{1ffeb}'});
+let querySet27 = device0.createQuerySet({
+label: '\u2d20\u{1f889}\u93f9\u272a\u12b7\ub94f\u018b\u675f',
+type: 'occlusion',
+count: 1084,
+});
+let textureView25 = texture11.createView({label: '\uf84a\u93a3', baseMipLevel: 1, mipLevelCount: 5});
+let computePassEncoder20 = commandEncoder23.beginComputePass({label: '\u914d\ubad1'});
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder9.draw(0);
+} catch {}
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 397, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline45 = device0.createComputePipeline({
+label: '\u{1f7bc}\u4354\ue987\uf59d\u0ded',
+layout: 'auto',
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline46 = await device0.createRenderPipelineAsync({
+label: '\ua0c4\u566f\u{1f8f5}',
+layout: pipelineLayout8,
+multisample: {
+mask: 0xecf82bbe,
+},
+fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba16sint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilWriteMask: 2105,
+depthBias: 16,
+depthBiasClamp: 38,
+},
+vertex: {
+  module: shaderModule4,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 896,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 346,
+shaderLocation: 5,
+}, {
+format: 'float32x4',
+offset: 728,
+shaderLocation: 13,
+}, {
+format: 'float16x2',
+offset: 336,
+shaderLocation: 15,
+}, {
+format: 'unorm8x2',
+offset: 456,
+shaderLocation: 2,
+}, {
+format: 'sint8x4',
+offset: 108,
+shaderLocation: 0,
+}, {
+format: 'uint32x2',
+offset: 120,
+shaderLocation: 4,
+}, {
+format: 'float32',
+offset: 72,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 68,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 36,
+shaderLocation: 11,
+}, {
+format: 'snorm16x2',
+offset: 48,
+shaderLocation: 7,
+}, {
+format: 'uint16x4',
+offset: 48,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x2',
+offset: 484,
+shaderLocation: 14,
+}, {
+format: 'float16x4',
+offset: 132,
+shaderLocation: 12,
+}, {
+format: 'snorm8x2',
+offset: 522,
+shaderLocation: 1,
+}],
+}
+]
+},
+});
+let imageBitmap5 = await createImageBitmap(offscreenCanvas1);
+let sampler22 = device0.createSampler({
+label: '\u7248\u{1ff23}\u{1fc03}\u5aad\u{1fb79}',
+addressModeU: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 59.805,
+lodMaxClamp: 60.296,
+maxAnisotropy: 11,
+});
+try {
+computePassEncoder20.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder8.draw(80, 48, 16);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer15, 5168);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: { x: 32, y: 40, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture30,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 10, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder21.clearBuffer(buffer1, 21068, 22040);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+let adapter3 = await promise2;
+let bindGroupLayout19 = device0.createBindGroupLayout({
+label: '\u{1fe9d}\ue75b\uca96\u9768\u0e3a\u084d\uc91a\u008d',
+entries: [{
+binding: 805,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}, {
+binding: 304,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '3d' },
+}],
+});
+let commandBuffer8 = commandEncoder21.finish({
+label: '\u16ef\u{1f6bd}\u0a10\ua984\u0f3e\u3f53',
+});
+let texture35 = device0.createTexture({
+label: '\u{1f710}\u09ab\u0a4a\ua5e8\u0072\u3c84\u827f\u078a\u6138\u{1fc75}',
+size: [80],
+dimension: '1d',
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r32uint'],
+});
+let renderBundle27 = renderBundleEncoder29.finish({});
+let sampler23 = device0.createSampler({
+label: '\u072a\ubd93\u80f8\u0b7d\u0714\u{1f614}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 17.840,
+});
+try {
+renderBundleEncoder12.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder17.draw(8, 56, 72);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer12, 17240);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline39);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture20,
+  mipLevel: 3,
+  origin: { x: 0, y: 3, z: 7 },
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder20.clearBuffer(buffer12);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer8,
+]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 3, y: 1, z: 168 },
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(16)), /* required buffer size: 258062 */
+{offset: 835, bytesPerRow: 667, rowsPerImage: 115}, {width: 27, height: 41, depthOrArrayLayers: 4});
+} catch {}
+canvas5.width = 941;
+let texture36 = device0.createTexture({
+label: '\u0b1b\u074c\ua068\u{1fa00}\ue863\ue569\u3a8a',
+size: [125, 80, 192],
+mipLevelCount: 6,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-5x5-unorm'],
+});
+let textureView26 = texture30.createView({label: '\u9593\u014e\u0faa', dimension: '2d-array', baseMipLevel: 4});
+let renderBundle28 = renderBundleEncoder27.finish({label: '\u6a51\u0453'});
+try {
+renderBundleEncoder17.drawIndirect(buffer12, 19076);
+} catch {}
+try {
+buffer5.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 8920, new Int16Array(38569), 3460, 2612);
+} catch {}
+let img8 = await imageWithData(298, 196, '#c2801653', '#bd10400d');
+let videoFrame7 = new VideoFrame(img4, {timestamp: 0});
+let commandEncoder25 = device0.createCommandEncoder({label: '\ud728\u0ae7\u{1fc6a}\u8d72'});
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({
+  colorFormats: ['bgra8unorm-srgb', 'rgba16uint', 'r8uint', 'rg11b10ufloat', 'r8uint'],
+  stencilReadOnly: true
+});
+let renderBundle29 = renderBundleEncoder8.finish({label: '\u0079\u{1fc6c}\u9ce1\uc63d\u18f5\u3afb\uc4f6\u69f2\ubf81\u0726'});
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(64, 48, 48, 416, 32);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(5, buffer0, 25248, 11248);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: { x: 89, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 816 */
+{offset: 816, rowsPerImage: 85}, {width: 68, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule11 = device0.createShaderModule({
+label: '\u72ac\u6c20\u0f91\u1e3f\u{1f62b}',
+code: `@group(2) @binding(934)
+var<storage, read_write> i4: array<u32>;
+@group(1) @binding(561)
+var<storage, read_write> function4: array<u32>;
+@group(2) @binding(289)
+var<storage, read_write> local3: array<u32>;
+@group(0) @binding(788)
+var<storage, read_write> field7: array<u32>;
+@group(0) @binding(803)
+var<storage, read_write> type5: array<u32>;
+
+@compute @workgroup_size(3, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec3<f32>,
+  @location(4) f1: vec4<u32>,
+  @location(1) f2: vec4<u32>,
+  @location(0) f3: vec4<f32>,
+  @location(2) f4: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(11) a0: vec2<f16>, @location(0) a1: vec3<f32>, @location(15) a2: vec4<u32>, @location(10) a3: vec2<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S8 {
+  @location(8) f0: vec2<f16>
+}
+struct VertexOutput0 {
+  @location(0) f32: vec3<f32>,
+  @location(10) f33: vec2<f16>,
+  @location(11) f34: vec2<f16>,
+  @location(15) f35: vec4<u32>,
+  @builtin(position) f36: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec2<f32>, @location(12) a1: vec4<u32>, @location(11) a2: vec2<f32>, @location(10) a3: vec2<f16>, a4: S8, @location(1) a5: i32, @location(6) a6: u32, @location(14) a7: vec2<f32>, @builtin(instance_index) a8: u32, @location(4) a9: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+});
+let buffer18 = device0.createBuffer({
+  label: '\u1234\u0b61\u6880\u0b1b\u{1ff77}\u0745\u0d29\uefb8\uf53a\u1ff2\u22d3',
+  size: 20160,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true
+});
+let textureView27 = texture13.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 1});
+try {
+renderBundleEncoder17.draw(56, 24);
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 94, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder25.clearBuffer(buffer10, 7928, 76);
+dissociateBuffer(device0, buffer10);
+} catch {}
+let pipeline47 = device0.createRenderPipeline({
+label: '\u31c1\u0739\u0e39\u00be\u{1f707}',
+layout: pipelineLayout0,
+fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: 0}, {format: 'r16uint', writeMask: GPUColorWrite.GREEN}, {format: 'rgba16uint', writeMask: 0}, {format: 'rgba16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}]
+},
+vertex: {
+  module: shaderModule5,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x2',
+offset: 144,
+shaderLocation: 6,
+}, {
+format: 'sint8x4',
+offset: 728,
+shaderLocation: 15,
+}],
+}
+]
+},
+});
+try {
+renderBundleEncoder17.drawIndexed(80);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+let pipeline48 = device0.createRenderPipeline({
+label: '\u6500\u0d32\u{1f663}\u{1ff98}\u098f\u856b\ubba1\ue95e\u{1fe65}\u45ea',
+layout: pipelineLayout7,
+fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'src'},
+alpha: {operation: 'subtract', srcFactor: 'src', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rgba16uint', writeMask: GPUColorWrite.BLUE}, {format: 'r8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rg11b10ufloat'}, {format: 'r8uint'}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'zero',
+depthFailOp: 'decrement-wrap',
+passOp: 'invert',
+},
+stencilReadMask: 2972,
+stencilWriteMask: 898,
+depthBias: 70,
+depthBiasSlopeScale: 2,
+depthBiasClamp: 28,
+},
+vertex: {
+  module: shaderModule11,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1320,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32',
+offset: 488,
+shaderLocation: 6,
+}, {
+format: 'uint32x3',
+offset: 844,
+shaderLocation: 4,
+}, {
+format: 'sint16x2',
+offset: 176,
+shaderLocation: 1,
+}, {
+format: 'unorm16x4',
+offset: 448,
+shaderLocation: 9,
+}, {
+format: 'float32x3',
+offset: 512,
+shaderLocation: 10,
+}, {
+format: 'float16x2',
+offset: 360,
+shaderLocation: 14,
+}, {
+format: 'float16x2',
+offset: 136,
+shaderLocation: 11,
+}, {
+format: 'uint8x2',
+offset: 1112,
+shaderLocation: 12,
+}, {
+format: 'unorm8x4',
+offset: 84,
+shaderLocation: 8,
+}],
+}
+]
+},
+});
+let img9 = await imageWithData(44, 199, '#a2aac7e3', '#eda8d366');
+let commandEncoder26 = device0.createCommandEncoder();
+let commandBuffer9 = commandEncoder25.finish({
+label: '\u0971\u{1ffa5}\u9261\u8fe0\uef51\u4e7b\u9f20',
+});
+let texture37 = device0.createTexture({
+label: '\u{1fdbc}\uc3d6\u4416\u5aab\ueccf\u3a45\udb29',
+size: {width: 84, height: 80, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x10-unorm', 'astc-12x10-unorm'],
+});
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({label: '\u34bf\u281c\u09fd', colorFormats: ['rg8uint', 'r16uint', 'rgba16uint', 'rgba16sint']});
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup9, new Uint32Array(2427), 1759, 0);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline47);
+} catch {}
+try {
+commandEncoder22.copyBufferToBuffer(buffer3, 61852, buffer14, 6064, 636);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder20.clearBuffer(buffer16, 22936, 25892);
+dissociateBuffer(device0, buffer16);
+} catch {}
+let pipeline49 = device0.createComputePipeline({
+label: '\u6c7b\ua61e\uefe2',
+layout: 'auto',
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline50 = await device0.createRenderPipelineAsync({
+label: '\u26a8\u{1fbcb}\u84ae\u0804\u{1ff60}\u{1f75a}\u6781\uf991\uf161\u4aea\u119e',
+layout: pipelineLayout1,
+multisample: {
+count: 4,
+mask: 0xcf5992f,
+},
+fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.ALL}, {format: 'rgba16uint'}, {format: 'rgba16sint'}]
+},
+vertex: {
+  module: shaderModule5,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1664,
+attributes: [{
+format: 'sint32x2',
+offset: 524,
+shaderLocation: 15,
+}, {
+format: 'snorm8x4',
+offset: 16,
+shaderLocation: 6,
+}],
+}
+]
+},
+});
+let commandEncoder27 = device0.createCommandEncoder();
+let texture38 = gpuCanvasContext4.getCurrentTexture();
+let renderBundle30 = renderBundleEncoder18.finish({});
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+renderBundleEncoder12.draw(32, 80, 8);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexedIndirect(buffer15, 5856);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(6, buffer6, 31056, 2721);
+} catch {}
+try {
+querySet12.destroy();
+} catch {}
+try {
+commandEncoder26.copyTextureToTexture({
+  texture: texture31,
+  mipLevel: 0,
+  origin: { x: 176, y: 84, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: { x: 232, y: 6, z: 0 },
+  aspect: 'all',
+}, {width: 1080, height: 6, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup14 = device0.createBindGroup({
+label: '\u02bc\u{1fb5b}\u0b0d\u2828\u93e5\u306a\ua1f8\u370d\ufa2e',
+layout: bindGroupLayout12,
+entries: [],
+});
+let pipelineLayout9 = device0.createPipelineLayout({label: '\u{1fbeb}\u9f62\ua75d', bindGroupLayouts: [bindGroupLayout1]});
+let texture39 = device0.createTexture({
+label: '\ud550\u5430\ubf76\u8fd5\u44cc',
+size: {width: 330, height: 24, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'astc-10x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder12.draw(40, 8, 32);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(3, buffer15, 2432, 2300);
+} catch {}
+try {
+commandEncoder27.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 3,
+  origin: { x: 0, y: 12, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 84, y: 132, z: 0 },
+  aspect: 'all',
+}, {width: 12, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline51 = device0.createComputePipeline({
+label: '\u3ad2\u0bf6\u0f88\ud7f8\u092c\u080c\u41d4',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let bindGroupLayout20 = pipeline49.getBindGroupLayout(3);
+let textureView28 = texture17.createView({
+  label: '\u0481\u3071\u066d\u2bdb\uc864\ub604\u0361\ueeab\u0d94',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  arrayLayerCount: 1
+});
+let renderBundleEncoder33 = device0.createRenderBundleEncoder({
+  label: '\ud48b\u{1fffc}\u3303\u37fc',
+  colorFormats: ['rg16uint', 'rg32float', 'r16uint', 'rg16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder32.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+commandEncoder27.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 10564, new DataView(new ArrayBuffer(43807)), 41413, 1164);
+} catch {}
+let pipeline52 = device0.createRenderPipeline({
+label: '\u7439\u{1f69f}\u1b22',
+layout: 'auto',
+multisample: {
+count: 4,
+mask: 0x414da1a,
+},
+fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.BLUE}, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+vertex: {
+  module: shaderModule8,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1112,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 500,
+shaderLocation: 1,
+}, {
+format: 'float32',
+offset: 996,
+shaderLocation: 4,
+}, {
+format: 'sint8x2',
+offset: 796,
+shaderLocation: 5,
+}, {
+format: 'snorm8x2',
+offset: 164,
+shaderLocation: 12,
+}, {
+format: 'snorm16x4',
+offset: 416,
+shaderLocation: 6,
+}, {
+format: 'sint16x2',
+offset: 236,
+shaderLocation: 3,
+}, {
+format: 'uint16x2',
+offset: 596,
+shaderLocation: 15,
+}, {
+format: 'snorm16x2',
+offset: 384,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 760,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 684,
+shaderLocation: 0,
+}, {
+format: 'snorm8x2',
+offset: 610,
+shaderLocation: 14,
+}, {
+format: 'snorm8x2',
+offset: 482,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 1760,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 1516,
+shaderLocation: 2,
+}, {
+format: 'unorm16x2',
+offset: 176,
+shaderLocation: 9,
+}, {
+format: 'float32x4',
+offset: 396,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 1428,
+attributes: [{
+format: 'float32x3',
+offset: 1276,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 512,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1292,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 2000,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 284,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x3',
+offset: 72,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+video4.height = 102;
+let videoFrame8 = new VideoFrame(canvas10, {timestamp: 0});
+let computePassEncoder21 = commandEncoder20.beginComputePass({});
+try {
+renderBundleEncoder9.draw(40);
+} catch {}
+try {
+commandEncoder22.copyBufferToBuffer(buffer2, 396, buffer1, 852, 240);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer9,
+]);
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+let commandEncoder28 = device0.createCommandEncoder({label: '\u08af\uf280\u0982\udd5c\u8ab0'});
+let renderBundle31 = renderBundleEncoder2.finish({});
+try {
+computePassEncoder21.setPipeline(pipeline45);
+} catch {}
+try {
+renderBundleEncoder12.drawIndirect(buffer15, 88);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer3, 32888, buffer11, 40304, 5288);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 13244, new Float32Array(16986), 1485, 224);
+} catch {}
+let pipeline53 = device0.createComputePipeline({
+label: '\u0009\ubf5d\u8b9b\u94d7',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+},
+});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+gc();
+let img10 = await imageWithData(87, 253, '#9ea2e79d', '#2c99c76a');
+try {
+externalTexture0.label = '\u0fb2\u0295\u0915';
+} catch {}
+let shaderModule12 = device0.createShaderModule({
+code: `@group(0) @binding(20)
+var<storage, read_write> type6: array<u32>;
+@group(1) @binding(257)
+var<storage, read_write> function5: array<u32>;
+@group(1) @binding(43)
+var<storage, read_write> parameter4: array<u32>;
+
+@compute @workgroup_size(4, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<f32>,
+  @location(0) f1: vec4<f32>,
+  @location(4) f2: u32,
+  @location(2) f3: u32,
+  @location(1) f4: vec4<u32>,
+  @location(6) f5: vec3<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S9 {
+  @builtin(instance_index) f0: u32,
+  @location(6) f1: vec2<f16>,
+  @builtin(vertex_index) f2: u32,
+  @location(10) f3: vec3<u32>,
+  @location(14) f4: vec2<f32>,
+  @location(3) f5: vec2<i32>,
+  @location(11) f6: vec4<f32>,
+  @location(7) f7: vec2<u32>
+}
+struct VertexOutput0 {
+  @location(12) f37: vec4<u32>,
+  @builtin(position) f38: vec4<f32>,
+  @location(11) f39: f32,
+  @location(6) f40: i32
+}
+
+@vertex
+fn vertex0(a0: S9, @location(0) a1: vec3<u32>, @location(13) a2: vec3<i32>, @location(1) a3: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup12, new Uint32Array(5517), 2902, 0);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexed(0);
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer16, 40200, 4348);
+dissociateBuffer(device0, buffer16);
+} catch {}
+canvas2.height = 999;
+let video5 = await videoWithData();
+let pipelineLayout10 = device0.createPipelineLayout({label: '\u482e\u29a2\u02aa\ubb1c', bindGroupLayouts: []});
+let commandEncoder29 = device0.createCommandEncoder({label: '\u3b5d\ubcec\u04a1\u05bc'});
+let querySet28 = device0.createQuerySet({
+label: '\ub426\u0149\u{1f73d}\uf31b\u{1f71e}\u00b7\ua956\u{1f69c}\u4c9b\u6a8d',
+type: 'occlusion',
+count: 342,
+});
+let texture40 = device0.createTexture({
+size: [128, 180, 1],
+mipLevelCount: 6,
+dimension: '2d',
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8a1unorm'],
+});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({
+  colorFormats: [undefined, 'r16uint', 'rg32uint', 'rg16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder12.draw(16, 8, 16);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexed(80, 72, 72, 96, 72);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer3, 8672, buffer4, 2384, 6732);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder22.clearBuffer(buffer8, 14260, 120);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 0, y: 48, z: 141 },
+  aspect: 'all',
+}, new Float32Array(arrayBuffer0), /* required buffer size: 22933767 */
+{offset: 599, bytesPerRow: 473, rowsPerImage: 240}, {width: 59, height: 5, depthOrArrayLayers: 203});
+} catch {}
+let pipeline54 = await device0.createComputePipelineAsync({
+label: '\u01f6\u2a4a\ub8e4\u4582\ua94d\u7f79\u{1f9b1}\u0be8',
+layout: pipelineLayout10,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+},
+});
+try {
+  await promise10;
+} catch {}
+let videoFrame9 = new VideoFrame(videoFrame4, {timestamp: 0});
+try {
+computePassEncoder21.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexed(80, 0, 80, 248, 64);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(0, buffer15, 2564, 2552);
+} catch {}
+let arrayBuffer8 = buffer10.getMappedRange(1768, 1176);
+try {
+commandEncoder24.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 7840 */
+offset: 7840,
+bytesPerRow: 256,
+buffer: buffer11,
+}, {width: 16, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder29.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 6,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 1,
+  origin: { x: 160, y: 40, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder18.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let querySet29 = device0.createQuerySet({
+type: 'occlusion',
+count: 2787,
+});
+let textureView29 = texture0.createView({dimension: '2d-array', baseMipLevel: 6, mipLevelCount: 2});
+try {
+renderBundleEncoder21.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer15, 3040);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer3, 2340, buffer16, 17700, 42036);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer16);
+} catch {}
+let pipeline55 = await device0.createRenderPipelineAsync({
+label: '\ucc85\u{1f733}\u6a4c\u3e57',
+layout: pipelineLayout2,
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: 0}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, undefined, {
+  format: 'rg32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'zero'},
+},
+  writeMask: 0
+}]
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 372,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x4',
+offset: 272,
+shaderLocation: 8,
+}, {
+format: 'snorm8x4',
+offset: 284,
+shaderLocation: 5,
+}, {
+format: 'sint8x4',
+offset: 236,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 1228,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x4',
+offset: 716,
+shaderLocation: 7,
+}, {
+format: 'float32',
+offset: 804,
+shaderLocation: 6,
+}, {
+format: 'uint16x4',
+offset: 240,
+shaderLocation: 10,
+}, {
+format: 'uint8x4',
+offset: 264,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 856,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1320,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 1862,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 1704,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32',
+offset: 1464,
+shaderLocation: 1,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'front',
+},
+});
+let pipelineLayout11 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout6, bindGroupLayout13, bindGroupLayout19, bindGroupLayout14]});
+let querySet30 = device0.createQuerySet({
+label: '\u02a6\u4f67\u08f0\u59f0\u9cb7',
+type: 'occlusion',
+count: 2718,
+});
+let texture41 = device0.createTexture({
+label: '\u8249\u2717\u4379\uc5d6\u00da\u14b7\u78a4\u3d18\u8075\u{1fcd1}',
+size: {width: 32},
+sampleCount: 1,
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg32sint', 'rg32sint'],
+});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder9.draw(64, 16, 40, 32);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline47);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer0, 6636, buffer10, 6652, 1280);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder27.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 0,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 112 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 35952 */
+offset: 35952,
+bytesPerRow: 256,
+rowsPerImage: 210,
+buffer: buffer1,
+}, {width: 56, height: 75, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder({});
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder9.draw(64);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer12, 13176);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline47);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer2, 284, buffer4, 1832, 824);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder29.clearBuffer(buffer4, 9928, 1080);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(querySet14, 2604, 19, buffer12, 27392);
+} catch {}
+let pipeline56 = device0.createRenderPipeline({
+layout: pipelineLayout7,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.RED}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'src-alpha-saturated'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'always',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'equal',
+depthFailOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 282,
+stencilWriteMask: 186,
+depthBiasSlopeScale: 91,
+depthBiasClamp: 87,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1992,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 662,
+shaderLocation: 4,
+}, {
+format: 'sint32x2',
+offset: 772,
+shaderLocation: 6,
+}, {
+format: 'float16x4',
+offset: 832,
+shaderLocation: 5,
+}, {
+format: 'snorm16x4',
+offset: 984,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 196,
+attributes: [{
+format: 'float16x4',
+offset: 116,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 1820,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 892,
+shaderLocation: 12,
+}],
+}
+]
+},
+});
+try {
+  await promise11;
+} catch {}
+let textureView30 = texture4.createView({label: '\u546f\uc768\u4e94\ucaa4\u8266', format: 'bgra8unorm-srgb'});
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({
+  label: '\uccd2\u5060\u805d',
+  colorFormats: [undefined, 'r16uint', 'rg32uint', 'rg16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder9.draw(16, 48);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer12, 31740);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer9, 'uint32');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16uint', 'bgra8unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer7,
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 9264, new BigUint64Array(16703), 8039, 660);
+} catch {}
+let querySet31 = device0.createQuerySet({
+label: '\u026f\u9211\ucc9f',
+type: 'occlusion',
+count: 422,
+});
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({
+  label: '\u{1fa18}\u{1fc24}\u{1f730}\u{1f8d3}\u624c\u843b\u{1f8bb}\u0651\u{1fdb2}',
+  colorFormats: ['rg8uint', 'r16uint', 'rgba16uint', 'rgba16sint']
+});
+try {
+renderBundleEncoder9.draw(72, 56, 16, 64);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexedIndirect(buffer12, 21500);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(7, buffer6, 25772, 5598);
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(buffer3, 37416, buffer4, 11604, 20);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer14);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+renderBundleEncoder21.pushDebugGroup('\u0a09');
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+colorSpace: 'srgb',
+});
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+let shaderModule13 = device0.createShaderModule({
+label: '\u16ac\uc36d\u{1f8bd}\u7f47\u{1fd40}\u0138',
+code: `@group(0) @binding(43)
+var<storage, read_write> field8: array<u32>;
+@group(0) @binding(257)
+var<storage, read_write> parameter5: array<u32>;
+
+@compute @workgroup_size(2, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<u32>,
+  @location(1) f1: vec2<u32>,
+  @location(0) f2: vec2<u32>,
+  @location(3) f3: vec4<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S10 {
+  @location(8) f0: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(13) a0: vec3<i32>, @location(4) a1: vec3<f32>, @location(11) a2: vec2<u32>, @location(14) a3: vec3<i32>, a4: S10, @builtin(instance_index) a5: u32, @location(6) a6: i32, @location(15) a7: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroup15 = device0.createBindGroup({
+layout: bindGroupLayout1,
+entries: [{
+binding: 257,
+resource: externalTexture0
+}, {
+binding: 43,
+resource: externalTexture0
+}],
+});
+let querySet32 = device0.createQuerySet({
+label: '\ufb2b\u0e91',
+type: 'occlusion',
+count: 2856,
+});
+let textureView31 = texture12.createView({
+  label: '\u89ca\u0284\u{1fadf}\u{1ff02}\ufa49\u7c87',
+  format: 'rgba32uint',
+  baseMipLevel: 3,
+  arrayLayerCount: 1
+});
+let renderBundle32 = renderBundleEncoder8.finish({});
+try {
+renderBundleEncoder33.setIndexBuffer(buffer6, 'uint16', 25688);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline47);
+} catch {}
+let arrayBuffer9 = buffer13.getMappedRange(26584);
+try {
+commandEncoder27.copyBufferToBuffer(buffer2, 704, buffer12, 20356, 84);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder30.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 7,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(canvas8);
+let offscreenCanvas7 = new OffscreenCanvas(307, 228);
+let bindGroup16 = device0.createBindGroup({
+label: '\u9f5f\u01d2\u{1fe08}\u066c\u4f76\ue517\uf1b8\u8746',
+layout: bindGroupLayout11,
+entries: [{
+binding: 823,
+resource: textureView20
+}, {
+binding: 297,
+resource: externalTexture0
+}],
+});
+let buffer19 = device0.createBuffer({
+  label: '\u036f\u3b0f',
+  size: 24468,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true
+});
+let renderBundleEncoder37 = device0.createRenderBundleEncoder({
+  label: '\udd54\u5861\u{1fd2a}\ud96d',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle33 = renderBundleEncoder8.finish();
+try {
+renderBundleEncoder12.draw(48, 8);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer15, 656);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline47);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 7772, new DataView(new ArrayBuffer(17811)), 13376, 1844);
+} catch {}
+let gpuCanvasContext8 = offscreenCanvas7.getContext('webgpu');
+let promise13 = navigator.gpu.requestAdapter({
+});
+let videoFrame10 = new VideoFrame(video0, {timestamp: 0});
+let bindGroup17 = device0.createBindGroup({
+label: '\u{1fdeb}\u32b4\ue700\uda83\u7686',
+layout: bindGroupLayout5,
+entries: [],
+});
+let commandBuffer10 = commandEncoder29.finish({
+label: '\u9cbe\u{1ff26}\uedab\u{1fca4}',
+});
+let pipeline57 = device0.createRenderPipeline({
+label: '\u6b0c\u7edb\uc61b\u086b\uf7aa\u06af\u273e',
+layout: pipelineLayout8,
+fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r16uint'}, {format: 'rgba16uint', writeMask: 0}, {format: 'rgba16sint'}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 2017,
+stencilWriteMask: 1268,
+depthBias: 62,
+depthBiasSlopeScale: 97,
+depthBiasClamp: 26,
+},
+vertex: {
+  module: shaderModule7,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x2',
+offset: 432,
+shaderLocation: 12,
+}, {
+format: 'float32x3',
+offset: 1092,
+shaderLocation: 4,
+}, {
+format: 'uint8x4',
+offset: 24,
+shaderLocation: 9,
+}, {
+format: 'uint32x4',
+offset: 1716,
+shaderLocation: 10,
+}, {
+format: 'snorm16x2',
+offset: 416,
+shaderLocation: 14,
+}, {
+format: 'uint16x4',
+offset: 288,
+shaderLocation: 5,
+}, {
+format: 'uint8x4',
+offset: 1272,
+shaderLocation: 15,
+}, {
+format: 'uint16x2',
+offset: 576,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32',
+offset: 760,
+shaderLocation: 2,
+}, {
+format: 'sint32',
+offset: 1364,
+shaderLocation: 6,
+}, {
+format: 'uint8x2',
+offset: 726,
+shaderLocation: 0,
+}, {
+format: 'float32',
+offset: 1688,
+shaderLocation: 1,
+}, {
+format: 'unorm16x4',
+offset: 1068,
+shaderLocation: 8,
+}, {
+format: 'uint16x4',
+offset: 1492,
+shaderLocation: 3,
+}, {
+format: 'uint16x2',
+offset: 664,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 580,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x3',
+offset: 968,
+shaderLocation: 7,
+}],
+}
+]
+},
+});
+let bindGroup18 = device0.createBindGroup({
+label: '\u{1fe13}\u{1fd33}\u83ba\uc866\u0e79\ud953',
+layout: bindGroupLayout11,
+entries: [{
+binding: 823,
+resource: textureView27
+}, {
+binding: 297,
+resource: externalTexture0
+}],
+});
+let querySet33 = device0.createQuerySet({
+label: '\u0c77\u0148\u2ff7\u065f',
+type: 'occlusion',
+count: 3771,
+});
+let texture42 = device0.createTexture({
+label: '\u796e\ud248\u{1f633}\u1c83\u0543\u7b1a\ubc92\u8954\u054b\u2b3d\u{1f801}',
+size: [330, 24, 1],
+sampleCount: 4,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth16unorm'],
+});
+let sampler24 = device0.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 32.826,
+lodMaxClamp: 92.101,
+});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup7, new Uint32Array(2050), 739, 0);
+} catch {}
+try {
+computePassEncoder21.end();
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 16148);
+} catch {}
+try {
+renderBundleEncoder36.drawIndirect(buffer15, 1796);
+} catch {}
+try {
+commandEncoder30.copyBufferToTexture({
+/* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 31943 */
+offset: 31941,
+buffer: buffer0,
+}, {
+  texture: texture16,
+  mipLevel: 5,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder28.resolveQuerySet(querySet33, 2355, 515, buffer12, 17152);
+} catch {}
+let pipeline58 = device0.createRenderPipeline({
+label: '\u0aa5\u2c9f\uead2\u1839\ue564\ue03a\ud6a2',
+layout: pipelineLayout3,
+fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rgba16uint'}, {format: 'rgba16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+vertex: {
+  module: shaderModule10,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1708,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 24,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 8,
+shaderLocation: 7,
+}, {
+format: 'uint32x4',
+offset: 0,
+shaderLocation: 15,
+}, {
+format: 'uint16x4',
+offset: 0,
+shaderLocation: 14,
+}, {
+format: 'sint8x4',
+offset: 0,
+shaderLocation: 2,
+}, {
+format: 'sint32x2',
+offset: 8,
+shaderLocation: 0,
+}, {
+format: 'float32x2',
+offset: 0,
+shaderLocation: 11,
+}, {
+format: 'uint16x2',
+offset: 4,
+shaderLocation: 9,
+}, {
+format: 'float32x3',
+offset: 8,
+shaderLocation: 4,
+}, {
+format: 'float16x2',
+offset: 12,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 1064,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 876,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 96,
+shaderLocation: 8,
+}, {
+format: 'unorm16x2',
+offset: 460,
+shaderLocation: 10,
+}, {
+format: 'sint16x2',
+offset: 208,
+shaderLocation: 13,
+}, {
+format: 'uint16x2',
+offset: 784,
+shaderLocation: 3,
+}, {
+format: 'unorm16x2',
+offset: 220,
+shaderLocation: 1,
+}, {
+format: 'snorm8x2',
+offset: 540,
+shaderLocation: 5,
+}, {
+format: 'float32x2',
+offset: 228,
+shaderLocation: 12,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let textureView32 = texture4.createView({label: '\u0ab3\u50ff\u{1f9fd}\uc336\u1d2d\ua606\ueef0\u{1f92b}\u01c1\u7c86'});
+let renderBundle34 = renderBundleEncoder4.finish({label: '\u47cb\u7d6d\u9d8c\u0621'});
+let sampler25 = device0.createSampler({
+label: '\u{1fc7f}\u{1f825}\u048e\u92db\ua091\u08ec\uba8a\ue284\ub2d7',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 24.805,
+lodMaxClamp: 33.908,
+compare: 'less',
+});
+try {
+renderBundleEncoder17.drawIndirect(buffer15, 5008);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer9, 'uint32', 1696, 2821);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(0, buffer0);
+} catch {}
+let arrayBuffer10 = buffer7.getMappedRange(37496, 1064);
+try {
+commandEncoder20.resolveQuerySet(querySet4, 168, 113, buffer12, 13568);
+} catch {}
+let videoFrame11 = new VideoFrame(canvas12, {timestamp: 0});
+let texture43 = device0.createTexture({
+size: [64, 90, 1],
+mipLevelCount: 4,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+commandEncoder20.resolveQuerySet(querySet27, 867, 140, buffer12, 25600);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 9256, new DataView(new ArrayBuffer(36226)), 29557, 2864);
+} catch {}
+let pipeline59 = device0.createRenderPipeline({
+label: '\u8ea5\ucf61\u{1fdf6}\u434b\u0c65\u833a\u2349\u09a1',
+layout: pipelineLayout8,
+multisample: {
+mask: 0xb06d2141,
+},
+fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'rgba8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-src'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {format: 'rg16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, undefined, {format: 'rg16float'}]
+},
+vertex: {
+  module: shaderModule3,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1292,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 68,
+shaderLocation: 4,
+}, {
+format: 'unorm16x2',
+offset: 812,
+shaderLocation: 7,
+}, {
+format: 'uint32x2',
+offset: 36,
+shaderLocation: 15,
+}, {
+format: 'sint16x2',
+offset: 1144,
+shaderLocation: 9,
+}, {
+format: 'uint8x2',
+offset: 136,
+shaderLocation: 14,
+}, {
+format: 'snorm8x4',
+offset: 404,
+shaderLocation: 8,
+}, {
+format: 'uint8x2',
+offset: 310,
+shaderLocation: 13,
+}, {
+format: 'sint32x2',
+offset: 408,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 620,
+attributes: [{
+format: 'float32',
+offset: 320,
+shaderLocation: 10,
+}, {
+format: 'unorm16x4',
+offset: 424,
+shaderLocation: 0,
+}, {
+format: 'float32',
+offset: 64,
+shaderLocation: 5,
+}, {
+format: 'sint32',
+offset: 320,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 1832,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x4',
+offset: 912,
+shaderLocation: 3,
+}],
+}
+]
+},
+});
+let shaderModule14 = device0.createShaderModule({
+label: '\u0b11\u0c20\u02fe\u85ee\u{1f74c}\u49f9\u0813\u07ac',
+code: `@group(1) @binding(257)
+var<storage, read_write> function6: array<u32>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S11 {
+  @location(2) f0: vec2<u32>,
+  @location(9) f1: vec4<i32>,
+  @builtin(sample_index) f2: u32,
+  @builtin(position) f3: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec3<u32>,
+  @location(1) f1: vec4<u32>,
+  @location(3) f2: vec3<f32>,
+  @location(4) f3: vec4<u32>,
+  @builtin(sample_mask) f4: u32,
+  @location(0) f5: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(7) a0: i32, a1: S11, @builtin(sample_mask) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(2) f41: vec2<u32>,
+  @location(9) f42: vec4<i32>,
+  @location(7) f43: i32,
+  @builtin(position) f44: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(3) a0: i32, @location(9) a1: vec4<u32>, @location(8) a2: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder31 = device0.createCommandEncoder();
+let texture44 = device0.createTexture({
+label: '\u0343\uffe3\uc53f\u3b07\u8952\u{1f6b0}\u13be\u{1f69e}\u4639\u0fd1',
+size: {width: 110, height: 20, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'astc-10x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x10-unorm-srgb', 'astc-10x10-unorm', 'astc-10x10-unorm-srgb'],
+});
+let textureView33 = texture35.createView({label: '\ufbd4\u0109\u75af\u36fe'});
+let renderBundle35 = renderBundleEncoder13.finish({label: '\uf223\u0ab0\u9c3c\u{1f70e}\u09f0\u0e38\u0422'});
+let sampler26 = device0.createSampler({
+label: '\uc215\u1ac6\ub201\ua10d\u{1fb94}\u04af\u2f7d\u0a8f\u{1f731}\u299b',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 31.640,
+lodMaxClamp: 51.698,
+maxAnisotropy: 17,
+});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup5, new Uint32Array(4289), 4038, 0);
+} catch {}
+try {
+renderBundleEncoder36.drawIndirect(buffer12, 25764);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer9, 'uint32', 9808, 5719);
+} catch {}
+try {
+commandEncoder26.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 5,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 6,
+  origin: { x: 0, y: 8, z: 0 },
+  aspect: 'all',
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline60 = device0.createComputePipeline({
+label: '\ud841\u1074\u{1f8f8}\u2cab\u2833\u00ca\u68fa',
+layout: pipelineLayout8,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline61 = device0.createRenderPipeline({
+label: '\u20fc\ub066\u{1f8e5}',
+layout: pipelineLayout8,
+fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r16uint', writeMask: 0}, {format: 'rgba16uint'}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 3330,
+stencilWriteMask: 1576,
+depthBias: 30,
+depthBiasSlopeScale: 4,
+depthBiasClamp: 46,
+},
+vertex: {
+  module: shaderModule10,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1808,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32',
+offset: 616,
+shaderLocation: 0,
+}, {
+format: 'float32x2',
+offset: 892,
+shaderLocation: 8,
+}, {
+format: 'snorm16x2',
+offset: 1736,
+shaderLocation: 12,
+}, {
+format: 'unorm8x4',
+offset: 572,
+shaderLocation: 1,
+}, {
+format: 'unorm8x2',
+offset: 434,
+shaderLocation: 11,
+}, {
+format: 'unorm16x4',
+offset: 356,
+shaderLocation: 4,
+}, {
+format: 'snorm16x2',
+offset: 1476,
+shaderLocation: 5,
+}, {
+format: 'uint8x4',
+offset: 780,
+shaderLocation: 3,
+}, {
+format: 'unorm10-10-10-2',
+offset: 652,
+shaderLocation: 7,
+}, {
+format: 'float32',
+offset: 60,
+shaderLocation: 10,
+}, {
+format: 'sint32',
+offset: 220,
+shaderLocation: 13,
+}, {
+format: 'float32x4',
+offset: 488,
+shaderLocation: 6,
+}, {
+format: 'uint32x3',
+offset: 684,
+shaderLocation: 9,
+}, {
+format: 'uint32x3',
+offset: 576,
+shaderLocation: 14,
+}, {
+format: 'uint16x4',
+offset: 1200,
+shaderLocation: 15,
+}, {
+format: 'sint32x3',
+offset: 1004,
+shaderLocation: 2,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'front',
+},
+});
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline47);
+} catch {}
+try {
+commandEncoder31.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: { x: 0, y: 40, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture43,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder24.resolveQuerySet(querySet25, 590, 279, buffer12, 256);
+} catch {}
+try {
+renderBundleEncoder21.popDebugGroup();
+} catch {}
+let imageData3 = new ImageData(108, 212);
+let commandEncoder32 = device0.createCommandEncoder({});
+let commandBuffer11 = commandEncoder24.finish({
+label: '\u{1f658}\u45bf\u490e\u09e5\u0122\ub6c7',
+});
+let textureView34 = texture39.createView({label: '\ufa70\u33fd\u0026\ub007\u{1f73b}\u89cf\u0ea4', baseMipLevel: 6, mipLevelCount: 1});
+try {
+computePassEncoder20.dispatchWorkgroups(5, 3, 1);
+} catch {}
+try {
+commandEncoder18.clearBuffer(buffer4, 5548, 800);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder28.resolveQuerySet(querySet23, 2032, 12, buffer12, 35584);
+} catch {}
+try {
+  await promise12;
+} catch {}
+try {
+renderBundleEncoder12.drawIndirect(buffer15, 1932);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder33 = device0.createCommandEncoder({label: '\u8567\u0790\u323d\uf593\u0c77\u88ec'});
+let computePassEncoder22 = commandEncoder18.beginComputePass({label: '\u{1f898}\u16c4\u083e\ubede\ub59d\u0b63\u0ce7\u0e21\ud9d3\u0e0d\u{1febd}'});
+try {
+computePassEncoder22.setPipeline(pipeline32);
+} catch {}
+try {
+querySet4.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer14, 416, new DataView(new ArrayBuffer(41833)), 18829, 1528);
+} catch {}
+let pipeline62 = device0.createComputePipeline({
+label: '\u09fc\u{1f863}\u211c\u0848\u84fc\ub145\u3bb0\ua8f3\u{1fad9}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline63 = device0.createRenderPipeline({
+layout: pipelineLayout7,
+multisample: {
+count: 4,
+},
+fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+vertex: {
+  module: shaderModule10,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1764,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 156,
+shaderLocation: 4,
+}, {
+format: 'float32x2',
+offset: 1284,
+shaderLocation: 1,
+}, {
+format: 'sint32x3',
+offset: 372,
+shaderLocation: 0,
+}, {
+format: 'float32x2',
+offset: 1608,
+shaderLocation: 6,
+}, {
+format: 'uint16x4',
+offset: 928,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 1416,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 448,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 1380,
+shaderLocation: 14,
+}, {
+format: 'sint16x2',
+offset: 344,
+shaderLocation: 13,
+}, {
+format: 'snorm16x2',
+offset: 508,
+shaderLocation: 5,
+}, {
+format: 'uint8x2',
+offset: 14,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 0,
+attributes: [{
+format: 'snorm8x4',
+offset: 792,
+shaderLocation: 8,
+}, {
+format: 'unorm8x4',
+offset: 836,
+shaderLocation: 11,
+}, {
+format: 'sint32',
+offset: 1024,
+shaderLocation: 2,
+}, {
+format: 'snorm16x4',
+offset: 1844,
+shaderLocation: 10,
+}, {
+format: 'uint16x2',
+offset: 1580,
+shaderLocation: 3,
+}, {
+format: 'float32',
+offset: 496,
+shaderLocation: 7,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+let textureView35 = texture41.createView({label: '\u029f\u0ae0\uca8a\uc183\u0f6d\u0244\u7b7e\u4272', baseMipLevel: 0});
+let computePassEncoder23 = commandEncoder28.beginComputePass({label: '\u{1fbf1}\u{1f77e}\u611e\u0092\u{1fae4}'});
+try {
+computePassEncoder22.dispatchWorkgroups(4, 5);
+} catch {}
+try {
+computePassEncoder20.dispatchWorkgroupsIndirect(buffer15, 2964);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup2, new Uint32Array(4378), 1204, 0);
+} catch {}
+try {
+renderBundleEncoder17.draw(8, 0, 24, 72);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer12, 19788);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(7, buffer15, 1156, 500);
+} catch {}
+let arrayBuffer11 = buffer3.getMappedRange(16352, 14116);
+try {
+commandEncoder26.resolveQuerySet(querySet13, 0, 1, buffer12, 27136);
+} catch {}
+let img11 = await imageWithData(298, 288, '#dd20136d', '#679569a0');
+let texture45 = device0.createTexture({
+label: '\u04cf\u012e\u03e0\u0e80\uf2d7\u{1fdae}\uf5a4\u{1fee2}\uc7c6\uc876',
+size: [320, 2, 37],
+mipLevelCount: 2,
+sampleCount: 1,
+dimension: '3d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle36 = renderBundleEncoder6.finish({});
+let promise14 = buffer14.mapAsync(GPUMapMode.READ, 0, 4192);
+try {
+commandEncoder22.copyBufferToBuffer(buffer17, 11556, buffer14, 8948, 3300);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer7), /* required buffer size: 685 */
+{offset: 613}, {width: 36, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline64 = await device0.createRenderPipelineAsync({
+label: '\u0120\u{1f76a}\u09c1\u896e\u74cf\u0a74\u0062\u{1fd95}',
+layout: pipelineLayout1,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'constant'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {format: 'rgba16uint'}, {format: 'r8uint'}, {
+  format: 'rg11b10ufloat',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'src'},
+},
+  writeMask: 0
+}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'invert',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilWriteMask: 2691,
+depthBiasSlopeScale: 7,
+depthBiasClamp: 49,
+},
+vertex: {
+  module: shaderModule11,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 884,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x2',
+offset: 776,
+shaderLocation: 10,
+}, {
+format: 'float16x2',
+offset: 116,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 104,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x3',
+offset: 4,
+shaderLocation: 6,
+}, {
+format: 'sint32',
+offset: 80,
+shaderLocation: 1,
+}, {
+format: 'unorm16x2',
+offset: 44,
+shaderLocation: 11,
+}, {
+format: 'uint16x4',
+offset: 28,
+shaderLocation: 4,
+}, {
+format: 'snorm16x4',
+offset: 60,
+shaderLocation: 14,
+}, {
+format: 'uint32',
+offset: 76,
+shaderLocation: 12,
+}, {
+format: 'float16x4',
+offset: 72,
+shaderLocation: 8,
+}],
+}
+]
+},
+});
+let imageBitmap6 = await createImageBitmap(imageData2);
+let querySet34 = device0.createQuerySet({
+label: '\u0467\u7b96\u0e50\uee1f\uf248\u{1fecd}',
+type: 'occlusion',
+count: 1732,
+});
+let texture46 = gpuCanvasContext3.getCurrentTexture();
+let textureView36 = texture3.createView({
+  label: '\u{1f90c}\u9db8\uc7f3\u01ea\u0806\u7939\u6837\u03a2\ua771\u{1f60b}\u863d',
+  dimension: '2d-array'
+});
+let renderBundleEncoder38 = device0.createRenderBundleEncoder({
+  label: '\u18f2\u00c7\u55ab\u{1ffd3}',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder22.dispatchWorkgroups(3);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(1, buffer0);
+} catch {}
+try {
+commandEncoder31.copyBufferToBuffer(buffer0, 31032, buffer9, 15384, 2080);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+/* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 26704 */
+offset: 26704,
+buffer: buffer0,
+}, {
+  texture: texture0,
+  mipLevel: 4,
+  origin: { x: 32, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 40, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline65 = device0.createComputePipeline({
+label: '\u9676\ua8a7\u{1fac0}\u0ecd\u94fa\u111c\u{1f94a}\u{1f64c}\u8833\u0b05',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+},
+});
+let promise15 = device0.createRenderPipelineAsync({
+label: '\udb18\u8b6b\ue039\u0db2\u2418\u9d16\u6cfd\uac62\u94f9',
+layout: pipelineLayout4,
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint'}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined, {
+  format: 'rg32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'bgra8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater-equal',
+depthFailOp: 'zero',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 336,
+stencilWriteMask: 328,
+depthBias: 83,
+depthBiasClamp: 64,
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 484,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32',
+offset: 356,
+shaderLocation: 6,
+}, {
+format: 'uint8x2',
+offset: 380,
+shaderLocation: 7,
+}, {
+format: 'uint32x3',
+offset: 36,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 1356,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 16,
+shaderLocation: 5,
+}, {
+format: 'sint16x2',
+offset: 740,
+shaderLocation: 4,
+}, {
+format: 'uint8x2',
+offset: 1022,
+shaderLocation: 14,
+}, {
+format: 'sint16x2',
+offset: 344,
+shaderLocation: 1,
+}, {
+format: 'snorm8x4',
+offset: 1196,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 1508,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x4',
+offset: 660,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+pseudoSubmit(device0, commandEncoder30);
+try {
+renderBundleEncoder31.setVertexBuffer(0, buffer6);
+} catch {}
+try {
+  await buffer11.mapAsync(GPUMapMode.READ, 0, 17516);
+} catch {}
+try {
+computePassEncoder2.insertDebugMarker('\u{1f6c7}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 2,
+  origin: { x: 30, y: 10, z: 1 },
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer1), /* required buffer size: 208 */
+{offset: 208, bytesPerRow: 861}, {width: 360, height: 20, depthOrArrayLayers: 0});
+} catch {}
+let pipeline66 = device0.createRenderPipeline({
+label: '\u132b\ubf17\u0af3\uf575\u81e0\u{1feb2}\u765e',
+layout: pipelineLayout11,
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'src-alpha', dstFactor: 'one-minus-src'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA
+}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 551,
+stencilWriteMask: 1362,
+depthBias: 66,
+depthBiasSlopeScale: 95,
+depthBiasClamp: 88,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1404,
+attributes: [{
+format: 'sint16x4',
+offset: 1252,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 1824,
+attributes: [],
+},
+{
+arrayStride: 1384,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 564,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+},
+});
+let renderBundle37 = renderBundleEncoder38.finish({label: '\u1720\u{1f639}\u0a2d\u0d08\uad48\u36a7\u07ca\u{1fcd9}'});
+try {
+renderBundleEncoder26.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder9.draw(64, 8, 80, 0);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer15, 5004);
+} catch {}
+try {
+renderBundleEncoder36.drawIndirect(buffer15, 5352);
+} catch {}
+try {
+commandEncoder33.resolveQuerySet(querySet13, 0, 1, buffer12, 28928);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 12780, new DataView(new ArrayBuffer(12004)), 4777, 1572);
+} catch {}
+let shaderModule15 = device0.createShaderModule({
+label: '\u0d46\u{1fa60}\u6eb2\u0c4c\u1993\u4e68\uaf5e\ufaab\ud808',
+code: `@group(1) @binding(788)
+var<storage, read_write> type7: array<u32>;
+@group(2) @binding(20)
+var<storage, read_write> local4: array<u32>;
+@group(0) @binding(561)
+var<storage, read_write> parameter6: array<u32>;
+@group(3) @binding(674)
+var<storage, read_write> i5: array<u32>;
+
+@compute @workgroup_size(8, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S13 {
+  @location(9) f0: vec4<f32>,
+  @location(5) f1: vec3<f16>,
+  @location(12) f2: f32,
+  @location(13) f3: vec4<f16>,
+  @location(6) f4: vec3<i32>,
+  @builtin(front_facing) f5: bool,
+  @location(1) f6: f32,
+  @location(10) f7: vec3<f16>,
+  @location(15) f8: f32,
+  @location(2) f9: vec2<f16>,
+  @location(3) f10: i32,
+  @location(8) f11: vec4<f32>,
+  @builtin(sample_index) f12: u32,
+  @builtin(position) f13: vec4<f32>,
+  @builtin(sample_mask) f14: u32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(1) f1: u32,
+  @location(3) f2: vec4<i32>,
+  @location(2) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(14) a0: vec2<i32>, a1: S13) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S12 {
+  @location(12) f0: i32,
+  @location(9) f1: vec4<f16>,
+  @location(14) f2: vec3<i32>,
+  @builtin(vertex_index) f3: u32,
+  @location(5) f4: vec3<f16>,
+  @location(7) f5: vec2<f16>,
+  @location(4) f6: vec2<u32>,
+  @location(1) f7: f16,
+  @location(6) f8: vec2<u32>
+}
+struct VertexOutput0 {
+  @location(2) f45: vec2<f16>,
+  @location(13) f46: vec4<f16>,
+  @location(8) f47: vec4<f32>,
+  @location(14) f48: vec2<i32>,
+  @location(5) f49: vec3<f16>,
+  @location(12) f50: f32,
+  @location(15) f51: f32,
+  @builtin(position) f52: vec4<f32>,
+  @location(10) f53: vec3<f16>,
+  @location(6) f54: vec3<i32>,
+  @location(9) f55: vec4<f32>,
+  @location(1) f56: f32,
+  @location(3) f57: i32
+}
+
+@vertex
+fn vertex0(a0: S12, @location(3) a1: vec4<f16>, @location(13) a2: vec3<i32>, @location(0) a3: f32, @location(8) a4: vec3<i32>, @location(15) a5: vec2<u32>, @builtin(instance_index) a6: u32, @location(11) a7: f16, @location(2) a8: vec3<f16>, @location(10) a9: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let querySet35 = device0.createQuerySet({
+type: 'occlusion',
+count: 1762,
+});
+let textureView37 = texture25.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+let sampler27 = device0.createSampler({
+label: '\u077b\u0a30\u9207\u0541\ua568\u5946\u3a03',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 3.474,
+compare: 'less',
+maxAnisotropy: 9,
+});
+try {
+computePassEncoder22.dispatchWorkgroupsIndirect(buffer12, 27676);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder12.draw(40, 56, 32, 16);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer15, 6000);
+} catch {}
+try {
+commandEncoder31.copyBufferToBuffer(buffer2, 540, buffer14, 2052, 828);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder27.clearBuffer(buffer11, 43428, 10024);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 188, y: 0, z: 0 },
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer2), /* required buffer size: 684 */
+{offset: 560}, {width: 31, height: 1, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let offscreenCanvas8 = new OffscreenCanvas(589, 623);
+let bindGroupLayout21 = device0.createBindGroupLayout({
+entries: [{
+binding: 690,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}, {
+binding: 635,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+}],
+});
+let texture47 = gpuCanvasContext3.getCurrentTexture();
+let computePassEncoder24 = commandEncoder22.beginComputePass();
+let renderBundle38 = renderBundleEncoder6.finish({label: '\u05f8\u0162'});
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer12, 14132);
+} catch {}
+try {
+renderBundleEncoder36.drawIndirect(buffer12, 2728);
+} catch {}
+let promise16 = device0.createRenderPipelineAsync({
+label: '\u66b0\u0473\u{1f747}\u0f59\u809b',
+layout: pipelineLayout8,
+fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba16sint'}]
+},
+vertex: {
+  module: shaderModule4,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 756,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x2',
+offset: 556,
+shaderLocation: 15,
+}, {
+format: 'float32',
+offset: 96,
+shaderLocation: 13,
+}, {
+format: 'snorm8x2',
+offset: 702,
+shaderLocation: 14,
+}, {
+format: 'unorm8x4',
+offset: 164,
+shaderLocation: 7,
+}, {
+format: 'unorm16x2',
+offset: 592,
+shaderLocation: 12,
+}, {
+format: 'sint8x2',
+offset: 76,
+shaderLocation: 0,
+}, {
+format: 'uint8x2',
+offset: 388,
+shaderLocation: 4,
+}, {
+format: 'float32x2',
+offset: 376,
+shaderLocation: 6,
+}, {
+format: 'snorm16x4',
+offset: 732,
+shaderLocation: 1,
+}, {
+format: 'snorm16x4',
+offset: 548,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 24,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 1248,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x2',
+offset: 224,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 1320,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1112,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1956,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1908,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 364,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32',
+offset: 296,
+shaderLocation: 5,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+  await promise14;
+} catch {}
+document.body.prepend(canvas11);
+let offscreenCanvas9 = new OffscreenCanvas(747, 191);
+let pipelineLayout12 = device0.createPipelineLayout({
+  label: '\u2be5\u76f1\uecdb\ue296\uf285',
+  bindGroupLayouts: [bindGroupLayout12, bindGroupLayout10, bindGroupLayout8]
+});
+let querySet36 = device0.createQuerySet({
+label: '\u0675\u09a1\u01f9\u2897\u{1f902}\u2b97\u317c\u{1faf7}\uda9c\u6c8a',
+type: 'occlusion',
+count: 99,
+});
+let textureView38 = texture19.createView({
+  label: '\u0bce\uf1c5\u0db9\u3f71\u0550\u0b68',
+  format: 'astc-6x5-unorm-srgb',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+  baseArrayLayer: 15,
+  arrayLayerCount: 121
+});
+let computePassEncoder25 = commandEncoder26.beginComputePass({label: '\u0d68\u063d\u{1f83e}\u{1fec0}\u{1fb15}\ua898\u7db5\u{1fd5a}\ue25f'});
+let renderBundleEncoder39 = device0.createRenderBundleEncoder({
+  label: '\u3724\u5346',
+  colorFormats: ['bgra8unorm-srgb', 'rgba16uint', 'r8uint', 'rg11b10ufloat', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler28 = device0.createSampler({
+label: '\u{1fad9}\u0281',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 22.298,
+lodMaxClamp: 67.028,
+maxAnisotropy: 13,
+});
+try {
+computePassEncoder20.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(1, buffer0, 27524, 6030);
+} catch {}
+try {
+commandEncoder32.resolveQuerySet(querySet26, 209, 22, buffer12, 12288);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: { x: 396, y: 0, z: 30 },
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer3), /* required buffer size: 995720 */
+{offset: 276, bytesPerRow: 2087, rowsPerImage: 68}, {width: 762, height: 5, depthOrArrayLayers: 8});
+} catch {}
+let pipeline67 = device0.createComputePipeline({
+layout: pipelineLayout3,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup18, new Uint32Array(1153), 719, 0);
+} catch {}
+try {
+renderBundleEncoder9.draw(8, 64, 64, 48);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer15, 1124);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline58);
+} catch {}
+try {
+commandEncoder32.copyTextureToBuffer({
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 48, y: 168, z: 1 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 224 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 44368 */
+offset: 44368,
+rowsPerImage: 79,
+buffer: buffer16,
+}, {width: 56, height: 4, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+});
+} catch {}
+let texture48 = gpuCanvasContext6.getCurrentTexture();
+let renderBundle39 = renderBundleEncoder18.finish();
+try {
+computePassEncoder23.setPipeline(pipeline62);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(72, 56, 56);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexedIndirect(buffer15, 5652);
+} catch {}
+try {
+commandEncoder15.resolveQuerySet(querySet18, 1641, 1001, buffer12, 15104);
+} catch {}
+try {
+commandEncoder20.insertDebugMarker('\u0fe4');
+} catch {}
+let canvas13 = document.createElement('canvas');
+let commandEncoder34 = device0.createCommandEncoder({});
+let renderBundle40 = renderBundleEncoder25.finish({label: '\u25e6\u0e57\uf344\uc96f\u{1f79f}\u0155\u5367\u2331\u4042\u0696\uc7ae'});
+let sampler29 = device0.createSampler({
+label: '\ua6dc\u{1fcba}\u{1f6a2}\ua666',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+lodMaxClamp: 74.105,
+compare: 'never',
+});
+try {
+computePassEncoder22.dispatchWorkgroupsIndirect(buffer15, 5428);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 40688);
+} catch {}
+try {
+commandEncoder34.clearBuffer(buffer1, 4816, 30852);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer11,
+]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 6 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer2), /* required buffer size: 163951 */
+{offset: 195, bytesPerRow: 86, rowsPerImage: 190}, {width: 3, height: 5, depthOrArrayLayers: 11});
+} catch {}
+let pipeline68 = device0.createComputePipeline({
+label: '\u9798\u06a1\u0f85',
+layout: pipelineLayout12,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+offscreenCanvas8.getContext('webgl');
+} catch {}
+let bindGroupLayout22 = device0.createBindGroupLayout({
+label: '\u03e2\u0a75\ub08e\u7e84\u{1fb07}\u27d5\uc43f\u{1fb65}\u02a9',
+entries: [{
+binding: 578,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+}],
+});
+let texture49 = device0.createTexture({
+label: '\u5bbf\uc5d5\ua77a\u9cdd\ub4a1\u0a59\u42df\ufb88\u{1f7b6}',
+size: [2060, 90, 1],
+mipLevelCount: 2,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder26 = commandEncoder27.beginComputePass({});
+try {
+computePassEncoder20.dispatchWorkgroups(2, 1, 3);
+} catch {}
+try {
+renderBundleEncoder9.draw(72);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 40024);
+} catch {}
+try {
+renderBundleEncoder12.drawIndirect(buffer15, 952);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer9, 'uint16', 11002, 855);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(4, buffer6, 4824);
+} catch {}
+let promise17 = buffer17.mapAsync(GPUMapMode.WRITE, 1584, 4272);
+try {
+device0.queue.submit([
+commandBuffer6,
+commandBuffer10,
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 10668, new Int16Array(14111), 6845, 420);
+} catch {}
+let pipeline69 = await device0.createComputePipelineAsync({
+label: '\u1cf6\u{1f691}\ue641\u{1f964}',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule10,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let canvas14 = document.createElement('canvas');
+let bindGroupLayout23 = device0.createBindGroupLayout({
+label: '\u0cc8\u{1f9b6}\u9fd6\u07ff\ub1ef',
+entries: [{
+binding: 487,
+visibility: 0,
+externalTexture: {},
+}, {
+binding: 486,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'bgra8unorm', access: 'write-only', viewDimension: '3d' },
+}],
+});
+let pipelineLayout13 = device0.createPipelineLayout({label: '\u{1f8fe}\u2466', bindGroupLayouts: [bindGroupLayout12]});
+let texture50 = device0.createTexture({
+label: '\u1513\u{1f82b}\ua888\ubf7e\u824d\u4975\u0521',
+size: {width: 660, height: 48, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x12-unorm', 'astc-12x12-unorm', 'astc-12x12-unorm-srgb'],
+});
+let computePassEncoder27 = commandEncoder34.beginComputePass({});
+let renderBundle41 = renderBundleEncoder35.finish({label: '\ufde3\u987f\u6f17'});
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer15, 5144);
+} catch {}
+try {
+renderBundleEncoder12.drawIndirect(buffer12, 8772);
+} catch {}
+try {
+commandEncoder20.resolveQuerySet(querySet2, 575, 317, buffer12, 35584);
+} catch {}
+let gpuCanvasContext9 = canvas14.getContext('webgpu');
+try {
+computePassEncoder26.setPipeline(pipeline49);
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(buffer12, 428, buffer18, 19232, 800);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer18);
+} catch {}
+let gpuCanvasContext10 = canvas13.getContext('webgpu');
+let texture51 = device0.createTexture({
+label: '\u937c\u0f58\u1dff',
+size: {width: 320},
+dimension: '1d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgba8unorm-srgb', 'rgba8unorm'],
+});
+let textureView39 = texture45.createView({baseMipLevel: 1, baseArrayLayer: 0});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup4, new Uint32Array(317), 61, 0);
+} catch {}
+try {
+renderBundleEncoder12.draw(0);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(3, buffer6, 31704, 2117);
+} catch {}
+try {
+  await promise17;
+} catch {}
+let img12 = await imageWithData(186, 3, '#47ba8089', '#72d63cbf');
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+try {
+computePassEncoder17.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(2, bindGroup8, new Uint32Array(1724), 238, 0);
+} catch {}
+try {
+renderBundleEncoder9.draw(16, 8, 0);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexedIndirect(buffer15, 304);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 45532, new Int16Array(8837), 2712, 1220);
+} catch {}
+let pipeline70 = await promise15;
+gc();
+try {
+offscreenCanvas9.getContext('webgpu');
+} catch {}
+let commandEncoder35 = device0.createCommandEncoder({label: '\u9ab2\u09c0\u1479\u0956\u{1f66e}\u04b2'});
+let querySet37 = device0.createQuerySet({
+type: 'occlusion',
+count: 699,
+});
+try {
+renderBundleEncoder17.draw(80, 24, 72, 40);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer15, 5748);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(6, buffer6, 14340, 12900);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder35.copyBufferToBuffer(buffer12, 28736, buffer10, 220, 6008);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder31.clearBuffer(buffer11, 27736, 20248);
+dissociateBuffer(device0, buffer11);
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+let video6 = await videoWithData();
+let imageBitmap7 = await createImageBitmap(canvas5);
+let computePassEncoder28 = commandEncoder20.beginComputePass({label: '\ue9d2\u6c4e\u6b84\u0752\u4a79\u{1f81d}\uc456\u0f01\u{1fa51}\u0f31\u{1fa3e}'});
+let renderBundleEncoder40 = device0.createRenderBundleEncoder({
+  label: '\u{1fbf9}\u0f57\u2e72\u51e8\uf1c7\u0900',
+  colorFormats: ['r8uint', 'rgba8sint', 'rg8uint', 'rg32uint', undefined, 'rg8uint', undefined, 'bgra8unorm-srgb'],
+  stencilReadOnly: true
+});
+let sampler30 = device0.createSampler({
+label: '\uf875\u37d7',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 7.856,
+lodMaxClamp: 10.491,
+maxAnisotropy: 11,
+});
+try {
+renderBundleEncoder40.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+commandEncoder33.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 3056 */
+offset: 3056,
+bytesPerRow: 0,
+buffer: buffer0,
+}, {
+  texture: texture44,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let texture52 = device0.createTexture({
+label: '\u213d\u15d4\u7862',
+size: [320, 2, 503],
+mipLevelCount: 9,
+dimension: '3d',
+format: 'rg32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let computePassEncoder29 = commandEncoder33.beginComputePass({});
+let renderBundleEncoder41 = device0.createRenderBundleEncoder({
+  label: '\u1de3\u{1fd2b}\u01ca\uf784\uc106',
+  colorFormats: ['rg16uint', 'rg32float', 'r16uint', 'rg16sint'],
+  depthReadOnly: true
+});
+let externalTexture1 = device0.importExternalTexture({
+source: videoFrame6,
+});
+try {
+renderBundleEncoder32.setPipeline(pipeline47);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(59, undefined);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer12, 24280, buffer1, 40620, 256);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder31.copyTextureToBuffer({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 44356 */
+offset: 44356,
+rowsPerImage: 46,
+buffer: buffer1,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 0,
+  origin: { x: 160, y: 2, z: 3 },
+  aspect: 'all',
+}, arrayBuffer11, /* required buffer size: 2270345 */
+{offset: 605, bytesPerRow: 362, rowsPerImage: 190}, {width: 50, height: 0, depthOrArrayLayers: 34});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: canvas14,
+  origin: { x: 135, y: 59 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 7,
+  origin: { x: 1, y: 1, z: 2 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData4 = new ImageData(92, 28);
+let bindGroupLayout24 = device0.createBindGroupLayout({
+label: '\u0a25\u6320\u070a\u0e89\u5605\u544f\ubeb5',
+entries: [{
+binding: 283,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+}],
+});
+let commandBuffer12 = commandEncoder32.finish();
+let texture53 = device0.createTexture({
+label: '\u33d7\uf0ec\u0147',
+size: [1320, 96, 1],
+mipLevelCount: 2,
+sampleCount: 1,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-8x8-unorm', 'astc-8x8-unorm'],
+});
+let computePassEncoder30 = commandEncoder31.beginComputePass({});
+let renderBundle42 = renderBundleEncoder39.finish({label: '\u06a2\u67d7\u0b08\u{1f8e6}\ua9e1'});
+try {
+renderBundleEncoder32.setBindGroup(1, bindGroup12, new Uint32Array(1919), 1277, 0);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(2, buffer6, 7104, 24370);
+} catch {}
+try {
+renderBundleEncoder37.pushDebugGroup('\u{1fbb5}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 5,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 20959 */
+{offset: 350, bytesPerRow: 92, rowsPerImage: 56}, {width: 1, height: 1, depthOrArrayLayers: 5});
+} catch {}
+let promise19 = device0.createComputePipelineAsync({
+layout: pipelineLayout1,
+compute: {
+module: shaderModule10,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let bindGroup19 = device0.createBindGroup({
+label: '\u0af3\ud720\ubc43\uab03\u0953\u{1f76b}',
+layout: bindGroupLayout11,
+entries: [{
+binding: 823,
+resource: textureView6
+}, {
+binding: 297,
+resource: externalTexture1
+}],
+});
+let querySet38 = device0.createQuerySet({
+label: '\uefcb\u0cca\u{1faed}\u0464',
+type: 'occlusion',
+count: 1991,
+});
+try {
+computePassEncoder28.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexed(0);
+} catch {}
+try {
+renderBundleEncoder36.drawIndirect(buffer12, 28172);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(4, buffer15, 2956, 610);
+} catch {}
+let arrayBuffer12 = buffer2.getMappedRange(1104, 4);
+try {
+commandEncoder15.resolveQuerySet(querySet16, 824, 943, buffer12, 30976);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 2 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 807298 */
+{offset: 626, bytesPerRow: 260, rowsPerImage: 141}, {width: 19, height: 1, depthOrArrayLayers: 23});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise20 = device0.createRenderPipelineAsync({
+label: '\u5e4c\u03cf\u04d7\u0b2e\u299b\u51ed\uf105\u03ef',
+layout: pipelineLayout9,
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint'}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, undefined, {format: 'rg32float'}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'zero', dstFactor: 'constant'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2385,
+depthBias: 37,
+depthBiasSlopeScale: 20,
+depthBiasClamp: 64,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1568,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x4',
+offset: 1400,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 228,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1104,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 2008,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 1884,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+unclippedDepth: true,
+},
+});
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let bindGroup20 = device0.createBindGroup({
+label: '\ufaf4\u23c6\u6cad',
+layout: bindGroupLayout16,
+entries: [],
+});
+let renderBundleEncoder42 = device0.createRenderBundleEncoder({
+  label: '\u5b78\ubb80\u{1f768}\u{1f625}\u0545\u2dad\u7c73\u{1f735}\uc5df',
+  colorFormats: [undefined, 'r16uint', 'rg32uint', 'rg16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+let renderBundle43 = renderBundleEncoder11.finish({label: '\u0ecc\u57be\ua545'});
+try {
+computePassEncoder29.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder9.draw(40, 48, 56);
+} catch {}
+try {
+buffer12.destroy();
+} catch {}
+let commandEncoder36 = device0.createCommandEncoder();
+let computePassEncoder31 = commandEncoder15.beginComputePass();
+let renderBundleEncoder43 = device0.createRenderBundleEncoder({
+  label: '\u0623\u8807\u946e\uef7c\u0d60\u436f\u0c55',
+  colorFormats: ['r8uint', undefined, 'rg8sint'],
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+computePassEncoder20.dispatchWorkgroups(1, 5, 5);
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline49);
+} catch {}
+try {
+renderBundleEncoder32.draw(56, 72, 0, 0);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(2, buffer0, 34372, 1081);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture48,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 200, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 13660, new BigUint64Array(53077), 29152, 188);
+} catch {}
+let renderBundleEncoder44 = device0.createRenderBundleEncoder({
+  label: '\u3d74\u0a0b\ub179\u0bfe\u3028\u5a9c\ua598\u234a\u{1f641}',
+  colorFormats: ['rg8uint', 'r16uint', 'rgba16uint', 'rgba16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup13, new Uint32Array(9684), 4936, 0);
+} catch {}
+try {
+renderBundleEncoder32.draw(72, 32, 40, 16);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexed(32, 8, 56, 760, 32);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer15, 328);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer15, 2624);
+} catch {}
+try {
+buffer10.destroy();
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 1,
+  origin: { x: 530, y: 70, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture29,
+  mipLevel: 2,
+  origin: { x: 130, y: 15, z: 0 },
+  aspect: 'all',
+}, {width: 210, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder36.clearBuffer(buffer4, 5232, 3800);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let pipelineLayout14 = device0.createPipelineLayout({label: '\u5588\uaeda\ua385', bindGroupLayouts: []});
+let renderBundle44 = renderBundleEncoder10.finish({label: '\u54f6\u{1f95d}\u0f5e\u1559\u{1fe36}\u71bd\ufcc8\u43d7\u09b1'});
+try {
+computePassEncoder22.dispatchWorkgroups(2, 3, 5);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer0, 'uint32', 10256, 19258);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(6, buffer0, 21732, 2341);
+} catch {}
+try {
+commandEncoder35.copyBufferToBuffer(buffer12, 13036, buffer10, 7500, 92);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder35.copyBufferToTexture({
+/* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 3296 */
+offset: 3296,
+bytesPerRow: 256,
+buffer: buffer12,
+}, {
+  texture: texture13,
+  mipLevel: 1,
+  origin: { x: 30, y: 10, z: 1 },
+  aspect: 'all',
+}, {width: 20, height: 35, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm'],
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 41116, new BigUint64Array(60013), 45799, 1260);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 16, y: 0, z: 0 },
+  aspect: 'all',
+}, new DataView(arrayBuffer8), /* required buffer size: 717 */
+{offset: 557}, {width: 40, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline71 = await promise16;
+try {
+  await promise18;
+} catch {}
+let renderBundleEncoder45 = device0.createRenderBundleEncoder({
+  label: '\u0407\uf9bd\u{1f723}\u0d35\u{1fb04}\u0a70\u08d2\u39ae\u0390\u9400',
+  colorFormats: ['rg16uint', 'rg32float', 'r16uint', 'rg16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle45 = renderBundleEncoder32.finish({label: '\uf479\u{1fbd4}\u2bbc\u0fd8\u98aa\u282f\u0f18\u0892'});
+try {
+computePassEncoder20.dispatchWorkgroupsIndirect(buffer12, 39580);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer12, 16896);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: { x: 920, y: 25, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture29,
+  mipLevel: 1,
+  origin: { x: 0, y: 5, z: 0 },
+  aspect: 'all',
+}, {width: 690, height: 65, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder35.clearBuffer(buffer18, 2356);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder36.resolveQuerySet(querySet12, 2115, 832, buffer12, 3072);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer12,
+]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, new Int32Array(arrayBuffer3), /* required buffer size: 1762 */
+{offset: 86, bytesPerRow: 1810, rowsPerImage: 141}, {width: 419, height: 1, depthOrArrayLayers: 1});
+} catch {}
+canvas5.height = 438;
+let offscreenCanvas10 = new OffscreenCanvas(1013, 91);
+let commandEncoder37 = device0.createCommandEncoder({label: '\u{1fef3}\u{1fd01}\u5109\ud53a\u229f\udd31\u09a2\uc3e2\u0c3e'});
+let texture54 = device0.createTexture({
+label: '\u{1fab6}\u0528',
+size: [1320],
+dimension: '1d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder17.drawIndirect(buffer12, 7732);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer6, 'uint16', 21932, 6599);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(6, buffer15, 3732, 1759);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 31}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 4,
+  origin: { x: 5, y: 0, z: 30 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 15, height: 0, depthOrArrayLayers: 1});
+} catch {}
+offscreenCanvas3.height = 319;
+let querySet39 = device0.createQuerySet({
+type: 'occlusion',
+count: 853,
+});
+try {
+computePassEncoder20.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder17.draw(8, 56, 8, 16);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer12, 37996);
+} catch {}
+try {
+commandEncoder35.clearBuffer(buffer14, 13680);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+renderBundleEncoder37.popDebugGroup();
+} catch {}
+let videoFrame12 = new VideoFrame(offscreenCanvas4, {timestamp: 0});
+let shaderModule16 = device0.createShaderModule({
+label: '\uc372\u{1f8ae}\ua04f\u068c\u0aa2\u06ac\u40f1\u0b5a\u{1f678}\u{1f71c}\u{1ff13}',
+code: `
+
+@compute @workgroup_size(2, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(frag_depth) f0: f32,
+  @location(0) f1: vec4<u32>,
+  @location(4) f2: vec3<f32>,
+  @location(1) f3: vec4<f32>,
+  @location(3) f4: vec4<i32>,
+  @location(2) f5: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @location(11) a1: vec2<i32>, @builtin(sample_index) a2: u32, @location(5) a3: vec2<i32>, @location(4) a4: vec4<f16>, @location(3) a5: vec2<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(14) f58: f16,
+  @location(3) f59: vec2<u32>,
+  @location(1) f60: vec4<i32>,
+  @location(8) f61: vec4<u32>,
+  @location(11) f62: vec2<i32>,
+  @location(0) f63: f32,
+  @builtin(position) f64: vec4<f32>,
+  @location(9) f65: vec3<u32>,
+  @location(15) f66: i32,
+  @location(4) f67: vec4<f16>,
+  @location(13) f68: vec3<u32>,
+  @location(5) f69: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(13) a0: u32, @location(14) a1: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let texture55 = device0.createTexture({
+label: '\u0265\u9e42\u0b82\u078c\u{1fd30}\u0aea',
+size: [2640, 192, 1],
+mipLevelCount: 10,
+format: 'rg8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg8unorm', 'rg8unorm'],
+});
+try {
+computePassEncoder17.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(1, bindGroup11, new Uint32Array(2156), 1556, 0);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexed(0, 32, 80, -648, 16);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer6, 'uint16', 9480, 13224);
+} catch {}
+try {
+commandEncoder37.resolveQuerySet(querySet26, 63, 19, buffer12, 4096);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise21 = device0.createComputePipelineAsync({
+label: '\u0a00\u0158\uca96\u{1feb7}\u5bc3',
+layout: pipelineLayout10,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+},
+});
+canvas0.height = 839;
+let computePassEncoder32 = commandEncoder35.beginComputePass({});
+try {
+computePassEncoder30.setPipeline(pipeline67);
+} catch {}
+try {
+renderBundleEncoder17.draw(0, 24, 0, 72);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexed(16, 48, 16);
+} catch {}
+try {
+renderBundleEncoder44.setPipeline(pipeline58);
+} catch {}
+try {
+commandEncoder36.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 16040, new DataView(new ArrayBuffer(26062)), 19107, 3048);
+} catch {}
+let computePassEncoder33 = commandEncoder36.beginComputePass({label: '\ue8ba\u09cb\u06ce\u0866\u1c7f'});
+let renderBundle46 = renderBundleEncoder31.finish({label: '\u09c7\ua2a8\u027f\ue1c3\u{1fc51}\ud26b\u{1fd6b}\u{1f7c9}'});
+try {
+renderBundleEncoder28.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexed(32, 8, 24, 712, 48);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer12, 20804);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer4, 'uint16', 7254, 2125);
+} catch {}
+let promise22 = buffer16.mapAsync(GPUMapMode.READ, 0, 59408);
+try {
+commandEncoder37.clearBuffer(buffer12, 24184);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder37.resolveQuerySet(querySet18, 2220, 607, buffer12, 8960);
+} catch {}
+let querySet40 = device0.createQuerySet({
+label: '\ud3ed\u8452\u0d5a\u0130\u66c3\u5cb3\u92c7\u0214\u77a2\u068f\u66e1',
+type: 'occlusion',
+count: 47,
+});
+let textureView40 = texture5.createView({label: '\u7d65\u3e68\u0774', dimension: '2d-array', aspect: 'all'});
+let renderBundle47 = renderBundleEncoder21.finish();
+try {
+computePassEncoder28.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline49);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer12, 28196);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+commandEncoder37.copyTextureToBuffer({
+  texture: texture49,
+  mipLevel: 1,
+  origin: { x: 290, y: 10, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 1136 widthInBlocks: 71 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 8016 */
+offset: 6880,
+bytesPerRow: 1280,
+buffer: buffer12,
+}, {width: 710, height: 10, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder37.copyTextureToTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 24, y: 155, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture30,
+  mipLevel: 1,
+  origin: { x: 8, y: 30, z: 1 },
+  aspect: 'all',
+}, {width: 8, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgba8unorm-srgb'],
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 1,
+  origin: { x: 35, y: 0, z: 1 },
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer10), /* required buffer size: 547604 */
+{offset: 519, bytesPerRow: 319, rowsPerImage: 245}, {width: 123, height: 0, depthOrArrayLayers: 8});
+} catch {}
+let videoFrame13 = new VideoFrame(img5, {timestamp: 0});
+let bindGroupLayout25 = pipeline66.getBindGroupLayout(2);
+let commandEncoder38 = device0.createCommandEncoder({label: '\uac3e\uf204\u{1fc02}\u{1fa9e}\u2b3d\ud7eb\u0483\ue895\u0a25\ub323'});
+pseudoSubmit(device0, commandEncoder26);
+try {
+computePassEncoder27.setBindGroup(2, bindGroup13, new Uint32Array(2878), 583, 0);
+} catch {}
+let arrayBuffer13 = buffer14.getMappedRange(0, 3124);
+try {
+buffer4.unmap();
+} catch {}
+try {
+commandEncoder37.clearBuffer(buffer10, 4, 1108);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 6240, new BigUint64Array(37251), 35381, 404);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 713 */
+{offset: 713, rowsPerImage: 269}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img7,
+  origin: { x: 162, y: 47 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 8,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext11 = offscreenCanvas10.getContext('webgpu');
+let bindGroupLayout26 = device0.createBindGroupLayout({
+label: '\u499f\u05bd\ucd20\u6f5b\u3a99',
+entries: [{
+binding: 423,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}],
+});
+let bindGroup21 = device0.createBindGroup({
+label: '\u6f44\u740b\u0146\u3e44\u0bb9\u{1fb5c}\ub713\u0234\ucc3e\u01a7',
+layout: bindGroupLayout1,
+entries: [{
+binding: 257,
+resource: externalTexture1
+}, {
+binding: 43,
+resource: externalTexture0
+}],
+});
+let querySet41 = device0.createQuerySet({
+type: 'occlusion',
+count: 1749,
+});
+let renderBundle48 = renderBundleEncoder5.finish({label: '\u0135\u{1f750}\u940d\u0e39'});
+try {
+renderBundleEncoder12.drawIndirect(buffer12, 36600);
+} catch {}
+try {
+commandEncoder37.copyBufferToBuffer(buffer2, 672, buffer16, 50420, 636);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 11484, new BigUint64Array(57805), 54259, 16);
+} catch {}
+let pipeline72 = await device0.createRenderPipelineAsync({
+label: '\u26cc\ue3d0\ubf09\u{1f7ec}\u254d\u0d3f\u01bb\u{1fbf8}\u0479',
+layout: pipelineLayout14,
+multisample: {
+count: 4,
+mask: 0x5dfc6a81,
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+failOp: 'increment-wrap',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'keep',
+},
+stencilReadMask: 1397,
+stencilWriteMask: 340,
+depthBias: 75,
+depthBiasSlopeScale: 8,
+depthBiasClamp: 12,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 1728,
+shaderLocation: 7,
+}, {
+format: 'uint32x3',
+offset: 996,
+shaderLocation: 15,
+}, {
+format: 'snorm8x2',
+offset: 962,
+shaderLocation: 1,
+}, {
+format: 'unorm8x2',
+offset: 948,
+shaderLocation: 2,
+}, {
+format: 'snorm8x4',
+offset: 1528,
+shaderLocation: 12,
+}, {
+format: 'float32x3',
+offset: 1168,
+shaderLocation: 13,
+}, {
+format: 'unorm16x4',
+offset: 1804,
+shaderLocation: 6,
+}, {
+format: 'sint32x3',
+offset: 84,
+shaderLocation: 3,
+}, {
+format: 'float16x2',
+offset: 424,
+shaderLocation: 4,
+}],
+}
+]
+},
+});
+let imageData5 = new ImageData(16, 28);
+let querySet42 = device0.createQuerySet({
+label: '\ue38b\u00d1\u{1f61e}\u273e\u2523\u{1fa52}\u931f\u{1fa11}\u{1fb84}\u{1f9d4}',
+type: 'occlusion',
+count: 235,
+});
+try {
+computePassEncoder22.dispatchWorkgroups(4, 4);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer15, 5300);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline58);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(4, buffer0, 34224, 1262);
+} catch {}
+try {
+computePassEncoder28.pushDebugGroup('\u095e');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 320, height: 2, depthOrArrayLayers: 503}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 0, y: 11 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: { x: 77, y: 0, z: 448 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let querySet43 = device0.createQuerySet({
+label: '\u8cf4\u9546\u{1fa07}',
+type: 'occlusion',
+count: 1021,
+});
+let renderBundleEncoder46 = device0.createRenderBundleEncoder({
+  label: '\u26e2\uf8e9',
+  colorFormats: [undefined, 'r16uint', 'rg32uint', 'rg16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder9.drawIndexed(72, 64, 0);
+} catch {}
+try {
+commandEncoder37.copyBufferToBuffer(buffer17, 3068, buffer1, 16376, 13288);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder38.copyBufferToTexture({
+/* bytesInLastRow: 30 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 40742 */
+offset: 40742,
+buffer: buffer12,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 3, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder37.resolveQuerySet(querySet35, 321, 1037, buffer12, 4096);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 320, height: 2, depthOrArrayLayers: 503}
+*/
+{
+  source: video3,
+  origin: { x: 2, y: 4 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: { x: 300, y: 0, z: 496 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 12, height: 2, depthOrArrayLayers: 1});
+} catch {}
+let commandBuffer13 = commandEncoder37.finish({
+label: '\u01eb\u{1f6fc}\ud0ac',
+});
+let computePassEncoder34 = commandEncoder38.beginComputePass();
+try {
+renderBundleEncoder17.setVertexBuffer(7, buffer6, 2016);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 1660, new Int16Array(683), 435);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: { x: 0, y: 5, z: 0 },
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 1396 */
+{offset: 484, bytesPerRow: 64}, {width: 8, height: 75, depthOrArrayLayers: 1});
+} catch {}
+let canvas15 = document.createElement('canvas');
+let promise23 = adapter0.requestAdapterInfo();
+let texture56 = device0.createTexture({
+label: '\ue090\u41cf\uf1c0\uae59\ua413\u0bf6\u24de\u03e3\u349c\u{1fe13}',
+size: {width: 32, height: 45, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView41 = texture13.createView({format: 'astc-10x5-unorm', baseMipLevel: 2, mipLevelCount: 1});
+try {
+renderBundleEncoder17.drawIndexed(16, 56, 0, -208);
+} catch {}
+try {
+renderBundleEncoder44.drawIndexedIndirect(buffer15, 5876);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer12, 13200);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(2, buffer15, 2400, 2004);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+computePassEncoder28.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['etc2-rgba8unorm', 'r8uint', 'rgba16float'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 396, new Float32Array(17941), 11071, 1764);
+} catch {}
+let imageData6 = new ImageData(208, 216);
+try {
+device0.label = '\uc290\u{1f704}\ua00c';
+} catch {}
+let pipelineLayout15 = device0.createPipelineLayout({
+  label: '\u60a7\ud89b',
+  bindGroupLayouts: [bindGroupLayout7, bindGroupLayout21, bindGroupLayout4, bindGroupLayout25]
+});
+let commandEncoder39 = device0.createCommandEncoder();
+let textureView42 = texture28.createView({label: '\u01da\u7dd7\u65eb\u09b5\u{1fa56}', format: 'rgba8uint'});
+let renderBundle49 = renderBundleEncoder40.finish({label: '\u{1fa07}\u129d\u{1fdad}\u0e84\u0b37\u{1fbaa}\u521b\u371f\u002a\u0604'});
+let sampler31 = device0.createSampler({
+label: '\u8f43\u00d0\u0b58\u4820\u0c57\u036f\u4b3c\ua021',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 86.148,
+maxAnisotropy: 4,
+});
+try {
+computePassEncoder22.dispatchWorkgroups(1, 3, 3);
+} catch {}
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+renderBundleEncoder36.drawIndexed(56, 32, 80, 448, 0);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexedIndirect(buffer12, 22532);
+} catch {}
+try {
+renderBundleEncoder36.drawIndirect(buffer15, 3980);
+} catch {}
+let promise24 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise24;
+} catch {}
+let commandEncoder40 = device0.createCommandEncoder({label: '\u{1fc21}\u0cba\u2eb6\u91b0\u{1fe21}\u05c0\u6dd2\u{1fb52}\uc921\u7c7d'});
+let textureView43 = texture27.createView({label: '\u7022\u5bcd\ub35e', dimension: '2d-array', baseMipLevel: 4});
+let renderBundleEncoder47 = device0.createRenderBundleEncoder({
+  label: '\u6f0c\u84ff\u0254\ue754',
+  colorFormats: ['r8uint', 'rgba8sint', 'rg8uint', 'rg32uint', undefined, 'rg8uint', undefined, 'bgra8unorm-srgb']
+});
+try {
+renderBundleEncoder28.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer15, 4876);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(6, buffer6, 15816, 20442);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder40.copyBufferToBuffer(buffer2, 56, buffer9, 5880, 732);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder39.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 1,
+  origin: { x: 0, y: 15, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture30,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 5, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder40.resolveQuerySet(querySet22, 1587, 32, buffer12, 16384);
+} catch {}
+let pipeline73 = await device0.createComputePipelineAsync({
+label: '\u2848\u0f49\uf42b\u7e58\u{1fc97}\u{1fdc7}',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline74 = await device0.createRenderPipelineAsync({
+label: '\u{1fe7e}\u3e44\uc2d9\u08b9\u4f6d',
+layout: pipelineLayout15,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.BLUE}, {format: 'rgba16uint'}, {format: 'r8uint'}, {format: 'rg11b10ufloat', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilReadMask: 1520,
+stencilWriteMask: 1987,
+depthBias: 52,
+depthBiasSlopeScale: 10,
+depthBiasClamp: 85,
+},
+vertex: {
+  module: shaderModule11,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 368,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 260,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 1244,
+attributes: [{
+format: 'unorm8x2',
+offset: 1194,
+shaderLocation: 14,
+}, {
+format: 'uint32x4',
+offset: 372,
+shaderLocation: 6,
+}, {
+format: 'snorm16x4',
+offset: 92,
+shaderLocation: 11,
+}, {
+format: 'uint8x2',
+offset: 998,
+shaderLocation: 12,
+}, {
+format: 'sint32x2',
+offset: 340,
+shaderLocation: 1,
+}, {
+format: 'unorm16x4',
+offset: 1120,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 524,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 948,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x2',
+offset: 696,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 348,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1832,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x4',
+offset: 488,
+shaderLocation: 4,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+},
+});
+try {
+renderBundleEncoder12.draw(64, 72, 32, 32);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(4, buffer15, 3132, 1609);
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer19);
+dissociateBuffer(device0, buffer19);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let promise25 = device0.queue.onSubmittedWorkDone();
+let pipeline75 = device0.createRenderPipeline({
+label: '\u52a0\u0713\u0422\u08d4\u50d7',
+layout: pipelineLayout10,
+fragment: {
+  module: shaderModule13,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {
+  format: 'rgba16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rgba16sint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'replace',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilReadMask: 2864,
+stencilWriteMask: 997,
+depthBiasSlopeScale: 99,
+depthBiasClamp: 61,
+},
+vertex: {
+  module: shaderModule13,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1684,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1068,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32',
+offset: 816,
+shaderLocation: 11,
+}, {
+format: 'sint32',
+offset: 904,
+shaderLocation: 6,
+}, {
+format: 'snorm16x4',
+offset: 620,
+shaderLocation: 4,
+}, {
+format: 'sint32x2',
+offset: 36,
+shaderLocation: 15,
+}, {
+format: 'sint8x4',
+offset: 968,
+shaderLocation: 13,
+}, {
+format: 'sint8x4',
+offset: 420,
+shaderLocation: 8,
+}, {
+format: 'sint32',
+offset: 960,
+shaderLocation: 14,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'front',
+},
+});
+let commandEncoder41 = device0.createCommandEncoder();
+let texture57 = device0.createTexture({
+label: '\u08fa\ua5f1\u3476',
+size: {width: 32, height: 45, depthOrArrayLayers: 1},
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x5-unorm', 'astc-8x5-unorm', 'astc-8x5-unorm-srgb'],
+});
+let computePassEncoder35 = commandEncoder40.beginComputePass();
+let renderBundle50 = renderBundleEncoder5.finish({label: '\u50cf\u5ee9\u036b'});
+try {
+renderBundleEncoder30.setVertexBuffer(4, buffer0, 4944);
+} catch {}
+try {
+commandEncoder41.copyBufferToBuffer(buffer2, 1036, buffer10, 1056, 188);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: videoFrame13,
+  origin: { x: 104, y: 74 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 7,
+  origin: { x: 1, y: 1, z: 3 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise23;
+} catch {}
+gc();
+let computePassEncoder36 = commandEncoder41.beginComputePass({label: '\u7839\u0e80\u91fc\u0e53\uc018\u9a4f\u627e'});
+let renderBundle51 = renderBundleEncoder38.finish();
+try {
+renderBundleEncoder36.drawIndirect(buffer12, 10004);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(2, buffer0);
+} catch {}
+let pipeline76 = await promise20;
+let gpuCanvasContext12 = canvas15.getContext('webgpu');
+try {
+  await promise22;
+} catch {}
+let computePassEncoder37 = commandEncoder39.beginComputePass({label: '\u{1f6e6}\u016f\u48fb\u02f0\u3851\uce56\u5693\u04e1\u5fc7\u{1fb31}\u01b7'});
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 21496);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(6, buffer0, 27700, 4418);
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer19);
+dissociateBuffer(device0, buffer19);
+} catch {}
+let imageBitmap8 = await createImageBitmap(canvas3);
+let querySet44 = device0.createQuerySet({
+label: '\ua1ec\ua85a\u0169\uee15\u063a',
+type: 'occlusion',
+count: 881,
+});
+let texture58 = device0.createTexture({
+label: '\ue31c\ub839\ub418\u{1fcb6}\u02c7\u2ffa',
+size: [660, 48, 1],
+mipLevelCount: 6,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['depth24plus-stencil8', 'depth24plus-stencil8', 'depth24plus-stencil8'],
+});
+let renderBundle52 = renderBundleEncoder29.finish({label: '\u7114\uf324\u3ba4\u04f6\u0a13\udc91\u05f1\u2915\u{1f951}\ub4fe'});
+try {
+computePassEncoder22.dispatchWorkgroups(2, 1, 3);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer15, 4208);
+} catch {}
+try {
+commandEncoder23.copyBufferToBuffer(buffer2, 1372, buffer18, 7156, 4);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer1, 6396, 35460);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder23.resolveQuerySet(querySet37, 118, 454, buffer12, 36096);
+} catch {}
+let pipeline77 = await promise6;
+let imageBitmap9 = await createImageBitmap(videoFrame8);
+let querySet45 = device0.createQuerySet({
+label: '\u83dd\u0824\u6b3d',
+type: 'occlusion',
+count: 1520,
+});
+let renderBundle53 = renderBundleEncoder39.finish({label: '\ue2d3\u75db\u0ac8\u8340\u{1fb40}\u0ae6\uc3f0\u8955\u051b'});
+try {
+computePassEncoder23.end();
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline49);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexed(32, 32, 16);
+} catch {}
+try {
+commandEncoder23.copyBufferToBuffer(buffer2, 1108, buffer14, 3292, 168);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder23.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 2,
+  origin: { x: 0, y: 15, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture13,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 10, height: 10, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 10316, new DataView(new ArrayBuffer(3816)), 1551, 248);
+} catch {}
+try {
+  await promise25;
+} catch {}
+let pipelineLayout16 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout3, bindGroupLayout5, bindGroupLayout2]});
+let textureView44 = texture3.createView({label: '\u8c13\u{1f7d6}\u{1f89b}\ue0f0\u4a12\ucf30\uedea', mipLevelCount: 1});
+let renderBundleEncoder48 = device0.createRenderBundleEncoder({
+  colorFormats: [undefined, 'r16uint', 'rg32uint', 'rg16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let sampler32 = device0.createSampler({
+label: '\ube66\u9ad0\uc5bb\u1bc7',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 26.163,
+lodMaxClamp: 78.885,
+maxAnisotropy: 7,
+});
+let externalTexture2 = device0.importExternalTexture({
+label: '\u72dc\u5538\ue715\ub664\udb9e\u029f\u{1ff52}\u97cd\u{1fa75}',
+source: videoFrame10,
+});
+try {
+renderBundleEncoder12.drawIndirect(buffer12, 11596);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(5, buffer6, 22908);
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(buffer3, 26388, buffer10, 6188, 188);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder23.copyTextureToBuffer({
+  texture: texture54,
+  mipLevel: 0,
+  origin: { x: 101, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 3996 widthInBlocks: 999 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 13240 */
+offset: 13240,
+rowsPerImage: 114,
+buffer: buffer1,
+}, {width: 999, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: { x: 1024, y: 56, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 3,
+  origin: { x: 16, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 136, height: 8, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder23.resolveQuerySet(querySet25, 653, 36, buffer12, 36096);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 17440, new Float32Array(62697), 18716, 500);
+} catch {}
+let renderBundleEncoder49 = device0.createRenderBundleEncoder({
+  label: '\ued6f\u06c8\ue2a3\u0d34\u{1fe94}\u1219\u0ee6',
+  colorFormats: ['rg8uint', 'r16uint', 'rgba16uint', 'rgba16sint'],
+  stencilReadOnly: true
+});
+let renderBundle54 = renderBundleEncoder22.finish({label: '\u{1fae9}\u{1f653}\u0d53'});
+let sampler33 = device0.createSampler({
+label: '\u{1fa29}\u0ce2\u0f2c\u{1fda2}\u64d4\u64e5',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 50.346,
+lodMaxClamp: 77.560,
+maxAnisotropy: 15,
+});
+try {
+computePassEncoder22.dispatchWorkgroups(2, 2, 4);
+} catch {}
+try {
+renderBundleEncoder44.drawIndexedIndirect(buffer12, 21692);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(2, buffer0);
+} catch {}
+let promise26 = device0.queue.onSubmittedWorkDone();
+let textureView45 = texture10.createView({
+  label: '\u{1f855}\u{1fedf}\u{1fd62}\u9262\ua900\u{1fe0f}\ufb2a\u{1fcad}',
+  dimension: '2d-array',
+  baseMipLevel: 0,
+  mipLevelCount: 4
+});
+let renderBundleEncoder50 = device0.createRenderBundleEncoder({
+  label: '\ubbc0\u53a8\u9c1f\u5313\u6ba8\u9d8f\u0197',
+  colorFormats: ['r8uint', 'rgba8sint', 'rg8uint', 'rg32uint', undefined, 'rg8uint', undefined, 'bgra8unorm-srgb'],
+  sampleCount: 1
+});
+let renderBundle55 = renderBundleEncoder44.finish();
+try {
+renderBundleEncoder43.setBindGroup(0, bindGroup3, new Uint32Array(2533), 1043, 0);
+} catch {}
+try {
+renderBundleEncoder9.draw(72, 64, 64, 0);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer15, 64);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(0, buffer15, 2708);
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(buffer2, 1188, buffer9, 7128, 72);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer10, 2668, 3548);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 4,
+  origin: { x: 0, y: 1, z: 2 },
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 197075 */
+{offset: 863, bytesPerRow: 197, rowsPerImage: 166}, {width: 2, height: 0, depthOrArrayLayers: 7});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas12);
+let offscreenCanvas11 = new OffscreenCanvas(209, 735);
+try {
+await adapter3.requestAdapterInfo();
+} catch {}
+try {
+renderBundleEncoder12.draw(8, 48);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(48, 40, 48);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer15, 2268);
+} catch {}
+try {
+renderBundleEncoder43.setIndexBuffer(buffer9, 'uint16', 10818, 5275);
+} catch {}
+try {
+commandEncoder23.copyTextureToBuffer({
+  texture: texture46,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 12972 */
+offset: 12972,
+buffer: buffer9,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture({
+  texture: texture54,
+  mipLevel: 0,
+  origin: { x: 476, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture20,
+  mipLevel: 1,
+  origin: { x: 0, y: 13, z: 67 },
+  aspect: 'all',
+}, {width: 11, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer4, 804, 4104);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+offscreenCanvas11.getContext('bitmaprenderer');
+} catch {}
+let textureView46 = texture3.createView({label: '\u09c1\u6235\u59ca\ud7ea\u46ab', mipLevelCount: 1});
+let computePassEncoder38 = commandEncoder28.beginComputePass({label: '\u0e05\u0b5f\ub4f8\ua6bd\u849e\u0479\u7881'});
+try {
+renderBundleEncoder17.drawIndexed(80);
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer1, 3284, 26248);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 1, depthOrArrayLayers: 251}
+*/
+{
+  source: img1,
+  origin: { x: 2, y: 84 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 1,
+  origin: { x: 21, y: 1, z: 89 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 37, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let canvas16 = document.createElement('canvas');
+try {
+canvas16.getContext('webgl2');
+} catch {}
+let commandEncoder42 = device0.createCommandEncoder({label: '\u0354\u{1fe89}\u20fb\u{1ffc4}\u{1fd78}\u94ec\ue614'});
+let textureView47 = texture31.createView({label: '\u2cb0\u07e3\u571d\ud684\udb4f', dimension: '2d-array', arrayLayerCount: 1});
+let computePassEncoder39 = commandEncoder42.beginComputePass({label: '\u004a\u0a0b\u0d5f\u7b52\u6042\u1644\u5787\u096d\u{1fab8}\u71fa'});
+try {
+renderBundleEncoder12.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer12, 21120);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer12, 25452);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm'],
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 1432, new Float32Array(37595), 18566, 3872);
+} catch {}
+try {
+  await promise26;
+} catch {}
+let device1 = await promise9;
+let commandEncoder43 = device0.createCommandEncoder({label: '\u7fcb\u{1fe77}\ud8e3\u{1fb6e}\ude69\u28a3'});
+let textureView48 = texture3.createView({
+  label: '\ua9a0\u{1ffd3}\u22c4\ued66\u147e\ucd98\u00b9\u{1ffa3}\u{1f679}\u9dd2',
+  aspect: 'all',
+  baseMipLevel: 0
+});
+try {
+renderBundleEncoder47.setBindGroup(2, bindGroup3, new Uint32Array(3539), 186, 0);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer15, 2108);
+} catch {}
+try {
+renderBundleEncoder12.drawIndirect(buffer12, 35004);
+} catch {}
+try {
+commandEncoder43.copyBufferToBuffer(buffer0, 15636, buffer14, 1008, 5540);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder23.copyTextureToTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 24, height: 35, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderBundleEncoder34.insertDebugMarker('\u56d5');
+} catch {}
+video6.height = 107;
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let querySet46 = device1.createQuerySet({
+label: '\u0d11\u{1fb8a}',
+type: 'occlusion',
+count: 783,
+});
+let texture59 = device1.createTexture({
+label: '\ufd8e\u50aa\u0bc6\u7f74\u{1f86b}\u2f36\ue252',
+size: [1920, 1, 1481],
+mipLevelCount: 8,
+sampleCount: 1,
+dimension: '3d',
+format: 'rgba32sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba32sint'],
+});
+let bindGroupLayout27 = device1.createBindGroupLayout({
+label: '\uf571\u{1f750}\u2e26\u3a4d\u{1fb9f}\u6fdc\u{1fe0f}\u015d\u0052\u841d',
+entries: [],
+});
+let sampler34 = device1.createSampler({
+label: '\u0fe4\u091e\ucd67\uc4a7\u9576\u0d2a\u117e\u97c0',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 58.970,
+lodMaxClamp: 94.620,
+maxAnisotropy: 4,
+});
+let imageBitmap10 = await createImageBitmap(imageData2);
+let shaderModule17 = device0.createShaderModule({
+label: '\u206c\u{1fada}\ueb4e\ud56b',
+code: `@group(1) @binding(257)
+var<storage, read_write> local5: array<u32>;
+@group(3) @binding(561)
+var<storage, read_write> parameter7: array<u32>;
+@group(1) @binding(43)
+var<storage, read_write> local6: array<u32>;
+@group(0) @binding(20)
+var<storage, read_write> type8: array<u32>;
+
+@compute @workgroup_size(6, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S14 {
+  @location(0) f0: vec2<i32>,
+  @location(14) f1: vec2<i32>,
+  @location(7) f2: vec2<f16>,
+  @location(1) f3: vec3<f32>,
+  @location(8) f4: vec3<f32>,
+  @location(10) f5: vec4<f32>,
+  @location(2) f6: vec4<u32>,
+  @location(3) f7: vec2<f16>,
+  @location(4) f8: i32,
+  @location(9) f9: f32,
+  @location(13) f10: vec4<u32>,
+  @location(15) f11: f16,
+  @location(12) f12: i32,
+  @location(6) f13: vec2<u32>,
+  @location(5) f14: vec3<i32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(0) f1: vec4<u32>,
+  @location(1) f2: vec4<f32>,
+  @location(4) f3: vec4<f32>,
+  @builtin(frag_depth) f4: f32
+}
+
+@fragment
+fn fragment0(a0: S14, @builtin(front_facing) a1: bool, @builtin(position) a2: vec4<f32>, @builtin(sample_mask) a3: u32, @builtin(sample_index) a4: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f70: vec4<f32>,
+  @location(13) f71: vec4<u32>,
+  @location(4) f72: i32,
+  @location(10) f73: vec4<f32>,
+  @location(2) f74: vec4<u32>,
+  @location(5) f75: vec3<i32>,
+  @location(9) f76: f32,
+  @location(6) f77: vec2<u32>,
+  @location(14) f78: vec2<i32>,
+  @location(3) f79: vec2<f16>,
+  @location(12) f80: i32,
+  @location(1) f81: vec3<f32>,
+  @location(15) f82: f16,
+  @location(0) f83: vec2<i32>,
+  @location(7) f84: vec2<f16>,
+  @location(8) f85: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: i32, @location(10) a1: vec3<f16>, @builtin(vertex_index) a2: u32, @location(6) a3: vec3<i32>, @location(11) a4: u32, @location(12) a5: f32, @location(7) a6: vec2<f32>, @location(5) a7: u32, @location(8) a8: f32, @location(14) a9: i32, @location(2) a10: vec3<u32>, @location(0) a11: vec3<f16>, @location(13) a12: vec3<f32>, @location(9) a13: vec4<u32>, @location(15) a14: f16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+});
+let bindGroupLayout28 = device0.createBindGroupLayout({
+label: '\ufa63\ua802\uc8cd',
+entries: [{
+binding: 143,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 362,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+let bindGroup22 = device0.createBindGroup({
+label: '\u015f\uf9a0\u921c',
+layout: bindGroupLayout4,
+entries: [],
+});
+let computePassEncoder40 = commandEncoder23.beginComputePass({label: '\u4100\u13d3\u38df\u2755\u2a1f\u08d6\uc98f\u5e2e\u{1f7b3}\u{1ffc0}'});
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup13, new Uint32Array(1891), 993, 0);
+} catch {}
+try {
+renderBundleEncoder36.draw(8, 64, 24, 40);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexed(80, 64, 24, -608, 40);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer15, 2004);
+} catch {}
+try {
+texture15.destroy();
+} catch {}
+try {
+commandEncoder43.clearBuffer(buffer11, 3720, 14140);
+dissociateBuffer(device0, buffer11);
+} catch {}
+let pipeline78 = await device0.createComputePipelineAsync({
+label: '\ub715\uebf6\ucd0b\u6503\ud91a\ud45d',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let shaderModule18 = device0.createShaderModule({
+label: '\u{1fbf7}\u{1ff34}\u367e\u0829\ufda3\u786d\u{1fd80}\u29cd\u77d7\u{1f8f4}',
+code: `@group(1) @binding(43)
+var<storage, read_write> type9: array<u32>;
+
+@compute @workgroup_size(8, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: u32,
+  @location(5) f1: vec3<u32>,
+  @location(7) f2: vec4<f32>,
+  @location(2) f3: vec4<u32>,
+  @location(3) f4: vec2<u32>,
+  @location(1) f5: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(2) a1: i32, @location(14) a2: f16, @location(1) a3: vec3<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+let bindGroup23 = device0.createBindGroup({
+label: '\ud263\u{1fc5d}\u0d76\u3e5f\udc75\u70c8\ua3ad\u{1fcc3}',
+layout: bindGroupLayout3,
+entries: [],
+});
+let computePassEncoder41 = commandEncoder43.beginComputePass();
+try {
+computePassEncoder24.setPipeline(pipeline60);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer15, 4916);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer9, 'uint16', 6964);
+} catch {}
+let pipeline79 = device0.createRenderPipeline({
+label: '\u00c5\u2514\u0f0f\u0395',
+layout: pipelineLayout9,
+multisample: {
+mask: 0x79aa5561,
+},
+fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rgba16uint', writeMask: 0}, {format: 'r8uint', writeMask: 0}, {
+  format: 'rg11b10ufloat',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'dst', dstFactor: 'one-minus-dst'},
+},
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+vertex: {
+  module: shaderModule12,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 88,
+attributes: [{
+format: 'snorm8x4',
+offset: 60,
+shaderLocation: 14,
+}, {
+format: 'snorm16x4',
+offset: 16,
+shaderLocation: 1,
+}, {
+format: 'uint8x4',
+offset: 68,
+shaderLocation: 0,
+}, {
+format: 'float16x4',
+offset: 44,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 1956,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x2',
+offset: 1000,
+shaderLocation: 7,
+}, {
+format: 'uint16x4',
+offset: 944,
+shaderLocation: 10,
+}, {
+format: 'sint32x4',
+offset: 1368,
+shaderLocation: 3,
+}, {
+format: 'sint16x2',
+offset: 720,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 1148,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1420,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 108,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 28,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let pipelineLayout17 = device1.createPipelineLayout({
+  label: '\u{1f70c}\u0d87\u{1fa97}',
+  bindGroupLayouts: [bindGroupLayout27, bindGroupLayout27, bindGroupLayout27]
+});
+let texture60 = device1.createTexture({
+label: '\u{1faff}\u89b1\u{1fa14}',
+size: {width: 2805, height: 480, depthOrArrayLayers: 190},
+mipLevelCount: 7,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-5x5-unorm-srgb'],
+});
+let sampler35 = device1.createSampler({
+label: '\u00a0\ud7c0\u3aa0\u2d9e\u0c58\u45d4\u0c36\u0d1a',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'nearest',
+lodMinClamp: 4.185,
+lodMaxClamp: 19.002,
+});
+try {
+gpuCanvasContext2.configure({
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.destroy();
+} catch {}
+let offscreenCanvas12 = new OffscreenCanvas(919, 641);
+let videoFrame14 = new VideoFrame(offscreenCanvas9, {timestamp: 0});
+offscreenCanvas7.width = 410;
+let imageData7 = new ImageData(144, 84);
+try {
+adapter0.label = '\u0f5a\u0cae\u{1f970}';
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55) };
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer12, 22368);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(5, buffer15, 2768, 2411);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 8508, new BigUint64Array(59691), 3962, 356);
+} catch {}
+let promise27 = device0.createComputePipelineAsync({
+label: '\u5152\ue4be\u8053\ua86c\u47fa\u5222',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let sampler36 = device0.createSampler({
+label: '\u0fa6\u{1fa1f}\u0f7b\u{1febb}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 0.095,
+lodMaxClamp: 94.725,
+compare: 'greater',
+});
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer12, 24856);
+} catch {}
+let promise28 = buffer2.mapAsync(GPUMapMode.WRITE, 0, 936);
+try {
+computePassEncoder9.pushDebugGroup('\u{1fc66}');
+} catch {}
+try {
+computePassEncoder9.popDebugGroup();
+} catch {}
+let pipeline80 = await device0.createRenderPipelineAsync({
+layout: pipelineLayout10,
+fragment: {
+  module: shaderModule15,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rgba16uint', writeMask: GPUColorWrite.BLUE}, {format: 'rgba16sint'}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 3363,
+depthBias: 81,
+},
+vertex: {
+  module: shaderModule15,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x4',
+offset: 884,
+shaderLocation: 5,
+}, {
+format: 'sint32',
+offset: 936,
+shaderLocation: 8,
+}, {
+format: 'unorm16x2',
+offset: 1820,
+shaderLocation: 11,
+}, {
+format: 'sint32x3',
+offset: 2008,
+shaderLocation: 14,
+}, {
+format: 'float32x3',
+offset: 1872,
+shaderLocation: 3,
+}, {
+format: 'float32x2',
+offset: 1272,
+shaderLocation: 10,
+}, {
+format: 'sint8x4',
+offset: 808,
+shaderLocation: 12,
+}, {
+format: 'unorm8x2',
+offset: 834,
+shaderLocation: 9,
+}, {
+format: 'sint16x4',
+offset: 1060,
+shaderLocation: 13,
+}, {
+format: 'uint32x4',
+offset: 1024,
+shaderLocation: 6,
+}, {
+format: 'float32x3',
+offset: 828,
+shaderLocation: 7,
+}, {
+format: 'uint8x2',
+offset: 538,
+shaderLocation: 4,
+}, {
+format: 'snorm8x4',
+offset: 792,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 1256,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x2',
+offset: 284,
+shaderLocation: 15,
+}, {
+format: 'float32x3',
+offset: 312,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 344,
+attributes: [{
+format: 'float16x4',
+offset: 20,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let gpuCanvasContext13 = offscreenCanvas12.getContext('webgpu');
+let shaderModule19 = device0.createShaderModule({
+label: '\u2932\u8dea',
+code: `@group(1) @binding(803)
+var<storage, read_write> local7: array<u32>;
+@group(2) @binding(20)
+var<storage, read_write> i6: array<u32>;
+@group(3) @binding(674)
+var<storage, read_write> field9: array<u32>;
+
+@compute @workgroup_size(8, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S15 {
+  @location(15) f0: vec2<f32>,
+  @location(7) f1: vec3<f32>,
+  @location(13) f2: vec2<u32>,
+  @location(0) f3: vec4<f16>,
+  @location(10) f4: vec4<f32>,
+  @location(4) f5: f16,
+  @location(11) f6: vec4<f16>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<i32>,
+  @location(5) f1: vec2<u32>,
+  @location(6) f2: vec3<i32>,
+  @location(4) f3: vec4<u32>,
+  @location(3) f4: vec3<f32>,
+  @location(1) f5: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(3) a0: vec4<f32>, @location(2) a1: vec3<u32>, @location(6) a2: vec3<i32>, @location(14) a3: vec3<f16>, @location(8) a4: vec2<i32>, @location(1) a5: vec3<f16>, @builtin(position) a6: vec4<f32>, @builtin(front_facing) a7: bool, @location(5) a8: vec4<f16>, @location(12) a9: vec2<u32>, a10: S15, @builtin(sample_mask) a11: u32, @builtin(sample_index) a12: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(7) f86: vec3<f32>,
+  @location(13) f87: vec2<u32>,
+  @location(15) f88: vec2<f32>,
+  @location(2) f89: vec3<u32>,
+  @builtin(position) f90: vec4<f32>,
+  @location(14) f91: vec3<f16>,
+  @location(1) f92: vec3<f16>,
+  @location(11) f93: vec4<f16>,
+  @location(6) f94: vec3<i32>,
+  @location(5) f95: vec4<f16>,
+  @location(12) f96: vec2<u32>,
+  @location(10) f97: vec4<f32>,
+  @location(8) f98: vec2<i32>,
+  @location(0) f99: vec4<f16>,
+  @location(3) f100: vec4<f32>,
+  @location(4) f101: f16
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec3<u32>, @location(12) a1: vec3<u32>, @builtin(instance_index) a2: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let texture61 = device0.createTexture({
+label: '\u4abc\u6c26',
+size: [320, 2, 55],
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView49 = texture38.createView({dimension: '2d-array', format: 'astc-10x5-unorm'});
+let renderBundle56 = renderBundleEncoder46.finish({label: '\u577a\u0a2f\u08fc\u5d7b\u6b74\u5257'});
+try {
+computePassEncoder28.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 14696);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let bindGroupLayout29 = device0.createBindGroupLayout({
+label: '\u0591\u{1f8b4}\u1148\u031e\u9ee5\u0a5d\u736f\u0ad0\u8822',
+entries: [{
+binding: 258,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '2d' },
+}, {
+binding: 79,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+}, {
+binding: 245,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}],
+});
+let bindGroup24 = device0.createBindGroup({
+label: '\u63ca\u{1fbf5}\u2223\u09cc',
+layout: bindGroupLayout14,
+entries: [],
+});
+let commandEncoder44 = device0.createCommandEncoder({label: '\uc196\u06b0\u9356\uc204\ub1ac\u0a50\u2e64\u{1fe66}\u{1fcac}\u0c25'});
+let computePassEncoder42 = commandEncoder44.beginComputePass({label: '\u87d0\u{1ffa8}'});
+let sampler37 = device0.createSampler({
+label: '\udbea\u{1fade}\u15dd\u{1fee5}',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 51.193,
+lodMaxClamp: 86.489,
+});
+try {
+renderBundleEncoder36.draw(64, 72, 80, 8);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexedIndirect(buffer15, 4);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(1, buffer6, 12056, 9528);
+} catch {}
+let promise29 = device0.queue.onSubmittedWorkDone();
+let pipeline81 = device0.createRenderPipeline({
+label: '\udaa0\u0afb\u{1fa5f}\u7540\u47a4\u96c8',
+layout: pipelineLayout11,
+multisample: {
+mask: 0x7c1f8c7f,
+},
+fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba16uint'}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {
+  format: 'rg11b10ufloat',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'zero'},
+alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'dst'},
+},
+  writeMask: 0
+}, {format: 'r8uint'}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2139,
+stencilWriteMask: 1167,
+depthBias: 3,
+depthBiasClamp: 83,
+},
+vertex: {
+  module: shaderModule9,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1544,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x2',
+offset: 184,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 672,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 80,
+shaderLocation: 6,
+}, {
+format: 'sint32',
+offset: 276,
+shaderLocation: 4,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'front',
+},
+});
+let video7 = await videoWithData();
+let imageBitmap11 = await createImageBitmap(imageBitmap10);
+let textureView50 = texture13.createView({label: '\u0880\u0074\u1a17\u7d03', baseMipLevel: 3});
+try {
+computePassEncoder40.setPipeline(pipeline40);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer4, 'uint32', 10764, 815);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture61,
+  mipLevel: 0,
+  origin: { x: 5, y: 2, z: 8 },
+  aspect: 'all',
+}, arrayBuffer12, /* required buffer size: 2362133 */
+{offset: 605, bytesPerRow: 2808, rowsPerImage: 29}, {width: 314, height: 0, depthOrArrayLayers: 30});
+} catch {}
+try {
+  await promise29;
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let bindGroupLayout30 = device0.createBindGroupLayout({
+label: '\u576f\u04e0\ucf51\u{1f95a}\u35cc\u2c49\u8090\u478f',
+entries: [],
+});
+let bindGroup25 = device0.createBindGroup({
+label: '\u028c\u0300\u{1f745}',
+layout: bindGroupLayout26,
+entries: [{
+binding: 423,
+resource: sampler14
+}],
+});
+let querySet47 = device0.createQuerySet({
+label: '\uf749\u8c61\u0d1d',
+type: 'occlusion',
+count: 771,
+});
+let texture62 = device0.createTexture({
+label: '\u{1fe6a}\u0086\uee39\u{1ffdf}\u058a\u{1fee2}\u0a35\u002a\u003c',
+size: {width: 2640, height: 192, depthOrArrayLayers: 1},
+mipLevelCount: 10,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x12-unorm', 'astc-12x12-unorm-srgb'],
+});
+let sampler38 = device0.createSampler({
+label: '\u3576\u0f94\u0c09\ua536\u0057\u036b\u{1fb8d}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 88.737,
+lodMaxClamp: 95.862,
+});
+try {
+computePassEncoder24.setBindGroup(1, bindGroup3, new Uint32Array(6127), 283, 0);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(24, 32, 16, 608, 72);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(4, buffer0, 8972, 6954);
+} catch {}
+try {
+querySet47.destroy();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 2, y: 1, z: 1 },
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer1), /* required buffer size: 776 */
+{offset: 776}, {width: 106, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline82 = await device0.createRenderPipelineAsync({
+label: '\u0aa2\u0715\u{1ff16}\udda5\u0b1e\u{1f8db}\u04a3\uec1d\u0e19\u02fb',
+layout: pipelineLayout9,
+fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint'}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-src-alpha'},
+},
+  writeMask: GPUColorWrite.BLUE
+}]
+},
+vertex: {
+  module: shaderModule8,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 1536,
+shaderLocation: 12,
+}, {
+format: 'uint32x3',
+offset: 288,
+shaderLocation: 15,
+}, {
+format: 'float32x2',
+offset: 1956,
+shaderLocation: 7,
+}, {
+format: 'uint32',
+offset: 808,
+shaderLocation: 11,
+}, {
+format: 'uint16x4',
+offset: 1588,
+shaderLocation: 2,
+}, {
+format: 'snorm8x2',
+offset: 622,
+shaderLocation: 0,
+}, {
+format: 'sint32x4',
+offset: 844,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 536,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x2',
+offset: 100,
+shaderLocation: 13,
+}, {
+format: 'float32x4',
+offset: 172,
+shaderLocation: 9,
+}, {
+format: 'float32x4',
+offset: 408,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 1408,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm16x2',
+offset: 992,
+shaderLocation: 6,
+}, {
+format: 'sint32x4',
+offset: 424,
+shaderLocation: 5,
+}, {
+format: 'snorm16x2',
+offset: 244,
+shaderLocation: 8,
+}, {
+format: 'unorm16x4',
+offset: 592,
+shaderLocation: 4,
+}, {
+format: 'float32',
+offset: 412,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 844,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x4',
+offset: 680,
+shaderLocation: 1,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: false,
+},
+});
+try {
+renderBundleEncoder36.drawIndexed(64);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer9, 'uint32', 6268, 8648);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+let promise30 = buffer14.mapAsync(GPUMapMode.READ);
+try {
+computePassEncoder34.pushDebugGroup('\ufec2');
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 13004, new DataView(new ArrayBuffer(46352)), 20060, 6664);
+} catch {}
+let commandEncoder45 = device0.createCommandEncoder();
+let textureView51 = texture48.createView({dimension: '2d'});
+try {
+renderBundleEncoder26.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder12.drawIndexed(40, 56, 56, -8, 0);
+} catch {}
+try {
+renderBundleEncoder12.drawIndirect(buffer15, 5744);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(buffer0, 37088, buffer12, 7012, 20);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder45.copyTextureToTexture({
+  texture: texture53,
+  mipLevel: 1,
+  origin: { x: 88, y: 16, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 536, y: 8, z: 1 },
+  aspect: 'all',
+}, {width: 496, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas11.width = 856;
+let sampler39 = device1.createSampler({
+label: '\uefc0\u5738\u0c8c\ud3e8\u{1f7a1}\u{1f9fc}\u0f24\u34dc\u0fcd',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 13.486,
+maxAnisotropy: 11,
+});
+let bindGroupLayout31 = device0.createBindGroupLayout({
+label: '\u366d\u4b8d\u0de8\u3381\u84e5\u0493',
+entries: [{
+binding: 26,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}, {
+binding: 748,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+}],
+});
+let querySet48 = device0.createQuerySet({
+label: '\u09d0\u0611\u068e\u{1f710}\u{1ffe4}\ub3eb\u1f96\u{1f90d}',
+type: 'occlusion',
+count: 789,
+});
+let sampler40 = device0.createSampler({
+label: '\u6a3d\u0b88',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 10.954,
+lodMaxClamp: 53.892,
+});
+try {
+computePassEncoder38.end();
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline32);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer12, 36716);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 3,
+  origin: { x: 10, y: 1, z: 19 },
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(56)), /* required buffer size: 209884 */
+{offset: 79, bytesPerRow: 213, rowsPerImage: 197}, {width: 22, height: 0, depthOrArrayLayers: 6});
+} catch {}
+let renderBundle57 = renderBundleEncoder12.finish();
+try {
+renderBundleEncoder43.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder36.draw(0, 64);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder28.resolveQuerySet(querySet25, 641, 77, buffer12, 8448);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 2092, new BigUint64Array(42947), 26101, 180);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: offscreenCanvas8,
+  origin: { x: 461, y: 467 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 7,
+  origin: { x: 0, y: 1, z: 3 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline83 = device0.createRenderPipeline({
+label: '\u{1f8c3}\u{1f641}\u2dd2\ua902',
+layout: pipelineLayout11,
+fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.RED}, {format: 'rgba8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg16float', writeMask: 0}, undefined, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'invert',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+failOp: 'keep',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilReadMask: 2811,
+stencilWriteMask: 3934,
+depthBias: 69,
+depthBiasSlopeScale: 24,
+},
+vertex: {
+  module: shaderModule16,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 772,
+attributes: [],
+},
+{
+arrayStride: 2024,
+attributes: [],
+},
+{
+arrayStride: 2024,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x4',
+offset: 1656,
+shaderLocation: 14,
+}, {
+format: 'uint32',
+offset: 1560,
+shaderLocation: 13,
+}],
+}
+]
+},
+});
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+canvas15.width = 623;
+let video8 = await videoWithData();
+let texture63 = device0.createTexture({
+label: '\u0510\uefca\u31c1\u096f\u{1fbbf}\ua793\ucf56\u{1f6cb}\u{1fd85}',
+size: {width: 438},
+mipLevelCount: 1,
+dimension: '1d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler41 = device0.createSampler({
+label: '\uc7d4\uc241\uf8aa\u{1fde5}\u0b2d\u921a\u3648\u5011\u07dc\uc6e6\u{1f9fa}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 32.633,
+lodMaxClamp: 91.349,
+compare: 'not-equal',
+});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup20, new Uint32Array(3795), 3106, 0);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder9.draw(24, 40, 0, 8);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer15, 5032);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+let pipeline84 = await device0.createRenderPipelineAsync({
+label: '\u{1fc87}\u8f90\u6efb\u{1f799}\ud511',
+layout: pipelineLayout8,
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint'}, {format: 'rg8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, undefined, {format: 'rg32float', writeMask: 0}, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilReadMask: 2105,
+stencilWriteMask: 813,
+depthBias: 80,
+depthBiasSlopeScale: 6,
+depthBiasClamp: 16,
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1196,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x4',
+offset: 292,
+shaderLocation: 14,
+}, {
+format: 'sint32x3',
+offset: 696,
+shaderLocation: 1,
+}, {
+format: 'snorm16x4',
+offset: 216,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 2016,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 638,
+shaderLocation: 8,
+}, {
+format: 'uint32x2',
+offset: 1312,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 688,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x2',
+offset: 316,
+shaderLocation: 5,
+}, {
+format: 'sint16x4',
+offset: 636,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 1368,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x4',
+offset: 1224,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 416,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32',
+offset: 288,
+shaderLocation: 10,
+}],
+}
+]
+},
+});
+let canvas17 = document.createElement('canvas');
+try {
+await adapter3.requestAdapterInfo();
+} catch {}
+let bindGroup26 = device0.createBindGroup({
+layout: bindGroupLayout1,
+entries: [{
+binding: 43,
+resource: externalTexture0
+}, {
+binding: 257,
+resource: externalTexture1
+}],
+});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup21, new Uint32Array(8949), 1991, 0);
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline43);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer15, 2400);
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 32, y: 36, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 24, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 48, height: 132, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder45.clearBuffer(buffer11, 23136, 31404);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+computePassEncoder34.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 31}
+*/
+{
+  source: img4,
+  origin: { x: 14, y: 40 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 4,
+  origin: { x: 5, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise31 = device0.createComputePipelineAsync({
+label: '\u{1ff3c}\u{1f987}\u2326\u004f\u{1f910}\u015e',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline85 = device0.createRenderPipeline({
+layout: pipelineLayout14,
+fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, undefined, {format: 'rg32float'}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'src'},
+},
+  writeMask: GPUColorWrite.BLUE
+}]
+},
+vertex: {
+  module: shaderModule8,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1904,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x4',
+offset: 1160,
+shaderLocation: 3,
+}, {
+format: 'snorm16x2',
+offset: 1860,
+shaderLocation: 4,
+}, {
+format: 'float16x4',
+offset: 1784,
+shaderLocation: 7,
+}, {
+format: 'snorm16x2',
+offset: 1644,
+shaderLocation: 0,
+}, {
+format: 'sint32x2',
+offset: 1264,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 788,
+attributes: [{
+format: 'uint32',
+offset: 236,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 904,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x2',
+offset: 722,
+shaderLocation: 13,
+}, {
+format: 'snorm16x4',
+offset: 484,
+shaderLocation: 12,
+}, {
+format: 'snorm8x4',
+offset: 148,
+shaderLocation: 14,
+}, {
+format: 'unorm10-10-10-2',
+offset: 748,
+shaderLocation: 6,
+}, {
+format: 'uint8x2',
+offset: 138,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 272,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x2',
+offset: 148,
+shaderLocation: 8,
+}, {
+format: 'sint16x4',
+offset: 136,
+shaderLocation: 1,
+}, {
+format: 'uint16x2',
+offset: 16,
+shaderLocation: 2,
+}, {
+format: 'unorm8x2',
+offset: 192,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 168,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 1560,
+shaderLocation: 10,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+},
+});
+let img13 = await imageWithData(41, 284, '#96cadc40', '#8ce5fb7f');
+let commandEncoder46 = device0.createCommandEncoder({label: '\u8fb7\u{1fb2d}\u34a5\udf95\udb8b\u06de'});
+try {
+renderBundleEncoder42.setBindGroup(1, bindGroup20, []);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline79);
+} catch {}
+let pipeline86 = await promise21;
+let videoFrame15 = new VideoFrame(img7, {timestamp: 0});
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+gc();
+try {
+canvas17.getContext('2d');
+} catch {}
+let buffer20 = device0.createBuffer({
+  label: '\u03c4\u782d\u{1f9aa}\u0f5d\u1ab8',
+  size: 4976,
+  usage: GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true
+});
+let textureView52 = texture48.createView({
+  label: '\u4176\u0205\u0d80\u{1fd70}\u90c5\u09d2\u0d08\u{1f84b}',
+  dimension: '2d-array',
+  baseArrayLayer: 0
+});
+let computePassEncoder43 = commandEncoder28.beginComputePass({label: '\u{1f68f}\u1941\ueb4b\u{1ff3a}\u{1f87f}\u91f3\u3d7d'});
+try {
+commandEncoder46.copyBufferToBuffer(buffer17, 13692, buffer18, 3656, 4900);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder46.copyTextureToBuffer({
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 40, y: 40, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 144 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 50432 */
+offset: 45424,
+bytesPerRow: 256,
+buffer: buffer1,
+}, {width: 72, height: 100, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder46.clearBuffer(buffer12);
+dissociateBuffer(device0, buffer12);
+} catch {}
+let pipeline87 = await device0.createComputePipelineAsync({
+label: '\u8bd8\u27a8',
+layout: 'auto',
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let renderBundleEncoder51 = device0.createRenderBundleEncoder({
+  label: '\u{1f68a}\u9d49\u7094\u358c\u07b1\ucae1\ufd11\udb65\u5244',
+  colorFormats: ['rgba8sint', 'rgba32sint', 'rg8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup0, new Uint32Array(2254), 1127, 0);
+} catch {}
+try {
+renderBundleEncoder20.drawIndirect(buffer12, 34196);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer6, 'uint16', 15702, 15727);
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(buffer12, 30444, buffer14, 8332, 2852);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder46.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 4,
+  origin: { x: 20, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture13,
+  mipLevel: 3,
+  origin: { x: 10, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 5, depthOrArrayLayers: 1});
+} catch {}
+let pipeline88 = device0.createRenderPipeline({
+label: '\u0176\u0d69\u0dec\u055b\u0421',
+layout: 'auto',
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint'}, {format: 'rg8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined, {format: 'rg32float'}, {
+  format: 'bgra8unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}]
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 52,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 16,
+shaderLocation: 4,
+}, {
+format: 'uint16x2',
+offset: 8,
+shaderLocation: 3,
+}, {
+format: 'float32x3',
+offset: 40,
+shaderLocation: 5,
+}, {
+format: 'float32x4',
+offset: 36,
+shaderLocation: 8,
+}, {
+format: 'sint8x4',
+offset: 44,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 876,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 16,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x2',
+offset: 8,
+shaderLocation: 7,
+}, {
+format: 'uint16x2',
+offset: 4,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 1912,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x3',
+offset: 1168,
+shaderLocation: 6,
+}, {
+format: 'uint8x2',
+offset: 956,
+shaderLocation: 14,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: false,
+},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+gc();
+try {
+renderBundleEncoder36.drawIndexed(0, 64, 8);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline79);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(buffer3, 55704, buffer10, 120, 2684);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder17.draw(40, 64, 40, 8);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(72, 72, 48, 192, 56);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer12, 26160);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(1, buffer0, 14864);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(buffer0, 15964, buffer11, 59276, 1672);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder45.clearBuffer(buffer14);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder45.resolveQuerySet(querySet15, 75, 7, buffer12, 10240);
+} catch {}
+try {
+  await promise30;
+} catch {}
+let shaderModule20 = device0.createShaderModule({
+label: '\u{1fc20}\ud790\u{1ff13}\u{1fac1}\ua1bc\u{1faa8}\u87d5\ud76d\u02c0\u{1feca}\u9c34',
+code: `@group(0) @binding(561)
+var<storage, read_write> function7: array<u32>;
+
+@compute @workgroup_size(1, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3<u32>,
+  @location(2) f1: vec4<i32>,
+  @location(7) f2: i32,
+  @location(6) f3: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(9) a0: vec2<i32>, @location(1) a1: vec2<i32>, @location(2) a2: vec2<f32>, @location(8) a3: vec3<f32>, @location(11) a4: vec3<f32>, @builtin(position) a5: vec4<f32>, @builtin(front_facing) a6: bool, @builtin(sample_mask) a7: u32, @builtin(sample_index) a8: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(2) f102: vec2<f32>,
+  @builtin(position) f103: vec4<f32>,
+  @location(8) f104: vec3<f32>,
+  @location(11) f105: vec3<f32>,
+  @location(1) f106: vec2<i32>,
+  @location(9) f107: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: f16, @location(14) a1: vec4<i32>, @location(5) a2: f16, @location(9) a3: vec2<f16>, @location(3) a4: vec2<f16>, @location(2) a5: vec4<f32>, @location(10) a6: vec4<f16>, @location(1) a7: vec3<f16>, @location(12) a8: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+});
+let commandBuffer14 = commandEncoder45.finish({
+label: '\u{1f79b}\uf7ce\uc77f\u0c25\u24fe\u05ed\ue3a9\ub6c9\u9c62\u1d9d',
+});
+let texture64 = device0.createTexture({
+label: '\u1df1\u96ba\u{1fffb}\ua888',
+size: [4895, 200, 21],
+mipLevelCount: 5,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-5x5-unorm-srgb', 'astc-5x5-unorm'],
+});
+let computePassEncoder44 = commandEncoder46.beginComputePass({label: '\uf142\u{1fd75}\u5ecb\u0f8d\u04e3\u{1f633}\u0d11\u1b5b'});
+try {
+computePassEncoder22.dispatchWorkgroups(2);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline44);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer13,
+]);
+} catch {}
+let pipeline89 = await device0.createComputePipelineAsync({
+layout: pipelineLayout14,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let adapter4 = await navigator.gpu.requestAdapter({
+});
+let querySet49 = device0.createQuerySet({
+label: '\u03f3\uadde\u{1f86c}\u1d08\u{1f70f}\u1615\u{1ffff}\udfe4\uc6ba\u15b2',
+type: 'occlusion',
+count: 2670,
+});
+let sampler42 = device0.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 83.373,
+});
+try {
+computePassEncoder33.setPipeline(pipeline78);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(4, buffer0, 28624);
+} catch {}
+let promise32 = adapter4.requestAdapterInfo();
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let querySet50 = device1.createQuerySet({
+label: '\u473c\u09f0\u{1f912}\ud4bd\u26b1\u0381\u04b5\u{1fcda}\u996b',
+type: 'occlusion',
+count: 2165,
+});
+let textureView53 = texture60.createView({
+  label: '\u{1fe54}\uab92\ud2ea\u7a3a\u045b',
+  format: 'astc-5x5-unorm-srgb',
+  baseMipLevel: 1,
+  mipLevelCount: 6,
+  baseArrayLayer: 96,
+  arrayLayerCount: 69
+});
+let sampler43 = device0.createSampler({
+label: '\u0bc5\ua448',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 89.689,
+lodMaxClamp: 92.638,
+compare: 'always',
+});
+try {
+renderBundleEncoder20.drawIndexed(48, 80, 40, -784, 72);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 6972, new BigUint64Array(38920), 17405, 356);
+} catch {}
+let bindGroupLayout32 = device0.createBindGroupLayout({
+label: '\u{1f965}\uecf9\uaef2\ue389\u{1f722}\u{1f901}\u{1f7a0}\u0b70',
+entries: [{
+binding: 730,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+}],
+});
+let querySet51 = device0.createQuerySet({
+label: '\ufc61\udae7',
+type: 'occlusion',
+count: 1978,
+});
+try {
+computePassEncoder40.dispatchWorkgroups(3, 1);
+} catch {}
+try {
+computePassEncoder43.end();
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(2, bindGroup3, []);
+} catch {}
+try {
+renderBundleEncoder17.draw(24, 80);
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(buffer17, 3444, buffer12, 24992, 4676);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer14);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+computePassEncoder33.pushDebugGroup('\u3f13');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 31}
+*/
+{
+  source: img7,
+  origin: { x: 234, y: 83 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 2 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 9, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise28;
+} catch {}
+let promise33 = navigator.gpu.requestAdapter({
+});
+let texture65 = device0.createTexture({
+label: '\u067e\u3cf6\u{1fce0}\u{1f730}\u7a4c\ue6ca\u{1fdc4}',
+size: [204, 100, 1],
+mipLevelCount: 2,
+sampleCount: 1,
+dimension: '2d',
+format: 'astc-12x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x10-unorm-srgb', 'astc-12x10-unorm'],
+});
+let computePassEncoder45 = commandEncoder28.beginComputePass();
+try {
+computePassEncoder26.setPipeline(pipeline69);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(8, 64, 40, 320);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 13420);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 3,
+  origin: { x: 0, y: 5, z: 0 },
+  aspect: 'all',
+}, new DataView(arrayBuffer8), /* required buffer size: 390 */
+{offset: 390}, {width: 20, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas13 = new OffscreenCanvas(813, 858);
+let canvas18 = document.createElement('canvas');
+let querySet52 = device0.createQuerySet({
+label: '\uc205\ud1b0\ufc9d',
+type: 'occlusion',
+count: 3066,
+});
+let renderBundleEncoder52 = device0.createRenderBundleEncoder({
+  label: '\u2a3c\u03b1\u0636\u06ac\u00ff',
+  colorFormats: ['bgra8unorm-srgb', 'rgba16uint', 'r8uint', 'rg11b10ufloat', 'r8uint'],
+  depthReadOnly: true
+});
+let renderBundle58 = renderBundleEncoder5.finish({});
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 29388);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer4, 'uint32');
+} catch {}
+try {
+window.someLabel = externalTexture2.label;
+} catch {}
+let bindGroup27 = device0.createBindGroup({
+label: '\u7c6c\u{1fbb2}\u072b\u0495\u5843\u0627\u{1fab8}\u{1ffe5}\u0b3d',
+layout: bindGroupLayout1,
+entries: [{
+binding: 257,
+resource: externalTexture1
+}, {
+binding: 43,
+resource: externalTexture2
+}],
+});
+let querySet53 = device0.createQuerySet({
+label: '\u{1ffb9}\u1b43\u1c86\u075b\u0dbd\ub40a',
+type: 'occlusion',
+count: 963,
+});
+try {
+renderBundleEncoder47.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexedIndirect(buffer15, 4380);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 5, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 402, y: 268 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 6,
+  origin: { x: 2, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline90 = device0.createComputePipeline({
+label: '\u{1f8ef}\u238b',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+  await promise32;
+} catch {}
+let commandEncoder47 = device0.createCommandEncoder({label: '\u2a7b\u{1f7f7}\u0dc7\uc06d\u{1f709}\u4a10\ue5cd'});
+let computePassEncoder46 = commandEncoder47.beginComputePass({});
+let renderBundle59 = renderBundleEncoder11.finish({label: '\u05d7\u{1fe8f}\u{1fb11}\u0fc7'});
+try {
+renderBundleEncoder34.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder36.draw(16, 8, 0, 32);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 12084);
+} catch {}
+canvas0.width = 471;
+let querySet54 = device0.createQuerySet({
+label: '\u{1fef8}\u052c\ua887\u2750\u0f8f\u062c\u07e4\u9f35\u05c6\u9c82\ue0f2',
+type: 'occlusion',
+count: 1622,
+});
+try {
+computePassEncoder33.popDebugGroup();
+} catch {}
+let canvas19 = document.createElement('canvas');
+let promise34 = adapter1.requestAdapterInfo();
+let sampler44 = device0.createSampler({
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 1.194,
+lodMaxClamp: 92.453,
+});
+try {
+renderBundleEncoder36.drawIndexed(48, 72, 24);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer12, 20984);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 1, depthOrArrayLayers: 15}
+*/
+{
+  source: video2,
+  origin: { x: 2, y: 16 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 5,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 8, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+document.body.prepend(canvas14);
+let bindGroupLayout33 = device0.createBindGroupLayout({
+label: '\u{1fcfd}\u0a09\u5210\u{1f79c}\u05da\u0a48\udec6',
+entries: [{
+binding: 989,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}, {
+binding: 910,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba16float', access: 'write-only', viewDimension: '1d' },
+}, {
+binding: 913,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '2d-array' },
+}],
+});
+pseudoSubmit(device0, commandEncoder34);
+let textureView54 = texture33.createView({label: '\u1b03\u0322\u5ca9\ua673\u{1f798}', dimension: '2d-array', mipLevelCount: 1});
+try {
+renderBundleEncoder36.drawIndexed(72, 8, 80, 528, 72);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 34444);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(3, buffer6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 1, depthOrArrayLayers: 125}
+*/
+{
+  source: videoFrame14,
+  origin: { x: 288, y: 33 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 2,
+  origin: { x: 10, y: 0, z: 55 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 26, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas20 = document.createElement('canvas');
+try {
+adapter2.label = '\u{1fcea}\u{1fc16}\u9af9\u{1fe52}';
+} catch {}
+try {
+canvas19.getContext('2d');
+} catch {}
+let querySet55 = device0.createQuerySet({
+label: '\u{1fef7}\ua8ea\ue6fa\u972b\u{1ffbd}\u87fa\u340d\u0cf8',
+type: 'occlusion',
+count: 1016,
+});
+pseudoSubmit(device0, commandEncoder44);
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder36.draw(8, 32, 32, 0);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(40, 8);
+} catch {}
+try {
+renderBundleEncoder36.drawIndirect(buffer15, 1360);
+} catch {}
+try {
+computePassEncoder35.insertDebugMarker('\u{1fb2e}');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 14952, new Float32Array(52055), 4694, 1288);
+} catch {}
+let gpuCanvasContext14 = offscreenCanvas13.getContext('webgpu');
+let img14 = await imageWithData(84, 264, '#03b02af8', '#37d26940');
+try {
+renderBundleEncoder52.setPipeline(pipeline79);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 320, height: 2, depthOrArrayLayers: 503}
+*/
+{
+  source: canvas4,
+  origin: { x: 186, y: 51 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: { x: 216, y: 0, z: 185 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 98, height: 2, depthOrArrayLayers: 1});
+} catch {}
+let pipeline91 = await device0.createComputePipelineAsync({
+label: '\uaeda\u{1f953}',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let promise35 = device0.createRenderPipelineAsync({
+label: '\ud0a8\u13ec\u8943\ua9df\u572c\u0e2b\u0eb2\u0fb9\u{1f6dc}',
+layout: 'auto',
+fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint'}, {format: 'r16uint'}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}]
+},
+vertex: {
+  module: shaderModule10,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 484,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x2',
+offset: 292,
+shaderLocation: 6,
+}, {
+format: 'uint16x4',
+offset: 72,
+shaderLocation: 15,
+}, {
+format: 'sint8x2',
+offset: 4,
+shaderLocation: 0,
+}, {
+format: 'snorm8x2',
+offset: 132,
+shaderLocation: 7,
+}, {
+format: 'float16x2',
+offset: 376,
+shaderLocation: 4,
+}, {
+format: 'uint32x4',
+offset: 308,
+shaderLocation: 3,
+}, {
+format: 'unorm16x2',
+offset: 160,
+shaderLocation: 8,
+}, {
+format: 'uint8x4',
+offset: 416,
+shaderLocation: 9,
+}, {
+format: 'uint32x3',
+offset: 436,
+shaderLocation: 14,
+}, {
+format: 'unorm16x4',
+offset: 168,
+shaderLocation: 1,
+}, {
+format: 'float32x4',
+offset: 356,
+shaderLocation: 11,
+}, {
+format: 'float32x4',
+offset: 332,
+shaderLocation: 12,
+}, {
+format: 'sint16x2',
+offset: 296,
+shaderLocation: 13,
+}, {
+format: 'snorm8x4',
+offset: 300,
+shaderLocation: 10,
+}, {
+format: 'snorm8x2',
+offset: 134,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 20,
+attributes: [{
+format: 'sint32x2',
+offset: 12,
+shaderLocation: 2,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: false,
+},
+});
+let shaderModule21 = device0.createShaderModule({
+label: '\u03ca\u0bdd\u1d4f\u583b\u4787\u70bc\u7608\u80bf\u00a1\u2053',
+code: `@group(0) @binding(561)
+var<storage, read_write> field10: array<u32>;
+@group(1) @binding(788)
+var<storage, read_write> type10: array<u32>;
+@group(1) @binding(803)
+var<storage, read_write> parameter8: array<u32>;
+@group(3) @binding(674)
+var<storage, read_write> global3: array<u32>;
+@group(2) @binding(20)
+var<storage, read_write> parameter9: array<u32>;
+
+@compute @workgroup_size(7, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(1) f1: vec4<i32>,
+  @location(3) f2: vec2<f32>,
+  @location(2) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(position) a2: vec4<f32>, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S16 {
+  @location(11) f0: vec2<i32>,
+  @location(0) f1: vec3<u32>,
+  @location(13) f2: vec3<f32>,
+  @location(5) f3: vec3<f16>,
+  @location(1) f4: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec3<i32>, a1: S16, @location(15) a2: vec4<i32>, @location(12) a3: vec4<u32>, @location(14) a4: vec2<i32>, @location(8) a5: vec2<i32>, @location(6) a6: vec4<u32>, @location(9) a7: vec2<i32>, @location(3) a8: vec3<u32>, @location(4) a9: vec4<f32>, @location(2) a10: vec4<f16>, @location(10) a11: u32, @builtin(instance_index) a12: u32, @builtin(vertex_index) a13: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let renderBundle60 = renderBundleEncoder18.finish({label: '\uf11c\u4855\u3a89\u523a\udc19\ua5d2\u084b\u{1f84a}'});
+try {
+renderBundleEncoder52.draw(8, 32, 72, 56);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: { x: 123, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 577 */
+{offset: 577}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline92 = device0.createComputePipeline({
+label: '\u{1fc43}\u{1f674}\u7cb9\u01ae',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+},
+});
+let pipeline93 = device0.createRenderPipeline({
+label: '\ud23e\u0d50\u{1ffc7}\u{1f731}\u0e0e\u05dc\ue0fa\u984c',
+layout: pipelineLayout16,
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {format: 'rg8sint', writeMask: GPUColorWrite.BLUE}, undefined, {format: 'rg32float'}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'one-minus-src-alpha'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilReadMask: 721,
+stencilWriteMask: 1456,
+depthBiasSlopeScale: 10,
+depthBiasClamp: 33,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 260,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 1484,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 168,
+attributes: [{
+format: 'float32',
+offset: 28,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+try {
+canvas18.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder48 = device0.createCommandEncoder({label: '\u{1f942}\u8090\u{1f9bd}\ud0b9\u51e6\u9c43\u07f7\u0514'});
+let querySet56 = device0.createQuerySet({
+label: '\u0981\u0721\u3a30\u3e08\ub1d5',
+type: 'occlusion',
+count: 3823,
+});
+let texture66 = device0.createTexture({
+label: '\u970f\u0fa4',
+size: {width: 438},
+dimension: '1d',
+format: 'rgba8sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8sint', 'rgba8sint', 'rgba8sint'],
+});
+let renderBundleEncoder53 = device0.createRenderBundleEncoder({
+  label: '\u{1fa60}\u8287\ue52f\ub1bd\u9efd\u{1f6e5}\u19e4',
+  colorFormats: ['rg8uint', 'r16uint', 'rgba16uint', 'rgba16sint']
+});
+let renderBundle61 = renderBundleEncoder0.finish();
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup3, new Uint32Array(8196), 5335, 0);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexedIndirect(buffer12, 8476);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(1, buffer0, 32380, 472);
+} catch {}
+let promise36 = device0.createComputePipelineAsync({
+label: '\u8044\u2925\uc6f9',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let gpuCanvasContext15 = canvas20.getContext('webgpu');
+canvas3.width = 392;
+let bindGroup28 = device1.createBindGroup({
+label: '\uca66\u687e\u{1fda9}\u0778\u3151\u8934',
+layout: bindGroupLayout27,
+entries: [],
+});
+let commandEncoder49 = device1.createCommandEncoder({label: '\uea20\u071a\u0c80\ufb4a\u05ba\u07c9'});
+let computePassEncoder47 = commandEncoder49.beginComputePass({label: '\u087e\u570e\uff96\ub7ac\u0174\u0285\u{1fb05}\u0dd4'});
+try {
+adapter0.label = '\uabcb\u95c3\u06fc\u3267\u{1ffe8}\u058c';
+} catch {}
+try {
+  await promise34;
+} catch {}
+let commandEncoder50 = device0.createCommandEncoder({});
+let commandBuffer15 = commandEncoder50.finish({
+label: '\uc86b\u{1fd8b}\u682a\u4692\u{1fd30}\uae46\u{1fe9d}\u{1f7e4}\ue87c',
+});
+let textureView55 = texture23.createView({label: '\u126a\ud570\u6d5a\u{1ff42}\uf7bd\uaee2\u05ee', dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder48 = commandEncoder48.beginComputePass({label: '\u07ef\u6bbd'});
+let renderBundle62 = renderBundleEncoder12.finish({label: '\uaba1\u006b\u2bfc\u{1f7c3}\udbb7\u8888\uf2b4'});
+try {
+computePassEncoder40.dispatchWorkgroups(1, 5, 1);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(6, buffer0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+computePassEncoder27.pushDebugGroup('\u0691');
+} catch {}
+let buffer21 = device0.createBuffer({label: '\u8f8c\u521a', size: 43968, usage: GPUBufferUsage.MAP_WRITE, mappedAtCreation: true});
+let texture67 = device0.createTexture({
+size: {width: 876},
+dimension: '1d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundleEncoder54 = device0.createRenderBundleEncoder({
+  colorFormats: [undefined, 'r32float', 'rgba16sint', 'r16float', 'rgb10a2uint', 'rg16uint', 'r32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle63 = renderBundleEncoder4.finish({label: '\u7791\uca86\ufeaa\ue414\uc89e\u{1f741}\u0a9d\u6f37\u{1fcc2}\u034a'});
+try {
+renderBundleEncoder49.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder36.draw(24, 56, 72, 16);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexed(56, 80, 80, -176, 64);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline79);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 9480, new BigUint64Array(28882), 12487, 168);
+} catch {}
+let canvas21 = document.createElement('canvas');
+let imageData8 = new ImageData(92, 228);
+try {
+canvas21.getContext('webgpu');
+} catch {}
+try {
+computePassEncoder47.setBindGroup(2, bindGroup28, new Uint32Array(6872), 5385, 0);
+} catch {}
+document.body.prepend(video2);
+let shaderModule22 = device0.createShaderModule({
+label: '\ud7e0\u04a6\u0cab\u0537\u{1f8b4}\u8db9\u08eb\u6c65\ubf1c\u969e',
+code: `@group(2) @binding(934)
+var<storage, read_write> i7: array<u32>;
+@group(1) @binding(20)
+var<storage, read_write> i8: array<u32>;
+@group(2) @binding(289)
+var<storage, read_write> global4: array<u32>;
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec2<f32>,
+  @location(1) f1: vec3<i32>,
+  @location(0) f2: u32,
+  @location(4) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @location(10) a1: vec3<f32>, @location(7) a2: vec4<f16>, @builtin(sample_mask) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f108: vec4<f32>,
+  @location(7) f109: vec4<f16>,
+  @location(10) f110: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec2<f16>, @location(7) a1: vec3<i32>, @location(2) a2: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder51 = device0.createCommandEncoder({label: '\u2586\u{1fbe4}\u5b1d\ue18e\u0c68\u5dea'});
+let renderBundleEncoder55 = device0.createRenderBundleEncoder({
+  label: '\ube9e\u0a03\u0c2d\uf71c\u444a\u490f\u5627\u06df',
+  colorFormats: ['r8unorm', 'rgb10a2uint', 'rg16sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline79);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder51.clearBuffer(buffer8, 9428, 3636);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder51.resolveQuerySet(querySet13, 0, 0, buffer12, 9472);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 10356, new DataView(new ArrayBuffer(8302)), 4274, 816);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+window.someLabel = externalTexture2.label;
+} catch {}
+let texture68 = device0.createTexture({
+size: {width: 40, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+computePassEncoder48.setPipeline(pipeline31);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer12, 33648);
+} catch {}
+try {
+commandEncoder51.clearBuffer(buffer18);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer14,
+]);
+} catch {}
+gc();
+let buffer22 = device0.createBuffer({
+  label: '\u2661\ub116\ubd0d\u05f4\u4851',
+  size: 2082,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX
+});
+try {
+renderBundleEncoder36.draw(48, 64, 56, 0);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexedIndirect(buffer12, 8104);
+} catch {}
+try {
+renderBundleEncoder51.setVertexBuffer(1, buffer6, 24180, 5151);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 269 */
+{offset: 269}, {width: 20, height: 0, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(video6);
+let buffer23 = device0.createBuffer({
+  label: '\u01e8\u4b7f\u9809\u0495\u02be',
+  size: 22412,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true
+});
+let texture69 = device0.createTexture({
+label: '\u4495\uee5b\u00f1\ucea6\u48eb\u3bbd\u00a9\u52ef\u5756',
+size: {width: 438, height: 1, depthOrArrayLayers: 679},
+mipLevelCount: 1,
+sampleCount: 1,
+dimension: '3d',
+format: 'rg8uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundleEncoder56 = device0.createRenderBundleEncoder({
+  label: '\u0680\u0a30',
+  colorFormats: [undefined, 'r16uint', 'rg32uint', 'rg16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+let renderBundle64 = renderBundleEncoder11.finish({label: '\ufbbd\u{1f667}\u0089\u{1fe55}\u0b8b\u16b0'});
+let sampler45 = device0.createSampler({
+label: '\u9de5\u0a19\u07ed\u0bb7\u5c29\ue2d6\u660c\u0051',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 99.169,
+});
+try {
+commandEncoder51.resolveQuerySet(querySet2, 461, 480, buffer12, 12032);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x10-unorm-srgb', 'astc-12x10-unorm', 'rgba16float', 'rgba16float'],
+});
+} catch {}
+let pipeline94 = device0.createComputePipeline({
+label: '\u269a\u96fb\u9c50\u0d59\u0187',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule21,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let commandEncoder52 = device0.createCommandEncoder({label: '\u{1fa41}\u04b2\u4397\uea1b\uf398'});
+pseudoSubmit(device0, commandEncoder19);
+let texture70 = device0.createTexture({
+label: '\u1577\uafc8',
+size: {width: 330},
+dimension: '1d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r16sint', 'r16sint'],
+});
+let renderBundle65 = renderBundleEncoder16.finish({});
+try {
+renderBundleEncoder48.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexed(8, 24, 80, 160);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexedIndirect(buffer12, 21536);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer9, 'uint32');
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(3, buffer0, 30784);
+} catch {}
+try {
+commandEncoder51.copyBufferToBuffer(buffer3, 12168, buffer4, 4120, 3612);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth32float-stencil8', 'etc2-rgba8unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer15,
+]);
+} catch {}
+let bindGroupLayout34 = device0.createBindGroupLayout({
+label: '\u{1f867}\u7533\uc2ec\u7870\u00b8',
+entries: [{
+binding: 55,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32uint', access: 'write-only', viewDimension: '3d' },
+}, {
+binding: 222,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+}, {
+binding: 926,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}],
+});
+let renderBundleEncoder57 = device0.createRenderBundleEncoder({
+  label: '\u062a\u0719\u{1fe79}\u843f\u62b1\u1f7a\uc87e\u0c28\ua44b',
+  colorFormats: ['bgra8unorm-srgb', 'rgba16uint', 'r8uint', 'rg11b10ufloat', 'r8uint']
+});
+let sampler46 = device0.createSampler({
+addressModeU: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 31.945,
+lodMaxClamp: 82.466,
+maxAnisotropy: 4,
+});
+try {
+computePassEncoder22.dispatchWorkgroups(4, 5, 3);
+} catch {}
+try {
+computePassEncoder30.end();
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(3, bindGroup1, new Uint32Array(8539), 3298, 0);
+} catch {}
+try {
+commandEncoder51.copyBufferToBuffer(buffer23, 7348, buffer8, 9420, 3040);
+dissociateBuffer(device0, buffer23);
+dissociateBuffer(device0, buffer8);
+} catch {}
+let pipeline95 = await promise35;
+let shaderModule23 = device0.createShaderModule({
+label: '\u{1ff69}\u0a2f\u0e8d\u3efc\u{1fd8a}\ued95\u908d',
+code: `@group(0) @binding(43)
+var<storage, read_write> parameter10: array<u32>;
+@group(0) @binding(257)
+var<storage, read_write> parameter11: array<u32>;
+
+@compute @workgroup_size(5, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S18 {
+  @builtin(sample_mask) f0: u32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(1) f1: vec4<u32>,
+  @location(3) f2: vec3<f32>,
+  @location(4) f3: u32,
+  @location(2) f4: vec2<u32>
+}
+
+@fragment
+fn fragment0(@location(4) a0: vec2<u32>, @location(0) a1: vec4<f16>, @location(7) a2: u32, a3: S18, @builtin(sample_index) a4: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S17 {
+  @location(9) f0: vec4<f32>,
+  @location(7) f1: vec2<f16>
+}
+struct VertexOutput0 {
+  @location(0) f111: vec4<f16>,
+  @location(4) f112: vec2<u32>,
+  @location(7) f113: u32,
+  @builtin(position) f114: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(0) a0: vec2<f16>, @location(8) a1: vec2<i32>, a2: S17, @location(6) a3: vec4<i32>, @location(10) a4: vec4<u32>, @location(12) a5: vec2<f16>, @location(5) a6: vec2<u32>, @location(15) a7: vec2<u32>, @location(14) a8: vec3<i32>, @location(2) a9: vec4<f32>, @location(4) a10: vec3<i32>, @location(13) a11: vec2<f16>, @builtin(instance_index) a12: u32, @location(3) a13: vec3<f16>, @builtin(vertex_index) a14: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let computePassEncoder49 = commandEncoder31.beginComputePass({label: '\u9e67\u67f4\u04f8'});
+try {
+computePassEncoder45.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexed(24, 0, 72, 672, 8);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(3, buffer0);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+try {
+commandEncoder52.copyTextureToBuffer({
+  texture: texture62,
+  mipLevel: 0,
+  origin: { x: 636, y: 60, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 272 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 7232 */
+offset: 3888,
+bytesPerRow: 512,
+rowsPerImage: 72,
+buffer: buffer16,
+}, {width: 204, height: 84, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder51.copyTextureToTexture({
+  texture: texture48,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 5, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let video9 = await videoWithData();
+let renderBundle66 = renderBundleEncoder49.finish({label: '\u{1f962}\u3633\u1788'});
+try {
+computePassEncoder37.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder36.draw(8, 64, 72, 64);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(80);
+} catch {}
+try {
+renderBundleEncoder26.drawIndirect(buffer22, 276);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(6, buffer0, 18452);
+} catch {}
+try {
+commandEncoder52.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 5,
+  origin: { x: 10, y: 5, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: { x: 10, y: 45, z: 1 },
+  aspect: 'all',
+}, {width: 40, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline96 = await device0.createRenderPipelineAsync({
+label: '\u524b\u5d45\ua322\u0393',
+layout: pipelineLayout14,
+fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  targets: [undefined, {format: 'r32float', writeMask: 0}, {format: 'rgba16sint', writeMask: 0}, {format: 'r16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.RED}, {format: 'rg16uint', writeMask: 0}, {format: 'r32sint'}]
+},
+vertex: {
+  module: shaderModule19,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1840,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x2',
+offset: 932,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 1192,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 842,
+shaderLocation: 12,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+document.body.prepend(img10);
+let imageBitmap12 = await createImageBitmap(offscreenCanvas2);
+let offscreenCanvas14 = new OffscreenCanvas(570, 1016);
+let shaderModule24 = device0.createShaderModule({
+label: '\u540b\u246f\u6eab\u{1fa66}\ufd77\u3a83\u0c7a',
+code: `@group(0) @binding(561)
+var<storage, read_write> global5: array<u32>;
+
+@compute @workgroup_size(7, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<u32>,
+  @location(2) f1: vec4<i32>,
+  @location(0) f2: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let texture71 = device0.createTexture({
+label: '\u06db\u{1ffc4}\u{1fb66}\u{1f9fd}\u703c\u{1fdfb}\u52cb\u{1fa9f}\u{1f9a0}\u{1f725}\u4528',
+size: {width: 2640, height: 192, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'etc2-rgb8a1unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView56 = texture31.createView({
+  label: '\u88bb\u6928\u0427\u378e\udd8f\u02fb\u436f\u{1fac2}\u0c6d',
+  format: 'astc-8x6-unorm',
+  baseArrayLayer: 0
+});
+let computePassEncoder50 = commandEncoder51.beginComputePass({label: '\u0f69\u{1fd30}\uecce\uc25f\ue217\u{1ff84}'});
+let renderBundle67 = renderBundleEncoder48.finish({label: '\u{1ff38}\u0777\u0215'});
+let sampler47 = device0.createSampler({
+label: '\u{1f8c2}\ucbed\uf289\u{1ffa1}\u013b\u8049\uf38f\u589a\ua335\u{1fdcd}',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 10.030,
+lodMaxClamp: 43.851,
+maxAnisotropy: 7,
+});
+try {
+renderBundleEncoder30.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder20.draw(16, 48, 80, 72);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(0, buffer6);
+} catch {}
+try {
+commandEncoder52.copyTextureToBuffer({
+  texture: texture47,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 62824 */
+offset: 62820,
+buffer: buffer16,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(querySet30, 760, 1233, buffer12, 2560);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float'],
+colorSpace: 'srgb',
+});
+} catch {}
+let pipeline97 = await device0.createComputePipelineAsync({
+label: '\u{1fdd9}\u0b22\u4773\u5ec2\uef5f\u0231\u0909\ubb15\u78b9\ucc52',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+},
+});
+try {
+renderBundleEncoder56.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder52.draw(32, 16);
+} catch {}
+try {
+renderBundleEncoder30.drawIndirect(buffer22, 556);
+} catch {}
+let commandEncoder53 = device0.createCommandEncoder({label: '\u{1fd7f}\u327a'});
+let texture72 = device0.createTexture({
+label: '\u{1fecc}\u0418\u061d\u{1fdb5}\u06c5\u{1f75e}\u7a7b\u0886\uecf3\ua140',
+size: [160],
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rg32sint', 'rg32sint'],
+});
+try {
+computePassEncoder22.dispatchWorkgroups(1, 1, 3);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(3, bindGroup15, new Uint32Array(1946), 1615, 0);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexed(8, 40, 16, 608, 16);
+} catch {}
+try {
+renderBundleEncoder52.drawIndirect(buffer22, 808);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline79);
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(buffer17, 9988, buffer10, 8040, 4);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+computePassEncoder27.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 769 */
+{offset: 753}, {width: 8, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandBuffer16 = commandEncoder53.finish({
+label: '\u04ac\u0d39',
+});
+let textureView57 = texture12.createView({label: '\u0130\uae8c\u77ba\u14f0\u962c\u0bbd\u7408\ueb56\u2c8d\u03e3\ud1ae', baseMipLevel: 7});
+try {
+renderBundleEncoder26.drawIndexed(40, 8, 24, -368, 32);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer12, 26868);
+} catch {}
+try {
+buffer18.destroy();
+} catch {}
+let pipeline98 = await device0.createRenderPipelineAsync({
+label: '\u0d76\u31d6\u905b\u{1fcbc}',
+layout: pipelineLayout14,
+fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'src-alpha', dstFactor: 'zero'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'r8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {
+  format: 'rg11b10ufloat',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'dst-alpha', dstFactor: 'zero'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED
+}, {format: 'r8uint'}]
+},
+vertex: {
+  module: shaderModule9,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 92,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x4',
+offset: 20,
+shaderLocation: 12,
+}, {
+format: 'sint32x4',
+offset: 28,
+shaderLocation: 4,
+}, {
+format: 'unorm8x4',
+offset: 84,
+shaderLocation: 6,
+}],
+}
+]
+},
+});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+gc();
+try {
+await adapter4.requestAdapterInfo();
+} catch {}
+pseudoSubmit(device0, commandEncoder20);
+try {
+renderBundleEncoder17.drawIndexed(32, 0, 80, 512, 24);
+} catch {}
+try {
+renderBundleEncoder57.setVertexBuffer(1, buffer15, 5960);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+commandEncoder52.copyTextureToBuffer({
+  texture: texture47,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 39424 */
+offset: 39420,
+rowsPerImage: 128,
+buffer: buffer16,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(querySet45, 840, 119, buffer12, 11520);
+} catch {}
+try {
+renderBundleEncoder17.insertDebugMarker('\u74b3');
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer16,
+]);
+} catch {}
+let pipeline99 = device0.createRenderPipeline({
+label: '\u0f4a\u001d\u81a8\u12ea\u{1fa21}\u9582\u{1fc21}\u{1fe3f}\u8c46',
+layout: pipelineLayout7,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: 0}, {format: 'rg8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, undefined, {format: 'rg32float', writeMask: 0}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-src'},
+alpha: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'zero'},
+},
+  writeMask: 0
+}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3341,
+stencilWriteMask: 1457,
+depthBias: 80,
+depthBiasClamp: 96,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1316,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 564,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 840,
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 300,
+shaderLocation: 5,
+}, {
+format: 'uint32x4',
+offset: 708,
+shaderLocation: 12,
+}, {
+format: 'float32',
+offset: 128,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 1172,
+attributes: [],
+},
+{
+arrayStride: 1856,
+attributes: [],
+},
+{
+arrayStride: 1200,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint16x4',
+offset: 1080,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 156,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1132,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 752,
+shaderLocation: 14,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'back',
+},
+});
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let shaderModule25 = device0.createShaderModule({
+label: '\u9e54\u5086\u0758',
+code: `@group(1) @binding(43)
+var<storage, read_write> type11: array<u32>;
+@group(3) @binding(561)
+var<storage, read_write> type12: array<u32>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(8) a0: vec4<f16>, @location(1) a1: f32, @location(3) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(5) f115: vec3<i32>,
+  @location(9) f116: vec4<i32>,
+  @location(11) f117: vec4<f32>,
+  @location(4) f118: vec2<u32>,
+  @location(0) f119: vec2<u32>,
+  @location(8) f120: vec4<f16>,
+  @builtin(position) f121: vec4<f32>,
+  @location(12) f122: vec2<f16>,
+  @location(14) f123: vec3<f32>,
+  @location(1) f124: f32,
+  @location(6) f125: f32,
+  @location(2) f126: vec4<f32>,
+  @location(15) f127: vec4<i32>,
+  @location(10) f128: vec3<u32>,
+  @location(3) f129: u32
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroup29 = device0.createBindGroup({
+layout: bindGroupLayout1,
+entries: [{
+binding: 257,
+resource: externalTexture2
+}, {
+binding: 43,
+resource: externalTexture2
+}],
+});
+let commandEncoder54 = device0.createCommandEncoder({label: '\u0c9b\u2efa\uc1cc\u{1f77e}\u7539\u{1ff63}\u{1f642}\u0f84\u{1fd10}'});
+let textureView58 = texture65.createView({
+  label: '\u6aca\u90b8\u{1f6c6}\u00d9\u9cd0\u6b44\ufb25\u{1f98e}',
+  dimension: '2d-array',
+  baseMipLevel: 0,
+  mipLevelCount: 1
+});
+let renderBundleEncoder58 = device0.createRenderBundleEncoder({
+  label: '\u{1fd49}\uba14\ua262\u6b8b',
+  colorFormats: ['rg16uint', 'rg32float', 'r16uint', 'rg16sint'],
+  depthReadOnly: true
+});
+try {
+computePassEncoder40.dispatchWorkgroupsIndirect(buffer22, 980);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 7324, new DataView(new ArrayBuffer(22664)), 17644);
+} catch {}
+let pipeline100 = device0.createRenderPipeline({
+label: '\u2f67\u0a6b\u3842\ubf4d\u094a\u05be\u18ed',
+layout: pipelineLayout0,
+fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint'}, {format: 'rg8sint'}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALPHA}, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALL}]
+},
+vertex: {
+  module: shaderModule8,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 184,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 66,
+shaderLocation: 9,
+}, {
+format: 'float32x3',
+offset: 8,
+shaderLocation: 0,
+}, {
+format: 'float16x4',
+offset: 100,
+shaderLocation: 10,
+}, {
+format: 'unorm8x4',
+offset: 128,
+shaderLocation: 12,
+}, {
+format: 'sint32',
+offset: 8,
+shaderLocation: 5,
+}, {
+format: 'sint32x2',
+offset: 108,
+shaderLocation: 3,
+}, {
+format: 'float32x2',
+offset: 172,
+shaderLocation: 8,
+}, {
+format: 'float32',
+offset: 44,
+shaderLocation: 6,
+}, {
+format: 'float32x4',
+offset: 116,
+shaderLocation: 4,
+}, {
+format: 'snorm8x2',
+offset: 24,
+shaderLocation: 13,
+}, {
+format: 'uint32x4',
+offset: 140,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 0,
+attributes: [{
+format: 'float16x2',
+offset: 708,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 960,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1224,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x3',
+offset: 620,
+shaderLocation: 15,
+}, {
+format: 'uint8x2',
+offset: 186,
+shaderLocation: 11,
+}, {
+format: 'sint16x2',
+offset: 760,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 252,
+attributes: [],
+},
+{
+arrayStride: 1052,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x2',
+offset: 276,
+shaderLocation: 14,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let imageBitmap13 = await createImageBitmap(videoFrame14);
+let textureView59 = texture8.createView({
+  label: '\u0322\u04fe\uf239\u0943\u36e9\u6304\u0c15\ue50f\u67dc\u826a\u6b6a',
+  baseMipLevel: 1,
+  mipLevelCount: 6
+});
+try {
+renderBundleEncoder26.draw(40);
+} catch {}
+try {
+renderBundleEncoder53.setPipeline(pipeline58);
+} catch {}
+try {
+commandEncoder54.copyBufferToBuffer(buffer12, 22292, buffer1, 50064, 684);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(querySet42, 81, 119, buffer12, 35840);
+} catch {}
+let promise37 = adapter0.requestAdapterInfo();
+try {
+offscreenCanvas14.getContext('webgl');
+} catch {}
+let commandEncoder55 = device0.createCommandEncoder({label: '\u2366\uab34\u4978\u010b'});
+let renderBundleEncoder59 = device0.createRenderBundleEncoder({
+  label: '\u062a\uea4e',
+  colorFormats: [undefined, 'r32float', 'rgba16sint', 'r16float', 'rgb10a2uint', 'rg16uint', 'r32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler48 = device0.createSampler({
+label: '\ud44c\u6201\ua9ec\uc00e\ud460\u0521',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 64.904,
+lodMaxClamp: 92.838,
+compare: 'equal',
+});
+try {
+renderBundleEncoder51.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(16, 56, 56, 640, 8);
+} catch {}
+try {
+renderBundleEncoder59.setVertexBuffer(6, buffer0, 26828, 8658);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 4856, new DataView(new ArrayBuffer(3686)), 1069, 932);
+} catch {}
+let promise38 = navigator.gpu.requestAdapter();
+let buffer24 = device0.createBuffer({
+  label: '\uca4d\u879b\u66c0\u{1fbe6}\u036c\u{1fe62}\u3e65\u9c4f',
+  size: 25384,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX
+});
+let texture73 = device0.createTexture({
+label: '\u2a6d\u09c2',
+size: {width: 320, height: 2, depthOrArrayLayers: 239},
+dimension: '3d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgb10a2uint', 'rgb10a2uint'],
+});
+let renderBundle68 = renderBundleEncoder38.finish({label: '\u9ccd\u023c\u9ed3\u2d1c\u7ad7\u{1fab3}\u07c3\u07a3\u5d97\u035e'});
+try {
+renderBundleEncoder45.setVertexBuffer(5, buffer15, 3968, 841);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(buffer23, 10144, buffer10, 4812, 2652);
+dissociateBuffer(device0, buffer23);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture62,
+  mipLevel: 3,
+  origin: { x: 24, y: 0, z: 0 },
+  aspect: 'all',
+}, new BigInt64Array(new ArrayBuffer(24)), /* required buffer size: 1028 */
+{offset: 692}, {width: 252, height: 12, depthOrArrayLayers: 1});
+} catch {}
+let pipeline101 = device0.createRenderPipeline({
+label: '\u07e0\u0cd1\u{1f6f1}\u01ad\u{1ffc4}\u0ba8\ua552\uf5a9\u8ee7',
+layout: pipelineLayout6,
+multisample: {
+count: 4,
+mask: 0x9bd729b0,
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint', writeMask: 0}, {format: 'rg8sint', writeMask: GPUColorWrite.GREEN}, undefined, {format: 'rg32float', writeMask: 0}, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 1933,
+stencilWriteMask: 4014,
+depthBias: 25,
+depthBiasSlopeScale: 24,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 224,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 192,
+shaderLocation: 8,
+}, {
+format: 'uint32x2',
+offset: 92,
+shaderLocation: 12,
+}, {
+format: 'snorm8x2',
+offset: 96,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 692,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 820,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x4',
+offset: 748,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 1570,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 1584,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1784,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1860,
+attributes: [{
+format: 'sint8x4',
+offset: 948,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let computePassEncoder51 = commandEncoder54.beginComputePass({label: '\u1dff\ub97a\u0f20\u1534\uaf8a\u22d4'});
+let renderBundleEncoder60 = device0.createRenderBundleEncoder({
+  label: '\uc982\u11b0\u{1f82f}\u22fd\u1dde',
+  colorFormats: ['rg8sint', 'rgba32sint'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder51.setBindGroup(3, bindGroup10, new Uint32Array(920), 59, 0);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder9.draw(16, 24, 24, 80);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(72, 64, 32, 328, 72);
+} catch {}
+try {
+commandEncoder55.clearBuffer(buffer10, 5516, 800);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+computePassEncoder40.dispatchWorkgroups(1, 2, 3);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+let bindGroup30 = device0.createBindGroup({
+layout: bindGroupLayout1,
+entries: [{
+binding: 43,
+resource: externalTexture2
+}, {
+binding: 257,
+resource: externalTexture1
+}],
+});
+let textureView60 = texture39.createView({baseMipLevel: 4, arrayLayerCount: 1});
+let renderBundleEncoder61 = device0.createRenderBundleEncoder({colorFormats: ['rgba16sint', 'rgba16uint'], depthStencilFormat: 'depth24plus-stencil8'});
+let renderBundle69 = renderBundleEncoder7.finish({label: '\u0711\u0c8a\u{1fbcf}\u1144\uc1e1\u{1fa56}\u0402\u{1fa18}\u{1fa39}'});
+let externalTexture3 = device0.importExternalTexture({
+label: '\u7369\u5a72\u{1f86e}\u2cc8\u82d4\u827c\u2377\u07b2',
+source: videoFrame4,
+colorSpace: 'display-p3',
+});
+try {
+computePassEncoder24.end();
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline32);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexed(48, 80, 72);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer22, 1964);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder55.copyTextureToTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 0, y: 44, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 0, y: 48, z: 0 },
+  aspect: 'all',
+}, {width: 124, height: 76, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder55.resolveQuerySet(querySet41, 271, 1225, buffer12, 768);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+}, new BigInt64Array(new ArrayBuffer(48)), /* required buffer size: 845 */
+{offset: 769, rowsPerImage: 138}, {width: 38, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: imageBitmap13,
+  origin: { x: 445, y: 189 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 7,
+  origin: { x: 1, y: 1, z: 2 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipelineLayout18 = device0.createPipelineLayout({
+  label: '\u{1f9c8}\u{1fe9b}\u7b14\u3bd8\u010d\u0cfa\u7e93\u2544\u9cfd\uf81d\u0df5',
+  bindGroupLayouts: [bindGroupLayout8, bindGroupLayout26]
+});
+let querySet57 = device0.createQuerySet({
+label: '\u0cd6\ue069\u{1ff3c}\u19e1\u{1f83e}\u39fc\u{1f671}\u4508\u066f',
+type: 'occlusion',
+count: 77,
+});
+try {
+commandEncoder22.copyBufferToBuffer(buffer0, 30188, buffer18, 6832, 1256);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+  await promise37;
+} catch {}
+let img15 = await imageWithData(166, 267, '#3cc76c3a', '#bf26e326');
+let querySet58 = device0.createQuerySet({
+label: '\uf3e5\u{1fb1b}\u03cd\u0ed7\ubefd\u82ef\u{1fe12}\ub235\u04ea\u2724',
+type: 'occlusion',
+count: 2993,
+});
+let computePassEncoder52 = commandEncoder55.beginComputePass({label: '\uc186\u1e84'});
+try {
+computePassEncoder40.dispatchWorkgroups(2, 3, 2);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(0, bindGroup30, new Uint32Array(5008), 4887, 0);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexedIndirect(buffer15, 3260);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline79);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 4856, new Float32Array(36450), 30819, 2344);
+} catch {}
+let video10 = await videoWithData();
+document.body.prepend(video1);
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageBitmap14 = await createImageBitmap(img4);
+try {
+device1.label = '\u017a\u5115\u5763\u08df\u76ee\u435f';
+} catch {}
+let commandEncoder56 = device0.createCommandEncoder({label: '\uaafe\ub20c'});
+pseudoSubmit(device0, commandEncoder51);
+let textureView61 = texture13.createView({label: '\u698a\u{1feb6}\u7a74\ub00d\u0c15\uf5c7', dimension: '2d-array', baseMipLevel: 3});
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline53);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexed(48, 16, 40);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexedIndirect(buffer15, 4440);
+} catch {}
+try {
+commandEncoder56.resolveQuerySet(querySet27, 412, 151, buffer12, 27392);
+} catch {}
+let pipeline102 = device0.createComputePipeline({
+layout: 'auto',
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let video11 = await videoWithData();
+video2.width = 247;
+let bindGroup31 = device0.createBindGroup({
+label: '\u{1fc05}\u0209\u6160\u06d9\u8897\u{1fa2e}\ua35c\u0935\u{1fc42}\u{1f864}',
+layout: bindGroupLayout10,
+entries: [{
+binding: 20,
+resource: externalTexture1
+}],
+});
+let querySet59 = device0.createQuerySet({
+label: '\u{1fc19}\u{1fbc7}\u90af\u06fb\ue6d5\u0cd8',
+type: 'occlusion',
+count: 2898,
+});
+let textureView62 = texture71.createView({
+  label: '\u8931\u00eb\ua061\u0622\u{1fa02}\u394d\u0f08\u047e\u5b2d',
+  dimension: '2d-array',
+  format: 'etc2-rgb8a1unorm-srgb',
+  baseMipLevel: 2
+});
+try {
+computePassEncoder51.end();
+} catch {}
+try {
+renderBundleEncoder52.setPipeline(pipeline98);
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(buffer2, 328, buffer8, 9988, 848);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float'],
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 17836, new Float32Array(35690), 10913, 324);
+} catch {}
+let pipeline103 = await promise19;
+let pipeline104 = await device0.createRenderPipelineAsync({
+label: '\ud2f9\u01f3\ua51c\udf82\u05b0\u{1fb6e}\u0400\u{1f6e7}',
+layout: pipelineLayout5,
+multisample: {
+mask: 0x1c07fb51,
+},
+fragment: {
+  module: shaderModule17,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg16float', writeMask: 0}, undefined, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'dst'},
+alpha: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'one-minus-dst-alpha'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'replace',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilWriteMask: 2959,
+depthBiasSlopeScale: 5,
+},
+vertex: {
+  module: shaderModule17,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 452,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x4',
+offset: 208,
+shaderLocation: 7,
+}, {
+format: 'sint32',
+offset: 236,
+shaderLocation: 1,
+}, {
+format: 'sint32',
+offset: 136,
+shaderLocation: 6,
+}, {
+format: 'float32x3',
+offset: 88,
+shaderLocation: 10,
+}, {
+format: 'uint32x3',
+offset: 48,
+shaderLocation: 5,
+}, {
+format: 'uint32',
+offset: 60,
+shaderLocation: 9,
+}, {
+format: 'snorm16x4',
+offset: 156,
+shaderLocation: 0,
+}, {
+format: 'snorm16x2',
+offset: 4,
+shaderLocation: 15,
+}, {
+format: 'sint32',
+offset: 68,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x2',
+offset: 1382,
+shaderLocation: 2,
+}, {
+format: 'snorm8x2',
+offset: 1930,
+shaderLocation: 8,
+}, {
+format: 'uint32x3',
+offset: 1204,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 1844,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 816,
+shaderLocation: 12,
+}, {
+format: 'float16x2',
+offset: 896,
+shaderLocation: 13,
+}],
+}
+]
+},
+});
+document.body.prepend(video1);
+gc();
+let canvas22 = document.createElement('canvas');
+try {
+canvas22.getContext('2d');
+} catch {}
+canvas16.width = 108;
+let computePassEncoder53 = commandEncoder22.beginComputePass({});
+try {
+renderBundleEncoder30.drawIndexed(56, 32, 64);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(3, buffer6, 33560, 2184);
+} catch {}
+try {
+commandEncoder33.clearBuffer(buffer14);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: { x: 51, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer11, /* required buffer size: 159 */
+{offset: 159, rowsPerImage: 60}, {width: 41, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let device2 = await promise4;
+let imageBitmap15 = await createImageBitmap(offscreenCanvas0);
+document.body.prepend(video5);
+try {
+videoFrame9.close();
+} catch {}
+try {
+await adapter4.requestAdapterInfo();
+} catch {}
+let img16 = await imageWithData(160, 224, '#3236082d', '#9f68f256');
+pseudoSubmit(device0, commandEncoder55);
+try {
+renderBundleEncoder36.drawIndirect(buffer12, 28512);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(2, buffer0, 36016, 461);
+} catch {}
+try {
+commandEncoder56.resolveQuerySet(querySet11, 158, 48, buffer12, 16384);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 2,
+  origin: { x: 6, y: 0, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 178 */
+{offset: 178, bytesPerRow: 95}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let sampler49 = device0.createSampler({
+label: '\u{1f7f0}\u792c\u0f14\u{1fcd8}\u09e1\ucb0c\u78d9',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 98.972,
+lodMaxClamp: 99.762,
+});
+try {
+renderBundleEncoder52.draw(64, 80, 80, 32);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexed(80, 32, 64, 112, 80);
+} catch {}
+try {
+renderBundleEncoder53.drawIndirect(buffer22, 372);
+} catch {}
+try {
+commandEncoder52.clearBuffer(buffer16, 7616, 6264);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 7532, new BigUint64Array(29671), 23879, 368);
+} catch {}
+let videoFrame16 = videoFrame10.clone();
+gc();
+let renderBundleEncoder62 = device0.createRenderBundleEncoder({label: '\u{1f84c}\u1f1a', colorFormats: ['rg8uint', 'r16uint', 'rgba16uint', 'rgba16sint']});
+try {
+renderBundleEncoder26.drawIndexed(64, 72);
+} catch {}
+try {
+renderBundleEncoder51.setVertexBuffer(2, buffer15);
+} catch {}
+try {
+commandEncoder56.clearBuffer(buffer1, 32072, 984);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+computePassEncoder33.insertDebugMarker('\u53d9');
+} catch {}
+let pipeline105 = await promise31;
+let imageBitmap16 = await createImageBitmap(imageBitmap7);
+let videoFrame17 = new VideoFrame(img11, {timestamp: 0});
+let querySet60 = device2.createQuerySet({
+label: '\ubfe6\u6ed8\u05c7\u56f6\u0768\uf8a7\u040c\u0fe6\uf10d',
+type: 'occlusion',
+count: 4036,
+});
+let texture74 = device2.createTexture({
+label: '\ue496\u5295\ufbe3',
+size: [540, 1, 201],
+mipLevelCount: 10,
+dimension: '3d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba16sint', 'rgba16sint'],
+});
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+try {
+commandEncoder56.copyTextureToTexture({
+  texture: texture72,
+  mipLevel: 0,
+  origin: { x: 13, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline106 = await device0.createComputePipelineAsync({
+label: '\u2359\u{1f6ac}\ub58f',
+layout: 'auto',
+compute: {
+module: shaderModule23,
+entryPoint: 'compute0',
+},
+});
+let imageBitmap17 = await createImageBitmap(offscreenCanvas2);
+let buffer25 = device2.createBuffer({size: 63523, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let querySet61 = device2.createQuerySet({
+label: '\u6385\u{1f852}\u{1f688}\ub0b7\u8089\u0d1e\u3cd7',
+type: 'occlusion',
+count: 1351,
+});
+let textureView63 = texture74.createView({label: '\u6a6e\u0c24\ua937\ub0b7\uf8ba\u{1fc7e}\u{1fcc8}\u3e4a\ud606\u036c\u9783', mipLevelCount: 1});
+let commandEncoder57 = device0.createCommandEncoder({label: '\u{1fb5b}\u{1f730}\u00fd\u0354\u6431'});
+let querySet62 = device0.createQuerySet({
+label: '\u{1f9ba}\uc53e\uaa2a\u{1fa0b}\u16d4\u59cc\ub7d0',
+type: 'occlusion',
+count: 313,
+});
+try {
+computePassEncoder41.setPipeline(pipeline23);
+} catch {}
+try {
+commandEncoder54.copyBufferToBuffer(buffer3, 9908, buffer11, 13928, 37412);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(querySet6, 82, 26, buffer12, 37376);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb', 'bgra8unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+adapter4.label = '\u000e\u{1fdf3}\u{1f662}\uf2ed\u{1fc07}\u0856\u0550\uee7b';
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let bindGroupLayout35 = device0.createBindGroupLayout({
+label: '\u9916\u{1f959}\u072a\ua94d\u{1fd5f}',
+entries: [],
+});
+let renderBundle70 = renderBundleEncoder59.finish({label: '\u0a2e\u0f56\u{1f7f0}\u0a85\u{1f9d7}\u194f'});
+try {
+renderBundleEncoder20.drawIndexedIndirect(buffer22, 1620);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer15, 6200);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder33.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture11,
+  mipLevel: 3,
+  origin: { x: 60, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder2.insertDebugMarker('\u{1f605}');
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img13);
+let video12 = await videoWithData();
+let commandEncoder58 = device2.createCommandEncoder({});
+let computePassEncoder54 = commandEncoder58.beginComputePass();
+let commandEncoder59 = device0.createCommandEncoder({label: '\u{1fab8}\uf6a7\u0178\u{1fd2a}\u3cd0\u07eb\u06a6'});
+let renderBundleEncoder63 = device0.createRenderBundleEncoder({
+  label: '\u9131\ud895\u0fab\u4cf4\u4f5d',
+  colorFormats: ['rg8uint', 'r16uint', 'rgba16uint', 'rgba16sint'],
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder44.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+computePassEncoder39.setBindGroup(0, bindGroup10, new Uint32Array(6117), 2135, 0);
+} catch {}
+try {
+renderBundleEncoder62.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder53.draw(8, 40, 64, 56);
+} catch {}
+let promise39 = device0.queue.onSubmittedWorkDone();
+let pipeline107 = await device0.createRenderPipelineAsync({
+label: '\u{1fc36}\ubdce\u082b\u{1fe6a}\u5af1',
+layout: pipelineLayout4,
+fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rg16float', writeMask: GPUColorWrite.GREEN}, undefined, {format: 'rg16float', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'keep',
+depthFailOp: 'invert',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+failOp: 'increment-wrap',
+depthFailOp: 'increment-wrap',
+},
+depthBiasSlopeScale: 83,
+depthBiasClamp: 44,
+},
+vertex: {
+  module: shaderModule16,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 920,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 152,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 1580,
+attributes: [],
+},
+{
+arrayStride: 1032,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x3',
+offset: 48,
+shaderLocation: 14,
+}],
+}
+]
+},
+});
+video4.height = 80;
+let renderBundle71 = renderBundleEncoder41.finish({label: '\u{1f903}\u09e1\u3f6e\u052c\ua5c9\u{1fcdc}\u{1f8e3}\u{1ff6f}\u9f3a\u5f9f\u1b52'});
+let sampler50 = device0.createSampler({
+addressModeU: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 6.889,
+lodMaxClamp: 54.349,
+});
+try {
+renderBundleEncoder60.setBindGroup(2, bindGroup12, new Uint32Array(1128), 742, 0);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexedIndirect(buffer22, 1560);
+} catch {}
+try {
+renderBundleEncoder53.drawIndirect(buffer12, 1216);
+} catch {}
+try {
+renderBundleEncoder62.setPipeline(pipeline71);
+} catch {}
+let promise40 = device0.popErrorScope();
+try {
+commandEncoder57.copyBufferToBuffer(buffer3, 23180, buffer18, 5632, 648);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder54.copyTextureToTexture({
+  texture: texture68,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'depth-only',
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: { x: 173, y: 5, z: 0 },
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder54.resolveQuerySet(querySet5, 1151, 19, buffer12, 24576);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 1, depthOrArrayLayers: 251}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 25, y: 35 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 1,
+  origin: { x: 63, y: 0, z: 153 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline108 = await device0.createRenderPipelineAsync({
+label: '\ucef4\u3e35\ua5c2\u{1ffc8}\u01e3\u{1f6a0}',
+layout: pipelineLayout16,
+fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32uint', writeMask: 0}, {format: 'rg8sint'}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALPHA}, {format: 'bgra8unorm'}]
+},
+vertex: {
+  module: shaderModule8,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 444,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 200,
+shaderLocation: 5,
+}, {
+format: 'uint32',
+offset: 288,
+shaderLocation: 11,
+}, {
+format: 'sint16x2',
+offset: 72,
+shaderLocation: 3,
+}, {
+format: 'unorm8x4',
+offset: 28,
+shaderLocation: 14,
+}, {
+format: 'snorm16x4',
+offset: 164,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 1188,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 640,
+shaderLocation: 4,
+}, {
+format: 'unorm16x2',
+offset: 412,
+shaderLocation: 6,
+}, {
+format: 'sint16x4',
+offset: 932,
+shaderLocation: 1,
+}, {
+format: 'unorm10-10-10-2',
+offset: 1056,
+shaderLocation: 7,
+}, {
+format: 'float32x2',
+offset: 1016,
+shaderLocation: 9,
+}, {
+format: 'uint16x2',
+offset: 588,
+shaderLocation: 2,
+}, {
+format: 'uint32x2',
+offset: 312,
+shaderLocation: 15,
+}, {
+format: 'unorm16x2',
+offset: 680,
+shaderLocation: 10,
+}, {
+format: 'unorm16x2',
+offset: 824,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 724,
+attributes: [{
+format: 'float32x2',
+offset: 592,
+shaderLocation: 8,
+}, {
+format: 'float32x2',
+offset: 628,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let querySet63 = device0.createQuerySet({
+label: '\u09dc\u6256\u0100',
+type: 'occlusion',
+count: 2615,
+});
+let computePassEncoder55 = commandEncoder57.beginComputePass();
+try {
+renderBundleEncoder36.setVertexBuffer(6, buffer15, 5124, 144);
+} catch {}
+try {
+commandEncoder52.clearBuffer(buffer9, 5892);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+computePassEncoder48.insertDebugMarker('\u8541');
+} catch {}
+let promise41 = device0.createComputePipelineAsync({
+label: '\u731d\u374c\u051d\u7527\u{1f8a3}\u6c08\u0d96',
+layout: pipelineLayout13,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+},
+});
+let imageBitmap18 = await createImageBitmap(videoFrame11);
+gc();
+let promise42 = navigator.gpu.requestAdapter({
+});
+let img17 = await imageWithData(204, 40, '#0f12ee16', '#497a0a65');
+pseudoSubmit(device2, commandEncoder58);
+try {
+await device2.popErrorScope();
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55) };
+} catch {}
+try {
+device1.label = '\u5184\u0705\u9e72\ubbd1\u{1f732}\u257c\u{1f72c}\u01ae\ucd4e\u2e98';
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let imageBitmap19 = await createImageBitmap(canvas13);
+let videoFrame18 = new VideoFrame(offscreenCanvas3, {timestamp: 0});
+let img18 = await imageWithData(146, 280, '#5c65218e', '#8fc88cf9');
+let imageData9 = new ImageData(192, 168);
+let commandEncoder60 = device2.createCommandEncoder();
+let renderBundleEncoder64 = device2.createRenderBundleEncoder({colorFormats: ['r8unorm', undefined], depthStencilFormat: 'depth24plus-stencil8', depthReadOnly: true});
+video3.height = 128;
+let imageBitmap20 = await createImageBitmap(offscreenCanvas2);
+let adapter5 = await promise38;
+let renderBundleEncoder65 = device2.createRenderBundleEncoder({
+  label: '\u0ba3\u7f62',
+  colorFormats: ['r8unorm', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true
+});
+try {
+computePassEncoder22.dispatchWorkgroups(2);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+commandEncoder54.resolveQuerySet(querySet11, 100, 103, buffer12, 7168);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 36964, new DataView(new ArrayBuffer(48144)), 527, 16728);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let imageBitmap21 = await createImageBitmap(videoFrame10);
+let buffer26 = device2.createBuffer({size: 9723, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let commandEncoder61 = device2.createCommandEncoder({label: '\u09fa\u15f6\u0172\u1716'});
+pseudoSubmit(device2, commandEncoder61);
+let textureView64 = texture74.createView({aspect: 'all', baseMipLevel: 1, mipLevelCount: 1});
+let computePassEncoder56 = commandEncoder60.beginComputePass({label: '\u39ac\u4ebf\u8e72\u0b9f\ub3a7\u9a58\u4541\u{1fbca}\ucfd0'});
+try {
+computePassEncoder56.insertDebugMarker('\u{1f677}');
+} catch {}
+let sampler51 = device0.createSampler({
+label: '\u05e5\u08b0\uad75\u00d7\u06c8\u{1ff3a}\uf6a5\u006b\u022b',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 39.358,
+lodMaxClamp: 64.078,
+});
+try {
+renderBundleEncoder62.draw(8, 24, 8, 64);
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(buffer24, 15596, buffer1, 50372, 6000);
+dissociateBuffer(device0, buffer24);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder56.copyTextureToTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: { x: 118, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 19, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 35, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(querySet11, 174, 36, buffer12, 25344);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 9420, new Int16Array(10684), 1650, 2340);
+} catch {}
+gc();
+let texture75 = device2.createTexture({
+label: '\u0cf3\uec0e\u0998\u4501',
+size: [420],
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder66 = device2.createRenderBundleEncoder({
+  colorFormats: ['r8unorm', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder64.setVertexBuffer(6, buffer26, 4480, 4780);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let querySet64 = device2.createQuerySet({
+label: '\u09c6\u462b\u0ea5\u2d83\u6574\u{1fad2}',
+type: 'occlusion',
+count: 1070,
+});
+pseudoSubmit(device2, commandEncoder60);
+try {
+renderBundleEncoder65.insertDebugMarker('\u{1f89f}');
+} catch {}
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+let video13 = await videoWithData();
+canvas10.width = 701;
+let bindGroupLayout36 = device2.createBindGroupLayout({
+label: '\u{1fab4}\u6d18\u5273',
+entries: [{
+binding: 241,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '2d-array' },
+}],
+});
+let pipelineLayout19 = device2.createPipelineLayout({bindGroupLayouts: [bindGroupLayout36, bindGroupLayout36, bindGroupLayout36]});
+let renderBundle72 = renderBundleEncoder64.finish();
+try {
+device2.queue.writeBuffer(buffer25, 1920, new DataView(new ArrayBuffer(41803)), 9272, 19708);
+} catch {}
+let promise43 = device2.queue.onSubmittedWorkDone();
+canvas5.width = 928;
+let commandEncoder62 = device2.createCommandEncoder({});
+let renderBundleEncoder67 = device2.createRenderBundleEncoder({
+  label: '\u0a82\u5646\u05a1',
+  colorFormats: ['r8unorm', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true
+});
+let video14 = await videoWithData();
+let bindGroupLayout37 = device2.createBindGroupLayout({
+label: '\uaa8a\u6eb6\u8bd5\u0339\uaa64\u0b07',
+entries: [{
+binding: 385,
+visibility: 0,
+sampler: { type: 'filtering' },
+}, {
+binding: 771,
+visibility: 0,
+externalTexture: {},
+}],
+});
+let querySet65 = device2.createQuerySet({
+label: '\u08da\u0572\u130e\u{1fa22}\u7973\ua558\u{1febd}\u{1f93a}\u{1fef5}\u741f\u0385',
+type: 'occlusion',
+count: 2133,
+});
+let renderBundle73 = renderBundleEncoder67.finish({label: '\u{1f8f0}\u33ea\u8c08'});
+let sampler52 = device2.createSampler({
+label: '\u629b\u0c63\u091f\u94aa\u09a3\u46d6\uc946\ue2fb\ub35e',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+minFilter: 'nearest',
+lodMaxClamp: 91.509,
+});
+let buffer27 = device2.createBuffer({
+  label: '\u{1fbad}\u80c6\u99f0\uee0e\u00f6\ub55a',
+  size: 29043,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let commandEncoder63 = device2.createCommandEncoder({label: '\u{1fbe7}\u07b3\u716a\u{1f67a}\u84ed\ueb54'});
+try {
+renderBundleEncoder65.setVertexBuffer(3, buffer26);
+} catch {}
+try {
+device2.pushErrorScope('internal');
+} catch {}
+try {
+gpuCanvasContext13.configure({
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg32float', 'rgba32sint', 'bgra8unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let canvas23 = document.createElement('canvas');
+let buffer28 = device0.createBuffer({
+  label: '\u9919\u705e\u0183\ua48d\u54ba',
+  size: 5688,
+  usage: GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true
+});
+let commandBuffer17 = commandEncoder56.finish({
+label: '\ud7ce\u{1f81a}\u6a85\u{1f87e}\u0afe\u0a44\u9852\ubb63\u{1f7c7}\ub0a3',
+});
+let computePassEncoder57 = commandEncoder33.beginComputePass({label: '\u{1fd68}\u1c3e\uee0a\u9b39\u0a8c\u062f\u{1ff3c}\u{1f90a}\ua8c1\uc0de'});
+let renderBundleEncoder68 = device0.createRenderBundleEncoder({
+  label: '\u06fb\ub73a\u{1ffa9}\u63ac\uf0d6\u{1fc64}',
+  colorFormats: ['bgra8unorm-srgb', 'rgba16uint', 'r8uint', 'rg11b10ufloat', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle74 = renderBundleEncoder32.finish({});
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 1,
+  origin: { x: 5, y: 7, z: 63 },
+  aspect: 'all',
+}, {
+  texture: texture20,
+  mipLevel: 2,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+}, {width: 7, height: 7, depthOrArrayLayers: 23});
+} catch {}
+try {
+commandEncoder54.clearBuffer(buffer14);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 2972, new Float32Array(65225), 63709, 696);
+} catch {}
+let promise44 = device0.createRenderPipelineAsync({
+label: '\uc0e9\ub67f\u0b06',
+layout: pipelineLayout1,
+fragment: {
+  module: shaderModule22,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'never',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+depthFailOp: 'decrement-clamp',
+passOp: 'invert',
+},
+stencilReadMask: 3153,
+stencilWriteMask: 3822,
+depthBiasClamp: 92,
+},
+vertex: {
+  module: shaderModule22,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1632,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 1624,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 1348,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 496,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 240,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1144,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 308,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 168,
+shaderLocation: 2,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'back',
+},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.prepend(img2);
+try {
+renderBundleEncoder65.setVertexBuffer(3, buffer26, 576, 6134);
+} catch {}
+try {
+commandEncoder62.copyBufferToBuffer(buffer26, 7908, buffer25, 20064, 1084);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer25, 33612, new BigUint64Array(63757), 22840, 2464);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let computePassEncoder58 = commandEncoder62.beginComputePass({label: '\u{1fe45}\u485b\u02a1'});
+let renderBundleEncoder69 = device2.createRenderBundleEncoder({colorFormats: ['r8unorm', undefined], depthStencilFormat: 'depth24plus-stencil8', depthReadOnly: true});
+try {
+commandEncoder63.copyBufferToBuffer(buffer26, 9376, buffer27, 5036, 12);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer27);
+} catch {}
+let gpuCanvasContext16 = canvas23.getContext('webgpu');
+let commandBuffer18 = commandEncoder59.finish({
+label: '\ub9f2\ud1a8\u1ae3\u{1f860}\u9ea6\ue5e9',
+});
+let texture76 = device0.createTexture({
+label: '\uafff\u{1f6bf}\u052a\u{1f795}\u0e2f\u795c\u0b9a\u4333\u4193\u{1f901}',
+size: {width: 60, height: 60, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-5x5-unorm', 'astc-5x5-unorm', 'astc-5x5-unorm-srgb'],
+});
+let textureView65 = texture14.createView({label: '\u44a6\uf392\u033f\u1560\u00da\ueb28\uf0d7', mipLevelCount: 5});
+let computePassEncoder59 = commandEncoder54.beginComputePass();
+try {
+renderBundleEncoder20.drawIndirect(buffer22, 568);
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+gc();
+let imageData10 = new ImageData(80, 60);
+let imageData11 = new ImageData(188, 176);
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder64 = device0.createCommandEncoder();
+try {
+computePassEncoder40.setBindGroup(0, bindGroup4, new Uint32Array(608), 243, 0);
+} catch {}
+try {
+computePassEncoder40.dispatchWorkgroupsIndirect(buffer22, 284);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer12, 17572);
+} catch {}
+try {
+renderBundleEncoder53.drawIndirect(buffer22, 1300);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer4, 'uint32', 1080, 839);
+} catch {}
+try {
+commandEncoder64.resolveQuerySet(querySet27, 946, 113, buffer12, 14080);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 200, y: 8, z: 0 },
+  aspect: 'all',
+}, arrayBuffer11, /* required buffer size: 13674 */
+{offset: 74, bytesPerRow: 1712, rowsPerImage: 108}, {width: 808, height: 64, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder65 = device2.createCommandEncoder({label: '\u1d4c\u9094\u{1f8a6}\uf521\u4ebf\u{1fa43}\u{1fb79}\u0f29\u5575\u{1fed5}\ue3ba'});
+let textureView66 = texture74.createView({label: '\uec0d\u0a0e', baseMipLevel: 6, mipLevelCount: 1});
+try {
+renderBundleEncoder65.setVertexBuffer(3, buffer26, 1716, 5660);
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer26, 988, buffer25, 25664, 4936);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['stencil8', 'bgra8unorm', 'bgra8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let texture77 = device0.createTexture({
+label: '\ubd19\u426c\u07b0\u{1fb58}\u{1fef1}\u4746\ufbd2\u{1f617}\ud3d5',
+size: [128, 180, 1],
+mipLevelCount: 4,
+format: 'etc2-rgb8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['etc2-rgb8unorm', 'etc2-rgb8unorm-srgb'],
+});
+let computePassEncoder60 = commandEncoder52.beginComputePass({});
+let renderBundleEncoder70 = device0.createRenderBundleEncoder({
+  label: '\ue94c\uf64b\u0abb\u5677',
+  colorFormats: [undefined, 'r16uint', 'rg32uint', 'rg16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+try {
+computePassEncoder36.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+commandEncoder64.copyTextureToTexture({
+  texture: texture39,
+  mipLevel: 4,
+  origin: { x: 10, y: 6, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture39,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder64.resolveQuerySet(querySet12, 2738, 390, buffer12, 13568);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 15308, new DataView(new ArrayBuffer(21924)), 9752, 140);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video13,
+  origin: { x: 7, y: 15 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas15 = new OffscreenCanvas(364, 221);
+try {
+offscreenCanvas15.getContext('webgl');
+} catch {}
+let querySet66 = device2.createQuerySet({
+type: 'occlusion',
+count: 422,
+});
+try {
+commandEncoder65.clearBuffer(buffer25, 32352, 27860);
+dissociateBuffer(device2, buffer25);
+} catch {}
+document.body.prepend(img7);
+canvas0.width = 970;
+try {
+commandBuffer12.label = '\u0bfe\u3aa2\u{1f8ab}\ua49a\u{1f826}\ua1cb\u{1fc45}\u9ce5\u66b8';
+} catch {}
+let buffer29 = device0.createBuffer({
+  label: '\u05d4\u093a\u{1f829}\u1bd9\u{1fc61}\u0e0a\u3022\u37ab\u49df\uf1bd\u72df',
+  size: 34968,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true
+});
+try {
+computePassEncoder55.end();
+} catch {}
+try {
+computePassEncoder31.setPipeline(pipeline40);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(7, buffer0, 29156, 1200);
+} catch {}
+try {
+commandEncoder64.copyTextureToTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: { x: 5, y: 0, z: 1 },
+  aspect: 'depth-only',
+}, {
+  texture: texture68,
+  mipLevel: 4,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture78 = device2.createTexture({
+size: [1680, 1, 1],
+mipLevelCount: 5,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['depth32float', 'depth32float'],
+});
+let sampler53 = device2.createSampler({
+label: '\u{1fe39}\u{1f875}\uba19\u088b\u{1f6a7}\u63a3\u907b\u95f4\u4b2e\uef02\u78f9',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 70.080,
+});
+try {
+commandEncoder63.copyBufferToBuffer(buffer26, 2248, buffer27, 22360, 2944);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let offscreenCanvas16 = new OffscreenCanvas(230, 559);
+try {
+offscreenCanvas16.getContext('webgl2');
+} catch {}
+let querySet67 = device0.createQuerySet({
+label: '\u873d\uc99d\u{1fcac}\u0b8a\u388e\ue435\u0c02\u0b92\u6664\u{1fe7a}',
+type: 'occlusion',
+count: 1390,
+});
+let textureView67 = texture66.createView({label: '\u40fd\ue740\ub2a7\u6eaf\u9ed2\ua8b9'});
+let renderBundle75 = renderBundleEncoder25.finish();
+let sampler54 = device0.createSampler({
+label: '\ub4c8\u0219\u5849\u7f3d\u4eec\u71ff\u0774',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 71.704,
+lodMaxClamp: 89.171,
+maxAnisotropy: 12,
+});
+try {
+computePassEncoder33.dispatchWorkgroups(3, 4, 4);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(7, buffer6);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer17,
+]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: imageBitmap11,
+  origin: { x: 74, y: 108 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 7,
+  origin: { x: 1, y: 1, z: 2 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline109 = await promise44;
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55) };
+} catch {}
+let buffer30 = device2.createBuffer({label: '\uc700\u10cf', size: 15940, usage: GPUBufferUsage.COPY_DST, mappedAtCreation: true});
+let texture79 = device2.createTexture({
+label: '\u8054\u0860\uc791\u0115\u02d6\u5974\u{1f7f4}',
+size: [48, 7, 100],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba32float', 'rgba32float'],
+});
+let sampler55 = device2.createSampler({
+label: '\ua406\u0334\uf621\ub5c4\u247f\u723f',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 96.780,
+lodMaxClamp: 98.474,
+});
+try {
+renderBundleEncoder65.setVertexBuffer(0, buffer26, 2556, 4534);
+} catch {}
+let offscreenCanvas17 = new OffscreenCanvas(551, 942);
+let imageBitmap22 = await createImageBitmap(canvas11);
+let texture80 = device2.createTexture({
+size: {width: 840, height: 1, depthOrArrayLayers: 63},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba16sint', 'rgba16sint', 'rgba16sint'],
+});
+let renderBundleEncoder71 = device2.createRenderBundleEncoder({
+  label: '\u67ac\u7b1a\u98ac\u19a1\u0123\ueddf\u{1fad7}\u0eff',
+  colorFormats: ['r8unorm', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true
+});
+let renderBundle76 = renderBundleEncoder65.finish({label: '\u8439\u5af5\u9aa3\u06e7\uf34a\u90fa'});
+try {
+renderBundleEncoder66.setVertexBuffer(0, buffer26);
+} catch {}
+let promise45 = buffer27.mapAsync(GPUMapMode.READ, 0, 13180);
+try {
+commandEncoder65.copyBufferToBuffer(buffer26, 5628, buffer30, 388, 592);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 3, height: 1, depthOrArrayLayers: 6}
+*/
+{
+  source: canvas5,
+  origin: { x: 204, y: 276 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 4,
+  origin: { x: 3, y: 0, z: 4 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let canvas24 = document.createElement('canvas');
+let textureView68 = texture38.createView({format: 'astc-8x6-unorm-srgb'});
+let sampler56 = device0.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 85.838,
+lodMaxClamp: 87.439,
+maxAnisotropy: 15,
+});
+try {
+computePassEncoder44.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder9.draw(0);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexed(48, 0, 24, -152);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer4, 'uint32', 5416, 1748);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline79);
+} catch {}
+let promise46 = buffer16.mapAsync(GPUMapMode.READ, 0, 2452);
+try {
+commandEncoder57.copyBufferToBuffer(buffer3, 40300, buffer8, 6072, 8180);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas3,
+  origin: { x: 2, y: 1 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView69 = texture74.createView({format: 'rgba16sint', baseMipLevel: 3, mipLevelCount: 4});
+try {
+device2.queue.writeBuffer(buffer25, 31108, new DataView(new ArrayBuffer(51095)), 37970, 9092);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 1, y: 0, z: 4 },
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer13), /* required buffer size: 194399 */
+{offset: 861, bytesPerRow: 411, rowsPerImage: 12}, {width: 23, height: 3, depthOrArrayLayers: 40});
+} catch {}
+video0.height = 158;
+let commandEncoder66 = device2.createCommandEncoder({label: '\u9b9e\u{1f9b6}\u{1fe2e}\u7c2d\uf8a7\u0195\u212d'});
+let renderBundleEncoder72 = device2.createRenderBundleEncoder({
+  label: '\u00cf\u052f\ub7ca\u812f\u{1f9db}\u0122\u{1fa78}\u0861\u0769',
+  colorFormats: ['r8unorm', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1,
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+try {
+  await promise46;
+} catch {}
+gc();
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let promise47 = navigator.gpu.requestAdapter({
+});
+let shaderModule26 = device0.createShaderModule({
+label: '\ue88e\u{1f671}\uacf1\ud7cd\u212d\u56e3\u{1ff38}\u02b4\ua839',
+code: `@group(0) @binding(257)
+var<storage, read_write> local8: array<u32>;
+@group(0) @binding(43)
+var<storage, read_write> function8: array<u32>;
+
+@compute @workgroup_size(6, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<i32>,
+  @location(0) f1: vec2<u32>,
+  @location(4) f2: vec4<f32>,
+  @location(3) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(14) a0: vec3<f16>, @location(9) a1: vec4<u32>, @location(12) a2: vec2<f16>, @location(5) a3: vec3<f16>, @location(1) a4: vec2<f32>, @location(15) a5: vec2<u32>, @location(10) a6: vec3<i32>, @location(11) a7: vec4<u32>, @location(13) a8: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let textureView70 = texture77.createView({label: '\ue1b5\u02f0', dimension: '2d-array', mipLevelCount: 1});
+let renderBundleEncoder73 = device0.createRenderBundleEncoder({
+  label: '\u0107\u67d7\u05f5\u{1ff43}\uec82\u3e90\u6320\u4368\u0e47',
+  colorFormats: ['rgba32sint', 'rgb10a2uint'],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+let renderBundle77 = renderBundleEncoder52.finish({label: '\u718b\u53d9\u4e71\u{1fd60}\u50e0\u3918\uda67\u{1f763}\u0294\u94c8\u{1fdf6}'});
+try {
+computePassEncoder32.setBindGroup(2, bindGroup5, new Uint32Array(6695), 3430, 0);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline97);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline110 = await device0.createRenderPipelineAsync({
+layout: pipelineLayout11,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule25,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'one-minus-dst'},
+alpha: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'dst'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}]
+},
+vertex: {module: shaderModule25, entryPoint: 'vertex0', buffers: [
+
+]},
+primitive: {
+topology: 'triangle-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let gpuCanvasContext17 = canvas24.getContext('webgpu');
+gc();
+let canvas25 = document.createElement('canvas');
+let video15 = await videoWithData();
+let buffer31 = device2.createBuffer({
+  label: '\uc8d7\uc9b7\uac48\u5a4d\ua10c\u01de\uf95c\u0a3e\u{1fad8}',
+  size: 35123,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false
+});
+let commandEncoder67 = device2.createCommandEncoder();
+let querySet68 = device2.createQuerySet({
+label: '\u0202\ue552\u4876\u2cf8',
+type: 'occlusion',
+count: 2553,
+});
+let texture81 = device2.createTexture({
+size: {width: 96, height: 15, depthOrArrayLayers: 192},
+dimension: '3d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let computePassEncoder61 = commandEncoder66.beginComputePass({label: '\u0dab\u32d5\u047a\u{1f739}\u{1fce8}\u{1fc4a}\u{1f828}\u{1f975}\u53ed\u660f\ua936'});
+try {
+device2.queue.writeBuffer(buffer25, 11540, new BigUint64Array(48962), 36791, 4908);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 0,
+  origin: { x: 16, y: 1, z: 2 },
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer9), /* required buffer size: 11404826 */
+{offset: 90, bytesPerRow: 242, rowsPerImage: 252}, {width: 1, height: 4, depthOrArrayLayers: 188});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 3, height: 1, depthOrArrayLayers: 6}
+*/
+{
+  source: imageBitmap22,
+  origin: { x: 222, y: 145 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 4,
+  origin: { x: 3, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise40;
+} catch {}
+let querySet69 = device2.createQuerySet({
+label: '\u526d\u{1fd51}\u7989\u{1ffe4}\u0ed3\u9081\ud609\u6290\u9f75',
+type: 'occlusion',
+count: 3006,
+});
+let renderBundle78 = renderBundleEncoder64.finish();
+try {
+querySet66.destroy();
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer26, 5604, buffer30, 8220, 2216);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer30);
+} catch {}
+let textureView71 = texture10.createView({baseMipLevel: 7, mipLevelCount: 1});
+try {
+computePassEncoder34.setBindGroup(1, bindGroup3, new Uint32Array(1042), 4, 0);
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline53);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexed(48, 72, 72, -640, 64);
+} catch {}
+try {
+renderBundleEncoder20.drawIndirect(buffer22, 1384);
+} catch {}
+try {
+renderBundleEncoder57.setIndexBuffer(buffer9, 'uint32', 12160, 4405);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline98);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(4, buffer22, 1900);
+} catch {}
+try {
+commandEncoder64.resolveQuerySet(querySet19, 1330, 1198, buffer12, 29440);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 31}
+*/
+{
+  source: canvas18,
+  origin: { x: 57, y: 9 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 4,
+  origin: { x: 19, y: 1, z: 9 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let shaderModule27 = device2.createShaderModule({
+label: '\ufbc8\u{1fa28}\u{1fa4c}\u0d9e\u05af\u2365\ue0e9\ue4ac',
+code: `@group(1) @binding(241)
+var<storage, read_write> global6: array<u32>;
+@group(0) @binding(241)
+var<storage, read_write> field11: array<u32>;
+@group(2) @binding(241)
+var<storage, read_write> i9: array<u32>;
+
+@compute @workgroup_size(5, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S19 {
+  @location(4) f0: vec2<f16>,
+  @location(14) f1: vec2<u32>,
+  @builtin(vertex_index) f2: u32,
+  @location(12) f3: vec3<i32>,
+  @location(0) f4: vec2<u32>,
+  @location(7) f5: vec4<u32>,
+  @location(15) f6: vec3<f16>,
+  @location(11) f7: vec4<f16>,
+  @location(10) f8: vec4<f32>,
+  @location(6) f9: vec4<f16>,
+  @builtin(instance_index) f10: u32,
+  @location(5) f11: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec2<i32>, @location(9) a1: vec4<i32>, @location(3) a2: vec2<u32>, @location(1) a3: vec2<f16>, @location(13) a4: vec2<f16>, @location(8) a5: vec3<u32>, a6: S19) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let externalTexture4 = device2.importExternalTexture({
+source: videoFrame14,
+colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder71.setVertexBuffer(7, buffer26, 736, 2207);
+} catch {}
+try {
+commandEncoder67.copyBufferToBuffer(buffer26, 6196, buffer27, 14296, 3000);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer27);
+} catch {}
+let promise48 = device2.queue.onSubmittedWorkDone();
+let pipeline111 = device2.createComputePipeline({
+label: '\u0037\u{1f82b}\u097c\ua059\u{1f6b7}\u0593\u1148\u827b\u69b9\u0b54\u{1fe8c}',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule27,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let promise49 = device2.createRenderPipelineAsync({
+layout: 'auto',
+fragment: {
+  module: shaderModule27,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'zero',
+},
+stencilReadMask: 2120,
+stencilWriteMask: 166,
+depthBias: 92,
+depthBiasSlopeScale: 100,
+depthBiasClamp: 21,
+},
+vertex: {
+  module: shaderModule27,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 648,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 76,
+shaderLocation: 1,
+}, {
+format: 'snorm16x4',
+offset: 12,
+shaderLocation: 15,
+}, {
+format: 'uint32x4',
+offset: 140,
+shaderLocation: 0,
+}, {
+format: 'unorm8x2',
+offset: 130,
+shaderLocation: 4,
+}, {
+format: 'sint32',
+offset: 204,
+shaderLocation: 2,
+}, {
+format: 'uint16x2',
+offset: 148,
+shaderLocation: 3,
+}, {
+format: 'sint8x4',
+offset: 344,
+shaderLocation: 5,
+}, {
+format: 'float32x3',
+offset: 592,
+shaderLocation: 13,
+}, {
+format: 'unorm16x2',
+offset: 584,
+shaderLocation: 11,
+}, {
+format: 'uint16x2',
+offset: 252,
+shaderLocation: 7,
+}, {
+format: 'uint8x2',
+offset: 476,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 1304,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 800,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 312,
+shaderLocation: 9,
+}, {
+format: 'sint8x2',
+offset: 482,
+shaderLocation: 12,
+}, {
+format: 'float16x2',
+offset: 556,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 1452,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 364,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 680,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 0,
+attributes: [],
+},
+{
+arrayStride: 1880,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 456,
+shaderLocation: 10,
+}],
+}
+]
+},
+});
+let video16 = await videoWithData();
+let imageBitmap23 = await createImageBitmap(offscreenCanvas6);
+let bindGroup32 = device2.createBindGroup({
+label: '\ue69a\ube00\u05ea\u5093\uf772\u0b2c\u15b4\u{1fcd5}\u090a\u0c97\u0e36',
+layout: bindGroupLayout37,
+entries: [{
+binding: 385,
+resource: sampler55
+}, {
+binding: 771,
+resource: externalTexture4
+}],
+});
+let querySet70 = device2.createQuerySet({
+label: '\u008e\u{1fe9a}',
+type: 'occlusion',
+count: 254,
+});
+try {
+computePassEncoder61.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+renderBundleEncoder71.insertDebugMarker('\u{1f839}');
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let imageData12 = new ImageData(140, 168);
+let videoFrame19 = new VideoFrame(video15, {timestamp: 0});
+let gpuCanvasContext18 = canvas25.getContext('webgpu');
+let buffer32 = device2.createBuffer({label: '\u017a\u0404\u32cb\u0ffa', size: 63020, usage: GPUBufferUsage.MAP_WRITE, mappedAtCreation: true});
+let texture82 = device2.createTexture({
+size: [540, 1, 1],
+mipLevelCount: 4,
+sampleCount: 1,
+format: 'r16uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+try {
+renderBundleEncoder69.setVertexBuffer(1, buffer26, 1540, 5558);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer25, 1964, new DataView(new ArrayBuffer(10239)), 5955, 1412);
+} catch {}
+let gpuCanvasContext19 = offscreenCanvas17.getContext('webgpu');
+try {
+adapter5.label = '\u5cfe\u{1f9f7}\u0f13\u{1fe8b}';
+} catch {}
+let bindGroupLayout38 = device0.createBindGroupLayout({
+label: '\u{1ff5d}\u{1fa6a}\u09c8',
+entries: [{
+binding: 232,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}, {
+binding: 670,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'rgba16uint', access: 'write-only', viewDimension: '2d' },
+}, {
+binding: 270,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d-array' },
+}],
+});
+let texture83 = device0.createTexture({
+label: '\u0504\ub3c7\u02ea\ub74d\ud1fe\u0b78\u04c7',
+size: {width: 330, height: 24, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+dimension: '2d',
+format: 'astc-6x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-6x6-unorm', 'astc-6x6-unorm-srgb'],
+});
+try {
+computePassEncoder40.dispatchWorkgroupsIndirect(buffer15, 2900);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer22, 476);
+} catch {}
+try {
+commandEncoder64.copyBufferToBuffer(buffer17, 9016, buffer8, 6928, 5600);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder57.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture20,
+  mipLevel: 2,
+  origin: { x: 0, y: 4, z: 40 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer18,
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 10944, new Int16Array(48110), 1823, 252);
+} catch {}
+let pipeline112 = await device0.createRenderPipelineAsync({
+layout: pipelineLayout18,
+fragment: {
+  module: shaderModule18,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: GPUColorWrite.ALL}, {format: 'rgba8sint'}, {format: 'rg8uint', writeMask: 0}, {format: 'rg32uint', writeMask: 0}, undefined, {format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'src-alpha', dstFactor: 'src-alpha-saturated'},
+},
+  writeMask: 0
+}]
+},
+vertex: {
+  module: shaderModule18,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1660,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1576,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1788,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1824,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1384,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 1116,
+shaderLocation: 2,
+}, {
+format: 'snorm8x4',
+offset: 576,
+shaderLocation: 14,
+}, {
+format: 'uint32',
+offset: 556,
+shaderLocation: 1,
+}],
+}
+]
+},
+primitive: {
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+canvas3.height = 299;
+gc();
+let imageData13 = new ImageData(156, 88);
+let offscreenCanvas18 = new OffscreenCanvas(3, 140);
+let bindGroupLayout39 = device2.createBindGroupLayout({
+label: '\u3071\u1d90\u820c\uc328\u12c4\u0e16\u{1f958}\u{1fb01}\u0d95',
+entries: [{
+binding: 311,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d' },
+}, {
+binding: 583,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}],
+});
+let texture84 = device2.createTexture({
+label: '\u1d57\uca38\u{1fa7f}\u{1fa69}\ue8cd\uc964\u0ec6\u9c09',
+size: [15],
+dimension: '1d',
+format: 'r8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup32, new Uint32Array(1091), 653, 0);
+} catch {}
+try {
+renderBundleEncoder69.setBindGroup(0, bindGroup32, new Uint32Array(389), 262, 0);
+} catch {}
+try {
+renderBundleEncoder66.setVertexBuffer(4, buffer26);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: imageBitmap18,
+  origin: { x: 29, y: 38 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame20 = new VideoFrame(offscreenCanvas2, {timestamp: 0});
+try {
+adapter0.label = '\u19b6\u0405\u{1fcac}';
+} catch {}
+let querySet71 = device2.createQuerySet({
+label: '\u06f3\u{1fefd}\uf212',
+type: 'occlusion',
+count: 3790,
+});
+let sampler57 = device2.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 86.644,
+maxAnisotropy: 11,
+});
+try {
+computePassEncoder58.setBindGroup(1, bindGroup32, new Uint32Array(4360), 1134, 0);
+} catch {}
+try {
+renderBundleEncoder72.setBindGroup(0, bindGroup32, new Uint32Array(8219), 5454, 0);
+} catch {}
+let promise50 = buffer25.mapAsync(GPUMapMode.READ, 58720, 1912);
+try {
+commandEncoder65.clearBuffer(buffer25, 63108, 104);
+dissociateBuffer(device2, buffer25);
+} catch {}
+let promise51 = device2.queue.onSubmittedWorkDone();
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: imageData6,
+  origin: { x: 87, y: 61 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let device3 = await adapter5.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+});
+let bindGroupLayout40 = pipeline30.getBindGroupLayout(0);
+let commandEncoder68 = device0.createCommandEncoder({label: '\u65bf\udc1e\u082d\u4208\u0faf\u11d3\ua39a\u9079\u0486'});
+let computePassEncoder62 = commandEncoder64.beginComputePass({label: '\u6e28\u8841\u{1feba}'});
+try {
+computePassEncoder45.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline41);
+} catch {}
+try {
+renderBundleEncoder26.drawIndirect(buffer22, 644);
+} catch {}
+try {
+commandEncoder57.copyBufferToTexture({
+/* bytesInLastRow: 624 widthInBlocks: 39 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 39760 */
+offset: 39760,
+bytesPerRow: 768,
+buffer: buffer12,
+}, {
+  texture: texture62,
+  mipLevel: 2,
+  origin: { x: 168, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 468, height: 36, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+let imageData14 = new ImageData(88, 164);
+try {
+offscreenCanvas18.getContext('webgpu');
+} catch {}
+gc();
+let renderBundleEncoder74 = device0.createRenderBundleEncoder({
+  label: '\u3c63\uf04e\u{1fd70}\u0f0e\u0144\u07cc',
+  colorFormats: ['r32uint', 'rg8sint', undefined, 'rg32float', 'bgra8unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+let sampler58 = device0.createSampler({
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 86.578,
+});
+try {
+computePassEncoder62.setPipeline(pipeline40);
+} catch {}
+try {
+commandEncoder68.copyBufferToBuffer(buffer24, 10132, buffer16, 56744, 2388);
+dissociateBuffer(device0, buffer24);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 6052, new DataView(new ArrayBuffer(46156)), 12228, 14272);
+} catch {}
+let canvas26 = document.createElement('canvas');
+gc();
+let bindGroup33 = device2.createBindGroup({
+label: '\u0764\u6c05\u0ad8\u{1f82b}',
+layout: bindGroupLayout37,
+entries: [{
+binding: 385,
+resource: sampler55
+}, {
+binding: 771,
+resource: externalTexture4
+}],
+});
+let textureView72 = texture79.createView({label: '\u{1f68a}\uefe2\u0ab4\u017c\uadad\u02b6\u{1f779}', baseMipLevel: 4});
+let computePassEncoder63 = commandEncoder67.beginComputePass({label: '\u9685\u0041'});
+let sampler59 = device2.createSampler({
+label: '\u{1fd3b}\u5085\u{1f79a}\u6057',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 22.596,
+lodMaxClamp: 39.331,
+});
+try {
+computePassEncoder63.setBindGroup(2, bindGroup32, new Uint32Array(2490), 350, 0);
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer26, 52, buffer31, 10856, 4272);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer31);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 3,
+  origin: { x: 1, y: 0, z: 2 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 52843 */
+{offset: 507, bytesPerRow: 152, rowsPerImage: 43}, {width: 3, height: 1, depthOrArrayLayers: 9});
+} catch {}
+let pipeline113 = device2.createComputePipeline({
+layout: pipelineLayout19,
+compute: {
+module: shaderModule27,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+try {
+  await promise43;
+} catch {}
+let canvas27 = document.createElement('canvas');
+let shaderModule28 = device2.createShaderModule({
+label: '\u{1fa10}\u03e9\u0dab\u53da\ude4f\u07ab',
+code: `@group(1) @binding(241)
+var<storage, read_write> i10: array<u32>;
+@group(2) @binding(241)
+var<storage, read_write> parameter12: array<u32>;
+
+@compute @workgroup_size(1, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<i32>,
+  @builtin(frag_depth) f1: f32,
+  @location(0) f2: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(11) a0: vec3<f16>, @location(7) a1: f32, @location(3) a2: vec2<f32>, @location(6) a3: vec3<f16>, @location(14) a4: vec3<f16>, @builtin(vertex_index) a5: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroupLayout41 = device2.createBindGroupLayout({
+label: '\uc0cd\u{1fc86}\u5ad4\u3244\u9463\u2fea',
+entries: [{
+binding: 240,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+}, {
+binding: 448,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}, {
+binding: 697,
+visibility: 0,
+storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '2d-array' },
+}],
+});
+let querySet72 = device2.createQuerySet({
+label: '\u4488\u0aad\u{1fb5c}\ud172\u7f99\u4fb8\u1dcb\uca0b',
+type: 'occlusion',
+count: 1909,
+});
+let texture85 = device2.createTexture({
+size: {width: 204, height: 160, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+dimension: '2d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let sampler60 = device2.createSampler({
+label: '\u4df1\u{1fab8}\ud0e0\u{1fa14}\u0a02\uc54f\u07a4\u0cd3\u6e43\u254e\u4809',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+lodMaxClamp: 44.913,
+});
+let bindGroupLayout42 = device0.createBindGroupLayout({
+label: '\u02c3\u{1fc82}',
+entries: [{
+binding: 951,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+}],
+});
+let texture86 = device0.createTexture({
+label: '\u75f2\u13a6\u8b9f\u{1fbe5}\u{1f71e}\u{1fb36}\u{1ff6a}\uc9f4\u7298',
+size: {width: 192, height: 200, depthOrArrayLayers: 175},
+mipLevelCount: 5,
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x10-unorm', 'astc-12x10-unorm', 'astc-12x10-unorm'],
+});
+let computePassEncoder64 = commandEncoder68.beginComputePass();
+try {
+renderBundleEncoder30.draw(64);
+} catch {}
+try {
+renderBundleEncoder26.drawIndirect(buffer12, 17792);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(4, buffer6, 22984, 13253);
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(buffer17, 16632, buffer18, 17628, 1384);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder57.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 13, y: 16, z: 176 },
+  aspect: 'all',
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 222, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder57.resolveQuerySet(querySet54, 884, 629, buffer12, 19456);
+} catch {}
+try {
+  await promise45;
+} catch {}
+let imageBitmap24 = await createImageBitmap(videoFrame16);
+let texture87 = device2.createTexture({
+label: '\u0477\u0fd2\ub23d\u{1ff3d}',
+size: {width: 25, height: 20, depthOrArrayLayers: 72},
+mipLevelCount: 6,
+dimension: '3d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['r8snorm', 'r8snorm'],
+});
+try {
+commandEncoder63.clearBuffer(buffer31, 4732, 29000);
+dissociateBuffer(device2, buffer31);
+} catch {}
+let gpuCanvasContext20 = canvas26.getContext('webgpu');
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let bindGroupLayout43 = device3.createBindGroupLayout({
+label: '\u17c6\u9d69\uc70a\ue5bb\u9916\ub0e7\u7b21\u92cd\u0d8d',
+entries: [{
+binding: 365,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d-array' },
+}, {
+binding: 95,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+document.body.prepend(canvas22);
+try {
+canvas27.getContext('webgpu');
+} catch {}
+try {
+window.someLabel = bindGroupLayout43.label;
+} catch {}
+let bindGroupLayout44 = device3.createBindGroupLayout({
+label: '\u{1f71a}\u0af4\u0c55\u{1f70d}',
+entries: [{
+binding: 983,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '1d' },
+}, {
+binding: 469,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '3d' },
+}, {
+binding: 83,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '3d' },
+}],
+});
+try {
+renderBundleEncoder69.setBindGroup(0, bindGroup32);
+} catch {}
+let arrayBuffer14 = buffer27.getMappedRange(3656, 5752);
+try {
+  await promise39;
+} catch {}
+let querySet73 = device0.createQuerySet({
+label: '\u053a\u{1fa66}\ue1d0\ua403\u3448',
+type: 'occlusion',
+count: 566,
+});
+let texture88 = device0.createTexture({
+size: [438, 1, 72],
+dimension: '3d',
+format: 'rg16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16float'],
+});
+try {
+renderBundleEncoder26.drawIndexed(0, 72, 16);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexedIndirect(buffer12, 20216);
+} catch {}
+try {
+renderBundleEncoder53.drawIndirect(buffer15, 756);
+} catch {}
+let arrayBuffer15 = buffer11.getMappedRange(0, 7104);
+try {
+commandEncoder57.clearBuffer(buffer10, 6248, 4);
+dissociateBuffer(device0, buffer10);
+} catch {}
+let bindGroupLayout45 = device3.createBindGroupLayout({
+label: '\u03fe\u2bf2\u{1f74a}\u0b8a\u5c77\u{1f9a1}\u030e\u5e20\u0662\u0aa6',
+entries: [],
+});
+let buffer33 = device3.createBuffer({
+  label: '\u0eb1\u{1fd14}\u0886\u9b0d\u{1ff23}\u{1f8a3}',
+  size: 56191,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let texture89 = device3.createTexture({
+label: '\u{1fcc9}\u0694\u03c8\u{1f978}\u{1fda6}',
+size: {width: 1434, height: 1, depthOrArrayLayers: 222},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb'],
+});
+document.body.prepend(img10);
+let buffer34 = device2.createBuffer({label: '\u065e\u074e\u0c69\u0d26\u73e1\u7edb\u1eb1', size: 15948, usage: GPUBufferUsage.COPY_DST});
+let commandEncoder69 = device2.createCommandEncoder({label: '\ud64b\u0527\uc50b\u8eef\u09f1\u06e6\u{1f718}\u{1fb41}\u4b2d\ua26d\u37c7'});
+let textureView73 = texture81.createView({label: '\u7674\ud4fd\ue138'});
+let renderBundleEncoder75 = device2.createRenderBundleEncoder({
+  label: '\u7c8f\ua8e5\u6a8a\u796a',
+  colorFormats: ['r8uint', 'bgra8unorm', 'rg32float', 'rg32uint', 'r32float']
+});
+let renderBundle79 = renderBundleEncoder69.finish({label: '\ubb5d\u{1fe4d}\u1d81\u1cb2'});
+try {
+commandEncoder65.copyBufferToBuffer(buffer26, 5324, buffer27, 17332, 1116);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 6, height: 1, depthOrArrayLayers: 12}
+*/
+{
+  source: videoFrame20,
+  origin: { x: 365, y: 683 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 3,
+  origin: { x: 2, y: 1, z: 4 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let shaderModule29 = device0.createShaderModule({
+label: '\u35c8\u0dc7\ude16\u{1fd7d}\u0e34\u535f\ueb5b\u095e\u0729',
+code: `@group(2) @binding(803)
+var<storage, read_write> parameter13: array<u32>;
+
+@compute @workgroup_size(1, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<i32>,
+  @location(1) f1: vec2<u32>,
+  @location(2) f2: vec4<u32>,
+  @location(0) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S20 {
+  @location(1) f0: vec3<i32>,
+  @location(0) f1: u32,
+  @location(6) f2: vec2<i32>,
+  @location(10) f3: i32
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec2<f16>, @location(15) a1: f32, @location(11) a2: vec4<f32>, @location(4) a3: f16, @location(7) a4: vec4<f16>, a5: S20, @location(5) a6: u32, @location(12) a7: vec4<u32>, @location(13) a8: vec4<f32>, @location(2) a9: vec4<f16>, @location(9) a10: vec4<f16>, @location(3) a11: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder70 = device0.createCommandEncoder({label: '\u248d\u0cf3\u0ea6\u73ef\u6b5c'});
+pseudoSubmit(device0, commandEncoder23);
+try {
+renderBundleEncoder26.drawIndirect(buffer15, 2856);
+} catch {}
+try {
+renderBundleEncoder51.setIndexBuffer(buffer9, 'uint32');
+} catch {}
+let pipeline114 = device0.createComputePipeline({
+layout: pipelineLayout6,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let bindGroupLayout46 = device0.createBindGroupLayout({
+label: '\ub40a\u8cb7\u6b99\u09fd\u9dce\ua2fd\u{1fc27}\ua421\u4370\ubcc6\u0c20',
+entries: [{
+binding: 883,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+}],
+});
+let bindGroupLayout47 = pipeline95.getBindGroupLayout(0);
+let commandEncoder71 = device0.createCommandEncoder({label: '\u0d2b\u97fd\u0428\u{1f84a}\u3d5f\u91a2\u683a\u{1f620}\u06e7\u03c2\u0fd8'});
+let renderBundle80 = renderBundleEncoder41.finish({label: '\uaf72\u0860\u{1fc3d}\u36df\u0f1c\u0ac6\ua70a'});
+try {
+renderBundleEncoder9.draw(64, 64, 56, 40);
+} catch {}
+try {
+renderBundleEncoder36.drawIndexedIndirect(buffer22, 1756);
+} catch {}
+try {
+renderBundleEncoder30.drawIndirect(buffer22, 1744);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(6, buffer15, 5000, 507);
+} catch {}
+try {
+commandEncoder57.copyTextureToBuffer({
+  texture: texture31,
+  mipLevel: 0,
+  origin: { x: 616, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 512 widthInBlocks: 32 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 28016 */
+offset: 28016,
+bytesPerRow: 512,
+rowsPerImage: 173,
+buffer: buffer12,
+}, {width: 256, height: 24, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder57.resolveQuerySet(querySet48, 767, 9, buffer12, 9728);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+try {
+  await promise48;
+} catch {}
+canvas10.height = 674;
+let imageBitmap25 = await createImageBitmap(canvas5);
+let commandEncoder72 = device3.createCommandEncoder({label: '\ud629\uf086\u21a8\u{1ffb6}\u76df\u0feb\ud67f'});
+let sampler61 = device3.createSampler({
+label: '\u05d4\u50c3\u3bdf\u3845\u0165',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 31.937,
+lodMaxClamp: 92.694,
+});
+try {
+texture89.destroy();
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device3,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let promise52 = device3.queue.onSubmittedWorkDone();
+let texture90 = device2.createTexture({
+label: '\u8677\ua2bf\u02b0\uff36',
+size: {width: 420, height: 1, depthOrArrayLayers: 6},
+mipLevelCount: 3,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth16unorm', 'depth16unorm', 'depth16unorm'],
+});
+let computePassEncoder65 = commandEncoder65.beginComputePass();
+let renderBundle81 = renderBundleEncoder66.finish({label: '\u0b69\u0d7b\u00a8\u6ecc\u{1fb5f}\u0b1b\u070b\u8782\u0bb1\u{1f791}'});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup32, new Uint32Array(1672), 656, 0);
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline111);
+} catch {}
+try {
+renderBundleEncoder75.setBindGroup(1, bindGroup33);
+} catch {}
+let arrayBuffer16 = buffer30.getMappedRange(8040, 7244);
+let pipeline115 = device2.createRenderPipeline({
+label: '\u{1ffb7}\u{1fac2}\ue459\u083e\u4c3c\u0e76\u1060\ud710\u0fb6\u02e4',
+layout: pipelineLayout19,
+multisample: {
+count: 4,
+mask: 0x64cbc36b,
+},
+fragment: {
+  module: shaderModule27,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined]
+},
+vertex: {
+  module: shaderModule27,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1928,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x2',
+offset: 276,
+shaderLocation: 13,
+}, {
+format: 'unorm8x4',
+offset: 1844,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 504,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x4',
+offset: 196,
+shaderLocation: 14,
+}, {
+format: 'sint8x4',
+offset: 32,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 1532,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1388,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32',
+offset: 420,
+shaderLocation: 2,
+}, {
+format: 'snorm8x4',
+offset: 728,
+shaderLocation: 1,
+}, {
+format: 'uint16x4',
+offset: 4,
+shaderLocation: 0,
+}, {
+format: 'uint32x4',
+offset: 180,
+shaderLocation: 8,
+}, {
+format: 'snorm8x4',
+offset: 1016,
+shaderLocation: 15,
+}, {
+format: 'unorm8x4',
+offset: 824,
+shaderLocation: 6,
+}, {
+format: 'sint16x4',
+offset: 120,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 956,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1376,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32',
+offset: 264,
+shaderLocation: 7,
+}, {
+format: 'sint32x4',
+offset: 404,
+shaderLocation: 9,
+}, {
+format: 'unorm16x2',
+offset: 372,
+shaderLocation: 4,
+}, {
+format: 'uint16x2',
+offset: 88,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 36,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 0,
+shaderLocation: 10,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+},
+});
+document.body.prepend(canvas14);
+let commandEncoder73 = device3.createCommandEncoder({label: '\uace2\u2856\u03f7\u{1ff84}\u{1f6a3}\u0ebd\u5321'});
+let textureView74 = texture89.createView({});
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+let adapter6 = await navigator.gpu.requestAdapter({
+});
+let offscreenCanvas19 = new OffscreenCanvas(866, 990);
+try {
+offscreenCanvas19.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder74 = device2.createCommandEncoder({label: '\u9195\uaf60\u0d16\u{1f897}\u3355\u658c\uf679\ua5bc\u{1fbd9}\ue01d'});
+let textureView75 = texture75.createView({label: '\u6147\u303a', dimension: '1d'});
+let renderBundleEncoder76 = device2.createRenderBundleEncoder({
+  label: '\u46a6\u0d77\u1860\u7a9b\u4032\u013a\u08fb',
+  colorFormats: ['bgra8unorm', undefined, undefined, 'rgba16float', 'bgra8unorm-srgb', 'rgba8sint'],
+  depthReadOnly: true
+});
+let sampler62 = device2.createSampler({
+label: '\u5446\u{1f7bd}\u3194\u0084\ubdcb\u7613\u23b6\u5e22',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 23.377,
+lodMaxClamp: 42.886,
+maxAnisotropy: 2,
+});
+try {
+commandEncoder69.copyBufferToBuffer(buffer26, 4912, buffer31, 24784, 2400);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer31);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8snorm', 'rgba8unorm', 'rgba8unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture90,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new Int16Array(arrayBuffer4), /* required buffer size: 83739 */
+{offset: 73, bytesPerRow: 326, rowsPerImage: 64}, {width: 105, height: 1, depthOrArrayLayers: 5});
+} catch {}
+document.body.prepend(video16);
+let texture91 = device3.createTexture({
+label: '\u{1ff95}\ua4c7\u798d\u059a\u5507\u{1fd27}\u{1f9a2}',
+size: [96, 48, 1],
+mipLevelCount: 7,
+format: 'eac-r11unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['eac-r11unorm', 'eac-r11unorm'],
+});
+let shaderModule30 = device2.createShaderModule({
+label: '\u013f\u{1ff51}\u06cf\uf1a7\ud92b\u2fd2\u25ca',
+code: `@group(2) @binding(241)
+var<storage, read_write> parameter14: array<u32>;
+@group(0) @binding(241)
+var<storage, read_write> parameter15: array<u32>;
+
+@compute @workgroup_size(3, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: u32,
+  @builtin(sample_mask) f1: u32,
+  @location(0) f2: vec2<f32>,
+  @builtin(frag_depth) f3: f32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S21 {
+  @location(1) f0: vec2<f32>,
+  @location(14) f1: vec2<i32>,
+  @location(6) f2: u32,
+  @location(11) f3: vec4<f32>,
+  @builtin(vertex_index) f4: u32,
+  @location(0) f5: i32,
+  @location(8) f6: f32,
+  @location(2) f7: vec3<f32>,
+  @location(9) f8: vec3<f32>,
+  @location(4) f9: vec4<u32>,
+  @location(15) f10: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec2<i32>, @location(12) a1: vec4<u32>, @location(3) a2: vec2<u32>, @location(5) a3: f16, @location(10) a4: vec4<f32>, @builtin(instance_index) a5: u32, a6: S21, @location(13) a7: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder75 = device2.createCommandEncoder({label: '\u06c5\u{1fc20}\u048c\u{1f8e2}\u5ab9'});
+let texture92 = device2.createTexture({
+label: '\uda9a\u0ee3\u795f\u0190\u0725\uf4fc\u{1f8c5}\ufd0f\u0748',
+size: {width: 25, height: 20, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16float', 'rg16float', 'rg16float'],
+});
+let textureView76 = texture82.createView({baseMipLevel: 1, mipLevelCount: 1});
+try {
+computePassEncoder61.setPipeline(pipeline111);
+} catch {}
+try {
+renderBundleEncoder72.insertDebugMarker('\u6d5e');
+} catch {}
+try {
+gpuCanvasContext16.configure({
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'r8unorm', 'rgba8snorm'],
+colorSpace: 'srgb',
+});
+} catch {}
+let img19 = await imageWithData(83, 226, '#f8a649a6', '#39462d0e');
+let querySet74 = device0.createQuerySet({
+label: '\u0808\ud62d\u0dbf\u00d4\u0e05\u2cbf\u8d9a\u091e\u{1fb99}\u0b41',
+type: 'occlusion',
+count: 3907,
+});
+let computePassEncoder66 = commandEncoder71.beginComputePass({label: '\uae5f\u{1fb0a}\u5adc\u{1f66a}\u{1fdf9}\u{1fa65}\u0207'});
+try {
+computePassEncoder59.dispatchWorkgroups(1, 2, 5);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(32, 80);
+} catch {}
+try {
+renderBundleEncoder53.drawIndirect(buffer12, 38072);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(0, buffer22, 420, 1335);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: imageBitmap21,
+  origin: { x: 3, y: 14 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+window.someLabel = device3.label;
+} catch {}
+let bindGroupLayout48 = device3.createBindGroupLayout({
+label: '\u6f3b\u2d44\u0235\u9e7e\u5297\u04b4\ucfb6\u9a4d\ua5a5',
+entries: [{
+binding: 554,
+visibility: 0,
+buffer: { type: 'storage', minBindingSize: 937657, hasDynamicOffset: false },
+}, {
+binding: 230,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '2d-array' },
+}],
+});
+let buffer35 = device3.createBuffer({
+  label: '\u{1ff70}\u1414',
+  size: 30737,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX
+});
+pseudoSubmit(device3, commandEncoder73);
+let computePassEncoder67 = commandEncoder72.beginComputePass({label: '\u02f5\u02d6\u{1fb3b}\u0482\ueb5e\u380b\u60c6\u0b8a'});
+try {
+device3.pushErrorScope('validation');
+} catch {}
+let promise53 = buffer33.mapAsync(GPUMapMode.WRITE, 13328, 1792);
+let commandEncoder76 = device3.createCommandEncoder({label: '\u7898\u6a8c\u08eb\ub819\u7e9c\ufdcd\u3410\u4b63\u2b06\u{1fc73}'});
+try {
+device3.queue.writeBuffer(buffer35, 22132, new Float32Array(49871), 38032, 1396);
+} catch {}
+let canvas28 = document.createElement('canvas');
+try {
+await adapter2.requestAdapterInfo();
+} catch {}
+try {
+canvas28.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder77 = device0.createCommandEncoder({label: '\ue0fc\u02a9\u{1fe17}\u0e76\ue551\u0e4a'});
+let querySet75 = device0.createQuerySet({
+label: '\u{1fb4d}\u8bc6\u8d63\u{1f81c}\u{1fe15}\u0b9b',
+type: 'occlusion',
+count: 1974,
+});
+let texture93 = gpuCanvasContext11.getCurrentTexture();
+let textureView77 = texture2.createView({
+  label: '\u04b7\u0708\u{1fb33}\u063d\ufc22\ud5b1\u00ac\u{1f96c}\ub9cb\uf2d2\u6eb3',
+  dimension: '2d-array',
+  format: 'astc-8x6-unorm-srgb',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 0
+});
+let renderBundle82 = renderBundleEncoder47.finish({label: '\u2cf3\u6452\uc44e\u91d7\u0e58\ue2f2\u6f54\u0a98\u6846\u{1fc5f}\u64e9'});
+try {
+renderBundleEncoder53.draw(56);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer22, 92);
+} catch {}
+try {
+renderBundleEncoder62.drawIndirect(buffer22, 376);
+} catch {}
+try {
+commandEncoder57.copyTextureToTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 72, y: 5, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture56,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 15, depthOrArrayLayers: 1});
+} catch {}
+let promise54 = device0.queue.onSubmittedWorkDone();
+let pipeline116 = device0.createRenderPipeline({
+label: '\ua2d0\udf95\u425b\u3ef1\u0f93\uad11\u0cb2\u{1f88f}\u3628\ue99d',
+layout: pipelineLayout9,
+fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: GPUColorWrite.ALL}, undefined, {format: 'rg8sint'}]
+},
+vertex: {
+  module: shaderModule20,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 52,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1372,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 220,
+shaderLocation: 10,
+}, {
+format: 'unorm8x4',
+offset: 380,
+shaderLocation: 8,
+}, {
+format: 'unorm8x2',
+offset: 704,
+shaderLocation: 5,
+}, {
+format: 'float32',
+offset: 316,
+shaderLocation: 2,
+}, {
+format: 'float32x2',
+offset: 640,
+shaderLocation: 3,
+}, {
+format: 'sint8x4',
+offset: 596,
+shaderLocation: 14,
+}, {
+format: 'float32x2',
+offset: 636,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 1232,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 860,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x2',
+offset: 776,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 1868,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x2',
+offset: 1340,
+shaderLocation: 12,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+unclippedDepth: true,
+},
+});
+let video17 = await videoWithData();
+let offscreenCanvas20 = new OffscreenCanvas(82, 926);
+try {
+offscreenCanvas20.getContext('2d');
+} catch {}
+let shaderModule31 = device0.createShaderModule({
+label: '\u2f07\ue7a3\u0f0f\u6a80\u{1f97b}\u{1fe72}\u0123\ua235\u9b0e',
+code: `@group(2) @binding(788)
+var<storage, read_write> global7: array<u32>;
+@group(2) @binding(803)
+var<storage, read_write> field12: array<u32>;
+
+@compute @workgroup_size(5, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec2<f32>,
+  @location(0) f1: vec4<i32>,
+  @location(1) f2: vec4<i32>,
+  @builtin(frag_depth) f3: f32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(9) a0: vec4<u32>, @location(2) a1: i32, @location(5) a2: u32, @location(15) a3: vec3<u32>, @location(3) a4: f16, @location(14) a5: u32, @location(11) a6: vec3<u32>, @location(4) a7: f16, @location(7) a8: vec2<u32>, @location(8) a9: vec2<u32>, @location(0) a10: vec2<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let texture94 = device0.createTexture({
+label: '\u1059\u0d52\u{1f9eb}',
+size: [876, 1, 99],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'r8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8unorm', 'r8unorm', 'r8unorm'],
+});
+try {
+computePassEncoder46.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+computePassEncoder31.dispatchWorkgroups(2);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline43);
+} catch {}
+let arrayBuffer17 = buffer21.getMappedRange(0, 20284);
+try {
+commandEncoder57.resolveQuerySet(querySet15, 64, 21, buffer12, 17152);
+} catch {}
+let promise55 = adapter6.requestDevice({
+label: '\ue26b\u2658\uf4f9\u34e0\u0263\udb4a\u6597\u{1fbc0}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-astc',
+'indirect-first-instance',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 33,
+maxVertexBufferArrayStride: 19063,
+maxStorageTexturesPerShaderStage: 18,
+maxStorageBuffersPerShaderStage: 23,
+maxDynamicStorageBuffersPerPipelineLayout: 837,
+maxBindingsPerBindGroup: 8283,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 14820,
+maxTextureDimension2D: 9960,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 265419649,
+maxUniformBuffersPerShaderStage: 40,
+maxInterStageShaderVariables: 87,
+maxInterStageShaderComponents: 80,
+},
+});
+let offscreenCanvas21 = new OffscreenCanvas(471, 650);
+try {
+offscreenCanvas21.getContext('2d');
+} catch {}
+let querySet76 = device0.createQuerySet({
+label: '\u0bcc\u04c1\u0185\u{1f6a1}\u0a86\uc309\uf06c\u7ffa\u{1fc6c}\u080c',
+type: 'occlusion',
+count: 462,
+});
+try {
+renderBundleEncoder37.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder30.draw(80, 16, 72, 56);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexed(16, 80);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder70.resolveQuerySet(querySet1, 1460, 422, buffer12, 23552);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 5132, new Float32Array(20370), 19277);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 62}
+*/
+{
+  source: offscreenCanvas8,
+  origin: { x: 312, y: 390 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 3,
+  origin: { x: 26, y: 0, z: 37 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let renderBundleEncoder77 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder60.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(buffer12, 7244, buffer11, 52312, 6616);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer11);
+} catch {}
+let pipeline117 = device0.createRenderPipeline({
+label: '\u{1fe30}\ue8fc\u040d\u{1fe57}\u{1f750}\u0150\ua5cb\ue333\u3d06\u9753\u0d3f',
+layout: pipelineLayout11,
+multisample: {
+count: 4,
+mask: 0xefb72299,
+},
+fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'rgba16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rgba16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+vertex: {
+  module: shaderModule10,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1048,
+attributes: [{
+format: 'uint32',
+offset: 4,
+shaderLocation: 14,
+}, {
+format: 'uint32x3',
+offset: 528,
+shaderLocation: 15,
+}, {
+format: 'unorm8x2',
+offset: 80,
+shaderLocation: 5,
+}, {
+format: 'sint16x4',
+offset: 188,
+shaderLocation: 2,
+}, {
+format: 'float32',
+offset: 248,
+shaderLocation: 10,
+}, {
+format: 'snorm16x4',
+offset: 936,
+shaderLocation: 12,
+}, {
+format: 'sint16x4',
+offset: 976,
+shaderLocation: 0,
+}, {
+format: 'float32x4',
+offset: 24,
+shaderLocation: 7,
+}, {
+format: 'unorm10-10-10-2',
+offset: 704,
+shaderLocation: 8,
+}, {
+format: 'sint32',
+offset: 500,
+shaderLocation: 13,
+}, {
+format: 'uint32x2',
+offset: 524,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 1148,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 0,
+attributes: [{
+format: 'unorm16x2',
+offset: 1676,
+shaderLocation: 11,
+}, {
+format: 'snorm16x2',
+offset: 48,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 476,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x4',
+offset: 368,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 1680,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 380,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 836,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 768,
+shaderLocation: 1,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+  await promise51;
+} catch {}
+let img20 = await imageWithData(99, 277, '#81aff9ad', '#d0181be1');
+let computePassEncoder68 = commandEncoder57.beginComputePass({label: '\u475a\ufdf2\u8ae9\u1f9c\ufae2\ubc8e\u0dba\u03d1\u0c74\u{1fa28}\u07eb'});
+try {
+renderBundleEncoder36.setBindGroup(3, bindGroup6, new Uint32Array(819), 494, 0);
+} catch {}
+try {
+renderBundleEncoder26.draw(0);
+} catch {}
+try {
+renderBundleEncoder62.drawIndirect(buffer15, 4512);
+} catch {}
+try {
+renderBundleEncoder57.setIndexBuffer(buffer9, 'uint32', 15328, 5074);
+} catch {}
+try {
+commandEncoder70.copyTextureToBuffer({
+  texture: texture42,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'depth-only',
+}, {
+/* bytesInLastRow: 660 widthInBlocks: 330 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 54224 */
+offset: 54224,
+bytesPerRow: 768,
+rowsPerImage: 237,
+buffer: buffer1,
+}, {width: 330, height: 24, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let pipeline118 = device0.createRenderPipeline({
+label: '\u0bc1\ub87d',
+layout: pipelineLayout13,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule25,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}]
+},
+vertex: {module: shaderModule25, entryPoint: 'vertex0', buffers: [
+
+]},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let bindGroupLayout49 = device0.createBindGroupLayout({
+label: '\u4a07\u{1feb3}\uf006\ue47f\u{1f7cd}\u4256\u5229\u5455\u0f31',
+entries: [],
+});
+let commandEncoder78 = device0.createCommandEncoder({label: '\u{1f996}\u0a1f\u9ba9\u5658\u9884\u3ec7\u0ed5\udf5c\u0da4'});
+try {
+computePassEncoder37.setPipeline(pipeline32);
+} catch {}
+try {
+renderBundleEncoder73.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexed(16, 72);
+} catch {}
+try {
+renderBundleEncoder53.drawIndirect(buffer12, 31916);
+} catch {}
+try {
+renderBundleEncoder63.setVertexBuffer(1, buffer6);
+} catch {}
+let querySet77 = device2.createQuerySet({
+label: '\u8e9f\u{1f6f6}\u{1f6ec}\u0901',
+type: 'occlusion',
+count: 988,
+});
+let renderBundleEncoder78 = device2.createRenderBundleEncoder({
+  label: '\u25dd\u0608\u03f1\u07fb\u1d31\u3b77\u{1f788}\u426a',
+  colorFormats: ['r8uint', 'bgra8unorm', 'rg32float', 'rg32uint', 'r32float'],
+  stencilReadOnly: true
+});
+let renderBundle83 = renderBundleEncoder76.finish();
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 48, height: 7, depthOrArrayLayers: 100}
+*/
+{
+  source: canvas4,
+  origin: { x: 229, y: 81 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: { x: 26, y: 0, z: 47 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 5, depthOrArrayLayers: 1});
+} catch {}
+let pipeline119 = await device2.createComputePipelineAsync({
+layout: pipelineLayout19,
+compute: {
+module: shaderModule27,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+video9.height = 222;
+let pipelineLayout20 = device3.createPipelineLayout({
+  label: '\u0fe4\u8545\u78ee\ubfc5\u{1fc63}\u0564\u56b1',
+  bindGroupLayouts: [bindGroupLayout44, bindGroupLayout48]
+});
+let sampler63 = device3.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 40.021,
+lodMaxClamp: 53.775,
+maxAnisotropy: 10,
+});
+let querySet78 = device2.createQuerySet({
+label: '\u1ffb\u{1fa54}\u064f\u3f0e\uffea\u757e\u64a5\u3d4e\u0822',
+type: 'occlusion',
+count: 2376,
+});
+let computePassEncoder69 = commandEncoder69.beginComputePass({label: '\ua85c\u0b53\u{1f946}\u94bc\u5efe\u0b37\u055a'});
+let arrayBuffer18 = buffer32.getMappedRange();
+try {
+commandEncoder75.copyBufferToBuffer(buffer26, 6988, buffer25, 10724, 2568);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+commandEncoder63.copyTextureToBuffer({
+  texture: texture92,
+  mipLevel: 1,
+  origin: { x: 4, y: 5, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 3684 */
+offset: 3660,
+buffer: buffer34,
+}, {width: 6, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer34);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 24, height: 3, depthOrArrayLayers: 50}
+*/
+{
+  source: img1,
+  origin: { x: 5, y: 95 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 20, y: 1, z: 13 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder63.clearBuffer(buffer27, 5080, 11328);
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let video18 = await videoWithData();
+let commandEncoder79 = device3.createCommandEncoder({label: '\u990d\ua81c\u02ff\u068b\u0d3a\u{1ff20}\u5cff\u0bce\u0595\u{1ff4e}'});
+let commandEncoder80 = device3.createCommandEncoder();
+let buffer36 = device2.createBuffer({
+  label: '\ub009\ua04d',
+  size: 44824,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM
+});
+try {
+renderBundleEncoder75.setBindGroup(2, bindGroup32, []);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+try {
+commandEncoder63.copyTextureToTexture({
+  texture: texture79,
+  mipLevel: 2,
+  origin: { x: 5, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 3, y: 3, z: 6 },
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 19});
+} catch {}
+try {
+commandEncoder63.clearBuffer(buffer27, 27156, 368);
+dissociateBuffer(device2, buffer27);
+} catch {}
+let promise56 = device2.queue.onSubmittedWorkDone();
+let imageData15 = new ImageData(52, 152);
+let commandEncoder81 = device0.createCommandEncoder({label: '\ud6ed\u{1ffe2}\u{1fc8b}\uc8bd'});
+try {
+renderBundleEncoder34.setVertexBuffer(1, buffer0, 24568);
+} catch {}
+try {
+commandEncoder81.copyBufferToBuffer(buffer0, 25488, buffer10, 996, 5724);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer10);
+} catch {}
+let texture95 = device2.createTexture({
+label: '\u{1fa11}\udf8a\u1639\u8efb\u{1fbfa}\u1379\ub48c\ue9e0\u9802\u5aa2\u0a73',
+size: [540, 1, 792],
+mipLevelCount: 3,
+dimension: '3d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm'],
+});
+let renderBundle84 = renderBundleEncoder71.finish({label: '\u07ad\ua376'});
+try {
+commandEncoder63.clearBuffer(buffer30);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer36, 25992, new Float32Array(53233), 5010, 3080);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 3, height: 1, depthOrArrayLayers: 6}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 184, y: 88 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 4,
+  origin: { x: 2, y: 1, z: 2 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline120 = device2.createComputePipeline({
+label: '\u002e\u0ae8\u{1f787}\u897f\ue6aa\ud827',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule28,
+entryPoint: 'compute0',
+},
+});
+let bindGroup34 = device0.createBindGroup({
+layout: bindGroupLayout4,
+entries: [],
+});
+let buffer37 = device0.createBuffer({size: 20886, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let querySet79 = device0.createQuerySet({
+type: 'occlusion',
+count: 1098,
+});
+let texture96 = device0.createTexture({
+label: '\u02de\u0b2f\u8677\u548a\ucb1a\u0e12\u018a',
+size: {width: 330, height: 24, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['depth24plus', 'depth24plus', 'depth24plus'],
+});
+let renderBundle85 = renderBundleEncoder56.finish({label: '\u0d74\udd19\u78d0\uf17f\u2eca\u2b3a'});
+try {
+renderBundleEncoder20.draw(56);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexed(80, 0, 8, -440);
+} catch {}
+try {
+renderBundleEncoder63.setPipeline(pipeline95);
+} catch {}
+try {
+commandEncoder77.resolveQuerySet(querySet51, 833, 668, buffer37, 9984);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer9), /* required buffer size: 497 */
+{offset: 497}, {width: 40, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise54;
+} catch {}
+let querySet80 = device2.createQuerySet({
+label: '\u{1fcfa}\u8185',
+type: 'occlusion',
+count: 3739,
+});
+pseudoSubmit(device2, commandEncoder75);
+let renderBundle86 = renderBundleEncoder66.finish({label: '\ua15d\uc4f1\u0d34\uc307\ue802\u{1fb84}'});
+try {
+renderBundleEncoder78.setVertexBuffer(7, buffer26);
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(buffer26, 5660, buffer36, 11320, 172);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer36);
+} catch {}
+try {
+commandEncoder63.clearBuffer(buffer36);
+dissociateBuffer(device2, buffer36);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 48, height: 7, depthOrArrayLayers: 100}
+*/
+{
+  source: canvas21,
+  origin: { x: 159, y: 50 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: { x: 0, y: 3, z: 4 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 37, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter1.label = '\uecc0\uede9\ue165\u06fb';
+} catch {}
+let video19 = await videoWithData();
+try {
+await device3.popErrorScope();
+} catch {}
+try {
+texture91.destroy();
+} catch {}
+try {
+commandEncoder76.clearBuffer(buffer35, 3684, 6584);
+dissociateBuffer(device3, buffer35);
+} catch {}
+let bindGroupLayout50 = device0.createBindGroupLayout({
+label: '\u535c\u8862\u4454\u{1f8ef}\u0150\u01d1\u5b71\u0e93\u{1fb8d}\ueeed',
+entries: [],
+});
+let pipelineLayout21 = device0.createPipelineLayout({
+  label: '\u0d88\ueff1\u45dd',
+  bindGroupLayouts: [bindGroupLayout47, bindGroupLayout5, bindGroupLayout14, bindGroupLayout1]
+});
+let texture97 = device0.createTexture({
+label: '\ua89c\u5aa0\u0208\u0d07\ua1b0\u{1fa30}\u051e\u{1fa2c}',
+size: [32, 45, 811],
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+});
+let computePassEncoder70 = commandEncoder77.beginComputePass({label: '\u00d8\u0950'});
+let renderPassEncoder0 = commandEncoder70.beginRenderPass({
+label: '\u34cf\u081a\u0f48\u159a\u97f1\u0544\u5e29',
+colorAttachments: [{
+  view: textureView71,
+  clearValue: { r: 870.2, g: -284.4, b: -702.1, a: 624.5, },
+  loadOp: 'load',
+  storeOp: 'store'
+}],
+occlusionQuerySet: querySet8,
+maxDrawCount: 603623897,
+});
+try {
+computePassEncoder59.dispatchWorkgroups(2, 4, 3);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -950.5, g: 117.5, b: -434.4, a: 631.3, });
+} catch {}
+try {
+renderPassEncoder0.setViewport(1.500, 0.00383, 3.224, 0.3532, 0.5927, 0.6589);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder62.drawIndexedIndirect(buffer15, 4900);
+} catch {}
+try {
+commandEncoder78.copyTextureToTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: { x: 17, y: 1, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 23, y: 1, z: 1 },
+  aspect: 'all',
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer38 = device3.createBuffer({
+  label: '\u0898\u0ab6\ue9fa\u8018\u08ef\ucdee\u0865\u32b5',
+  size: 15083,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let texture98 = device3.createTexture({
+size: [60, 96, 1],
+mipLevelCount: 6,
+dimension: '2d',
+format: 'rg16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16float', 'rg16float', 'rg16float'],
+});
+let adapter7 = await navigator.gpu.requestAdapter({
+});
+let shaderModule32 = device3.createShaderModule({
+label: '\u0efb\u{1f6bd}\ud5b6\u{1ffa4}',
+code: `@group(0) @binding(983)
+var<storage, read_write> i11: array<u32>;
+@group(1) @binding(554)
+var<storage, read_write> local9: array<u32>;
+@group(0) @binding(469)
+var<storage, read_write> parameter16: array<u32>;
+@group(0) @binding(83)
+var<storage, read_write> function9: array<u32>;
+
+@compute @workgroup_size(7, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S22 {
+  @location(6) f0: vec4<f32>,
+  @location(8) f1: u32,
+  @location(15) f2: vec2<u32>,
+  @location(13) f3: vec2<u32>,
+  @builtin(sample_index) f4: u32,
+  @builtin(sample_mask) f5: u32
+}
+struct FragmentOutput0 {
+  @location(3) f0: vec3<u32>,
+  @builtin(sample_mask) f1: u32
+}
+
+@fragment
+fn fragment0(@location(10) a0: vec2<u32>, @location(5) a1: vec3<f16>, @builtin(front_facing) a2: bool, a3: S22) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(8) f130: u32,
+  @location(5) f131: vec3<f16>,
+  @location(15) f132: vec2<u32>,
+  @location(13) f133: vec2<u32>,
+  @location(10) f134: vec2<u32>,
+  @builtin(position) f135: vec4<f32>,
+  @location(6) f136: vec4<f32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @builtin(instance_index) a1: u32, @location(4) a2: f16, @location(15) a3: vec3<u32>, @location(5) a4: vec4<i32>, @location(3) a5: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder82 = device3.createCommandEncoder({label: '\u0aa9\u177d\u{1fce0}\uac0c\u9640\u7982\uc071'});
+pseudoSubmit(device3, commandEncoder79);
+let texture99 = device3.createTexture({
+label: '\u1993\u{1f877}',
+size: [64, 5, 7],
+mipLevelCount: 2,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['depth24plus-stencil8', 'depth24plus-stencil8'],
+});
+let textureView78 = texture99.createView({
+  label: '\u0405\u{1fbf6}\u3581\u05c2\u{1fea2}\u{1fb36}\u88ae\u6336\u02a7',
+  format: 'depth24plus-stencil8',
+  mipLevelCount: 1,
+  baseArrayLayer: 2,
+  arrayLayerCount: 3
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let video20 = await videoWithData();
+try {
+if (!arrayBuffer17.detached) { new Uint8Array(arrayBuffer17).fill(0x55) };
+} catch {}
+let promise57 = adapter7.requestAdapterInfo();
+let texture100 = gpuCanvasContext5.getCurrentTexture();
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -756.6, g: 370.8, b: -696.8, a: -702.3, });
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(3755);
+} catch {}
+try {
+renderBundleEncoder68.setPipeline(pipeline98);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas11,
+  origin: { x: 730, y: 3 },
+  flipY: true,
+}, {
+  texture: texture100,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+pseudoSubmit(device3, commandEncoder82);
+try {
+device3.queue.writeBuffer(buffer35, 21088, new DataView(new ArrayBuffer(1409)), 229, 876);
+} catch {}
+let pipeline121 = await device3.createComputePipelineAsync({
+label: '\u{1fbe6}\u154b',
+layout: pipelineLayout20,
+compute: {
+module: shaderModule32,
+entryPoint: 'compute0',
+},
+});
+let shaderModule33 = device0.createShaderModule({
+label: '\ua1ab\u{1fbfb}\u9708\ud41e\u5287\ub2df\u78a5',
+code: `@group(1) @binding(803)
+var<storage, read_write> parameter17: array<u32>;
+@group(3) @binding(788)
+var<storage, read_write> parameter18: array<u32>;
+@group(1) @binding(788)
+var<storage, read_write> local10: array<u32>;
+@group(0) @binding(788)
+var<storage, read_write> function10: array<u32>;
+
+@compute @workgroup_size(4, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(frag_depth) f0: f32,
+  @location(7) f1: vec2<i32>,
+  @location(0) f2: vec4<i32>,
+  @builtin(sample_mask) f3: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(1) a0: f32, @builtin(vertex_index) a1: u32, @location(6) a2: vec2<i32>, @location(9) a3: vec4<f32>, @location(14) a4: vec2<u32>, @location(4) a5: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+});
+let querySet81 = device0.createQuerySet({
+label: '\u{1feea}\u{1fbc8}\u0284\u9ec7\u88bb',
+type: 'occlusion',
+count: 2039,
+});
+let texture101 = device0.createTexture({
+label: '\u050f\u7ac7\uf62a',
+size: [1320, 96, 1],
+mipLevelCount: 9,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-8x8-unorm'],
+});
+let renderBundleEncoder79 = device0.createRenderBundleEncoder({
+  label: '\u{1f718}\u1d70',
+  colorFormats: ['rgba32uint', 'rg16sint', 'rgb10a2unorm', 'r32float', undefined],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle87 = renderBundleEncoder59.finish();
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(3, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder0.setViewport(3.226, 0.1775, 0.8456, 0.3505, 0.6274, 0.9419);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder53.draw(48);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder78.resolveQuerySet(querySet9, 955, 519, buffer37, 15360);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData14,
+  origin: { x: 39, y: 133 },
+  flipY: false,
+}, {
+  texture: texture93,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline122 = await device0.createRenderPipelineAsync({
+label: '\u5cc1\u082f\u{1ff2f}\u030b\u{1fe0e}\ua127\ua02d\u040e\u0c72\u1add',
+layout: pipelineLayout9,
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg8sint'}, undefined, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'constant', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}]
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 204,
+shaderLocation: 10,
+}, {
+format: 'sint16x4',
+offset: 1288,
+shaderLocation: 1,
+}, {
+format: 'uint32x2',
+offset: 1576,
+shaderLocation: 14,
+}, {
+format: 'snorm8x2',
+offset: 598,
+shaderLocation: 6,
+}, {
+format: 'sint16x4',
+offset: 656,
+shaderLocation: 4,
+}, {
+format: 'uint16x4',
+offset: 284,
+shaderLocation: 3,
+}, {
+format: 'float32x2',
+offset: 1372,
+shaderLocation: 8,
+}, {
+format: 'snorm16x4',
+offset: 112,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 456,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 960,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x2',
+offset: 822,
+shaderLocation: 7,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+},
+});
+offscreenCanvas17.height = 239;
+let textureView79 = texture91.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 4});
+try {
+computePassEncoder67.end();
+} catch {}
+try {
+device3.queue.writeBuffer(buffer35, 30452, new Float32Array(58655), 35309, 68);
+} catch {}
+try {
+  await promise50;
+} catch {}
+let shaderModule34 = device2.createShaderModule({
+label: '\ufee8\u6698\u8fcb',
+code: `@group(0) @binding(241)
+var<storage, read_write> parameter19: array<u32>;
+@group(2) @binding(241)
+var<storage, read_write> type13: array<u32>;
+
+@compute @workgroup_size(6, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<f32>,
+  @location(5) f1: vec4<i32>,
+  @location(4) f2: vec4<f32>,
+  @location(0) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool, @builtin(sample_mask) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f137: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec4<i32>, @location(1) a1: vec2<f16>, @location(3) a2: vec4<f32>, @location(12) a3: vec4<f32>, @location(5) a4: i32, @location(7) a5: vec4<f16>, @builtin(vertex_index) a6: u32, @location(2) a7: vec3<f32>, @builtin(instance_index) a8: u32, @location(9) a9: vec4<f16>, @location(14) a10: vec4<f16>, @location(4) a11: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let textureView80 = texture75.createView({label: '\u969e\u5dd2', mipLevelCount: 1});
+try {
+computePassEncoder63.setBindGroup(1, bindGroup33);
+} catch {}
+try {
+computePassEncoder61.end();
+} catch {}
+let promise58 = device2.queue.onSubmittedWorkDone();
+let img21 = await imageWithData(41, 190, '#fb454c81', '#09e93d62');
+let shaderModule35 = device0.createShaderModule({
+label: '\u60cf\u{1fa1e}\u03e4\u998a\u6a03\u1bc2',
+code: `@group(0) @binding(794)
+var<storage, read_write> local11: array<u32>;
+@group(0) @binding(297)
+var<storage, read_write> parameter20: array<u32>;
+@group(1) @binding(43)
+var<storage, read_write> function11: array<u32>;
+@group(1) @binding(257)
+var<storage, read_write> i12: array<u32>;
+
+@compute @workgroup_size(3, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S24 {
+  @location(5) f0: vec2<f16>,
+  @builtin(front_facing) f1: bool,
+  @location(1) f2: vec4<f32>,
+  @builtin(position) f3: vec4<f32>,
+  @location(13) f4: vec3<f32>,
+  @location(10) f5: vec3<f32>,
+  @builtin(sample_index) f6: u32,
+  @location(8) f7: vec3<i32>,
+  @location(6) f8: i32,
+  @location(11) f9: vec3<f32>,
+  @location(7) f10: vec2<u32>,
+  @location(12) f11: vec2<f32>,
+  @builtin(sample_mask) f12: u32,
+  @location(4) f13: vec2<f16>,
+  @location(15) f14: f16,
+  @location(0) f15: vec4<u32>,
+  @location(2) f16: vec2<u32>,
+  @location(9) f17: vec2<f32>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<i32>,
+  @location(0) f1: vec2<i32>,
+  @builtin(sample_mask) f2: u32
+}
+
+@fragment
+fn fragment0(a0: S24, @location(14) a1: f16) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S23 {
+  @location(7) f0: vec2<f32>,
+  @location(2) f1: u32,
+  @location(14) f2: vec4<i32>,
+  @location(8) f3: vec2<f16>
+}
+struct VertexOutput0 {
+  @location(9) f138: vec2<f32>,
+  @location(8) f139: vec3<i32>,
+  @location(10) f140: vec3<f32>,
+  @builtin(position) f141: vec4<f32>,
+  @location(1) f142: vec4<f32>,
+  @location(5) f143: vec2<f16>,
+  @location(15) f144: f16,
+  @location(6) f145: i32,
+  @location(11) f146: vec3<f32>,
+  @location(7) f147: vec2<u32>,
+  @location(2) f148: vec2<u32>,
+  @location(0) f149: vec4<u32>,
+  @location(13) f150: vec3<f32>,
+  @location(4) f151: vec2<f16>,
+  @location(14) f152: f16,
+  @location(12) f153: vec2<f32>
+}
+
+@vertex
+fn vertex0(a0: S23, @location(11) a1: vec4<f16>, @location(3) a2: vec3<f16>, @location(15) a3: vec3<i32>, @location(0) a4: i32, @location(10) a5: vec2<f16>, @location(9) a6: vec4<i32>, @location(4) a7: vec2<u32>, @location(5) a8: vec2<u32>, @builtin(vertex_index) a9: u32, @location(13) a10: vec3<u32>, @location(6) a11: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+});
+let renderBundle88 = renderBundleEncoder79.finish({label: '\ud48b\u396d\u{1fd90}'});
+try {
+computePassEncoder22.dispatchWorkgroupsIndirect(buffer15, 5864);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer22, 156, 496);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup19, new Uint32Array(9359), 7299, 0);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer15, 4672);
+} catch {}
+try {
+renderBundleEncoder26.drawIndirect(buffer22, 1012);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(6, buffer6, 11752, 12487);
+} catch {}
+try {
+commandEncoder78.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 1,
+  origin: { x: 10, y: 45, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture13,
+  mipLevel: 2,
+  origin: { x: 10, y: 5, z: 1 },
+  aspect: 'all',
+}, {width: 10, height: 10, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder78.insertDebugMarker('\u341e');
+} catch {}
+let texture102 = device3.createTexture({
+label: '\u56ed\u0070\u06de\u04c0',
+size: [228, 3, 16],
+mipLevelCount: 6,
+sampleCount: 1,
+dimension: '3d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['r8snorm', 'r8snorm'],
+});
+let computePassEncoder71 = commandEncoder80.beginComputePass({});
+try {
+computePassEncoder71.setPipeline(pipeline121);
+} catch {}
+try {
+commandEncoder72.copyTextureToTexture({
+  texture: texture102,
+  mipLevel: 2,
+  origin: { x: 6, y: 1, z: 2 },
+  aspect: 'all',
+}, {
+  texture: texture102,
+  mipLevel: 0,
+  origin: { x: 16, y: 3, z: 6 },
+  aspect: 'all',
+}, {width: 51, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device3.queue.writeBuffer(buffer35, 15536, new Int16Array(7935), 2266, 76);
+} catch {}
+let pipeline123 = device3.createComputePipeline({
+label: '\u0a1d\u61fa\u2a78\u{1fca2}\udc61\u2712\u69e8\ub4bf\u063c',
+layout: pipelineLayout20,
+compute: {
+module: shaderModule32,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let sampler64 = device2.createSampler({
+label: '\u0c4a\ub909\ubb0c\u0fb2\u4827\u026b',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 29.915,
+lodMaxClamp: 76.290,
+});
+try {
+renderBundleEncoder78.setBindGroup(1, bindGroup33);
+} catch {}
+try {
+commandEncoder66.copyTextureToBuffer({
+  texture: texture78,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'depth-only',
+}, {
+/* bytesInLastRow: 840 widthInBlocks: 210 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 43232 */
+offset: 42392,
+bytesPerRow: 1024,
+rowsPerImage: 183,
+buffer: buffer36,
+}, {width: 210, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer36);
+} catch {}
+try {
+commandEncoder66.copyTextureToTexture({
+  texture: texture92,
+  mipLevel: 0,
+  origin: { x: 5, y: 10, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture92,
+  mipLevel: 0,
+  origin: { x: 3, y: 13, z: 1 },
+  aspect: 'all',
+}, {width: 13, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder66.clearBuffer(buffer30, 1140);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+try {
+commandEncoder76.copyTextureToBuffer({
+  texture: texture91,
+  mipLevel: 2,
+  origin: { x: 0, y: 8, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 24 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 3640 */
+offset: 3640,
+buffer: buffer35,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout51 = device2.createBindGroupLayout({
+label: '\u0796\ud55b\u{1fed3}\u5622\u{1ff23}\u727b\u{1f914}\u8029\u01a8\u0814',
+entries: [],
+});
+try {
+computePassEncoder63.setPipeline(pipeline119);
+} catch {}
+let querySet82 = device0.createQuerySet({
+label: '\uafc8\u{1f6db}\u6bfc\u{1fea1}',
+type: 'occlusion',
+count: 3403,
+});
+let commandBuffer19 = commandEncoder81.finish({
+label: '\u003c\u8b86\ua6c8\u3386\u2431\u0a2f\u{1ffd6}\ua199\u{1f931}\u0742',
+});
+let computePassEncoder72 = commandEncoder78.beginComputePass({label: '\u{1f950}\u14f3\u9e20\u0a81\u{1f919}\u0570\u06fe\ua0e0\u1075\u8d90'});
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -21.40, g: 55.39, b: -837.2, a: 356.7, });
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer12, 9300);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline79);
+} catch {}
+try {
+renderBundleEncoder70.setVertexBuffer(2, buffer0, 300, 10605);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer19,
+]);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas22 = new OffscreenCanvas(868, 108);
+let renderBundleEncoder80 = device0.createRenderBundleEncoder({
+  label: '\u{1f734}\ud52c\u7c8d\u0428\u{1f65b}\u{1fc9e}\u{1fcaa}\u002a\u{1fe42}\u0d20\u05fb',
+  colorFormats: ['r8unorm', 'rgb10a2uint', 'rg16sint'],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+let sampler65 = device0.createSampler({
+label: '\u5dd1\ue39c\u642a\u{1fc2c}',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 88.349,
+maxAnisotropy: 10,
+});
+try {
+renderBundleEncoder54.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder68.drawIndexed(56, 0);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexedIndirect(buffer22, 104);
+} catch {}
+try {
+renderBundleEncoder54.setVertexBuffer(7, buffer6, 6640, 6784);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let arrayBuffer19 = buffer14.getMappedRange(0, 2312);
+try {
+device0.queue.writeBuffer(buffer4, 1668, new Int16Array(2427), 1584, 80);
+} catch {}
+let video21 = await videoWithData();
+try {
+device1.queue.label = '\u{1fa4f}\u0e6c\u0eaa\u{1fcef}';
+} catch {}
+let bindGroup35 = device1.createBindGroup({
+label: '\u09c0\u0314\u077e\u296c\u31c0\u09dc\u05ce\u1f75',
+layout: bindGroupLayout27,
+entries: [],
+});
+let pipelineLayout22 = device1.createPipelineLayout({
+  label: '\u8f21\u{1fb07}\u9069',
+  bindGroupLayouts: [bindGroupLayout27, bindGroupLayout27, bindGroupLayout27]
+});
+let textureView81 = texture60.createView({
+  label: '\uac39\ub58c\u0975\u7c18\u{1fdb4}\ue347\u39ef\u{1fdeb}\u05e1\u9fbd',
+  dimension: '2d',
+  format: 'astc-5x5-unorm-srgb',
+  baseMipLevel: 6,
+  mipLevelCount: 1,
+  baseArrayLayer: 150
+});
+let gpuCanvasContext21 = offscreenCanvas22.getContext('webgpu');
+let img22 = await imageWithData(260, 53, '#55c4446d', '#f237a102');
+let imageData16 = new ImageData(36, 84);
+let videoFrame21 = new VideoFrame(videoFrame4, {timestamp: 0});
+let commandEncoder83 = device2.createCommandEncoder({});
+let texture103 = device2.createTexture({
+label: '\u{1ff95}\ud922',
+size: [2160, 1, 64],
+mipLevelCount: 12,
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgb10a2unorm'],
+});
+try {
+computePassEncoder69.end();
+} catch {}
+try {
+gpuCanvasContext8.configure({
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba8unorm', 'rg8uint', 'rgba8unorm-srgb', 'r32sint'],
+colorSpace: 'srgb',
+});
+} catch {}
+let promise59 = device2.createComputePipelineAsync({
+label: '\u0ea4\u{1fe0f}\u0a48\ub31a\uc541',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule27,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let imageData17 = new ImageData(188, 176);
+let texture104 = device2.createTexture({
+label: '\ubd81\u{1fc0e}\u0db7\uabd4',
+size: {width: 24},
+dimension: '1d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg11b10ufloat'],
+});
+let renderBundle89 = renderBundleEncoder67.finish({label: '\uf500\u0f6d\u206d\u{1fe35}\u0a68\u{1fa1f}\u0e86'});
+let sampler66 = device2.createSampler({
+label: '\u03e0\u{1f704}\u0070\u{1fd89}\u83ab\uca4d\u022b\u8420\u44ee\u7036\u0c7b',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMaxClamp: 96.909,
+compare: 'never',
+maxAnisotropy: 1,
+});
+try {
+computePassEncoder63.setBindGroup(1, bindGroup32);
+} catch {}
+try {
+commandEncoder72.copyBufferToBuffer(buffer38, 6684, buffer35, 11360, 4340);
+dissociateBuffer(device3, buffer38);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder72.copyBufferToTexture({
+/* bytesInLastRow: 12 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 24109 */
+offset: 14381,
+bytesPerRow: 256,
+rowsPerImage: 38,
+buffer: buffer35,
+}, {
+  texture: texture102,
+  mipLevel: 3,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 12, height: 0, depthOrArrayLayers: 2});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame22 = videoFrame0.clone();
+let shaderModule36 = device2.createShaderModule({
+label: '\u5043\u{1fd33}\u1c40',
+code: `@group(1) @binding(241)
+var<storage, read_write> function12: array<u32>;
+@group(2) @binding(241)
+var<storage, read_write> global8: array<u32>;
+
+@compute @workgroup_size(4, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec3<f32>,
+  @location(0) f1: u32,
+  @location(3) f2: vec2<u32>,
+  @location(1) f3: vec4<f32>,
+  @location(2) f4: vec3<f32>,
+  @location(5) f5: vec4<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(4) a0: vec2<f16>, @location(9) a1: vec3<f32>, @location(0) a2: vec3<f32>, @location(5) a3: vec3<f32>, @location(2) a4: vec2<i32>, @location(12) a5: vec4<f32>, @location(13) a6: i32, @location(15) a7: vec3<f32>, @location(1) a8: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let querySet83 = device2.createQuerySet({
+label: '\uf10c\uf45c\u0dd7\u07d2\u2d78\u5e56\u{1f83e}\u3a5a\uf2a9\u196f\u05db',
+type: 'occlusion',
+count: 3276,
+});
+let renderBundleEncoder81 = device2.createRenderBundleEncoder({
+  label: '\udd58\u{1fd5f}\ufade\u1b87\uc06a\u{1f6e1}\u0c49\u03e1\u00ee\u8ea2',
+  colorFormats: ['r8unorm', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+let sampler67 = device2.createSampler({
+label: '\uff1e\ud226\ua503\u061b\u271a\u07ed\u{1fd92}\u{1f857}\uc463\u{1ff6b}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 36.589,
+lodMaxClamp: 58.333,
+});
+try {
+computePassEncoder65.setBindGroup(3, bindGroup32, new Uint32Array(5688), 4933, 0);
+} catch {}
+try {
+renderBundleEncoder72.setBindGroup(2, bindGroup32, []);
+} catch {}
+try {
+await device2.popErrorScope();
+} catch {}
+let arrayBuffer20 = buffer27.getMappedRange(9408, 3152);
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 3, height: 1, depthOrArrayLayers: 6}
+*/
+{
+  source: canvas2,
+  origin: { x: 489, y: 809 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 4,
+  origin: { x: 2, y: 1, z: 6 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise53;
+} catch {}
+let imageBitmap26 = await createImageBitmap(offscreenCanvas6);
+try {
+  await promise57;
+} catch {}
+gc();
+let renderBundleEncoder82 = device0.createRenderBundleEncoder({
+  label: '\u0e99\uab80\u476e\uc395',
+  colorFormats: ['rgba8sint', 'rgba32sint', 'rg16float', 'rg16sint', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+let renderBundle90 = renderBundleEncoder37.finish({});
+try {
+renderBundleEncoder82.setIndexBuffer(buffer9, 'uint32', 1636, 14321);
+} catch {}
+let canvas29 = document.createElement('canvas');
+let bindGroup36 = device2.createBindGroup({
+layout: bindGroupLayout51,
+entries: [],
+});
+let texture105 = device2.createTexture({
+label: '\u{1fb0a}\u3012\uebf3\u2684\ua191\u8eef',
+size: [5280, 1, 176],
+mipLevelCount: 10,
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgb9e5ufloat'],
+});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup32, new Uint32Array(7566), 887, 0);
+} catch {}
+try {
+renderBundleEncoder81.setBindGroup(2, bindGroup36, new Uint32Array(421), 291, 0);
+} catch {}
+try {
+commandEncoder83.clearBuffer(buffer31, 34836, 12);
+dissociateBuffer(device2, buffer31);
+} catch {}
+let gpuCanvasContext22 = canvas29.getContext('webgpu');
+let querySet84 = device3.createQuerySet({
+label: '\ud7da\ufab5\u2dd0\u6dc3\u01a4\u{1f90b}\ua65f\u0a91\u0509',
+type: 'occlusion',
+count: 1894,
+});
+let textureView82 = texture102.createView({label: '\u{1f6d9}\ub2e2\u{1ff06}\u5de9\u2aae', aspect: 'all', baseMipLevel: 4});
+let sampler68 = device3.createSampler({
+label: '\u{1fe1a}\u7ee3\u01dd\u3846\u1a47\u{1fc98}\uf284\ub6bc\u{1f991}',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 73.656,
+lodMaxClamp: 86.797,
+});
+try {
+commandEncoder72.copyBufferToBuffer(buffer33, 24048, buffer35, 22776, 6348);
+dissociateBuffer(device3, buffer33);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder76.copyTextureToTexture({
+  texture: texture102,
+  mipLevel: 2,
+  origin: { x: 16, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture102,
+  mipLevel: 0,
+  origin: { x: 51, y: 0, z: 5 },
+  aspect: 'all',
+}, {width: 41, height: 1, depthOrArrayLayers: 3});
+} catch {}
+try {
+commandEncoder72.clearBuffer(buffer35, 12864, 12568);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer35, 7248, new Int16Array(44946), 41985, 984);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture102,
+  mipLevel: 4,
+  origin: { x: 6, y: 0, z: 0 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer17), /* required buffer size: 508 */
+{offset: 507}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device3.destroy();
+} catch {}
+let videoFrame23 = new VideoFrame(videoFrame21, {timestamp: 0});
+let bindGroup37 = device2.createBindGroup({
+layout: bindGroupLayout37,
+entries: [{
+binding: 771,
+resource: externalTexture4
+}, {
+binding: 385,
+resource: sampler62
+}],
+});
+let commandEncoder84 = device2.createCommandEncoder({label: '\u{1ff61}\u{1f703}\u0af6\u{1fd65}\u0fbb'});
+let renderBundleEncoder83 = device2.createRenderBundleEncoder({
+  label: '\u0ccd\uabe1\u0710',
+  colorFormats: ['bgra8unorm', undefined, undefined, 'rgba16float', 'bgra8unorm-srgb', 'rgba8sint']
+});
+try {
+computePassEncoder58.setPipeline(pipeline113);
+} catch {}
+try {
+renderBundleEncoder72.setVertexBuffer(0, buffer26);
+} catch {}
+try {
+commandEncoder74.clearBuffer(buffer25, 49496, 12244);
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline124 = device2.createRenderPipeline({
+label: '\u0b63\ue751\ubdfc\uc0a1\u{1fff5}\u{1ff7c}',
+layout: pipelineLayout19,
+multisample: {
+count: 4,
+mask: 0xa6c4d309,
+},
+fragment: {
+  module: shaderModule36,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'bgra8unorm', writeMask: 0}, {format: 'rg32float', writeMask: GPUColorWrite.BLUE}, {format: 'rg32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater',
+depthFailOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 114,
+stencilWriteMask: 31,
+depthBias: 61,
+depthBiasSlopeScale: 7,
+depthBiasClamp: 50,
+},
+vertex: {
+  module: shaderModule36,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1672,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x2',
+offset: 1556,
+shaderLocation: 1,
+}, {
+format: 'sint32x2',
+offset: 1280,
+shaderLocation: 2,
+}, {
+format: 'snorm8x4',
+offset: 392,
+shaderLocation: 4,
+}, {
+format: 'float32x3',
+offset: 832,
+shaderLocation: 12,
+}, {
+format: 'snorm8x4',
+offset: 1228,
+shaderLocation: 5,
+}, {
+format: 'snorm16x4',
+offset: 584,
+shaderLocation: 0,
+}, {
+format: 'sint8x4',
+offset: 916,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 744,
+attributes: [{
+format: 'float32x2',
+offset: 688,
+shaderLocation: 15,
+}, {
+format: 'unorm8x4',
+offset: 532,
+shaderLocation: 9,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+},
+});
+document.body.prepend(img15);
+let bindGroup38 = device1.createBindGroup({
+label: '\u0988\u0d53\u3eff\u2b07\uda56',
+layout: bindGroupLayout27,
+entries: [],
+});
+let textureView83 = texture59.createView({baseMipLevel: 3, mipLevelCount: 1});
+let commandEncoder85 = device1.createCommandEncoder({label: '\u{1f7ce}\ub1a2\u6db8\u79c3\u8d0d\u2632\u5831\uf3e4\u{1f824}\u{1f920}\u9c76'});
+let textureView84 = texture10.createView({
+  label: '\u0c5a\ub127\u1db0\uf1db\u5009\ub69c\u0e5e\u0ae0\ua34b\ubd33',
+  dimension: '2d-array',
+  baseMipLevel: 3
+});
+try {
+computePassEncoder53.setPipeline(pipeline78);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(1598);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(534);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer22);
+} catch {}
+try {
+renderBundleEncoder62.drawIndexedIndirect(buffer22, 552);
+} catch {}
+try {
+commandEncoder85.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 28992 */
+offset: 28992,
+buffer: buffer0,
+}, {
+  texture: texture30,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 15244, new Int16Array(21601), 12988, 28);
+} catch {}
+let pipeline125 = device0.createRenderPipeline({
+label: '\u6c3d\u{1f8a5}\u{1fab7}\u{1f8cd}\u0c41\u0e9d\u066d\u0e8a',
+layout: pipelineLayout18,
+multisample: {
+mask: 0xaed6dab1,
+},
+fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r8uint', writeMask: 0}, undefined, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilReadMask: 1822,
+depthBias: 93,
+depthBiasSlopeScale: 11,
+depthBiasClamp: 19,
+},
+vertex: {
+  module: shaderModule20,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 960,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x2',
+offset: 864,
+shaderLocation: 3,
+}, {
+format: 'sint8x4',
+offset: 744,
+shaderLocation: 12,
+}, {
+format: 'sint8x2',
+offset: 868,
+shaderLocation: 14,
+}, {
+format: 'unorm8x4',
+offset: 816,
+shaderLocation: 2,
+}, {
+format: 'float16x4',
+offset: 336,
+shaderLocation: 10,
+}, {
+format: 'unorm8x2',
+offset: 844,
+shaderLocation: 1,
+}, {
+format: 'unorm8x2',
+offset: 556,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 1724,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x4',
+offset: 504,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1400,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 400,
+shaderLocation: 5,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+canvas26.height = 891;
+try {
+  await promise58;
+} catch {}
+gc();
+let video22 = await videoWithData();
+let imageBitmap27 = await createImageBitmap(videoFrame5);
+let texture106 = device0.createTexture({
+label: '\u80c6\u0a63\u{1f614}',
+size: [64],
+dimension: '1d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['r8snorm'],
+});
+let textureView85 = texture100.createView({label: '\u9ca8\ue6e2\u3c53\ud597\u895a', dimension: '2d-array', format: 'eac-rg11snorm'});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup6, []);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer0, 13644, 19642);
+} catch {}
+try {
+renderBundleEncoder68.drawIndirect(buffer22, 1928);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(1, buffer24, 9752, 9292);
+} catch {}
+try {
+  await promise52;
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+video6.height = 148;
+offscreenCanvas18.height = 326;
+let imageData18 = new ImageData(112, 132);
+try {
+window.someLabel = commandEncoder40.label;
+} catch {}
+let querySet85 = device0.createQuerySet({
+label: '\u{1ff62}\u5ed0\u0c3b\uade3\uf5a3\u0ab1\u{1ff01}',
+type: 'occlusion',
+count: 3255,
+});
+try {
+computePassEncoder22.dispatchWorkgroups(2, 4, 1);
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setViewport(0.9961, 0.1283, 1.888, 0.01577, 0.9754, 0.9780);
+} catch {}
+try {
+commandEncoder85.resolveQuerySet(querySet14, 1334, 178, buffer37, 12544);
+} catch {}
+document.body.prepend(video4);
+let offscreenCanvas23 = new OffscreenCanvas(149, 178);
+let shaderModule37 = device0.createShaderModule({
+label: '\u0ec2\u{1feef}\u0c8b\uad17\ub415\u029d\u0d49\u09dc',
+code: `@group(1) @binding(803)
+var<storage, read_write> function13: array<u32>;
+@group(1) @binding(788)
+var<storage, read_write> function14: array<u32>;
+@group(0) @binding(561)
+var<storage, read_write> type14: array<u32>;
+@group(2) @binding(20)
+var<storage, read_write> i13: array<u32>;
+@group(3) @binding(674)
+var<storage, read_write> parameter21: array<u32>;
+
+@compute @workgroup_size(4, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @location(7) f1: vec2<f32>,
+  @location(3) f2: vec4<i32>,
+  @location(1) f3: vec4<i32>,
+  @location(2) f4: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(sample_index) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandBuffer20 = commandEncoder85.finish();
+pseudoSubmit(device0, commandEncoder38);
+let texture107 = device0.createTexture({
+label: '\u{1fd65}\ue10d\u{1f826}\ud887\u{1f9a1}\u0cdc\ufce6\ua588\u4ea4\u{1f6a3}',
+size: [80, 1, 1635],
+dimension: '3d',
+format: 'rg16uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+try {
+renderPassEncoder0.setStencilReference(2196);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(8);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(0, buffer6, 31308);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm', 'rgba8unorm', 'rgba8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer20,
+]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData10,
+  origin: { x: 49, y: 52 },
+  flipY: false,
+}, {
+  texture: texture100,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline126 = device0.createRenderPipeline({
+label: '\u9e15\u{1fd95}\u{1f71d}\ud765',
+layout: pipelineLayout14,
+fragment: {
+  module: shaderModule15,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint'}, {format: 'r16uint', writeMask: GPUColorWrite.RED}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rgba16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}]
+},
+vertex: {
+  module: shaderModule15,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 48,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 4,
+shaderLocation: 13,
+}, {
+format: 'sint32',
+offset: 20,
+shaderLocation: 8,
+}, {
+format: 'float32',
+offset: 36,
+shaderLocation: 1,
+}, {
+format: 'uint32x2',
+offset: 4,
+shaderLocation: 6,
+}, {
+format: 'unorm8x2',
+offset: 44,
+shaderLocation: 7,
+}, {
+format: 'uint32x3',
+offset: 8,
+shaderLocation: 15,
+}, {
+format: 'unorm10-10-10-2',
+offset: 36,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 1824,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 596,
+shaderLocation: 11,
+}, {
+format: 'uint32',
+offset: 1308,
+shaderLocation: 4,
+}, {
+format: 'unorm10-10-10-2',
+offset: 1408,
+shaderLocation: 5,
+}, {
+format: 'sint32',
+offset: 1512,
+shaderLocation: 14,
+}, {
+format: 'snorm8x4',
+offset: 528,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 844,
+attributes: [{
+format: 'float32x4',
+offset: 112,
+shaderLocation: 9,
+}, {
+format: 'sint8x2',
+offset: 184,
+shaderLocation: 12,
+}, {
+format: 'unorm16x2',
+offset: 284,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 428,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 520,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x4',
+offset: 412,
+shaderLocation: 2,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas23.getContext('2d');
+} catch {}
+let shaderModule38 = device0.createShaderModule({
+label: '\ue414\u{1f68f}',
+code: `@group(1) @binding(803)
+var<storage, read_write> global9: array<u32>;
+@group(3) @binding(674)
+var<storage, read_write> parameter22: array<u32>;
+@group(2) @binding(20)
+var<storage, read_write> i14: array<u32>;
+@group(1) @binding(788)
+var<storage, read_write> type15: array<u32>;
+
+@compute @workgroup_size(1, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @location(2) f1: vec4<f32>,
+  @location(6) f2: vec4<f32>,
+  @location(1) f3: vec3<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(11) a0: f16, @location(13) a1: f32, @location(2) a2: vec2<f32>, @location(5) a3: vec2<f32>, @location(6) a4: vec2<f16>, @location(15) a5: vec2<f16>, @location(10) a6: vec3<f32>, @location(0) a7: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let commandEncoder86 = device0.createCommandEncoder({label: '\u{1fbe8}\u{1f9af}\u41d9\u0762\u9ea5\u55f3\u09e1\ufb08\u028c'});
+let textureView86 = texture28.createView({label: '\u4545\ua4c7\u38c0\u3f0b\u{1fc4c}\u{1fb9b}', arrayLayerCount: 1});
+try {
+computePassEncoder57.setPipeline(pipeline86);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder30.drawIndexedIndirect(buffer22, 1008);
+} catch {}
+try {
+renderBundleEncoder80.setVertexBuffer(7, buffer37, 12560, 2046);
+} catch {}
+try {
+texture35.destroy();
+} catch {}
+let pipeline127 = device0.createRenderPipeline({
+layout: pipelineLayout0,
+multisample: {
+count: 4,
+mask: 0xcdcd8865,
+},
+fragment: {
+  module: shaderModule15,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: 0}, {format: 'r16uint'}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgba16sint', writeMask: 0}]
+},
+vertex: {
+  module: shaderModule15,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 792,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 720,
+shaderLocation: 5,
+}, {
+format: 'uint32x3',
+offset: 100,
+shaderLocation: 15,
+}, {
+format: 'sint8x2',
+offset: 424,
+shaderLocation: 8,
+}, {
+format: 'uint32x3',
+offset: 740,
+shaderLocation: 4,
+}, {
+format: 'unorm16x2',
+offset: 316,
+shaderLocation: 3,
+}, {
+format: 'float16x4',
+offset: 528,
+shaderLocation: 11,
+}, {
+format: 'sint32',
+offset: 640,
+shaderLocation: 14,
+}, {
+format: 'unorm8x2',
+offset: 598,
+shaderLocation: 2,
+}, {
+format: 'sint32',
+offset: 236,
+shaderLocation: 12,
+}, {
+format: 'unorm8x2',
+offset: 502,
+shaderLocation: 9,
+}, {
+format: 'float16x2',
+offset: 544,
+shaderLocation: 0,
+}, {
+format: 'sint32x3',
+offset: 8,
+shaderLocation: 13,
+}, {
+format: 'float32x4',
+offset: 528,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 1644,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 400,
+shaderLocation: 7,
+}, {
+format: 'uint32x3',
+offset: 1564,
+shaderLocation: 6,
+}, {
+format: 'float32x4',
+offset: 1508,
+shaderLocation: 10,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let offscreenCanvas24 = new OffscreenCanvas(332, 937);
+let videoFrame24 = new VideoFrame(img0, {timestamp: 0});
+try {
+gpuCanvasContext22.unconfigure();
+} catch {}
+try {
+window.someLabel = device1.label;
+} catch {}
+let imageBitmap28 = await createImageBitmap(canvas10);
+let video23 = await videoWithData();
+try {
+adapter5.label = '\u{1fe72}\u{1fbdc}\u{1feae}\u{1ff2a}';
+} catch {}
+try {
+computePassEncoder57.dispatchWorkgroupsIndirect(buffer22, 1236);
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline29);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(2, 0, 3, 0);
+} catch {}
+try {
+renderPassEncoder0.setViewport(1.488, 0.1082, 1.529, 0.3566, 0.2817, 0.7339);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer9, 'uint32', 8192, 4158);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer37, 80, 1598);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer22, 1112);
+} catch {}
+let promise60 = buffer8.mapAsync(GPUMapMode.READ, 0, 5940);
+try {
+commandEncoder86.copyBufferToBuffer(buffer12, 14360, buffer4, 8440, 40);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder86.copyTextureToBuffer({
+  texture: texture36,
+  mipLevel: 2,
+  origin: { x: 30, y: 0, z: 54 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 5472 */
+offset: 5472,
+bytesPerRow: 0,
+rowsPerImage: 72,
+buffer: buffer1,
+}, {width: 0, height: 15, depthOrArrayLayers: 138});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder86.copyTextureToTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: { x: 16, y: 25, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture30,
+  mipLevel: 2,
+  origin: { x: 8, y: 20, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise61 = device0.queue.onSubmittedWorkDone();
+let pipeline128 = device0.createRenderPipeline({
+label: '\ua6bb\u7cac\ud966\u2c3f\u1472\u{1f933}\u71d2\u0bf6\u9f2c\ufc5e\u0d0f',
+layout: pipelineLayout6,
+multisample: {
+count: 4,
+},
+fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint'}, {format: 'rgba8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN
+}, undefined, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'zero', dstFactor: 'dst-alpha'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'replace',
+},
+stencilReadMask: 3345,
+depthBias: 65,
+depthBiasSlopeScale: 84,
+},
+vertex: {
+  module: shaderModule16,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1160,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x2',
+offset: 152,
+shaderLocation: 13,
+}, {
+format: 'unorm16x2',
+offset: 252,
+shaderLocation: 14,
+}],
+}
+]
+},
+});
+video7.height = 2;
+let bindGroupLayout52 = device0.createBindGroupLayout({
+label: '\u5434\uc9ec\u5bd6\u{1fb36}\uab96\u13c4',
+entries: [{
+binding: 822,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+}, {
+binding: 56,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '2d-array' },
+}, {
+binding: 516,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}],
+});
+let textureView87 = texture73.createView({arrayLayerCount: 1});
+let renderBundle91 = renderBundleEncoder0.finish({label: '\u5f4f\u{1f7bc}\uaa14'});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup4, new Uint32Array(7712), 3471, 0);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(1571);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder53.draw(32, 80, 48);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder86.copyBufferToBuffer(buffer12, 5796, buffer11, 54244, 1708);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer39 = device0.createBuffer({label: '\u5045\u{1fda1}\u05f0\u0d59\u11e9\u9a5a\u{1f9b4}', size: 58249, usage: GPUBufferUsage.MAP_WRITE});
+let textureView88 = texture43.createView({
+  label: '\u{1f838}\ude85\ue2d2\u01d9\u{1f74c}\ufc1b',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 1
+});
+let renderBundleEncoder84 = device0.createRenderBundleEncoder({
+  label: '\u1167\u1e5e\u{1fa6a}\u0ccb\u0625\u614e\u01ad',
+  colorFormats: ['rg16uint', 'rg32float', 'r16uint', 'rg16sint'],
+  depthReadOnly: true
+});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup10, new Uint32Array(2662), 1768, 0);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 598.4, g: 23.12, b: -221.2, a: 890.7, });
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(3476);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer9, 'uint32', 10188, 9103);
+} catch {}
+try {
+renderBundleEncoder73.setBindGroup(0, bindGroup16, new Uint32Array(2485), 1166, 0);
+} catch {}
+let promise62 = buffer39.mapAsync(GPUMapMode.WRITE, 28880, 4376);
+try {
+commandEncoder86.copyBufferToBuffer(buffer2, 116, buffer8, 6896, 920);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder86.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 1,
+  origin: { x: 4, y: 20, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 88, y: 116, z: 0 },
+  aspect: 'all',
+}, {width: 32, height: 60, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder86.resolveQuerySet(querySet52, 837, 1915, buffer12, 256);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 8960, new DataView(new ArrayBuffer(965)), 801, 160);
+} catch {}
+let pipeline129 = device0.createRenderPipeline({
+label: '\u069f\u3235\u052a\u{1ff84}\u0c0e\u8eb6\uf44b',
+layout: pipelineLayout3,
+multisample: {
+mask: 0x41239aa5,
+},
+fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rgba8unorm', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'rg16float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, undefined, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'src-alpha-saturated'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+}
+}]
+},
+vertex: {
+  module: shaderModule3,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1120,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 416,
+shaderLocation: 0,
+}, {
+format: 'unorm8x4',
+offset: 1032,
+shaderLocation: 3,
+}, {
+format: 'sint32x4',
+offset: 980,
+shaderLocation: 6,
+}, {
+format: 'sint8x4',
+offset: 1048,
+shaderLocation: 9,
+}, {
+format: 'uint8x2',
+offset: 670,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 888,
+attributes: [{
+format: 'unorm16x4',
+offset: 460,
+shaderLocation: 4,
+}, {
+format: 'unorm10-10-10-2',
+offset: 780,
+shaderLocation: 7,
+}, {
+format: 'unorm16x4',
+offset: 436,
+shaderLocation: 8,
+}, {
+format: 'snorm8x4',
+offset: 224,
+shaderLocation: 5,
+}, {
+format: 'sint32x3',
+offset: 492,
+shaderLocation: 2,
+}, {
+format: 'uint32x4',
+offset: 596,
+shaderLocation: 13,
+}, {
+format: 'unorm8x4',
+offset: 352,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 500,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1232,
+attributes: [],
+},
+{
+arrayStride: 232,
+attributes: [],
+},
+{
+arrayStride: 212,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 40,
+shaderLocation: 14,
+}],
+}
+]
+},
+});
+try {
+offscreenCanvas24.getContext('2d');
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline119);
+} catch {}
+let device4 = await adapter7.requestDevice({
+requiredFeatures: [
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 56,
+maxVertexAttributes: 18,
+maxVertexBufferArrayStride: 8941,
+maxStorageTexturesPerShaderStage: 9,
+maxStorageBuffersPerShaderStage: 17,
+maxDynamicStorageBuffersPerPipelineLayout: 24823,
+maxBindingsPerBindGroup: 6818,
+maxTextureDimension1D: 12394,
+maxTextureDimension2D: 10494,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 159452209,
+maxUniformBuffersPerShaderStage: 23,
+maxInterStageShaderVariables: 90,
+maxInterStageShaderComponents: 87,
+maxSamplersPerShaderStage: 22,
+},
+});
+let img23 = await imageWithData(114, 239, '#cb4a84a1', '#f5703767');
+let videoFrame25 = new VideoFrame(offscreenCanvas2, {timestamp: 0});
+let computePassEncoder73 = commandEncoder72.beginComputePass({label: '\u{1fc32}\u90fd'});
+let sampler69 = device3.createSampler({
+label: '\ubd70\u09b9\u{1fa61}\ua2f4\u{1fb84}\u7754',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 59.807,
+lodMaxClamp: 76.244,
+maxAnisotropy: 4,
+});
+try {
+commandEncoder76.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 22324 */
+offset: 22324,
+buffer: buffer35,
+}, {
+  texture: texture102,
+  mipLevel: 5,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+gpuCanvasContext16.configure({
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture102,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 430 */
+{offset: 430}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise63 = device3.queue.onSubmittedWorkDone();
+let pipeline130 = device3.createRenderPipeline({
+label: '\u{1f713}\u{1f888}\udb58\u{1f729}\u0211\u05ad\u8f9e',
+layout: pipelineLayout20,
+fragment: {module: shaderModule32, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 1143,
+stencilWriteMask: 3496,
+depthBiasSlopeScale: 46,
+depthBiasClamp: 48,
+},
+vertex: {
+  module: shaderModule32,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1544,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 288,
+shaderLocation: 4,
+}, {
+format: 'uint8x4',
+offset: 480,
+shaderLocation: 15,
+}, {
+format: 'sint32x3',
+offset: 260,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 804,
+attributes: [{
+format: 'unorm16x4',
+offset: 320,
+shaderLocation: 3,
+}],
+}
+]
+},
+});
+let querySet86 = device4.createQuerySet({
+label: '\u30a6\u{1fabb}\u{1fd58}',
+type: 'occlusion',
+count: 721,
+});
+let texture108 = device4.createTexture({
+size: {width: 96, height: 10, depthOrArrayLayers: 237},
+mipLevelCount: 7,
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgba16uint'],
+});
+let renderBundleEncoder85 = device4.createRenderBundleEncoder({
+  label: '\u0573\u0d1c\u0055\u0abb\ucbe3\u204e\u0d37\u0cdb\u0ff8',
+  colorFormats: ['rg16sint', 'rgba8unorm-srgb'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+let offscreenCanvas25 = new OffscreenCanvas(524, 781);
+try {
+adapter1.label = '\uf79a\u7461';
+} catch {}
+let bindGroupLayout53 = device4.createBindGroupLayout({
+label: '\ue00c\ufdb6',
+entries: [],
+});
+let renderBundleEncoder86 = device4.createRenderBundleEncoder({
+  label: '\uab77\u377a\ub441\u{1ffbe}\u{1f920}\uf160\u067c\u{1f6d3}\ucf70\u03f8\u12fb',
+  colorFormats: ['rg16sint', 'rgba8unorm-srgb'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+let sampler70 = device4.createSampler({
+label: '\u1c62\u5b8e\ub6af',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 76.455,
+lodMaxClamp: 83.673,
+});
+try {
+renderBundleEncoder86.setVertexBuffer(37, undefined);
+} catch {}
+try {
+offscreenCanvas25.getContext('2d');
+} catch {}
+let pipelineLayout23 = device4.createPipelineLayout({bindGroupLayouts: [bindGroupLayout53, bindGroupLayout53, bindGroupLayout53, bindGroupLayout53]});
+let commandEncoder87 = device4.createCommandEncoder({label: '\ua83e\u83f2\ubae9\u0e80\u0177\u2ccd\u{1fcca}\u9961'});
+let querySet87 = device4.createQuerySet({
+label: '\u{1fcf9}\u421e\u06b4\u158a\uece2\u0961\uaf5f',
+type: 'occlusion',
+count: 333,
+});
+let textureView89 = texture108.createView({dimension: '2d', format: 'rgba16uint', baseMipLevel: 4, mipLevelCount: 1, baseArrayLayer: 44});
+let canvas30 = document.createElement('canvas');
+try {
+window.someLabel = sampler70.label;
+} catch {}
+let computePassEncoder74 = commandEncoder87.beginComputePass({});
+try {
+renderBundleEncoder86.pushDebugGroup('\u8c32');
+} catch {}
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img24 = await imageWithData(34, 199, '#7b989b41', '#20dc5677');
+let bindGroupLayout54 = device4.createBindGroupLayout({
+label: '\u{1facf}\u{1fcf2}\u3dec\uf7b5\u{1fcde}\u{1faa1}\u{1fb21}\ua746\u{1f626}\u68e3\u1cfc',
+entries: [{
+binding: 2018,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'filtering' },
+}, {
+binding: 2479,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'comparison' },
+}, {
+binding: 3217,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}],
+});
+let querySet88 = device4.createQuerySet({
+label: '\u{1fec6}\u0318',
+type: 'occlusion',
+count: 1912,
+});
+try {
+renderBundleEncoder86.popDebugGroup();
+} catch {}
+let querySet89 = device4.createQuerySet({
+label: '\u82f4\u7c9f\ufcf1\u892c\u3127\u310f\u0e9e\u43e9\ufa7a\u{1fe97}\u0206',
+type: 'occlusion',
+count: 3229,
+});
+document.body.prepend(video23);
+try {
+canvas30.getContext('2d');
+} catch {}
+let shaderModule39 = device2.createShaderModule({
+label: '\uecdb\uc595\u05aa\u{1fb71}',
+code: `@group(2) @binding(241)
+var<storage, read_write> local12: array<u32>;
+@group(1) @binding(241)
+var<storage, read_write> parameter23: array<u32>;
+@group(0) @binding(241)
+var<storage, read_write> function15: array<u32>;
+
+@compute @workgroup_size(7, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S26 {
+  @location(14) f0: vec4<i32>,
+  @location(3) f1: vec3<f16>
+}
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(4) f1: vec4<f32>,
+  @location(5) f2: vec4<i32>,
+  @location(3) f3: vec4<f32>,
+  @location(0) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(15) a0: u32, @location(4) a1: vec4<f32>, @location(6) a2: i32, @location(8) a3: vec3<u32>, a4: S26, @location(7) a5: vec4<f16>, @location(13) a6: f16, @builtin(front_facing) a7: bool, @location(11) a8: vec4<f16>, @location(9) a9: i32, @location(2) a10: vec4<i32>, @location(5) a11: vec4<u32>, @location(0) a12: vec4<f16>, @builtin(sample_index) a13: u32, @builtin(position) a14: vec4<f32>, @builtin(sample_mask) a15: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S25 {
+  @location(0) f0: vec2<f32>,
+  @location(15) f1: vec3<i32>,
+  @location(1) f2: vec3<u32>,
+  @location(7) f3: vec2<f16>,
+  @location(6) f4: vec4<f32>,
+  @location(10) f5: vec3<f16>,
+  @location(2) f6: f16,
+  @location(4) f7: vec4<f16>,
+  @location(5) f8: vec3<i32>,
+  @location(3) f9: f32,
+  @location(11) f10: vec3<i32>,
+  @location(8) f11: u32,
+  @builtin(vertex_index) f12: u32,
+  @builtin(instance_index) f13: u32,
+  @location(9) f14: vec3<i32>,
+  @location(14) f15: u32,
+  @location(12) f16: vec2<u32>,
+  @location(13) f17: vec2<i32>
+}
+struct VertexOutput0 {
+  @location(9) f154: i32,
+  @location(6) f155: i32,
+  @builtin(position) f156: vec4<f32>,
+  @location(8) f157: vec3<u32>,
+  @location(3) f158: vec3<f16>,
+  @location(15) f159: u32,
+  @location(13) f160: f16,
+  @location(4) f161: vec4<f32>,
+  @location(14) f162: vec4<i32>,
+  @location(0) f163: vec4<f16>,
+  @location(5) f164: vec4<u32>,
+  @location(2) f165: vec4<i32>,
+  @location(11) f166: vec4<f16>,
+  @location(7) f167: vec4<f16>
+}
+
+@vertex
+fn vertex0(a0: S25) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+try {
+device2.queue.writeBuffer(buffer36, 7904, new Int16Array(42413), 11131, 14140);
+} catch {}
+gc();
+let bindGroupLayout55 = pipeline124.getBindGroupLayout(1);
+let buffer40 = device2.createBuffer({size: 30121, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture109 = device2.createTexture({
+label: '\ud41d\u0601\u{1f70c}\u5eb0\u8cfd\u6652\u65c5\ub9a9\u0587\u0faf\u71df',
+size: {width: 96},
+dimension: '1d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgba8unorm-srgb', 'rgba8unorm'],
+});
+try {
+commandEncoder83.copyBufferToBuffer(buffer26, 3276, buffer40, 9704, 1268);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer40);
+} catch {}
+let shaderModule40 = device2.createShaderModule({
+code: `@group(2) @binding(241)
+var<storage, read_write> parameter24: array<u32>;
+
+@compute @workgroup_size(6, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool) -> @builtin(sample_mask) u32 {
+return u32();
+}
+
+struct S27 {
+  @location(10) f0: vec3<f16>,
+  @location(9) f1: i32,
+  @location(11) f2: vec2<u32>,
+  @location(3) f3: vec3<f32>,
+  @location(4) f4: vec3<f32>,
+  @location(7) f5: f16,
+  @location(13) f6: f16,
+  @location(6) f7: vec2<f32>,
+  @builtin(vertex_index) f8: u32,
+  @builtin(instance_index) f9: u32
+}
+
+@vertex
+fn vertex0(a0: S27, @location(1) a1: vec2<i32>, @location(14) a2: vec4<f32>, @location(15) a3: f16, @location(8) a4: vec2<f32>, @location(0) a5: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+let computePassEncoder75 = commandEncoder83.beginComputePass({label: '\uda54\ubc5d\u4e3a\u20e7\u6639\u0bba\u{1f9e9}'});
+let sampler71 = device2.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 61.769,
+lodMaxClamp: 63.123,
+});
+try {
+computePassEncoder75.setPipeline(pipeline120);
+} catch {}
+try {
+renderBundleEncoder78.setBindGroup(0, bindGroup37, []);
+} catch {}
+try {
+renderBundleEncoder75.setVertexBuffer(0, buffer26, 9072, 502);
+} catch {}
+try {
+commandEncoder69.copyBufferToBuffer(buffer26, 76, buffer27, 15716, 5776);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture105,
+  mipLevel: 2,
+  origin: { x: 53, y: 0, z: 0 },
+  aspect: 'all',
+}, new Float64Array(new ArrayBuffer(40)), /* required buffer size: 919 */
+{offset: 919}, {width: 494, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder88 = device1.createCommandEncoder({label: '\u{1fa3b}\u72ed\u9b58\u2c39\uf69e\uf267\ud095'});
+let texture110 = device1.createTexture({
+label: '\u0f7f\ua7ce\u050f',
+size: {width: 5160, height: 112, depthOrArrayLayers: 162},
+mipLevelCount: 11,
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['eac-rg11snorm', 'eac-rg11snorm', 'eac-rg11snorm'],
+});
+let computePassEncoder76 = commandEncoder88.beginComputePass({label: '\u{1fdc4}\u8c49\u8043\u1b33\u86d2\u1f44\u5855\u0080\u0c57\u0833\u{1fe5c}'});
+let video24 = await videoWithData();
+try {
+adapter1.label = '\u1033\u0206\ubb6c\uc727\u160a\u06db';
+} catch {}
+let texture111 = device1.createTexture({
+label: '\u3262\u0714\u{1f85a}\u0995\u4763\u6b2e\u{1fe5b}',
+size: {width: 1290, height: 28, depthOrArrayLayers: 162},
+mipLevelCount: 10,
+dimension: '2d',
+format: 'depth24plus',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth24plus', 'depth24plus'],
+});
+let renderBundleEncoder87 = device1.createRenderBundleEncoder({
+  colorFormats: ['rg16sint', 'rgba8unorm-srgb', 'rgba32sint', 'rg8unorm', 'r16sint'],
+  stencilReadOnly: true
+});
+let renderBundle92 = renderBundleEncoder87.finish({label: '\u9434\uc1fa\ub86b\ud529'});
+let sampler72 = device0.createSampler({
+label: '\ud2bb\u560d\uaf45\u{1fda8}\ucbb8\u{1fc26}\u{1f77c}\u0f4f\u07b0',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 30.056,
+maxAnisotropy: 14,
+});
+try {
+computePassEncoder44.setBindGroup(2, bindGroup4, new Uint32Array(3194), 623, 0);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+commandEncoder86.copyTextureToBuffer({
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 45, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 564 widthInBlocks: 141 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 11140 */
+offset: 11140,
+buffer: buffer18,
+}, {width: 141, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 2, y: 7 },
+  flipY: true,
+}, {
+  texture: texture93,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline131 = device0.createComputePipeline({
+layout: pipelineLayout13,
+compute: {
+module: shaderModule29,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+document.body.prepend(img6);
+try {
+renderBundleEncoder78.setBindGroup(2, bindGroup37);
+} catch {}
+let promise64 = device2.popErrorScope();
+let pipeline132 = await promise49;
+video24.width = 151;
+let bindGroup39 = device3.createBindGroup({
+label: '\uf8f2\u{1f796}\u6425\u{1fd1e}\u7fd9\ucd00\u{1fe9c}\ud420\u0939',
+layout: bindGroupLayout45,
+entries: [],
+});
+let querySet90 = device3.createQuerySet({
+label: '\u39c7\u32ac\u0276\u6241\u4e1e\u0e99',
+type: 'occlusion',
+count: 708,
+});
+let texture112 = device3.createTexture({
+label: '\u0232\u0fe1',
+size: {width: 240},
+mipLevelCount: 1,
+dimension: '1d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgb10a2uint', 'rgb10a2uint'],
+});
+try {
+computePassEncoder73.setBindGroup(0, bindGroup39, new Uint32Array(3183), 2665, 0);
+} catch {}
+try {
+commandEncoder76.clearBuffer(buffer35, 3520, 19360);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer35, 29040, new Float32Array(14810), 12666, 132);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+offscreenCanvas25.width = 248;
+let canvas31 = document.createElement('canvas');
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let video25 = await videoWithData();
+let bindGroup40 = device0.createBindGroup({
+layout: bindGroupLayout35,
+entries: [],
+});
+let texture113 = device0.createTexture({
+label: '\u{1fd1b}\u85a2\u608b\u0790\u{1f61f}',
+size: {width: 80, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+dimension: '2d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+});
+let sampler73 = device0.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 78.742,
+lodMaxClamp: 99.347,
+compare: 'greater',
+maxAnisotropy: 15,
+});
+try {
+renderBundleEncoder61.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexedIndirect(buffer12, 4952);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: canvas8,
+  origin: { x: 238, y: 119 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 7,
+  origin: { x: 0, y: 1, z: 3 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline133 = device0.createComputePipeline({
+label: '\ubc7a\u2fac\u53d1\u0def\u{1f8f3}\u6870\u{1f8ce}\ud8ef',
+layout: pipelineLayout13,
+compute: {
+module: shaderModule38,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let gpuCanvasContext23 = canvas31.getContext('webgpu');
+let shaderModule41 = device2.createShaderModule({
+label: '\uaa3b\u{1ff33}\ued56\u329c\ue146',
+code: `@group(1) @binding(241)
+var<storage, read_write> parameter25: array<u32>;
+@group(0) @binding(241)
+var<storage, read_write> type16: array<u32>;
+
+@compute @workgroup_size(8, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S28 {
+  @location(10) f0: vec2<u32>,
+  @location(4) f1: vec2<f32>,
+  @location(7) f2: f16,
+  @location(9) f3: vec2<f16>,
+  @location(11) f4: vec4<u32>,
+  @location(6) f5: vec3<u32>,
+  @location(8) f6: vec3<i32>,
+  @location(15) f7: vec2<f32>,
+  @location(3) f8: vec2<f32>,
+  @location(14) f9: vec2<f32>,
+  @location(5) f10: vec2<f32>,
+  @location(12) f11: vec3<f16>,
+  @builtin(front_facing) f12: bool
+}
+
+@fragment
+fn fragment0(@location(13) a0: f32, a1: S28, @builtin(sample_mask) a2: u32, @builtin(sample_index) a3: u32, @builtin(position) a4: vec4<f32>) -> @builtin(frag_depth) f32 {
+return f32();
+}
+
+struct VertexOutput0 {
+  @location(4) f168: vec2<f32>,
+  @location(10) f169: vec2<u32>,
+  @location(12) f170: vec3<f16>,
+  @location(3) f171: vec2<f32>,
+  @location(14) f172: vec2<f32>,
+  @location(11) f173: vec4<u32>,
+  @location(5) f174: vec2<f32>,
+  @location(13) f175: f32,
+  @location(9) f176: vec2<f16>,
+  @location(15) f177: vec2<f32>,
+  @builtin(position) f178: vec4<f32>,
+  @location(6) f179: vec3<u32>,
+  @location(8) f180: vec3<i32>,
+  @location(7) f181: f16
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let texture114 = device2.createTexture({
+label: '\u3a20\u{1f849}\u2d5d\u{1fb59}\u0315',
+size: [540],
+dimension: '1d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm'],
+});
+let textureView90 = texture92.createView({label: '\uaee2\u0305\ud8ad', dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder75.setPipeline(pipeline111);
+} catch {}
+try {
+commandEncoder66.copyBufferToBuffer(buffer26, 7524, buffer34, 3700, 1188);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer34);
+} catch {}
+try {
+commandEncoder74.copyTextureToTexture({
+  texture: texture79,
+  mipLevel: 3,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture79,
+  mipLevel: 4,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 5});
+} catch {}
+let pipeline134 = device2.createComputePipeline({
+label: '\ue68e\u00be\uf9a1\u0613\u{1fde6}\u8690\u88cb',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule40,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+gc();
+let texture115 = device2.createTexture({
+label: '\u0f67\ub9f6\u{1fd6e}\u5487\u093f\u2958\u{1fd64}\u0829',
+size: [420],
+dimension: '1d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rg8snorm'],
+});
+let textureView91 = texture115.createView({mipLevelCount: 1});
+let renderBundleEncoder88 = device2.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'depth24plus-stencil8', depthReadOnly: true, stencilReadOnly: true});
+try {
+commandEncoder84.clearBuffer(buffer30, 11648);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture90,
+  mipLevel: 1,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+}, new Int32Array(arrayBuffer9), /* required buffer size: 442478 */
+{offset: 878, bytesPerRow: 690, rowsPerImage: 160}, {width: 210, height: 0, depthOrArrayLayers: 5});
+} catch {}
+let querySet91 = device0.createQuerySet({
+label: '\u{1f883}\u02b4\u02d3\u76d9\u0129\u9d15\u9e56\u7a95',
+type: 'occlusion',
+count: 3724,
+});
+let computePassEncoder77 = commandEncoder86.beginComputePass({});
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder26.draw(72, 80);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(72, 72);
+} catch {}
+try {
+renderBundleEncoder74.setVertexBuffer(61, undefined);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+querySet56.destroy();
+} catch {}
+let imageData19 = new ImageData(104, 148);
+let texture116 = device4.createTexture({
+label: '\uac23\u0923\u1bf3',
+size: {width: 4320, height: 96, depthOrArrayLayers: 177},
+mipLevelCount: 4,
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundle93 = renderBundleEncoder86.finish({label: '\u{1f927}\ua42f\u0a6f\u{1fdf8}'});
+let sampler74 = device4.createSampler({
+label: '\ub9ab\u0740',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+});
+let commandEncoder89 = device2.createCommandEncoder({label: '\uad66\u600d'});
+try {
+renderBundleEncoder83.setVertexBuffer(7, buffer26, 1580, 381);
+} catch {}
+try {
+commandEncoder66.insertDebugMarker('\u8968');
+} catch {}
+try {
+if (!arrayBuffer15.detached) { new Uint8Array(arrayBuffer15).fill(0x55) };
+} catch {}
+gc();
+let imageBitmap29 = await createImageBitmap(imageData13);
+let canvas32 = document.createElement('canvas');
+let imageData20 = new ImageData(244, 168);
+let textureView92 = texture116.createView({
+  label: '\u{1fe15}\ua09e\u6121\ud9ff\u2ec1\u59e7\u4cf2\u9424\u059a\u0129',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 110
+});
+let renderBundleEncoder89 = device4.createRenderBundleEncoder({
+  label: '\u8018\u0e3d\u857b\u883e\u48c5\u4b9e\u56de\u0fe1\u{1ffe3}\u{1fc95}',
+  colorFormats: ['rg16sint', 'rgba8unorm-srgb'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let renderBundle94 = renderBundleEncoder85.finish({label: '\u0e60\uaf1c\u{1feb8}\u{1fb5e}'});
+try {
+  await promise56;
+} catch {}
+let offscreenCanvas26 = new OffscreenCanvas(751, 471);
+let shaderModule42 = device0.createShaderModule({
+label: '\u0b18\u239b\uba98\u80f6\u02b7',
+code: `@group(1) @binding(20)
+var<storage, read_write> parameter26: array<u32>;
+@group(2) @binding(289)
+var<storage, read_write> type17: array<u32>;
+
+@compute @workgroup_size(4, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @builtin(frag_depth) f1: f32,
+  @location(2) f2: vec2<f32>,
+  @location(3) f3: vec2<f32>,
+  @location(1) f4: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(11) a0: vec4<i32>, @location(3) a1: vec2<f16>, @location(10) a2: vec4<i32>, @location(5) a3: vec2<i32>, @builtin(sample_index) a4: u32, @location(8) a5: vec2<i32>, @location(15) a6: vec4<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(2) f182: u32,
+  @location(14) f183: vec4<f16>,
+  @location(3) f184: vec2<f16>,
+  @location(15) f185: vec4<f16>,
+  @location(0) f186: u32,
+  @location(8) f187: vec2<i32>,
+  @location(4) f188: vec3<f32>,
+  @builtin(position) f189: vec4<f32>,
+  @location(5) f190: vec2<i32>,
+  @location(7) f191: vec2<f32>,
+  @location(6) f192: vec4<f16>,
+  @location(11) f193: vec4<i32>,
+  @location(9) f194: vec4<i32>,
+  @location(10) f195: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: f32, @location(8) a1: vec2<f32>, @location(9) a2: vec3<u32>, @location(4) a3: vec2<u32>, @location(13) a4: u32, @location(2) a5: u32, @location(11) a6: f16, @location(5) a7: vec3<f32>, @builtin(instance_index) a8: u32, @location(6) a9: f32, @location(14) a10: f32, @location(1) a11: vec4<f16>, @location(15) a12: vec2<f32>, @location(12) a13: u32, @location(3) a14: i32, @builtin(vertex_index) a15: u32, @location(7) a16: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let pipelineLayout24 = device0.createPipelineLayout({
+  label: '\u6819\u519e\u6dbe\u5d13',
+  bindGroupLayouts: [bindGroupLayout6, bindGroupLayout47, bindGroupLayout18, bindGroupLayout4]
+});
+try {
+renderBundleEncoder45.setBindGroup(0, bindGroup24, new Uint32Array(4875), 3656, 0);
+} catch {}
+try {
+renderBundleEncoder20.drawIndexed(64, 24);
+} catch {}
+try {
+renderBundleEncoder68.drawIndirect(buffer15, 5504);
+} catch {}
+try {
+renderBundleEncoder53.setIndexBuffer(buffer6, 'uint16', 32796, 2679);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 9516, new BigUint64Array(37199), 26858, 164);
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas26.getContext('2d');
+} catch {}
+pseudoSubmit(device4, commandEncoder87);
+let textureView93 = texture116.createView({
+  label: '\u{1ffa5}\u0a70\u92dd\u0146\u57af\u{1f978}\u{1fbb7}\u1eda\u{1ff47}\ucec1',
+  mipLevelCount: 1,
+  baseArrayLayer: 86,
+  arrayLayerCount: 81
+});
+let externalTexture5 = device4.importExternalTexture({
+source: video13,
+colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder89.setVertexBuffer(33, undefined);
+} catch {}
+let commandEncoder90 = device4.createCommandEncoder({label: '\u036e\u9fa5\u5951\u{1fdec}\u{1ff45}\u{1fd92}\ueab6\u06a5\u144c'});
+try {
+canvas32.getContext('2d');
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let shaderModule43 = device0.createShaderModule({
+label: '\u0419\udc22\u{1f7ca}\u7c42\u{1f669}\u886d\uac78\u0908\uf013\u530c',
+code: `@group(0) @binding(561)
+var<storage, read_write> parameter27: array<u32>;
+@group(3) @binding(43)
+var<storage, read_write> function16: array<u32>;
+@group(3) @binding(257)
+var<storage, read_write> function17: array<u32>;
+
+@compute @workgroup_size(3, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(5) f0: vec4<u32>,
+  @builtin(frag_depth) f1: f32,
+  @location(2) f2: vec4<i32>,
+  @location(3) f3: vec2<f32>,
+  @location(1) f4: vec2<f32>,
+  @location(4) f5: vec4<u32>,
+  @location(6) f6: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S29 {
+  @location(11) f0: vec4<u32>,
+  @location(10) f1: vec3<f32>,
+  @location(14) f2: vec4<f16>,
+  @location(0) f3: vec2<i32>,
+  @location(6) f4: vec4<f32>,
+  @location(9) f5: f32,
+  @location(13) f6: vec4<u32>,
+  @location(4) f7: vec4<f32>,
+  @location(15) f8: vec2<f32>,
+  @location(12) f9: u32,
+  @location(1) f10: vec4<i32>,
+  @location(3) f11: vec4<f32>,
+  @builtin(vertex_index) f12: u32
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec2<u32>, @location(8) a1: vec3<f16>, @location(7) a2: vec2<u32>, @location(5) a3: vec3<f16>, a4: S29, @builtin(instance_index) a5: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let renderBundle95 = renderBundleEncoder7.finish({label: '\ue0bf\uaf43'});
+try {
+renderBundleEncoder58.setBindGroup(3, bindGroup31);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer22, 1632);
+} catch {}
+try {
+buffer28.destroy();
+} catch {}
+try {
+gpuCanvasContext9.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16float', 'astc-8x8-unorm-srgb', 'rgba32float'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 8236, new Float32Array(64268), 36244, 2984);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(16)), /* required buffer size: 955 */
+{offset: 955, bytesPerRow: 114, rowsPerImage: 65}, {width: 32, height: 40, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder90 = device2.createRenderBundleEncoder({
+  label: '\u{1fe42}\u{1f688}\u0fc9\u0660\uc818\u5e0c\uc52e\u068c\u054d\ufc72\u05d4',
+  colorFormats: ['bgra8unorm', 'rgba8unorm', 'rgba32sint', undefined],
+  depthReadOnly: true
+});
+let renderBundle96 = renderBundleEncoder66.finish({label: '\u{1fa8b}\u{1fe66}\u9564\ud8f8\u7d52\u93ab\u{1fbe9}\u0883\u961a\u20ee\u006b'});
+let sampler75 = device2.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 74.190,
+lodMaxClamp: 78.651,
+compare: 'less-equal',
+});
+try {
+commandEncoder66.copyBufferToBuffer(buffer26, 1752, buffer27, 28208, 248);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer27);
+} catch {}
+let pipeline135 = device2.createRenderPipeline({
+label: '\u0df1\u5d6f\u2d42\u0bc7\uea09\u0bfd\ub1e7\ua906\uf4ba',
+layout: pipelineLayout19,
+multisample: {
+count: 4,
+mask: 0xf70abdde,
+},
+fragment: {
+  module: shaderModule39,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, undefined, undefined, {format: 'rgba16float', writeMask: 0}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.BLUE}, {format: 'rgba8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'less',
+failOp: 'invert',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'keep',
+},
+stencilReadMask: 2594,
+stencilWriteMask: 2090,
+depthBias: 13,
+depthBiasSlopeScale: 29,
+depthBiasClamp: 30,
+},
+vertex: {
+  module: shaderModule39,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1568,
+attributes: [{
+format: 'snorm16x4',
+offset: 1444,
+shaderLocation: 0,
+}, {
+format: 'sint8x4',
+offset: 1464,
+shaderLocation: 11,
+}, {
+format: 'float32x2',
+offset: 1264,
+shaderLocation: 10,
+}, {
+format: 'uint32',
+offset: 1160,
+shaderLocation: 8,
+}, {
+format: 'float32x3',
+offset: 76,
+shaderLocation: 2,
+}, {
+format: 'uint32x2',
+offset: 1184,
+shaderLocation: 14,
+}, {
+format: 'sint16x4',
+offset: 240,
+shaderLocation: 9,
+}, {
+format: 'float32x3',
+offset: 1200,
+shaderLocation: 3,
+}, {
+format: 'unorm16x2',
+offset: 1112,
+shaderLocation: 6,
+}, {
+format: 'sint32x3',
+offset: 48,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 68,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x2',
+offset: 0,
+shaderLocation: 12,
+}, {
+format: 'sint8x4',
+offset: 40,
+shaderLocation: 5,
+}, {
+format: 'float16x4',
+offset: 48,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 980,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1460,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 524,
+shaderLocation: 7,
+}, {
+format: 'uint32x2',
+offset: 624,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 1152,
+attributes: [],
+},
+{
+arrayStride: 1888,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 1742,
+shaderLocation: 15,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+},
+});
+video20.width = 114;
+let pipelineLayout25 = device0.createPipelineLayout({label: '\ud758\u02b7\ue52c\u4839', bindGroupLayouts: []});
+let querySet92 = device0.createQuerySet({
+type: 'occlusion',
+count: 3628,
+});
+try {
+computePassEncoder72.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexedIndirect(buffer22, 1780);
+} catch {}
+try {
+renderBundleEncoder68.drawIndirect(buffer15, 1480);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap13,
+  origin: { x: 734, y: 183 },
+  flipY: false,
+}, {
+  texture: texture93,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline136 = device0.createComputePipeline({
+label: '\uc875\u0f8f\u249f',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule42,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let promise65 = device0.createRenderPipelineAsync({
+layout: pipelineLayout15,
+multisample: {
+count: 4,
+mask: 0x14c969df,
+},
+fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint'}, undefined, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'equal',
+depthFailOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 700,
+stencilWriteMask: 4021,
+depthBias: 94,
+depthBiasClamp: 33,
+},
+vertex: {
+  module: shaderModule20,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1408,
+attributes: [{
+format: 'float32x4',
+offset: 1236,
+shaderLocation: 2,
+}, {
+format: 'float32',
+offset: 708,
+shaderLocation: 10,
+}, {
+format: 'snorm8x4',
+offset: 940,
+shaderLocation: 9,
+}, {
+format: 'sint8x2',
+offset: 1044,
+shaderLocation: 12,
+}, {
+format: 'unorm16x4',
+offset: 884,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 764,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x4',
+offset: 404,
+shaderLocation: 1,
+}, {
+format: 'sint8x2',
+offset: 220,
+shaderLocation: 14,
+}, {
+format: 'unorm8x2',
+offset: 244,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 404,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 828,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 2028,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1352,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1324,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 572,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 144,
+shaderLocation: 8,
+}],
+}
+]
+},
+});
+let buffer41 = device4.createBuffer({
+  label: '\u0b0a\u{1fa4a}\u2e83',
+  size: 63861,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false
+});
+let querySet93 = device4.createQuerySet({
+label: '\u07c9\ua4fc\u1312\u{1ff98}\u0964\u0803\u{1fa18}\u{1fd13}\u1b26\u{1f9bf}',
+type: 'occlusion',
+count: 277,
+});
+let renderBundle97 = renderBundleEncoder89.finish({label: '\u{1f9f7}\u{1fe06}\u629e\u9435'});
+let querySet94 = device2.createQuerySet({
+label: '\u0b36\u0ba2\u5971\u03a7\u182f\ucd79\u{1f888}\u0c2a\u{1fcab}\u7fed\u8463',
+type: 'occlusion',
+count: 3931,
+});
+let renderBundle98 = renderBundleEncoder75.finish({label: '\u0e3b\ued06\u5b5c\uc3a4\uecda\ue731\uc957\u{1f9f3}\u4587\u5527'});
+try {
+computePassEncoder65.pushDebugGroup('\u{1faf2}');
+} catch {}
+try {
+device2.queue.writeBuffer(buffer31, 7288, new Int16Array(64290), 18230, 6776);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture104,
+  mipLevel: 0,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer13), /* required buffer size: 971 */
+{offset: 947, bytesPerRow: 139}, {width: 6, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let video26 = await videoWithData();
+try {
+buffer41.destroy();
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture116,
+  mipLevel: 0,
+  origin: { x: 1302, y: 25, z: 98 },
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 429068 */
+{offset: 756, bytesPerRow: 22544, rowsPerImage: 83}, {width: 2815, height: 19, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let adapter8 = await promise33;
+video24.height = 101;
+try {
+adapter7.label = '\u{1fe91}\u0e26\u45d2\u9882\u8192\u{1fa98}';
+} catch {}
+try {
+window.someLabel = pipeline120.label;
+} catch {}
+let querySet95 = device2.createQuerySet({
+label: '\uc1ad\u1664\u{1fb8f}\u7d5d\ua92f\u0e8e\u0058\ua8bb\u755c',
+type: 'occlusion',
+count: 389,
+});
+let texture117 = device2.createTexture({
+label: '\u117d\u0ec6\u5e68\ua6c7\u6a0f\u0d4a\u6182\u0613\u05f4',
+size: {width: 1080},
+dimension: '1d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView94 = texture75.createView({label: '\u{1fb95}\u0f1f\u{1f882}\u0426\uadcc\u5c0c'});
+let renderBundle99 = renderBundleEncoder75.finish({label: '\u91db\u{1f8e0}\u{1fdcb}\u8539\uc302\u{1f8fc}\ubb2e\u{1fe89}'});
+let sampler76 = device2.createSampler({
+label: '\u0f24\uddd6\u{1fac8}\ud81e\u08f3\u0171\u1ff9\u8270\u0919\u{1fbbb}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 71.824,
+lodMaxClamp: 99.118,
+});
+try {
+computePassEncoder58.setPipeline(pipeline113);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth16unorm', 'depth24plus-stencil8', 'rgba8unorm-srgb', 'rgba32float'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 48, height: 7, depthOrArrayLayers: 100}
+*/
+{
+  source: videoFrame16,
+  origin: { x: 1, y: 3 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: { x: 21, y: 1, z: 34 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 12, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder91 = device2.createCommandEncoder({label: '\u0725\u09cb\u0d96\uedf4\uc8ce'});
+try {
+renderBundleEncoder81.setBindGroup(3, bindGroup36, new Uint32Array(1003), 26, 0);
+} catch {}
+try {
+commandEncoder66.clearBuffer(buffer27, 19852, 6776);
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture90,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 2 },
+  aspect: 'depth-only',
+}, new BigUint64Array(arrayBuffer12), /* required buffer size: 6713 */
+{offset: 721, bytesPerRow: 428, rowsPerImage: 14}, {width: 210, height: 0, depthOrArrayLayers: 2});
+} catch {}
+let pipeline137 = await promise59;
+let img25 = await imageWithData(74, 67, '#9868326a', '#2fa4cbf2');
+let commandEncoder92 = device4.createCommandEncoder({label: '\u{1f7cc}\u4635\u05f7\ue9e6\u{1f79e}'});
+let textureView95 = texture116.createView({baseMipLevel: 3, baseArrayLayer: 116, arrayLayerCount: 6});
+let sampler77 = device4.createSampler({
+label: '\u{1f6f1}\u{1fafe}\ueb72\u{1f9a7}\u520d\uabf2\u{1f81e}\ufea3',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMaxClamp: 92.748,
+compare: 'greater-equal',
+});
+try {
+gpuCanvasContext8.configure({
+device: device4,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule44 = device0.createShaderModule({
+label: '\u0ee6\u4801',
+code: `@group(3) @binding(805)
+var<storage, read_write> local13: array<u32>;
+@group(0) @binding(791)
+var<storage, read_write> parameter28: array<u32>;
+@group(1) @binding(635)
+var<storage, read_write> i15: array<u32>;
+@group(1) @binding(690)
+var<storage, read_write> parameter29: array<u32>;
+@group(3) @binding(304)
+var<storage, read_write> field13: array<u32>;
+
+@compute @workgroup_size(7, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S31 {
+  @builtin(front_facing) f0: bool
+}
+struct FragmentOutput0 {
+  @location(3) f0: vec4<i32>,
+  @location(2) f1: vec4<u32>,
+  @location(0) f2: vec2<u32>,
+  @builtin(sample_mask) f3: u32,
+  @location(1) f4: u32
+}
+
+@fragment
+fn fragment0(@location(1) a0: vec4<i32>, @builtin(sample_mask) a1: u32, @builtin(position) a2: vec4<f32>, @location(7) a3: u32, @location(10) a4: vec4<i32>, @location(12) a5: vec2<f16>, @location(9) a6: vec3<u32>, @location(14) a7: vec2<i32>, @location(13) a8: vec2<i32>, @location(6) a9: vec2<f16>, @location(11) a10: i32, a11: S31) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S30 {
+  @location(15) f0: vec2<f32>,
+  @location(14) f1: vec3<f32>,
+  @location(4) f2: vec2<f16>,
+  @location(2) f3: vec4<f16>,
+  @location(0) f4: vec4<f16>
+}
+struct VertexOutput0 {
+  @location(1) f196: vec4<i32>,
+  @location(9) f197: vec3<u32>,
+  @location(0) f198: vec3<f32>,
+  @location(13) f199: vec2<i32>,
+  @location(11) f200: i32,
+  @location(7) f201: u32,
+  @location(14) f202: vec2<i32>,
+  @location(12) f203: vec2<f16>,
+  @location(3) f204: vec2<u32>,
+  @builtin(position) f205: vec4<f32>,
+  @location(10) f206: vec4<i32>,
+  @location(6) f207: vec2<f16>
+}
+
+@vertex
+fn vertex0(a0: S30, @location(1) a1: vec4<u32>, @location(3) a2: vec4<u32>, @location(7) a3: vec2<i32>, @location(8) a4: vec2<f16>, @location(6) a5: vec4<i32>, @location(5) a6: u32, @location(11) a7: vec4<i32>, @location(12) a8: vec4<f16>, @location(10) a9: i32, @location(9) a10: vec4<u32>, @location(13) a11: vec4<f16>, @builtin(instance_index) a12: u32, @builtin(vertex_index) a13: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let renderBundle100 = renderBundleEncoder30.finish();
+let sampler78 = device0.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 12.922,
+lodMaxClamp: 51.165,
+maxAnisotropy: 13,
+});
+try {
+computePassEncoder62.dispatchWorkgroups(3, 4);
+} catch {}
+try {
+renderBundleEncoder62.drawIndexedIndirect(buffer22, 1136);
+} catch {}
+try {
+renderBundleEncoder50.setPipeline(pipeline112);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 6832, new DataView(new ArrayBuffer(5610)), 243, 2032);
+} catch {}
+let bindGroupLayout56 = device2.createBindGroupLayout({
+label: '\u{1f624}\u{1fae1}\u7b5c\uded7\u0dbc\ube34',
+entries: [{
+binding: 628,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+}],
+});
+let computePassEncoder78 = commandEncoder91.beginComputePass({label: '\u05ba\u71bd\u06ea\u2dbd\u0e5b\ud24e\u8a33\u1420\u{1ffac}\ueadb\u2fee'});
+let pipeline138 = device2.createComputePipeline({
+layout: pipelineLayout19,
+compute: {
+module: shaderModule34,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let videoFrame26 = new VideoFrame(img10, {timestamp: 0});
+offscreenCanvas19.width = 941;
+let shaderModule45 = device0.createShaderModule({
+label: '\uf3e9\u{1ff85}\u066b\u02e2\u{1f6ba}\u01d9\uc147\ue02a',
+code: `@group(1) @binding(43)
+var<storage, read_write> function18: array<u32>;
+@group(0) @binding(297)
+var<storage, read_write> type18: array<u32>;
+
+@compute @workgroup_size(3, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec3<i32>,
+  @location(4) f2: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroupLayout57 = device0.createBindGroupLayout({
+label: '\u{1fb40}\u1bac\u920a\u0126\u6893\u3754\u{1ff88}',
+entries: [{
+binding: 728,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+}, {
+binding: 411,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}],
+});
+let querySet96 = device0.createQuerySet({
+label: '\u865c\u4e12\u{1fa73}\u{1fc93}',
+type: 'occlusion',
+count: 963,
+});
+let sampler79 = device0.createSampler({
+label: '\udc2d\u3784\u0714\u0f5f\u{1fed6}',
+addressModeU: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 11.208,
+lodMaxClamp: 43.184,
+maxAnisotropy: 18,
+});
+try {
+renderBundleEncoder54.setBindGroup(3, bindGroup31);
+} catch {}
+try {
+renderBundleEncoder63.drawIndexed(24, 16, 40, 368, 0);
+} catch {}
+try {
+renderBundleEncoder20.drawIndirect(buffer15, 1816);
+} catch {}
+video13.width = 203;
+gc();
+let textureView96 = texture108.createView({
+  label: '\ub201\u0bd7\u8d6d\u{1fe7a}\u0b94\u0755\u0ae9\u{1fdc3}\u3869',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+  baseArrayLayer: 38,
+  arrayLayerCount: 96
+});
+try {
+buffer41.destroy();
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+try {
+computePassEncoder53.end();
+} catch {}
+try {
+renderBundleEncoder26.drawIndexedIndirect(buffer22, 1208);
+} catch {}
+try {
+commandEncoder22.copyBufferToBuffer(buffer12, 1216, buffer14, 5516, 8444);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder22.copyTextureToBuffer({
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 72, y: 88, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 32912 */
+offset: 30272,
+bytesPerRow: 256,
+buffer: buffer12,
+}, {width: 20, height: 44, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+computePassEncoder5.insertDebugMarker('\u08d2');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video4,
+  origin: { x: 12, y: 13 },
+  flipY: true,
+}, {
+  texture: texture100,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise62;
+} catch {}
+let img26 = await imageWithData(169, 135, '#4e62dc6b', '#2c082b26');
+try {
+window.someLabel = device4.label;
+} catch {}
+try {
+commandEncoder92.label = '\u{1f939}\u08fb\u{1fa44}\u8247\uabde\u0326\u{1fb85}\u759c';
+} catch {}
+let querySet97 = device4.createQuerySet({
+label: '\u01a5\ud96b\ub0c9\u4da4\u091c\ufbc3\ud5f8\u3e9e',
+type: 'occlusion',
+count: 2384,
+});
+let commandBuffer21 = commandEncoder92.finish();
+let texture118 = device4.createTexture({
+label: '\ue10e\ucc20\u{1f7e1}\u09f3\u0150\u05de\u070a',
+size: {width: 192, height: 20, depthOrArrayLayers: 203},
+mipLevelCount: 4,
+dimension: '2d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+});
+let textureView97 = texture116.createView({
+  label: '\ufdb3\u3d71\u8672\u68f7\u9553\u{1fe7e}\u{1ff71}\u8ac7\u36a6',
+  baseMipLevel: 3,
+  baseArrayLayer: 163,
+  arrayLayerCount: 2
+});
+let sampler80 = device4.createSampler({
+label: '\u{1fcd1}\ub748\u{1fb99}\u1612\u4d37\u{1fe86}\udd43\ub3e7\u{1fd59}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 2.947,
+lodMaxClamp: 44.795,
+maxAnisotropy: 5,
+});
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+try {
+  await promise60;
+} catch {}
+let videoFrame27 = new VideoFrame(img11, {timestamp: 0});
+let querySet98 = device2.createQuerySet({
+label: '\uf886\udf86\u0539\u0de5\u0abe\u{1ffdd}',
+type: 'occlusion',
+count: 1781,
+});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+  await buffer40.mapAsync(GPUMapMode.READ, 0, 22716);
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(buffer26, 160, buffer34, 13068, 24);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer34);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 5,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 33029 */
+{offset: 480, bytesPerRow: 269, rowsPerImage: 121}, {width: 0, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 24, height: 3, depthOrArrayLayers: 50}
+*/
+{
+  source: canvas17,
+  origin: { x: 49, y: 49 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 4, y: 0, z: 27 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline139 = device2.createRenderPipeline({
+label: '\u67b7\u1234\u{1f91a}\u0617\u6e17\u0153\uc54c\u057a',
+layout: pipelineLayout19,
+multisample: {
+mask: 0xed519586,
+},
+fragment: {
+  module: shaderModule30,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'constant'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'equal',
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'zero',
+depthFailOp: 'increment-wrap',
+passOp: 'invert',
+},
+stencilReadMask: 364,
+stencilWriteMask: 876,
+depthBiasSlopeScale: 85,
+},
+vertex: {
+  module: shaderModule30,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 1768,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x4',
+offset: 672,
+shaderLocation: 1,
+}, {
+format: 'uint32x4',
+offset: 1032,
+shaderLocation: 4,
+}, {
+format: 'snorm8x4',
+offset: 1612,
+shaderLocation: 10,
+}, {
+format: 'sint8x2',
+offset: 1032,
+shaderLocation: 13,
+}, {
+format: 'unorm8x2',
+offset: 134,
+shaderLocation: 2,
+}, {
+format: 'float16x2',
+offset: 72,
+shaderLocation: 9,
+}, {
+format: 'sint8x2',
+offset: 1670,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 592,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 188,
+shaderLocation: 5,
+}, {
+format: 'float32x3',
+offset: 460,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x2',
+offset: 648,
+shaderLocation: 3,
+}, {
+format: 'sint16x2',
+offset: 816,
+shaderLocation: 7,
+}, {
+format: 'sint16x2',
+offset: 1032,
+shaderLocation: 0,
+}, {
+format: 'uint32',
+offset: 1484,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 808,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x2',
+offset: 508,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 264,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x2',
+offset: 228,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 1332,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 688,
+attributes: [],
+},
+{
+arrayStride: 1964,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 1752,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+unclippedDepth: false,
+},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise61;
+} catch {}
+try {
+window.someLabel = shaderModule6.label;
+} catch {}
+let computePassEncoder79 = commandEncoder22.beginComputePass();
+try {
+computePassEncoder44.setBindGroup(3, bindGroup8, new Uint32Array(2205), 331, 0);
+} catch {}
+try {
+computePassEncoder60.end();
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer12, 31944);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(2, buffer0);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(querySet76, 294, 157, buffer37, 14080);
+} catch {}
+video13.height = 267;
+let querySet99 = device4.createQuerySet({
+label: '\u7ce4\u{1fcfb}',
+type: 'occlusion',
+count: 3186,
+});
+let textureView98 = texture116.createView({label: '\u0b3d\ucc3f\u{1fc1b}\ue1e2', dimension: '2d', baseMipLevel: 1, mipLevelCount: 2, baseArrayLayer: 43});
+let computePassEncoder80 = commandEncoder90.beginComputePass();
+let offscreenCanvas27 = new OffscreenCanvas(16, 205);
+let commandEncoder93 = device2.createCommandEncoder();
+try {
+renderBundleEncoder88.setVertexBuffer(2, buffer26, 8596, 339);
+} catch {}
+try {
+computePassEncoder65.popDebugGroup();
+} catch {}
+try {
+device2.queue.writeBuffer(buffer36, 31408, new BigUint64Array(7516), 2926, 784);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 0,
+  origin: { x: 68, y: 4, z: 28 },
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 1103226 */
+{offset: 762, bytesPerRow: 90, rowsPerImage: 85}, {width: 27, height: 10, depthOrArrayLayers: 145});
+} catch {}
+try {
+offscreenCanvas27.getContext('2d');
+} catch {}
+let pipelineLayout26 = device2.createPipelineLayout({label: '\u833c\ud58d\u0625\u0df7\ua437\u3aba\u007b', bindGroupLayouts: []});
+let computePassEncoder81 = commandEncoder89.beginComputePass({label: '\u{1fd9f}\u0dc4\u7fcc\u9d45\uecb8\u{1fda1}'});
+try {
+renderBundleEncoder90.setBindGroup(2, bindGroup36);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture115,
+  mipLevel: 0,
+  origin: { x: 59, y: 1, z: 0 },
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(16)), /* required buffer size: 184 */
+{offset: 184}, {width: 344, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame28 = new VideoFrame(video7, {timestamp: 0});
+let bindGroup41 = device4.createBindGroup({
+label: '\ufc41\u{1fa80}',
+layout: bindGroupLayout53,
+entries: [],
+});
+pseudoSubmit(device4, commandEncoder90);
+let textureView99 = texture116.createView({baseMipLevel: 3, baseArrayLayer: 33, arrayLayerCount: 40});
+let renderBundleEncoder91 = device4.createRenderBundleEncoder({
+  label: '\u{1fc2b}\ubf14\u{1fd35}\ue17e\u0f67\ub630\u65c6',
+  colorFormats: ['rg16sint', 'rgba8unorm-srgb'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder91.setIndexBuffer(buffer41, 'uint16', 41386, 17184);
+} catch {}
+try {
+device4.queue.submit([
+]);
+} catch {}
+let textureView100 = texture0.createView({
+  label: '\u{1fd12}\u87c0\ub431\u{1f99e}\u{1f8a9}',
+  dimension: '2d-array',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  arrayLayerCount: 1
+});
+let sampler81 = device0.createSampler({
+label: '\uf06b\u0c97\u{1f682}',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMaxClamp: 98.510,
+maxAnisotropy: 1,
+});
+try {
+computePassEncoder62.dispatchWorkgroupsIndirect(buffer22, 972);
+} catch {}
+try {
+renderBundleEncoder63.drawIndexed(32, 32, 8, -368, 32);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer22, 1476);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline39);
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(buffer12, 40176, buffer18, 10608, 752);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder52.clearBuffer(buffer18);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 52924, new Int16Array(37637), 11273, 2816);
+} catch {}
+let pipeline140 = device0.createComputePipeline({
+label: '\u0667\u9d9f\u{1f82f}\u2b19\u0dcb\u0e68\uc473\u{1fdd6}',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule19,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let bindGroup42 = device3.createBindGroup({
+label: '\u0762\u1f33\u{1ff85}\u{1fbc5}\ub896\u057d',
+layout: bindGroupLayout45,
+entries: [],
+});
+let textureView101 = texture91.createView({
+  label: '\u0d07\u1277\u1eeb\udfbe\u67c7\u0087\u56b0\u2f71\u4c87',
+  dimension: '2d-array',
+  baseMipLevel: 5,
+  mipLevelCount: 1
+});
+let sampler82 = device2.createSampler({
+label: '\u{1f6fb}\ub423\u01d4\u526c\u0eaa',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 46.425,
+});
+try {
+commandEncoder76.clearBuffer(buffer35, 7152, 940);
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder76.insertDebugMarker('\u5e87');
+} catch {}
+let buffer42 = device0.createBuffer({size: 38563, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let textureView102 = texture7.createView({label: '\u{1f9ae}\u{1f617}', format: 'astc-8x5-unorm', baseMipLevel: 1});
+let computePassEncoder82 = commandEncoder52.beginComputePass({});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder59.dispatchWorkgroupsIndirect(buffer15, 1736);
+} catch {}
+try {
+renderBundleEncoder73.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder9.draw(24, 32, 48);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(24, 48, 56, -128, 80);
+} catch {}
+try {
+renderBundleEncoder36.drawIndirect(buffer12, 35616);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(1, buffer6);
+} catch {}
+let promise66 = device0.createRenderPipelineAsync({
+label: '\u{1f6dd}\u0d64\uf1b3\u0e22\u62a6\u8527\uca11\u3026',
+layout: pipelineLayout3,
+multisample: {
+count: 4,
+},
+fragment: {
+  module: shaderModule29,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba16uint'}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}]
+},
+vertex: {
+  module: shaderModule29,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 1488,
+attributes: [{
+format: 'unorm8x4',
+offset: 1332,
+shaderLocation: 15,
+}, {
+format: 'sint32x4',
+offset: 1440,
+shaderLocation: 1,
+}, {
+format: 'unorm10-10-10-2',
+offset: 324,
+shaderLocation: 4,
+}, {
+format: 'float32',
+offset: 928,
+shaderLocation: 8,
+}, {
+format: 'sint32x2',
+offset: 456,
+shaderLocation: 6,
+}, {
+format: 'uint8x2',
+offset: 444,
+shaderLocation: 0,
+}, {
+format: 'unorm8x4',
+offset: 884,
+shaderLocation: 7,
+}, {
+format: 'uint16x2',
+offset: 1432,
+shaderLocation: 12,
+}, {
+format: 'uint32',
+offset: 944,
+shaderLocation: 5,
+}, {
+format: 'unorm8x2',
+offset: 474,
+shaderLocation: 9,
+}, {
+format: 'float32',
+offset: 1440,
+shaderLocation: 2,
+}, {
+format: 'unorm8x4',
+offset: 380,
+shaderLocation: 13,
+}, {
+format: 'sint32x2',
+offset: 236,
+shaderLocation: 10,
+}, {
+format: 'sint8x2',
+offset: 8,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 616,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x2',
+offset: 300,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+offscreenCanvas14.height = 825;
+let textureView103 = texture97.createView({label: '\u654f\u0763', baseMipLevel: 1, mipLevelCount: 1});
+let renderBundleEncoder92 = device0.createRenderBundleEncoder({
+  label: '\u6ad9\ua2e8\u56ff\u{1ffb8}\u35f5\u3fac\u335c',
+  colorFormats: ['rgb10a2uint', 'rgba8unorm', 'rg16float', undefined, 'rg16float'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true
+});
+let renderBundle101 = renderBundleEncoder46.finish();
+try {
+renderBundleEncoder60.setBindGroup(1, bindGroup5, new Uint32Array(1477), 340, 0);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexedIndirect(buffer22, 960);
+} catch {}
+try {
+renderBundleEncoder68.drawIndirect(buffer12, 16428);
+} catch {}
+let texture119 = device2.createTexture({
+label: '\u314c\u{1fea0}\u6d7d\uc451\u0e8a\uced8\u6dbe\ude69',
+size: [25],
+dimension: '1d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm-srgb', 'rgba8unorm'],
+});
+let renderBundle102 = renderBundleEncoder67.finish({label: '\u1c56\u0da0\u{1f882}\u{1fb4d}\u0688\u0dce\uc434\u49fc'});
+try {
+renderBundleEncoder72.setBindGroup(3, bindGroup33);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer34, 8604, new BigUint64Array(4700), 2244, 688);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 6, height: 1, depthOrArrayLayers: 12}
+*/
+{
+  source: canvas27,
+  origin: { x: 182, y: 112 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 10 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let video27 = await videoWithData();
+let bindGroupLayout58 = device4.createBindGroupLayout({
+label: '\u{1f80a}\u0c75',
+entries: [],
+});
+let renderBundleEncoder93 = device4.createRenderBundleEncoder({
+  colorFormats: ['rg16sint', 'rgba8unorm-srgb'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+let bindGroup43 = device1.createBindGroup({
+label: '\u{1fff9}\u8071\u037e\u9b32',
+layout: bindGroupLayout27,
+entries: [],
+});
+let renderBundle103 = renderBundleEncoder87.finish({label: '\u0905\ub0dd'});
+let video28 = await videoWithData();
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let device5 = await promise55;
+let commandEncoder94 = device2.createCommandEncoder();
+let querySet100 = device2.createQuerySet({
+label: '\u8e6e\ua809\u{1f6e3}\u026e\u62bf\u0195\u26f9\u0865',
+type: 'occlusion',
+count: 1639,
+});
+let texture120 = device2.createTexture({
+label: '\u{1fff6}\u47de\u{1f900}\u65bc\u7c48\u83e2\u3267\uce7d\u08ae',
+size: {width: 30},
+dimension: '1d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [],
+});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup33);
+} catch {}
+try {
+computePassEncoder81.setBindGroup(0, bindGroup32, new Uint32Array(6596), 2799, 0);
+} catch {}
+try {
+commandEncoder69.copyBufferToBuffer(buffer26, 8652, buffer25, 6528, 856);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 24, height: 3, depthOrArrayLayers: 50}
+*/
+{
+  source: canvas8,
+  origin: { x: 273, y: 149 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 3, y: 0, z: 24 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 10, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame29 = new VideoFrame(imageBitmap25, {timestamp: 0});
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let buffer43 = device4.createBuffer({
+  label: '\u8b40\u032a\u{1fe61}\u46a7\ubb85\u087c\u{1f8cd}\u0937\ufbc4',
+  size: 621,
+  usage: GPUBufferUsage.MAP_READ
+});
+let texture121 = device4.createTexture({
+label: '\uac95\ufe6b\u0bef',
+size: [240, 640, 1],
+mipLevelCount: 4,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let renderBundle104 = renderBundleEncoder86.finish();
+let sampler83 = device4.createSampler({
+label: '\ued2e\u094a\ufbfc\ucee2',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 22.197,
+lodMaxClamp: 90.614,
+maxAnisotropy: 7,
+});
+try {
+renderBundleEncoder91.setBindGroup(1, bindGroup41, new Uint32Array(2562), 1804, 0);
+} catch {}
+try {
+buffer43.destroy();
+} catch {}
+let bindGroupLayout59 = device4.createBindGroupLayout({
+label: '\u093e\u73c3\u{1fe90}\uf6a9\u5eeb\uec4b\uf865\u07bd\u{1fde4}',
+entries: [{
+binding: 2052,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+}],
+});
+let bindGroup44 = device4.createBindGroup({
+label: '\u3f4d\u{1fc73}\u0ce3\u{1fd59}\u{1f7db}\u8dd0\ue7fc\u8080\u08c9\uf447\u92c7',
+layout: bindGroupLayout59,
+entries: [{
+binding: 2052,
+resource: sampler70
+}],
+});
+let textureView104 = texture108.createView({
+  label: '\u05f9\u{1f6df}\u{1ff56}\u01c9',
+  dimension: '2d',
+  aspect: 'all',
+  mipLevelCount: 5,
+  baseArrayLayer: 37
+});
+try {
+gpuCanvasContext17.configure({
+device: device4,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'astc-8x6-unorm-srgb', 'eac-rg11unorm'],
+alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup45 = device4.createBindGroup({
+layout: bindGroupLayout53,
+entries: [],
+});
+let pipelineLayout27 = device4.createPipelineLayout({
+  label: '\u0042\u0d7c\u0fd4\uf46c',
+  bindGroupLayouts: [bindGroupLayout58, bindGroupLayout53, bindGroupLayout58]
+});
+let querySet101 = device4.createQuerySet({
+label: '\u0442\u04d6\ue8fe\u{1f7c0}\uae83\u0916\ueecc\ub93d\u{1ff4f}\u0e92',
+type: 'occlusion',
+count: 501,
+});
+try {
+gpuCanvasContext9.configure({
+device: device4,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgba8sint', 'rg11b10ufloat', 'bgra8unorm', 'bgra8unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture116,
+  mipLevel: 1,
+  origin: { x: 931, y: 24, z: 140 },
+  aspect: 'all',
+}, new Int8Array(arrayBuffer18), /* required buffer size: 65237 */
+{offset: 588, bytesPerRow: 4055}, {width: 478, height: 16, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let bindGroup46 = device2.createBindGroup({
+label: '\u92a8\u05da\u01a8\u4aef\u{1fd7e}\u3839\u99ae\uee9f',
+layout: bindGroupLayout37,
+entries: [{
+binding: 385,
+resource: sampler64
+}, {
+binding: 771,
+resource: externalTexture4
+}],
+});
+let querySet102 = device2.createQuerySet({
+label: '\u0b1c\u7662\u0552',
+type: 'occlusion',
+count: 2710,
+});
+let textureView105 = texture90.createView({
+  label: '\udd07\u1bc9\uda28\u050e\ua1d7\u083b\u0599\u103d',
+  dimension: '2d',
+  aspect: 'depth-only',
+  mipLevelCount: 2,
+  baseArrayLayer: 2
+});
+let computePassEncoder83 = commandEncoder69.beginComputePass({label: '\u32d2\u{1fe91}'});
+let renderBundle105 = renderBundleEncoder76.finish({label: '\u016a\u1d11\u0254\ua47c\ubc9c\u16c9\ue998\u0ef5\u{1f67a}\u0866'});
+try {
+renderBundleEncoder83.setBindGroup(1, bindGroup32, new Uint32Array(3112), 2233, 0);
+} catch {}
+try {
+renderBundleEncoder90.setVertexBuffer(7, buffer26, 4512, 5170);
+} catch {}
+try {
+commandEncoder63.copyTextureToTexture({
+  texture: texture79,
+  mipLevel: 0,
+  origin: { x: 4, y: 0, z: 7 },
+  aspect: 'all',
+}, {
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 3, y: 2, z: 15 },
+  aspect: 'all',
+}, {width: 13, height: 0, depthOrArrayLayers: 23});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let pipeline141 = device2.createRenderPipeline({
+label: '\uf459\u6c97\u0df8\u691d\u085d\u5a25\uc04a\u00c5\ubf1d\ub126\u1e38',
+layout: pipelineLayout19,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule34,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, undefined, undefined, {format: 'rgba16float', writeMask: 0}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'src-alpha'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED
+}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}]
+},
+vertex: {
+  module: shaderModule34,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 420,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x2',
+offset: 176,
+shaderLocation: 7,
+}, {
+format: 'float32x3',
+offset: 68,
+shaderLocation: 4,
+}, {
+format: 'float16x2',
+offset: 144,
+shaderLocation: 12,
+}, {
+format: 'unorm16x2',
+offset: 348,
+shaderLocation: 1,
+}, {
+format: 'sint8x2',
+offset: 116,
+shaderLocation: 10,
+}, {
+format: 'unorm10-10-10-2',
+offset: 392,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 288,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm16x4',
+offset: 24,
+shaderLocation: 14,
+}, {
+format: 'snorm16x2',
+offset: 200,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 668,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 468,
+attributes: [{
+format: 'sint32x2',
+offset: 20,
+shaderLocation: 5,
+}, {
+format: 'unorm16x4',
+offset: 76,
+shaderLocation: 2,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let video29 = await videoWithData();
+let imageBitmap30 = await createImageBitmap(offscreenCanvas2);
+let commandEncoder95 = device0.createCommandEncoder({label: '\u3492\u0127\u03d2\u{1f6fc}\u0e2b\u8ca1\u{1fd61}\u{1fa29}'});
+let texture122 = device0.createTexture({
+label: '\u127f\u79ed\uc61e\udf72\u9f82\u0180',
+size: {width: 64, height: 90, depthOrArrayLayers: 1},
+sampleCount: 1,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x5-unorm'],
+});
+let computePassEncoder84 = commandEncoder95.beginComputePass({});
+let renderBundleEncoder94 = device0.createRenderBundleEncoder({
+  label: '\u04e2\u84f9\u0177',
+  colorFormats: ['rg16uint', 'rg32float', 'r16uint', 'rg16sint'],
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder70.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder50.draw(64, 8, 32);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(1, buffer24);
+} catch {}
+let pipeline142 = device0.createComputePipeline({
+label: '\u032a\u8ee8',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline143 = await promise66;
+let adapter9 = await navigator.gpu.requestAdapter();
+let video30 = await videoWithData();
+let commandEncoder96 = device0.createCommandEncoder({label: '\u{1f814}\u37be\u06b8\u0676\u06e4'});
+let renderBundle106 = renderBundleEncoder0.finish();
+let sampler84 = device0.createSampler({
+label: '\u2171\uaada\u{1f6d3}\u15e7\u8b26\u{1f6d9}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 1.593,
+lodMaxClamp: 49.866,
+compare: 'greater-equal',
+});
+try {
+computePassEncoder68.setBindGroup(3, bindGroup16, new Uint32Array(795), 317, 0);
+} catch {}
+try {
+computePassEncoder31.dispatchWorkgroups(3);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(1, bindGroup1, []);
+} catch {}
+try {
+renderBundleEncoder36.draw(40, 64, 40, 48);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexed(16, 64, 32, 48, 40);
+} catch {}
+try {
+renderBundleEncoder62.setPipeline(pipeline58);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+try {
+device1.label = '\u3cd9\u0fa2\u36b9';
+} catch {}
+let adapter10 = await promise47;
+let videoFrame30 = new VideoFrame(videoFrame5, {timestamp: 0});
+let promise67 = adapter8.requestAdapterInfo();
+try {
+renderBundleEncoder73.setBindGroup(0, bindGroup25, new Uint32Array(6834), 5329, 0);
+} catch {}
+try {
+renderBundleEncoder63.drawIndirect(buffer12, 24136);
+} catch {}
+try {
+commandEncoder96.copyBufferToBuffer(buffer23, 7532, buffer10, 2172, 5132);
+dissociateBuffer(device0, buffer23);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder96.clearBuffer(buffer9);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+gpuCanvasContext18.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer42, 4832, new Float32Array(41419), 23961, 1076);
+} catch {}
+try {
+device0.destroy();
+} catch {}
+try {
+  await promise67;
+} catch {}
+document.body.prepend(video30);
+let imageData21 = new ImageData(100, 184);
+let offscreenCanvas28 = new OffscreenCanvas(657, 237);
+gc();
+gc();
+try {
+offscreenCanvas28.getContext('webgl2');
+} catch {}
+let img27 = await imageWithData(136, 182, '#b915c74a', '#fd8a36b3');
+let buffer44 = device5.createBuffer({
+  label: '\ue0ba\u0e21\u{1f787}\uab0f\u950f\u07c4\u{1fcb3}\u0c75\u6ba4',
+  size: 64499,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE
+});
+let device6 = await adapter9.requestDevice({
+label: '\u0e98\u163f\u060c\ua35e\u{1f84b}\u0244',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 41,
+maxVertexAttributes: 24,
+maxVertexBufferArrayStride: 8695,
+maxStorageTexturesPerShaderStage: 27,
+maxStorageBuffersPerShaderStage: 26,
+maxDynamicStorageBuffersPerPipelineLayout: 35303,
+maxBindingsPerBindGroup: 5882,
+maxTextureDimension1D: 11985,
+maxTextureDimension2D: 9906,
+maxVertexBuffers: 10,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 100293634,
+maxUniformBuffersPerShaderStage: 37,
+maxInterStageShaderComponents: 65,
+maxSamplersPerShaderStage: 21,
+},
+});
+let canvas33 = document.createElement('canvas');
+try {
+canvas33.getContext('webgl');
+} catch {}
+let querySet103 = device5.createQuerySet({
+label: '\u4160\ue517\uc61e\u051e\ue5fd\u{1f6eb}\u{1fdd2}\u04f3\u0247\u845f\ufdda',
+type: 'occlusion',
+count: 1565,
+});
+let renderBundleEncoder95 = device5.createRenderBundleEncoder({
+  label: '\u0adf\u07ce\u{1f6cd}\u8e89\u34ca\u041a\uaea3\u1154\u576e\u3f96',
+  colorFormats: ['r8unorm', 'rgba8unorm', undefined],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle107 = renderBundleEncoder95.finish({});
+let sampler85 = device5.createSampler({
+label: '\u70d7\u{1f8f1}\u9fda',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 41.927,
+});
+let imageData22 = new ImageData(4, 188);
+let texture123 = device5.createTexture({
+label: '\u5632\u0b6a\u90d3\uc988\u1cba\ua83c\u849c\u{1fe27}',
+size: [4224],
+dimension: '1d',
+format: 'rgba8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba8sint', 'rgba8sint', 'rgba8sint'],
+});
+let textureView106 = texture123.createView({label: '\u{1fd1d}\u5f3a\u06e5\ub396'});
+let renderBundle108 = renderBundleEncoder95.finish();
+try {
+device5.addEventListener('uncapturederror', e => { log('device5.uncapturederror'); log(e); e.label = device5.label; });
+} catch {}
+try {
+device5.destroy();
+} catch {}
+video16.height = 10;
+let imageData23 = new ImageData(176, 236);
+gc();
+let device7 = await adapter10.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 61,
+maxVertexAttributes: 25,
+maxVertexBufferArrayStride: 31519,
+maxStorageTexturesPerShaderStage: 14,
+maxStorageBuffersPerShaderStage: 34,
+maxDynamicStorageBuffersPerPipelineLayout: 44716,
+maxBindingsPerBindGroup: 3750,
+maxTextureDimension1D: 11463,
+maxTextureDimension2D: 14801,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 236744093,
+maxUniformBuffersPerShaderStage: 36,
+maxInterStageShaderVariables: 38,
+maxInterStageShaderComponents: 84,
+maxSamplersPerShaderStage: 17,
+},
+});
+let video31 = await videoWithData();
+try {
+  await promise63;
+} catch {}
+let commandEncoder97 = device6.createCommandEncoder({label: '\ufa0f\u4add\u1d99\u410f\u{1feae}\u8915\u052f\u0900\u0f97\u{1fb3b}\u05cf'});
+let canvas34 = document.createElement('canvas');
+let buffer45 = device6.createBuffer({label: '\u8f17\u{1ff90}\u0477\u5a78', size: 54497, usage: GPUBufferUsage.UNIFORM});
+let sampler86 = device6.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 98.853,
+lodMaxClamp: 99.075,
+});
+try {
+device4.queue.writeTexture({
+  texture: texture116,
+  mipLevel: 1,
+  origin: { x: 11, y: 1, z: 13 },
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 2222502 */
+{offset: 734, bytesPerRow: 9032, rowsPerImage: 211}, {width: 1116, height: 35, depthOrArrayLayers: 2});
+} catch {}
+let commandEncoder98 = device6.createCommandEncoder();
+let sampler87 = device6.createSampler({
+label: '\u002f\u0643\u4379\u3313\u0efc',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMaxClamp: 80.605,
+});
+try {
+gpuCanvasContext6.configure({
+device: device6,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm-srgb', 'astc-8x8-unorm'],
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+  await promise64;
+} catch {}
+try {
+canvas34.getContext('2d');
+} catch {}
+try {
+adapter0.label = '\ufdf5\u065a\u478b\ua1da\u0958\u{1fdb4}\u8f6a\u{1fb21}\u2ede\u087b\u091d';
+} catch {}
+let buffer46 = device2.createBuffer({
+  label: '\u7746\u001c\u65ef\u9e0d\u0918\u7bf2\ue789\u1ad3\u0cfc\u7b91',
+  size: 46705,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false
+});
+let querySet104 = device2.createQuerySet({
+label: '\u1bb3\u0928\u052a\u2220\u{1fb75}\u073f\u3581',
+type: 'occlusion',
+count: 1645,
+});
+try {
+renderBundleEncoder83.setVertexBuffer(3, buffer46, 2196, 15102);
+} catch {}
+try {
+commandEncoder66.clearBuffer(buffer36);
+dissociateBuffer(device2, buffer36);
+} catch {}
+try {
+commandEncoder74.resolveQuerySet(querySet60, 2185, 104, buffer46, 25856);
+} catch {}
+let pipeline144 = device2.createComputePipeline({
+label: '\u0796\ub9f6\u23fe\u{1f964}\u09d4\u0512',
+layout: pipelineLayout26,
+compute: {
+module: shaderModule30,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let canvas35 = document.createElement('canvas');
+let texture124 = device6.createTexture({
+label: '\u098a\ub934\u0fa9\u0b28',
+size: {width: 880, height: 16, depthOrArrayLayers: 43},
+mipLevelCount: 6,
+format: 'eac-r11unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['eac-r11unorm'],
+});
+let textureView107 = texture124.createView({
+  label: '\ue506\ua072\u{1f87f}\u0a9f\u45ef\u0388\u0b33',
+  dimension: '2d',
+  aspect: 'all',
+  mipLevelCount: 1,
+  baseArrayLayer: 34
+});
+let renderBundleEncoder96 = device6.createRenderBundleEncoder({
+  label: '\u0423\u04a4\u7f8f\u{1f900}\u{1ff22}\u0c6b\u06d2\u{1f8f0}\u79fc\u{1f9f6}',
+  colorFormats: ['rg32float', 'rg11b10ufloat', undefined, 'rg11b10ufloat', 'rgba8uint'],
+  sampleCount: 4
+});
+try {
+commandEncoder98.copyTextureToTexture({
+  texture: texture124,
+  mipLevel: 4,
+  origin: { x: 32, y: 0, z: 2 },
+  aspect: 'all',
+}, {
+  texture: texture124,
+  mipLevel: 3,
+  origin: { x: 88, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 16, height: 0, depthOrArrayLayers: 41});
+} catch {}
+let promise68 = device6.queue.onSubmittedWorkDone();
+document.body.prepend(img26);
+try {
+await adapter2.requestAdapterInfo();
+} catch {}
+try {
+renderBundleEncoder81.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+renderBundleEncoder90.setBindGroup(0, bindGroup32, new Uint32Array(9718), 3985, 0);
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer26, 6816, buffer31, 1044, 1776);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer31);
+} catch {}
+try {
+commandEncoder94.copyBufferToTexture({
+/* bytesInLastRow: 976 widthInBlocks: 488 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 2522 */
+offset: 2522,
+buffer: buffer26,
+}, {
+  texture: texture117,
+  mipLevel: 0,
+  origin: { x: 137, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 488, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer26);
+} catch {}
+try {
+commandEncoder84.resolveQuerySet(querySet78, 2223, 0, buffer46, 42496);
+} catch {}
+let pipeline145 = device2.createRenderPipeline({
+label: '\u011c\u03b9\u01cf\u7a1b\u0d4e\ucef7\u0b55',
+layout: pipelineLayout19,
+fragment: {
+  module: shaderModule30,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'src'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+}
+}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 150,
+stencilWriteMask: 1921,
+depthBias: 23,
+depthBiasSlopeScale: 49,
+depthBiasClamp: 100,
+},
+vertex: {
+  module: shaderModule30,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 736,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x4',
+offset: 584,
+shaderLocation: 6,
+}, {
+format: 'sint8x2',
+offset: 468,
+shaderLocation: 7,
+}, {
+format: 'unorm10-10-10-2',
+offset: 672,
+shaderLocation: 2,
+}, {
+format: 'uint16x4',
+offset: 72,
+shaderLocation: 4,
+}, {
+format: 'snorm16x4',
+offset: 596,
+shaderLocation: 5,
+}, {
+format: 'sint32x4',
+offset: 84,
+shaderLocation: 14,
+}, {
+format: 'float16x2',
+offset: 472,
+shaderLocation: 11,
+}, {
+format: 'uint32x3',
+offset: 536,
+shaderLocation: 3,
+}, {
+format: 'unorm16x4',
+offset: 592,
+shaderLocation: 1,
+}, {
+format: 'uint8x4',
+offset: 324,
+shaderLocation: 12,
+}, {
+format: 'float32x3',
+offset: 108,
+shaderLocation: 8,
+}, {
+format: 'float32',
+offset: 364,
+shaderLocation: 15,
+}, {
+format: 'sint8x2',
+offset: 446,
+shaderLocation: 13,
+}, {
+format: 'float16x2',
+offset: 704,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 820,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 600,
+shaderLocation: 0,
+}, {
+format: 'unorm16x2',
+offset: 524,
+shaderLocation: 9,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: false,
+},
+});
+let video32 = await videoWithData();
+let imageBitmap31 = await createImageBitmap(offscreenCanvas0);
+offscreenCanvas11.height = 597;
+try {
+await device7.popErrorScope();
+} catch {}
+let imageBitmap32 = await createImageBitmap(imageBitmap10);
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+let promise69 = navigator.gpu.requestAdapter({
+powerPreference: 'low-power',
+});
+try {
+canvas35.getContext('webgl');
+} catch {}
+let bindGroupLayout60 = device7.createBindGroupLayout({
+label: '\uc08b\u0698\u1c45',
+entries: [],
+});
+let texture125 = device7.createTexture({
+label: '\u30ae\u2f0c\u7ec5\u53fa\u3ee4\u{1fe06}\u7779\udce6',
+size: {width: 4336},
+dimension: '1d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['rg8sint'],
+});
+try {
+gpuCanvasContext19.unconfigure();
+} catch {}
+try {
+  await promise68;
+} catch {}
+let renderBundleEncoder97 = device2.createRenderBundleEncoder({
+  label: '\udfed\u0cd7\u{1fe31}\u{1feb8}',
+  colorFormats: ['r8unorm', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1
+});
+let renderBundle109 = renderBundleEncoder90.finish({label: '\udc17\u3c70\u0823\u0e7f\u08ef\udddf\uad05'});
+let sampler88 = device2.createSampler({
+label: '\u4e95\u3b4a\u1bbc\u016e\u0401\uabbd\uddf4',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 24.722,
+lodMaxClamp: 66.691,
+maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder72.setBindGroup(1, bindGroup46, new Uint32Array(8523), 7918, 0);
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(buffer26, 204, buffer30, 11416, 4276);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+commandEncoder63.copyTextureToBuffer({
+  texture: texture87,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 5 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 6 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 34198 */
+offset: 34192,
+buffer: buffer36,
+}, {width: 6, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer36);
+} catch {}
+try {
+commandEncoder66.clearBuffer(buffer36);
+dissociateBuffer(device2, buffer36);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer36, 6900, new Float32Array(3895));
+} catch {}
+let pipeline146 = await device2.createRenderPipelineAsync({
+label: '\u721f\u7923\u2b9c\u028e',
+layout: pipelineLayout19,
+fragment: {
+  module: shaderModule27,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+failOp: 'increment-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3961,
+stencilWriteMask: 3471,
+depthBiasClamp: 63,
+},
+vertex: {
+  module: shaderModule27,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1560,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32',
+offset: 52,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 1216,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x4',
+offset: 800,
+shaderLocation: 6,
+}, {
+format: 'unorm16x4',
+offset: 848,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 732,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x3',
+offset: 652,
+shaderLocation: 14,
+}, {
+format: 'snorm16x4',
+offset: 404,
+shaderLocation: 4,
+}, {
+format: 'float16x4',
+offset: 400,
+shaderLocation: 11,
+}, {
+format: 'float32x2',
+offset: 352,
+shaderLocation: 13,
+}, {
+format: 'sint8x4',
+offset: 56,
+shaderLocation: 2,
+}, {
+format: 'sint32',
+offset: 540,
+shaderLocation: 12,
+}, {
+format: 'uint8x2',
+offset: 684,
+shaderLocation: 8,
+}, {
+format: 'sint32x2',
+offset: 412,
+shaderLocation: 9,
+}, {
+format: 'uint32x2',
+offset: 712,
+shaderLocation: 3,
+}, {
+format: 'snorm8x2',
+offset: 604,
+shaderLocation: 10,
+}, {
+format: 'sint8x4',
+offset: 720,
+shaderLocation: 5,
+}, {
+format: 'uint16x2',
+offset: 344,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 116,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 70,
+shaderLocation: 1,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+},
+});
+let offscreenCanvas29 = new OffscreenCanvas(120, 535);
+let video33 = await videoWithData();
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let offscreenCanvas30 = new OffscreenCanvas(418, 480);
+let bindGroupLayout61 = device7.createBindGroupLayout({
+label: '\u{1f6f2}\u0955\u019e\u0641\u0e38\u028c\ub49a\u0d17',
+entries: [{
+binding: 2644,
+visibility: 0,
+externalTexture: {},
+}, {
+binding: 993,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}],
+});
+let querySet105 = device7.createQuerySet({
+type: 'occlusion',
+count: 2507,
+});
+let texture126 = device7.createTexture({
+label: '\u{1fcc0}\u{1f70c}\u0c4c\u05e1\u6773\u00bb',
+size: {width: 200, height: 4, depthOrArrayLayers: 27},
+mipLevelCount: 4,
+sampleCount: 1,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8unorm'],
+});
+let renderBundleEncoder98 = device7.createRenderBundleEncoder({
+  label: '\u808a\u5d49\u{1fe61}\u{1fbfe}\udd61\u0737\u9cb6\u00ae\u05a9\u{1f9fe}',
+  colorFormats: ['rg16float'],
+  depthReadOnly: true
+});
+let gpuCanvasContext24 = offscreenCanvas29.getContext('webgpu');
+let bindGroup47 = device7.createBindGroup({
+layout: bindGroupLayout60,
+entries: [],
+});
+let querySet106 = device7.createQuerySet({
+label: '\ud98b\uf313\u{1fc65}\u{1fff0}\u{1ffab}\u2f23\ube44\u22ee',
+type: 'occlusion',
+count: 2732,
+});
+let renderBundleEncoder99 = device7.createRenderBundleEncoder({
+  label: '\u059c\u4aba\u065b\u{1f616}\u0c45\uad98\u049a\u16ac',
+  colorFormats: ['rg16float'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle110 = renderBundleEncoder98.finish({label: '\u{1f8cc}\uc391\u{1ff5d}\u1ba3\u974f\u0a2d\ud2ce'});
+let sampler89 = device7.createSampler({
+label: '\u{1fa7f}\u2c01\u{1f957}\u{1fc1d}\u0692\u0eeb\ufd0b\u558e\uad57\u72c4\ub74b',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 6.200,
+lodMaxClamp: 36.591,
+});
+try {
+gpuCanvasContext21.configure({
+device: device7,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba16float', 'rgba16float', 'eac-rg11unorm'],
+colorSpace: 'srgb',
+});
+} catch {}
+let imageBitmap33 = await createImageBitmap(videoFrame27);
+let texture127 = device6.createTexture({
+size: {width: 96, height: 80, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let gpuCanvasContext25 = offscreenCanvas30.getContext('webgpu');
+let promise70 = adapter6.requestAdapterInfo();
+let commandEncoder99 = device6.createCommandEncoder();
+let texture128 = device6.createTexture({
+size: {width: 3, height: 1, depthOrArrayLayers: 238},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder100 = device6.createRenderBundleEncoder({
+  label: '\u09c4\uc642\u08ea\u5d7f\u6203',
+  colorFormats: ['rg32float', 'rg11b10ufloat', undefined, 'rg11b10ufloat', 'rgba8uint'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+await adapter4.requestAdapterInfo();
+} catch {}
+let commandEncoder100 = device4.createCommandEncoder({label: '\u8ff1\u45d8\uaef4\u7e2f\u0e88\u0792'});
+let texture129 = gpuCanvasContext8.getCurrentTexture();
+let textureView108 = texture121.createView({
+  label: '\u{1fb75}\u2252\u8abe\uaae4\uc139',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  arrayLayerCount: 1
+});
+let renderBundleEncoder101 = device4.createRenderBundleEncoder({
+  label: '\u090e\u48a9',
+  colorFormats: ['rg16sint', 'rgba8unorm-srgb'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder93.setBindGroup(3, bindGroup44, new Uint32Array(7988), 1270, 0);
+} catch {}
+try {
+device4.destroy();
+} catch {}
+let imageBitmap34 = await createImageBitmap(img3);
+let sampler90 = device2.createSampler({
+label: '\u08ef\u64c7\ud49f\u040c\ua126\u176a\u5381\u1f53\u0ecd\u0982\u91ff',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 87.518,
+lodMaxClamp: 87.920,
+compare: 'greater',
+});
+try {
+commandEncoder84.copyBufferToBuffer(buffer26, 7268, buffer36, 17156, 1876);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer36);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer31, 15108, new Int16Array(10867), 1182, 4900);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 12, height: 1, depthOrArrayLayers: 25}
+*/
+{
+  source: canvas9,
+  origin: { x: 287, y: 90 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 2,
+  origin: { x: 3, y: 0, z: 10 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 9, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline147 = await device2.createRenderPipelineAsync({
+label: '\u2b45\u0776\u{1f900}\uee80',
+layout: pipelineLayout26,
+multisample: {
+count: 4,
+mask: 0x900d00b1,
+},
+fragment: {module: shaderModule40, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+passOp: 'keep',
+},
+stencilBack: {
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 64,
+stencilWriteMask: 3926,
+depthBias: 73,
+depthBiasClamp: 99,
+},
+vertex: {
+  module: shaderModule40,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 588,
+shaderLocation: 3,
+}, {
+format: 'unorm10-10-10-2',
+offset: 1844,
+shaderLocation: 10,
+}, {
+format: 'float32',
+offset: 768,
+shaderLocation: 14,
+}, {
+format: 'snorm8x2',
+offset: 32,
+shaderLocation: 0,
+}, {
+format: 'snorm8x2',
+offset: 1018,
+shaderLocation: 13,
+}, {
+format: 'sint8x4',
+offset: 620,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 316,
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 24,
+shaderLocation: 7,
+}, {
+format: 'unorm8x4',
+offset: 108,
+shaderLocation: 15,
+}, {
+format: 'float32x3',
+offset: 236,
+shaderLocation: 8,
+}, {
+format: 'uint32',
+offset: 288,
+shaderLocation: 11,
+}, {
+format: 'float32x2',
+offset: 196,
+shaderLocation: 4,
+}, {
+format: 'sint32x2',
+offset: 160,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 1960,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x4',
+offset: 1264,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+cullMode: 'front',
+},
+});
+try {
+gpuCanvasContext25.unconfigure();
+} catch {}
+gc();
+let imageData24 = new ImageData(248, 228);
+let bindGroupLayout62 = device2.createBindGroupLayout({
+label: '\u12f2\u86a3\u030f\ub562\u001e\uafce\u087b\u709e\ua631\u0988',
+entries: [{
+binding: 920,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'comparison' },
+}, {
+binding: 478,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+}, {
+binding: 334,
+visibility: 0,
+externalTexture: {},
+}],
+});
+let commandBuffer22 = commandEncoder84.finish({
+});
+let textureView109 = texture103.createView({
+  label: '\u{1fb1c}\u0b85\u484c\u{1fbba}\u0771\ua37d\u8641\ud882',
+  baseMipLevel: 10,
+  baseArrayLayer: 35,
+  arrayLayerCount: 10
+});
+let computePassEncoder85 = commandEncoder74.beginComputePass({label: '\u{1fdb4}\u{1f93f}\u573c\uccfb'});
+let renderBundleEncoder102 = device2.createRenderBundleEncoder({
+  label: '\u2e8b\ub308\u0e64\ua694\u1e3a',
+  colorFormats: ['bgra8unorm', 'rgba8unorm', 'rgba32sint', undefined]
+});
+try {
+computePassEncoder65.setPipeline(pipeline138);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 3,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, new Int32Array(arrayBuffer15), /* required buffer size: 327309 */
+{offset: 775, bytesPerRow: 153, rowsPerImage: 194}, {width: 2, height: 1, depthOrArrayLayers: 12});
+} catch {}
+let pipeline148 = await device2.createRenderPipelineAsync({
+label: '\u74d2\u0c63\u06dc\u1d4c\u57d5\u{1fe5f}\u0455\u4fe5\u{1f7b9}\uedf4',
+layout: 'auto',
+multisample: {
+mask: 0x6ab8d2a0,
+},
+fragment: {module: shaderModule40, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'invert',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'zero',
+depthFailOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 3695,
+stencilWriteMask: 2544,
+depthBias: 42,
+depthBiasSlopeScale: 46,
+depthBiasClamp: 36,
+},
+vertex: {
+  module: shaderModule40,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1912,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x4',
+offset: 1572,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 1748,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x2',
+offset: 1420,
+shaderLocation: 13,
+}, {
+format: 'unorm16x2',
+offset: 720,
+shaderLocation: 0,
+}, {
+format: 'float16x2',
+offset: 1448,
+shaderLocation: 15,
+}, {
+format: 'snorm8x2',
+offset: 1246,
+shaderLocation: 10,
+}, {
+format: 'sint32',
+offset: 56,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 1944,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x2',
+offset: 1092,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 1732,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 1604,
+shaderLocation: 1,
+}, {
+format: 'float32',
+offset: 1668,
+shaderLocation: 14,
+}, {
+format: 'float32x4',
+offset: 864,
+shaderLocation: 7,
+}, {
+format: 'snorm16x2',
+offset: 364,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 1436,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x2',
+offset: 1404,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 204,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 348,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 200,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 172,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'none',
+},
+});
+gc();
+let textureView110 = texture125.createView({format: 'rg8sint', mipLevelCount: 1, arrayLayerCount: 1});
+try {
+renderBundleEncoder99.setBindGroup(5, bindGroup47, new Uint32Array(1850), 695, 0);
+} catch {}
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55) };
+} catch {}
+let canvas36 = document.createElement('canvas');
+let bindGroup48 = device7.createBindGroup({
+label: '\u{1fe3b}\u833b',
+layout: bindGroupLayout60,
+entries: [],
+});
+let sampler91 = device7.createSampler({
+label: '\ub1b3\u6aea\u075b\u{1fdb2}\u{1fa38}\u{1fe58}\u288f\uf5b0',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 13.706,
+lodMaxClamp: 84.671,
+maxAnisotropy: 14,
+});
+try {
+renderBundleEncoder99.setVertexBuffer(20, undefined, 3736152090, 312105631);
+} catch {}
+offscreenCanvas20.height = 106;
+let videoFrame31 = new VideoFrame(videoFrame5, {timestamp: 0});
+let offscreenCanvas31 = new OffscreenCanvas(314, 61);
+try {
+adapter6.label = '\u0a34\ufc69\udcd4\u8f6a\u{1fb4f}\ua5df\u{1fb50}';
+} catch {}
+let videoFrame32 = new VideoFrame(videoFrame24, {timestamp: 0});
+try {
+window.someLabel = device1.queue.label;
+} catch {}
+try {
+if (!arrayBuffer18.detached) { new Uint8Array(arrayBuffer18).fill(0x55) };
+} catch {}
+let texture130 = device7.createTexture({
+label: '\uba06\u2709\u0e00\u2ad1',
+size: {width: 3060, height: 66, depthOrArrayLayers: 33},
+mipLevelCount: 3,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let sampler92 = device7.createSampler({
+label: '\u27d6\u2438\u4c13\u8ae1\u0b49\ueac1\u7c48\u{1fe74}\ubb62',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 75.855,
+lodMaxClamp: 92.766,
+maxAnisotropy: 15,
+});
+try {
+await device7.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext26 = canvas36.getContext('webgpu');
+let shaderModule46 = device2.createShaderModule({
+label: '\u{1fa35}\u161f\u25de\u{1fb2d}\u06d8\u66b9\u0663\u0e34',
+code: `@group(1) @binding(241)
+var<storage, read_write> type19: array<u32>;
+
+@compute @workgroup_size(1, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(0) f1: vec4<f32>,
+  @location(2) f2: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S32 {
+  @location(6) f0: vec2<u32>,
+  @location(2) f1: vec2<f32>,
+  @location(13) f2: i32,
+  @location(11) f3: u32,
+  @location(14) f4: vec4<i32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(5) a1: f16, @location(9) a2: i32, @location(10) a3: vec2<f32>, @location(12) a4: vec3<f32>, @location(7) a5: vec3<i32>, @location(8) a6: f16, @location(0) a7: i32, @location(15) a8: vec2<f32>, @location(4) a9: vec2<i32>, @location(1) a10: vec4<u32>, @location(3) a11: vec3<u32>, a12: S32, @builtin(vertex_index) a13: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let commandEncoder101 = device2.createCommandEncoder();
+pseudoSubmit(device2, commandEncoder89);
+let textureView111 = texture78.createView({
+  label: '\ub217\u04c5\u01b9\u4154\ubdc4\u076e',
+  dimension: '2d-array',
+  aspect: 'all',
+  format: 'depth32float',
+  baseMipLevel: 1,
+  mipLevelCount: 2
+});
+try {
+renderBundleEncoder88.setVertexBuffer(6, buffer46, 27420, 5606);
+} catch {}
+try {
+commandEncoder66.copyBufferToBuffer(buffer26, 9200, buffer27, 24804, 392);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+gpuCanvasContext18.configure({
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer31, 17336, new DataView(new ArrayBuffer(1229)), 896, 84);
+} catch {}
+let gpuCanvasContext27 = offscreenCanvas31.getContext('webgpu');
+try {
+  await promise70;
+} catch {}
+document.body.prepend(img7);
+let promise71 = adapter9.requestAdapterInfo();
+let querySet107 = device2.createQuerySet({
+label: '\u224e\u0f81\u22d0\u199b\u622f\u7bb0\u0b8e\u05ec',
+type: 'occlusion',
+count: 1846,
+});
+let texture131 = device2.createTexture({
+label: '\u01fc\u8688\u846b\u6f18\uaedc\u72b3',
+size: [1080, 1, 1304],
+mipLevelCount: 8,
+dimension: '3d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+device2.queue.writeBuffer(buffer31, 23556, new DataView(new ArrayBuffer(50540)), 49715, 264);
+} catch {}
+try {
+  await promise71;
+} catch {}
+let querySet108 = device6.createQuerySet({
+label: '\u5e9a\u2301\u0331\u05de\ua568\u0400\u0a19\u0f04\ua8cb',
+type: 'occlusion',
+count: 2632,
+});
+let renderBundle111 = renderBundleEncoder96.finish({label: '\u{1fd56}\u783a\u92d1'});
+try {
+gpuCanvasContext14.configure({
+device: device6,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba8uint', 'rg32float', 'astc-10x8-unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let buffer47 = device6.createBuffer({
+  label: '\ub703\u6d89\u0051\u083f\ue9e5\u04c2\u835e\u80ed\u7147',
+  size: 61041,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let commandBuffer23 = commandEncoder99.finish();
+try {
+commandEncoder97.copyTextureToTexture({
+  texture: texture124,
+  mipLevel: 5,
+  origin: { x: 12, y: 4, z: 20 },
+  aspect: 'all',
+}, {
+  texture: texture124,
+  mipLevel: 3,
+  origin: { x: 32, y: 4, z: 11 },
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 23});
+} catch {}
+try {
+device6.queue.writeBuffer(buffer47, 12832, new Int16Array(31209), 25298, 2956);
+} catch {}
+let img28 = await imageWithData(93, 104, '#5b0fd7ea', '#bfaab4c2');
+let commandEncoder102 = device6.createCommandEncoder({label: '\u{1fe65}\u3624\u{1fc02}\uf16a\ud2c9\u0dff\ue761\u6cf8\u{1fa42}'});
+let texture132 = device6.createTexture({
+label: '\u9513\u{1fc0e}\u{1ff25}\u9faf\u917d\u95ae\u66a4\u{1f636}',
+size: [15],
+dimension: '1d',
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['r8unorm', 'r8unorm'],
+});
+let renderBundle112 = renderBundleEncoder100.finish({label: '\u{1f718}\ua4e7\uecba\ucbb1'});
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+let adapter11 = await promise69;
+try {
+renderBundle92.label = '\u{1ff19}\u{1f745}\u0798';
+} catch {}
+document.body.prepend(video15);
+let img29 = await imageWithData(136, 207, '#00f31f91', '#94e8c2d2');
+try {
+renderBundleEncoder99.setBindGroup(4, bindGroup47, new Uint32Array(8299), 6113, 0);
+} catch {}
+let device8 = await adapter11.requestDevice({
+label: '\u{1fe15}\u3106\u9541\u{1f9f6}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 52,
+maxVertexAttributes: 26,
+maxVertexBufferArrayStride: 35588,
+maxStorageTexturesPerShaderStage: 8,
+maxStorageBuffersPerShaderStage: 18,
+maxDynamicStorageBuffersPerPipelineLayout: 8054,
+maxBindingsPerBindGroup: 4736,
+maxTextureDimension1D: 8997,
+maxTextureDimension2D: 9180,
+maxVertexBuffers: 11,
+maxUniformBufferBindingSize: 27880921,
+maxUniformBuffersPerShaderStage: 13,
+maxInterStageShaderVariables: 33,
+maxInterStageShaderComponents: 63,
+maxSamplersPerShaderStage: 19,
+},
+});
+let adapter12 = await navigator.gpu.requestAdapter({
+});
+let promise72 = adapter12.requestDevice({
+label: '\u5488\u099f\u{1f770}\ucac5\u0521\u0507\u{1ff98}\u{1f64a}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 63,
+maxVertexAttributes: 25,
+maxVertexBufferArrayStride: 35389,
+maxStorageTexturesPerShaderStage: 39,
+maxStorageBuffersPerShaderStage: 37,
+maxDynamicStorageBuffersPerPipelineLayout: 52339,
+maxBindingsPerBindGroup: 9290,
+maxTextureDimension1D: 14178,
+maxTextureDimension2D: 15880,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 164015924,
+maxUniformBuffersPerShaderStage: 37,
+maxInterStageShaderVariables: 82,
+maxInterStageShaderComponents: 99,
+maxSamplersPerShaderStage: 19,
+},
+});
+try {
+adapter12.label = '\u4931\u8df0\u077d\u03d9\ub400';
+} catch {}
+let renderBundleEncoder103 = device7.createRenderBundleEncoder({colorFormats: ['rg16float'], depthReadOnly: false});
+let sampler93 = device7.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 49.159,
+lodMaxClamp: 88.514,
+maxAnisotropy: 19,
+});
+let videoFrame33 = new VideoFrame(offscreenCanvas18, {timestamp: 0});
+try {
+device8.label = '\u41ab\u0499\u{1f69a}\u{1f621}\u03b2\u{1ff65}\u0af0';
+} catch {}
+let texture133 = device8.createTexture({
+label: '\u1bb7\u0813\u7c1f\u320c\u0f84',
+size: {width: 3240, height: 110, depthOrArrayLayers: 179},
+mipLevelCount: 3,
+format: 'astc-10x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x10-unorm-srgb', 'astc-10x10-unorm-srgb', 'astc-10x10-unorm-srgb'],
+});
+let img30 = await imageWithData(237, 153, '#3e22e513', '#06cce2c5');
+try {
+if (!arrayBuffer20.detached) { new Uint8Array(arrayBuffer20).fill(0x55) };
+} catch {}
+let imageData25 = new ImageData(224, 72);
+try {
+gpuCanvasContext8.configure({
+device: device8,
+format: 'astc-5x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-5x4-unorm-srgb', 'astc-5x4-unorm', 'astc-5x4-unorm', 'astc-5x4-unorm'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device8.queue.writeTexture({
+  texture: texture133,
+  mipLevel: 0,
+  origin: { x: 10, y: 100, z: 23 },
+  aspect: 'all',
+}, arrayBuffer20, /* required buffer size: 467730 */
+{offset: 466, bytesPerRow: 4768, rowsPerImage: 7}, {width: 2930, height: 0, depthOrArrayLayers: 15});
+} catch {}
+let offscreenCanvas32 = new OffscreenCanvas(558, 845);
+let querySet109 = device3.createQuerySet({
+type: 'occlusion',
+count: 746,
+});
+let texture134 = device3.createTexture({
+label: '\u085b\u3b38',
+size: [384, 192, 1],
+mipLevelCount: 3,
+format: 'etc2-rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let pipeline149 = device3.createRenderPipeline({
+label: '\u0e95\u9d1f',
+layout: pipelineLayout20,
+fragment: {module: shaderModule32, entryPoint: 'fragment0', targets: []},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 1391,
+stencilWriteMask: 3550,
+depthBias: 52,
+depthBiasSlopeScale: 52,
+depthBiasClamp: 8,
+},
+vertex: {
+  module: shaderModule32,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 456,
+attributes: [{
+format: 'uint32x4',
+offset: 312,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 20,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x4',
+offset: 8,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 768,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 436,
+shaderLocation: 3,
+}, {
+format: 'sint32x4',
+offset: 496,
+shaderLocation: 5,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let gpuCanvasContext28 = offscreenCanvas32.getContext('webgpu');
+document.body.prepend(canvas12);
+let offscreenCanvas33 = new OffscreenCanvas(336, 204);
+let imageData26 = new ImageData(200, 140);
+let img31 = await imageWithData(194, 200, '#08245857', '#1973f1e1');
+let imageBitmap35 = await createImageBitmap(video18);
+try {
+offscreenCanvas33.getContext('webgl2');
+} catch {}
+let buffer48 = device8.createBuffer({
+  label: '\u0c54\ua82f\u0d6f\ua4ab\u091b\ua413\u{1f990}\u31ed\ua550',
+  size: 53735,
+  usage: GPUBufferUsage.MAP_READ
+});
+let commandEncoder103 = device8.createCommandEncoder({label: '\u55f8\u090e\u6b81\ue490\u0f52\ub7a1\u0656\u{1ff03}\u{1f718}\u2b29'});
+let texture135 = device8.createTexture({
+label: '\u{1f84f}\u3196\u0be9\u{1fd5a}\u0846\u02e0\u0faf\uaa00',
+size: {width: 2215, height: 5, depthOrArrayLayers: 118},
+mipLevelCount: 9,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-5x5-unorm-srgb', 'astc-5x5-unorm', 'astc-5x5-unorm-srgb'],
+});
+let textureView112 = texture133.createView({
+  label: '\u1b40\u{1fa69}\u{1f83b}\udb56\u{1f89d}\u{1fdd3}\u1ce8\u6f36\u0aa2\u62cb',
+  dimension: '2d',
+  mipLevelCount: 2,
+  baseArrayLayer: 77
+});
+let computePassEncoder86 = commandEncoder103.beginComputePass({label: '\u5c3d\u{1fc2d}\u62de\u01fe\ue2b8\u0cf8\uedcb'});
+try {
+computePassEncoder86.end();
+} catch {}
+try {
+await adapter9.requestAdapterInfo();
+} catch {}
+document.body.prepend(img26);
+let img32 = await imageWithData(223, 52, '#2d48f247', '#bbe08c2f');
+let video34 = await videoWithData();
+let imageData27 = new ImageData(88, 196);
+canvas24.height = 27;
+let computePassEncoder87 = commandEncoder63.beginComputePass({});
+let renderBundle113 = renderBundleEncoder78.finish({label: '\ua2ef\u0653\u842f\udaea\uee36\u{1f636}\u6e2e\ued1a\u610c'});
+let sampler94 = device2.createSampler({
+label: '\u7696\uacc9\u2954\u{1fa2f}\ufa66\u{1f976}\u{1fe6c}\u{1f7cb}\u{1f817}',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 46.519,
+lodMaxClamp: 49.630,
+});
+try {
+renderBundleEncoder102.setBindGroup(1, bindGroup46);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 48, height: 7, depthOrArrayLayers: 100}
+*/
+{
+  source: imageBitmap24,
+  origin: { x: 3, y: 15 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: { x: 21, y: 5, z: 59 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline150 = device2.createRenderPipeline({
+layout: 'auto',
+multisample: {
+count: 4,
+mask: 0x61112d0,
+},
+fragment: {
+  module: shaderModule46,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm'}, {format: 'rgba8unorm', writeMask: 0}, {format: 'rgba32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, undefined]
+},
+vertex: {
+  module: shaderModule46,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 1628,
+shaderLocation: 4,
+}, {
+format: 'float16x4',
+offset: 1268,
+shaderLocation: 8,
+}, {
+format: 'unorm8x2',
+offset: 1578,
+shaderLocation: 2,
+}, {
+format: 'unorm8x4',
+offset: 1648,
+shaderLocation: 5,
+}, {
+format: 'unorm8x4',
+offset: 1228,
+shaderLocation: 15,
+}, {
+format: 'uint32x4',
+offset: 964,
+shaderLocation: 11,
+}, {
+format: 'unorm10-10-10-2',
+offset: 1376,
+shaderLocation: 12,
+}, {
+format: 'sint16x4',
+offset: 280,
+shaderLocation: 13,
+}, {
+format: 'sint32x3',
+offset: 1444,
+shaderLocation: 14,
+}, {
+format: 'uint32x3',
+offset: 1616,
+shaderLocation: 3,
+}, {
+format: 'uint32',
+offset: 1596,
+shaderLocation: 1,
+}, {
+format: 'unorm16x2',
+offset: 608,
+shaderLocation: 10,
+}, {
+format: 'sint16x4',
+offset: 828,
+shaderLocation: 9,
+}, {
+format: 'sint32x3',
+offset: 676,
+shaderLocation: 0,
+}, {
+format: 'sint32',
+offset: 396,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 468,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 2008,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x4',
+offset: 1744,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: false,
+},
+});
+let commandEncoder104 = device8.createCommandEncoder({label: '\u{1fd54}\ud3ea\u93ae\u8138\u4403\u0f07\u{1f6aa}\u3512\u3137\u0ccd'});
+let texture136 = device8.createTexture({
+label: '\u05a6\u09b5',
+size: [320, 96, 21],
+mipLevelCount: 9,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-8x8-unorm', 'astc-8x8-unorm-srgb', 'astc-8x8-unorm'],
+});
+let textureView113 = texture136.createView({
+  label: '\u{1f858}\uf86b\u3a35\u03c7\u{1f7cc}',
+  dimension: '2d',
+  format: 'astc-8x8-unorm',
+  baseMipLevel: 5,
+  mipLevelCount: 1,
+  baseArrayLayer: 15
+});
+offscreenCanvas27.height = 12;
+try {
+pipelineLayout25.label = '\uc090\u{1fd8a}\u{1f806}';
+} catch {}
+let commandBuffer24 = commandEncoder98.finish({
+});
+let textureView114 = texture132.createView({label: '\uf4ef\ue835\u{1f8db}\u0ad4\u5417\u9e5e\u{1f9fc}\u7a48\u17bb'});
+let computePassEncoder88 = commandEncoder97.beginComputePass({label: '\u70ef\u76fa\u02ae\u01d4\u0536\u2a93\u{1ff4d}\ua9f3\uc3c8'});
+try {
+device6.queue.writeTexture({
+  texture: texture124,
+  mipLevel: 3,
+  origin: { x: 0, y: 4, z: 0 },
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(16)), /* required buffer size: 208060 */
+{offset: 723, bytesPerRow: 389, rowsPerImage: 13}, {width: 108, height: 0, depthOrArrayLayers: 42});
+} catch {}
+document.body.prepend(video13);
+let textureView115 = texture84.createView({label: '\u0da7\u4ba5\u46f1\u4713', aspect: 'all'});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup46, new Uint32Array(1), 0, 0);
+} catch {}
+try {
+commandEncoder94.resolveQuerySet(querySet60, 2767, 841, buffer46, 38656);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 24, height: 3, depthOrArrayLayers: 50}
+*/
+{
+  source: video20,
+  origin: { x: 3, y: 7 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 0, y: 2, z: 36 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageData28 = new ImageData(80, 32);
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let adapter13 = await navigator.gpu.requestAdapter({
+powerPreference: 'high-performance',
+});
+let sampler95 = device8.createSampler({
+label: '\u{1fe8e}\u134b\u0727\u{1fca8}\u01df\u{1f836}\u5163\ucde9',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 86.751,
+lodMaxClamp: 92.360,
+maxAnisotropy: 8,
+});
+try {
+buffer48.destroy();
+} catch {}
+offscreenCanvas31.height = 718;
+document.body.prepend(canvas36);
+offscreenCanvas4.width = 534;
+let adapter14 = await navigator.gpu.requestAdapter({
+});
+try {
+renderBundleEncoder83.setBindGroup(1, bindGroup36);
+} catch {}
+try {
+commandEncoder66.clearBuffer(buffer25, 5844, 51848);
+dissociateBuffer(device2, buffer25);
+} catch {}
+canvas10.width = 11;
+gc();
+canvas21.width = 671;
+let videoFrame34 = new VideoFrame(imageBitmap19, {timestamp: 0});
+let promise73 = navigator.gpu.requestAdapter();
+let device9 = await adapter13.requestDevice({
+label: '\ud7ce\u{1f7b9}\u470e\u1670\u97ca\u0ac3\u0e8c\u{1f76a}\u{1fdca}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+});
+document.body.prepend(video0);
+try {
+commandEncoder102.clearBuffer(buffer47, 628, 35024);
+dissociateBuffer(device6, buffer47);
+} catch {}
+try {
+device6.queue.writeBuffer(buffer47, 18140, new Int16Array(45381), 18198, 15628);
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture124,
+  mipLevel: 3,
+  origin: { x: 12, y: 0, z: 11 },
+  aspect: 'all',
+}, arrayBuffer20, /* required buffer size: 1090467 */
+{offset: 495, bytesPerRow: 234, rowsPerImage: 274}, {width: 96, height: 0, depthOrArrayLayers: 18});
+} catch {}
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup49 = device2.createBindGroup({
+label: '\u5618\u0719\u792c\u{1fd1b}\uc382\u7957\udf66\u2ed3\u{1f616}\ucb75',
+layout: bindGroupLayout37,
+entries: [{
+binding: 385,
+resource: sampler52
+}, {
+binding: 771,
+resource: externalTexture4
+}],
+});
+try {
+computePassEncoder85.setBindGroup(1, bindGroup49, new Uint32Array(4513), 1512, 0);
+} catch {}
+try {
+commandEncoder93.clearBuffer(buffer34);
+dissociateBuffer(device2, buffer34);
+} catch {}
+let pipeline151 = device2.createComputePipeline({
+label: '\uc363\u2be3\ud2a7\u{1fe40}\u84e9\ud3c5\u3750\u8925\u0530\u0043',
+layout: pipelineLayout26,
+compute: {
+module: shaderModule28,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline152 = await device2.createRenderPipelineAsync({
+label: '\u0ae8\u{1f8d4}',
+layout: pipelineLayout19,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule34,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'dst', dstFactor: 'src'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+}
+}, undefined, undefined, {format: 'rgba16float'}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL
+}, {format: 'rgba8sint', writeMask: 0}]
+},
+vertex: {
+  module: shaderModule34,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32',
+offset: 1800,
+shaderLocation: 14,
+}, {
+format: 'float32x3',
+offset: 1004,
+shaderLocation: 3,
+}, {
+format: 'float32x2',
+offset: 1112,
+shaderLocation: 2,
+}, {
+format: 'sint8x2',
+offset: 818,
+shaderLocation: 10,
+}, {
+format: 'unorm16x4',
+offset: 1184,
+shaderLocation: 7,
+}, {
+format: 'unorm8x4',
+offset: 2028,
+shaderLocation: 9,
+}, {
+format: 'float32',
+offset: 1696,
+shaderLocation: 12,
+}, {
+format: 'float32x4',
+offset: 832,
+shaderLocation: 1,
+}, {
+format: 'float32x4',
+offset: 1224,
+shaderLocation: 4,
+}, {
+format: 'sint32x4',
+offset: 1012,
+shaderLocation: 5,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+},
+});
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+let imageData29 = new ImageData(44, 32);
+let renderBundleEncoder104 = device9.createRenderBundleEncoder({
+  label: '\u43a9\u0b9a\u06ab\uef6b\ub9ce\uc41d\u9628\uf67a\uf90b',
+  colorFormats: ['rgba16float', 'rgba32uint', 'rgb10a2uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let buffer49 = device2.createBuffer({size: 46012, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let texture137 = device2.createTexture({
+label: '\u{1f784}\u6dde\u{1f801}\u07c1\u{1ffe2}\u0654\u0c1f\u0807\u7563',
+size: [30],
+dimension: '1d',
+format: 'rg16uint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+let computePassEncoder89 = commandEncoder94.beginComputePass();
+let renderBundleEncoder105 = device2.createRenderBundleEncoder({label: '\u00aa\u2b4e\u0cff', colorFormats: ['bgra8unorm', 'rgba8unorm', 'rgba32sint', undefined]});
+try {
+computePassEncoder83.setBindGroup(0, bindGroup46, new Uint32Array(9898), 5409, 0);
+} catch {}
+try {
+renderBundleEncoder97.setBindGroup(0, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder97.setVertexBuffer(3, buffer26, 280, 6621);
+} catch {}
+let arrayBuffer21 = buffer27.getMappedRange(12608, 204);
+try {
+commandEncoder66.resolveQuerySet(querySet65, 1948, 17, buffer46, 19456);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture131,
+  mipLevel: 0,
+  origin: { x: 104, y: 0, z: 917 },
+  aspect: 'all',
+}, new ArrayBuffer(2314239), /* required buffer size: 2314239 */
+{offset: 895, bytesPerRow: 3774, rowsPerImage: 6}, {width: 914, height: 1, depthOrArrayLayers: 103});
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+try {
+if (!arrayBuffer21.detached) { new Uint8Array(arrayBuffer21).fill(0x55) };
+} catch {}
+let promise74 = adapter14.requestDevice({
+label: '\u{1f7dd}\u5059\u8014\u0051\u0413\u{1ff19}\u0a1f\u{1fc65}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxColorAttachmentBytesPerSample: 50,
+maxVertexAttributes: 22,
+maxVertexBufferArrayStride: 64417,
+maxStorageTexturesPerShaderStage: 22,
+maxStorageBuffersPerShaderStage: 15,
+maxDynamicStorageBuffersPerPipelineLayout: 6134,
+maxBindingsPerBindGroup: 1630,
+maxTextureDimension1D: 12361,
+maxTextureDimension2D: 12570,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 256,
+maxUniformBufferBindingSize: 174875661,
+maxUniformBuffersPerShaderStage: 16,
+maxInterStageShaderVariables: 27,
+maxInterStageShaderComponents: 84,
+maxSamplersPerShaderStage: 16,
+},
+});
+let canvas37 = document.createElement('canvas');
+let imageBitmap36 = await createImageBitmap(imageData29);
+try {
+canvas37.getContext('webgpu');
+} catch {}
+try {
+window.someLabel = device2.label;
+} catch {}
+let commandEncoder105 = device2.createCommandEncoder({label: '\u1e32\u{1faff}\u{1f9c4}\u{1faa4}\uf6dc\ub16b\u{1fff0}\u4f7a'});
+let querySet110 = device2.createQuerySet({
+label: '\u{1ffd1}\u1063\u00a0\u9b74\u0e22',
+type: 'occlusion',
+count: 1588,
+});
+let textureView116 = texture137.createView({});
+let computePassEncoder90 = commandEncoder93.beginComputePass({label: '\u{1fdff}\u0a22\ufeac\u9921\u0684\u39d2'});
+try {
+computePassEncoder85.end();
+} catch {}
+try {
+renderBundleEncoder88.setBindGroup(1, bindGroup49, new Uint32Array(648), 561, 0);
+} catch {}
+try {
+renderBundleEncoder81.setVertexBuffer(0, buffer46, 14068);
+} catch {}
+try {
+commandEncoder101.copyTextureToTexture({
+  texture: texture109,
+  mipLevel: 0,
+  origin: { x: 63, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture119,
+  mipLevel: 0,
+  origin: { x: 17, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 7, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderBundleEncoder88.insertDebugMarker('\u0849');
+} catch {}
+let pipeline153 = device2.createComputePipeline({
+label: '\ub5ac\u{1f6ba}\u6aea\u9618\u1959\udd89\u044f\uf517',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule46,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline154 = device2.createRenderPipeline({
+label: '\u004d\u53f3\u0bc1\u0f17',
+layout: pipelineLayout26,
+multisample: {
+count: 4,
+mask: 0x8c7686e1,
+},
+fragment: {module: shaderModule40, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 3917,
+depthBias: 8,
+depthBiasSlopeScale: 4,
+depthBiasClamp: 58,
+},
+vertex: {
+  module: shaderModule40,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 808,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 20,
+shaderLocation: 3,
+}, {
+format: 'uint16x4',
+offset: 608,
+shaderLocation: 11,
+}, {
+format: 'snorm8x4',
+offset: 756,
+shaderLocation: 7,
+}, {
+format: 'sint32x3',
+offset: 212,
+shaderLocation: 1,
+}, {
+format: 'snorm8x2',
+offset: 534,
+shaderLocation: 10,
+}, {
+format: 'unorm16x2',
+offset: 776,
+shaderLocation: 0,
+}, {
+format: 'unorm10-10-10-2',
+offset: 728,
+shaderLocation: 6,
+}, {
+format: 'sint32',
+offset: 20,
+shaderLocation: 9,
+}, {
+format: 'unorm16x4',
+offset: 16,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 1388,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1224,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x4',
+offset: 1084,
+shaderLocation: 14,
+}, {
+format: 'unorm16x2',
+offset: 644,
+shaderLocation: 8,
+}, {
+format: 'snorm16x4',
+offset: 584,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 16,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1928,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 512,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x4',
+offset: 168,
+shaderLocation: 4,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+},
+});
+document.body.prepend(video14);
+let canvas38 = document.createElement('canvas');
+let renderBundle114 = renderBundleEncoder99.finish({label: '\uc0d7\u{1f91c}\u6847'});
+try {
+renderBundleEncoder103.setBindGroup(10, bindGroup48);
+} catch {}
+let gpuCanvasContext29 = canvas38.getContext('webgpu');
+let bindGroupLayout63 = device6.createBindGroupLayout({
+label: '\u0e1e\u22b5\uf9d0\u4e82\u400b\u1702\u9946\u0dd0',
+entries: [{
+binding: 5070,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+}],
+});
+let querySet111 = device9.createQuerySet({
+label: '\u{1fdad}\u08b0\u0b74\u0cfa',
+type: 'occlusion',
+count: 2600,
+});
+let renderBundleEncoder106 = device9.createRenderBundleEncoder({
+  colorFormats: ['rgba16float', 'rgba32uint', 'rgb10a2uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder106.setVertexBuffer(42, undefined, 619901384, 3164504200);
+} catch {}
+let img33 = await imageWithData(213, 9, '#9c7a7cbb', '#df83b042');
+offscreenCanvas32.height = 162;
+let videoFrame35 = new VideoFrame(imageBitmap21, {timestamp: 0});
+let pipelineLayout28 = device6.createPipelineLayout({
+  label: '\u{1f8f5}\u0606\ubf7a\u{1ff0c}\ua1d0\u0faf\u641c\u{1f604}\u0a9e',
+  bindGroupLayouts: [bindGroupLayout63, bindGroupLayout63, bindGroupLayout63, bindGroupLayout63, bindGroupLayout63, bindGroupLayout63]
+});
+let commandEncoder106 = device6.createCommandEncoder();
+let querySet112 = device6.createQuerySet({
+label: '\u9678\u0041\u{1f600}\u095a\u{1fc1a}\ub295\u03a2\ub9d5\ubadd',
+type: 'occlusion',
+count: 2720,
+});
+let commandBuffer25 = commandEncoder106.finish({
+label: '\u3997\ue58a\uea0d\uce16\u006a\u2173\u0f2b\u5d1f\u5235\u0cac\u0d7e',
+});
+let renderBundleEncoder107 = device6.createRenderBundleEncoder({
+  label: '\u0461\u0e81\u8909\u{1fb8a}\uea30\u065e\u{1f991}\ufe21\u097c\u0991',
+  colorFormats: ['rg32float', 'rg11b10ufloat', undefined, 'rg11b10ufloat', 'rgba8uint'],
+  sampleCount: 4
+});
+let sampler96 = device6.createSampler({
+label: '\u5071\u{1f79d}\u0d74\u{1f679}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 67.698,
+lodMaxClamp: 80.852,
+});
+try {
+commandEncoder102.clearBuffer(buffer47, 8088, 7692);
+dissociateBuffer(device6, buffer47);
+} catch {}
+try {
+device6.queue.writeBuffer(buffer47, 42764, new DataView(new ArrayBuffer(52995)), 14344, 11676);
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let promise75 = navigator.gpu.requestAdapter({
+});
+let sampler97 = device2.createSampler({
+label: '\u2813\ube0e\ua3e8\u26a7\u04f8\uf22a\u{1fca9}\u0a35\u0906\u{1ffb7}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 60.945,
+lodMaxClamp: 94.474,
+});
+try {
+renderBundleEncoder105.setVertexBuffer(4, buffer46, 1620);
+} catch {}
+try {
+commandEncoder66.copyBufferToBuffer(buffer26, 4464, buffer25, 19288, 240);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer25);
+} catch {}
+try {
+commandEncoder101.copyTextureToBuffer({
+  texture: texture105,
+  mipLevel: 1,
+  origin: { x: 152, y: 0, z: 115 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 8704 widthInBlocks: 2176 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 16868 */
+offset: 16868,
+buffer: buffer31,
+}, {width: 2176, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer31);
+} catch {}
+try {
+commandEncoder105.clearBuffer(buffer31, 32380, 824);
+dissociateBuffer(device2, buffer31);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb'],
+colorSpace: 'display-p3',
+});
+} catch {}
+let canvas39 = document.createElement('canvas');
+let offscreenCanvas34 = new OffscreenCanvas(941, 702);
+let img34 = await imageWithData(149, 111, '#0e977015', '#d6da5d4f');
+let bindGroupLayout64 = device6.createBindGroupLayout({
+label: '\u05d4\u044b\ua96e\ub4ed\u35ac\u8464\u{1ff77}',
+entries: [{
+binding: 5734,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+}, {
+binding: 2694,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '1d' },
+}],
+});
+try {
+gpuCanvasContext3.configure({
+device: device6,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['astc-12x10-unorm'],
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+offscreenCanvas34.getContext('webgl2');
+} catch {}
+let bindGroupLayout65 = device9.createBindGroupLayout({
+label: '\u9e7e\u{1fd05}\u5398\u0417\u0857\u{1fdf8}\u{1f90d}\u7fb9',
+entries: [{
+binding: 573,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+}, {
+binding: 342,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}],
+});
+let buffer50 = device9.createBuffer({
+  label: '\u08c4\u345d\u{1fd34}\ue05a\u005b\u9b25\ua0b1\u0a8b\uf1bf\u{1fd46}',
+  size: 36391,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE
+});
+let sampler98 = device9.createSampler({
+label: '\u2a31\ubd73\u{1f978}\u98cc\u3c41\u008b\ua4ca\u06c5\u0025',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 91.054,
+lodMaxClamp: 98.180,
+compare: 'equal',
+maxAnisotropy: 17,
+});
+try {
+device1.label = '\u{1f958}\u2abe';
+} catch {}
+let renderBundleEncoder108 = device7.createRenderBundleEncoder({colorFormats: ['rg16float'], depthReadOnly: false, stencilReadOnly: true});
+let sampler99 = device7.createSampler({
+label: '\uf12f\u0c97\u0572\u0dfc',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 6.853,
+lodMaxClamp: 39.977,
+maxAnisotropy: 13,
+});
+try {
+renderBundleEncoder108.setBindGroup(4, bindGroup47);
+} catch {}
+document.body.prepend(img32);
+let commandEncoder107 = device7.createCommandEncoder({label: '\u4029\u034b\u{1fda4}\u616f\u81af\u{1f8db}'});
+let querySet113 = device7.createQuerySet({
+label: '\u{1f6db}\u3c4c\ud02b\u71d8\u{1fb7b}',
+type: 'occlusion',
+count: 1314,
+});
+let sampler100 = device7.createSampler({
+label: '\uaaa8\u{1fde7}\uf61b\u0a17\u17a6\u05ee\u{1f86c}\u0afc\u{1fc9f}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 41.904,
+maxAnisotropy: 15,
+});
+try {
+await device7.popErrorScope();
+} catch {}
+try {
+await adapter2.requestAdapterInfo();
+} catch {}
+video19.width = 232;
+canvas31.height = 687;
+let videoFrame36 = new VideoFrame(imageBitmap26, {timestamp: 0});
+let textureView117 = texture132.createView({format: 'r8unorm'});
+try {
+buffer47.unmap();
+} catch {}
+try {
+gpuCanvasContext11.configure({
+device: device6,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm', 'rg16sint', 'rgba8unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+gc();
+let renderBundleEncoder109 = device6.createRenderBundleEncoder({
+  label: '\ub41a\u{1f608}\u7b93\u{1fd28}\u{1ff50}\u26b4\u{1fee4}\u{1fee8}\ue939',
+  colorFormats: ['rg32float', 'rg11b10ufloat', undefined, 'rg11b10ufloat', 'rgba8uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let gpuCanvasContext30 = canvas39.getContext('webgpu');
+let img35 = await imageWithData(252, 261, '#f9a8c34a', '#d1e0fee9');
+let textureView118 = texture124.createView({label: '\u01cd\uaf89\u1ead', baseMipLevel: 3, mipLevelCount: 2, baseArrayLayer: 26, arrayLayerCount: 10});
+try {
+commandEncoder102.clearBuffer(buffer47, 30376, 26688);
+dissociateBuffer(device6, buffer47);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+device: device6,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas35 = new OffscreenCanvas(775, 38);
+try {
+window.someLabel = device1.label;
+} catch {}
+let renderBundle115 = renderBundleEncoder104.finish({label: '\u018e\u0afb\u0594\u79fc\u0d80\u{1f895}\u0150\u0666\ua124\u0681\u4473'});
+try {
+renderBundleEncoder106.setVertexBuffer(25, undefined);
+} catch {}
+try {
+buffer50.unmap();
+} catch {}
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup50 = device7.createBindGroup({
+label: '\u014f\u{1fdba}\u1296\u{1f8f9}\u286a',
+layout: bindGroupLayout60,
+entries: [],
+});
+let pipelineLayout29 = device7.createPipelineLayout({
+  label: '\uc6d0\u{1feef}\ud042\ub16b',
+  bindGroupLayouts: [bindGroupLayout61, bindGroupLayout61, bindGroupLayout60, bindGroupLayout61, bindGroupLayout61, bindGroupLayout61, bindGroupLayout61, bindGroupLayout60, bindGroupLayout60, bindGroupLayout60]
+});
+let querySet114 = device7.createQuerySet({
+label: '\u3806\u{1f9ba}\u{1f721}\u0060\u{1f716}',
+type: 'occlusion',
+count: 3225,
+});
+let textureView119 = texture130.createView({aspect: 'stencil-only', baseMipLevel: 2, baseArrayLayer: 15, arrayLayerCount: 8});
+let renderBundle116 = renderBundleEncoder99.finish({label: '\u00fd\u9d1b'});
+let gpuCanvasContext31 = offscreenCanvas35.getContext('webgpu');
+let imageData30 = new ImageData(84, 208);
+try {
+window.someLabel = commandEncoder98.label;
+} catch {}
+try {
+commandEncoder102.clearBuffer(buffer47, 27780, 23868);
+dissociateBuffer(device6, buffer47);
+} catch {}
+let img36 = await imageWithData(209, 96, '#edb8550e', '#63556f9e');
+let buffer51 = device8.createBuffer({
+  label: '\u0399\u7e9f\u6983\u0d66\ud6de\u0adb\u{1f836}\ucdd6',
+  size: 41439,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let commandBuffer26 = commandEncoder103.finish({
+label: '\u{1faa0}\u8f13\u0cec\u{1fc3f}',
+});
+let videoFrame37 = new VideoFrame(canvas20, {timestamp: 0});
+offscreenCanvas29.height = 366;
+try {
+adapter14.label = '\uf9ab\u{1fc5d}\u07b7\u3737\u7f93\ud544';
+} catch {}
+let querySet115 = device6.createQuerySet({
+type: 'occlusion',
+count: 2754,
+});
+let computePassEncoder91 = commandEncoder102.beginComputePass({label: '\u2f1a\u08a4\ufe23\u879d\u5434\u7b08'});
+let renderBundleEncoder110 = device6.createRenderBundleEncoder({
+  label: '\u0bd9\u8706\ub676',
+  colorFormats: ['rg32float', 'rg11b10ufloat', undefined, 'rg11b10ufloat', 'rgba8uint'],
+  sampleCount: 4
+});
+let sampler101 = device6.createSampler({
+label: '\u0855\u0ffb\u0345',
+magFilter: 'linear',
+minFilter: 'nearest',
+lodMinClamp: 27.907,
+lodMaxClamp: 97.917,
+});
+let commandEncoder108 = device7.createCommandEncoder({label: '\u{1f738}\u{1f768}'});
+let texture138 = device7.createTexture({
+label: '\ueb42\u51e0\u{1f8fb}\u0b52\u01b0',
+size: {width: 5606},
+dimension: '1d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundle117 = renderBundleEncoder103.finish({label: '\u050e\u0706\ud869\u1ec5\u0f7e\u002e\u1e25\u{1f8d6}'});
+try {
+await device7.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder92 = commandEncoder104.beginComputePass({label: '\u3b42\u30a1\u{1f7c9}\u543f\u0fe7'});
+document.body.prepend(canvas37);
+canvas29.height = 316;
+let querySet116 = device7.createQuerySet({
+type: 'occlusion',
+count: 934,
+});
+try {
+gpuCanvasContext8.configure({
+device: device7,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['bgra8unorm', 'astc-8x8-unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture138,
+  mipLevel: 0,
+  origin: { x: 1644, y: 1, z: 1 },
+  aspect: 'all',
+}, arrayBuffer11, /* required buffer size: 453 */
+{offset: 453, rowsPerImage: 60}, {width: 151, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas19.width = 35;
+let videoFrame38 = new VideoFrame(offscreenCanvas8, {timestamp: 0});
+let adapter15 = await navigator.gpu.requestAdapter({
+});
+let shaderModule47 = device7.createShaderModule({
+label: '\u0b42\u14a1\uaf8f\u{1ff26}',
+code: `@group(0) @binding(993)
+var<storage, read_write> parameter30: array<u32>;
+@group(0) @binding(2644)
+var<storage, read_write> field14: array<u32>;
+@group(3) @binding(993)
+var<storage, read_write> function19: array<u32>;
+@group(6) @binding(2644)
+var<storage, read_write> i16: array<u32>;
+@group(3) @binding(2644)
+var<storage, read_write> field15: array<u32>;
+@group(5) @binding(993)
+var<storage, read_write> global10: array<u32>;
+@group(4) @binding(2644)
+var<storage, read_write> i17: array<u32>;
+@group(1) @binding(993)
+var<storage, read_write> parameter31: array<u32>;
+@group(4) @binding(993)
+var<storage, read_write> type20: array<u32>;
+
+@compute @workgroup_size(5, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S33 {
+  @builtin(vertex_index) f0: u32,
+  @location(17) f1: vec2<f32>,
+  @location(20) f2: vec2<i32>,
+  @builtin(instance_index) f3: u32,
+  @location(13) f4: vec3<u32>,
+  @location(9) f5: vec3<i32>,
+  @location(7) f6: vec2<f16>,
+  @location(16) f7: vec4<f32>,
+  @location(5) f8: vec4<f32>,
+  @location(8) f9: f32,
+  @location(6) f10: f16
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec3<f16>, @location(18) a1: vec2<f16>, @location(23) a2: vec4<f32>, a3: S33, @location(15) a4: vec3<i32>, @location(19) a5: vec2<i32>, @location(3) a6: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+let textureView120 = texture126.createView({
+  label: '\ub788\udcff\ud615\u1aa7\u{1fb9e}\u826f\ufbca\u0ced\ua201\u{1f7cc}',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 12
+});
+let renderBundleEncoder111 = device7.createRenderBundleEncoder({label: '\u0d78\u0458\u1cc2\u6331', colorFormats: ['rg16float'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderBundleEncoder111.setVertexBuffer(53, undefined, 1654486242, 2401168264);
+} catch {}
+let promise76 = device7.createComputePipelineAsync({
+label: '\u595a\uc99c\u0b49\u{1fb23}\uac5c\u7a5c',
+layout: pipelineLayout29,
+compute: {
+module: shaderModule47,
+entryPoint: 'compute0',
+},
+});
+let pipeline155 = device7.createRenderPipeline({
+layout: pipelineLayout29,
+multisample: {
+},
+fragment: {
+  module: shaderModule47,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg16float',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'one-minus-src'},
+alpha: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'one-minus-dst'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE
+}]
+},
+vertex: {
+  module: shaderModule47,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 8184,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 7824,
+shaderLocation: 23,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x2',
+offset: 5844,
+shaderLocation: 17,
+}],
+},
+{
+arrayStride: 7224,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x2',
+offset: 5472,
+shaderLocation: 6,
+}, {
+format: 'unorm8x4',
+offset: 1688,
+shaderLocation: 2,
+}, {
+format: 'sint16x4',
+offset: 5012,
+shaderLocation: 19,
+}, {
+format: 'snorm8x4',
+offset: 4056,
+shaderLocation: 8,
+}, {
+format: 'sint32x2',
+offset: 3088,
+shaderLocation: 15,
+}, {
+format: 'snorm16x4',
+offset: 1736,
+shaderLocation: 18,
+}, {
+format: 'float16x2',
+offset: 108,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 5840,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x2',
+offset: 5658,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 31236,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 18508,
+shaderLocation: 13,
+}, {
+format: 'sint32x3',
+offset: 9420,
+shaderLocation: 9,
+}, {
+format: 'uint8x4',
+offset: 14128,
+shaderLocation: 3,
+}, {
+format: 'sint32x4',
+offset: 29964,
+shaderLocation: 20,
+}, {
+format: 'float16x4',
+offset: 4948,
+shaderLocation: 5,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let renderBundleEncoder112 = device8.createRenderBundleEncoder({colorFormats: ['rg8sint'], stencilReadOnly: true});
+try {
+device8.queue.submit([
+commandBuffer26,
+]);
+} catch {}
+video9.width = 216;
+let adapter16 = await navigator.gpu.requestAdapter();
+let img37 = await imageWithData(223, 226, '#a4c9e8ab', '#3312c924');
+let imageData31 = new ImageData(4, 140);
+let renderBundle118 = renderBundleEncoder37.finish({label: '\ud9df\ue35d\ub3b5\u8e72\u01f3\u0bc6'});
+try {
+renderBundleEncoder54.setBindGroup(0, bindGroup29, new Uint32Array(5555), 936, 0);
+} catch {}
+try {
+renderBundleEncoder68.draw(0, 16, 0, 48);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+commandEncoder96.copyTextureToBuffer({
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 9, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 1216 widthInBlocks: 304 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 30456 */
+offset: 30456,
+buffer: buffer12,
+}, {width: 304, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+let pipeline156 = device0.createRenderPipeline({
+label: '\u03b5\u0ee0\ue71a\uf0e7\u{1fa21}\u{1fc9a}\u0377\u{1fdaf}\ub829\udea6',
+layout: pipelineLayout11,
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint'}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, undefined, {format: 'rg32float'}, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}]
+},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3014,
+stencilWriteMask: 710,
+depthBias: 12,
+depthBiasSlopeScale: 95,
+depthBiasClamp: 94,
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1800,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x2',
+offset: 868,
+shaderLocation: 5,
+}, {
+format: 'uint32x3',
+offset: 1384,
+shaderLocation: 14,
+}, {
+format: 'uint8x2',
+offset: 252,
+shaderLocation: 10,
+}, {
+format: 'unorm8x2',
+offset: 666,
+shaderLocation: 8,
+}, {
+format: 'sint32',
+offset: 1252,
+shaderLocation: 1,
+}, {
+format: 'snorm8x4',
+offset: 1360,
+shaderLocation: 6,
+}, {
+format: 'uint16x2',
+offset: 1396,
+shaderLocation: 3,
+}, {
+format: 'sint8x4',
+offset: 556,
+shaderLocation: 4,
+}, {
+format: 'uint32x4',
+offset: 1440,
+shaderLocation: 7,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+document.body.prepend(video18);
+let device10 = await adapter15.requestDevice({
+label: '\u8fe9\u5a47\u0c3c',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 41,
+maxVertexAttributes: 22,
+maxVertexBufferArrayStride: 6947,
+maxStorageTexturesPerShaderStage: 39,
+maxStorageBuffersPerShaderStage: 29,
+maxDynamicStorageBuffersPerPipelineLayout: 38944,
+maxBindingsPerBindGroup: 8830,
+maxTextureDimension1D: 10181,
+maxTextureDimension2D: 16223,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 256,
+maxUniformBufferBindingSize: 92724221,
+maxUniformBuffersPerShaderStage: 30,
+maxInterStageShaderVariables: 53,
+maxInterStageShaderComponents: 67,
+maxSamplersPerShaderStage: 21,
+},
+});
+let video35 = await videoWithData();
+let promise77 = adapter5.requestAdapterInfo();
+let pipelineLayout30 = device9.createPipelineLayout({label: '\u6373\u227c\u02d0', bindGroupLayouts: []});
+let texture139 = device9.createTexture({
+label: '\u{1fb39}\u8bb4\u8fd9\u2b9a\u{1f8d7}\u0a44\u{1fda0}',
+size: {width: 80, height: 192, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x6-unorm-srgb', 'astc-8x6-unorm'],
+});
+let sampler102 = device9.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 48.220,
+lodMaxClamp: 57.480,
+});
+try {
+buffer50.unmap();
+} catch {}
+let video36 = await videoWithData();
+pseudoSubmit(device3, commandEncoder80);
+let textureView121 = texture102.createView({label: '\ubf33\udc0c\u8eda\ue3c5\u{1ff1d}\ube24\u06f4\u0043\u8c4d', baseMipLevel: 2});
+let computePassEncoder93 = commandEncoder76.beginComputePass({label: '\u{1f7d2}\u{1f69d}\u0bb9\u08cb'});
+try {
+computePassEncoder93.setBindGroup(2, bindGroup39, new Uint32Array(8647), 3018, 0);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer35, 26128, new Float32Array(38495), 27179, 624);
+} catch {}
+try {
+  await promise77;
+} catch {}
+let device11 = await promise72;
+let texture140 = device11.createTexture({
+label: '\u2afc\u080b\u3b13\u03f8\udbeb\u0b99\u0a67\u0787\u4db1',
+size: {width: 640, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture141 = device10.createTexture({
+label: '\u{1fe1c}\u{1fe53}\u2996\u08d8\u95ec',
+size: {width: 64, height: 3, depthOrArrayLayers: 1},
+sampleCount: 4,
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16float', 'rg16float', 'rg16float'],
+});
+gc();
+let renderBundle119 = renderBundleEncoder104.finish();
+try {
+buffer50.unmap();
+} catch {}
+try {
+gpuCanvasContext17.configure({
+device: device9,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+try {
+querySet106.label = '\u74c3\u0018\u0893\u{1f644}\u1eb7\u0913\u010f\uc85f\u0e73';
+} catch {}
+pseudoSubmit(device7, commandEncoder107);
+try {
+renderBundleEncoder111.setBindGroup(4, bindGroup48, new Uint32Array(1814), 1496, 0);
+} catch {}
+let imageBitmap37 = await createImageBitmap(offscreenCanvas26);
+let shaderModule48 = device6.createShaderModule({
+label: '\u059b\uade5\u0ae1\u86cf\u{1f937}\u075b\u085c',
+code: `@group(4) @binding(5070)
+var<storage, read_write> global11: array<u32>;
+@group(2) @binding(5070)
+var<storage, read_write> i18: array<u32>;
+@group(5) @binding(5070)
+var<storage, read_write> function20: array<u32>;
+@group(0) @binding(5070)
+var<storage, read_write> i19: array<u32>;
+@group(3) @binding(5070)
+var<storage, read_write> type21: array<u32>;
+
+@compute @workgroup_size(4, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec3<f32>,
+  @builtin(sample_mask) f1: u32,
+  @location(3) f2: vec4<f32>,
+  @location(4) f3: vec4<u32>,
+  @location(0) f4: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(10) a1: u32, @builtin(instance_index) a2: u32, @location(13) a3: vec4<i32>, @location(8) a4: vec4<f32>, @location(0) a5: vec2<f16>, @location(19) a6: vec2<f16>, @location(7) a7: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+});
+let pipelineLayout31 = device6.createPipelineLayout({
+  label: '\u029a\u{1ff56}\u126f\u5c43\u8b1c\ubd55',
+  bindGroupLayouts: [bindGroupLayout63, bindGroupLayout63, bindGroupLayout64]
+});
+let querySet117 = device6.createQuerySet({
+label: '\u0d87\udcc8\u0178\u{1fe2a}\ub511\u08a1',
+type: 'occlusion',
+count: 2173,
+});
+try {
+buffer47.unmap();
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture124,
+  mipLevel: 0,
+  origin: { x: 136, y: 8, z: 20 },
+  aspect: 'all',
+}, new ArrayBuffer(4183370), /* required buffer size: 4183370 */
+{offset: 766, bytesPerRow: 1261, rowsPerImage: 195}, {width: 564, height: 8, depthOrArrayLayers: 18});
+} catch {}
+let pipeline157 = await device6.createComputePipelineAsync({
+label: '\u0cfa\u{1f81a}\u0c3f',
+layout: pipelineLayout28,
+compute: {
+module: shaderModule48,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let offscreenCanvas36 = new OffscreenCanvas(659, 343);
+let bindGroupLayout66 = device11.createBindGroupLayout({
+label: '\u8588\u9720\u{1f900}\u{1fee4}\u0a17\u{1fcfc}\u{1fd17}\u66b2\u{1fe90}\u{1fc1e}',
+entries: [{
+binding: 8165,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+}, {
+binding: 3085,
+visibility: 0,
+sampler: { type: 'non-filtering' },
+}, {
+binding: 899,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+}],
+});
+let renderBundleEncoder113 = device11.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb', 'r8uint', 'rgba16float'], sampleCount: 4, stencilReadOnly: true});
+let promise78 = device11.popErrorScope();
+let commandEncoder109 = device11.createCommandEncoder({label: '\uecaa\u0f36\u6dff\ua5da\u{1f6b3}\u0288\ud063\u{1f897}'});
+let texture142 = device11.createTexture({
+label: '\u9986\u075f\ud6da\u{1f9d3}',
+size: [2880, 1, 1],
+mipLevelCount: 7,
+format: 'rg32float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder94 = commandEncoder109.beginComputePass({label: '\u{1fe82}\u1de7\u049d\u{1ffb3}\u{1f776}\u0770\u0c80\u02b1\u08fc\uf567\u{1fb08}'});
+let renderBundle120 = renderBundleEncoder113.finish({label: '\u{1fabb}\uf04f\u{1fb5e}\u0de2\u0f41\u3902\u{1feb5}'});
+try {
+texture142.destroy();
+} catch {}
+try {
+gpuCanvasContext5.configure({
+device: device11,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+});
+} catch {}
+let commandEncoder110 = device3.createCommandEncoder();
+try {
+computePassEncoder93.setBindGroup(3, bindGroup39, new Uint32Array(9292), 5225, 0);
+} catch {}
+let pipeline158 = await device3.createRenderPipelineAsync({
+layout: pipelineLayout20,
+fragment: {module: shaderModule32, entryPoint: 'fragment0', targets: []},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilWriteMask: 1054,
+depthBias: 79,
+depthBiasSlopeScale: 13,
+},
+vertex: {
+  module: shaderModule32,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1500,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x2',
+offset: 1164,
+shaderLocation: 15,
+}, {
+format: 'snorm8x4',
+offset: 1040,
+shaderLocation: 3,
+}, {
+format: 'snorm16x2',
+offset: 1308,
+shaderLocation: 4,
+}, {
+format: 'sint16x4',
+offset: 544,
+shaderLocation: 5,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+offscreenCanvas20.height = 568;
+let bindGroupLayout67 = device7.createBindGroupLayout({
+label: '\u08ed\u0243\uce66\u05f8',
+entries: [{
+binding: 3612,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+}, {
+binding: 3352,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+}, {
+binding: 2255,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+}],
+});
+let sampler103 = device7.createSampler({
+label: '\u5f1e\u50e9',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+lodMinClamp: 69.247,
+lodMaxClamp: 97.544,
+});
+try {
+renderBundleEncoder111.setBindGroup(0, bindGroup48);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+device: device7,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm-srgb'],
+alphaMode: 'opaque',
+});
+} catch {}
+let pipeline159 = await promise76;
+let sampler104 = device10.createSampler({
+label: '\u7917\u490d\uaa55\u38a2\u4b73\u07e7\u6b4e\u3703\u1f31\ua470\u09db',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMaxClamp: 51.324,
+});
+let querySet118 = device10.createQuerySet({
+label: '\u06e1\ub296\ud456\ub115',
+type: 'occlusion',
+count: 2925,
+});
+let texture143 = device10.createTexture({
+label: '\u3fe6\u{1f6bb}\u{1fe13}\ucd27\u8b03\u65ed\ub131\u33af',
+size: {width: 12, height: 120, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let videoFrame39 = new VideoFrame(canvas21, {timestamp: 0});
+let shaderModule49 = device6.createShaderModule({
+label: '\ud1c8\u1838\u8644\u{1f963}\udf6e\u01ee\u{1fcf0}\u7c1d\u0777\u0c5f\u0127',
+code: `@group(4) @binding(5070)
+var<storage, read_write> global12: array<u32>;
+@group(0) @binding(5070)
+var<storage, read_write> local14: array<u32>;
+@group(3) @binding(5070)
+var<storage, read_write> global13: array<u32>;
+@group(5) @binding(5070)
+var<storage, read_write> local15: array<u32>;
+
+@compute @workgroup_size(6, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec4<u32>,
+  @location(3) f1: vec4<f32>,
+  @builtin(sample_mask) f2: u32,
+  @location(0) f3: vec3<f32>,
+  @location(1) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S34 {
+  @location(19) f0: vec4<i32>,
+  @location(21) f1: vec2<u32>,
+  @location(0) f2: vec3<f16>,
+  @location(20) f3: vec2<i32>,
+  @location(7) f4: vec2<f16>,
+  @builtin(instance_index) f5: u32,
+  @location(5) f6: vec2<i32>,
+  @location(15) f7: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(13) a0: vec2<f32>, @location(14) a1: vec4<f32>, @location(17) a2: f32, @location(8) a3: vec4<f16>, @location(22) a4: vec2<u32>, @location(9) a5: vec3<u32>, @location(10) a6: i32, a7: S34, @location(4) a8: vec3<f16>, @builtin(vertex_index) a9: u32, @location(2) a10: vec4<u32>, @location(23) a11: vec2<i32>, @location(1) a12: vec4<i32>, @location(12) a13: vec3<u32>, @location(18) a14: vec2<f32>, @location(16) a15: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let querySet119 = device6.createQuerySet({
+label: '\uefd7\u0a46',
+type: 'occlusion',
+count: 3463,
+});
+let texture144 = device6.createTexture({
+label: '\u3a54\u1c6f\udf4f\u96de\ua4e8\u31d8\u8860\u8869',
+size: {width: 1, height: 1, depthOrArrayLayers: 624},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let textureView122 = texture124.createView({
+  label: '\u{1f613}\u{1f67d}\u806f\u{1fa8a}\u0e90\u{1f844}\u3aa2\u3cc4\u0c85',
+  dimension: '2d',
+  baseMipLevel: 4,
+  baseArrayLayer: 8
+});
+let sampler105 = device6.createSampler({
+label: '\u{1faa4}\u61fd\uec2f\u0a3a\u0e1f\u248c\uf2e5\u217f\u5d0b\u0baf',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 24.167,
+lodMaxClamp: 64.459,
+maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder110.setVertexBuffer(45, undefined, 3736379258, 70847252);
+} catch {}
+try {
+buffer47.destroy();
+} catch {}
+let promise79 = device6.createRenderPipelineAsync({
+label: '\u{1f7fb}\u0224\u{1f7ab}\u{1fb21}',
+layout: pipelineLayout28,
+fragment: {
+  module: shaderModule49,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg32float'}, {
+  format: 'rg11b10ufloat',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'dst'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'zero'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN
+}, undefined, {
+  format: 'rg11b10ufloat',
+  blend: {
+color: {operation: 'add', srcFactor: 'one', dstFactor: 'one-minus-dst-alpha'},
+alpha: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-src-alpha'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN
+}, {format: 'rgba8uint', writeMask: GPUColorWrite.GREEN}]
+},
+vertex: {
+  module: shaderModule49,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 3728,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x4',
+offset: 956,
+shaderLocation: 12,
+}, {
+format: 'uint32',
+offset: 3596,
+shaderLocation: 22,
+}, {
+format: 'snorm8x4',
+offset: 1784,
+shaderLocation: 18,
+}, {
+format: 'float16x2',
+offset: 2728,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 8636,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 6460,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 4360,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 188,
+shaderLocation: 7,
+}, {
+format: 'sint32x4',
+offset: 1848,
+shaderLocation: 19,
+}, {
+format: 'sint32',
+offset: 3300,
+shaderLocation: 23,
+}, {
+format: 'sint32',
+offset: 308,
+shaderLocation: 10,
+}, {
+format: 'sint32',
+offset: 3408,
+shaderLocation: 20,
+}, {
+format: 'float16x2',
+offset: 1624,
+shaderLocation: 16,
+}, {
+format: 'uint32',
+offset: 2376,
+shaderLocation: 9,
+}, {
+format: 'sint16x4',
+offset: 448,
+shaderLocation: 5,
+}, {
+format: 'float16x2',
+offset: 316,
+shaderLocation: 17,
+}, {
+format: 'float32',
+offset: 732,
+shaderLocation: 8,
+}, {
+format: 'unorm8x4',
+offset: 2292,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 7112,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 7396,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 624,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x4',
+offset: 24,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 1244,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x4',
+offset: 616,
+shaderLocation: 0,
+}, {
+format: 'uint8x4',
+offset: 696,
+shaderLocation: 21,
+}, {
+format: 'sint16x4',
+offset: 1120,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 5124,
+shaderLocation: 14,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let gpuCanvasContext32 = offscreenCanvas36.getContext('webgpu');
+try {
+  await promise78;
+} catch {}
+try {
+shaderModule49.label = '\u0e51\u039e\u08fe\ueafe\u{1fbf7}\u0b28\u078d\u6435\u0f07\ucbdd\u{1f97c}';
+} catch {}
+let commandEncoder111 = device6.createCommandEncoder({label: '\u5c28\u909b\u8412\ufd42\uae98\u641b\u7e87\u0ed7\u{1fcd3}'});
+let texture145 = device6.createTexture({
+size: {width: 15},
+sampleCount: 1,
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundle121 = renderBundleEncoder100.finish();
+let externalTexture6 = device6.importExternalTexture({
+label: '\u0e19\u{1fa85}\u0177\u{1fbe1}\u{1feb8}\ufecc\ub176',
+source: videoFrame13,
+colorSpace: 'display-p3',
+});
+try {
+commandEncoder111.copyTextureToTexture({
+  texture: texture124,
+  mipLevel: 2,
+  origin: { x: 116, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture124,
+  mipLevel: 3,
+  origin: { x: 52, y: 4, z: 0 },
+  aspect: 'all',
+}, {width: 60, height: 0, depthOrArrayLayers: 42});
+} catch {}
+let textureView123 = texture141.createView({label: '\uf5de\u5734', arrayLayerCount: 1});
+let renderBundleEncoder114 = device10.createRenderBundleEncoder({
+  label: '\u{1fd73}\ub839\ucd9b',
+  colorFormats: ['r8sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 1,
+  depthReadOnly: false,
+  stencilReadOnly: false
+});
+let sampler106 = device10.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 14.189,
+lodMaxClamp: 26.682,
+compare: 'equal',
+});
+let commandBuffer27 = commandEncoder108.finish({
+label: '\u29db\u{1facf}\u0817\u242c\ubbfc\ud59b',
+});
+let texture146 = device7.createTexture({
+label: '\u05e7\u0f88\u323b\u{1f793}\u{1f622}\u9535\ub1cc\u{1f706}',
+size: {width: 232, height: 224, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8unorm-srgb'],
+});
+let renderBundleEncoder115 = device7.createRenderBundleEncoder({
+  label: '\u50cd\u{1fda7}\ub761\u8f5f\u07b7\u567d\u8b3e\u0fab\u0beb\ua3db\u97c1',
+  colorFormats: ['rg16float'],
+  sampleCount: 1
+});
+let pipeline160 = device7.createComputePipeline({
+label: '\uc86c\u7dbf\u0b58\uc9a2',
+layout: pipelineLayout29,
+compute: {
+module: shaderModule47,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let canvas40 = document.createElement('canvas');
+try {
+sampler80.label = '\u5d3f\u12cd\ub776\u{1fa05}\u{1ffe2}\u{1f7d6}\u8ab2\udb77';
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer18.detached) { new Uint8Array(arrayBuffer18).fill(0x55) };
+} catch {}
+let texture147 = device6.createTexture({
+label: '\u{1fa1d}\u0531\uf18b\u00d3\u5393\u0809\u5724\u3929\ue052\u08c5',
+size: [3520],
+dimension: '1d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle122 = renderBundleEncoder100.finish();
+try {
+computePassEncoder91.pushDebugGroup('\uafc7');
+} catch {}
+document.body.prepend(img8);
+gc();
+let offscreenCanvas37 = new OffscreenCanvas(936, 797);
+let gpuCanvasContext33 = offscreenCanvas37.getContext('webgpu');
+let imageData32 = new ImageData(124, 136);
+let sampler107 = device11.createSampler({
+label: '\u8e97\u{1f694}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 23.175,
+});
+try {
+gpuCanvasContext2.configure({
+device: device11,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['astc-8x6-unorm', 'astc-10x10-unorm', 'rgb10a2uint'],
+colorSpace: 'srgb',
+});
+} catch {}
+gc();
+let canvas41 = document.createElement('canvas');
+let querySet120 = device2.createQuerySet({
+label: '\u0a0b\u0ef5\ucf40\u96ae\u{1fdea}\u{1fae7}\u10dd\ub99e\uf69d\u0a33',
+type: 'occlusion',
+count: 1804,
+});
+try {
+computePassEncoder75.setPipeline(pipeline153);
+} catch {}
+let arrayBuffer22 = buffer30.getMappedRange(1912, 3272);
+try {
+commandEncoder105.clearBuffer(buffer31, 17368, 11408);
+dissociateBuffer(device2, buffer31);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 48, height: 7, depthOrArrayLayers: 100}
+*/
+{
+  source: videoFrame24,
+  origin: { x: 8, y: 42 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: { x: 7, y: 1, z: 14 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 16, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let pipeline161 = device2.createComputePipeline({
+label: '\u7e04\uf6bb\u02a4\u3a18\u132b',
+layout: pipelineLayout26,
+compute: {
+module: shaderModule36,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline162 = device2.createRenderPipeline({
+layout: pipelineLayout19,
+fragment: {
+  module: shaderModule39,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, undefined, undefined, {format: 'rgba16float', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rgba8sint', writeMask: GPUColorWrite.BLUE}]
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'invert',
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'not-equal',
+depthFailOp: 'decrement-clamp',
+passOp: 'zero',
+},
+depthBias: 97,
+depthBiasSlopeScale: 30,
+depthBiasClamp: 76,
+},
+vertex: {
+  module: shaderModule39,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 296,
+attributes: [{
+format: 'sint16x4',
+offset: 60,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 1060,
+attributes: [{
+format: 'sint32',
+offset: 576,
+shaderLocation: 15,
+}, {
+format: 'uint16x4',
+offset: 660,
+shaderLocation: 8,
+}, {
+format: 'uint16x4',
+offset: 476,
+shaderLocation: 12,
+}, {
+format: 'sint16x2',
+offset: 904,
+shaderLocation: 11,
+}, {
+format: 'uint16x2',
+offset: 592,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x2',
+offset: 160,
+shaderLocation: 13,
+}, {
+format: 'sint16x2',
+offset: 108,
+shaderLocation: 9,
+}, {
+format: 'uint32x4',
+offset: 88,
+shaderLocation: 14,
+}, {
+format: 'snorm8x2',
+offset: 1566,
+shaderLocation: 6,
+}, {
+format: 'unorm8x4',
+offset: 124,
+shaderLocation: 4,
+}, {
+format: 'unorm8x4',
+offset: 248,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 240,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 56,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 20,
+shaderLocation: 2,
+}, {
+format: 'unorm16x2',
+offset: 44,
+shaderLocation: 7,
+}, {
+format: 'snorm16x2',
+offset: 8,
+shaderLocation: 0,
+}, {
+format: 'unorm10-10-10-2',
+offset: 20,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'back',
+},
+});
+let img38 = await imageWithData(290, 254, '#1201b2fc', '#957d5a01');
+let textureView124 = texture138.createView({label: '\u2139\uc220\u8a96'});
+let renderBundle123 = renderBundleEncoder115.finish({label: '\u785f\uf7a1\u{1f8ea}\ub482'});
+try {
+await device7.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas32);
+let texture148 = device7.createTexture({
+label: '\u2afc\u384e',
+size: {width: 845, height: 1, depthOrArrayLayers: 420},
+mipLevelCount: 4,
+sampleCount: 1,
+dimension: '3d',
+format: 'r32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['r32float', 'r32float', 'r32float'],
+});
+try {
+gpuCanvasContext3.configure({
+device: device7,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device7.queue.submit([
+commandBuffer27,
+]);
+} catch {}
+try {
+device7.queue.copyExternalImageToTexture(/*
+{width: 845, height: 1, depthOrArrayLayers: 420}
+*/
+{
+  source: imageData29,
+  origin: { x: 9, y: 25 },
+  flipY: true,
+}, {
+  texture: texture148,
+  mipLevel: 0,
+  origin: { x: 192, y: 1, z: 249 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video4.height = 55;
+try {
+canvas40.getContext('webgl2');
+} catch {}
+let adapter17 = await promise13;
+let device12 = await adapter17.requestDevice({
+label: '\u426f\uc550\ucd69\u{1fbe9}\uae5a\u9ef4\u{1fc58}\ub9c9',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 52,
+maxVertexAttributes: 25,
+maxVertexBufferArrayStride: 65141,
+maxStorageTexturesPerShaderStage: 7,
+maxStorageBuffersPerShaderStage: 9,
+maxDynamicStorageBuffersPerPipelineLayout: 34483,
+maxBindingsPerBindGroup: 9649,
+maxTextureDimension1D: 13699,
+maxTextureDimension2D: 13434,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 196350669,
+maxUniformBuffersPerShaderStage: 20,
+maxInterStageShaderVariables: 38,
+maxInterStageShaderComponents: 90,
+maxSamplersPerShaderStage: 22,
+},
+});
+let buffer52 = device9.createBuffer({
+  label: '\u{1f7d3}\u0e01\u{1f86c}\u0251\u69cb\u2e0f',
+  size: 63474,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE
+});
+let commandEncoder112 = device9.createCommandEncoder({});
+let texture149 = device9.createTexture({
+label: '\u2ab1\u7330\ufca1',
+size: [72, 40, 1],
+mipLevelCount: 4,
+format: 'astc-6x5-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-6x5-unorm-srgb', 'astc-6x5-unorm-srgb'],
+});
+let textureView125 = texture139.createView({
+  label: '\ub9b2\ue6f2\u{1f81e}\u0d17\ua623\u0ea6\uc4d0',
+  dimension: '2d-array',
+  format: 'astc-8x6-unorm',
+  baseMipLevel: 6,
+  baseArrayLayer: 0
+});
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+let img39 = await imageWithData(256, 44, '#780f32be', '#e45e4679');
+let imageData33 = new ImageData(236, 32);
+let computePassEncoder95 = commandEncoder101.beginComputePass({label: '\u{1ff83}\udec0\u4569\u{1fce4}\ucf6e\uc820\u3104\u05e4'});
+let renderBundle124 = renderBundleEncoder75.finish({label: '\u3183\u{1f7b5}\u{1ff13}\u3b02\u032d\u61be\u92d9\u8b26\ua994'});
+try {
+computePassEncoder63.setPipeline(pipeline120);
+} catch {}
+try {
+renderBundleEncoder97.setPipeline(pipeline146);
+} catch {}
+try {
+renderBundleEncoder81.setVertexBuffer(2, buffer26, 3816, 4370);
+} catch {}
+try {
+commandEncoder105.copyBufferToBuffer(buffer26, 8728, buffer30, 8704, 860);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+device2.queue.submit([
+commandBuffer22,
+]);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 24, height: 3, depthOrArrayLayers: 50}
+*/
+{
+  source: canvas5,
+  origin: { x: 530, y: 156 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 6 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 13, height: 3, depthOrArrayLayers: 1});
+} catch {}
+let pipeline163 = device2.createComputePipeline({
+label: '\u0847\u00dd\u{1f7c3}\u00c8\ufbc6\u6380\u02a4',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule46,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline164 = device2.createRenderPipeline({
+layout: 'auto',
+fragment: {module: shaderModule41, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'replace',
+depthFailOp: 'decrement-clamp',
+passOp: 'replace',
+},
+depthBias: 93,
+depthBiasSlopeScale: 19,
+depthBiasClamp: 35,
+},
+vertex: {
+  module: shaderModule41,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1060,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1696,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 648,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+},
+});
+let commandEncoder113 = device8.createCommandEncoder();
+let querySet121 = device8.createQuerySet({
+label: '\u4304\u{1f941}\u0fd3',
+type: 'occlusion',
+count: 3872,
+});
+let texture150 = device8.createTexture({
+label: '\u488b\u{1fbfc}\u2ced',
+size: [928, 1, 175],
+mipLevelCount: 10,
+dimension: '3d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [],
+});
+let computePassEncoder96 = commandEncoder113.beginComputePass({label: '\u6bac\u{1f7a5}'});
+let renderBundleEncoder116 = device8.createRenderBundleEncoder({
+  label: '\u1b99\u2015\u035d\u{1fc2c}\ue97b\uce9b\ua529\u0a36\u816b\u{1f630}',
+  colorFormats: ['rgba8uint', 'rg8uint', 'rgb10a2uint'],
+  sampleCount: 4,
+  depthReadOnly: false
+});
+let shaderModule50 = device6.createShaderModule({
+label: '\u044d\u853d\u{1f90f}\u{1fab5}\u9b34',
+code: `@group(2) @binding(5070)
+var<storage, read_write> i20: array<u32>;
+@group(1) @binding(5070)
+var<storage, read_write> type22: array<u32>;
+@group(3) @binding(5070)
+var<storage, read_write> global14: array<u32>;
+@group(4) @binding(5070)
+var<storage, read_write> field16: array<u32>;
+@group(5) @binding(5070)
+var<storage, read_write> field17: array<u32>;
+
+@compute @workgroup_size(7, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(3) f1: vec4<f32>,
+  @location(1) f2: vec4<f32>,
+  @location(4) f3: vec4<u32>,
+  @location(0) f4: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(11) a0: vec4<f32>, @location(1) a1: vec2<i32>, @location(8) a2: i32, @location(14) a3: vec3<f16>, @location(13) a4: u32, @location(15) a5: vec3<i32>, @location(3) a6: vec3<u32>, @location(0) a7: vec3<u32>, @location(4) a8: vec4<u32>, @location(2) a9: vec2<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S35 {
+  @location(7) f0: vec2<u32>,
+  @location(21) f1: u32,
+  @location(18) f2: f32,
+  @builtin(vertex_index) f3: u32,
+  @location(13) f4: f32
+}
+struct VertexOutput0 {
+  @location(8) f208: i32,
+  @location(4) f209: vec4<u32>,
+  @location(15) f210: vec3<i32>,
+  @location(11) f211: vec4<f32>,
+  @location(14) f212: vec3<f16>,
+  @location(2) f213: vec2<i32>,
+  @location(3) f214: vec3<u32>,
+  @builtin(position) f215: vec4<f32>,
+  @location(1) f216: vec2<i32>,
+  @location(13) f217: u32,
+  @location(0) f218: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec4<u32>, @location(10) a1: vec3<i32>, a2: S35, @location(1) a3: vec3<u32>, @location(4) a4: vec4<i32>, @location(9) a5: vec4<f16>, @location(15) a6: i32, @location(20) a7: vec3<i32>, @location(23) a8: vec4<u32>, @location(12) a9: vec3<u32>, @location(0) a10: f16, @location(14) a11: f32, @location(3) a12: vec2<f32>, @location(5) a13: vec4<f32>, @location(11) a14: vec3<u32>, @builtin(instance_index) a15: u32, @location(22) a16: vec4<u32>, @location(19) a17: u32, @location(2) a18: vec4<u32>, @location(8) a19: vec4<f16>, @location(16) a20: vec3<f16>, @location(17) a21: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let querySet122 = device6.createQuerySet({
+type: 'occlusion',
+count: 2084,
+});
+let texture151 = device6.createTexture({
+label: '\u2843\u0f0c\u07c0\u43ac',
+size: {width: 192, height: 132, depthOrArrayLayers: 114},
+mipLevelCount: 3,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-8x6-unorm', 'astc-8x6-unorm-srgb', 'astc-8x6-unorm'],
+});
+let textureView126 = texture151.createView({dimension: '2d', baseMipLevel: 1, baseArrayLayer: 15});
+let sampler108 = device6.createSampler({
+label: '\u6a39\ud29d\u0006\uabcb\u0bec\u117b\u{1fbcd}\u{1f632}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 87.272,
+compare: 'greater-equal',
+maxAnisotropy: 8,
+});
+try {
+device8.queue.label = '\u25d9\u0ad6\u{1fccb}\u883d\u{1fc6b}\ub923\u5a52\u46f6';
+} catch {}
+let querySet123 = device8.createQuerySet({
+label: '\u{1f694}\ud626\u0c5a\u060c\u59c7\u0193',
+type: 'occlusion',
+count: 2741,
+});
+let textureView127 = texture135.createView({dimension: '2d', format: 'astc-5x5-unorm-srgb', baseMipLevel: 2, baseArrayLayer: 73});
+try {
+renderBundleEncoder116.setVertexBuffer(29, undefined, 4049748586, 216284967);
+} catch {}
+let bindGroupLayout68 = device10.createBindGroupLayout({
+entries: [{
+binding: 7885,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '2d-array', sampleType: 'depth', multisampled: false },
+}, {
+binding: 3777,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '2d-array' },
+}],
+});
+let querySet124 = device10.createQuerySet({
+type: 'occlusion',
+count: 2673,
+});
+let textureView128 = texture143.createView({label: '\u{1fadb}\u5d56\ua919\ud463\u02a6\uadd6\u{1fd36}\u0a62\u0e47', baseMipLevel: 1});
+let renderBundle125 = renderBundleEncoder114.finish({label: '\uc780\u0da3\u7084\u1350\u0710\ub6f7\u0b48'});
+try {
+gpuCanvasContext30.configure({
+device: device10,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder114 = device8.createCommandEncoder({label: '\u116d\u047b\u995f\u5fbd\u6d0c\ua699\u02e1\ue5a0'});
+pseudoSubmit(device8, commandEncoder104);
+let texture152 = gpuCanvasContext9.getCurrentTexture();
+let textureView129 = texture135.createView({
+  label: '\uc221\ud86f',
+  dimension: '2d',
+  format: 'astc-5x5-unorm',
+  baseMipLevel: 2,
+  mipLevelCount: 7,
+  baseArrayLayer: 8
+});
+try {
+renderBundleEncoder105.setBindGroup(3, bindGroup32, []);
+} catch {}
+try {
+renderBundleEncoder97.draw(0, 0, 48, 8);
+} catch {}
+try {
+renderBundleEncoder97.drawIndexedIndirect(buffer36, 12516);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer34, 12776, new DataView(new ArrayBuffer(24392)), 20552, 1436);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 24, height: 3, depthOrArrayLayers: 50}
+*/
+{
+  source: video16,
+  origin: { x: 7, y: 13 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 39 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 9, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+await adapter9.requestAdapterInfo();
+} catch {}
+let videoFrame40 = new VideoFrame(video29, {timestamp: 0});
+let commandEncoder115 = device12.createCommandEncoder({label: '\u69ea\u4a65\u0bcd\u0585\u4069\uad3e\u08c8\ue2de\ub603'});
+let texture153 = device12.createTexture({
+label: '\u0251\ua51d\uebc3\u1921\u{1fcd7}\u4761\ua544\u9f64\u0084\u5c7c',
+size: [160, 1, 149],
+mipLevelCount: 2,
+format: 'stencil8',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['stencil8'],
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend(canvas21);
+let img40 = await imageWithData(71, 116, '#482b95fc', '#d1ef858d');
+let bindGroupLayout69 = device10.createBindGroupLayout({
+label: '\u030b\ubd49\u1ec2\u0d90\u{1ff0b}\uf1cc\u6a92',
+entries: [],
+});
+let buffer53 = device10.createBuffer({
+  label: '\uecf9\uf589\u04c9\ub9a9\u5519\u0d1e\u01db\u013f\u2066\u01cb',
+  size: 57026,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM
+});
+let textureView130 = texture74.createView({label: '\u1e96\u5565\u4e7c\u1e94\u6367\u{1fda8}\ube03\u{1f853}\u0a2e', aspect: 'all', mipLevelCount: 6});
+try {
+computePassEncoder89.setBindGroup(3, bindGroup36, new Uint32Array(9438), 2860, 0);
+} catch {}
+try {
+renderBundleEncoder81.setVertexBuffer(1, buffer26, 1516);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture131,
+  mipLevel: 3,
+  origin: { x: 94, y: 0, z: 79 },
+  aspect: 'all',
+}, new Int8Array(arrayBuffer1), /* required buffer size: 862251 */
+{offset: 351, bytesPerRow: 325, rowsPerImage: 221}, {width: 17, height: 0, depthOrArrayLayers: 13});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 48, height: 7, depthOrArrayLayers: 100}
+*/
+{
+  source: imageBitmap22,
+  origin: { x: 677, y: 106 },
+  flipY: true,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: { x: 2, y: 0, z: 34 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 37, height: 5, depthOrArrayLayers: 1});
+} catch {}
+let pipeline165 = device2.createRenderPipeline({
+label: '\u{1fe18}\u{1f9d7}\u{1fa61}\u532f\u1232\uc2de\ua36d\ude10',
+layout: pipelineLayout19,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule34,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED
+}, undefined, undefined, {
+  format: 'rgba16float',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+}
+}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {format: 'rgba8sint'}]
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+},
+stencilReadMask: 2174,
+stencilWriteMask: 3361,
+depthBias: 9,
+depthBiasSlopeScale: 2,
+depthBiasClamp: 4,
+},
+vertex: {
+  module: shaderModule34,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1468,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x3',
+offset: 652,
+shaderLocation: 14,
+}, {
+format: 'sint8x2',
+offset: 776,
+shaderLocation: 10,
+}, {
+format: 'float32x3',
+offset: 1216,
+shaderLocation: 1,
+}, {
+format: 'float32x2',
+offset: 920,
+shaderLocation: 12,
+}, {
+format: 'unorm16x2',
+offset: 364,
+shaderLocation: 9,
+}, {
+format: 'snorm16x4',
+offset: 440,
+shaderLocation: 3,
+}, {
+format: 'float32x4',
+offset: 676,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 48,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 24,
+shaderLocation: 5,
+}, {
+format: 'unorm8x2',
+offset: 34,
+shaderLocation: 2,
+}, {
+format: 'snorm8x2',
+offset: 38,
+shaderLocation: 7,
+}],
+}
+]
+},
+});
+let offscreenCanvas38 = new OffscreenCanvas(654, 599);
+let buffer54 = device12.createBuffer({
+  label: '\u{1f72f}\ua037\u0a58\u063e\uf30b\u{1fa69}\u0fd4\ua97f\u{1ff94}\u{1ffab}\u6429',
+  size: 64184,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true
+});
+let texture154 = device12.createTexture({
+label: '\uc80d\udd39\u07d1\ub9e9\u036a\ueff7',
+size: [80, 1, 145],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let arrayBuffer23 = buffer54.getMappedRange(57968, 5068);
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+canvas40.width = 552;
+let img41 = await imageWithData(244, 177, '#5e4e0ee7', '#d9004c96');
+let video37 = await videoWithData();
+let imageBitmap38 = await createImageBitmap(videoFrame27);
+try {
+adapter4.label = '\u1170\uf425\u{1fa26}\u0b10\u1a5a\u190f\uc5e1\u{1fd98}\uc3cd\u5b3c';
+} catch {}
+let promise80 = navigator.gpu.requestAdapter();
+let shaderModule51 = device7.createShaderModule({
+label: '\u650b\u{1f931}\u3280\udd3a\u5abe\u0830\u{1f939}',
+code: `@group(5) @binding(993)
+var<storage, read_write> parameter32: array<u32>;
+@group(4) @binding(993)
+var<storage, read_write> parameter33: array<u32>;
+@group(0) @binding(2644)
+var<storage, read_write> local16: array<u32>;
+@group(0) @binding(993)
+var<storage, read_write> field18: array<u32>;
+@group(6) @binding(993)
+var<storage, read_write> global15: array<u32>;
+@group(6) @binding(2644)
+var<storage, read_write> type23: array<u32>;
+@group(5) @binding(2644)
+var<storage, read_write> function21: array<u32>;
+@group(3) @binding(2644)
+var<storage, read_write> i21: array<u32>;
+@group(1) @binding(2644)
+var<storage, read_write> local17: array<u32>;
+@group(3) @binding(993)
+var<storage, read_write> global16: array<u32>;
+
+@compute @workgroup_size(4, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S36 {
+  @location(1) f0: f32,
+  @builtin(vertex_index) f1: u32,
+  @location(24) f2: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec2<f16>, @location(8) a1: vec4<u32>, @location(0) a2: vec4<u32>, @location(17) a3: vec3<i32>, a4: S36, @location(23) a5: vec2<f16>, @location(2) a6: vec2<f16>, @location(4) a7: vec3<f32>, @location(11) a8: f16, @location(14) a9: vec4<i32>, @builtin(instance_index) a10: u32, @location(18) a11: vec4<u32>, @location(16) a12: vec4<i32>, @location(7) a13: vec2<f16>, @location(5) a14: vec2<i32>, @location(10) a15: vec4<f32>, @location(19) a16: vec3<f16>, @location(6) a17: vec2<u32>, @location(3) a18: vec4<f16>, @location(9) a19: f32, @location(22) a20: vec3<u32>, @location(20) a21: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let bindGroupLayout70 = device7.createBindGroupLayout({
+label: '\ub052\u03ae\u292b\u8ace\u{1f8b7}\uf296\u30a2\u{1ff00}\uc0d6\u2292\u{1fb4c}',
+entries: [{
+binding: 916,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+}, {
+binding: 1848,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}],
+});
+let commandEncoder116 = device7.createCommandEncoder({label: '\u83d0\u5826\ue7ff\u1c4f\ud939\u33a1\ub889\u06d9\u2266\u{1f8dc}\u{1fcbb}'});
+let renderBundle126 = renderBundleEncoder108.finish({label: '\ua0d2\u{1fff9}\u{1f85c}'});
+try {
+renderBundleEncoder111.setBindGroup(9, bindGroup50);
+} catch {}
+try {
+renderBundleEncoder111.setVertexBuffer(54, undefined, 1781810133, 883098312);
+} catch {}
+try {
+device7.queue.copyExternalImageToTexture(/*
+{width: 422, height: 1, depthOrArrayLayers: 210}
+*/
+{
+  source: imageBitmap33,
+  origin: { x: 267, y: 57 },
+  flipY: false,
+}, {
+  texture: texture148,
+  mipLevel: 1,
+  origin: { x: 357, y: 0, z: 115 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext34 = offscreenCanvas38.getContext('webgpu');
+let imageBitmap39 = await createImageBitmap(canvas20);
+let gpuCanvasContext35 = canvas41.getContext('webgpu');
+let offscreenCanvas39 = new OffscreenCanvas(724, 816);
+try {
+buffer48.destroy();
+} catch {}
+try {
+commandEncoder114.copyTextureToTexture({
+  texture: texture152,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture152,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout32 = device10.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout69, bindGroupLayout68, bindGroupLayout68, bindGroupLayout69, bindGroupLayout68, bindGroupLayout69, bindGroupLayout69, bindGroupLayout69, bindGroupLayout69, bindGroupLayout69]
+});
+try {
+gpuCanvasContext23.unconfigure();
+} catch {}
+let texture155 = gpuCanvasContext4.getCurrentTexture();
+let textureView131 = texture147.createView({label: '\u0008\u55c9\u{1f9ed}', dimension: '1d'});
+let video38 = await videoWithData();
+let commandEncoder117 = device2.createCommandEncoder({label: '\u9e25\u0cc5'});
+let renderBundle127 = renderBundleEncoder72.finish({label: '\u0ad7\u844a'});
+try {
+computePassEncoder58.setPipeline(pipeline151);
+} catch {}
+try {
+renderBundleEncoder102.setBindGroup(1, bindGroup32, new Uint32Array(5975), 4784, 0);
+} catch {}
+try {
+renderBundleEncoder97.drawIndirect(buffer36, 13320);
+} catch {}
+try {
+renderBundleEncoder97.setPipeline(pipeline139);
+} catch {}
+try {
+renderBundleEncoder102.setVertexBuffer(1, buffer26, 6684, 1167);
+} catch {}
+try {
+commandEncoder66.copyBufferToBuffer(buffer26, 3384, buffer31, 25760, 1748);
+dissociateBuffer(device2, buffer26);
+dissociateBuffer(device2, buffer31);
+} catch {}
+canvas41.width = 43;
+let commandEncoder118 = device10.createCommandEncoder({label: '\ub837\u031f\u0a68\u5cc5\u0dab\u0592\udcd1\u0ad4\u2af4'});
+let textureView132 = texture136.createView({format: 'astc-8x8-unorm', baseMipLevel: 7, baseArrayLayer: 4, arrayLayerCount: 16});
+let computePassEncoder97 = commandEncoder114.beginComputePass({label: '\u18ff\u8947\u{1fbb5}\udb91\u14cd\u62da\u89b2\u0303'});
+let renderBundle128 = renderBundleEncoder112.finish({});
+let sampler109 = device8.createSampler({
+label: '\u75f6\u1d82\ufa88\u055e\u00bf\u{1f982}\u0fec\u{1fffe}\u4ea2\u0b42\u964c',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 91.221,
+lodMaxClamp: 98.671,
+});
+try {
+device8.queue.writeTexture({
+  texture: texture152,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer22), /* required buffer size: 731 */
+{offset: 723}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(canvas21);
+let bindGroupLayout71 = device12.createBindGroupLayout({
+label: '\u0048\u1b7c\u006f',
+entries: [{
+binding: 2237,
+visibility: 0,
+sampler: { type: 'filtering' },
+}],
+});
+let commandEncoder119 = device12.createCommandEncoder({label: '\ue5eb\u{1f83f}\u{1f8fb}\u000a'});
+try {
+buffer54.destroy();
+} catch {}
+try {
+gpuCanvasContext13.configure({
+device: device12,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb', 'rg11b10ufloat', 'rg32uint', 'bgra8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device12.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 4}
+*/
+{
+  source: imageBitmap33,
+  origin: { x: 93, y: 170 },
+  flipY: false,
+}, {
+  texture: texture154,
+  mipLevel: 5,
+  origin: { x: 0, y: 1, z: 3 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+offscreenCanvas39.getContext('webgl2');
+} catch {}
+try {
+window.someLabel = device10.label;
+} catch {}
+let bindGroup51 = device10.createBindGroup({
+label: '\uedbb\u08ba\u{1f7d4}\u0b84\u1ca2\u{1fa49}\u{1fb38}',
+layout: bindGroupLayout69,
+entries: [],
+});
+let commandEncoder120 = device8.createCommandEncoder({});
+let textureView133 = texture135.createView({
+  label: '\ubd73\ub2b0\u5d46\u0a2f\u{1fe00}\u44c8\u5715\u{1fe84}\u0cdb\u0066\u5d4a',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 112
+});
+let renderBundleEncoder117 = device8.createRenderBundleEncoder({label: '\u{1f791}\u0a26\u{1f868}', colorFormats: ['rg8sint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder96.insertDebugMarker('\u0269');
+} catch {}
+try {
+renderBundleEncoder117.insertDebugMarker('\u6eea');
+} catch {}
+try {
+device8.queue.writeTexture({
+  texture: texture150,
+  mipLevel: 6,
+  origin: { x: 3, y: 0, z: 0 },
+  aspect: 'all',
+}, new Int8Array(arrayBuffer2), /* required buffer size: 51768 */
+{offset: 254, bytesPerRow: 232, rowsPerImage: 222}, {width: 5, height: 1, depthOrArrayLayers: 2});
+} catch {}
+let canvas42 = document.createElement('canvas');
+try {
+canvas42.getContext('2d');
+} catch {}
+let buffer55 = device8.createBuffer({
+  label: '\u0753\u1fea\u7f70',
+  size: 11980,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true
+});
+let texture156 = gpuCanvasContext6.getCurrentTexture();
+let sampler110 = device8.createSampler({
+label: '\uf421\u004b\u2e19\u{1f7e8}\ua073',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 27.395,
+lodMaxClamp: 74.609,
+maxAnisotropy: 10,
+});
+try {
+commandEncoder120.copyBufferToTexture({
+/* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 2344 */
+offset: 2344,
+buffer: buffer51,
+}, {
+  texture: texture152,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device8, buffer51);
+} catch {}
+try {
+commandEncoder120.clearBuffer(buffer55, 5564);
+dissociateBuffer(device8, buffer55);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+device: device8,
+format: 'rgba16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device8.queue.writeTexture({
+  texture: texture133,
+  mipLevel: 2,
+  origin: { x: 150, y: 0, z: 38 },
+  aspect: 'all',
+}, new ArrayBuffer(5890459), /* required buffer size: 5890459 */
+{offset: 897, bytesPerRow: 254, rowsPerImage: 177}, {width: 40, height: 10, depthOrArrayLayers: 132});
+} catch {}
+let commandEncoder121 = device12.createCommandEncoder({label: '\u{1f869}\u02b4\u0daa\u{1f933}\u801a\u0f7a\u52a6\u{1f80f}'});
+try {
+commandEncoder121.copyTextureToTexture({
+  texture: texture154,
+  mipLevel: 2,
+  origin: { x: 1, y: 1, z: 18 },
+  aspect: 'all',
+}, {
+  texture: texture154,
+  mipLevel: 3,
+  origin: { x: 5, y: 1, z: 5 },
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 13});
+} catch {}
+try {
+commandEncoder119.clearBuffer(buffer54);
+dissociateBuffer(device12, buffer54);
+} catch {}
+try {
+adapter11.label = '\u{1fde2}\u{1f813}\u6c09';
+} catch {}
+let textureView134 = texture140.createView({dimension: '2d-array', baseMipLevel: 3});
+let renderBundleEncoder118 = device11.createRenderBundleEncoder({
+  label: '\u1c12\u6764',
+  colorFormats: ['rgba8unorm-srgb', 'r8uint', 'rgba16float'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler111 = device11.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 58.502,
+lodMaxClamp: 92.427,
+});
+try {
+device11.queue.writeTexture({
+  texture: texture140,
+  mipLevel: 0,
+  origin: { x: 122, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer17, /* required buffer size: 861 */
+{offset: 861}, {width: 518, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise81 = device11.queue.onSubmittedWorkDone();
+let video39 = await videoWithData();
+let imageBitmap40 = await createImageBitmap(imageData8);
+let buffer56 = device11.createBuffer({
+  label: '\u{1f787}\u8df3\u3118\u0c97\u03b0',
+  size: 46981,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let commandEncoder122 = device11.createCommandEncoder({label: '\ubde7\u7dce\u0c04\uc227\u41b1\u{1f751}\u0aca\u49ab\uc678\u9c48\u54fa'});
+let texture157 = device11.createTexture({
+size: {width: 192, height: 96, depthOrArrayLayers: 228},
+mipLevelCount: 6,
+sampleCount: 1,
+format: 'rg16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundle129 = renderBundleEncoder113.finish({label: '\ue7f7\u9d9a\u1763\ue028\u084f\u9d4b\u0aaf\u9711\ubc1f\u9ea8'});
+let sampler112 = device11.createSampler({
+label: '\uc501\u6225\udbe7\u01fc\u12df',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+lodMinClamp: 99.620,
+lodMaxClamp: 99.978,
+});
+let querySet125 = device8.createQuerySet({
+label: '\uae4c\u02b4\u{1fc73}\u09c5\u{1fd73}',
+type: 'occlusion',
+count: 2759,
+});
+let textureView135 = texture150.createView({label: '\u5759\ub0c8\u0786\u1eac\u{1f9d8}\ua5b1\u0f94', baseMipLevel: 7, mipLevelCount: 3});
+try {
+  await buffer51.mapAsync(GPUMapMode.WRITE, 0, 28140);
+} catch {}
+let bindGroup52 = device9.createBindGroup({
+layout: bindGroupLayout65,
+entries: [{
+binding: 342,
+resource: sampler98
+}, {
+binding: 573,
+resource: textureView125
+}],
+});
+let renderBundleEncoder119 = device9.createRenderBundleEncoder({
+  colorFormats: [undefined, undefined, undefined, undefined, 'r16uint', 'rg16sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle130 = renderBundleEncoder119.finish();
+try {
+commandEncoder112.copyBufferToBuffer(buffer50, 26300, buffer52, 12088, 7672);
+dissociateBuffer(device9, buffer50);
+dissociateBuffer(device9, buffer52);
+} catch {}
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule52 = device6.createShaderModule({
+label: '\u8aa4\u0dc1\u625c\u9845\u03dc\u3bf7\ua119\u083b\u2156\u6e27\u{1f7f0}',
+code: `@group(4) @binding(5070)
+var<storage, read_write> parameter34: array<u32>;
+@group(5) @binding(5070)
+var<storage, read_write> parameter35: array<u32>;
+@group(2) @binding(5070)
+var<storage, read_write> i22: array<u32>;
+@group(1) @binding(5070)
+var<storage, read_write> parameter36: array<u32>;
+@group(3) @binding(5070)
+var<storage, read_write> function22: array<u32>;
+
+@compute @workgroup_size(5, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<f32>,
+  @location(4) f1: vec4<u32>,
+  @location(0) f2: vec3<f32>,
+  @location(1) f3: vec3<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S37 {
+  @location(17) f0: u32
+}
+
+@vertex
+fn vertex0(@location(6) a0: i32, @location(16) a1: f32, @location(7) a2: vec4<u32>, @location(14) a3: vec3<f16>, @builtin(instance_index) a4: u32, @location(11) a5: f32, @location(9) a6: f32, @location(4) a7: f32, a8: S37, @location(2) a9: vec2<f16>, @location(21) a10: vec2<u32>, @location(0) a11: f32, @location(13) a12: vec4<f16>, @location(12) a13: vec4<f16>, @location(3) a14: vec3<i32>, @builtin(vertex_index) a15: u32, @location(20) a16: vec4<f16>, @location(18) a17: vec2<u32>, @location(10) a18: vec4<f32>, @location(8) a19: vec4<f16>, @location(1) a20: vec4<f16>, @location(23) a21: vec4<u32>, @location(19) a22: vec3<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let textureView136 = texture128.createView({label: '\u8e22\uf2ea\u0ce2\u{1ffa9}', aspect: 'all', baseMipLevel: 4});
+try {
+computePassEncoder91.setPipeline(pipeline157);
+} catch {}
+try {
+commandEncoder111.clearBuffer(buffer47, 53696, 3960);
+dissociateBuffer(device6, buffer47);
+} catch {}
+let adapter18 = await navigator.gpu.requestAdapter({
+powerPreference: 'high-performance',
+});
+let canvas43 = document.createElement('canvas');
+let img42 = await imageWithData(93, 298, '#17599f3c', '#755f3f26');
+let commandEncoder123 = device10.createCommandEncoder({});
+pseudoSubmit(device10, commandEncoder123);
+let renderBundleEncoder120 = device10.createRenderBundleEncoder({
+  label: '\u0903\u7253\udf25\u0628\udb38',
+  colorFormats: ['r8sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder120.setBindGroup(4, bindGroup51);
+} catch {}
+try {
+  await promise81;
+} catch {}
+let offscreenCanvas40 = new OffscreenCanvas(215, 182);
+let imageBitmap41 = await createImageBitmap(videoFrame20);
+try {
+offscreenCanvas40.getContext('bitmaprenderer');
+} catch {}
+let texture158 = device0.createTexture({
+label: '\ua268\u0534\u{1fca6}\u3b88\u{1fafe}\u05d1\u7e63\ue757\u2d35\u82f7',
+size: {width: 1752},
+sampleCount: 1,
+dimension: '1d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['r16sint'],
+});
+try {
+renderBundleEncoder42.setBindGroup(3, bindGroup31);
+} catch {}
+try {
+renderBundleEncoder60.setBindGroup(3, bindGroup24, new Uint32Array(8162), 929, 0);
+} catch {}
+try {
+renderBundleEncoder17.draw(8, 64, 24);
+} catch {}
+try {
+renderBundleEncoder68.drawIndexedIndirect(buffer22, 1652);
+} catch {}
+try {
+renderBundleEncoder36.drawIndirect(buffer12, 13168);
+} catch {}
+let arrayBuffer24 = buffer21.getMappedRange(20288, 14196);
+try {
+buffer19.destroy();
+} catch {}
+try {
+commandEncoder96.copyTextureToBuffer({
+  texture: texture48,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 32928 */
+offset: 32928,
+rowsPerImage: 18,
+buffer: buffer42,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer42);
+} catch {}
+try {
+commandEncoder96.copyTextureToTexture({
+  texture: texture93,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 349, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder45.insertDebugMarker('\ucd8e');
+} catch {}
+let promise82 = adapter13.requestAdapterInfo();
+let bindGroupLayout72 = device6.createBindGroupLayout({
+label: '\ub11a\u{1f80d}\u{1fb28}\u78b0',
+entries: [{
+binding: 3129,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}, {
+binding: 2007,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}],
+});
+let texture159 = device6.createTexture({
+label: '\u3aef\uc3c8\uf7ed\uf074\u3cc3\uf5ef\u6758\ufed9\ud7af',
+size: {width: 880, height: 16, depthOrArrayLayers: 43},
+mipLevelCount: 3,
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['etc2-rgb8a1unorm'],
+});
+try {
+computePassEncoder91.pushDebugGroup('\u9c61');
+} catch {}
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline166 = await device6.createComputePipelineAsync({
+label: '\u4b15\u0995\u0dc3\u04e2\u0f38\u07f4\u2cc6\uf01d\u0fee',
+layout: pipelineLayout31,
+compute: {
+module: shaderModule52,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let bindGroup53 = device3.createBindGroup({
+label: '\u{1fdd9}\u0898\u9a39\u1f36\uf5d7\u89b3\u6e45\u{1f963}',
+layout: bindGroupLayout45,
+entries: [],
+});
+let textureView137 = texture99.createView({
+  label: '\u{1f9b4}\u0f17\u543a\u973e\u0213\u1340\u71a9\u7ffd\ue06d\u3a83',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  mipLevelCount: 1,
+  arrayLayerCount: 3
+});
+try {
+computePassEncoder73.setBindGroup(2, bindGroup53);
+} catch {}
+try {
+commandEncoder110.copyBufferToTexture({
+/* bytesInLastRow: 192 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 12704 */
+offset: 12704,
+bytesPerRow: 256,
+buffer: buffer35,
+}, {
+  texture: texture134,
+  mipLevel: 2,
+  origin: { x: 24, y: 4, z: 1 },
+  aspect: 'all',
+}, {width: 48, height: 40, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder110.copyTextureToBuffer({
+  texture: texture102,
+  mipLevel: 4,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 11 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 11660 */
+offset: 11660,
+rowsPerImage: 239,
+buffer: buffer35,
+}, {width: 11, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder110.copyTextureToTexture({
+  texture: texture102,
+  mipLevel: 5,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture102,
+  mipLevel: 0,
+  origin: { x: 180, y: 1, z: 1 },
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline167 = await device3.createRenderPipelineAsync({
+label: '\u2ec1\uaf25\u9422\ucada\uce8e\u4838\u9c96\u{1f8e9}\ufc27',
+layout: 'auto',
+fragment: {module: shaderModule32, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'not-equal',
+depthFailOp: 'increment-clamp',
+},
+stencilBack: {
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'keep',
+},
+stencilReadMask: 2391,
+stencilWriteMask: 849,
+depthBias: 95,
+depthBiasClamp: 2,
+},
+vertex: {
+  module: shaderModule32,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 216,
+attributes: [{
+format: 'unorm16x4',
+offset: 164,
+shaderLocation: 3,
+}, {
+format: 'sint32x4',
+offset: 152,
+shaderLocation: 5,
+}, {
+format: 'uint8x4',
+offset: 196,
+shaderLocation: 15,
+}, {
+format: 'float16x2',
+offset: 8,
+shaderLocation: 4,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+},
+});
+try {
+gpuCanvasContext33.unconfigure();
+} catch {}
+offscreenCanvas1.width = 701;
+try {
+window.someLabel = texture147.label;
+} catch {}
+let shaderModule53 = device6.createShaderModule({
+label: '\u23bf\u0feb\u0fb2',
+code: `@group(1) @binding(5070)
+var<storage, read_write> parameter37: array<u32>;
+@group(2) @binding(2694)
+var<storage, read_write> local18: array<u32>;
+@group(0) @binding(5070)
+var<storage, read_write> function23: array<u32>;
+
+@compute @workgroup_size(6, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S39 {
+  @builtin(sample_index) f0: u32
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(7) f1: vec3<i32>,
+  @location(0) f2: vec4<f32>,
+  @location(4) f3: vec4<u32>,
+  @location(3) f4: vec3<f32>
+}
+
+@fragment
+fn fragment0(a0: S39, @builtin(sample_mask) a1: u32, @builtin(position) a2: vec4<f32>, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S38 {
+  @location(23) f0: vec4<f16>,
+  @location(15) f1: vec2<f16>,
+  @location(8) f2: vec2<u32>,
+  @location(5) f3: vec4<f16>,
+  @location(22) f4: vec3<f32>,
+  @location(9) f5: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec3<u32>, @location(2) a1: f16, a2: S38, @location(16) a3: vec3<u32>, @location(10) a4: f32, @location(0) a5: i32, @location(21) a6: vec3<f16>, @location(4) a7: f32, @location(11) a8: vec4<f16>, @location(18) a9: vec3<f32>, @location(6) a10: vec4<f16>, @location(1) a11: vec3<u32>, @location(3) a12: vec3<f32>, @location(7) a13: vec4<u32>, @location(12) a14: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+let querySet126 = device6.createQuerySet({
+label: '\u4c53\u{1febb}',
+type: 'occlusion',
+count: 1486,
+});
+let sampler113 = device6.createSampler({
+label: '\u{1f8d0}\u{1f962}\u9443\u07b2\u{1fc3b}\u205b\ud4c0\ubc00',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 92.682,
+lodMaxClamp: 94.555,
+});
+try {
+commandEncoder111.copyTextureToBuffer({
+  texture: texture128,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 92 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 31312 */
+offset: 31312,
+bytesPerRow: 0,
+rowsPerImage: 114,
+buffer: buffer47,
+}, {width: 0, height: 0, depthOrArrayLayers: 48});
+dissociateBuffer(device6, buffer47);
+} catch {}
+try {
+computePassEncoder91.popDebugGroup();
+} catch {}
+try {
+computePassEncoder88.insertDebugMarker('\u0df8');
+} catch {}
+try {
+  await promise82;
+} catch {}
+let bindGroupLayout73 = device11.createBindGroupLayout({
+label: '\u{1fb17}\u078c\u8ffa\u{1f6b4}\u2f67\u0215',
+entries: [{
+binding: 7288,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '2d-array' },
+}, {
+binding: 3008,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 763472, hasDynamicOffset: false },
+}, {
+binding: 3438,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+let pipelineLayout33 = device11.createPipelineLayout({bindGroupLayouts: [bindGroupLayout73]});
+let texture160 = device11.createTexture({
+label: '\uccb8\u0abc\u08f3\u2809\u{1ff3b}\ua1a0\uda57',
+size: {width: 864, height: 60, depthOrArrayLayers: 200},
+mipLevelCount: 2,
+format: 'etc2-rgb8a1unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8a1unorm-srgb', 'etc2-rgb8a1unorm-srgb', 'etc2-rgb8a1unorm-srgb'],
+});
+let computePassEncoder98 = commandEncoder122.beginComputePass();
+let renderBundle131 = renderBundleEncoder118.finish({});
+try {
+gpuCanvasContext4.configure({
+device: device11,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float', 'astc-4x4-unorm-srgb'],
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let canvas44 = document.createElement('canvas');
+let texture161 = device12.createTexture({
+label: '\udda3\u0703',
+size: {width: 72, height: 10, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'depth32float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+commandEncoder121.insertDebugMarker('\uc301');
+} catch {}
+let imageData34 = new ImageData(208, 252);
+let bindGroupLayout74 = device2.createBindGroupLayout({
+label: '\u{1f6d5}\u77aa\u{1f847}\u{1fe0d}\u5dd7\u0def',
+entries: [],
+});
+let texture162 = device2.createTexture({
+label: '\u{1fb8a}\u5dad\u{1fd34}\u4bb6\ub0c2\u{1f8c3}\uee6b\u{1f72c}\u{1fc17}\uaf8f',
+size: {width: 192, height: 30, depthOrArrayLayers: 120},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'r8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['r8unorm', 'r8unorm', 'r8unorm'],
+});
+let textureView138 = texture120.createView({label: '\u{1f6e0}\u0b51\u0866\u03e1\u08e8\u77b7\u786c\u{1fdcf}'});
+let computePassEncoder99 = commandEncoder74.beginComputePass({label: '\ua3c3\u0453\u3c59\u5532\u08b0'});
+try {
+computePassEncoder87.setPipeline(pipeline151);
+} catch {}
+try {
+renderBundleEncoder97.draw(40, 24);
+} catch {}
+let promise83 = buffer49.mapAsync(GPUMapMode.READ);
+try {
+renderBundleEncoder97.insertDebugMarker('\uec8e');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture117,
+  mipLevel: 0,
+  origin: { x: 49, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer17, /* required buffer size: 1269 */
+{offset: 601, rowsPerImage: 142}, {width: 334, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 12, height: 1, depthOrArrayLayers: 25}
+*/
+{
+  source: img41,
+  origin: { x: 213, y: 38 },
+  flipY: false,
+}, {
+  texture: texture79,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 12, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext36 = canvas44.getContext('webgpu');
+try {
+gpuCanvasContext22.unconfigure();
+} catch {}
+document.body.prepend(img5);
+try {
+device8.queue.writeTexture({
+  texture: texture152,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 374 */
+{offset: 374, bytesPerRow: 281}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise83;
+} catch {}
+let img43 = await imageWithData(245, 115, '#7e7870e1', '#3f446f07');
+let buffer57 = device2.createBuffer({
+  label: '\ub1a8\u0ca8\ue788\u08f1\u6a0d\u{1fe35}\ufe16',
+  size: 56095,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT
+});
+let renderBundle132 = renderBundleEncoder71.finish({label: '\u{1fea6}\u404f\u854f\u393e\u0760'});
+let sampler114 = device2.createSampler({
+label: '\u{1f9fd}\ubba4\u0bed\u498d\u{1f875}\u{1f80b}\u7a62\u{1fb21}\u6a23',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 68.076,
+maxAnisotropy: 3,
+});
+try {
+computePassEncoder78.setPipeline(pipeline144);
+} catch {}
+try {
+renderBundleEncoder97.draw(72, 8, 32, 56);
+} catch {}
+try {
+renderBundleEncoder97.drawIndexed(48, 64, 8, 112, 0);
+} catch {}
+try {
+renderBundleEncoder97.drawIndirect(buffer46, 20504);
+} catch {}
+let gpuCanvasContext37 = canvas43.getContext('webgpu');
+let imageBitmap42 = await createImageBitmap(imageBitmap36);
+try {
+await device8.popErrorScope();
+} catch {}
+try {
+commandEncoder120.clearBuffer(buffer55);
+dissociateBuffer(device8, buffer55);
+} catch {}
+try {
+renderBundleEncoder116.insertDebugMarker('\u63c1');
+} catch {}
+gc();
+let texture163 = device8.createTexture({
+label: '\u0f13\u0fb1\u{1fef4}\ua21b',
+size: {width: 15, height: 1, depthOrArrayLayers: 230},
+mipLevelCount: 3,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth16unorm', 'depth16unorm'],
+});
+let textureView139 = texture135.createView({format: 'astc-5x5-unorm-srgb', baseMipLevel: 6, baseArrayLayer: 55, arrayLayerCount: 26});
+let computePassEncoder100 = commandEncoder120.beginComputePass({label: '\u9d64\u{1fbe8}\u3aaa\u0e65\u9934\u01d0\uf451\u{1f892}\u0d8c\u7132\ue903'});
+let renderBundleEncoder121 = device8.createRenderBundleEncoder({label: '\u58b7\u0d82\ubfa9\u0b48\u13ae', colorFormats: ['rg8sint']});
+let sampler115 = device8.createSampler({
+label: '\u08c7\u{1ff6b}\uc639\u{1f96e}\ue6fa\u004a\u{1ff31}\u{1f6f6}\u44dc',
+addressModeU: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 86.014,
+lodMaxClamp: 98.238,
+compare: 'not-equal',
+});
+try {
+renderBundleEncoder117.pushDebugGroup('\ub2ca');
+} catch {}
+let canvas45 = document.createElement('canvas');
+let textureView140 = texture161.createView({dimension: '2d-array', aspect: 'depth-only'});
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame40.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/LayoutTests/fast/webgpu/fuzz-273566-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-273566-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-273566.html
+++ b/LayoutTests/fast/webgpu/fuzz-273566.html
@@ -1,0 +1,13634 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter({
+powerPreference: 'high-performance',
+});
+let device0 = await adapter0.requestDevice({
+label: '\u33b5\u0cd5\uc792\ua797\u0cdf\u0f67\u4367',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 52,
+maxVertexAttributes: 17,
+maxVertexBufferArrayStride: 6749,
+maxStorageTexturesPerShaderStage: 43,
+maxDynamicStorageBuffersPerPipelineLayout: 2874,
+maxBindingsPerBindGroup: 2626,
+maxTextureDimension1D: 16058,
+maxTextureDimension2D: 8306,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 166896281,
+maxUniformBuffersPerShaderStage: 28,
+maxInterStageShaderVariables: 108,
+maxInterStageShaderComponents: 94,
+maxSamplersPerShaderStage: 22,
+},
+});
+let texture0 = device0.createTexture({
+size: {width: 80, height: 32, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rg16sint'],
+});
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 53, y: 1, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 6 */
+{offset: 6, bytesPerRow: 198, rowsPerImage: 114}, {width: 26, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(488, 545);
+let textureView0 = texture0.createView({
+  label: '\u8a76\ue831\ub045\u0c3c\u{1fba2}\u1d5c\u{1ff2e}\uf483\u{1fde6}\ucc66',
+  dimension: '2d-array',
+  baseMipLevel: 3
+});
+let img0 = await imageWithData(8, 242, '#84fb0a72', '#b52759ff');
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\u{1ffef}\u9ff7\uc3f8\u{1fc16}\ua3d1',
+  colorFormats: ['rgba8sint', 'bgra8unorm', 'rg8uint', 'r16float', 'r16float'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let videoFrame0 = new VideoFrame(img0, {timestamp: 0});
+let texture1 = device0.createTexture({
+label: '\u8eec\u6585\u639e\u3b39\u4da6\u59b9\u{1ff43}\u{1fdcb}\u3d3c',
+size: {width: 3580},
+mipLevelCount: 1,
+dimension: '1d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['r8uint', 'r8uint'],
+});
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 2,
+  origin: { x: 8, y: 5, z: 0 },
+  aspect: 'all',
+}, new Float32Array(new ArrayBuffer(48)), /* required buffer size: 319 */
+{offset: 319}, {width: 7, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let texture2 = device0.createTexture({
+label: '\u8efe\u053a\u019f',
+size: [7848, 10, 137],
+mipLevelCount: 7,
+format: 'astc-12x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundle0 = renderBundleEncoder0.finish();
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 1,
+  origin: { x: 7, y: 6, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 404 */
+{offset: 404, bytesPerRow: 86}, {width: 11, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer0 = device0.createBuffer({label: '\u{1fe61}\u{1f911}\ud903\u0172\u{1f717}\u{1fd7d}', size: 43802, usage: GPUBufferUsage.MAP_READ});
+let querySet0 = device0.createQuerySet({
+label: '\u{1fb75}\ua28c\u{1f766}\ufcd4\u01c5\ud001',
+type: 'occlusion',
+count: 643,
+});
+let texture3 = device0.createTexture({
+label: '\u0a18\u{1fa5a}\u{1fc17}\u{1f989}\uf79f\u69ee\u0e7c\ua226\u0ddb',
+size: {width: 120, height: 10, depthOrArrayLayers: 145},
+mipLevelCount: 3,
+dimension: '2d',
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x10-unorm-srgb', 'astc-12x10-unorm', 'astc-12x10-unorm-srgb'],
+});
+let textureView1 = texture2.createView({dimension: '2d', baseMipLevel: 5, baseArrayLayer: 85});
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+let texture4 = device0.createTexture({
+size: [155, 155, 1],
+mipLevelCount: 5,
+dimension: '2d',
+format: 'astc-5x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-5x5-unorm'],
+});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8sint', 'bgra8unorm', 'rg8uint', 'r16float', 'r16float'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler0 = device0.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMaxClamp: 13.638,
+});
+let commandEncoder0 = device0.createCommandEncoder({label: '\ub247\u04ff\u1091\uf927\u322d\u80e1\u252f\u{1fd88}\u0839\u{1f9bc}'});
+try {
+renderBundleEncoder1.setVertexBuffer(29, undefined, 865908546, 3355725068);
+} catch {}
+try {
+buffer0.destroy();
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer1 = device0.createBuffer({label: '\ue5cd\u{1fcec}\u0d85\u4da7\u30c4\u{1facf}\u9281', size: 48112, usage: GPUBufferUsage.MAP_WRITE});
+let textureView2 = texture3.createView({
+  label: '\uc9d7\ua886\u7baa\ub7cc\u{1f799}\u83d6\u0bdd\u6a55\u6ba4',
+  baseMipLevel: 2,
+  baseArrayLayer: 142,
+  arrayLayerCount: 2
+});
+let textureView3 = texture2.createView({dimension: '2d', mipLevelCount: 5, baseArrayLayer: 26, arrayLayerCount: 1});
+try {
+commandEncoder0.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+adapter0.label = '\ud508\u2ba7\u08fd\u{1f6af}\u8405\u{1f7e3}\u0e43\u29c6\u4f10\u44cd';
+} catch {}
+let textureView4 = texture2.createView({label: '\ua6cd\u85d0', baseMipLevel: 2, mipLevelCount: 4, arrayLayerCount: 56});
+try {
+commandEncoder0.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 3,
+  origin: { x: 2, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 3,
+  origin: { x: 5, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 3, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba16float', 'rgba16float', 'rgba16uint'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let textureView5 = texture2.createView({dimension: '2d-array', baseMipLevel: 4, baseArrayLayer: 118, arrayLayerCount: 1});
+let renderBundle1 = renderBundleEncoder0.finish({});
+let sampler1 = device0.createSampler({
+label: '\u0cd3\u{1feae}\u{1f731}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 96.673,
+lodMaxClamp: 99.182,
+maxAnisotropy: 17,
+});
+try {
+commandEncoder0.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 51, y: 10, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 1,
+  origin: { x: 9, y: 3, z: 0 },
+  aspect: 'all',
+}, {width: 18, height: 8, depthOrArrayLayers: 1});
+} catch {}
+let canvas0 = document.createElement('canvas');
+let commandEncoder1 = device0.createCommandEncoder({label: '\u04d4\u7048\ud4a0\ub1db\u{1fd2c}\u0e24\u8fb4\u600a\u{1fc09}\u{1fdfb}'});
+let renderBundle2 = renderBundleEncoder0.finish({label: '\u0e56\u{1f854}\ub40f\ue92e\u4a53'});
+let externalTexture0 = device0.importExternalTexture({
+source: videoFrame0,
+colorSpace: 'display-p3',
+});
+try {
+  await buffer1.mapAsync(GPUMapMode.WRITE, 0, 43588);
+} catch {}
+let textureView6 = texture4.createView({dimension: '2d-array', baseMipLevel: 3, mipLevelCount: 1});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  label: '\u020d\u07f6\u4f0b\u2502\u3b77\u{1f7ad}\u7a9b\u0da0',
+  colorFormats: ['rgba8sint', 'bgra8unorm', 'rg8uint', 'r16float', 'r16float'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle3 = renderBundleEncoder0.finish({label: '\u1e79\u4c1f\uf488'});
+try {
+commandEncoder0.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 1,
+  origin: { x: 30, y: 11, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 4,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder0.insertDebugMarker('\u00f9');
+} catch {}
+canvas0.width = 63;
+let img1 = await imageWithData(194, 242, '#0929149f', '#f1bea200');
+let textureView7 = texture0.createView({format: 'rg16sint', baseMipLevel: 1, mipLevelCount: 2});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 47 },
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 644739 */
+{offset: 3, bytesPerRow: 146, rowsPerImage: 69}, {width: 24, height: 0, depthOrArrayLayers: 65});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout0 = device0.createBindGroupLayout({
+entries: [{
+binding: 2456,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}],
+});
+let computePassEncoder0 = commandEncoder0.beginComputePass({label: '\u{1fe4f}\u0c07\u00b3\u0a52\u{1f772}\u801a'});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\ud127\u0d33\u0c2f',
+  colorFormats: ['rgba8sint', 'bgra8unorm', 'rg8uint', 'r16float', 'r16float'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle4 = renderBundleEncoder3.finish();
+try {
+computePassEncoder0.end();
+} catch {}
+document.body.prepend(canvas0);
+let imageData0 = new ImageData(188, 124);
+let textureView8 = texture1.createView({label: '\u9acb\u{1fc3d}\u08a5\u{1fdae}\ub3b1'});
+let renderBundle5 = renderBundleEncoder0.finish();
+let querySet1 = device0.createQuerySet({
+label: '\u{1fe3e}\u{1fe5b}\u11b5\u67cf\u3ec1\u7cfc\uf19f\ud7c9\u022b\u42de',
+type: 'occlusion',
+count: 1278,
+});
+let sampler2 = device0.createSampler({
+label: '\u0e3a\u16ae',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 98.462,
+maxAnisotropy: 3,
+});
+let texture5 = device0.createTexture({
+label: '\ub1a6\u096c\u343c\u0c92',
+size: [8050, 5, 1],
+mipLevelCount: 7,
+format: 'astc-5x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-5x5-unorm', 'astc-5x5-unorm-srgb', 'astc-5x5-unorm-srgb'],
+});
+let textureView9 = texture3.createView({
+  label: '\u6aeb\u0c6e\u7003\u64f9\u95de\u{1f65b}\ua492\u{1f985}\u061b\ucbbe',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 63
+});
+let computePassEncoder1 = commandEncoder0.beginComputePass({});
+let img2 = await imageWithData(220, 187, '#10aea5fb', '#d0fa5c80');
+try {
+adapter0.label = '\u658c\u0510\u{1f64c}\u{1fba8}\u{1ffbe}\u7a47\ud4be\u{1faa0}\u93b2\u{1f7e3}';
+} catch {}
+let pipelineLayout0 = device0.createPipelineLayout({
+  label: '\u020e\u{1f782}\ubd9e\u796b\u0a7b\u0c1b',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0]
+});
+let computePassEncoder2 = commandEncoder1.beginComputePass();
+try {
+renderBundleEncoder2.setVertexBuffer(88, undefined, 50126183, 1342198190);
+} catch {}
+let promise0 = device0.queue.onSubmittedWorkDone();
+let querySet2 = device0.createQuerySet({
+label: '\u5b41\u9785\udc8b\uef0c\u{1fa4f}\u{1fe30}\u0399',
+type: 'occlusion',
+count: 1949,
+});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\u{1f803}\u{1fa13}\u06f3\u{1fc86}',
+  colorFormats: ['rgba32sint', 'r16uint', 'rg16sint', 'rg16uint', 'rg16uint', 'bgra8unorm'],
+  stencilReadOnly: true
+});
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 772, y: 1, z: 0 },
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(56)), /* required buffer size: 266 */
+{offset: 266, bytesPerRow: 2463}, {width: 2459, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let computePassEncoder3 = commandEncoder0.beginComputePass();
+try {
+renderBundleEncoder2.setVertexBuffer(9, undefined, 262018594);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 36, y: 0, z: 82 },
+  aspect: 'all',
+}, new Float64Array(new ArrayBuffer(24)), /* required buffer size: 150347 */
+{offset: 275, bytesPerRow: 222, rowsPerImage: 13}, {width: 0, height: 0, depthOrArrayLayers: 53});
+} catch {}
+let textureView10 = texture1.createView({label: '\u046d\u8879\u0ede\u{1f7dc}\u09d8\u1250\u7c2f\u{1f8bd}\u5690\u0b24', arrayLayerCount: 1});
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 4,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(72)), /* required buffer size: 810 */
+{offset: 657, bytesPerRow: 137}, {width: 4, height: 2, depthOrArrayLayers: 1});
+} catch {}
+try {
+canvas0.getContext('2d');
+} catch {}
+try {
+textureView7.label = '\u{1fd40}\u0c2c\u{1fc41}\u0082\u{1fd6b}\u{1fa8e}';
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+label: '\uce3c\u48a9\u9e63\u0415\u{1fee2}\u8237\u{1f685}',
+code: `@group(3) @binding(2456)
+var<storage, read_write> field0: array<u32>;
+@group(7) @binding(2456)
+var<storage, read_write> parameter0: array<u32>;
+@group(8) @binding(2456)
+var<storage, read_write> global0: array<u32>;
+@group(4) @binding(2456)
+var<storage, read_write> field1: array<u32>;
+@group(0) @binding(2456)
+var<storage, read_write> type0: array<u32>;
+@group(1) @binding(2456)
+var<storage, read_write> local0: array<u32>;
+@group(2) @binding(2456)
+var<storage, read_write> i0: array<u32>;
+@group(5) @binding(2456)
+var<storage, read_write> parameter1: array<u32>;
+
+@compute @workgroup_size(5, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S0 {
+  @location(59) f0: u32,
+  @location(23) f1: vec2<f16>,
+  @builtin(position) f2: vec4<f32>,
+  @location(58) f3: vec2<f16>,
+  @location(4) f4: vec2<f32>,
+  @location(19) f5: vec3<i32>,
+  @builtin(front_facing) f6: bool,
+  @location(14) f7: f16,
+  @location(77) f8: f32,
+  @location(50) f9: vec2<f16>,
+  @location(79) f10: f32,
+  @location(55) f11: f16,
+  @location(76) f12: vec4<f32>,
+  @location(72) f13: vec4<u32>,
+  @location(60) f14: vec3<f16>,
+  @builtin(sample_index) f15: u32,
+  @location(87) f16: vec3<f16>,
+  @builtin(sample_mask) f17: u32,
+  @location(40) f18: vec3<f32>,
+  @location(1) f19: vec2<f16>,
+  @location(101) f20: vec4<i32>,
+  @location(73) f21: vec3<u32>,
+  @location(102) f22: vec4<f16>,
+  @location(51) f23: i32,
+  @location(44) f24: vec2<i32>,
+  @location(9) f25: vec2<i32>,
+  @location(83) f26: vec2<f16>,
+  @location(33) f27: vec2<i32>,
+  @location(86) f28: u32,
+  @location(81) f29: vec4<i32>,
+  @location(94) f30: vec4<f16>,
+  @location(41) f31: f16,
+  @location(18) f32: f16,
+  @location(34) f33: vec2<i32>,
+  @location(17) f34: vec4<f32>,
+  @location(103) f35: vec4<f16>,
+  @location(82) f36: vec4<i32>,
+  @location(21) f37: f16
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @location(2) f1: vec2<i32>,
+  @location(4) f2: vec4<u32>,
+  @location(5) f3: vec4<f32>,
+  @location(3) f4: vec4<u32>,
+  @location(1) f5: u32
+}
+
+@fragment
+fn fragment0(@location(105) a0: vec3<i32>, @location(20) a1: vec3<i32>, a2: S0, @location(89) a3: vec4<u32>, @location(16) a4: vec2<u32>, @location(0) a5: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(103) f0: vec4<f16>,
+  @location(94) f1: vec4<f16>,
+  @location(20) f2: vec3<i32>,
+  @location(44) f3: vec2<i32>,
+  @location(19) f4: vec3<i32>,
+  @location(0) f5: u32,
+  @location(73) f6: vec3<u32>,
+  @location(41) f7: f16,
+  @location(59) f8: u32,
+  @location(58) f9: vec2<f16>,
+  @location(101) f10: vec4<i32>,
+  @location(16) f11: vec2<u32>,
+  @location(81) f12: vec4<i32>,
+  @location(23) f13: vec2<f16>,
+  @location(72) f14: vec4<u32>,
+  @location(17) f15: vec4<f32>,
+  @location(76) f16: vec4<f32>,
+  @location(1) f17: vec2<f16>,
+  @location(82) f18: vec4<i32>,
+  @location(51) f19: i32,
+  @location(9) f20: vec2<i32>,
+  @location(87) f21: vec3<f16>,
+  @location(83) f22: vec2<f16>,
+  @location(18) f23: f16,
+  @location(55) f24: f16,
+  @location(14) f25: f16,
+  @location(102) f26: vec4<f16>,
+  @location(86) f27: u32,
+  @location(105) f28: vec3<i32>,
+  @location(79) f29: f32,
+  @location(34) f30: vec2<i32>,
+  @location(89) f31: vec4<u32>,
+  @builtin(position) f32: vec4<f32>,
+  @location(40) f33: vec3<f32>,
+  @location(50) f34: vec2<f16>,
+  @location(33) f35: vec2<i32>,
+  @location(60) f36: vec3<f16>,
+  @location(77) f37: f32,
+  @location(21) f38: f16,
+  @location(4) f39: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec4<u32>, @location(15) a1: f32, @location(3) a2: vec3<f16>, @location(14) a3: vec3<f16>, @location(11) a4: vec3<f32>, @builtin(vertex_index) a5: u32, @location(16) a6: f16, @location(2) a7: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let textureView11 = texture5.createView({label: '\uca6a\uc80a\u48f6\u{1fdc7}\u0881\ua642\u0694\u8ffc\udef2\u28f3', baseMipLevel: 5});
+let externalTexture1 = device0.importExternalTexture({
+label: '\u0a2b\ua4f5\u3d9a\ue821\u0b2c',
+source: videoFrame0,
+colorSpace: 'srgb',
+});
+let textureView12 = texture3.createView({
+  label: '\u2b36\ub0a7\u{1f875}\u79f9\ud445\u5ff9\u2f40\u070d\u64d6\ufa35\ubb2f',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 133,
+  arrayLayerCount: 1
+});
+let renderBundle6 = renderBundleEncoder3.finish({label: '\uefdc\u0ac3'});
+try {
+computePassEncoder3.end();
+} catch {}
+let commandEncoder2 = device0.createCommandEncoder({label: '\u3d6c\u669f\u{1fdb6}\u3058\ue6c6\u43dc'});
+pseudoSubmit(device0, commandEncoder0);
+let texture6 = device0.createTexture({
+size: {width: 320, height: 128, depthOrArrayLayers: 1},
+mipLevelCount: 9,
+dimension: '2d',
+format: 'astc-5x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-5x4-unorm', 'astc-5x4-unorm', 'astc-5x4-unorm-srgb'],
+});
+let renderBundle7 = renderBundleEncoder0.finish({label: '\u{1fc03}\u01c5\u{1fd4b}\u0f0e\u{1ffb9}\u8a48\u{1ffb1}'});
+let texture7 = gpuCanvasContext0.getCurrentTexture();
+try {
+buffer1.destroy();
+} catch {}
+try {
+  await promise0;
+} catch {}
+try {
+adapter0.label = '\u06cc\u4b21\u0f04\u7e31\u8409';
+} catch {}
+let texture8 = device0.createTexture({
+label: '\u05d6\u{1fc91}\u{1f830}\u700b\u44d5\u0ea8\u6491',
+size: [7160, 4, 154],
+mipLevelCount: 12,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth24plus', 'depth24plus', 'depth24plus'],
+});
+let renderBundle8 = renderBundleEncoder2.finish({label: '\u{1f735}\u33ac\udf08\u0295\u8257\u{1fca5}\u199a\ua192'});
+try {
+renderBundleEncoder4.setVertexBuffer(56, undefined, 787699320, 2175249951);
+} catch {}
+let computePassEncoder4 = commandEncoder2.beginComputePass({label: '\u0c45\ud3df\u0477\u4755\u{1f6a8}\u6295\u{1fca0}\u6490\u0a5f\u6622\uffdb'});
+let renderBundle9 = renderBundleEncoder1.finish();
+try {
+renderBundleEncoder4.setVertexBuffer(59, undefined, 487860217, 2666862365);
+} catch {}
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let buffer2 = device0.createBuffer({label: '\u0aa5\u{1f69f}', size: 50612, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture9 = device0.createTexture({
+size: [5310],
+dimension: '1d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm'],
+});
+let textureView13 = texture6.createView({dimension: '2d-array', format: 'astc-5x4-unorm', baseMipLevel: 6});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  label: '\u0aef\u68ca\u7c73',
+  colorFormats: ['rgba8sint', 'bgra8unorm', 'rg8uint', 'r16float', 'r16float'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler3 = device0.createSampler({
+label: '\u061a\uc8cf\u7e40\u{1f7a5}\u2887\u{1f97a}\u5174\ub58e\u{1fb2e}\u57ab\u0d96',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 82.774,
+lodMaxClamp: 97.163,
+});
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-10x10-unorm'],
+});
+} catch {}
+let pipeline0 = device0.createComputePipeline({
+label: '\ua0a7\uf80c',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let querySet3 = device0.createQuerySet({
+label: '\u0539\ubd53\u87ed',
+type: 'occlusion',
+count: 2601,
+});
+let texture10 = device0.createTexture({
+label: '\ucf14\u44cc\u047d',
+size: {width: 3280, height: 225, depthOrArrayLayers: 34},
+mipLevelCount: 12,
+format: 'astc-10x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+let pipeline1 = device0.createComputePipeline({
+label: '\u05bb\uc69d\u176d\u89fb\ucaca\ub746\u{1fbd1}\u0182\u0709\uca40',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let bindGroupLayout1 = device0.createBindGroupLayout({
+entries: [{
+binding: 2519,
+visibility: 0,
+sampler: { type: 'filtering' },
+}, {
+binding: 1779,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}],
+});
+let commandEncoder3 = device0.createCommandEncoder({label: '\u9483\u4817'});
+let computePassEncoder5 = commandEncoder3.beginComputePass({label: '\u{1fdd5}\ufdea\u5b2e\u056b\ua599\uacd4'});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  label: '\u01bf\u1b88',
+  colorFormats: ['rgba32sint', 'r16uint', 'rg16sint', 'rg16uint', 'rg16uint', 'bgra8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let img3 = await imageWithData(200, 43, '#0b529a26', '#cea18a24');
+let texture11 = device0.createTexture({
+size: {width: 90, height: 280, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+sampleCount: 1,
+dimension: '2d',
+format: 'astc-10x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x10-unorm-srgb', 'astc-10x10-unorm-srgb'],
+});
+let renderBundle10 = renderBundleEncoder3.finish({});
+let pipeline2 = device0.createRenderPipeline({
+layout: 'auto',
+multisample: {
+count: 4,
+mask: 0xd8320130,
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint'}, {format: 'r16uint', writeMask: 0}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg16uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg16uint', writeMask: GPUColorWrite.GREEN}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'src', dstFactor: 'one-minus-src-alpha'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+}
+}]
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 352,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32',
+offset: 176,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 480,
+attributes: [{
+format: 'float16x2',
+offset: 468,
+shaderLocation: 14,
+}, {
+format: 'snorm16x4',
+offset: 196,
+shaderLocation: 15,
+}, {
+format: 'snorm8x4',
+offset: 476,
+shaderLocation: 16,
+}, {
+format: 'unorm8x4',
+offset: 420,
+shaderLocation: 2,
+}, {
+format: 'snorm8x2',
+offset: 416,
+shaderLocation: 11,
+}, {
+format: 'float16x4',
+offset: 272,
+shaderLocation: 3,
+}],
+}
+]
+},
+});
+try {
+renderBundleEncoder4.setVertexBuffer(20, undefined, 304782030, 3261591287);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb', 'astc-12x10-unorm', 'bgra8unorm-srgb', 'bgra8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let bindGroupLayout2 = device0.createBindGroupLayout({
+label: '\u4a18\udfe0\u0e62\ud4bd\u{1fd76}\u08db\uf4ee\u096d\u0e4d\u{1f7cc}',
+entries: [{
+binding: 579,
+visibility: GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}, {
+binding: 927,
+visibility: 0,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}, {
+binding: 426,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'comparison' },
+}],
+});
+let img4 = await imageWithData(266, 253, '#ccaaf105', '#f4cb0204');
+let textureView14 = texture3.createView({
+  label: '\u{1f69c}\uaa66\u9860\uf291\u8421\u0640\u{1f69e}\u017f\ud3ea',
+  baseMipLevel: 2,
+  baseArrayLayer: 45,
+  arrayLayerCount: 34
+});
+try {
+  await buffer2.mapAsync(GPUMapMode.WRITE, 0, 9592);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm'],
+colorSpace: 'srgb',
+});
+} catch {}
+document.body.prepend(img0);
+try {
+renderBundleEncoder6.setVertexBuffer(43, undefined);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 542 */
+{offset: 542}, {width: 10, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline3 = device0.createRenderPipeline({
+label: '\u3426\u{1f629}\u0e62\u7123\u0cf5\u4fb4\u{1f9ea}',
+layout: pipelineLayout0,
+multisample: {
+count: 4,
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: 0}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rg16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg16uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'greater',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'invert',
+},
+stencilReadMask: 3026,
+stencilWriteMask: 4054,
+depthBiasSlopeScale: 29,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 6584,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 4008,
+attributes: [{
+format: 'float32',
+offset: 124,
+shaderLocation: 3,
+}, {
+format: 'unorm8x4',
+offset: 2240,
+shaderLocation: 2,
+}, {
+format: 'snorm16x2',
+offset: 2544,
+shaderLocation: 14,
+}, {
+format: 'snorm8x2',
+offset: 2300,
+shaderLocation: 16,
+}, {
+format: 'float32x4',
+offset: 1708,
+shaderLocation: 15,
+}, {
+format: 'uint16x2',
+offset: 3644,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 2492,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 5112,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 2884,
+attributes: [{
+format: 'unorm8x2',
+offset: 1744,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let querySet4 = device0.createQuerySet({
+label: '\u09a4\u028b\u{1fa66}\u04f7\u{1f99e}\u09e7',
+type: 'occlusion',
+count: 2608,
+});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\ue437\u{1f8e1}\ua7d1\u0e91\u{1f9f2}\u1751\u0851\uec8b\u96cd\ud520\ua654',
+  colorFormats: ['rgba32sint', 'r16uint', 'rg16sint', 'rg16uint', 'rg16uint', 'bgra8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+let renderBundle11 = renderBundleEncoder4.finish();
+let pipelineLayout1 = device0.createPipelineLayout({
+  label: '\u233c\uc906\ud865\u0734\ue1f3\u{1f700}\uaef2\u2d89\u77a1',
+  bindGroupLayouts: [bindGroupLayout1]
+});
+let textureView15 = texture1.createView({label: '\uf617\u09d4\u1b11\u0333\u5ce3\u0c82\u0098\u046d\u8b85'});
+let renderBundle12 = renderBundleEncoder5.finish({label: '\ucc5e\u9690\uf67d\u{1fd23}'});
+try {
+renderBundleEncoder6.setVertexBuffer(48, undefined, 2609033553, 756980345);
+} catch {}
+let texture12 = device0.createTexture({
+label: '\uf86a\u069d\uf994',
+size: {width: 66, height: 1, depthOrArrayLayers: 88},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm', 'bgra8unorm'],
+});
+try {
+computePassEncoder4.setPipeline(pipeline1);
+} catch {}
+let imageData1 = new ImageData(96, 236);
+let buffer3 = device0.createBuffer({
+  label: '\uedf7\u43c4\u03db\u0470\u57fb\u0d90',
+  size: 38972,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let textureView16 = texture2.createView({
+  label: '\u0966\u{1fa30}\u{1ff66}\u3bcc\u200c',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 2,
+  mipLevelCount: 4,
+  baseArrayLayer: 45
+});
+let sampler4 = device0.createSampler({
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 83.932,
+lodMaxClamp: 95.689,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: { x: 50, y: 50, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(412), /* required buffer size: 412 */
+{offset: 412, bytesPerRow: 290}, {width: 30, height: 120, depthOrArrayLayers: 0});
+} catch {}
+let textureView17 = texture6.createView({label: '\ub077\u{1fc95}\uf59a\u308f', dimension: '2d-array', baseMipLevel: 2, mipLevelCount: 4});
+let renderBundle13 = renderBundleEncoder7.finish({label: '\u0af1\u0a2a\u{1faf6}\ufc26'});
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 84, y: 0, z: 66 },
+  aspect: 'all',
+}, new ArrayBuffer(40), /* required buffer size: 470283 */
+{offset: 121, bytesPerRow: 71, rowsPerImage: 86}, {width: 24, height: 0, depthOrArrayLayers: 78});
+} catch {}
+let pipeline4 = await device0.createRenderPipelineAsync({
+label: '\u93e8\u040d\u0d75\u01e6\u08e7',
+layout: pipelineLayout1,
+multisample: {
+mask: 0x9d8868a4,
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'r16uint'}, {format: 'rg16sint', writeMask: 0}, {format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}]
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 4588,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 3184,
+shaderLocation: 3,
+}, {
+format: 'float32',
+offset: 3140,
+shaderLocation: 16,
+}, {
+format: 'uint16x4',
+offset: 2332,
+shaderLocation: 6,
+}, {
+format: 'float32',
+offset: 2336,
+shaderLocation: 11,
+}, {
+format: 'float32',
+offset: 980,
+shaderLocation: 14,
+}, {
+format: 'snorm16x4',
+offset: 2576,
+shaderLocation: 2,
+}, {
+format: 'snorm8x2',
+offset: 368,
+shaderLocation: 15,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 63 },
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 346762 */
+{offset: 829, bytesPerRow: 289, rowsPerImage: 133}, {width: 24, height: 0, depthOrArrayLayers: 10});
+} catch {}
+let texture13 = device0.createTexture({
+label: '\uf9c7\u0a60\u0e52\u{1ff28}\u48a4\u0165\uf663\ub2d1\u{1ff82}\u013f',
+size: [1790, 1, 154],
+mipLevelCount: 2,
+dimension: '2d',
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_DST,
+});
+let textureView18 = texture10.createView({label: '\u49df\uf528', dimension: '2d', baseMipLevel: 3, mipLevelCount: 5, baseArrayLayer: 28});
+try {
+renderBundleEncoder6.setVertexBuffer(17, undefined);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let canvas1 = document.createElement('canvas');
+try {
+renderBundleEncoder6.setVertexBuffer(69, undefined);
+} catch {}
+let arrayBuffer0 = buffer2.getMappedRange(0, 7804);
+let gpuCanvasContext1 = canvas1.getContext('webgpu');
+canvas0.width = 227;
+let pipelineLayout2 = device0.createPipelineLayout({
+  label: '\u{1fde2}\uf447\ua488\u{1f8c9}\uec80\u{1fa25}\u54dd\u4280\ueaf0\u29eb\ufc9c',
+  bindGroupLayouts: [bindGroupLayout2, bindGroupLayout2, bindGroupLayout0, bindGroupLayout1, bindGroupLayout1, bindGroupLayout2, bindGroupLayout2, bindGroupLayout0]
+});
+let querySet5 = device0.createQuerySet({
+label: '\u0a27\u{1fb33}\u7470\u697b\u3300',
+type: 'occlusion',
+count: 985,
+});
+let textureView19 = texture3.createView({
+  label: '\uf5e7\u{1f683}\u0f43\u1077\u22ed\u8572',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+  baseArrayLayer: 53
+});
+let renderBundle14 = renderBundleEncoder2.finish({});
+let sampler5 = device0.createSampler({
+label: '\u{1ff83}\u0a2e\u{1fc29}\u038a\u0d8d\ue4bc\ucf1b\u102a\u0e6e',
+addressModeU: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 80.023,
+compare: 'always',
+});
+try {
+buffer0.destroy();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 1,
+  origin: { x: 10, y: 15, z: 1 },
+  aspect: 'all',
+}, new Int8Array(arrayBuffer0), /* required buffer size: 217 */
+{offset: 217, bytesPerRow: 432}, {width: 60, height: 25, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 22}
+*/
+{
+  source: canvas0,
+  origin: { x: 97, y: 96 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 20 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 15, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline5 = device0.createRenderPipeline({
+label: '\u{1fbc8}\uac3d\u0182\u7e41',
+layout: pipelineLayout2,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: 0}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg16uint', writeMask: 0}, {format: 'rg16uint', writeMask: 0}, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}]
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 6472,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 2840,
+shaderLocation: 2,
+}, {
+format: 'float32x4',
+offset: 5020,
+shaderLocation: 16,
+}, {
+format: 'float32x3',
+offset: 2888,
+shaderLocation: 3,
+}, {
+format: 'unorm8x4',
+offset: 1964,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 76,
+attributes: [{
+format: 'unorm16x4',
+offset: 0,
+shaderLocation: 14,
+}, {
+format: 'float32',
+offset: 28,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 5508,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'back',
+},
+});
+try {
+window.someLabel = renderBundleEncoder2.label;
+} catch {}
+let texture14 = device0.createTexture({
+label: '\u8088\u4fa2\uf3f6\u0d97\u26f7\u{1f726}\u3c68\u545f\u{1fa68}\u4253',
+size: [33, 1, 136],
+mipLevelCount: 4,
+sampleCount: 1,
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rgba32uint', 'rgba32uint', 'rgba32uint'],
+});
+let textureView20 = texture1.createView({label: '\u808a\ue754\ud028\ufdd4\u7698\u6bdb', aspect: 'all'});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  label: '\uf7fb\u8c73\u2d1d\ua038\u{1f81b}\ufeb1\u1380',
+  colorFormats: ['rgba32sint', 'r16uint', 'rg16sint', 'rg16uint', 'rg16uint', 'bgra8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle15 = renderBundleEncoder4.finish({label: '\u12c1\ue052\u09be\u{1f69a}\u42ad\u22c0\u00b6\u{1f6d2}\u3e55\u{1f66f}\u6e01'});
+try {
+buffer1.destroy();
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 46 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 3064217 */
+{offset: 977, bytesPerRow: 335, rowsPerImage: 127}, {width: 3, height: 0, depthOrArrayLayers: 73});
+} catch {}
+let pipeline6 = await device0.createRenderPipelineAsync({
+label: '\u0176\uad57\u0e15\u024f\u336b',
+layout: pipelineLayout2,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.BLUE}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg16uint', writeMask: GPUColorWrite.GREEN}, {format: 'rg16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'one', dstFactor: 'dst-alpha'},
+alpha: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'src-alpha-saturated'},
+}
+}]
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 5768,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x4',
+offset: 5432,
+shaderLocation: 14,
+}, {
+format: 'float32x2',
+offset: 496,
+shaderLocation: 2,
+}, {
+format: 'float32x3',
+offset: 3756,
+shaderLocation: 11,
+}, {
+format: 'unorm16x4',
+offset: 3236,
+shaderLocation: 16,
+}, {
+format: 'unorm8x2',
+offset: 520,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 1692,
+attributes: [{
+format: 'float32x3',
+offset: 108,
+shaderLocation: 15,
+}, {
+format: 'uint16x4',
+offset: 1244,
+shaderLocation: 6,
+}],
+}
+]
+},
+});
+let promise1 = adapter0.requestAdapterInfo();
+let pipelineLayout3 = device0.createPipelineLayout({label: '\u8425\u1ac1\u99ac\u1eb0', bindGroupLayouts: [bindGroupLayout2, bindGroupLayout2]});
+let commandEncoder4 = device0.createCommandEncoder({label: '\ucca4\u95d5\u0a35\uf551\ud6c6\u4a8e\ufa6b\u{1fccd}\u5253\u8564\u9c22'});
+try {
+computePassEncoder4.setPipeline(pipeline1);
+} catch {}
+let pipeline7 = device0.createComputePipeline({
+label: '\ud46d\u4c0b\u{1fe17}\uac63\ue915\u2fe8\u1b63\u{1f778}\u0278',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let bindGroup0 = device0.createBindGroup({
+label: '\u01da\u906e\u0561\udf8d\u0ccf\u9b5a\u83b4\u0381\u98e7',
+layout: bindGroupLayout1,
+entries: [{
+binding: 2519,
+resource: sampler3
+}, {
+binding: 1779,
+resource: sampler5
+}],
+});
+pseudoSubmit(device0, commandEncoder1);
+let texture15 = device0.createTexture({
+label: '\u00bc\udb6a\u{1fdba}\u43c4\u{1ff67}\u86ea\u01c0\u08f9\u0740\u{1ff2e}',
+size: [1790, 1, 154],
+mipLevelCount: 7,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth32float-stencil8', 'depth32float-stencil8', 'depth32float-stencil8'],
+});
+try {
+computePassEncoder5.setBindGroup(6, bindGroup0, new Uint32Array(359), 358, 0);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 34, y: 23, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 2,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 18, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame1 = new VideoFrame(img1, {timestamp: 0});
+let bindGroupLayout3 = device0.createBindGroupLayout({
+entries: [],
+});
+let renderBundle16 = renderBundleEncoder7.finish();
+let bindGroup1 = device0.createBindGroup({
+label: '\ued2c\u{1fb9e}\u{1feef}\u0e33\u3c72\uc2b8\uac0f\u{1fea2}',
+layout: bindGroupLayout3,
+entries: [],
+});
+let querySet6 = device0.createQuerySet({
+type: 'occlusion',
+count: 1234,
+});
+let texture16 = device0.createTexture({
+label: '\u97f8\u{1fbf5}\u3a2e\ucf5d\uaaf1\u75f1\ud915\u1c20\u1cd8',
+size: [6972, 12, 1],
+mipLevelCount: 9,
+format: 'astc-12x12-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-12x12-unorm-srgb'],
+});
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 1,
+  origin: { x: 485, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 45, y: 125, z: 0 },
+  aspect: 'all',
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8uint', 'rgba16float', 'rgba16float'],
+alphaMode: 'premultiplied',
+});
+} catch {}
+canvas1.width = 679;
+let commandEncoder5 = device0.createCommandEncoder({});
+let texture17 = device0.createTexture({
+label: '\u065d\ude39\u586d\u{1f83f}\uefd2\uc395\ucec9\u{1feba}\u0033\u7078',
+size: {width: 1104},
+mipLevelCount: 1,
+dimension: '1d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb'],
+});
+let textureView21 = texture9.createView({label: '\u4a42\u0345\u0579\u7e9f\uc226'});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup0);
+} catch {}
+let pipeline8 = device0.createComputePipeline({
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline9 = await device0.createRenderPipelineAsync({
+label: '\u0d57\u0b32',
+layout: pipelineLayout2,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint'}, {format: 'r16uint', writeMask: 0}, {format: 'rg16sint'}, {format: 'rg16uint', writeMask: GPUColorWrite.ALL}, {format: 'rg16uint', writeMask: GPUColorWrite.ALL}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'one-minus-dst'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+}
+}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+failOp: 'increment-clamp',
+},
+stencilReadMask: 36,
+depthBias: 18,
+depthBiasSlopeScale: 4,
+depthBiasClamp: 3,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 2648,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x2',
+offset: 1936,
+shaderLocation: 2,
+}, {
+format: 'unorm16x4',
+offset: 2464,
+shaderLocation: 3,
+}, {
+format: 'snorm8x2',
+offset: 606,
+shaderLocation: 11,
+}, {
+format: 'snorm16x4',
+offset: 1048,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+attributes: [{
+format: 'unorm8x4',
+offset: 736,
+shaderLocation: 16,
+}, {
+format: 'uint32',
+offset: 2656,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 4760,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 2048,
+attributes: [{
+format: 'float16x2',
+offset: 1540,
+shaderLocation: 14,
+}],
+}
+]
+},
+});
+let imageData2 = new ImageData(216, 132);
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let bindGroupLayout4 = pipeline3.getBindGroupLayout(2);
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u0570\u2d83',
+  colorFormats: ['rgba32sint', 'r16uint', 'rg16sint', 'rg16uint', 'rg16uint', 'bgra8unorm'],
+  stencilReadOnly: true
+});
+let renderBundle17 = renderBundleEncoder0.finish({label: '\u0224\u01c7\ud94d\u36f3\u2aff\u0170\u327c\u3965\u0cf6'});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup1, new Uint32Array(80), 48, 0);
+} catch {}
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture12,
+  mipLevel: 1,
+  origin: { x: 29, y: 0, z: 38 },
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 1, depthOrArrayLayers: 11}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 181, y: 138 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 3 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline10 = await device0.createComputePipelineAsync({
+layout: pipelineLayout3,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+});
+let imageBitmap0 = await createImageBitmap(img3);
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline5);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [],
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise1;
+} catch {}
+let commandEncoder6 = device0.createCommandEncoder();
+let texture18 = device0.createTexture({
+size: {width: 160, height: 64, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'astc-4x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-4x4-unorm', 'astc-4x4-unorm', 'astc-4x4-unorm-srgb'],
+});
+try {
+computePassEncoder4.setBindGroup(6, bindGroup0);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder8.draw(72);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 1, y: 6, z: 0 },
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(32)), /* required buffer size: 991 */
+{offset: 991, bytesPerRow: 219}, {width: 48, height: 15, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+label: '\ue141\u0e95',
+layout: bindGroupLayout1,
+entries: [{
+binding: 1779,
+resource: sampler5
+}, {
+binding: 2519,
+resource: sampler0
+}],
+});
+let computePassEncoder6 = commandEncoder4.beginComputePass({label: '\udd5c\u0ea8\u0f56\u0aa9\u002b\u{1fb8a}\ueadb\u0c80\u{1fad5}\u1694\u647d'});
+let sampler6 = device0.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 86.415,
+maxAnisotropy: 15,
+});
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder8.draw(8, 8, 24);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline6);
+} catch {}
+document.body.prepend(img3);
+let querySet7 = device0.createQuerySet({
+label: '\u3c6d\u019f\u0ab3',
+type: 'occlusion',
+count: 3160,
+});
+let texture19 = device0.createTexture({
+label: '\u00e5\u0bc9',
+size: [258, 6, 146],
+mipLevelCount: 3,
+format: 'astc-6x6-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+try {
+renderBundleEncoder8.setBindGroup(4, bindGroup0, new Uint32Array(2932), 2561, 0);
+} catch {}
+try {
+renderBundleEncoder8.draw(0, 80);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(64);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline5);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let imageBitmap1 = await createImageBitmap(img4);
+let buffer4 = device0.createBuffer({label: '\u23e5\u0cd8\u0d93\u{1fbfb}\u621b', size: 20479, usage: GPUBufferUsage.STORAGE});
+let texture20 = device0.createTexture({
+label: '\u2631\u592a\u{1ff2a}\u{1fcad}\u3bbd\u0509\u43d8\ube8f\u{1fe1d}',
+size: [66],
+dimension: '1d',
+format: 'rg8uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg8uint', 'rg8uint'],
+});
+let computePassEncoder7 = commandEncoder6.beginComputePass({});
+let renderBundle18 = renderBundleEncoder1.finish();
+try {
+computePassEncoder5.setBindGroup(5, bindGroup2, new Uint32Array(1602), 641, 0);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 66, height: 1, depthOrArrayLayers: 88}
+*/
+{
+  source: img2,
+  origin: { x: 86, y: 176 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 20, y: 0, z: 59 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 16, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline11 = device0.createComputePipeline({
+label: '\ufd3d\u2ccf\u9281\u{1f887}\u5888\u91d5\u4823\u0256\u{1f62c}\uab4f\u{1f9c7}',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+});
+document.body.prepend(img2);
+let img5 = await imageWithData(8, 133, '#fa75f26a', '#679bf8a2');
+let commandEncoder7 = device0.createCommandEncoder({label: '\u456f\u077c\u{1ff26}\u{1fd10}\uf1c9\udaea\ua273\udf58'});
+try {
+renderBundleEncoder6.draw(8, 16, 72, 64);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 6,
+  origin: { x: 0, y: 1, z: 34 },
+  aspect: 'stencil-only',
+}, new ArrayBuffer(80), /* required buffer size: 391874 */
+{offset: 414, bytesPerRow: 92, rowsPerImage: 185}, {width: 27, height: 0, depthOrArrayLayers: 24});
+} catch {}
+let pipeline12 = device0.createComputePipeline({
+label: '\ub1a0\u0630',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline13 = await device0.createRenderPipelineAsync({
+label: '\u{1f74d}\u9f91\u07ba\ubea4\u0276\ue7f4\u07d3\u0599\u{1fdb4}\u6993\u857f',
+layout: pipelineLayout2,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r16uint'}, {format: 'rg16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg16uint', writeMask: GPUColorWrite.ALL}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'src-alpha-saturated'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 3943,
+stencilWriteMask: 2703,
+depthBias: 76,
+depthBiasSlopeScale: 7,
+depthBiasClamp: 30,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 6508,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 5832,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x4',
+offset: 5804,
+shaderLocation: 6,
+}, {
+format: 'float16x2',
+offset: 3932,
+shaderLocation: 2,
+}, {
+format: 'snorm8x4',
+offset: 2712,
+shaderLocation: 15,
+}, {
+format: 'unorm8x4',
+offset: 3312,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 4596,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1560,
+attributes: [{
+format: 'float16x2',
+offset: 1348,
+shaderLocation: 3,
+}, {
+format: 'unorm8x2',
+offset: 566,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 2140,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 6212,
+shaderLocation: 16,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+try {
+adapter0.label = '\u6137\u0cc9\ub1dc\ub43d\uefea\u0530\ueceb\u{1f7e0}';
+} catch {}
+let bindGroup3 = device0.createBindGroup({
+label: '\u{1faef}\ue75a\u0955\u0856\u433d\u04cd\u02c1\u5dff\ubbd4\ucb30\u005a',
+layout: bindGroupLayout1,
+entries: [{
+binding: 2519,
+resource: sampler1
+}, {
+binding: 1779,
+resource: sampler5
+}],
+});
+let texture21 = device0.createTexture({
+label: '\u83d1\ud86b\ucfc9\u0f7d\u01f9\u0355\u06b7\ue46d\ucb8c\ub9f7\u{1fa4f}',
+size: {width: 552, height: 16, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+dimension: '2d',
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [],
+});
+let sampler7 = device0.createSampler({
+label: '\ufca6\u2ef1\u0a0b\u7c94\ua316\u022a\u6d98\u0dab\ua1d7',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 17.570,
+compare: 'always',
+});
+try {
+computePassEncoder7.setPipeline(pipeline0);
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+label: '\u{1ffa0}\ufeb6',
+code: `@group(0) @binding(426)
+var<storage, read_write> parameter2: array<u32>;
+@group(1) @binding(426)
+var<storage, read_write> i1: array<u32>;
+@group(1) @binding(579)
+var<storage, read_write> field2: array<u32>;
+@group(1) @binding(927)
+var<storage, read_write> global1: array<u32>;
+@group(0) @binding(579)
+var<storage, read_write> i2: array<u32>;
+
+@compute @workgroup_size(7, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec3<u32>,
+  @location(4) f1: vec2<u32>,
+  @location(0) f2: vec4<i32>,
+  @location(5) f3: vec4<f32>,
+  @location(2) f4: vec4<i32>,
+  @location(1) f5: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S1 {
+  @location(14) f0: vec2<f32>,
+  @builtin(instance_index) f1: u32,
+  @location(15) f2: vec2<f16>,
+  @location(4) f3: vec4<i32>,
+  @location(1) f4: u32,
+  @location(9) f5: vec4<u32>,
+  @location(5) f6: vec2<i32>,
+  @location(7) f7: vec2<f32>,
+  @location(16) f8: f16,
+  @location(6) f9: vec2<f16>,
+  @location(8) f10: f32
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec3<i32>, @location(2) a1: vec2<f16>, @location(0) a2: vec2<i32>, a3: S1, @location(13) a4: vec4<f32>, @location(3) a5: vec4<f32>, @builtin(vertex_index) a6: u32, @location(12) a7: vec3<f16>, @location(10) a8: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let computePassEncoder8 = commandEncoder5.beginComputePass({label: '\u5a75\u00e8'});
+let sampler8 = device0.createSampler({
+label: '\u0f5e\u0136\u0be2\u5891',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMaxClamp: 20.914,
+});
+try {
+renderBundleEncoder6.setPipeline(pipeline4);
+} catch {}
+let pipeline14 = await device0.createRenderPipelineAsync({
+label: '\ub526\u076e\uc54d\u5f68\u{1f7c8}\u077c\u0770\u054e',
+layout: pipelineLayout3,
+multisample: {
+mask: 0x9feec697,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint'}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg16uint'}, {format: 'rg16uint', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'bgra8unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'not-equal',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilWriteMask: 3929,
+depthBias: 73,
+depthBiasSlopeScale: 33,
+depthBiasClamp: 15,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 4100,
+attributes: [{
+format: 'float32',
+offset: 1356,
+shaderLocation: 14,
+}, {
+format: 'sint32x3',
+offset: 892,
+shaderLocation: 4,
+}, {
+format: 'sint8x4',
+offset: 268,
+shaderLocation: 5,
+}, {
+format: 'uint8x2',
+offset: 970,
+shaderLocation: 9,
+}, {
+format: 'unorm8x2',
+offset: 3544,
+shaderLocation: 2,
+}, {
+format: 'sint32x3',
+offset: 3780,
+shaderLocation: 11,
+}, {
+format: 'unorm8x2',
+offset: 2994,
+shaderLocation: 6,
+}, {
+format: 'float16x4',
+offset: 868,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 2340,
+attributes: [{
+format: 'sint32x3',
+offset: 876,
+shaderLocation: 0,
+}, {
+format: 'float32',
+offset: 928,
+shaderLocation: 13,
+}, {
+format: 'float16x2',
+offset: 884,
+shaderLocation: 7,
+}, {
+format: 'sint8x4',
+offset: 1396,
+shaderLocation: 10,
+}, {
+format: 'float16x2',
+offset: 288,
+shaderLocation: 12,
+}, {
+format: 'float32x4',
+offset: 1244,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x2',
+offset: 4376,
+shaderLocation: 1,
+}, {
+format: 'unorm8x4',
+offset: 6744,
+shaderLocation: 3,
+}, {
+format: 'float32x3',
+offset: 4616,
+shaderLocation: 16,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let canvas2 = document.createElement('canvas');
+try {
+adapter0.label = '\u{1fe68}\u543c\u06cf\u8860\ue5e8\u{1f6b8}\u8f74\u{1f645}\uaee7\u0425\ube58';
+} catch {}
+let texture22 = device0.createTexture({
+label: '\u013f\u4e7c\u{1fa85}\u{1fa4e}\u1bea\u{1f8d5}',
+size: [552, 16, 1],
+mipLevelCount: 4,
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [],
+});
+let sampler9 = device0.createSampler({
+label: '\u9736\uc0ed',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 48.743,
+lodMaxClamp: 97.901,
+});
+try {
+renderBundleEncoder9.setBindGroup(8, bindGroup0, new Uint32Array(3615), 3468, 0);
+} catch {}
+try {
+renderBundleEncoder6.draw(8, 56, 64, 72);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 3,
+  origin: { x: 0, y: 4, z: 0 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 282 */
+{offset: 282, bytesPerRow: 218}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext2 = canvas2.getContext('webgpu');
+let imageBitmap2 = await createImageBitmap(imageBitmap1);
+let shaderModule2 = device0.createShaderModule({
+code: `@group(0) @binding(927)
+var<storage, read_write> function0: array<u32>;
+@group(0) @binding(579)
+var<storage, read_write> parameter3: array<u32>;
+@group(1) @binding(426)
+var<storage, read_write> field3: array<u32>;
+
+@compute @workgroup_size(5, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec3<f32>,
+  @location(2) f1: vec4<f32>,
+  @location(1) f2: vec3<i32>,
+  @location(4) f3: vec4<f32>,
+  @location(0) f4: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S2 {
+  @location(3) f0: vec2<i32>,
+  @location(0) f1: vec2<f16>,
+  @location(14) f2: u32,
+  @builtin(instance_index) f3: u32,
+  @location(5) f4: u32
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec3<f16>, @location(1) a1: f32, a2: S2, @location(12) a3: vec2<u32>, @location(7) a4: vec3<u32>, @location(6) a5: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+try {
+renderBundleEncoder6.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 1, depthOrArrayLayers: 5}
+*/
+{
+  source: canvas1,
+  origin: { x: 350, y: 9 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 4,
+  origin: { x: 1, y: 0, z: 4 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let texture23 = device0.createTexture({
+label: '\u{1f88e}\u89d2\ua8df\u{1fee5}\u{1f9e9}\uf971\u1a5a\uf640\u15a5',
+size: [895],
+mipLevelCount: 1,
+dimension: '1d',
+format: 'rg16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+try {
+renderBundleEncoder9.drawIndexed(8);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(58, undefined, 289969504, 3985791280);
+} catch {}
+let pipeline15 = await device0.createComputePipelineAsync({
+layout: pipelineLayout3,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline16 = await device0.createRenderPipelineAsync({
+label: '\u0565\uc278\u7cfd\uc540\u06be\u78e0\u00d3\u009e\u9add',
+layout: 'auto',
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.ALPHA}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rg16uint'}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'src'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+}
+}]
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 2640,
+attributes: [{
+format: 'float32',
+offset: 1800,
+shaderLocation: 15,
+}, {
+format: 'unorm8x2',
+offset: 2398,
+shaderLocation: 3,
+}, {
+format: 'float32',
+offset: 1080,
+shaderLocation: 7,
+}, {
+format: 'sint8x4',
+offset: 660,
+shaderLocation: 4,
+}, {
+format: 'unorm10-10-10-2',
+offset: 1476,
+shaderLocation: 6,
+}, {
+format: 'float16x2',
+offset: 860,
+shaderLocation: 12,
+}, {
+format: 'unorm10-10-10-2',
+offset: 220,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 2284,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x2',
+offset: 2252,
+shaderLocation: 0,
+}, {
+format: 'float16x2',
+offset: 1188,
+shaderLocation: 14,
+}, {
+format: 'sint8x4',
+offset: 0,
+shaderLocation: 5,
+}, {
+format: 'sint8x2',
+offset: 1944,
+shaderLocation: 11,
+}, {
+format: 'uint8x2',
+offset: 2158,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 3528,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 2356,
+shaderLocation: 10,
+}, {
+format: 'snorm8x2',
+offset: 684,
+shaderLocation: 16,
+}, {
+format: 'unorm8x4',
+offset: 3212,
+shaderLocation: 8,
+}, {
+format: 'unorm8x2',
+offset: 1830,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 2468,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x2',
+offset: 68,
+shaderLocation: 9,
+}],
+}
+]
+},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageBitmap3 = await createImageBitmap(imageData2);
+let shaderModule3 = device0.createShaderModule({
+label: '\u0399\u07a2',
+code: `@group(0) @binding(1779)
+var<storage, read_write> global2: array<u32>;
+@group(0) @binding(2519)
+var<storage, read_write> function1: array<u32>;
+
+@compute @workgroup_size(1, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @location(1) f1: vec4<f32>,
+  @location(2) f2: vec2<u32>,
+  @location(4) f3: vec4<f32>,
+  @builtin(frag_depth) f4: f32,
+  @location(3) f5: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(13) a0: vec3<f32>, @location(5) a1: i32, @builtin(instance_index) a2: u32, @location(6) a3: vec2<f32>, @location(3) a4: vec2<f16>, @location(12) a5: vec2<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+try {
+renderBundleEncoder8.setVertexBuffer(81, undefined, 2643834733, 963256047);
+} catch {}
+let buffer5 = device0.createBuffer({
+  label: '\u56b9\u0859\ud6e1',
+  size: 56138,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE
+});
+let texture24 = device0.createTexture({
+size: [320, 128, 1],
+mipLevelCount: 8,
+format: 'astc-10x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x8-unorm', 'astc-10x8-unorm'],
+});
+let textureView22 = texture14.createView({
+  label: '\u9534\u103b\ua46a\uebbc\ud73a',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 2,
+  baseArrayLayer: 85
+});
+let computePassEncoder9 = commandEncoder7.beginComputePass({label: '\ua36c\u{1f7d5}\u06cd\u5598\u1a99'});
+try {
+renderBundleEncoder9.draw(0);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 52260, new Int16Array(52700), 6880, 1380);
+} catch {}
+let texture25 = device0.createTexture({
+label: '\u00a8\u01c3\u5a7f\u0656\u5ede\u94ea',
+size: {width: 66, height: 1, depthOrArrayLayers: 88},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['r16sint', 'r16sint', 'r16sint'],
+});
+try {
+renderBundleEncoder9.setPipeline(pipeline5);
+} catch {}
+canvas0.width = 382;
+let texture26 = device0.createTexture({
+label: '\u0113\u2d6b\u3f77\u3c9f\u03a8\u92fa\u2991\u9111\u{1f859}',
+size: {width: 5310, height: 1, depthOrArrayLayers: 133},
+mipLevelCount: 4,
+format: 'rgba8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderBundleEncoder6.drawIndexed(0, 16, 0, 32);
+} catch {}
+try {
+  await buffer3.mapAsync(GPUMapMode.WRITE, 36128);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 855, y: 1, z: 17 },
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer0), /* required buffer size: 2510107 */
+{offset: 967, bytesPerRow: 310, rowsPerImage: 71}, {width: 36, height: 0, depthOrArrayLayers: 115});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 1, depthOrArrayLayers: 5}
+*/
+{
+  source: img2,
+  origin: { x: 208, y: 106 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 2 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let querySet8 = device0.createQuerySet({
+label: '\u0e05\u6460\u13b7\u2ee9\uafee\u0a34\u258c\u8623\u9cbf',
+type: 'occlusion',
+count: 3797,
+});
+let textureView23 = texture5.createView({baseMipLevel: 2, mipLevelCount: 1});
+let promise3 = device0.queue.onSubmittedWorkDone();
+let adapter1 = await navigator.gpu.requestAdapter({
+});
+let querySet9 = device0.createQuerySet({
+label: '\uf0cb\ufcbd\u{1fda4}\u585f\uf910\u6400',
+type: 'occlusion',
+count: 1364,
+});
+let renderBundle19 = renderBundleEncoder9.finish({label: '\u{1ff07}\ub37b\ud4ab\u86c8\u4b11'});
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup0, new Uint32Array(9413), 7150, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let bindGroupLayout5 = device0.createBindGroupLayout({
+label: '\u09b2\u0757',
+entries: [{
+binding: 169,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+let commandEncoder8 = device0.createCommandEncoder({label: '\u7920\u{1fb2f}\u{1fe93}\u{1fda2}\u971a\u0143\u244f'});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\u{1ff00}\ueabe\u4b7e\u2119\u{1fca7}\u0f68\u3059\u06b9\ubccd',
+  colorFormats: ['rgba8sint', 'bgra8unorm', 'rg8uint', 'r16float', 'r16float'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder8.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(56, undefined, 1564435042, 240718050);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+commandEncoder8.copyBufferToBuffer(buffer2, 8236, buffer5, 25692, 12328);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+device: device0,
+format: 'astc-10x6-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-10x6-unorm-srgb', 'astc-10x6-unorm-srgb'],
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 45300, new BigUint64Array(46536), 14371, 680);
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+let bindGroup4 = device0.createBindGroup({
+layout: bindGroupLayout1,
+entries: [{
+binding: 1779,
+resource: sampler7
+}, {
+binding: 2519,
+resource: sampler0
+}],
+});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({
+  label: '\u073e\uede0\u{1ffb9}\uac60\uee78\u{1fa91}',
+  colorFormats: ['rgba32sint', 'r16uint', 'rg16sint', 'rg16uint', 'rg16uint', 'bgra8unorm'],
+  stencilReadOnly: false
+});
+let renderBundle20 = renderBundleEncoder8.finish({label: '\u3927\u{1f6e1}\u0719\u029b\u1361\u0091'});
+let sampler10 = device0.createSampler({
+label: '\u03df\u0ee6',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 98.083,
+lodMaxClamp: 99.730,
+maxAnisotropy: 19,
+});
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+renderBundleEncoder6.draw(40, 72, 16, 64);
+} catch {}
+try {
+renderBundleEncoder6.drawIndexed(32, 32, 56, 120, 48);
+} catch {}
+try {
+commandEncoder5.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 6,
+  origin: { x: 5, y: 5, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 272 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 27392 */
+offset: 27392,
+buffer: buffer5,
+}, {width: 85, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+let promise5 = device0.createComputePipelineAsync({
+label: '\u0fc8\u322a\u5c71\u08c8\u{1f8fe}\u{1f631}\u64c6\uf1eb\u01df\u3963',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+},
+});
+let bindGroup5 = device0.createBindGroup({
+label: '\u4fec\u6740\u{1f7a8}\u0e33',
+layout: bindGroupLayout3,
+entries: [],
+});
+let buffer6 = device0.createBuffer({label: '\u8447\u72a8\u34a0\u0471', size: 41520, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder9 = device0.createCommandEncoder({label: '\u{1fa4b}\u4660\u1726'});
+let texture27 = gpuCanvasContext2.getCurrentTexture();
+let textureView24 = texture10.createView({label: '\u3f72\u096a', dimension: '2d', baseMipLevel: 11, baseArrayLayer: 27});
+let renderBundle21 = renderBundleEncoder8.finish({label: '\u0fad\u2962\u11c6\u0412\ua9cf\udc93'});
+try {
+renderBundleEncoder6.setPipeline(pipeline16);
+} catch {}
+try {
+commandEncoder8.copyBufferToBuffer(buffer2, 12612, buffer6, 25996, 5384);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder8.copyTextureToBuffer({
+  texture: texture27,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 35552 */
+offset: 35552,
+buffer: buffer6,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder5.resolveQuerySet(querySet2, 1908, 0, buffer5, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 48, y: 0, z: 17 },
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 2185726 */
+{offset: 886, bytesPerRow: 170, rowsPerImage: 204}, {width: 15, height: 0, depthOrArrayLayers: 64});
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+label: '\u{1fcd2}\u{1fc0c}\u0660\ub523\u0244\u{1f786}\uf6e3\u{1ff9f}',
+code: `@group(2) @binding(2456)
+var<storage, read_write> parameter4: array<u32>;
+@group(5) @binding(426)
+var<storage, read_write> function2: array<u32>;
+@group(6) @binding(579)
+var<storage, read_write> function3: array<u32>;
+@group(0) @binding(927)
+var<storage, read_write> i3: array<u32>;
+@group(6) @binding(426)
+var<storage, read_write> type1: array<u32>;
+@group(3) @binding(2519)
+var<storage, read_write> function4: array<u32>;
+@group(1) @binding(927)
+var<storage, read_write> global3: array<u32>;
+@group(0) @binding(579)
+var<storage, read_write> parameter5: array<u32>;
+@group(1) @binding(579)
+var<storage, read_write> field4: array<u32>;
+@group(0) @binding(426)
+var<storage, read_write> type2: array<u32>;
+@group(6) @binding(927)
+var<storage, read_write> function5: array<u32>;
+@group(3) @binding(1779)
+var<storage, read_write> i4: array<u32>;
+@group(5) @binding(579)
+var<storage, read_write> function6: array<u32>;
+@group(1) @binding(426)
+var<storage, read_write> function7: array<u32>;
+@group(7) @binding(2456)
+var<storage, read_write> function8: array<u32>;
+@group(5) @binding(927)
+var<storage, read_write> local1: array<u32>;
+@group(4) @binding(2519)
+var<storage, read_write> i5: array<u32>;
+@group(4) @binding(1779)
+var<storage, read_write> parameter6: array<u32>;
+
+@compute @workgroup_size(8, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S3 {
+  @location(82) f0: vec3<u32>,
+  @location(54) f1: f32,
+  @location(1) f2: vec2<f16>,
+  @location(69) f3: vec4<i32>,
+  @location(41) f4: vec4<f32>,
+  @location(35) f5: vec4<i32>,
+  @location(43) f6: vec3<i32>,
+  @builtin(front_facing) f7: bool,
+  @location(65) f8: vec4<i32>,
+  @location(45) f9: vec4<u32>,
+  @location(104) f10: f32,
+  @location(57) f11: f32,
+  @builtin(position) f12: vec4<f32>,
+  @location(64) f13: vec3<f16>,
+  @location(100) f14: vec4<f16>,
+  @location(58) f15: u32,
+  @location(77) f16: vec3<f16>,
+  @location(98) f17: vec3<f32>,
+  @location(50) f18: vec4<f32>,
+  @location(85) f19: u32,
+  @location(59) f20: f16,
+  @location(61) f21: vec2<u32>,
+  @location(60) f22: vec4<f16>,
+  @location(2) f23: f16,
+  @location(94) f24: vec3<i32>,
+  @location(42) f25: vec4<i32>,
+  @location(40) f26: vec3<u32>,
+  @location(49) f27: vec3<u32>,
+  @builtin(sample_index) f28: u32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @builtin(sample_mask) f1: u32
+}
+
+@fragment
+fn fragment0(a0: S3, @location(14) a1: i32, @location(34) a2: u32, @location(47) a3: f32, @location(107) a4: vec3<f32>, @location(90) a5: vec3<f16>, @location(84) a6: vec2<u32>, @location(89) a7: vec3<u32>, @location(22) a8: vec2<f16>, @location(19) a9: vec2<u32>, @location(86) a10: i32, @location(103) a11: vec4<f32>, @builtin(sample_mask) a12: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(47) f40: f32,
+  @location(82) f41: vec3<u32>,
+  @location(43) f42: vec3<i32>,
+  @location(69) f43: vec4<i32>,
+  @location(77) f44: vec3<f16>,
+  @location(85) f45: u32,
+  @location(49) f46: vec3<u32>,
+  @location(2) f47: f16,
+  @location(94) f48: vec3<i32>,
+  @location(57) f49: f32,
+  @location(61) f50: vec2<u32>,
+  @location(107) f51: vec3<f32>,
+  @location(54) f52: f32,
+  @location(98) f53: vec3<f32>,
+  @location(90) f54: vec3<f16>,
+  @location(84) f55: vec2<u32>,
+  @location(41) f56: vec4<f32>,
+  @location(103) f57: vec4<f32>,
+  @location(34) f58: u32,
+  @location(89) f59: vec3<u32>,
+  @location(40) f60: vec3<u32>,
+  @location(86) f61: i32,
+  @location(50) f62: vec4<f32>,
+  @location(42) f63: vec4<i32>,
+  @location(64) f64: vec3<f16>,
+  @location(60) f65: vec4<f16>,
+  @builtin(position) f66: vec4<f32>,
+  @location(22) f67: vec2<f16>,
+  @location(14) f68: i32,
+  @location(35) f69: vec4<i32>,
+  @location(104) f70: f32,
+  @location(58) f71: u32,
+  @location(100) f72: vec4<f16>,
+  @location(59) f73: f16,
+  @location(45) f74: vec4<u32>,
+  @location(19) f75: vec2<u32>,
+  @location(65) f76: vec4<i32>,
+  @location(1) f77: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec4<f16>, @location(0) a1: i32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandBuffer0 = commandEncoder5.finish({
+label: '\u0dd5\u{1f805}\uf616\u1bfa\u{1f833}\u{1fee4}\u{1f843}\u{1f841}\uf538\u{1fc6d}\udd14',
+});
+let texture28 = device0.createTexture({
+size: {width: 640, height: 256, depthOrArrayLayers: 70},
+mipLevelCount: 1,
+sampleCount: 1,
+dimension: '3d',
+format: 'r32sint',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['r32sint', 'r32sint', 'r32sint'],
+});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup5, new Uint32Array(1043), 1027, 0);
+} catch {}
+try {
+commandEncoder8.copyBufferToBuffer(buffer2, 26652, buffer6, 34884, 6540);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder8.copyBufferToTexture({
+/* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 22932 */
+offset: 22932,
+buffer: buffer2,
+}, {
+  texture: texture12,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 2600, new Float32Array(37757), 19645, 5816);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(9, bindGroup3, []);
+} catch {}
+try {
+renderBundleEncoder6.draw(72, 24);
+} catch {}
+try {
+renderBundleEncoder6.drawIndexed(72, 0);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder9.clearBuffer(buffer5, 17940, 2176);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 47336, new Int16Array(39832), 20096, 2940);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 66, height: 1, depthOrArrayLayers: 88}
+*/
+{
+  source: canvas1,
+  origin: { x: 473, y: 82 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 4, y: 0, z: 30 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 22, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline17 = device0.createComputePipeline({
+label: '\u041e\u075b\ue066\u0d9d\u0363\u0653\u0f33',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let offscreenCanvas1 = new OffscreenCanvas(249, 170);
+let bindGroupLayout6 = device0.createBindGroupLayout({
+label: '\u848e\ud4b1\u0549\u{1ff34}\ua289\u{1ffeb}\u00c0\u0e08\u2da5\u0797',
+entries: [{
+binding: 2290,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+}, {
+binding: 785,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+}, {
+binding: 1406,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}],
+});
+let buffer7 = device0.createBuffer({
+  label: '\u0bc4\u{1fc60}\u0b76\u4fba\u627b\u{1ff61}\u0aa4\uc31c\ud5a2',
+  size: 54661,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+pseudoSubmit(device0, commandEncoder3);
+let renderBundle22 = renderBundleEncoder4.finish();
+let sampler11 = device0.createSampler({
+label: '\u4e42\ueee8\u4df1\u05e5\u1128\u74f3\u{1f8c1}\u861a\u60e2',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 37.627,
+lodMaxClamp: 44.704,
+maxAnisotropy: 3,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'stencil-only',
+}, new ArrayBuffer(881), /* required buffer size: 881 */
+{offset: 881, bytesPerRow: 733}, {width: 552, height: 16, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 33, height: 1, depthOrArrayLayers: 44}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 91, y: 216 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 1,
+  origin: { x: 25, y: 0, z: 30 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline18 = await promise5;
+let video0 = await videoWithData();
+let videoFrame2 = new VideoFrame(video0, {timestamp: 0});
+let texture29 = device0.createTexture({
+label: '\ua9bd\u{1fca9}\u{1ff6c}\uc955\u35dd\u{1ffb1}\ue25f',
+size: [1104, 32, 1],
+mipLevelCount: 4,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder10 = commandEncoder9.beginComputePass({label: '\u06d1\u0505\u0f23\u5097\u0167\uaa5b\uc643\u6a8f'});
+let sampler12 = device0.createSampler({
+label: '\u{1f73f}\u0261\u7897\u22b6',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 26.204,
+lodMaxClamp: 27.414,
+});
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup2, []);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(34, undefined, 331883197);
+} catch {}
+try {
+buffer0.destroy();
+} catch {}
+try {
+commandEncoder8.copyBufferToBuffer(buffer3, 15936, buffer5, 55908, 12);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let texture30 = device0.createTexture({
+label: '\u{1fd57}\u67c7\u03ba\u5c51\u562e\u0c2c\u{1fae7}\u0d5d\u7baa\u553c',
+size: {width: 140, height: 25, depthOrArrayLayers: 227},
+mipLevelCount: 7,
+format: 'astc-10x5-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x5-unorm-srgb', 'astc-10x5-unorm', 'astc-10x5-unorm-srgb'],
+});
+let textureView25 = texture2.createView({label: '\u208a\u056f', dimension: '2d', baseMipLevel: 1, baseArrayLayer: 23});
+try {
+computePassEncoder9.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(41, undefined, 3844956226, 100929316);
+} catch {}
+try {
+commandEncoder8.copyBufferToBuffer(buffer2, 3468, buffer6, 30352, 9964);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder8.resolveQuerySet(querySet8, 1013, 471, buffer5, 11008);
+} catch {}
+document.body.prepend(canvas2);
+let textureView26 = texture1.createView({label: '\u{1faed}\u9f06\u0e21\u{1ff87}\u042b\u0086\u{1fb02}\u85d1\u2bdf\ued3b\u0f0d'});
+let computePassEncoder11 = commandEncoder8.beginComputePass({label: '\u{1ff76}\u9811\u0abc\uc20c\u8f26\u3703\u7b5b\u2d0b\u5e42\ub64c\u5a82'});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  label: '\u0642\uff48\u08fc\ue4a1\u0692\u07ae\ua69f\u094e',
+  colorFormats: ['rgba8sint', 'bgra8unorm', 'rg8uint', 'r16float', 'r16float'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+let renderBundle23 = renderBundleEncoder11.finish({label: '\uab46\u632e\u0d36\u43a3\u7255\uea6f'});
+try {
+renderBundleEncoder6.setVertexBuffer(75, undefined, 731747079, 1252468608);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer0,
+]);
+} catch {}
+let canvas3 = document.createElement('canvas');
+let textureView27 = texture10.createView({label: '\ua8de\u022e\u0faf\ubf69', dimension: '2d', mipLevelCount: 6, baseArrayLayer: 14, arrayLayerCount: 1});
+let sampler13 = device0.createSampler({
+label: '\u5af7\u1097\uc408',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 68.935,
+lodMaxClamp: 97.066,
+});
+let externalTexture2 = device0.importExternalTexture({
+label: '\u0688\ue490',
+source: videoFrame1,
+colorSpace: 'srgb',
+});
+try {
+computePassEncoder6.setPipeline(pipeline0);
+} catch {}
+let pipeline19 = device0.createComputePipeline({
+label: '\u{1f6aa}\u8ecc\u{1fe7d}\u{1f629}\u{1fa5b}\u0245\u0387\ud443\u{1f853}\u{1fbd6}',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let canvas4 = document.createElement('canvas');
+let imageData3 = new ImageData(96, 72);
+let commandEncoder10 = device0.createCommandEncoder({label: '\u{1fbab}\u{1fd08}\uac7d\u01ae\uc33b\u4c68'});
+let texture31 = device0.createTexture({
+size: {width: 80, height: 32, depthOrArrayLayers: 1},
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgba8unorm'],
+});
+let textureView28 = texture17.createView({label: '\u0f98\u{1f96b}\u0cf8\u0fc6\u005b\ue13d', format: 'rgba8unorm-srgb', baseArrayLayer: 0});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  label: '\u{1fb7e}\u030b\u969b\uef3d\u04f8\u00ec\u853d',
+  colorFormats: ['rg8uint', undefined, 'rgba32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder13.setBindGroup(5, bindGroup3);
+} catch {}
+try {
+commandEncoder10.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let texture32 = device0.createTexture({
+size: {width: 2208, height: 64, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x8-unorm-srgb', 'astc-8x8-unorm', 'astc-8x8-unorm-srgb'],
+});
+let textureView29 = texture25.createView({label: '\u753f\u0b2b\u9962', dimension: '3d', mipLevelCount: 1, arrayLayerCount: 1});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({
+  colorFormats: ['rg32sint', 'r32sint', 'bgra8unorm', 'rg11b10ufloat'],
+  sampleCount: 4,
+  depthReadOnly: false
+});
+try {
+renderBundleEncoder6.draw(48, 80);
+} catch {}
+try {
+commandEncoder10.resolveQuerySet(querySet8, 3095, 66, buffer5, 20480);
+} catch {}
+let computePassEncoder12 = commandEncoder10.beginComputePass();
+try {
+renderBundleEncoder6.draw(32, 8, 64, 56);
+} catch {}
+let arrayBuffer1 = buffer3.getMappedRange(37544, 4);
+let promise6 = device0.queue.onSubmittedWorkDone();
+let pipeline20 = device0.createRenderPipeline({
+label: '\u4f7c\u44ee\u4d0f\ua3fa\u0b80\u5c04\u88b8\u5c2b\ub3d2\u0537\ufec9',
+layout: pipelineLayout1,
+fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less',
+depthFailOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilWriteMask: 2168,
+depthBias: 3,
+depthBiasSlopeScale: 68,
+depthBiasClamp: 45,
+},
+vertex: {
+  module: shaderModule4,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 2892,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 1676,
+shaderLocation: 6,
+}, {
+format: 'sint32x2',
+offset: 724,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+},
+});
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+label: '\ufb97\u{1f847}\u4403\u{1fb75}\u0c09\u0189\u02f7\u6980\u8b68',
+code: `@group(0) @binding(579)
+var<storage, read_write> i6: array<u32>;
+@group(3) @binding(2519)
+var<storage, read_write> field5: array<u32>;
+@group(6) @binding(579)
+var<storage, read_write> global4: array<u32>;
+@group(5) @binding(927)
+var<storage, read_write> i7: array<u32>;
+@group(3) @binding(1779)
+var<storage, read_write> function9: array<u32>;
+@group(0) @binding(927)
+var<storage, read_write> i8: array<u32>;
+@group(5) @binding(426)
+var<storage, read_write> type3: array<u32>;
+@group(6) @binding(426)
+var<storage, read_write> global5: array<u32>;
+@group(4) @binding(2519)
+var<storage, read_write> function10: array<u32>;
+@group(1) @binding(579)
+var<storage, read_write> global6: array<u32>;
+@group(7) @binding(2456)
+var<storage, read_write> global7: array<u32>;
+@group(6) @binding(927)
+var<storage, read_write> type4: array<u32>;
+@group(0) @binding(426)
+var<storage, read_write> local2: array<u32>;
+@group(1) @binding(927)
+var<storage, read_write> global8: array<u32>;
+@group(4) @binding(1779)
+var<storage, read_write> parameter7: array<u32>;
+@group(5) @binding(579)
+var<storage, read_write> type5: array<u32>;
+
+@compute @workgroup_size(4, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S5 {
+  @builtin(sample_mask) f0: u32,
+  @builtin(sample_index) f1: u32
+}
+struct FragmentOutput0 {
+  @location(4) f0: vec2<u32>,
+  @location(3) f1: vec3<u32>,
+  @location(0) f2: vec4<i32>,
+  @location(2) f3: vec3<i32>,
+  @location(5) f4: vec4<f32>,
+  @location(1) f5: vec2<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(front_facing) a1: bool, a2: S5) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S4 {
+  @location(13) f0: vec4<i32>
+}
+
+@vertex
+fn vertex0(a0: S4, @location(1) a1: vec2<u32>, @location(0) a2: vec4<i32>, @builtin(vertex_index) a3: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let texture33 = device0.createTexture({
+label: '\u{1fc96}\u0354',
+size: {width: 216, height: 5, depthOrArrayLayers: 53},
+mipLevelCount: 4,
+format: 'astc-6x5-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundle24 = renderBundleEncoder12.finish({label: '\uc641\u53db\u681f\u5499\ub6d2\ubb6f\u0e27\u{1fff4}\u03ee\u{1fed0}\u0632'});
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+renderBundleEncoder6.drawIndexed(8);
+} catch {}
+try {
+renderBundleEncoder6.insertDebugMarker('\ue010');
+} catch {}
+try {
+  await promise3;
+} catch {}
+document.body.prepend(img5);
+let bindGroupLayout7 = device0.createBindGroupLayout({
+label: '\u4c5f\u8ee7\u{1f6dd}\ua6b6\u{1f65f}\u86ef\uaeac\u0c4b\ufc10\u0358\u0d7f',
+entries: [{
+binding: 1668,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 155530, hasDynamicOffset: false },
+}],
+});
+let texture34 = device0.createTexture({
+label: '\u{1fed0}\u8c5f\u70f9\u0163\u{1fe50}',
+size: {width: 33},
+dimension: '1d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({
+  label: '\u{1f845}\ueb7b\u09b6\u{1f942}',
+  colorFormats: ['rg8uint', undefined, 'rgba32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let sampler14 = device0.createSampler({
+label: '\ue406\u{1f8a0}\u9571\uf71e\u0ca4',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 59.942,
+lodMaxClamp: 93.890,
+});
+try {
+computePassEncoder4.setBindGroup(6, bindGroup0, new Uint32Array(1260), 623, 0);
+} catch {}
+try {
+renderBundleEncoder6.draw(40, 16, 32, 72);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(34, undefined, 695247767, 1734167893);
+} catch {}
+let arrayBuffer2 = buffer3.getMappedRange(37552, 56);
+try {
+commandEncoder7.copyBufferToTexture({
+/* bytesInLastRow: 552 widthInBlocks: 552 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 7704 */
+offset: 7704,
+bytesPerRow: 1024,
+buffer: buffer2,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'stencil-only',
+}, {width: 552, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder7.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let imageData4 = new ImageData(244, 52);
+let commandEncoder11 = device0.createCommandEncoder({label: '\u0aab\u907b\u9be3\u2257\u00ee\u0ac3\u0183'});
+try {
+renderBundleEncoder6.drawIndexed(48, 8, 8, 800);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(1, undefined, 1594311772, 504523612);
+} catch {}
+let arrayBuffer3 = buffer3.getMappedRange(37608, 0);
+try {
+commandEncoder11.resolveQuerySet(querySet9, 1285, 17, buffer5, 20736);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas1.getContext('webgl');
+} catch {}
+let querySet10 = device0.createQuerySet({
+type: 'occlusion',
+count: 1028,
+});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  label: '\u2a9a\u{1fce6}\u3fe3\u1a82\u0c8a\uca6d\u0df9\u0b78\ue8bb',
+  colorFormats: ['rgba32sint', 'r16uint', 'rg16sint', 'rg16uint', 'rg16uint', 'bgra8unorm']
+});
+try {
+computePassEncoder6.setBindGroup(4, bindGroup1, new Uint32Array(2429), 1180, 0);
+} catch {}
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+renderBundleEncoder6.drawIndexed(56, 80, 0, 96);
+} catch {}
+let pipeline21 = device0.createRenderPipeline({
+label: '\u{1fbc3}\u9547\u0d3d\u{1fc04}\ua511\u0aa1\uf926\u09a5\u0ef5\u5a98',
+layout: pipelineLayout0,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: 0}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rg16uint', writeMask: 0}, {format: 'rg16uint', writeMask: 0}, {format: 'bgra8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'equal',
+failOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'invert',
+},
+stencilReadMask: 3290,
+depthBias: 95,
+depthBiasClamp: 37,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 3720,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 4140,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 326,
+shaderLocation: 16,
+}, {
+format: 'float32',
+offset: 996,
+shaderLocation: 11,
+}, {
+format: 'snorm8x4',
+offset: 1220,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 3228,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 3220,
+shaderLocation: 14,
+}, {
+format: 'unorm10-10-10-2',
+offset: 196,
+shaderLocation: 15,
+}, {
+format: 'uint8x4',
+offset: 2904,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 3016,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 5188,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 5992,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x4',
+offset: 2540,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let video1 = await videoWithData();
+try {
+adapter1.label = '\u01d6\u2bd9\u42a4\u07fe\u{1f811}\ub220\u3ba7';
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+label: '\u02bb\u0f28\u4cf2\u{1f943}\u0db8',
+layout: bindGroupLayout5,
+entries: [{
+binding: 169,
+resource: externalTexture0
+}],
+});
+let commandBuffer1 = commandEncoder7.finish({
+label: '\u0286\u{1fa1e}\u0c5c\uc88d\ua640\u6f4c\u0248\u{1fb84}\u{1f9f2}\u0655',
+});
+let computePassEncoder13 = commandEncoder6.beginComputePass({label: '\u83d8\u7c8a\u7f8b\u0d0f\udacb\u428d\u359d'});
+try {
+computePassEncoder11.setBindGroup(4, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder6.draw(32, 48);
+} catch {}
+try {
+renderBundleEncoder6.drawIndexed(8, 40, 56, 360, 48);
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(querySet0, 3, 469, buffer5, 3328);
+} catch {}
+let texture35 = device0.createTexture({
+size: [5, 30, 92],
+mipLevelCount: 5,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-5x5-unorm-srgb', 'astc-5x5-unorm-srgb'],
+});
+let renderBundle25 = renderBundleEncoder15.finish({label: '\u73e1\ufa8a\u{1f644}\u0955\u{1fc6a}\u197c\u2887\u60f8\u9352'});
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 2,
+  origin: { x: 321, y: 1, z: 7 },
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 23738615 */
+{offset: 791, bytesPerRow: 3894, rowsPerImage: 127}, {width: 946, height: 0, depthOrArrayLayers: 49});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: canvas1,
+  origin: { x: 353, y: 138 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 5,
+  origin: { x: 2, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture36 = device0.createTexture({
+label: '\ufaa6\u{1fc38}\ud356',
+size: [640],
+dimension: '1d',
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['r32sint', 'r32sint'],
+});
+try {
+commandEncoder11.copyBufferToBuffer(buffer7, 29920, buffer6, 12016, 6352);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder11.copyTextureToBuffer({
+  texture: texture31,
+  mipLevel: 0,
+  origin: { x: 13, y: 9, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 47552 */
+offset: 42412,
+bytesPerRow: 256,
+buffer: buffer5,
+}, {width: 5, height: 21, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let gpuCanvasContext3 = canvas4.getContext('webgpu');
+let shaderModule6 = device0.createShaderModule({
+code: `@group(4) @binding(2456)
+var<storage, read_write> parameter8: array<u32>;
+@group(1) @binding(2456)
+var<storage, read_write> local3: array<u32>;
+@group(2) @binding(2456)
+var<storage, read_write> type6: array<u32>;
+@group(6) @binding(2456)
+var<storage, read_write> global9: array<u32>;
+@group(3) @binding(2456)
+var<storage, read_write> parameter9: array<u32>;
+@group(5) @binding(2456)
+var<storage, read_write> field6: array<u32>;
+@group(7) @binding(2456)
+var<storage, read_write> i9: array<u32>;
+@group(0) @binding(2456)
+var<storage, read_write> local4: array<u32>;
+
+@compute @workgroup_size(6, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec3<i32>,
+  @location(4) f1: vec4<u32>,
+  @builtin(sample_mask) f2: u32,
+  @location(3) f3: vec2<u32>,
+  @location(0) f4: vec4<i32>,
+  @location(5) f5: vec4<f32>,
+  @location(1) f6: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(12) a0: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder12 = device0.createCommandEncoder({});
+try {
+renderBundleEncoder6.drawIndexed(0, 72, 56, -480, 72);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 13380, new DataView(new ArrayBuffer(11385)), 9103, 792);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 2,
+  origin: { x: 828, y: 0, z: 22 },
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer3), /* required buffer size: 7817507 */
+{offset: 281, bytesPerRow: 2047, rowsPerImage: 46}, {width: 445, height: 1, depthOrArrayLayers: 84});
+} catch {}
+let pipeline22 = await device0.createRenderPipelineAsync({
+label: '\uc1b9\u{1f77c}\u2ebe\u{1fdbe}\u90b3\ufabe\u93a4',
+layout: pipelineLayout0,
+fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.BLUE}]
+},
+vertex: {
+  module: shaderModule4,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 3720,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 2128,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 1356,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 4028,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 5968,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x3',
+offset: 4648,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+try {
+canvas3.getContext('bitmaprenderer');
+} catch {}
+pseudoSubmit(device0, commandEncoder12);
+let renderBundle26 = renderBundleEncoder9.finish({label: '\u2c5a\u{1fcc0}\u0e3c'});
+try {
+renderBundleEncoder6.drawIndexed(8, 24);
+} catch {}
+try {
+commandEncoder11.copyBufferToBuffer(buffer2, 24384, buffer6, 32340, 5868);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let canvas5 = document.createElement('canvas');
+let commandBuffer2 = commandEncoder11.finish({
+label: '\u388c\u{1ff5e}\u{1ff61}\u5c3d\u1cca\u3495\ubddd',
+});
+let texture37 = gpuCanvasContext0.getCurrentTexture();
+let textureView30 = texture37.createView({label: '\ua9f9\u{1fde7}'});
+let renderBundle27 = renderBundleEncoder14.finish({label: '\u{1fa42}\u1faf'});
+let sampler15 = device0.createSampler({
+label: '\u0c3b\u{1fbdc}\u946f\u0763\u2729\u12db\u0c4c\u1c7e\u40d0\u3772\u0a31',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 1.653,
+});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder6.clearBuffer(buffer5, 7060, 42788);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 2,
+  origin: { x: 2, y: 0, z: 89 },
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer1), /* required buffer size: 137916 */
+{offset: 576, bytesPerRow: 42, rowsPerImage: 218}, {width: 2, height: 0, depthOrArrayLayers: 16});
+} catch {}
+let pipeline23 = device0.createComputePipeline({
+label: '\u{1f780}\u01ca\u0b0c\ufd30\u0723',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+},
+});
+let shaderModule7 = device0.createShaderModule({
+code: `@group(0) @binding(927)
+var<storage, read_write> field7: array<u32>;
+@group(2) @binding(2456)
+var<storage, read_write> function11: array<u32>;
+@group(6) @binding(579)
+var<storage, read_write> field8: array<u32>;
+@group(5) @binding(426)
+var<storage, read_write> global10: array<u32>;
+@group(1) @binding(426)
+var<storage, read_write> function12: array<u32>;
+@group(1) @binding(579)
+var<storage, read_write> type7: array<u32>;
+@group(4) @binding(1779)
+var<storage, read_write> field9: array<u32>;
+@group(1) @binding(927)
+var<storage, read_write> function13: array<u32>;
+@group(5) @binding(927)
+var<storage, read_write> i10: array<u32>;
+@group(0) @binding(579)
+var<storage, read_write> parameter10: array<u32>;
+@group(3) @binding(1779)
+var<storage, read_write> local5: array<u32>;
+@group(7) @binding(2456)
+var<storage, read_write> i11: array<u32>;
+@group(3) @binding(2519)
+var<storage, read_write> function14: array<u32>;
+
+@compute @workgroup_size(8, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(3) f1: vec4<f32>,
+  @location(0) f2: vec2<i32>,
+  @location(1) f3: i32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S6 {
+  @location(12) f0: vec2<f16>,
+  @location(13) f1: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec3<f16>, a1: S6) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let renderBundle28 = renderBundleEncoder12.finish({label: '\u1556\u{1fb98}\u7c15\u2bab\u8d7b'});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup5, []);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(9, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder6.drawIndexed(56, 32, 0, 456, 24);
+} catch {}
+try {
+commandEncoder6.copyTextureToBuffer({
+  texture: texture30,
+  mipLevel: 3,
+  origin: { x: 10, y: 0, z: 114 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 28096 */
+offset: 28096,
+bytesPerRow: 0,
+rowsPerImage: 243,
+buffer: buffer6,
+}, {width: 0, height: 5, depthOrArrayLayers: 19});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 4108, new BigUint64Array(37807), 37037, 148);
+} catch {}
+let computePassEncoder14 = commandEncoder6.beginComputePass();
+try {
+computePassEncoder10.setBindGroup(3, bindGroup3, new Uint32Array(1001), 675, 0);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder6.drawIndexed(64);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer2,
+commandBuffer1,
+]);
+} catch {}
+let pipeline24 = device0.createComputePipeline({
+label: '\ufe80\u3deb\u9d74\u2dd4\u580a\u0c72\u{1fb06}\ud581\u0daf\u709f',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let promise7 = device0.createRenderPipelineAsync({
+label: '\u5abd\u003f\u0b7c\ua30b\u333d\u02e7\ue012',
+layout: pipelineLayout3,
+multisample: {
+count: 4,
+mask: 0x28174d8d,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {format: 'r16uint', writeMask: 0}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rg16uint'}, {format: 'bgra8unorm', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 2868,
+stencilWriteMask: 2464,
+depthBias: 44,
+depthBiasSlopeScale: 22,
+depthBiasClamp: 77,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1832,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x4',
+offset: 1788,
+shaderLocation: 2,
+}, {
+format: 'sint16x4',
+offset: 1688,
+shaderLocation: 4,
+}, {
+format: 'sint32x2',
+offset: 76,
+shaderLocation: 5,
+}, {
+format: 'snorm16x4',
+offset: 20,
+shaderLocation: 3,
+}, {
+format: 'float16x4',
+offset: 1624,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 0,
+attributes: [{
+format: 'sint16x4',
+offset: 5856,
+shaderLocation: 0,
+}, {
+format: 'snorm16x4',
+offset: 28,
+shaderLocation: 8,
+}, {
+format: 'sint16x2',
+offset: 1572,
+shaderLocation: 11,
+}, {
+format: 'float16x4',
+offset: 5948,
+shaderLocation: 14,
+}, {
+format: 'unorm16x2',
+offset: 4096,
+shaderLocation: 7,
+}, {
+format: 'uint32',
+offset: 2020,
+shaderLocation: 9,
+}, {
+format: 'uint16x4',
+offset: 984,
+shaderLocation: 1,
+}, {
+format: 'snorm16x4',
+offset: 3904,
+shaderLocation: 15,
+}, {
+format: 'float32',
+offset: 2344,
+shaderLocation: 6,
+}, {
+format: 'float16x4',
+offset: 4096,
+shaderLocation: 13,
+}, {
+format: 'snorm16x4',
+offset: 4600,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 1296,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 6640,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x2',
+offset: 12,
+shaderLocation: 10,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+},
+});
+let gpuCanvasContext4 = canvas5.getContext('webgpu');
+let canvas6 = document.createElement('canvas');
+let commandEncoder13 = device0.createCommandEncoder();
+let renderBundle29 = renderBundleEncoder5.finish({label: '\u756e\u77f2\u312a'});
+try {
+renderBundleEncoder6.drawIndexed(48, 72, 16, -160, 64);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: { x: 0, y: 120, z: 0 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 1802 */
+{offset: 90, bytesPerRow: 160}, {width: 70, height: 110, depthOrArrayLayers: 1});
+} catch {}
+let textureView31 = texture7.createView({label: '\u5667\u0ac3\u00cd\u{1fba0}\u06c2\u0c1c\u8187\ub809', baseArrayLayer: 0});
+let sampler16 = device0.createSampler({
+label: '\u1aa9\u1fd9',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 88.894,
+lodMaxClamp: 89.567,
+});
+try {
+commandEncoder13.copyBufferToBuffer(buffer2, 3644, buffer6, 11660, 23460);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder13.copyBufferToTexture({
+/* bytesInLastRow: 3824 widthInBlocks: 239 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 37120 */
+offset: 37120,
+buffer: buffer7,
+}, {
+  texture: texture16,
+  mipLevel: 1,
+  origin: { x: 348, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 2868, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: { x: 7, y: 0, z: 22 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 7264691 */
+{offset: 807, bytesPerRow: 243, rowsPerImage: 282}, {width: 8, height: 1, depthOrArrayLayers: 107});
+} catch {}
+let bindGroupLayout8 = pipeline20.getBindGroupLayout(0);
+try {
+computePassEncoder11.setBindGroup(7, bindGroup6);
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder6.draw(32, 0, 48, 48);
+} catch {}
+try {
+renderBundleEncoder6.drawIndexed(56);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder13.copyBufferToTexture({
+/* bytesInLastRow: 2570 widthInBlocks: 2570 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 30599 */
+offset: 30599,
+buffer: buffer2,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 846, y: 1, z: 1 },
+  aspect: 'all',
+}, {width: 2570, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder13.clearBuffer(buffer5, 27660, 1016);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+renderBundleEncoder13.pushDebugGroup('\u{1f7a4}');
+} catch {}
+let gpuCanvasContext5 = canvas6.getContext('webgpu');
+let externalTexture3 = device0.importExternalTexture({
+label: '\u0225\u0cca\u07a2\u{1fad0}\u6493\u{1fa36}\u0f1e\u4ce7',
+source: video0,
+colorSpace: 'display-p3',
+});
+try {
+computePassEncoder11.setBindGroup(8, bindGroup0, new Uint32Array(9922), 3776, 0);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(80, undefined, 3174844130, 883394171);
+} catch {}
+try {
+computePassEncoder14.insertDebugMarker('\u030a');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 33, height: 1, depthOrArrayLayers: 44}
+*/
+{
+  source: img4,
+  origin: { x: 208, y: 82 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 1,
+  origin: { x: 8, y: 0, z: 14 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 22, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline25 = device0.createComputePipeline({
+label: '\u971e\u95ae\u0486\u0c69\u{1fe60}',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+},
+});
+video1.height = 260;
+gc();
+let buffer8 = device0.createBuffer({
+  label: '\u0753\ue2ab\u7c1e\u5850\ubd09\ue599\u7b97\ua747\u{1f7f5}',
+  size: 14108,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: true
+});
+try {
+renderBundleEncoder6.draw(72, 64);
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(querySet6, 420, 157, buffer5, 49408);
+} catch {}
+try {
+commandEncoder13.pushDebugGroup('\u{1fcdc}');
+} catch {}
+let adapter2 = await navigator.gpu.requestAdapter({
+});
+let renderBundle30 = renderBundleEncoder1.finish({label: '\u009f\u0899\u00bb'});
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer8, 'uint16', 1108, 8368);
+} catch {}
+try {
+commandEncoder13.copyTextureToBuffer({
+  texture: texture25,
+  mipLevel: 3,
+  origin: { x: 1, y: 0, z: 9 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 14 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 55322 */
+offset: 55308,
+buffer: buffer5,
+}, {width: 7, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 7, y: 240 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 6,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let device1 = await adapter2.requestDevice({
+label: '\u065b\u7c7e\u{1fbe4}\u2296\u78fc\u8e7a',
+});
+let querySet11 = device0.createQuerySet({
+label: '\u{1f6f4}\u{1fb85}\u30db\uf5c4\ua38f\uacf6',
+type: 'occlusion',
+count: 3549,
+});
+let textureView32 = texture12.createView({label: '\u{1f625}\ub413\ue9ab\u{1f749}\u{1fc2e}', baseMipLevel: 1, mipLevelCount: 2});
+try {
+renderBundleEncoder16.setIndexBuffer(buffer8, 'uint32', 10680, 2076);
+} catch {}
+try {
+renderBundleEncoder13.pushDebugGroup('\u0e0e');
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm', 'r32float', 'rg16float', 'bgra8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 31260, new DataView(new ArrayBuffer(52525)), 42011, 4696);
+} catch {}
+let video2 = await videoWithData();
+pseudoSubmit(device0, commandEncoder10);
+let textureView33 = texture30.createView({
+  label: '\u089d\udc54\u0edb\u084d\u8b01\u0904\u{1f666}\u0138\u39c5',
+  dimension: '2d-array',
+  format: 'astc-10x5-unorm-srgb',
+  baseMipLevel: 5,
+  baseArrayLayer: 6,
+  arrayLayerCount: 205
+});
+let computePassEncoder15 = commandEncoder2.beginComputePass({label: '\u5bee\uda63\u{1f680}\u0b6e\uaea7\u5718\u01ef'});
+let renderBundle31 = renderBundleEncoder2.finish({label: '\u08ee\u32e4\ufa03\uc4e1\u1c66\u0a04'});
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder16.draw(24);
+} catch {}
+try {
+renderBundleEncoder13.insertDebugMarker('\ud88d');
+} catch {}
+let imageBitmap4 = await createImageBitmap(offscreenCanvas0);
+let shaderModule8 = device0.createShaderModule({
+code: `@group(0) @binding(2519)
+var<storage, read_write> local6: array<u32>;
+@group(0) @binding(1779)
+var<storage, read_write> field10: array<u32>;
+
+@compute @workgroup_size(6, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec3<u32>,
+  @location(2) f1: vec2<i32>,
+  @location(1) f2: vec3<u32>,
+  @location(5) f3: vec4<f32>,
+  @location(4) f4: vec3<u32>,
+  @builtin(sample_mask) f5: u32,
+  @location(0) f6: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S7 {
+  @location(2) f0: vec4<i32>,
+  @location(4) f1: vec2<f16>,
+  @location(3) f2: vec3<f16>,
+  @location(1) f3: vec4<f16>,
+  @location(10) f4: vec3<u32>,
+  @location(11) f5: vec2<f32>,
+  @location(7) f6: f16,
+  @builtin(instance_index) f7: u32
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec2<f16>, @location(12) a1: vec2<f16>, @location(6) a2: i32, @location(13) a3: vec4<f16>, @builtin(vertex_index) a4: u32, @location(15) a5: vec2<i32>, @location(0) a6: vec4<u32>, @location(16) a7: vec3<u32>, @location(8) a8: vec2<f16>, a9: S7, @location(14) a10: vec3<i32>, @location(5) a11: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+try {
+renderBundleEncoder6.draw(0);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(buffer7, 19484, buffer6, 1436, 6488);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let sampler17 = device1.createSampler({
+label: '\u5dfc\u5c4a\u3fbe',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 58.440,
+lodMaxClamp: 66.463,
+});
+try {
+  await promise2;
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder();
+let renderBundle32 = renderBundleEncoder16.finish({});
+try {
+computePassEncoder6.setBindGroup(9, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder6.drawIndexed(56, 0, 40);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(buffer2, 44372, buffer5, 8932, 4);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 3,
+  origin: { x: 35, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture6,
+  mipLevel: 7,
+  origin: { x: 5, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 1, depthOrArrayLayers: 11}
+*/
+{
+  source: canvas2,
+  origin: { x: 226, y: 62 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 3,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas0.height = 750;
+gc();
+let commandEncoder15 = device1.createCommandEncoder({label: '\u3c33\u2fd4\u{1fd19}\u10a8\u5325\u{1f7b2}\u02b6\u06ac'});
+pseudoSubmit(device1, commandEncoder15);
+try {
+gpuCanvasContext0.configure({
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(859, 321);
+let buffer9 = device1.createBuffer({
+  label: '\u6359\ucca3\u{1f8b9}\u1cae',
+  size: 24762,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT
+});
+try {
+device1.queue.writeBuffer(buffer9, 9500, new DataView(new ArrayBuffer(59856)), 15259, 696);
+} catch {}
+let promise8 = device1.queue.onSubmittedWorkDone();
+gc();
+let commandEncoder16 = device1.createCommandEncoder();
+let renderBundleEncoder17 = device1.createRenderBundleEncoder({
+  colorFormats: ['rgba16float', 'r32float', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true
+});
+try {
+  await promise4;
+} catch {}
+let sampler18 = device1.createSampler({
+label: '\u861e\ufe11\u0e59\u0f04\u8988\uea88',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 55.250,
+lodMaxClamp: 92.214,
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let imageData5 = new ImageData(132, 132);
+try {
+computePassEncoder15.setBindGroup(7, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder6.drawIndexed(40, 64, 16, -96);
+} catch {}
+try {
+commandEncoder13.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 17664 */
+offset: 17664,
+bytesPerRow: 0,
+buffer: buffer6,
+}, {width: 0, height: 30, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(querySet10, 467, 417, buffer5, 33792);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer3), /* required buffer size: 633 */
+{offset: 633}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline26 = await promise7;
+gc();
+let texture38 = device1.createTexture({
+size: [1584, 1, 157],
+mipLevelCount: 4,
+format: 'depth24plus',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let texture39 = gpuCanvasContext0.getCurrentTexture();
+let renderBundle33 = renderBundleEncoder17.finish({label: '\ubddb\u1a1f'});
+let sampler19 = device1.createSampler({
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 62.497,
+maxAnisotropy: 15,
+});
+try {
+buffer9.unmap();
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer9, 8856, 2676);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+canvas3.width = 964;
+let buffer10 = device1.createBuffer({size: 47593, usage: GPUBufferUsage.STORAGE});
+let computePassEncoder16 = commandEncoder16.beginComputePass({});
+let externalTexture4 = device1.importExternalTexture({
+label: '\ubda4\uc7b5\u0e6a',
+source: videoFrame0,
+colorSpace: 'display-p3',
+});
+try {
+device1.pushErrorScope('internal');
+} catch {}
+canvas0.width = 958;
+let commandBuffer3 = commandEncoder14.finish({
+label: '\u0d9c\u5932\u0952\u{1f9b5}\u5830\u016e\u07c9',
+});
+let texture40 = device0.createTexture({
+label: '\u0822\u660d',
+size: [320, 128, 1],
+mipLevelCount: 2,
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-10x8-unorm-srgb', 'astc-10x8-unorm', 'astc-10x8-unorm-srgb'],
+});
+try {
+computePassEncoder14.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder6.drawIndexed(24, 24);
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture({
+  texture: texture15,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 151 },
+  aspect: 'all',
+}, {
+  texture: texture21,
+  mipLevel: 2,
+  origin: { x: 58, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 55, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(querySet4, 415, 562, buffer5, 47104);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 35444, new Int16Array(22015), 17999, 276);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let video3 = await videoWithData();
+let texture41 = device1.createTexture({
+label: '\u6bd8\u35a4\ubba5\u9e75\u{1f933}\ubb39',
+size: [1216, 160, 200],
+mipLevelCount: 8,
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let promise9 = device1.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let textureView34 = texture14.createView({
+  label: '\u{1f6d5}\u0a99\u6c22\u94b4\u{1feeb}\u{1fd1c}\u456c\u0560\ube5c\u0363\u4191',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  baseArrayLayer: 68,
+  arrayLayerCount: 46
+});
+try {
+renderBundleEncoder6.drawIndexed(32, 40, 32, 752);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(buffer7, 8616, buffer5, 21292, 13068);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder13.clearBuffer(buffer5, 10404, 1120);
+dissociateBuffer(device0, buffer5);
+} catch {}
+document.body.prepend(img4);
+let commandEncoder17 = device0.createCommandEncoder({label: '\u{1f93b}\u020c'});
+let renderBundle34 = renderBundleEncoder1.finish({label: '\uad35\u37b5\u078f\u0387\uc8ce\uf253\u{1fa73}\u{1f867}\u457b\u91d8'});
+try {
+computePassEncoder14.setBindGroup(6, bindGroup2, new Uint32Array(184), 177, 0);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(buffer3, 24868, buffer6, 28256, 9696);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let pipeline27 = await device0.createComputePipelineAsync({
+label: '\u4135\u02d8\u08d8\u3067\u7cd4',
+layout: 'auto',
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipelineLayout4 = device0.createPipelineLayout({
+  label: '\u0c52\u6373\u0477\uf0ed\uf4d9\u61fd',
+  bindGroupLayouts: [bindGroupLayout5, bindGroupLayout7, bindGroupLayout1, bindGroupLayout5, bindGroupLayout1]
+});
+try {
+renderBundleEncoder13.setBindGroup(9, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder6.draw(80);
+} catch {}
+try {
+renderBundleEncoder6.drawIndexed(48);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(38, undefined, 1474650485);
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(querySet2, 1057, 463, buffer8, 5888);
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout({
+entries: [{
+binding: 2491,
+visibility: 0,
+texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+}],
+});
+pseudoSubmit(device0, commandEncoder8);
+let renderBundle35 = renderBundleEncoder2.finish({label: '\ua4b1\u0ab6\u446e\u{1fa79}\u0461\u0398\u82b2\ued36\u024c'});
+try {
+computePassEncoder10.setBindGroup(6, bindGroup2, new Uint32Array(3147), 1126, 0);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder6.drawIndexed(72, 48);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer8, 'uint32', 13984, 21);
+} catch {}
+try {
+commandEncoder13.clearBuffer(buffer5, 4192, 17744);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+canvas4.height = 721;
+try {
+window.someLabel = sampler19.label;
+} catch {}
+let commandEncoder18 = device1.createCommandEncoder({label: '\u0514\u795f\u06c1\u{1fb38}\u09ce\ub251\u7515'});
+try {
+commandEncoder18.clearBuffer(buffer9, 22504, 2012);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+  await promise9;
+} catch {}
+gc();
+try {
+adapter1.label = '\ueeca\ua5e8\ua723\ua8f8';
+} catch {}
+try {
+commandEncoder18.copyTextureToTexture({
+  texture: texture41,
+  mipLevel: 2,
+  origin: { x: 125, y: 21, z: 9 },
+  aspect: 'all',
+}, {
+  texture: texture41,
+  mipLevel: 7,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 3,
+  origin: { x: 87, y: 1, z: 10 },
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(48)), /* required buffer size: 587 */
+{offset: 587, bytesPerRow: 271}, {width: 13, height: 16, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 9, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 1, y: 21 },
+  flipY: false,
+}, {
+  texture: texture41,
+  mipLevel: 7,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup7 = device0.createBindGroup({
+label: '\u1018\u7f6e\u{1fc09}\u6361',
+layout: bindGroupLayout2,
+entries: [{
+binding: 927,
+resource: {
+buffer: buffer4,
+offset: 9344,
+size: 8160,
+}
+}, {
+binding: 579,
+resource: {
+buffer: buffer4,
+offset: 5216,
+size: 4196,
+}
+}, {
+binding: 426,
+resource: sampler7
+}],
+});
+let commandBuffer4 = commandEncoder17.finish({
+label: '\ud671\u037a\u{1f744}\u5a52\u00c5\ufd2d\uf23a\u8075',
+});
+let textureView35 = texture3.createView({
+  label: '\u9e2b\uf73e\u0cea\u08f9\u{1fae2}\u0200\u0d91\u4834\u927c',
+  dimension: '2d',
+  format: 'astc-12x10-unorm-srgb',
+  baseMipLevel: 2,
+  baseArrayLayer: 66
+});
+let renderBundle36 = renderBundleEncoder3.finish();
+try {
+commandEncoder13.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 1,
+  origin: { x: 361, y: 0, z: 70 },
+  aspect: 'all',
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 1905, y: 0, z: 105 },
+  aspect: 'all',
+}, {width: 1785, height: 1, depthOrArrayLayers: 23});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: { x: 650, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 403 */
+{offset: 403}, {width: 197, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData6 = new ImageData(204, 20);
+let bindGroup8 = device0.createBindGroup({
+label: '\u02ba\u3568\u{1fade}\u083a\ufd4c\u{1fe34}\u{1fda5}\u85dd',
+layout: bindGroupLayout1,
+entries: [{
+binding: 2519,
+resource: sampler6
+}, {
+binding: 1779,
+resource: sampler5
+}],
+});
+let pipelineLayout5 = device0.createPipelineLayout({
+  label: '\u95a3\u{1fffb}\ua557\u013d',
+  bindGroupLayouts: [bindGroupLayout9, bindGroupLayout9, bindGroupLayout7, bindGroupLayout7, bindGroupLayout5, bindGroupLayout4]
+});
+pseudoSubmit(device0, commandEncoder9);
+let texture42 = device0.createTexture({
+label: '\u07da\u7775\ue6b8\u8fbb\u020f\u7305\u081a\u{1ffaa}\u{1fe7f}',
+size: [640, 256, 1],
+mipLevelCount: 4,
+sampleCount: 1,
+dimension: '2d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16uint', 'rgba16uint', 'rgba16uint'],
+});
+let textureView36 = texture5.createView({label: '\u00d6\u49e8\u0d44\u9d40\u0e50\u{1fa5f}\u{1f7ce}\u41bb', dimension: '2d-array', baseMipLevel: 2});
+try {
+computePassEncoder15.setBindGroup(6, bindGroup5, new Uint32Array(4989), 1237, 0);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(9, bindGroup3, []);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 43744, new Float32Array(51172), 3326, 164);
+} catch {}
+offscreenCanvas2.width = 675;
+let commandEncoder19 = device1.createCommandEncoder({label: '\u813a\u92f6\u{1ffaf}\ubecb\u0dd4\u0081\u049f\ub92d\u{1fb61}'});
+let renderBundleEncoder18 = device1.createRenderBundleEncoder({
+  label: '\u0989\uf463\u57ce\u{1fcdf}\ud4c1\u2642\u5cf9\u025b\ubfcc\u0354\ufa0d',
+  colorFormats: ['rgba16float', 'r32float', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+device1.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder19.copyTextureToTexture({
+  texture: texture41,
+  mipLevel: 1,
+  origin: { x: 433, y: 10, z: 86 },
+  aspect: 'all',
+}, {
+  texture: texture41,
+  mipLevel: 7,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 4, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 152, height: 20, depthOrArrayLayers: 25}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 98, y: 9 },
+  flipY: false,
+}, {
+  texture: texture41,
+  mipLevel: 3,
+  origin: { x: 47, y: 13, z: 15 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 20, height: 3, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext6 = offscreenCanvas2.getContext('webgpu');
+let texture43 = device1.createTexture({
+label: '\u06e3\ude44\u{1f7ee}\ub773',
+size: {width: 1680, height: 1, depthOrArrayLayers: 584},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r16sint', 'r16sint'],
+});
+let textureView37 = texture43.createView({
+  label: '\ua45b\u0610\u2618\u0dfd\u0426\u00b1\u{1f774}',
+  dimension: '3d',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 2
+});
+let computePassEncoder17 = commandEncoder18.beginComputePass({label: '\u{1f7c3}\u0d2d\u670c\u6c1c'});
+let renderBundleEncoder19 = device1.createRenderBundleEncoder({
+  label: '\u0df4\u407e\u009f\u5027\u5b51\u8ced',
+  colorFormats: ['rgba16float', 'r32float', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+document.body.prepend(canvas6);
+let renderBundleEncoder20 = device1.createRenderBundleEncoder({
+  label: '\u86ac\u0b84\u6c9c\u6904\u0db7\u0af8\u1e13\u0c9a\u01a5\u2674\u{1fee5}',
+  colorFormats: ['rgba16float', 'r32float', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1,
+  depthReadOnly: true
+});
+try {
+device1.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 3,
+  origin: { x: 0, y: 6, z: 1 },
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 402784 */
+{offset: 288, bytesPerRow: 316, rowsPerImage: 55}, {width: 57, height: 9, depthOrArrayLayers: 24});
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundleEncoder21 = device1.createRenderBundleEncoder({
+  label: '\uc006\u035f\u{1fa2e}\u97e6\ub6d8',
+  colorFormats: ['rgba16float', 'r32float', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: false
+});
+try {
+buffer9.unmap();
+} catch {}
+try {
+commandEncoder19.copyTextureToBuffer({
+  texture: texture41,
+  mipLevel: 7,
+  origin: { x: 8, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 23080 */
+offset: 23080,
+buffer: buffer9,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer9);
+} catch {}
+let video4 = await videoWithData();
+let renderBundle37 = renderBundleEncoder17.finish({label: '\ud187\u{1f6c4}\u{1f62e}\u0c37\udfee\u50e2\u6f03'});
+try {
+buffer9.unmap();
+} catch {}
+try {
+commandEncoder19.copyTextureToTexture({
+  texture: texture43,
+  mipLevel: 1,
+  origin: { x: 262, y: 0, z: 13 },
+  aspect: 'all',
+}, {
+  texture: texture43,
+  mipLevel: 2,
+  origin: { x: 33, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 110, height: 1, depthOrArrayLayers: 145});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 608, height: 80, depthOrArrayLayers: 100}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 12, y: 102 },
+  flipY: true,
+}, {
+  texture: texture41,
+  mipLevel: 1,
+  origin: { x: 259, y: 2, z: 89 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 173, height: 44, depthOrArrayLayers: 0});
+} catch {}
+canvas5.width = 884;
+let texture44 = device1.createTexture({
+label: '\u4721\u53ba\ue9ca\u2fc4\u0b85\u0c90\ud125\u{1fcf4}',
+size: {width: 6720, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'r8sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8sint', 'r8sint'],
+});
+try {
+renderBundleEncoder18.setIndexBuffer(buffer9, 'uint32');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer9, 19976, new Int16Array(38637), 30155, 1336);
+} catch {}
+let videoFrame3 = new VideoFrame(canvas4, {timestamp: 0});
+let commandEncoder20 = device1.createCommandEncoder();
+let textureView38 = texture38.createView({
+  label: '\ue896\u{1f670}\u19d6\u9d64\u90f9\ufe35\u0823\u{1fa15}\u232e\u04df',
+  dimension: '2d',
+  baseMipLevel: 3
+});
+let sampler20 = device1.createSampler({
+label: '\u0ad1\u0ca7\u{1fb8d}\u01b6\u10a7\u1ea8\u43e9\ueaf2\u0283\u36b6\u0b74',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 46.956,
+lodMaxClamp: 63.262,
+});
+let externalTexture5 = device1.importExternalTexture({
+label: '\uec17\u5348\u{1fce4}\ud006\u{1f6a3}\u{1fced}\u0979',
+source: video2,
+colorSpace: 'srgb',
+});
+try {
+buffer9.unmap();
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture({
+  texture: texture41,
+  mipLevel: 5,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: { x: 622, y: 2, z: 161 },
+  aspect: 'all',
+}, {width: 1, height: 5, depthOrArrayLayers: 3});
+} catch {}
+try {
+renderBundleEncoder20.pushDebugGroup('\u09de');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1216, height: 160, depthOrArrayLayers: 200}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 107, y: 9 },
+  flipY: false,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: { x: 549, y: 42, z: 181 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 78, height: 10, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+buffer9.destroy();
+} catch {}
+try {
+computePassEncoder17.insertDebugMarker('\u8228');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 2,
+  origin: { x: 143, y: 0, z: 6 },
+  aspect: 'all',
+}, new Float64Array(new ArrayBuffer(64)), /* required buffer size: 7000547 */
+{offset: 455, bytesPerRow: 856, rowsPerImage: 215}, {width: 145, height: 8, depthOrArrayLayers: 39});
+} catch {}
+gc();
+let shaderModule9 = device0.createShaderModule({
+label: '\u0df2\u{1f834}\u{1f741}\u{1f738}\ue7d3\u479d\u7b69\u8469\ub00c\ud1ae',
+code: `@group(3) @binding(2456)
+var<storage, read_write> local7: array<u32>;
+@group(7) @binding(2456)
+var<storage, read_write> parameter11: array<u32>;
+@group(0) @binding(2456)
+var<storage, read_write> global11: array<u32>;
+@group(8) @binding(2456)
+var<storage, read_write> local8: array<u32>;
+@group(5) @binding(2456)
+var<storage, read_write> i12: array<u32>;
+@group(6) @binding(2456)
+var<storage, read_write> type8: array<u32>;
+@group(1) @binding(2456)
+var<storage, read_write> local9: array<u32>;
+
+@compute @workgroup_size(8, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3<i32>,
+  @location(3) f1: vec3<f32>,
+  @location(1) f2: vec3<i32>,
+  @location(2) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(80) a0: vec2<u32>, @location(24) a1: vec2<u32>, @location(102) a2: vec2<i32>, @location(37) a3: vec3<f32>, @location(100) a4: vec4<f16>, @location(73) a5: f32, @location(74) a6: f32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S8 {
+  @location(5) f0: vec2<i32>,
+  @location(1) f1: vec4<u32>,
+  @location(3) f2: vec3<f16>,
+  @location(15) f3: vec2<i32>,
+  @location(7) f4: f32,
+  @builtin(instance_index) f5: u32,
+  @location(2) f6: vec3<u32>,
+  @location(6) f7: vec3<f16>,
+  @location(14) f8: i32,
+  @location(16) f9: vec3<i32>,
+  @location(12) f10: f32,
+  @location(11) f11: vec3<f16>,
+  @location(8) f12: vec3<i32>,
+  @location(9) f13: vec4<u32>
+}
+struct VertexOutput0 {
+  @location(66) f78: vec2<i32>,
+  @location(10) f79: vec4<u32>,
+  @location(53) f80: vec2<f32>,
+  @location(100) f81: vec4<f16>,
+  @location(37) f82: vec3<f32>,
+  @location(74) f83: f32,
+  @location(84) f84: vec2<f32>,
+  @location(95) f85: f32,
+  @location(73) f86: f32,
+  @location(8) f87: f32,
+  @location(97) f88: vec4<u32>,
+  @location(80) f89: vec2<u32>,
+  @location(102) f90: vec2<i32>,
+  @location(24) f91: vec2<u32>,
+  @builtin(position) f92: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec2<f32>, @location(0) a1: vec4<u32>, @builtin(vertex_index) a2: u32, @location(13) a3: vec4<f32>, a4: S8, @location(4) a5: vec4<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder21 = device0.createCommandEncoder({label: '\u0e9e\u042d\u306f\u8c49\u84f0\u{1f650}'});
+let querySet12 = device0.createQuerySet({
+label: '\uca3f\u7225\ucdc6\u0482\u0a3f\u4673\u9197\u{1ff0e}\u9e78\ue41f',
+type: 'occlusion',
+count: 2297,
+});
+let textureView39 = texture10.createView({
+  label: '\ue249\u0154\u6d00\u0e63\u0bf9\u783a\u6502\u2152',
+  baseMipLevel: 9,
+  mipLevelCount: 2,
+  arrayLayerCount: 5
+});
+try {
+renderBundleEncoder6.drawIndexed(72, 80, 72, 120, 24);
+} catch {}
+try {
+renderBundleEncoder13.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg32float'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await promise6;
+} catch {}
+let querySet13 = device0.createQuerySet({
+type: 'occlusion',
+count: 3095,
+});
+let pipeline28 = device0.createRenderPipeline({
+label: '\u03e0\u3a81\uffb2\u62b6\u3176\u0099\u00af\udda3',
+layout: pipelineLayout0,
+vertex: {
+  module: shaderModule8,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 6220,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x2',
+offset: 4744,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 5584,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 4452,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 4328,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 3962,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 884,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x4',
+offset: 236,
+shaderLocation: 0,
+}, {
+format: 'uint16x2',
+offset: 380,
+shaderLocation: 10,
+}, {
+format: 'snorm8x2',
+offset: 446,
+shaderLocation: 4,
+}, {
+format: 'sint16x4',
+offset: 548,
+shaderLocation: 15,
+}, {
+format: 'float32',
+offset: 84,
+shaderLocation: 13,
+}, {
+format: 'sint32x4',
+offset: 296,
+shaderLocation: 14,
+}, {
+format: 'snorm16x2',
+offset: 212,
+shaderLocation: 1,
+}, {
+format: 'unorm16x4',
+offset: 96,
+shaderLocation: 11,
+}, {
+format: 'unorm16x4',
+offset: 464,
+shaderLocation: 12,
+}, {
+format: 'uint32x3',
+offset: 120,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint16x4',
+offset: 4272,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 5494,
+shaderLocation: 7,
+}, {
+format: 'snorm8x4',
+offset: 1108,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 3812,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 2140,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+},
+});
+let offscreenCanvas3 = new OffscreenCanvas(661, 543);
+let video5 = await videoWithData();
+let imageBitmap5 = await createImageBitmap(canvas6);
+let texture45 = device1.createTexture({
+label: '\u{1f6af}\u0e71\u6d44\u2863\udacc\u{1fada}\u{1fa98}\u0351\u0aa6\u{1fb90}',
+size: {width: 198, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let adapter3 = await navigator.gpu.requestAdapter({
+});
+let querySet14 = device1.createQuerySet({
+type: 'occlusion',
+count: 2229,
+});
+let computePassEncoder18 = commandEncoder20.beginComputePass({label: '\u{1ffc4}\u078b\u{1f90c}\u{1fc65}\u7614\u5e6b\ua59b\u904c\u0349'});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+video4.width = 203;
+let offscreenCanvas4 = new OffscreenCanvas(516, 514);
+let commandEncoder22 = device1.createCommandEncoder({label: '\u3dbe\u0fd5'});
+let texture46 = device1.createTexture({
+size: [336],
+dimension: '1d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r16sint'],
+});
+let computePassEncoder19 = commandEncoder22.beginComputePass({label: '\u2ca9\u{1f8a6}\u144b\u4cb9\u00e5\u703a\u25c9'});
+try {
+commandEncoder19.clearBuffer(buffer9, 15432, 6536);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 304, height: 40, depthOrArrayLayers: 50}
+*/
+{
+  source: img3,
+  origin: { x: 64, y: 15 },
+  flipY: true,
+}, {
+  texture: texture41,
+  mipLevel: 2,
+  origin: { x: 153, y: 0, z: 3 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 75, height: 6, depthOrArrayLayers: 1});
+} catch {}
+video5.width = 196;
+let shaderModule10 = device0.createShaderModule({
+label: '\u04ab\u{1f9c4}\u642f\u96bf\u0641\u00fb\u{1fea4}\u0201\u{1f851}\ufd25\ub839',
+code: `@group(0) @binding(927)
+var<storage, read_write> field11: array<u32>;
+@group(0) @binding(426)
+var<storage, read_write> local10: array<u32>;
+@group(1) @binding(927)
+var<storage, read_write> local11: array<u32>;
+@group(0) @binding(579)
+var<storage, read_write> global12: array<u32>;
+@group(1) @binding(579)
+var<storage, read_write> local12: array<u32>;
+@group(1) @binding(426)
+var<storage, read_write> i13: array<u32>;
+
+@compute @workgroup_size(8, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(7) f0: vec3<u32>,
+  @location(0) f1: vec2<i32>,
+  @location(1) f2: i32,
+  @location(3) f3: vec3<f32>,
+  @location(2) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S9 {
+  @location(9) f0: f32,
+  @location(15) f1: vec2<u32>,
+  @location(3) f2: vec4<i32>,
+  @location(11) f3: vec4<f16>,
+  @location(5) f4: vec3<i32>,
+  @location(0) f5: vec3<f32>,
+  @location(8) f6: vec3<f16>,
+  @location(6) f7: vec4<i32>,
+  @location(10) f8: f16,
+  @builtin(instance_index) f9: u32,
+  @location(12) f10: vec2<f32>,
+  @location(4) f11: i32,
+  @location(14) f12: vec3<i32>,
+  @builtin(vertex_index) f13: u32
+}
+
+@vertex
+fn vertex0(@location(2) a0: u32, @location(7) a1: vec4<f32>, @location(16) a2: u32, @location(1) a3: f16, @location(13) a4: vec2<u32>, a5: S9) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+pseudoSubmit(device0, commandEncoder13);
+let textureView40 = texture21.createView({aspect: 'depth-only', baseMipLevel: 1});
+let computePassEncoder20 = commandEncoder21.beginComputePass();
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint', 'r16uint', 'rg16sint', 'rg16uint', 'rg16uint', 'bgra8unorm']});
+try {
+renderBundleEncoder6.draw(64, 80, 56);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(43, undefined, 2723237084, 1129888892);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+gc();
+let offscreenCanvas5 = new OffscreenCanvas(770, 259);
+let shaderModule11 = device0.createShaderModule({
+code: `@group(3) @binding(1779)
+var<storage, read_write> field12: array<u32>;
+@group(5) @binding(579)
+var<storage, read_write> field13: array<u32>;
+@group(0) @binding(579)
+var<storage, read_write> field14: array<u32>;
+@group(0) @binding(426)
+var<storage, read_write> function15: array<u32>;
+@group(4) @binding(1779)
+var<storage, read_write> parameter12: array<u32>;
+@group(5) @binding(426)
+var<storage, read_write> i14: array<u32>;
+@group(6) @binding(927)
+var<storage, read_write> local13: array<u32>;
+@group(1) @binding(579)
+var<storage, read_write> function16: array<u32>;
+@group(4) @binding(2519)
+var<storage, read_write> local14: array<u32>;
+@group(6) @binding(426)
+var<storage, read_write> type9: array<u32>;
+@group(3) @binding(2519)
+var<storage, read_write> function17: array<u32>;
+@group(2) @binding(2456)
+var<storage, read_write> parameter13: array<u32>;
+@group(1) @binding(426)
+var<storage, read_write> parameter14: array<u32>;
+
+@compute @workgroup_size(2, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S11 {
+  @location(91) f0: vec3<f32>,
+  @location(83) f1: f16,
+  @location(80) f2: u32,
+  @location(103) f3: f16,
+  @builtin(front_facing) f4: bool,
+  @location(25) f5: vec4<f32>,
+  @location(106) f6: vec3<f32>,
+  @location(60) f7: vec3<f32>,
+  @location(29) f8: vec4<i32>,
+  @location(66) f9: vec3<f32>,
+  @location(57) f10: vec3<i32>,
+  @location(44) f11: f16,
+  @location(31) f12: vec4<f16>,
+  @location(51) f13: f32,
+  @location(27) f14: vec3<u32>,
+  @location(104) f15: vec2<f16>,
+  @location(64) f16: vec3<u32>,
+  @location(39) f17: i32,
+  @location(81) f18: i32,
+  @location(20) f19: vec4<u32>,
+  @location(72) f20: vec4<i32>,
+  @location(17) f21: i32,
+  @location(1) f22: vec4<i32>,
+  @location(53) f23: f32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec2<u32>,
+  @location(2) f1: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(22) a0: vec4<i32>, @builtin(sample_mask) a1: u32, @builtin(position) a2: vec4<f32>, @location(107) a3: vec3<f32>, @location(73) a4: vec2<u32>, @location(4) a5: vec2<f32>, @location(99) a6: u32, @location(97) a7: vec2<f16>, @builtin(sample_index) a8: u32, @location(102) a9: vec2<f16>, @location(43) a10: vec4<f16>, @location(35) a11: vec3<f16>, @location(7) a12: vec3<f32>, @location(3) a13: vec4<u32>, a14: S11, @location(82) a15: f16, @location(33) a16: vec2<i32>, @location(34) a17: f32, @location(92) a18: vec4<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S10 {
+  @location(10) f0: u32,
+  @location(11) f1: vec3<f32>,
+  @builtin(instance_index) f2: u32,
+  @location(0) f3: u32,
+  @location(13) f4: vec3<u32>,
+  @location(16) f5: vec4<f16>,
+  @location(8) f6: i32,
+  @location(6) f7: vec3<f16>,
+  @location(12) f8: vec4<u32>,
+  @location(9) f9: vec3<u32>,
+  @location(15) f10: f32,
+  @location(1) f11: vec4<f16>,
+  @location(7) f12: vec3<u32>,
+  @location(14) f13: vec4<f32>
+}
+struct VertexOutput0 {
+  @location(64) f93: vec3<u32>,
+  @location(25) f94: vec4<f32>,
+  @location(82) f95: f16,
+  @location(104) f96: vec2<f16>,
+  @location(81) f97: i32,
+  @location(103) f98: f16,
+  @location(73) f99: vec2<u32>,
+  @location(91) f100: vec3<f32>,
+  @location(4) f101: vec2<f32>,
+  @location(43) f102: vec4<f16>,
+  @location(39) f103: i32,
+  @location(1) f104: vec4<i32>,
+  @builtin(position) f105: vec4<f32>,
+  @location(7) f106: vec3<f32>,
+  @location(51) f107: f32,
+  @location(72) f108: vec4<i32>,
+  @location(3) f109: vec4<u32>,
+  @location(22) f110: vec4<i32>,
+  @location(27) f111: vec3<u32>,
+  @location(80) f112: u32,
+  @location(106) f113: vec3<f32>,
+  @location(57) f114: vec3<i32>,
+  @location(31) f115: vec4<f16>,
+  @location(34) f116: f32,
+  @location(102) f117: vec2<f16>,
+  @location(97) f118: vec2<f16>,
+  @location(107) f119: vec3<f32>,
+  @location(92) f120: vec4<f16>,
+  @location(83) f121: f16,
+  @location(99) f122: u32,
+  @location(53) f123: f32,
+  @location(35) f124: vec3<f16>,
+  @location(33) f125: vec2<i32>,
+  @location(60) f126: vec3<f32>,
+  @location(66) f127: vec3<f32>,
+  @location(20) f128: vec4<u32>,
+  @location(29) f129: vec4<i32>,
+  @location(17) f130: i32,
+  @location(44) f131: f16
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec4<i32>, @builtin(vertex_index) a1: u32, @location(4) a2: i32, a3: S10, @location(5) a4: vec4<f16>, @location(2) a5: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+try {
+renderBundleEncoder6.drawIndexed(72);
+} catch {}
+try {
+computePassEncoder2.insertDebugMarker('\ue1af');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 4, y: 3 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+video4.height = 263;
+let textureView41 = texture38.createView({
+  label: '\u63df\u{1f918}\u9a3e\u{1f672}',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+  baseArrayLayer: 119
+});
+let computePassEncoder21 = commandEncoder19.beginComputePass({});
+let sampler21 = device1.createSampler({
+label: '\u0d22\u294a\ud74a',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMaxClamp: 98.823,
+compare: 'not-equal',
+});
+try {
+renderBundleEncoder18.setVertexBuffer(86, undefined);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 608, height: 80, depthOrArrayLayers: 100}
+*/
+{
+  source: imageData4,
+  origin: { x: 82, y: 13 },
+  flipY: true,
+}, {
+  texture: texture41,
+  mipLevel: 1,
+  origin: { x: 370, y: 39, z: 41 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 140, height: 38, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(1007, 713);
+let pipelineLayout6 = device0.createPipelineLayout({
+  label: '\u1a2a\u{1f8a6}\u{1fb30}\u026c\u6f18\uf258\u{1fc2a}\u7836\ue505\u01ff',
+  bindGroupLayouts: [bindGroupLayout4, bindGroupLayout5, bindGroupLayout8, bindGroupLayout7, bindGroupLayout3, bindGroupLayout5, bindGroupLayout1, bindGroupLayout7, bindGroupLayout4, bindGroupLayout1, bindGroupLayout0]
+});
+let renderBundle38 = renderBundleEncoder9.finish();
+try {
+renderBundleEncoder6.draw(56, 80, 80);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture43,
+  mipLevel: 2,
+  origin: { x: 10, y: 0, z: 19 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 3322515 */
+{offset: 150, bytesPerRow: 855, rowsPerImage: 35}, {width: 345, height: 1, depthOrArrayLayers: 112});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 38, height: 5, depthOrArrayLayers: 6}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 355, y: 254 },
+  flipY: true,
+}, {
+  texture: texture41,
+  mipLevel: 5,
+  origin: { x: 1, y: 0, z: 3 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 34, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup9 = device0.createBindGroup({
+label: '\u{1fef7}\u01dc\u{1feb8}',
+layout: bindGroupLayout8,
+entries: [{
+binding: 1779,
+resource: sampler5
+}, {
+binding: 2519,
+resource: sampler10
+}],
+});
+let texture47 = device0.createTexture({
+label: '\u03a0\u{1f604}\u2aad\u7da9\u53f6',
+size: [66],
+dimension: '1d',
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rgba16float'],
+});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint', 'r16uint', 'rg16sint', 'rg16uint', 'rg16uint', 'bgra8unorm']});
+try {
+renderBundleEncoder6.drawIndexed(0, 72, 32, -184, 72);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 20228, new BigUint64Array(55345), 53489, 372);
+} catch {}
+let gpuCanvasContext7 = offscreenCanvas3.getContext('webgpu');
+document.body.prepend(video3);
+try {
+offscreenCanvas4.getContext('2d');
+} catch {}
+let texture48 = device1.createTexture({
+label: '\uf086\uff47\u8d1e\u{1f930}\u40d5\ucc1d\u0692\u628a',
+size: {width: 84, height: 1, depthOrArrayLayers: 70},
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba8uint'],
+});
+let textureView42 = texture39.createView({label: '\u{1f83a}\u0177\u5958\u{1f95d}\ub6eb', dimension: '2d-array'});
+let renderBundleEncoder24 = device1.createRenderBundleEncoder({
+  label: '\u053a\u283f\u6b06\u{1f77e}\uf4e2',
+  colorFormats: ['rgba16float', 'r32float', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true
+});
+try {
+device1.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer2), /* required buffer size: 458 */
+{offset: 458}, {width: 99, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 38, height: 5, depthOrArrayLayers: 6}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 125, y: 445 },
+  flipY: false,
+}, {
+  texture: texture41,
+  mipLevel: 5,
+  origin: { x: 1, y: 2, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 8, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas1);
+try {
+offscreenCanvas6.getContext('webgl2');
+} catch {}
+let bindGroupLayout10 = device1.createBindGroupLayout({
+label: '\u582e\u{1f963}\u67d3\u3935\u0285\u{1f864}\u{1f998}\u05e9\ua4df\ub8f8\u{1f8c5}',
+entries: [],
+});
+let bindGroup10 = device1.createBindGroup({
+label: '\ucfdd\ubdff\ube7f\u7fb0',
+layout: bindGroupLayout10,
+entries: [],
+});
+let pipelineLayout7 = device1.createPipelineLayout({
+  label: '\u{1f91f}\u4b51\u050c\u010b\uee1a\u0b66\uf51b\u3482\ub37a\u9409\u{1f71b}',
+  bindGroupLayouts: [bindGroupLayout10, bindGroupLayout10]
+});
+let texture49 = device1.createTexture({
+size: {width: 3072, height: 1, depthOrArrayLayers: 51},
+mipLevelCount: 4,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderBundleEncoder24.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture39,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 805 */
+{offset: 805}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroupLayout11 = device1.createBindGroupLayout({
+label: '\ub60f\u8860\u09c5\u{1ff7b}\u90c7\u{1f8de}\u{1fbd5}\u00b4\u{1f71d}\ud698\u0701',
+entries: [],
+});
+let querySet15 = device1.createQuerySet({
+label: '\u86a0\uc493\u671f\u03bb\u03d0\u82ac',
+type: 'occlusion',
+count: 1829,
+});
+let promise10 = device1.queue.onSubmittedWorkDone();
+let device2 = await adapter1.requestDevice({
+label: '\u0af0\u0b9e\u477b\u8b64\u3f79\ua1a4\ub5d3',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 43,
+maxVertexAttributes: 22,
+maxVertexBufferArrayStride: 64440,
+maxStorageTexturesPerShaderStage: 23,
+maxStorageBuffersPerShaderStage: 39,
+maxDynamicStorageBuffersPerPipelineLayout: 39693,
+maxBindingsPerBindGroup: 9974,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 15849,
+maxTextureDimension2D: 11731,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 158750475,
+maxUniformBuffersPerShaderStage: 34,
+maxInterStageShaderVariables: 95,
+maxInterStageShaderComponents: 88,
+maxSamplersPerShaderStage: 18,
+},
+});
+let textureView43 = texture16.createView({
+  label: '\u0466\uf2d8\u0f4e\u81d9\u{1fdd9}\u7380\u0834\u5ca4',
+  dimension: '2d-array',
+  format: 'astc-12x12-unorm-srgb',
+  baseMipLevel: 4,
+  mipLevelCount: 4
+});
+try {
+device0.queue.submit([
+commandBuffer4,
+commandBuffer3,
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 32192, new DataView(new ArrayBuffer(5034)), 4103, 668);
+} catch {}
+try {
+offscreenCanvas5.getContext('webgpu');
+} catch {}
+let texture50 = device1.createTexture({
+label: '\u9614\u0ff7\u3215\u{1f7c0}\ub027',
+size: [198],
+dimension: '1d',
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+computePassEncoder16.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba8snorm', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 76, height: 10, depthOrArrayLayers: 12}
+*/
+{
+  source: imageBitmap5,
+  origin: { x: 171, y: 70 },
+  flipY: true,
+}, {
+  texture: texture41,
+  mipLevel: 4,
+  origin: { x: 20, y: 2, z: 9 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 52, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder23 = device2.createCommandEncoder({});
+let querySet16 = device2.createQuerySet({
+label: '\u3e01\u0552\u0bac\u0e26',
+type: 'occlusion',
+count: 499,
+});
+let querySet17 = device0.createQuerySet({
+label: '\u2012\u0fe8\u00cd\uae06',
+type: 'occlusion',
+count: 2187,
+});
+try {
+computePassEncoder6.end();
+} catch {}
+let promise11 = device0.popErrorScope();
+let promise12 = buffer2.mapAsync(GPUMapMode.WRITE, 48776, 1736);
+try {
+commandEncoder4.resolveQuerySet(querySet17, 453, 1310, buffer5, 34560);
+} catch {}
+let pipeline29 = device0.createRenderPipeline({
+label: '\u0499\ud304\uf46a\u04dd\ua0e3\u{1fa9d}\u6cfd\u{1f8cc}',
+layout: pipelineLayout6,
+fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'never',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'zero',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilWriteMask: 633,
+depthBiasClamp: 28,
+},
+vertex: {
+  module: shaderModule4,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+attributes: [{
+format: 'sint32x2',
+offset: 4620,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 6332,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x2',
+offset: 4772,
+shaderLocation: 6,
+}],
+}
+]
+},
+});
+let commandEncoder24 = device2.createCommandEncoder({label: '\u0801\uc005\u4eba\u8458\u{1faad}\uc1d7\ua912\u05b2\u544a\u4825'});
+let computePassEncoder22 = commandEncoder23.beginComputePass();
+let renderBundleEncoder25 = device2.createRenderBundleEncoder({
+  colorFormats: ['bgra8unorm', 'r16uint', undefined, 'bgra8unorm', 'r32uint', 'rgb10a2uint'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let sampler22 = device2.createSampler({
+label: '\ua4cd\u0b39\u6266\u5abf\u{1fae2}\u0b62',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 12.223,
+lodMaxClamp: 99.291,
+});
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let computePassEncoder23 = commandEncoder24.beginComputePass({label: '\ud915\u{1ff97}\u05a7\ue64a'});
+try {
+renderBundleEncoder25.setVertexBuffer(97, undefined);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundleEncoder26 = device2.createRenderBundleEncoder({
+  label: '\u34a4\u{1fa15}\u0d4f\uff63\u4c70\ue427\u{1f71a}\u2f8d\u{1fb51}\u0a45\u5d76',
+  colorFormats: ['bgra8unorm', 'r16uint', undefined, 'bgra8unorm', 'r32uint', 'rgb10a2uint'],
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let renderBundle39 = renderBundleEncoder26.finish({label: '\ub1f5\u{1fe8e}\u014e'});
+let externalTexture6 = device2.importExternalTexture({
+label: '\ucb38\u0b66\u022c\u5c47\u8f5d\u5d6a\u0234\ubd29\u7998\u{1f8a4}',
+source: video3,
+colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder25.setVertexBuffer(7, undefined, 747672541, 3284955430);
+} catch {}
+video0.height = 53;
+let bindGroupLayout12 = device1.createBindGroupLayout({
+label: '\u1a80\u7cd9\ufcaf\u{1fa48}\u{1f8c7}\u{1f7b5}\u0b6f\u098d\u{1f866}\uc4b9\ue157',
+entries: [{
+binding: 802,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}, {
+binding: 602,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 270,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+let querySet18 = device1.createQuerySet({
+label: '\u5db1\u07ed\u78a0\ucd39\u92dc\u0996',
+type: 'occlusion',
+count: 3932,
+});
+pseudoSubmit(device1, commandEncoder22);
+let textureView44 = texture45.createView({
+  label: '\u6ab4\u2c2e\ue876\u80e4',
+  dimension: '2d-array',
+  aspect: 'depth-only',
+  baseArrayLayer: 0,
+  arrayLayerCount: 1
+});
+let sampler23 = device1.createSampler({
+label: '\u0943\u54ce\u79c4\u{1fb04}\udd5b\udb1e\u{1fd62}\ub24b\u0950\u4ff4',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 26.446,
+lodMaxClamp: 74.655,
+compare: 'greater-equal',
+});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(11, undefined, 175849626, 1880653570);
+} catch {}
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+try {
+computePassEncoder16.setBindGroup(0, bindGroup10, new Uint32Array(475), 32, 0);
+} catch {}
+video4.height = 152;
+let promise13 = navigator.gpu.requestAdapter({
+});
+let video6 = await videoWithData();
+let bindGroupLayout13 = device2.createBindGroupLayout({
+label: '\ue97e\u{1fcfa}\ufaec',
+entries: [{
+binding: 4783,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '2d-array' },
+}, {
+binding: 9855,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+}, {
+binding: 418,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}],
+});
+let pipelineLayout8 = device2.createPipelineLayout({bindGroupLayouts: []});
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let texture51 = device1.createTexture({
+label: '\u{1fbfa}\u{1fffd}\u00ca\u246c\u{1fa6a}\u02ff',
+size: [6144],
+sampleCount: 1,
+dimension: '1d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let renderBundleEncoder27 = device1.createRenderBundleEncoder({
+  label: '\u04a2\u0ca2\u0707\u60df',
+  colorFormats: ['rgba16float', 'r32float', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+buffer10.unmap();
+} catch {}
+offscreenCanvas3.width = 100;
+gc();
+let bindGroup11 = device1.createBindGroup({
+label: '\u6890\uefbf\u3e28\u8f05\u0905',
+layout: bindGroupLayout10,
+entries: [],
+});
+let buffer11 = device1.createBuffer({size: 53517, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let querySet19 = device1.createQuerySet({
+label: '\ua402\u03d3\u0f4e\u8845\u0850\ub8e4\u{1fdb6}\ud10b\u324d\ue13a',
+type: 'occlusion',
+count: 442,
+});
+let texture52 = device1.createTexture({
+label: '\u0ad6\u462c\u05ee\u0dcc\u{1f70e}\ue765\u3053',
+size: {width: 336, height: 1, depthOrArrayLayers: 243},
+mipLevelCount: 8,
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba8unorm-srgb'],
+});
+try {
+renderBundleEncoder20.popDebugGroup();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 5,
+  origin: { x: 5, y: 1, z: 1 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 1441 */
+{offset: 891, bytesPerRow: 142}, {width: 31, height: 4, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 42, height: 1, depthOrArrayLayers: 243}
+*/
+{
+  source: canvas4,
+  origin: { x: 6, y: 143 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 3,
+  origin: { x: 23, y: 0, z: 207 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 11, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let adapter4 = await promise13;
+let pipelineLayout9 = device0.createPipelineLayout({
+  label: '\ue73a\u5afa\u09a1\u073a\ub46d\u{1f7e6}',
+  bindGroupLayouts: [bindGroupLayout8, bindGroupLayout0, bindGroupLayout6, bindGroupLayout2, bindGroupLayout7, bindGroupLayout6, bindGroupLayout9, bindGroupLayout9, bindGroupLayout5, bindGroupLayout7, bindGroupLayout4]
+});
+let commandEncoder25 = device0.createCommandEncoder({});
+try {
+renderBundleEncoder6.draw(8, 16, 8);
+} catch {}
+try {
+commandEncoder4.copyBufferToBuffer(buffer2, 1344, buffer6, 27020, 9160);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder25.clearBuffer(buffer5, 41308, 14452);
+dissociateBuffer(device0, buffer5);
+} catch {}
+let offscreenCanvas7 = new OffscreenCanvas(803, 859);
+let bindGroupLayout14 = device2.createBindGroupLayout({
+label: '\u1347\u0fc4\ue347\u3eea\u04cf\u0ec7\u96f3\uc0d2\u6444',
+entries: [{
+binding: 521,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+}, {
+binding: 992,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '2d' },
+}, {
+binding: 191,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+}],
+});
+try {
+gpuCanvasContext1.configure({
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+alphaMode: 'opaque',
+});
+} catch {}
+let imageData7 = new ImageData(116, 80);
+try {
+window.someLabel = device1.label;
+} catch {}
+let commandEncoder26 = device1.createCommandEncoder({});
+let texture53 = device1.createTexture({
+size: {width: 768},
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+commandEncoder26.copyBufferToBuffer(buffer11, 13308, buffer9, 23336, 332);
+dissociateBuffer(device1, buffer11);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: { x: 47, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer1), /* required buffer size: 939 */
+{offset: 939, bytesPerRow: 719, rowsPerImage: 142}, {width: 264, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise8;
+} catch {}
+let buffer12 = device2.createBuffer({
+  label: '\u{1fc5b}\u2ecb\u{1f75c}\u7729\u1b4c\u52c0\u0aea\ucd77',
+  size: 42731,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let commandEncoder27 = device2.createCommandEncoder();
+let querySet20 = device2.createQuerySet({
+label: '\u{1f924}\u{1fd98}\u7bcd\ufa32\u0819\u04af\u7457',
+type: 'occlusion',
+count: 1308,
+});
+let sampler24 = device2.createSampler({
+label: '\u{1f9cd}\ue7a3',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 28.159,
+lodMaxClamp: 67.359,
+maxAnisotropy: 11,
+});
+let buffer13 = device0.createBuffer({
+  label: '\ud3fc\u{1f771}\ucc24\u0aa3\uf40c\uc7bd\u045a\uc990',
+  size: 41280,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let texture54 = device0.createTexture({
+label: '\u0c04\udd1d\u060a\u6c4c\u029c',
+size: {width: 66},
+dimension: '1d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16uint', 'rgba16uint', 'rgba16uint'],
+});
+let textureView45 = texture12.createView({format: 'bgra8unorm', baseMipLevel: 1, mipLevelCount: 2});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({
+  label: '\uce82\ue9b9',
+  colorFormats: ['rg8uint', undefined, 'rgba32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder14.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(19, undefined);
+} catch {}
+try {
+commandEncoder25.resolveQuerySet(querySet1, 767, 138, buffer5, 26880);
+} catch {}
+try {
+renderBundleEncoder13.popDebugGroup();
+} catch {}
+let adapter5 = await navigator.gpu.requestAdapter({
+});
+try {
+adapter4.label = '\u{1fb01}\u{1fc94}\u{1fc5d}\u20a9\u0ea4\u06df\u06a4';
+} catch {}
+try {
+offscreenCanvas7.getContext('webgpu');
+} catch {}
+let commandEncoder28 = device0.createCommandEncoder();
+let sampler25 = device0.createSampler({
+label: '\u1bfe\u{1f8e1}\u027a\u{1f9e3}\u97e1\u{1fa57}\u8616\u08cb',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 41.782,
+lodMaxClamp: 49.941,
+});
+try {
+commandEncoder28.clearBuffer(buffer5, 332, 20232);
+dissociateBuffer(device0, buffer5);
+} catch {}
+let adapter6 = await navigator.gpu.requestAdapter({
+});
+let texture55 = device0.createTexture({
+label: '\uc117\u690a\u8a0c\u0ffe\u0329\uf923\ub524\u4dc8\u{1fa40}',
+size: [198, 30, 1],
+mipLevelCount: 3,
+dimension: '2d',
+format: 'astc-6x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+device0.queue.writeBuffer(buffer6, 35148, new DataView(new ArrayBuffer(471)), 342, 124);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 3,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 834 */
+{offset: 834, bytesPerRow: 101}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer14 = device2.createBuffer({
+  label: '\u322a\ud26f\u{1fdc7}\u{1ffed}\ubfbc',
+  size: 25624,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true
+});
+let computePassEncoder24 = commandEncoder27.beginComputePass({label: '\ua7fd\u0705\u{1f68e}\u8cf8\ubcc0\u0ee9\u{1f8e2}\u514f\u{1ff33}'});
+try {
+renderBundleEncoder25.setVertexBuffer(98, undefined, 3632785711);
+} catch {}
+let videoFrame4 = new VideoFrame(offscreenCanvas1, {timestamp: 0});
+let commandEncoder29 = device1.createCommandEncoder({label: '\u{1fe83}\ufb57\u5606'});
+let renderBundleEncoder29 = device1.createRenderBundleEncoder({
+  label: '\u3dc6\u0403\ud5c1\u05b8\uc86e\u3d0f\u{1fcbf}\u{1f65d}',
+  colorFormats: ['rgba16float', 'r32float', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+let sampler26 = device1.createSampler({
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 38.090,
+lodMaxClamp: 90.684,
+maxAnisotropy: 10,
+});
+try {
+commandEncoder29.clearBuffer(buffer9, 24260, 284);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(59, undefined, 3946482000, 26640234);
+} catch {}
+try {
+querySet4.destroy();
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+commandEncoder4.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 1,
+  origin: { x: 8, y: 28, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 256 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 18688 */
+offset: 18688,
+buffer: buffer6,
+}, {width: 64, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder25.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 2,
+  origin: { x: 15, y: 24, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture6,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 4, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder28.resolveQuerySet(querySet3, 769, 1761, buffer5, 28416);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 25524, new BigUint64Array(31772), 2769, 428);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 1, depthOrArrayLayers: 11}
+*/
+{
+  source: imageBitmap5,
+  origin: { x: 231, y: 21 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 3,
+  origin: { x: 6, y: 0, z: 7 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout15 = device0.createBindGroupLayout({
+entries: [{
+binding: 1616,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}, {
+binding: 332,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d-array', sampleType: 'depth', multisampled: false },
+}],
+});
+pseudoSubmit(device0, commandEncoder28);
+let computePassEncoder25 = commandEncoder4.beginComputePass({label: '\u0765\u{1f772}\u82b0\u0257\u071f\u{1fb24}\u{1fee0}'});
+try {
+computePassEncoder25.setBindGroup(10, bindGroup4);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder6.draw(40);
+} catch {}
+try {
+commandEncoder25.copyBufferToBuffer(buffer7, 19984, buffer5, 29016, 4908);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder25.copyTextureToBuffer({
+  texture: texture24,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 22112 */
+offset: 22112,
+buffer: buffer5,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+await adapter2.requestAdapterInfo();
+} catch {}
+let bindGroup12 = device1.createBindGroup({
+label: '\u1eaf\u020d\u{1fb96}\u0909\u0216\u02d0\u8877\u5be5\u1318\ud376',
+layout: bindGroupLayout11,
+entries: [],
+});
+let querySet21 = device1.createQuerySet({
+label: '\ufc2b\u0c0f\u{1fcf9}\uf6e3\udd1c\u0df0\u0f5d',
+type: 'occlusion',
+count: 3938,
+});
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup10, new Uint32Array(3421), 611, 0);
+} catch {}
+try {
+  await promise12;
+} catch {}
+let adapter7 = await navigator.gpu.requestAdapter({
+});
+let shaderModule12 = device0.createShaderModule({
+label: '\u0de2\u{1f66f}\u0916\u9c3b',
+code: `@group(2) @binding(2519)
+var<storage, read_write> type10: array<u32>;
+@group(2) @binding(1779)
+var<storage, read_write> type11: array<u32>;
+@group(6) @binding(1779)
+var<storage, read_write> i15: array<u32>;
+@group(1) @binding(169)
+var<storage, read_write> global13: array<u32>;
+@group(8) @binding(2456)
+var<storage, read_write> local15: array<u32>;
+@group(6) @binding(2519)
+var<storage, read_write> type12: array<u32>;
+@group(10) @binding(2456)
+var<storage, read_write> function18: array<u32>;
+@group(0) @binding(2456)
+var<storage, read_write> i16: array<u32>;
+
+@compute @workgroup_size(1, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<u32>,
+  @location(4) f1: vec4<u32>,
+  @location(0) f2: vec4<i32>,
+  @location(2) f3: vec3<i32>,
+  @location(5) f4: vec4<f32>,
+  @location(1) f5: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool, @builtin(position) a3: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S12 {
+  @location(8) f0: i32,
+  @location(12) f1: vec3<f16>,
+  @location(3) f2: i32,
+  @location(1) f3: vec3<i32>,
+  @location(4) f4: vec2<u32>,
+  @location(10) f5: vec2<f16>,
+  @builtin(instance_index) f6: u32,
+  @location(0) f7: vec3<u32>,
+  @location(16) f8: vec3<i32>,
+  @location(9) f9: vec3<u32>,
+  @location(13) f10: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec4<f16>, @location(14) a1: i32, @location(5) a2: vec4<f32>, @location(11) a3: u32, @location(6) a4: u32, @location(2) a5: vec4<i32>, @location(15) a6: f16, a7: S12, @builtin(vertex_index) a8: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroup13 = device0.createBindGroup({
+layout: bindGroupLayout3,
+entries: [],
+});
+try {
+renderBundleEncoder23.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder6.drawIndexed(24, 64, 8, -528, 40);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 705, y: 1, z: 87 },
+  aspect: 'all',
+}, new BigInt64Array(new ArrayBuffer(64)), /* required buffer size: 758 */
+{offset: 758}, {width: 3397, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise11;
+} catch {}
+offscreenCanvas6.width = 284;
+let bindGroup14 = device1.createBindGroup({
+label: '\ud107\u{1f9f8}\u{1f7d1}',
+layout: bindGroupLayout11,
+entries: [],
+});
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder29.copyBufferToTexture({
+/* bytesInLastRow: 48 widthInBlocks: 24 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 12786 */
+offset: 12738,
+buffer: buffer11,
+}, {
+  texture: texture46,
+  mipLevel: 0,
+  origin: { x: 35, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 24, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer11);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16float'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder({label: '\uc1c2\u64da\u7146\ua038\u{1f881}\u01d4'});
+let texture56 = device0.createTexture({
+label: '\u0776\uc1a8',
+size: {width: 640, height: 256, depthOrArrayLayers: 1900},
+mipLevelCount: 10,
+sampleCount: 1,
+dimension: '3d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg32sint', 'rg32sint', 'rg32sint'],
+});
+let computePassEncoder26 = commandEncoder25.beginComputePass({label: '\u0288\u19a8\u43f4\u7602\u{1f600}\u06f2\u960a\u0ea7\u0703\u2356\u{1f953}'});
+let renderBundle40 = renderBundleEncoder7.finish({label: '\uc8e0\u1745\u80cc\u079f\u016f'});
+try {
+renderBundleEncoder6.draw(16, 8);
+} catch {}
+let promise14 = buffer13.mapAsync(GPUMapMode.READ, 0, 25716);
+try {
+commandEncoder30.copyTextureToTexture({
+  texture: texture30,
+  mipLevel: 3,
+  origin: { x: 10, y: 0, z: 18 },
+  aspect: 'all',
+}, {
+  texture: texture10,
+  mipLevel: 3,
+  origin: { x: 300, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 34});
+} catch {}
+try {
+commandEncoder30.clearBuffer(buffer5, 47488, 2180);
+dissociateBuffer(device0, buffer5);
+} catch {}
+document.body.prepend(img2);
+let shaderModule13 = device0.createShaderModule({
+code: `@group(1) @binding(169)
+var<storage, read_write> i17: array<u32>;
+@group(2) @binding(1779)
+var<storage, read_write> field15: array<u32>;
+@group(0) @binding(2456)
+var<storage, read_write> field16: array<u32>;
+@group(6) @binding(2519)
+var<storage, read_write> local16: array<u32>;
+@group(3) @binding(1668)
+var<storage, read_write> local17: array<u32>;
+@group(8) @binding(2456)
+var<storage, read_write> field17: array<u32>;
+@group(9) @binding(1779)
+var<storage, read_write> global14: array<u32>;
+@group(2) @binding(2519)
+var<storage, read_write> i18: array<u32>;
+@group(10) @binding(2456)
+var<storage, read_write> function19: array<u32>;
+@group(5) @binding(169)
+var<storage, read_write> function20: array<u32>;
+
+@compute @workgroup_size(2, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S13 {
+  @location(25) f0: vec2<u32>,
+  @location(47) f1: vec4<f16>,
+  @location(99) f2: i32,
+  @location(39) f3: f32,
+  @location(34) f4: f16,
+  @location(100) f5: vec4<i32>,
+  @location(58) f6: vec2<f16>,
+  @location(85) f7: vec3<f16>,
+  @location(54) f8: vec4<i32>,
+  @location(104) f9: vec4<f32>,
+  @location(23) f10: i32,
+  @location(56) f11: vec2<u32>,
+  @location(71) f12: vec3<i32>,
+  @location(75) f13: vec2<i32>,
+  @location(28) f14: vec2<u32>,
+  @location(77) f15: vec2<u32>,
+  @builtin(position) f16: vec4<f32>,
+  @location(82) f17: vec4<f16>,
+  @location(50) f18: f32,
+  @location(18) f19: vec2<f32>
+}
+struct FragmentOutput0 {
+  @location(5) f0: vec4<f32>,
+  @location(0) f1: vec4<i32>,
+  @location(1) f2: u32,
+  @location(2) f3: vec3<i32>,
+  @location(4) f4: vec2<u32>,
+  @location(3) f5: vec3<u32>
+}
+
+@fragment
+fn fragment0(a0: S13, @location(74) a1: u32, @location(89) a2: f32, @builtin(sample_mask) a3: u32, @location(22) a4: vec2<u32>, @location(92) a5: vec4<i32>, @location(83) a6: u32, @location(69) a7: f16, @builtin(sample_index) a8: u32, @builtin(front_facing) a9: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(47) f132: vec4<f16>,
+  @location(56) f133: vec2<u32>,
+  @location(92) f134: vec4<i32>,
+  @location(18) f135: vec2<f32>,
+  @location(54) f136: vec4<i32>,
+  @location(77) f137: vec2<u32>,
+  @location(34) f138: f16,
+  @location(25) f139: vec2<u32>,
+  @location(85) f140: vec3<f16>,
+  @location(71) f141: vec3<i32>,
+  @location(100) f142: vec4<i32>,
+  @location(39) f143: f32,
+  @builtin(position) f144: vec4<f32>,
+  @location(23) f145: i32,
+  @location(58) f146: vec2<f16>,
+  @location(22) f147: vec2<u32>,
+  @location(89) f148: f32,
+  @location(82) f149: vec4<f16>,
+  @location(99) f150: i32,
+  @location(83) f151: u32,
+  @location(50) f152: f32,
+  @location(69) f153: f16,
+  @location(75) f154: vec2<i32>,
+  @location(104) f155: vec4<f32>,
+  @location(74) f156: u32,
+  @location(28) f157: vec2<u32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @builtin(vertex_index) a1: u32, @location(0) a2: vec2<f16>, @location(8) a3: f16, @location(7) a4: vec3<u32>, @location(1) a5: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+});
+let computePassEncoder27 = commandEncoder30.beginComputePass({label: '\u6b79\u3270\u5461\u186d\u{1fa98}\u7a83\udb80\u8dc8\u0740\ubfd8'});
+let sampler27 = device0.createSampler({
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 76.182,
+lodMaxClamp: 88.597,
+});
+try {
+computePassEncoder25.setBindGroup(7, bindGroup4, new Uint32Array(4428), 77, 0);
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline18);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 66, height: 1, depthOrArrayLayers: 88}
+*/
+{
+  source: offscreenCanvas3,
+  origin: { x: 51, y: 90 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 9, y: 0, z: 50 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 47, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline30 = await device0.createComputePipelineAsync({
+label: '\u8ac2\u04c5\u{1fe31}\u05d2',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+},
+});
+try {
+  await promise14;
+} catch {}
+try {
+externalTexture6.label = '\u70dd\u9ad8\u057d\u{1fd86}\u5bd5\u78f4\u0b7c\ue208';
+} catch {}
+let bindGroupLayout16 = device2.createBindGroupLayout({
+label: '\u7609\u5629\u{1f8c1}\u0b5d\u995c\u9351',
+entries: [],
+});
+let querySet22 = device2.createQuerySet({
+label: '\ub80f\u82ba\u4919\u{1fd94}\u{1f6ac}\u{1f744}',
+type: 'occlusion',
+count: 1068,
+});
+try {
+renderBundleEncoder25.setVertexBuffer(65, undefined);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float'],
+alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder31 = device2.createCommandEncoder({label: '\u0ff4\u0040\ucd28\ua3ac\u052d\ucb44\u3c66\u{1f69b}\u6c80\u0065\u0274'});
+let sampler28 = device2.createSampler({
+label: '\udc5d\ub1ac',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 93.625,
+compare: 'greater',
+maxAnisotropy: 18,
+});
+try {
+renderBundleEncoder25.setVertexBuffer(20, undefined, 2965532265, 533056078);
+} catch {}
+try {
+device2.label = '\u0a16\u{1ffad}\u7d95\u08e4\u7670\u{1fbb9}\u03a8';
+} catch {}
+let querySet23 = device2.createQuerySet({
+label: '\u01c7\u9c1b',
+type: 'occlusion',
+count: 1615,
+});
+let texture57 = device2.createTexture({
+size: [960, 44, 2],
+mipLevelCount: 1,
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg8snorm', 'rg8snorm', 'rg8snorm'],
+});
+let renderBundle41 = renderBundleEncoder25.finish({label: '\u{1f993}\u7e56\u{1fe58}\u1de9\u5b06\u5fc1'});
+try {
+gpuCanvasContext5.configure({
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+alphaMode: 'premultiplied',
+});
+} catch {}
+let device3 = await adapter3.requestDevice({
+label: '\ua427\u0d03\uf4c5\u9a71\u{1fbf3}\u0762\u6f0a\u{1fa24}\u8706',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'indirect-first-instance',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 57,
+maxVertexAttributes: 17,
+maxVertexBufferArrayStride: 4703,
+maxStorageTexturesPerShaderStage: 39,
+maxStorageBuffersPerShaderStage: 11,
+maxDynamicStorageBuffersPerPipelineLayout: 5614,
+maxBindingsPerBindGroup: 2639,
+maxTextureDimension1D: 14717,
+maxTextureDimension2D: 8681,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 56151515,
+maxUniformBuffersPerShaderStage: 33,
+maxInterStageShaderVariables: 46,
+maxInterStageShaderComponents: 110,
+maxSamplersPerShaderStage: 19,
+},
+});
+let bindGroupLayout17 = device0.createBindGroupLayout({
+label: '\uafb4\u5ab3\u0ab3\u{1f762}\u{1f6e8}\u5436\ud4e2',
+entries: [{
+binding: 944,
+visibility: 0,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+}],
+});
+let querySet24 = device0.createQuerySet({
+label: '\u05bf\u{1fa59}\u0ac9\u{1f612}\u07f7\u0bb5\u{1f69c}\u0880\ufaa7',
+type: 'occlusion',
+count: 966,
+});
+let renderBundle42 = renderBundleEncoder6.finish();
+try {
+renderBundleEncoder13.setBindGroup(2, bindGroup7, new Uint32Array(4893), 1952, 1);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(72, undefined);
+} catch {}
+let arrayBuffer4 = buffer3.getMappedRange(36720, 584);
+canvas1.width = 879;
+let promise15 = adapter4.requestDevice({
+label: '\u0f7c\u0146\u{1f8dc}',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 8,
+maxColorAttachmentBytesPerSample: 37,
+maxVertexAttributes: 28,
+maxVertexBufferArrayStride: 41486,
+maxStorageTexturesPerShaderStage: 5,
+maxStorageBuffersPerShaderStage: 18,
+maxDynamicStorageBuffersPerPipelineLayout: 7414,
+maxBindingsPerBindGroup: 8516,
+maxTextureDimension1D: 14557,
+maxTextureDimension2D: 11495,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 208949678,
+maxUniformBuffersPerShaderStage: 28,
+maxInterStageShaderVariables: 78,
+maxInterStageShaderComponents: 88,
+maxSamplersPerShaderStage: 21,
+},
+});
+let video7 = await videoWithData();
+let imageBitmap6 = await createImageBitmap(canvas6);
+let bindGroupLayout18 = device3.createBindGroupLayout({
+label: '\u{1f681}\u2345\u081f',
+entries: [{
+binding: 1812,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '2d' },
+}],
+});
+let texture58 = gpuCanvasContext6.getCurrentTexture();
+let textureView46 = texture41.createView({
+  label: '\uc806\u236b\u{1fdd9}\u455b\u0a5c\u1cbf\u0db8\u094c\uc3d9',
+  baseMipLevel: 6,
+  mipLevelCount: 1,
+  baseArrayLayer: 0
+});
+let computePassEncoder28 = commandEncoder26.beginComputePass({label: '\u0e66\ud94b\ud436\uc66e\uc644\u4b38'});
+let renderBundle43 = renderBundleEncoder29.finish({label: '\u{1ff8b}\u3c03'});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+computePassEncoder28.end();
+} catch {}
+let promise16 = device1.popErrorScope();
+let texture59 = device2.createTexture({
+label: '\u68bf\uec75\ue9fb\u02c3\ub2de\u{1f8b4}',
+size: [240, 11, 2],
+mipLevelCount: 2,
+format: 'rg32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler29 = device2.createSampler({
+label: '\u0b48\u9506',
+addressModeU: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 56.760,
+lodMaxClamp: 91.316,
+});
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+commandEncoder31.pushDebugGroup('\u059e');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16float', 'astc-8x5-unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: { x: 693, y: 19, z: 0 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 578 */
+{offset: 578, bytesPerRow: 311}, {width: 105, height: 22, depthOrArrayLayers: 0});
+} catch {}
+let texture60 = device1.createTexture({
+size: {width: 198},
+sampleCount: 1,
+dimension: '1d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView47 = texture50.createView({label: '\u22bf\u{1ff70}\u2fec\uc386'});
+let externalTexture7 = device1.importExternalTexture({
+label: '\u395d\u{1f83b}\u{1fe6a}\u762f\u64e9\ub9b0',
+source: videoFrame2,
+});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup11, new Uint32Array(2159), 1033, 0);
+} catch {}
+try {
+commandEncoder29.copyBufferToBuffer(buffer11, 34736, buffer9, 5520, 4704);
+dissociateBuffer(device1, buffer11);
+dissociateBuffer(device1, buffer9);
+} catch {}
+let imageData8 = new ImageData(168, 244);
+let renderBundle44 = renderBundleEncoder8.finish({label: '\u1199\u210b\ud75e\u2707\u{1fea9}'});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer8, 'uint16', 5280);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 48120, new Float32Array(48364), 45551, 1024);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture47,
+  mipLevel: 0,
+  origin: { x: 7, y: 1, z: 1 },
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer2), /* required buffer size: 867 */
+{offset: 867}, {width: 28, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline31 = device0.createRenderPipeline({
+label: '\uc7ae\uff48\u4463\u95fc',
+layout: pipelineLayout1,
+fragment: {
+  module: shaderModule13,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rg16uint', writeMask: 0}, {format: 'rg16uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'bgra8unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'less',
+failOp: 'keep',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 749,
+stencilWriteMask: 3717,
+depthBias: 63,
+depthBiasSlopeScale: 46,
+depthBiasClamp: 74,
+},
+vertex: {
+  module: shaderModule13,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 6220,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x4',
+offset: 4396,
+shaderLocation: 7,
+}, {
+format: 'uint16x2',
+offset: 2672,
+shaderLocation: 1,
+}, {
+format: 'float32x2',
+offset: 4020,
+shaderLocation: 8,
+}, {
+format: 'float16x4',
+offset: 6000,
+shaderLocation: 0,
+}],
+}
+]
+},
+});
+let pipelineLayout10 = device3.createPipelineLayout({
+  label: '\u0375\u{1fc59}\u1933\u0917\u0d37\u2e24\u{1fe52}\u05a2\uaf85',
+  bindGroupLayouts: [bindGroupLayout18, bindGroupLayout18, bindGroupLayout18, bindGroupLayout18]
+});
+let renderBundleEncoder30 = device3.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb', 'r8sint', 'rgba8unorm-srgb'], sampleCount: 4, depthReadOnly: true});
+let img6 = await imageWithData(111, 300, '#45bc5ec3', '#ade73721');
+let commandEncoder32 = device1.createCommandEncoder({label: '\u7c5a\u{1f728}\ud093\u57eb\u1b76\u01c3\ud23a\u89a6'});
+let texture61 = device1.createTexture({
+size: [608, 80, 45],
+mipLevelCount: 10,
+dimension: '3d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['rg11b10ufloat', 'rg11b10ufloat', 'rg11b10ufloat'],
+});
+let renderBundleEncoder31 = device1.createRenderBundleEncoder({
+  label: '\u00db\u0916\u3a0d',
+  colorFormats: ['rgba16float', 'r32float', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1
+});
+try {
+commandEncoder29.copyTextureToBuffer({
+  texture: texture50,
+  mipLevel: 0,
+  origin: { x: 156, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 164 widthInBlocks: 41 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 15760 */
+offset: 15760,
+buffer: buffer9,
+}, {width: 41, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(6265), /* required buffer size: 6265 */
+{offset: 137}, {width: 766, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let textureView48 = texture37.createView({aspect: 'all'});
+try {
+computePassEncoder26.setBindGroup(10, bindGroup3);
+} catch {}
+try {
+computePassEncoder26.end();
+} catch {}
+try {
+commandEncoder25.copyBufferToBuffer(buffer7, 10988, buffer5, 620, 19148);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder25.resolveQuerySet(querySet17, 1164, 514, buffer8, 4864);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData8,
+  origin: { x: 65, y: 47 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 6,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let buffer15 = device1.createBuffer({
+  label: '\udd6c\u09e6\uc982\u0d1a\ue477\u11fb\u0696\u0f9b',
+  size: 28372,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+try {
+device1.queue.writeBuffer(buffer15, 20544, new Int16Array(40948), 29039, 1668);
+} catch {}
+let commandEncoder33 = device2.createCommandEncoder({label: '\u{1fbf3}\uc54c\u0b52\u05f7\u764c\u{1ffbe}\ua6df\u93be'});
+let textureView49 = texture59.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 1});
+let img7 = await imageWithData(225, 102, '#a210c9d0', '#313f2750');
+let shaderModule14 = device3.createShaderModule({
+label: '\u075e\u{1fcc9}',
+code: `@group(1) @binding(1812)
+var<storage, read_write> global15: array<u32>;
+@group(3) @binding(1812)
+var<storage, read_write> type13: array<u32>;
+@group(0) @binding(1812)
+var<storage, read_write> i19: array<u32>;
+@group(2) @binding(1812)
+var<storage, read_write> type14: array<u32>;
+
+@compute @workgroup_size(8, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(1) f1: i32,
+  @location(2) f2: vec4<f32>,
+  @location(6) f3: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(10) a0: i32, @location(9) a1: vec4<f32>, @location(6) a2: vec4<f32>, @location(2) a3: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let querySet25 = device3.createQuerySet({
+label: '\u3c46\u{1f67a}',
+type: 'occlusion',
+count: 3683,
+});
+let bindGroupLayout19 = device3.createBindGroupLayout({
+label: '\u{1fbf2}\u39fb\u0ebc\u62be\ue9a4\u61da',
+entries: [{
+binding: 1417,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+}, {
+binding: 559,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+}],
+});
+let commandEncoder34 = device3.createCommandEncoder({});
+let computePassEncoder29 = commandEncoder34.beginComputePass({label: '\ufad3\ubcba\uca35\u5f62'});
+try {
+device1.label = '\uc414\u4b58\u{1fcd4}\ude3a\u9d0b\u{1fe15}\udd7a\u01f0\u030e\u43ee';
+} catch {}
+let bindGroupLayout20 = device1.createBindGroupLayout({
+label: '\u5d66\ub30e\u06f5\u0735\u0d86\u{1f9ea}\ua3cc\u0eba\u04fe',
+entries: [{
+binding: 974,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}, {
+binding: 342,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}],
+});
+let commandEncoder35 = device1.createCommandEncoder({});
+let sampler30 = device1.createSampler({
+label: '\u9c39\u53f0\u074e\ue637',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 81.151,
+maxAnisotropy: 10,
+});
+try {
+renderBundleEncoder24.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(2, bindGroup10, new Uint32Array(7292), 1912, 0);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder32.copyBufferToBuffer(buffer11, 44000, buffer9, 23928, 808);
+dissociateBuffer(device1, buffer11);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+commandEncoder29.clearBuffer(buffer9, 16288, 4396);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise10;
+} catch {}
+let bindGroupLayout21 = device2.createBindGroupLayout({
+label: '\u{1ff91}\uf9ca\u{1fd2b}',
+entries: [{
+binding: 2571,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32sint', access: 'write-only', viewDimension: '2d' },
+}, {
+binding: 2930,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}],
+});
+let pipelineLayout11 = device2.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout21, bindGroupLayout16, bindGroupLayout16, bindGroupLayout13, bindGroupLayout16, bindGroupLayout21, bindGroupLayout13, bindGroupLayout16, bindGroupLayout21]
+});
+let querySet26 = device2.createQuerySet({
+label: '\u{1fc0a}\u2a8c\u0428\u5f51\u7670\u0666',
+type: 'occlusion',
+count: 2489,
+});
+let texture62 = device2.createTexture({
+label: '\u4779\uef9c',
+size: [108, 120, 223],
+mipLevelCount: 5,
+format: 'etc2-rgba8unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgba8unorm', 'etc2-rgba8unorm'],
+});
+let computePassEncoder30 = commandEncoder31.beginComputePass({label: '\u{1ff96}\u1c09\u05d9\u{1fb14}'});
+let renderBundle45 = renderBundleEncoder26.finish({label: '\udce8\u{1fc9c}\u037f\u4d15\u{1f6e9}\uf7ea\u{1f8f4}\u1fcd'});
+try {
+computePassEncoder30.insertDebugMarker('\u{1faaf}');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: { x: 7, y: 7, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(562), /* required buffer size: 562 */
+{offset: 562, bytesPerRow: 1380}, {width: 140, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let img8 = await imageWithData(34, 127, '#cae2e0f5', '#6934418d');
+try {
+shaderModule14.label = '\ua404\u{1fefa}\u097f\u{1ffb6}\u{1fb11}\u07e9\u3531\u{1faf9}\u0e65\ubc47';
+} catch {}
+let buffer16 = device3.createBuffer({size: 45965, usage: GPUBufferUsage.MAP_WRITE});
+let commandEncoder36 = device3.createCommandEncoder({label: '\ue42f\u788c\u0521\u{1fd03}\uc83e\u0fe1\ud70f'});
+let sampler31 = device3.createSampler({
+label: '\u5e01\u{1fe33}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 15.305,
+});
+let promise17 = adapter5.requestAdapterInfo();
+let textureView50 = texture55.createView({label: '\u7cdd\uc93d', dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 2});
+let computePassEncoder31 = commandEncoder25.beginComputePass({label: '\u8f36\u{1f802}\u69b1\u{1f865}\uc450'});
+try {
+texture28.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 35332, new DataView(new ArrayBuffer(11772)), 9316);
+} catch {}
+let commandEncoder37 = device2.createCommandEncoder({label: '\u056b\u8c24\ubc32\u3013\ue350\u0207\u8819'});
+let commandBuffer5 = commandEncoder37.finish({
+label: '\u83ab\u0ebb\u0d6c\uee36\u0be6\u05b0\u4252\u{1f9bc}\ucd44',
+});
+let textureView51 = texture57.createView({label: '\u0670\uedcc\ue193\u{1fe86}\u82ce\u{1fc2b}', aspect: 'all', arrayLayerCount: 1});
+let computePassEncoder32 = commandEncoder33.beginComputePass({label: '\u0b1d\u0a45\u03e5\uee4e\u0d7b\u00c7\uc532\u02f7\u{1fc02}\u841c'});
+let sampler32 = device2.createSampler({
+label: '\u01d4\u{1f8aa}\u{1fcbb}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 53.520,
+lodMaxClamp: 65.229,
+});
+let textureView52 = texture11.createView({label: '\u392f\u{1fc79}\ua9cd\ucd69\ufda5', dimension: '2d', baseMipLevel: 5, baseArrayLayer: 0});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 1, depthOrArrayLayers: 5}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 69, y: 107 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 4,
+  origin: { x: 0, y: 1, z: 3 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle46 = renderBundleEncoder25.finish();
+let arrayBuffer5 = buffer14.getMappedRange(856, 24084);
+let computePassEncoder33 = commandEncoder36.beginComputePass({label: '\u{1fd0d}\u{1f881}\u0b91\ufcc6\ud433\u1297'});
+let renderBundleEncoder32 = device3.createRenderBundleEncoder({
+  label: '\u7169\uf1d2\u{1faaa}\u09a2\ua66c',
+  colorFormats: ['rgba8unorm-srgb', 'r8sint', 'rgba8unorm-srgb'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let pipeline32 = await device3.createRenderPipelineAsync({
+label: '\u0cc7\u887b',
+layout: pipelineLayout10,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba8unorm-srgb', writeMask: 0}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}]
+},
+vertex: {
+  module: shaderModule14,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1564,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x4',
+offset: 212,
+shaderLocation: 9,
+}, {
+format: 'unorm8x2',
+offset: 1298,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 2076,
+attributes: [{
+format: 'sint8x2',
+offset: 248,
+shaderLocation: 10,
+}, {
+format: 'uint32x2',
+offset: 956,
+shaderLocation: 2,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let texture63 = device2.createTexture({
+label: '\u066e\u0810\u0bc8\u{1fcbb}\u52c0\u{1fbd6}\uf7b0\uc8a1\ua40a',
+size: {width: 80},
+dimension: '1d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba8snorm', 'rgba8snorm'],
+});
+try {
+await device2.popErrorScope();
+} catch {}
+try {
+texture59.destroy();
+} catch {}
+try {
+buffer14.destroy();
+} catch {}
+try {
+sampler17.label = '\u40b1\u6941\u9067\u845c\u34b7\u0f4d';
+} catch {}
+let commandBuffer6 = commandEncoder35.finish();
+let textureView53 = texture45.createView({label: '\u{1fe9d}\u574e\udb8a\u9368\u6ad6\u{1fe09}\u0ef6\u0077\uf96b\u0b12', aspect: 'depth-only'});
+let renderBundleEncoder33 = device1.createRenderBundleEncoder({
+  label: '\u0f20\u0e06\u{1f8ed}\uc1ec\u1cab\u6c88',
+  colorFormats: ['rgba16float', 'r32float', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder27.setIndexBuffer(buffer9, 'uint32', 21224, 80);
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer11, 32548, buffer9, 6472, 5784);
+dissociateBuffer(device1, buffer11);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+commandEncoder26.copyTextureToTexture({
+  texture: texture43,
+  mipLevel: 1,
+  origin: { x: 90, y: 0, z: 18 },
+  aspect: 'all',
+}, {
+  texture: texture43,
+  mipLevel: 2,
+  origin: { x: 1, y: 0, z: 49 },
+  aspect: 'all',
+}, {width: 411, height: 0, depthOrArrayLayers: 49});
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth16unorm', 'rgba8unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let imageData9 = new ImageData(192, 28);
+let querySet27 = device0.createQuerySet({
+label: '\u0247\ufe2a\u{1fd98}\u017d\u0e06\u{1f9d0}\u083b',
+type: 'occlusion',
+count: 3019,
+});
+let texture64 = device0.createTexture({
+label: '\ue82c\u{1ffca}\udc43\ufc64\ua750\u016b\u5ed8\u033b\ue899',
+size: {width: 2208},
+dimension: '1d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['r16sint'],
+});
+let sampler33 = device0.createSampler({
+label: '\ufd33\u0270\ud403\u0724\u040e\u0e78\u{1fd95}\u{1ffbb}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 68.384,
+maxAnisotropy: 12,
+});
+try {
+computePassEncoder27.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline16);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+device: device0,
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16sint'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: { x: 180, y: 80, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(1587), /* required buffer size: 1587 */
+{offset: 493, bytesPerRow: 338}, {width: 50, height: 32, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: imageBitmap5,
+  origin: { x: 204, y: 73 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipelineLayout12 = device0.createPipelineLayout({
+  label: '\u6ab6\u{1fa59}\u4a51\u{1fd21}\u2679\u36de\ua818\u0c73\u614e',
+  bindGroupLayouts: [bindGroupLayout9, bindGroupLayout5, bindGroupLayout4, bindGroupLayout9]
+});
+let commandEncoder38 = device0.createCommandEncoder({label: '\uf506\u{1f7b7}\u{1ffbb}\u038d\u{1fad9}\u{1ff4a}\u3ef6\u{1f762}'});
+try {
+commandEncoder38.resolveQuerySet(querySet11, 1962, 315, buffer8, 9472);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 22}
+*/
+{
+  source: img6,
+  origin: { x: 22, y: 156 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 6, y: 0, z: 13 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise18 = device0.createRenderPipelineAsync({
+layout: pipelineLayout1,
+multisample: {
+count: 4,
+},
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: 0}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {
+  format: 'rg16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {format: 'rg16uint', writeMask: GPUColorWrite.ALL}, {format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'src'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+}
+}]
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 3464,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 2048,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1304,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm16x2',
+offset: 868,
+shaderLocation: 12,
+}],
+}
+]
+},
+});
+let canvas7 = document.createElement('canvas');
+let imageData10 = new ImageData(232, 144);
+let computePassEncoder34 = commandEncoder26.beginComputePass({label: '\uc1f4\u8625\u712f\uc093\u6560\u48c6\u{1fefd}\u{1ff43}'});
+let renderBundleEncoder34 = device1.createRenderBundleEncoder({colorFormats: ['r16uint', 'rg16uint', 'rg32sint', undefined], depthReadOnly: true});
+let sampler34 = device1.createSampler({
+label: '\u{1f8e8}\u08cf\uee04\u080a\u9b93\uc0f4\u7239\u7719\u02ee\u0ec7\udcef',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 89.277,
+maxAnisotropy: 3,
+});
+try {
+commandEncoder32.clearBuffer(buffer9, 18804, 4952);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer17 = device2.createBuffer({
+  label: '\u{1fca1}\u05cf\u{1fe43}\u07d0\u0b35\u25e4\u0397\u27ec\u3e14',
+  size: 2864,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true
+});
+let textureView54 = texture59.createView({label: '\u{1f92c}\u{1f743}\u03e9', mipLevelCount: 1});
+let renderBundle47 = renderBundleEncoder26.finish({label: '\u81fb\u075c\uae26\u5786\u061a\u56f1\u02e5\u0626\u099b\u7697\uec41'});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+gc();
+let imageData11 = new ImageData(132, 244);
+let bindGroup15 = device0.createBindGroup({
+label: '\u0559\u047e\u44cc\u08f3\u{1f852}\ufdb8',
+layout: bindGroupLayout1,
+entries: [{
+binding: 2519,
+resource: sampler2
+}, {
+binding: 1779,
+resource: sampler5
+}],
+});
+let sampler35 = device0.createSampler({
+label: '\u0fa9\u0c55\u121d\u0863\u89f1\u035a\u9623\u0b37\u0627\u0b91\u1569',
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 72.598,
+lodMaxClamp: 93.754,
+});
+try {
+computePassEncoder14.setPipeline(pipeline25);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(24, undefined, 2433623191, 944471726);
+} catch {}
+try {
+commandEncoder38.copyBufferToBuffer(buffer2, 38056, buffer13, 26816, 3528);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['bgra8unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let computePassEncoder35 = commandEncoder38.beginComputePass({label: '\ubd56\u1b5c'});
+let renderBundle48 = renderBundleEncoder13.finish({label: '\ubea4\ue018\u8ce5\u0dd9\ud7eb\ub838\u0de5\u2645\u7461'});
+try {
+renderBundleEncoder22.drawIndexed(40, 72, 8);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 24540, new DataView(new ArrayBuffer(7174)), 4269, 2780);
+} catch {}
+try {
+commandEncoder29.copyBufferToBuffer(buffer11, 5268, buffer15, 2360, 252);
+dissociateBuffer(device1, buffer11);
+dissociateBuffer(device1, buffer15);
+} catch {}
+try {
+renderBundleEncoder24.pushDebugGroup('\u{1ff36}');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer15, 1272, new Float32Array(60047), 10048, 192);
+} catch {}
+let imageBitmap7 = await createImageBitmap(img1);
+try {
+window.someLabel = computePassEncoder29.label;
+} catch {}
+let pipelineLayout13 = device3.createPipelineLayout({
+  label: '\u8084\u7595\u0ca8\u{1f8a1}\u{1f933}\u7fda\ue5a2\u78cf\u0292\ue435\u4ec5',
+  bindGroupLayouts: [bindGroupLayout18, bindGroupLayout19, bindGroupLayout19, bindGroupLayout18, bindGroupLayout19, bindGroupLayout18, bindGroupLayout18]
+});
+let renderBundle49 = renderBundleEncoder30.finish({label: '\u{1fc92}\ud1f1\u14d7\u0cd0\u9d22\u0746\u35ea\ua3fd\uc8f5'});
+try {
+renderBundleEncoder32.setVertexBuffer(6, undefined, 601697998, 2671836501);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let videoFrame5 = new VideoFrame(offscreenCanvas3, {timestamp: 0});
+let buffer18 = device2.createBuffer({label: '\u1ac8\u{1ff2f}\u{1f8fa}\ud97c\u{1f931}', size: 25990, usage: GPUBufferUsage.INDEX});
+let renderBundle50 = renderBundleEncoder26.finish({});
+try {
+canvas7.getContext('webgpu');
+} catch {}
+let querySet28 = device3.createQuerySet({
+label: '\u0484\u{1fa61}\u0a4f\u02f3\u026d\u{1fc0c}\u{1f949}\u9d84\u5b15',
+type: 'occlusion',
+count: 4078,
+});
+let renderBundleEncoder35 = device3.createRenderBundleEncoder({
+  label: '\u{1fbcb}\u{1fe7a}\u4fb9',
+  colorFormats: ['rgba8unorm-srgb', 'r8sint', 'rgba8unorm-srgb'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+device3.pushErrorScope('out-of-memory');
+} catch {}
+try {
+buffer16.destroy();
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule15 = device0.createShaderModule({
+label: '\ud12a\u{1fb5d}\u00fa\u0436\u023f\u3cfe\u410a\u0146',
+code: `@group(0) @binding(2491)
+var<storage, read_write> parameter15: array<u32>;
+@group(5) @binding(2456)
+var<storage, read_write> local18: array<u32>;
+@group(2) @binding(1668)
+var<storage, read_write> function21: array<u32>;
+@group(1) @binding(2491)
+var<storage, read_write> type15: array<u32>;
+@group(4) @binding(169)
+var<storage, read_write> type16: array<u32>;
+@group(3) @binding(1668)
+var<storage, read_write> type17: array<u32>;
+
+@compute @workgroup_size(7, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<f32>,
+  @location(1) f1: i32,
+  @location(0) f2: vec3<i32>,
+  @location(2) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(54) a0: f32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(6) f158: vec4<f16>,
+  @location(72) f159: f32,
+  @location(76) f160: vec3<f16>,
+  @location(58) f161: u32,
+  @location(8) f162: vec4<f16>,
+  @location(13) f163: vec3<i32>,
+  @location(48) f164: i32,
+  @location(30) f165: vec2<u32>,
+  @location(85) f166: f32,
+  @location(32) f167: vec3<i32>,
+  @location(49) f168: vec2<f32>,
+  @location(103) f169: vec2<f32>,
+  @location(84) f170: vec4<u32>,
+  @location(37) f171: vec3<i32>,
+  @location(29) f172: f32,
+  @builtin(position) f173: vec4<f32>,
+  @location(4) f174: vec3<f32>,
+  @location(2) f175: vec2<i32>,
+  @location(92) f176: vec3<f16>,
+  @location(96) f177: vec2<f32>,
+  @location(14) f178: vec4<u32>,
+  @location(74) f179: vec3<u32>,
+  @location(33) f180: vec4<i32>,
+  @location(44) f181: f32,
+  @location(40) f182: vec3<f16>,
+  @location(34) f183: vec3<i32>,
+  @location(62) f184: vec2<f16>,
+  @location(54) f185: f32,
+  @location(61) f186: vec3<u32>,
+  @location(70) f187: vec3<f16>,
+  @location(47) f188: vec4<f16>,
+  @location(0) f189: vec4<f32>,
+  @location(107) f190: vec3<f32>,
+  @location(10) f191: vec2<u32>,
+  @location(65) f192: vec3<u32>,
+  @location(9) f193: vec2<f16>,
+  @location(46) f194: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: i32, @location(10) a1: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+});
+let buffer19 = device0.createBuffer({label: '\ue969\u{1ff7a}\u{1fa2d}', size: 47860, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let querySet29 = device0.createQuerySet({
+label: '\u0da0\ua3f9\u0fa9\u14a4\u0e87\uc3f7',
+type: 'occlusion',
+count: 2298,
+});
+try {
+renderBundleEncoder10.setBindGroup(7, bindGroup0, new Uint32Array(5034), 3717, 0);
+} catch {}
+try {
+renderBundleEncoder23.draw(72);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: { x: 8, y: 0, z: 6 },
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer4), /* required buffer size: 6355524 */
+{offset: 516, bytesPerRow: 528, rowsPerImage: 236}, {width: 19, height: 0, depthOrArrayLayers: 52});
+} catch {}
+let pipeline33 = device0.createRenderPipeline({
+layout: pipelineLayout12,
+fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint'}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one', dstFactor: 'one-minus-dst'},
+alpha: {operation: 'add', srcFactor: 'one', dstFactor: 'constant'},
+},
+  writeMask: 0
+}, {
+  format: 'rg11b10ufloat',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'dst-alpha'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED
+}]
+},
+vertex: {
+  module: shaderModule10,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 2200,
+attributes: [{
+format: 'uint32x4',
+offset: 1180,
+shaderLocation: 15,
+}, {
+format: 'unorm16x2',
+offset: 1672,
+shaderLocation: 7,
+}, {
+format: 'uint8x2',
+offset: 1564,
+shaderLocation: 13,
+}, {
+format: 'sint32x2',
+offset: 1500,
+shaderLocation: 4,
+}, {
+format: 'unorm16x2',
+offset: 808,
+shaderLocation: 8,
+}, {
+format: 'float32x4',
+offset: 776,
+shaderLocation: 9,
+}, {
+format: 'sint8x2',
+offset: 296,
+shaderLocation: 14,
+}, {
+format: 'uint16x4',
+offset: 32,
+shaderLocation: 2,
+}, {
+format: 'snorm8x2',
+offset: 1124,
+shaderLocation: 1,
+}, {
+format: 'float16x4',
+offset: 356,
+shaderLocation: 11,
+}, {
+format: 'sint32',
+offset: 1672,
+shaderLocation: 3,
+}, {
+format: 'sint16x2',
+offset: 956,
+shaderLocation: 5,
+}, {
+format: 'uint32x3',
+offset: 2116,
+shaderLocation: 16,
+}, {
+format: 'float32x3',
+offset: 1832,
+shaderLocation: 10,
+}, {
+format: 'float32x3',
+offset: 620,
+shaderLocation: 12,
+}, {
+format: 'sint32x3',
+offset: 1028,
+shaderLocation: 6,
+}, {
+format: 'snorm8x4',
+offset: 1416,
+shaderLocation: 0,
+}],
+}
+]
+},
+});
+let shaderModule16 = device3.createShaderModule({
+label: '\u05c2\u4560\u0577\u1631\u0e9c\u0068\uebba\u0040\u1c93',
+code: `@group(0) @binding(1812)
+var<storage, read_write> parameter16: array<u32>;
+@group(2) @binding(559)
+var<storage, read_write> type18: array<u32>;
+@group(5) @binding(1812)
+var<storage, read_write> parameter17: array<u32>;
+@group(2) @binding(1417)
+var<storage, read_write> i20: array<u32>;
+@group(6) @binding(1812)
+var<storage, read_write> type19: array<u32>;
+@group(4) @binding(1417)
+var<storage, read_write> type20: array<u32>;
+@group(3) @binding(1812)
+var<storage, read_write> parameter18: array<u32>;
+
+@compute @workgroup_size(1, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(1) f1: vec2<i32>,
+  @location(0) f2: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(13) a0: i32, @location(4) a1: vec4<i32>, @location(6) a2: vec4<f16>, @location(14) a3: vec3<u32>, @location(0) a4: vec2<u32>, @location(5) a5: vec4<u32>, @location(1) a6: vec2<u32>, @location(7) a7: vec4<i32>, @location(11) a8: vec4<u32>, @location(12) a9: f16, @location(15) a10: vec4<f16>, @location(10) a11: f16, @builtin(vertex_index) a12: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+let commandEncoder39 = device3.createCommandEncoder({label: '\uab01\ufc1d\u1c13\uc0be'});
+let computePassEncoder36 = commandEncoder39.beginComputePass({});
+try {
+adapter2.label = '\u012d\u0cd0\u2ea6\u00cf\u4271';
+} catch {}
+let shaderModule17 = device2.createShaderModule({
+label: '\u75ff\u0026',
+code: `@group(3) @binding(4783)
+var<storage, read_write> field18: array<u32>;
+@group(6) @binding(4783)
+var<storage, read_write> parameter19: array<u32>;
+@group(0) @binding(2930)
+var<storage, read_write> global16: array<u32>;
+@group(0) @binding(2571)
+var<storage, read_write> parameter20: array<u32>;
+@group(8) @binding(2930)
+var<storage, read_write> local19: array<u32>;
+@group(6) @binding(9855)
+var<storage, read_write> parameter21: array<u32>;
+@group(5) @binding(2930)
+var<storage, read_write> field19: array<u32>;
+@group(8) @binding(2571)
+var<storage, read_write> local20: array<u32>;
+@group(5) @binding(2571)
+var<storage, read_write> function22: array<u32>;
+@group(6) @binding(418)
+var<storage, read_write> type21: array<u32>;
+@group(3) @binding(9855)
+var<storage, read_write> global17: array<u32>;
+
+@compute @workgroup_size(7, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S15 {
+  @location(11) f0: vec2<f32>,
+  @location(18) f1: vec3<f16>,
+  @location(88) f2: vec2<i32>,
+  @location(92) f3: vec3<f32>,
+  @location(47) f4: vec4<i32>,
+  @location(10) f5: vec3<f32>,
+  @location(27) f6: vec3<u32>,
+  @location(37) f7: vec4<f16>,
+  @builtin(position) f8: vec4<f32>,
+  @location(62) f9: u32,
+  @location(36) f10: vec4<i32>,
+  @location(57) f11: vec4<u32>
+}
+struct FragmentOutput0 {
+  @location(5) f0: vec4<u32>,
+  @location(4) f1: vec2<u32>,
+  @location(3) f2: vec4<f32>,
+  @location(7) f3: vec3<i32>,
+  @location(1) f4: vec4<u32>,
+  @location(0) f5: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(17) a0: vec4<i32>, @location(15) a1: vec2<f32>, @location(60) a2: vec2<f16>, @location(65) a3: vec3<u32>, @location(87) a4: u32, @location(39) a5: vec2<f16>, @location(81) a6: vec3<u32>, @location(77) a7: u32, @location(7) a8: u32, @location(64) a9: vec3<i32>, @builtin(sample_mask) a10: u32, a11: S15, @location(43) a12: i32, @location(90) a13: vec3<i32>, @builtin(sample_index) a14: u32, @builtin(front_facing) a15: bool, @location(68) a16: vec3<i32>, @location(51) a17: f32, @location(1) a18: vec2<f32>, @location(49) a19: vec2<f32>, @location(56) a20: f16, @location(38) a21: vec2<f16>, @location(63) a22: f32, @location(40) a23: vec3<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S14 {
+  @location(19) f0: vec2<f16>,
+  @location(14) f1: vec4<u32>,
+  @location(0) f2: vec3<f16>,
+  @location(17) f3: vec4<f16>,
+  @location(1) f4: f32,
+  @location(6) f5: vec3<i32>,
+  @builtin(instance_index) f6: u32,
+  @location(4) f7: vec4<i32>,
+  @location(15) f8: f32,
+  @location(21) f9: vec4<i32>,
+  @location(7) f10: u32,
+  @location(20) f11: vec4<f16>
+}
+struct VertexOutput0 {
+  @location(90) f195: vec3<i32>,
+  @location(65) f196: vec3<u32>,
+  @location(1) f197: vec2<f32>,
+  @location(60) f198: vec2<f16>,
+  @builtin(position) f199: vec4<f32>,
+  @location(27) f200: vec3<u32>,
+  @location(64) f201: vec3<i32>,
+  @location(47) f202: vec4<i32>,
+  @location(19) f203: f16,
+  @location(81) f204: vec3<u32>,
+  @location(37) f205: vec4<f16>,
+  @location(40) f206: vec3<u32>,
+  @location(51) f207: f32,
+  @location(10) f208: vec3<f32>,
+  @location(9) f209: f16,
+  @location(39) f210: vec2<f16>,
+  @location(56) f211: f16,
+  @location(77) f212: u32,
+  @location(5) f213: vec2<i32>,
+  @location(36) f214: vec4<i32>,
+  @location(7) f215: u32,
+  @location(63) f216: f32,
+  @location(68) f217: vec3<i32>,
+  @location(62) f218: u32,
+  @location(17) f219: vec4<i32>,
+  @location(38) f220: vec2<f16>,
+  @location(92) f221: vec3<f32>,
+  @location(31) f222: vec3<u32>,
+  @location(45) f223: u32,
+  @location(73) f224: vec3<f32>,
+  @location(57) f225: vec4<u32>,
+  @location(11) f226: vec2<f32>,
+  @location(29) f227: vec3<f16>,
+  @location(87) f228: u32,
+  @location(49) f229: vec2<f32>,
+  @location(43) f230: i32,
+  @location(88) f231: vec2<i32>,
+  @location(18) f232: vec3<f16>,
+  @location(15) f233: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec4<u32>, @location(2) a1: vec4<f16>, @location(5) a2: vec4<f16>, @location(13) a3: vec4<f32>, @location(10) a4: u32, @location(18) a5: vec2<i32>, @location(12) a6: vec4<f32>, @location(11) a7: vec4<i32>, @location(16) a8: vec2<f32>, @location(9) a9: vec2<i32>, @location(8) a10: i32, a11: S14, @builtin(vertex_index) a12: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+});
+pseudoSubmit(device2, commandEncoder27);
+let textureView55 = texture57.createView({
+  label: '\ube52\u{1fd83}\u0d1d\u05df\u0aad\u38ae\ud269\uba71\u9ac8\u4c2e',
+  dimension: '2d',
+  mipLevelCount: 1,
+  baseArrayLayer: 1
+});
+let sampler36 = device2.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 67.756,
+lodMaxClamp: 71.630,
+compare: 'not-equal',
+});
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline34 = await device2.createRenderPipelineAsync({
+layout: pipelineLayout11,
+multisample: {
+mask: 0x7f4f3956,
+},
+fragment: {
+  module: shaderModule17,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, undefined, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+vertex: {
+  module: shaderModule17,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x4',
+offset: 14304,
+shaderLocation: 13,
+}, {
+format: 'snorm16x2',
+offset: 14596,
+shaderLocation: 20,
+}, {
+format: 'uint32x2',
+offset: 18516,
+shaderLocation: 7,
+}, {
+format: 'sint32x3',
+offset: 1220,
+shaderLocation: 9,
+}, {
+format: 'float32x3',
+offset: 45124,
+shaderLocation: 15,
+}, {
+format: 'float32',
+offset: 50288,
+shaderLocation: 12,
+}, {
+format: 'float32x3',
+offset: 30468,
+shaderLocation: 1,
+}, {
+format: 'sint32x2',
+offset: 24332,
+shaderLocation: 6,
+}, {
+format: 'sint32x4',
+offset: 5308,
+shaderLocation: 21,
+}, {
+format: 'uint32x2',
+offset: 45364,
+shaderLocation: 14,
+}, {
+format: 'float32x2',
+offset: 63408,
+shaderLocation: 0,
+}, {
+format: 'unorm16x2',
+offset: 6612,
+shaderLocation: 19,
+}, {
+format: 'snorm8x2',
+offset: 34964,
+shaderLocation: 17,
+}, {
+format: 'sint8x4',
+offset: 58264,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 37676,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 23912,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x2',
+offset: 8072,
+shaderLocation: 4,
+}, {
+format: 'float16x2',
+offset: 11296,
+shaderLocation: 16,
+}, {
+format: 'float32x3',
+offset: 1860,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 42644,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 34788,
+shaderLocation: 2,
+}, {
+format: 'sint32x3',
+offset: 30452,
+shaderLocation: 11,
+}, {
+format: 'uint8x4',
+offset: 25176,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 0,
+attributes: [{
+format: 'sint8x4',
+offset: 35704,
+shaderLocation: 18,
+}, {
+format: 'uint16x2',
+offset: 26104,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+try {
+  await promise17;
+} catch {}
+try {
+window.someLabel = bindGroupLayout19.label;
+} catch {}
+let commandEncoder40 = device3.createCommandEncoder();
+try {
+renderBundleEncoder35.insertDebugMarker('\u7ec2');
+} catch {}
+try {
+gpuCanvasContext4.configure({
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise16;
+} catch {}
+let commandEncoder41 = device0.createCommandEncoder({label: '\udd6f\u{1f937}'});
+let texture65 = device0.createTexture({
+label: '\u82b3\u08d5\u52f2\u{1ff4e}\uf5fa\uaba0\u782d\u{1fb53}\u001e',
+size: {width: 70, height: 65, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'astc-10x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-10x5-unorm'],
+});
+let renderBundle51 = renderBundleEncoder15.finish({label: '\u4a8e\u89ac\u6289\u6d99\u6301\u{1fbf3}\u0d2d\u{1fa26}\u008b\u0ea9\u00b8'});
+try {
+computePassEncoder25.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(2, bindGroup2, new Uint32Array(6897), 5982, 0);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline16);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder41.resolveQuerySet(querySet24, 703, 212, buffer8, 6400);
+} catch {}
+let bindGroup16 = device1.createBindGroup({
+layout: bindGroupLayout12,
+entries: [{
+binding: 270,
+resource: externalTexture5
+}, {
+binding: 802,
+resource: {
+buffer: buffer10,
+offset: 29952,
+size: 6144,
+}
+}, {
+binding: 602,
+resource: externalTexture7
+}],
+});
+let buffer20 = device1.createBuffer({size: 30744, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture66 = device1.createTexture({
+label: '\u7dc6\u25ce\u{1f8e8}\u{1ff2d}',
+size: {width: 1584},
+dimension: '1d',
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler37 = device1.createSampler({
+label: '\u07b3\ub911\u7cb0\ub52e\u6999\u03d0\u0ea2\u0342',
+addressModeU: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 69.331,
+lodMaxClamp: 73.560,
+});
+try {
+device1.destroy();
+} catch {}
+let commandEncoder42 = device3.createCommandEncoder({label: '\u08a3\ub992\ua17f\u0d9b\uc6d7\u0e03\uab44'});
+canvas6.width = 511;
+try {
+renderBundleEncoder35.setPipeline(pipeline32);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline35 = await device3.createRenderPipelineAsync({
+label: '\u05c2\u{1f656}\u250f\ua1a9\ued48',
+layout: pipelineLayout10,
+multisample: {
+mask: 0x9857811e,
+},
+fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'constant'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'invert',
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 3722,
+stencilWriteMask: 3357,
+depthBias: 99,
+depthBiasSlopeScale: 97,
+depthBiasClamp: 57,
+},
+vertex: {
+  module: shaderModule14,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1864,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x4',
+offset: 1268,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 4432,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x4',
+offset: 1008,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 2368,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32',
+offset: 868,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 2536,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 2056,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x2',
+offset: 1244,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let canvas8 = document.createElement('canvas');
+let img9 = await imageWithData(225, 222, '#3c8181c2', '#82c60db6');
+let imageBitmap8 = await createImageBitmap(canvas7);
+let bindGroupLayout22 = device0.createBindGroupLayout({
+label: '\uf801\u{1fa42}\u0cf0\u92cd',
+entries: [{
+binding: 1999,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 314,
+visibility: 0,
+texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+}, {
+binding: 2124,
+visibility: 0,
+externalTexture: {},
+}],
+});
+try {
+renderBundleEncoder22.drawIndexed(32, 80, 8, -712, 64);
+} catch {}
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 226, y: 1, z: 37 },
+  aspect: 'all',
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 517, y: 0, z: 7 },
+  aspect: 'all',
+}, {width: 4023, height: 0, depthOrArrayLayers: 9});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 2,
+  origin: { x: 0, y: 1, z: 95 },
+  aspect: 'all',
+}, new Int32Array(arrayBuffer1), /* required buffer size: 471879 */
+{offset: 647, bytesPerRow: 199, rowsPerImage: 74}, {width: 8, height: 0, depthOrArrayLayers: 33});
+} catch {}
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer15, 24612, new Int16Array(30384), 23806, 992);
+} catch {}
+let querySet30 = device3.createQuerySet({
+label: '\ue89d\u64dd\u3794\uce41\u12f3',
+type: 'occlusion',
+count: 988,
+});
+let renderBundle52 = renderBundleEncoder35.finish({});
+try {
+renderBundleEncoder32.setVertexBuffer(54, undefined, 3207654585);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let videoFrame6 = new VideoFrame(canvas2, {timestamp: 0});
+let querySet31 = device3.createQuerySet({
+label: '\u08c9\uef88\u3701\u813c\u0bea\u0598\u3fd5\u1a13',
+type: 'occlusion',
+count: 3044,
+});
+let computePassEncoder37 = commandEncoder40.beginComputePass({label: '\u1b69\u6119'});
+let renderBundle53 = renderBundleEncoder30.finish({label: '\u{1fdcf}\uc969\u0cd9\ufe70\u03cd'});
+canvas4.height = 877;
+let img10 = await imageWithData(208, 53, '#2001be8f', '#c2de2ed1');
+try {
+adapter2.label = '\uac0e\u{1fdbb}\u0979\u{1f9f6}\u76f2\u{1faa0}\u{1f662}\u14e4';
+} catch {}
+try {
+canvas8.getContext('2d');
+} catch {}
+pseudoSubmit(device2, commandEncoder23);
+let texture67 = device2.createTexture({
+label: '\u0315\uca2a\u5477\u0138\u2877\u702e\u0be6\u38bb\u{1fdb8}\u08f5\u{1fbae}',
+size: [8400, 160, 1],
+mipLevelCount: 5,
+dimension: '2d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['bgra8unorm'],
+});
+let sampler38 = device2.createSampler({
+label: '\uaf22\u{1f957}\u08d0\u0151\u06ee\uff62\u{1f8c1}\u{1f67a}\ub0d0\u0143',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 27.472,
+lodMaxClamp: 50.127,
+compare: 'always',
+maxAnisotropy: 1,
+});
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+let commandBuffer7 = commandEncoder42.finish({
+label: '\uc1ae\ue910\u577e\u0e50\u042e\u0f62\u8099\u2b28\u3648',
+});
+let texture68 = device3.createTexture({
+label: '\ub2f2\u229a\ub9ed',
+size: [160, 60, 1],
+mipLevelCount: 2,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder32.setPipeline(pipeline32);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline36 = device3.createRenderPipeline({
+label: '\uf33a\u4a6a\uea4c\u0032\u2c14\u0c52\u{1fb99}\u{1fe1c}',
+layout: pipelineLayout10,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'dst'},
+alpha: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'dst-alpha'},
+},
+  writeMask: 0
+}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'src'},
+},
+  writeMask: GPUColorWrite.ALPHA
+}]
+},
+vertex: {
+  module: shaderModule14,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 3172,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x2',
+offset: 2868,
+shaderLocation: 9,
+}, {
+format: 'sint8x4',
+offset: 1412,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 2816,
+shaderLocation: 6,
+}, {
+format: 'uint32x4',
+offset: 3480,
+shaderLocation: 2,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+video0.height = 77;
+let texture69 = device0.createTexture({
+size: {width: 895, height: 1, depthOrArrayLayers: 154},
+mipLevelCount: 7,
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let renderBundle54 = renderBundleEncoder8.finish();
+let sampler39 = device0.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'linear',
+lodMinClamp: 97.310,
+lodMaxClamp: 98.450,
+compare: 'always',
+});
+try {
+computePassEncoder20.setPipeline(pipeline30);
+} catch {}
+try {
+commandEncoder41.copyTextureToBuffer({
+  texture: texture34,
+  mipLevel: 0,
+  origin: { x: 6, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 60 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 40032 */
+offset: 39972,
+buffer: buffer5,
+}, {width: 15, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder41.resolveQuerySet(querySet4, 270, 466, buffer5, 26368);
+} catch {}
+let promise19 = device0.queue.onSubmittedWorkDone();
+try {
+externalTexture3.label = '\u50f4\u0f4b\uebe6\u44db\u0bff\u6ed5\u077e\u343d\u3f85\u0e9a';
+} catch {}
+let computePassEncoder38 = commandEncoder41.beginComputePass({label: '\u0219\u{1fc98}\ud86b\u93f7\u0790'});
+let renderBundle55 = renderBundleEncoder22.finish({label: '\u1fd7\u7378\u{1ff39}\u3986\u094a'});
+try {
+renderBundleEncoder23.draw(40, 56, 80, 32);
+} catch {}
+let promise20 = buffer6.mapAsync(GPUMapMode.READ, 6800);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 1, depthOrArrayLayers: 5}
+*/
+{
+  source: imageData8,
+  origin: { x: 50, y: 83 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 4,
+  origin: { x: 0, y: 1, z: 2 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise21 = device0.createComputePipelineAsync({
+label: '\u6f73\u4642\u{1f97c}\u0916\ua6f1\u{1fa1e}',
+layout: pipelineLayout9,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+},
+});
+canvas0.height = 825;
+let bindGroup17 = device0.createBindGroup({
+label: '\u{1fd5c}\u54e0\u0b43\ub2e6',
+layout: bindGroupLayout9,
+entries: [{
+binding: 2491,
+resource: textureView28
+}],
+});
+let pipelineLayout14 = device0.createPipelineLayout({
+  label: '\u0846\u979d\u7923\u0e3a\u073c\u1dd2\ub4be\u8311\u27a6',
+  bindGroupLayouts: [bindGroupLayout9, bindGroupLayout6, bindGroupLayout2, bindGroupLayout8, bindGroupLayout2, bindGroupLayout22, bindGroupLayout7, bindGroupLayout8, bindGroupLayout4, bindGroupLayout3, bindGroupLayout22]
+});
+let textureView56 = texture10.createView({
+  label: '\u7f7e\u0c52\u{1f8fb}\u768a\u07e2\u{1ffd9}',
+  format: 'astc-10x5-unorm',
+  baseMipLevel: 9,
+  mipLevelCount: 1,
+  baseArrayLayer: 24,
+  arrayLayerCount: 7
+});
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({
+  label: '\uf388\u0773\u{1fe35}\u06f6',
+  colorFormats: ['rgba32sint', 'r16uint', 'rg16sint', 'rg16uint', 'rg16uint', 'bgra8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder35.setPipeline(pipeline15);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+device: device0,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x5-unorm', 'astc-6x5-unorm-srgb'],
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 48560, new DataView(new ArrayBuffer(27606)), 4820, 1892);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 1,
+  origin: { x: 18, y: 6, z: 0 },
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer2), /* required buffer size: 479 */
+{offset: 479, bytesPerRow: 388, rowsPerImage: 144}, {width: 54, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let pipeline37 = device0.createComputePipeline({
+label: '\u809b\u{1f7ea}\u{1fa91}\u3954\u26e8\u06a2\u0ade\u{1f92b}\u2829',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule10,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let commandEncoder43 = device2.createCommandEncoder({label: '\u5897\u{1ff4a}\u0e7b\u3d41\u19d6'});
+let texture70 = gpuCanvasContext6.getCurrentTexture();
+try {
+device2.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 383 */
+{offset: 383}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let video8 = await videoWithData();
+let commandEncoder44 = device0.createCommandEncoder({label: '\u4187\u35da\ubae6\u2ebc\u002f\u8e27\ufde0\u{1ff12}\u07c1'});
+let textureView57 = texture7.createView({label: '\u7c90\u008b', baseMipLevel: 0, arrayLayerCount: 1});
+let renderBundle56 = renderBundleEncoder11.finish({label: '\u03b4\u405b\u98fc\uea90\u6d24\ud583\u00c6\ua15e\u6961\u47c2\u{1fd81}'});
+try {
+renderBundleEncoder23.draw(16, 40, 56, 72);
+} catch {}
+try {
+renderBundleEncoder23.drawIndexed(24, 32, 64);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer8, 'uint32', 8544, 3193);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(43, undefined, 2543314033, 1422199411);
+} catch {}
+try {
+texture37.destroy();
+} catch {}
+try {
+commandEncoder44.clearBuffer(buffer5, 55184, 588);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 20744, new BigUint64Array(60904), 43124, 52);
+} catch {}
+let promise22 = device0.createComputePipelineAsync({
+label: '\u4060\u1a7e\u{1fa94}\uac7a\u20e3',
+layout: pipelineLayout12,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+},
+});
+let bindGroupLayout23 = device3.createBindGroupLayout({
+label: '\u{1f9e9}\uec73\u{1f864}\u{1fe78}\u5998\u{1f78c}\uad59',
+entries: [{
+binding: 1548,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}],
+});
+let commandEncoder45 = device3.createCommandEncoder({label: '\u0965\u45fb\u{1fde8}\u0da0\u0716\uabbe'});
+let texture71 = device3.createTexture({
+label: '\u25c6\uc4bf\u{1fbb3}\u3ad4\u02b3\uec40\u8895\ud88a\u0f2e\u04ce\u7481',
+size: {width: 32, height: 10, depthOrArrayLayers: 19},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'r8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundleEncoder37 = device3.createRenderBundleEncoder({
+  label: '\u{1fec2}\u{1faa1}\u73e7\u8f95\u0135\u56af\u0193\u0dae',
+  colorFormats: ['rgba8unorm-srgb', 'r8sint', 'rgba8unorm-srgb'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler40 = device3.createSampler({
+label: '\u0bbd\ufb24\u00e6\u4228\u23ed\u87fa\u08a4',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 0.692,
+});
+try {
+renderBundleEncoder32.draw(72, 16, 0);
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+let promise23 = device3.queue.onSubmittedWorkDone();
+try {
+adapter6.label = '\u{1f651}\u{1f777}\u8d68\u0e14\u0d68\u3f86\u0fdc\u050e\u6902\u0a28\u{1fcd2}';
+} catch {}
+let textureView58 = texture57.createView({dimension: '2d'});
+let computePassEncoder39 = commandEncoder43.beginComputePass();
+let renderBundleEncoder38 = device2.createRenderBundleEncoder({
+  colorFormats: ['bgra8unorm', 'r16uint', undefined, 'bgra8unorm', 'r32uint', 'rgb10a2uint'],
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+device2.queue.submit([
+]);
+} catch {}
+let adapter8 = await navigator.gpu.requestAdapter({
+powerPreference: 'high-performance',
+});
+let imageBitmap9 = await createImageBitmap(img7);
+let sampler41 = device3.createSampler({
+label: '\ude91\u{1fd2e}\u5f1e\u9cb5\u3008\ua215\u0c0c\u9f5b',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 84.618,
+lodMaxClamp: 97.522,
+maxAnisotropy: 17,
+});
+try {
+renderBundleEncoder32.draw(48, 32, 16, 8);
+} catch {}
+offscreenCanvas4.height = 909;
+let sampler42 = device2.createSampler({
+label: '\u{1f991}\u005d\u{1fa2e}\u0eb0\u0339\u0603\u0031',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 33.771,
+lodMaxClamp: 79.182,
+});
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas3,
+  origin: { x: 26, y: 52 },
+  flipY: true,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let querySet32 = device3.createQuerySet({
+label: '\u2f6d\u0bba\ubbcd\u{1fa2d}\u015e\u340d\u{1fb2a}\u0b11',
+type: 'occlusion',
+count: 1148,
+});
+let texture72 = device3.createTexture({
+label: '\u077a\u0427\u0b9b\u04e6\u0334\u3f7a\u5e10\u7758\ufcb3\u0068\u7cb4',
+size: [320, 120, 241],
+mipLevelCount: 7,
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['r32uint', 'r32uint', 'r32uint'],
+});
+try {
+device3.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 1,
+  origin: { x: 0, y: 15, z: 0 },
+  aspect: 'depth-only',
+}, new Uint8Array(arrayBuffer5), /* required buffer size: 462 */
+{offset: 302, bytesPerRow: 284}, {width: 80, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline38 = await device3.createComputePipelineAsync({
+label: '\u0957\ued25\u641e\u968d\u4d3c\u{1fe3c}\u909c\u77f4\u911d\ucdfc\u{1ff7b}',
+layout: pipelineLayout13,
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline39 = await device3.createRenderPipelineAsync({
+label: '\u{1ffaa}\ua0b9\ud4c0\u1f94',
+layout: pipelineLayout13,
+multisample: {
+count: 4,
+mask: 0x7f26c1e4,
+},
+fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'src-alpha-saturated'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {format: 'r8sint', writeMask: 0}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-constant'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'constant'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilWriteMask: 1084,
+depthBias: 63,
+depthBiasSlopeScale: 42,
+depthBiasClamp: 80,
+},
+vertex: {
+  module: shaderModule16,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 3208,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32',
+offset: 376,
+shaderLocation: 10,
+}, {
+format: 'uint16x2',
+offset: 1296,
+shaderLocation: 0,
+}, {
+format: 'sint32x2',
+offset: 1156,
+shaderLocation: 7,
+}, {
+format: 'uint32',
+offset: 1112,
+shaderLocation: 1,
+}, {
+format: 'sint32x4',
+offset: 868,
+shaderLocation: 13,
+}, {
+format: 'uint32',
+offset: 1056,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 3724,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 1692,
+shaderLocation: 4,
+}, {
+format: 'float16x4',
+offset: 280,
+shaderLocation: 12,
+}, {
+format: 'float32x4',
+offset: 3160,
+shaderLocation: 6,
+}, {
+format: 'uint32x3',
+offset: 2480,
+shaderLocation: 14,
+}, {
+format: 'uint16x2',
+offset: 1988,
+shaderLocation: 5,
+}, {
+format: 'float32',
+offset: 2056,
+shaderLocation: 15,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let canvas9 = document.createElement('canvas');
+let texture73 = device3.createTexture({
+label: '\u{1f98a}\u4525\u039f\uf0e3',
+size: {width: 80, height: 30, depthOrArrayLayers: 51},
+mipLevelCount: 5,
+sampleCount: 1,
+dimension: '3d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgb10a2uint', 'rgb10a2uint', 'rgb10a2uint'],
+});
+let renderBundleEncoder39 = device3.createRenderBundleEncoder({label: '\ua5f5\u3ba4\u{1fcdc}\ue896\u0f82', colorFormats: ['rg8sint'], sampleCount: 4});
+try {
+renderBundleEncoder32.drawIndexed(48, 64, 40, -376);
+} catch {}
+try {
+renderBundleEncoder37.setPipeline(pipeline32);
+} catch {}
+let video9 = await videoWithData();
+offscreenCanvas0.height = 717;
+let texture74 = gpuCanvasContext3.getCurrentTexture();
+let textureView59 = texture22.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 3});
+let renderBundle57 = renderBundleEncoder7.finish({label: '\u{1fcc3}\u{1f8cc}\u2a4e\u0124\u{1f75b}\u{1f7de}'});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup17, new Uint32Array(3295), 1892, 0);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(5, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder23.draw(40);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder44.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 39456 */
+offset: 39456,
+rowsPerImage: 265,
+buffer: buffer7,
+}, {
+  texture: texture55,
+  mipLevel: 2,
+  origin: { x: 6, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 6, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer7);
+} catch {}
+let promise24 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise19;
+} catch {}
+canvas7.height = 21;
+let gpuCanvasContext8 = canvas9.getContext('webgpu');
+offscreenCanvas2.width = 377;
+let textureView60 = texture63.createView({label: '\u2659\uf6ff', baseMipLevel: 0});
+let sampler43 = device2.createSampler({
+label: '\u{1f84d}\u{1fe12}\u0673\u00f5',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 45.297,
+lodMaxClamp: 67.758,
+});
+try {
+buffer14.unmap();
+} catch {}
+let textureView61 = texture57.createView({label: '\uf98d\u01c3\u04d3\u99d0\u03e6', dimension: '2d', baseArrayLayer: 1});
+try {
+renderBundleEncoder38.setIndexBuffer(buffer18, 'uint16', 8870, 13014);
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(18, undefined, 3974369891, 210799136);
+} catch {}
+try {
+computePassEncoder23.pushDebugGroup('\u{1fee1}');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: { x: 145, y: 10, z: 1 },
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer5), /* required buffer size: 200 */
+{offset: 200, bytesPerRow: 1538, rowsPerImage: 288}, {width: 710, height: 31, depthOrArrayLayers: 0});
+} catch {}
+let canvas10 = document.createElement('canvas');
+let promise25 = adapter3.requestAdapterInfo();
+let querySet33 = device0.createQuerySet({
+label: '\u0544\u{1fada}\u0dd0\uc36c',
+type: 'occlusion',
+count: 3448,
+});
+let commandBuffer8 = commandEncoder44.finish({
+label: '\u{1fb71}\u07f8\u014b\u3250\u{1fcff}\u248e\u0403\u331f',
+});
+let textureView62 = texture35.createView({
+  label: '\u{1fc0f}\u013a\ufe26\u{1f8fd}\u07c2',
+  dimension: '2d',
+  aspect: 'all',
+  format: 'astc-5x5-unorm-srgb',
+  mipLevelCount: 1,
+  baseArrayLayer: 14
+});
+let renderBundle58 = renderBundleEncoder2.finish({label: '\u{1fea2}\ubeba\ucb0e\u0437\u{1f77a}\u3488\u7117\uace3'});
+try {
+renderBundleEncoder23.setBindGroup(2, bindGroup7, new Uint32Array(6877), 3644, 1);
+} catch {}
+try {
+renderBundleEncoder23.draw(40, 0, 16, 72);
+} catch {}
+offscreenCanvas4.height = 753;
+let commandEncoder46 = device2.createCommandEncoder({});
+let texture75 = device2.createTexture({
+label: '\ufb7f\u8c1c',
+size: [108, 120, 1],
+mipLevelCount: 7,
+format: 'etc2-rgb8a1unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+device2.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer4), /* required buffer size: 685 */
+{offset: 685, bytesPerRow: 275}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline40 = await device2.createRenderPipelineAsync({
+label: '\u06b6\uffd3\u6d44\u0dc3',
+layout: pipelineLayout11,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule17,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'one-minus-constant'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'r16uint', writeMask: 0}, undefined, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'one-minus-dst'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED
+}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'replace',
+depthFailOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 330,
+stencilWriteMask: 549,
+depthBias: 72,
+depthBiasSlopeScale: 41,
+depthBiasClamp: 39,
+},
+vertex: {
+  module: shaderModule17,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 39524,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32',
+offset: 21492,
+shaderLocation: 6,
+}, {
+format: 'float16x4',
+offset: 38216,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 31408,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x4',
+offset: 20560,
+shaderLocation: 19,
+}, {
+format: 'unorm8x4',
+offset: 22052,
+shaderLocation: 15,
+}, {
+format: 'uint32x4',
+offset: 28004,
+shaderLocation: 10,
+}, {
+format: 'uint8x4',
+offset: 16228,
+shaderLocation: 14,
+}, {
+format: 'unorm16x4',
+offset: 11624,
+shaderLocation: 5,
+}, {
+format: 'sint16x4',
+offset: 25240,
+shaderLocation: 9,
+}, {
+format: 'sint16x2',
+offset: 7892,
+shaderLocation: 21,
+}, {
+format: 'float32',
+offset: 11092,
+shaderLocation: 12,
+}, {
+format: 'sint32x2',
+offset: 11652,
+shaderLocation: 18,
+}, {
+format: 'unorm16x2',
+offset: 5928,
+shaderLocation: 1,
+}, {
+format: 'sint8x4',
+offset: 24120,
+shaderLocation: 4,
+}, {
+format: 'snorm16x4',
+offset: 9856,
+shaderLocation: 2,
+}, {
+format: 'float16x2',
+offset: 23668,
+shaderLocation: 17,
+}, {
+format: 'uint32x3',
+offset: 27596,
+shaderLocation: 3,
+}, {
+format: 'float16x4',
+offset: 25876,
+shaderLocation: 13,
+}, {
+format: 'sint32x4',
+offset: 20864,
+shaderLocation: 11,
+}, {
+format: 'sint32x4',
+offset: 24612,
+shaderLocation: 8,
+}, {
+format: 'uint32x4',
+offset: 13916,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 63476,
+attributes: [{
+format: 'unorm8x2',
+offset: 50120,
+shaderLocation: 20,
+}],
+},
+{
+arrayStride: 28728,
+attributes: [],
+},
+{
+arrayStride: 27404,
+attributes: [],
+},
+{
+arrayStride: 5868,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 48936,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 22612,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 280,
+shaderLocation: 16,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let shaderModule18 = device3.createShaderModule({
+label: '\ucc64\u97f1',
+code: `@group(0) @binding(1812)
+var<storage, read_write> field20: array<u32>;
+@group(2) @binding(1812)
+var<storage, read_write> global18: array<u32>;
+@group(3) @binding(1812)
+var<storage, read_write> parameter22: array<u32>;
+
+@compute @workgroup_size(4, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S17 {
+  @location(35) f0: vec2<u32>,
+  @location(45) f1: vec2<i32>,
+  @location(13) f2: vec4<f32>,
+  @location(11) f3: vec4<f16>,
+  @location(12) f4: vec3<i32>,
+  @location(36) f5: vec4<f32>,
+  @location(2) f6: vec2<u32>
+}
+struct FragmentOutput0 {
+  @builtin(frag_depth) f0: f32,
+  @location(4) f1: vec3<u32>,
+  @location(6) f2: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(44) a0: f32, a1: S17, @location(14) a2: f16, @location(31) a3: vec3<i32>, @location(8) a4: vec3<f16>, @location(30) a5: vec2<i32>, @location(0) a6: i32, @location(39) a7: f32, @location(20) a8: vec3<u32>, @location(3) a9: vec4<i32>, @location(42) a10: i32, @location(15) a11: vec3<f16>, @location(10) a12: vec4<f32>, @location(43) a13: u32, @location(37) a14: u32, @location(40) a15: u32, @location(23) a16: vec3<u32>, @builtin(sample_mask) a17: u32, @builtin(front_facing) a18: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S16 {
+  @location(9) f0: u32,
+  @location(2) f1: i32,
+  @location(4) f2: vec2<i32>,
+  @location(0) f3: vec2<u32>,
+  @location(3) f4: vec3<i32>,
+  @builtin(vertex_index) f5: u32,
+  @location(1) f6: vec4<f16>,
+  @location(11) f7: vec3<u32>
+}
+struct VertexOutput0 {
+  @location(0) f234: i32,
+  @location(45) f235: vec2<i32>,
+  @location(42) f236: i32,
+  @location(37) f237: u32,
+  @location(20) f238: vec3<u32>,
+  @location(2) f239: vec2<u32>,
+  @location(10) f240: vec4<f32>,
+  @location(14) f241: f16,
+  @location(31) f242: vec3<i32>,
+  @location(44) f243: f32,
+  @location(30) f244: vec2<i32>,
+  @location(39) f245: f32,
+  @location(15) f246: vec3<f16>,
+  @location(35) f247: vec2<u32>,
+  @location(8) f248: vec3<f16>,
+  @location(36) f249: vec4<f32>,
+  @location(12) f250: vec3<i32>,
+  @location(23) f251: vec3<u32>,
+  @builtin(position) f252: vec4<f32>,
+  @location(3) f253: vec4<i32>,
+  @location(13) f254: vec4<f32>,
+  @location(40) f255: u32,
+  @location(43) f256: u32,
+  @location(11) f257: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec2<i32>, @location(14) a1: f16, @location(13) a2: vec3<u32>, a3: S16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let buffer21 = device3.createBuffer({
+  size: 61796,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true
+});
+let texture76 = device3.createTexture({
+size: {width: 40, height: 15, depthOrArrayLayers: 25},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder40 = commandEncoder45.beginComputePass({label: '\u{1fc6b}\ue8c7\u0f4b\u9a11\u{1fb5a}'});
+let renderBundleEncoder40 = device3.createRenderBundleEncoder({
+  label: '\u{1f814}\u0bf2',
+  colorFormats: ['r16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1
+});
+try {
+renderBundleEncoder37.setVertexBuffer(5, buffer21, 19532, 39249);
+} catch {}
+try {
+renderBundleEncoder32.drawIndexed(24, 72, 72, 104);
+} catch {}
+try {
+computePassEncoder29.insertDebugMarker('\u0beb');
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let video10 = await videoWithData();
+let bindGroupLayout24 = device3.createBindGroupLayout({
+label: '\u0fc8\u0ff4\uf3f0\ue695\u6589\u{1ff9a}\u65da\u9c63\u{1fa5d}',
+entries: [{
+binding: 1950,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+}, {
+binding: 819,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+}, {
+binding: 1034,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}],
+});
+let texture77 = device3.createTexture({
+label: '\u0a79\u0d71\u0a79\u2409',
+size: {width: 768},
+dimension: '1d',
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['r32sint', 'r32sint', 'r32sint'],
+});
+let textureView63 = texture77.createView({label: '\u0ce5\u{1faf8}'});
+let renderBundle59 = renderBundleEncoder37.finish({label: '\u{1ff9d}\ude47\u7e2e\uc13e'});
+let sampler44 = device3.createSampler({
+label: '\u944c\u4c51\udc48\u9f52\u78bd\u0e03\uef6d',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 91.958,
+lodMaxClamp: 94.214,
+maxAnisotropy: 12,
+});
+try {
+renderBundleEncoder32.setVertexBuffer(8, buffer21, 19652, 24220);
+} catch {}
+let bindGroupLayout25 = device0.createBindGroupLayout({
+label: '\u3690\u0b30\u3139\u96fb\uc505\u3492\udbc5\ube23',
+entries: [{
+binding: 432,
+visibility: 0,
+externalTexture: {},
+}],
+});
+let renderBundle60 = renderBundleEncoder36.finish({label: '\u93ca\ue526\ub3f2\u520d\u1e77\u03f7'});
+try {
+renderBundleEncoder23.drawIndexed(40, 56, 24, 464, 32);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer8,
+]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 3,
+  origin: { x: 96, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 339 */
+{offset: 339, bytesPerRow: 641, rowsPerImage: 44}, {width: 264, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext9 = canvas10.getContext('webgpu');
+let offscreenCanvas8 = new OffscreenCanvas(465, 86);
+let imageData12 = new ImageData(232, 16);
+let imageBitmap10 = await createImageBitmap(video9);
+try {
+offscreenCanvas8.getContext('webgl2');
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let texture78 = device3.createTexture({
+label: '\u6f00\u2ef9\uba3c\u0850\u0330\u0d4b',
+size: [128, 40, 106],
+dimension: '3d',
+format: 'r16sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['r16sint', 'r16sint'],
+});
+let sampler45 = device3.createSampler({
+label: '\u0700\u453a\u1fd3\u0c41\u03fd\ubfba\uf7b0\u127c\u8d65',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 24.145,
+lodMaxClamp: 79.119,
+});
+try {
+renderBundleEncoder32.setPipeline(pipeline36);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(1, buffer21, 36300, 23889);
+} catch {}
+try {
+computePassEncoder40.insertDebugMarker('\u{1f6b5}');
+} catch {}
+let pipeline41 = await device3.createComputePipelineAsync({
+label: '\u{1f7ed}\udf64\uf935\u0b79\u{1ff17}\ue141',
+layout: pipelineLayout10,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let adapter9 = await navigator.gpu.requestAdapter({
+});
+let bindGroupLayout26 = pipeline36.getBindGroupLayout(3);
+let textureView64 = texture68.createView({aspect: 'depth-only'});
+try {
+renderBundleEncoder32.setPipeline(pipeline32);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture77,
+  mipLevel: 0,
+  origin: { x: 562, y: 0, z: 1 },
+  aspect: 'all',
+}, new Int32Array(arrayBuffer5), /* required buffer size: 484 */
+{offset: 484}, {width: 37, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup18 = device0.createBindGroup({
+layout: bindGroupLayout1,
+entries: [{
+binding: 2519,
+resource: sampler2
+}, {
+binding: 1779,
+resource: sampler7
+}],
+});
+let textureView65 = texture1.createView({baseArrayLayer: 0});
+try {
+renderBundleEncoder28.setBindGroup(2, bindGroup2);
+} catch {}
+let pipeline42 = await device0.createRenderPipelineAsync({
+label: '\u6dfc\u23b1\u2801\u04bd\u086a\u{1f844}\uc8c6',
+layout: pipelineLayout14,
+fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: 0}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'one-minus-src-alpha'},
+},
+  writeMask: 0
+}, {format: 'rg11b10ufloat', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+vertex: {
+  module: shaderModule7,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x2',
+offset: 804,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 4428,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 2196,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 1704,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1016,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 5912,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x4',
+offset: 3208,
+shaderLocation: 14,
+}],
+}
+]
+},
+});
+let shaderModule19 = device3.createShaderModule({
+label: '\u{1ff1b}\u23da\u7551\u6757\u8feb\uca1d\u06dd\u417a\u{1faf8}\u{1fb72}',
+code: `@group(5) @binding(1812)
+var<storage, read_write> local21: array<u32>;
+@group(0) @binding(1812)
+var<storage, read_write> i21: array<u32>;
+@group(1) @binding(559)
+var<storage, read_write> type22: array<u32>;
+@group(3) @binding(1812)
+var<storage, read_write> global19: array<u32>;
+@group(2) @binding(559)
+var<storage, read_write> type23: array<u32>;
+@group(6) @binding(1812)
+var<storage, read_write> field21: array<u32>;
+@group(4) @binding(559)
+var<storage, read_write> i22: array<u32>;
+@group(1) @binding(1417)
+var<storage, read_write> local22: array<u32>;
+
+@compute @workgroup_size(4, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: u32,
+  @builtin(frag_depth) f1: f32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S18 {
+  @location(2) f0: vec2<u32>,
+  @location(4) f1: f32,
+  @builtin(instance_index) f2: u32,
+  @location(15) f3: vec2<f32>,
+  @location(16) f4: vec3<f16>,
+  @location(6) f5: f16,
+  @location(13) f6: vec4<f16>,
+  @location(8) f7: i32,
+  @location(10) f8: vec4<f16>,
+  @location(0) f9: vec3<f16>,
+  @location(3) f10: vec3<i32>,
+  @location(1) f11: i32,
+  @location(11) f12: vec4<i32>,
+  @location(5) f13: i32
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, a1: S18, @location(14) a2: vec3<u32>, @location(12) a3: vec3<f32>, @location(9) a4: vec2<i32>, @location(7) a5: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let buffer22 = device3.createBuffer({
+  label: '\uad65\u69ae\u{1ffe8}\u0adc',
+  size: 23810,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let textureView66 = texture78.createView({label: '\ufc84\u0414\u0a3e\u0888\u{1fcc9}\u{1faf5}\u16d7\u36c3'});
+try {
+renderBundleEncoder39.setVertexBuffer(0, buffer21, 2096);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: { x: 5, y: 15, z: 23 },
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(64)), /* required buffer size: 1235925 */
+{offset: 241, bytesPerRow: 435, rowsPerImage: 118}, {width: 71, height: 9, depthOrArrayLayers: 25});
+} catch {}
+let pipeline43 = device3.createRenderPipeline({
+label: '\u080f\ue6a6',
+layout: pipelineLayout13,
+multisample: {
+mask: 0x435a2e80,
+},
+fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'src-alpha', dstFactor: 'zero'},
+alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {
+  format: 'r8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'keep',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'zero',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 2271,
+stencilWriteMask: 1614,
+depthBias: 23,
+depthBiasSlopeScale: 10,
+depthBiasClamp: 1,
+},
+vertex: {
+  module: shaderModule16,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 3956,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x4',
+offset: 2376,
+shaderLocation: 6,
+}, {
+format: 'unorm8x4',
+offset: 232,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 3496,
+shaderLocation: 1,
+}, {
+format: 'sint32',
+offset: 448,
+shaderLocation: 13,
+}, {
+format: 'snorm8x2',
+offset: 1800,
+shaderLocation: 15,
+}, {
+format: 'float16x4',
+offset: 268,
+shaderLocation: 10,
+}, {
+format: 'uint16x4',
+offset: 1896,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 1196,
+attributes: [{
+format: 'sint32',
+offset: 380,
+shaderLocation: 7,
+}, {
+format: 'uint32',
+offset: 340,
+shaderLocation: 11,
+}, {
+format: 'sint32x4',
+offset: 812,
+shaderLocation: 4,
+}, {
+format: 'uint16x2',
+offset: 92,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 84,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 4180,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x2',
+offset: 1088,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let commandEncoder47 = device3.createCommandEncoder({label: '\ufac6\u{1ff28}\u5775\u4005\ubd66\u{1fd2c}'});
+let renderBundleEncoder41 = device3.createRenderBundleEncoder({
+  label: '\u8941\u08a0\u0c9e\ufc39\u03a9\u99c8\u3eaf\u{1fbd6}\ub473',
+  colorFormats: ['r16uint'],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+try {
+renderBundleEncoder32.draw(40, 56, 24);
+} catch {}
+try {
+device3.queue.submit([
+]);
+} catch {}
+let pipeline44 = device3.createComputePipeline({
+layout: pipelineLayout13,
+compute: {
+module: shaderModule18,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let buffer23 = device3.createBuffer({
+  label: '\u{1fa22}\ue02e\u0aa0\u{1fd94}',
+  size: 56500,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let renderBundleEncoder42 = device3.createRenderBundleEncoder({
+  label: '\u0c70\u1b23\u2758\ud286\u5f9f\u745c\u{1f6b5}\uefd2',
+  colorFormats: ['rgba8sint', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+try {
+computePassEncoder29.setPipeline(pipeline41);
+} catch {}
+let pipeline45 = await device3.createRenderPipelineAsync({
+layout: pipelineLayout13,
+fragment: {module: shaderModule18, entryPoint: 'fragment0', targets: []},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'equal',
+depthFailOp: 'decrement-wrap',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilReadMask: 584,
+stencilWriteMask: 422,
+depthBias: 38,
+depthBiasClamp: 71,
+},
+vertex: {
+  module: shaderModule18,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1400,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x2',
+offset: 1352,
+shaderLocation: 5,
+}, {
+format: 'uint32',
+offset: 840,
+shaderLocation: 11,
+}, {
+format: 'uint32',
+offset: 144,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 3644,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x2',
+offset: 288,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 3732,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x3',
+offset: 1444,
+shaderLocation: 9,
+}, {
+format: 'uint8x2',
+offset: 550,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 3672,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1252,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 812,
+shaderLocation: 4,
+}, {
+format: 'unorm10-10-10-2',
+offset: 800,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 1444,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x2',
+offset: 156,
+shaderLocation: 14,
+}, {
+format: 'sint8x2',
+offset: 142,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+},
+});
+let texture79 = device3.createTexture({
+label: '\u053f\u5f1f\ucfcc\u0d0a\u{1fe69}\ud309\ufd88\ud91b\u{1f95f}\u0d5f\u{1fd9a}',
+size: [40],
+mipLevelCount: 1,
+dimension: '1d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder41 = commandEncoder47.beginComputePass({label: '\u9b1f\u{1f847}'});
+let promise26 = device3.queue.onSubmittedWorkDone();
+let video11 = await videoWithData();
+let imageBitmap11 = await createImageBitmap(video6);
+try {
+adapter0.label = '\ue89b\u{1fbe6}\u0021\uff85\u955c\u0a17';
+} catch {}
+let commandEncoder48 = device0.createCommandEncoder({label: '\ufba7\u41b8'});
+let renderBundleEncoder43 = device0.createRenderBundleEncoder({
+  label: '\uabb8\u75a3\ub6e4\u92f0\u{1fd17}\ub190\uc35c\u6d12\u0c33\u2c33\u{1ff17}',
+  colorFormats: ['rg32sint', 'r32sint', 'bgra8unorm', 'rg11b10ufloat'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle61 = renderBundleEncoder13.finish({label: '\u4c8f\u35c4\u0f44\u{1f838}\u4e1a\u0773\u7390\u{1fccb}'});
+let sampler46 = device0.createSampler({
+label: '\u3a9e\ud454\u{1f735}\u{1fa94}\u{1f6eb}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 64.649,
+lodMaxClamp: 75.623,
+maxAnisotropy: 14,
+});
+try {
+computePassEncoder31.setBindGroup(10, bindGroup7, new Uint32Array(2718), 2483, 1);
+} catch {}
+try {
+  await buffer7.mapAsync(GPUMapMode.WRITE, 42528, 8484);
+} catch {}
+try {
+commandEncoder48.copyBufferToBuffer(buffer7, 3132, buffer13, 23448, 4408);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder48.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 34, y: 2, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 60 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 49516 */
+offset: 49516,
+bytesPerRow: 512,
+buffer: buffer5,
+}, {width: 30, height: 10, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 4,
+  origin: { x: 4, y: 1, z: 5 },
+  aspect: 'all',
+}, {
+  texture: texture12,
+  mipLevel: 5,
+  origin: { x: 1, y: 0, z: 2 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder48.resolveQuerySet(querySet12, 1646, 138, buffer8, 1536);
+} catch {}
+let pipeline46 = await device0.createComputePipelineAsync({
+label: '\u{1f7b8}\uf5fc\u669e\u{1f8d4}\ue558\u{1fba0}\ub984',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let buffer24 = device0.createBuffer({
+  label: '\u{1fe31}\u096a\u0e93\u{1f668}\u{1f943}\u{1fabb}\u8221\ud823',
+  size: 41737,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+try {
+renderBundleEncoder23.setBindGroup(4, bindGroup5);
+} catch {}
+try {
+commandEncoder48.copyBufferToBuffer(buffer2, 49416, buffer5, 26776, 368);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder48.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 1,
+  origin: { x: 21, y: 3, z: 1 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 64 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 9240 */
+offset: 9240,
+bytesPerRow: 256,
+buffer: buffer24,
+}, {width: 16, height: 2, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer24);
+} catch {}
+let promise27 = device0.createRenderPipelineAsync({
+layout: pipelineLayout14,
+multisample: {
+mask: 0xef670895,
+},
+fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.BLUE}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'zero', dstFactor: 'zero'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-dst'},
+},
+  writeMask: GPUColorWrite.BLUE
+}, {format: 'rg8uint'}, {
+  format: 'r16float',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'one-minus-dst'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {format: 'r16float', writeMask: GPUColorWrite.ALPHA}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'zero',
+depthFailOp: 'decrement-wrap',
+passOp: 'keep',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'zero',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+depthBias: 0,
+depthBiasSlopeScale: 5,
+depthBiasClamp: 41,
+},
+vertex: {
+  module: shaderModule3,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 4212,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x2',
+offset: 82,
+shaderLocation: 12,
+}, {
+format: 'snorm8x4',
+offset: 1976,
+shaderLocation: 3,
+}, {
+format: 'float16x2',
+offset: 728,
+shaderLocation: 6,
+}, {
+format: 'sint32x2',
+offset: 3224,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 2788,
+attributes: [],
+},
+{
+arrayStride: 452,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 5492,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 2680,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 6588,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 4876,
+shaderLocation: 13,
+}],
+}
+]
+},
+});
+let buffer25 = device0.createBuffer({label: '\u6cd6\u57ed', size: 10958, usage: GPUBufferUsage.COPY_SRC});
+let commandEncoder49 = device0.createCommandEncoder({label: '\udbb0\u2712\u8229\uf26b\u9e1c\u7f50\u0a95'});
+let renderBundleEncoder44 = device0.createRenderBundleEncoder({
+  label: '\u9d83\ufaa3\u72d2\u1315\u066f',
+  colorFormats: ['rg32sint', 'r32sint', 'bgra8unorm', 'rg11b10ufloat'],
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder23.setBindGroup(8, bindGroup8, new Uint32Array(8421), 7765, 0);
+} catch {}
+try {
+renderBundleEncoder23.drawIndexed(40, 0, 48, -192, 0);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(61, undefined);
+} catch {}
+try {
+commandEncoder49.copyTextureToTexture({
+  texture: texture30,
+  mipLevel: 2,
+  origin: { x: 0, y: 5, z: 183 },
+  aspect: 'all',
+}, {
+  texture: texture65,
+  mipLevel: 1,
+  origin: { x: 0, y: 20, z: 0 },
+  aspect: 'all',
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder48.resolveQuerySet(querySet9, 259, 55, buffer5, 15616);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: { x: 52, y: 1, z: 1 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 385 */
+{offset: 385, rowsPerImage: 163}, {width: 819, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline47 = device0.createComputePipeline({
+label: '\u073f\ufafa\u{1fcb1}\u3786\u8d87',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+document.body.prepend(canvas4);
+let shaderModule20 = device2.createShaderModule({
+label: '\udfb1\u{1f9bb}\u7b52\ue3b7',
+code: `@group(6) @binding(418)
+var<storage, read_write> i23: array<u32>;
+@group(0) @binding(2571)
+var<storage, read_write> i24: array<u32>;
+@group(8) @binding(2930)
+var<storage, read_write> field22: array<u32>;
+@group(5) @binding(2930)
+var<storage, read_write> type24: array<u32>;
+@group(6) @binding(9855)
+var<storage, read_write> local23: array<u32>;
+@group(3) @binding(9855)
+var<storage, read_write> type25: array<u32>;
+@group(0) @binding(2930)
+var<storage, read_write> parameter23: array<u32>;
+@group(8) @binding(2571)
+var<storage, read_write> i25: array<u32>;
+@group(5) @binding(2571)
+var<storage, read_write> type26: array<u32>;
+@group(6) @binding(4783)
+var<storage, read_write> parameter24: array<u32>;
+
+@compute @workgroup_size(5, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S20 {
+  @location(7) f0: f16,
+  @builtin(front_facing) f1: bool,
+  @location(80) f2: vec3<f16>,
+  @location(68) f3: vec2<f32>,
+  @location(67) f4: i32,
+  @location(82) f5: vec2<u32>,
+  @location(26) f6: vec3<u32>,
+  @location(63) f7: vec3<f32>,
+  @location(16) f8: u32,
+  @location(79) f9: vec3<f16>,
+  @location(91) f10: vec2<f16>,
+  @location(92) f11: vec3<i32>,
+  @location(3) f12: vec3<f16>,
+  @location(2) f13: vec2<i32>,
+  @location(22) f14: vec2<f32>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @location(4) f1: vec2<u32>,
+  @location(0) f2: vec4<f32>,
+  @location(5) f3: vec4<u32>,
+  @location(3) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(1) a0: vec3<i32>, @location(65) a1: i32, @location(31) a2: u32, @location(62) a3: vec2<f32>, @location(89) a4: vec3<f32>, @location(24) a5: u32, @builtin(position) a6: vec4<f32>, @location(47) a7: vec2<f32>, @location(29) a8: vec2<i32>, @location(46) a9: vec2<i32>, a10: S20, @location(33) a11: vec2<i32>, @location(42) a12: u32, @location(36) a13: i32, @location(50) a14: f32, @location(75) a15: vec4<i32>, @location(38) a16: vec3<i32>, @location(61) a17: vec2<i32>, @location(6) a18: vec4<f16>, @location(13) a19: vec3<f16>, @builtin(sample_mask) a20: u32, @location(0) a21: vec4<f16>, @location(30) a22: vec3<i32>, @location(57) a23: vec3<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S19 {
+  @location(1) f0: i32,
+  @location(8) f1: vec3<f32>,
+  @location(0) f2: i32,
+  @builtin(vertex_index) f3: u32,
+  @location(14) f4: vec4<f32>,
+  @location(16) f5: u32,
+  @location(17) f6: vec2<f32>,
+  @location(19) f7: vec2<u32>,
+  @location(5) f8: vec3<u32>,
+  @location(4) f9: vec3<f16>,
+  @location(20) f10: vec2<f32>,
+  @location(9) f11: vec2<i32>,
+  @location(2) f12: vec2<u32>,
+  @location(3) f13: vec3<f16>,
+  @location(6) f14: vec2<u32>,
+  @location(12) f15: vec4<f16>
+}
+struct VertexOutput0 {
+  @location(47) f258: vec2<f32>,
+  @location(46) f259: vec2<i32>,
+  @location(57) f260: vec3<u32>,
+  @location(13) f261: vec3<f16>,
+  @location(80) f262: vec3<f16>,
+  @location(1) f263: vec3<i32>,
+  @location(62) f264: vec2<f32>,
+  @location(68) f265: vec2<f32>,
+  @location(82) f266: vec2<u32>,
+  @location(75) f267: vec4<i32>,
+  @location(30) f268: vec3<i32>,
+  @location(38) f269: vec3<i32>,
+  @location(79) f270: vec3<f16>,
+  @location(50) f271: f32,
+  @location(92) f272: vec3<i32>,
+  @location(91) f273: vec2<f16>,
+  @location(31) f274: u32,
+  @location(42) f275: u32,
+  @location(65) f276: i32,
+  @location(3) f277: vec3<f16>,
+  @location(2) f278: vec2<i32>,
+  @location(17) f279: vec2<i32>,
+  @location(6) f280: vec4<f16>,
+  @location(0) f281: vec4<f16>,
+  @location(59) f282: vec4<u32>,
+  @location(61) f283: vec2<i32>,
+  @builtin(position) f284: vec4<f32>,
+  @location(7) f285: f16,
+  @location(26) f286: vec3<u32>,
+  @location(36) f287: i32,
+  @location(28) f288: vec3<f16>,
+  @location(67) f289: i32,
+  @location(24) f290: u32,
+  @location(29) f291: vec2<i32>,
+  @location(89) f292: vec3<f32>,
+  @location(63) f293: vec3<f32>,
+  @location(22) f294: vec2<f32>,
+  @location(33) f295: vec2<i32>,
+  @location(16) f296: u32
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(13) a1: vec4<f16>, @location(21) a2: vec3<i32>, @location(18) a3: vec2<i32>, @location(11) a4: vec3<u32>, a5: S19, @location(10) a6: vec3<u32>, @location(7) a7: u32, @location(15) a8: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+});
+let texture80 = device2.createTexture({
+label: '\ue10f\u92ec\u{1fca1}',
+size: {width: 4200, height: 80, depthOrArrayLayers: 1},
+mipLevelCount: 13,
+dimension: '2d',
+format: 'astc-10x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-10x10-unorm-srgb'],
+});
+let renderBundle62 = renderBundleEncoder26.finish({label: '\u08f4\u0a5d\u{1f6bb}\ue5b3\u{1ffb3}'});
+try {
+commandEncoder46.copyTextureToTexture({
+  texture: texture80,
+  mipLevel: 6,
+  origin: { x: 10, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture80,
+  mipLevel: 6,
+  origin: { x: 30, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder46.clearBuffer(buffer17);
+dissociateBuffer(device2, buffer17);
+} catch {}
+try {
+computePassEncoder23.popDebugGroup();
+} catch {}
+try {
+computePassEncoder23.insertDebugMarker('\ub58c');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: { x: 355, y: 4, z: 0 },
+  aspect: 'all',
+}, new Int8Array(arrayBuffer1), /* required buffer size: 104500 */
+{offset: 776, bytesPerRow: 702, rowsPerImage: 110}, {width: 265, height: 38, depthOrArrayLayers: 2});
+} catch {}
+video10.height = 28;
+let textureView67 = texture6.createView({
+  label: '\uc19c\u{1fc9f}\u07b1\u2e54\u1e16\u16ae\u08ce\u1de8',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  mipLevelCount: 4
+});
+let renderBundleEncoder45 = device0.createRenderBundleEncoder({
+  label: '\u135e\ua944\u07e4\u0f2b\u3eba\u9b1a\u3ffd\u{1f881}\u{1fa8f}\u{1f768}\u1387',
+  colorFormats: ['rg8uint', undefined, 'rgba32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let sampler47 = device0.createSampler({
+label: '\ufe78\u59ed\u04ea\u{1f93c}\u0356\u916e\uf916\u0947\u{1fc51}',
+addressModeU: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 31.083,
+lodMaxClamp: 49.525,
+compare: 'never',
+maxAnisotropy: 15,
+});
+try {
+renderBundleEncoder23.draw(32, 0, 32, 24);
+} catch {}
+try {
+commandEncoder48.clearBuffer(buffer5, 35160, 20052);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.destroy();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline44);
+} catch {}
+try {
+device3.queue.submit([
+]);
+} catch {}
+let pipeline48 = device3.createRenderPipeline({
+label: '\u148d\u0126\u0049\u0e35\u0811\u9326\ub03d\u2fcc\u{1fcf2}\u4fd4',
+layout: pipelineLayout10,
+fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8unorm-srgb', writeMask: 0}, {format: 'r8sint', writeMask: GPUColorWrite.RED}, {format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.BLUE}]
+},
+vertex: {
+  module: shaderModule14,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 3092,
+attributes: [{
+format: 'float32x2',
+offset: 520,
+shaderLocation: 6,
+}, {
+format: 'sint32x4',
+offset: 1452,
+shaderLocation: 10,
+}, {
+format: 'uint32',
+offset: 2656,
+shaderLocation: 2,
+}, {
+format: 'snorm16x2',
+offset: 1660,
+shaderLocation: 9,
+}],
+}
+]
+},
+});
+try {
+commandEncoder46.copyBufferToBuffer(buffer12, 25452, buffer17, 688, 460);
+dissociateBuffer(device2, buffer12);
+dissociateBuffer(device2, buffer17);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 42 */
+{offset: 42}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline49 = device2.createComputePipeline({
+label: '\u{1f6d4}\u26ea\u{1f731}\ua202\u5d83\u0ce1\u03f7\u630a',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+video4.height = 6;
+try {
+textureView34.label = '\u9c45\udad7\u02df\ubc9d\u{1fb3b}\ud25e\u0cf0\u04dc\u{1fe03}\u0297\ueb1f';
+} catch {}
+let texture81 = device3.createTexture({
+label: '\ub603\u90a7\ub14c\uf77e\u01b2\uf0f9\u02e4\u0e7b\u{1fb89}\u4f37',
+size: {width: 3072, height: 1, depthOrArrayLayers: 1},
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundle63 = renderBundleEncoder39.finish({label: '\u3fa9\u03d1\u00e7\u{1fa9c}\u2348'});
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+renderBundleEncoder32.setPipeline(pipeline32);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(9, buffer21);
+} catch {}
+gc();
+let commandBuffer9 = commandEncoder34.finish({
+label: '\ua5b9\u779f\u0bda\u53f3\u313a\u{1fe43}\u{1fd18}\u0616\u{1fe51}\u068e\u3f62',
+});
+let renderBundleEncoder46 = device3.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb', 'r8sint', 'rgba8unorm-srgb'], sampleCount: 4, stencilReadOnly: true});
+let renderBundle64 = renderBundleEncoder41.finish({label: '\u5773\u{1f9f7}\u{1f9a4}\u7c5c'});
+try {
+computePassEncoder33.setPipeline(pipeline41);
+} catch {}
+try {
+device3.queue.submit([
+commandBuffer7,
+]);
+} catch {}
+let pipeline50 = device3.createComputePipeline({
+layout: pipelineLayout13,
+compute: {
+module: shaderModule19,
+entryPoint: 'compute0',
+},
+});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let shaderModule21 = device3.createShaderModule({
+label: '\u9c16\ud1a4\u71c7\u6570\u8d0a\u04f8\u0d24\u01fd\u{1f641}\u{1f8eb}\ue065',
+code: `@group(3) @binding(1812)
+var<storage, read_write> local24: array<u32>;
+@group(2) @binding(1812)
+var<storage, read_write> type27: array<u32>;
+@group(0) @binding(1812)
+var<storage, read_write> local25: array<u32>;
+
+@compute @workgroup_size(7, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S21 {
+  @builtin(position) f0: vec4<f32>,
+  @builtin(sample_index) f1: u32,
+  @builtin(front_facing) f2: bool
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @location(4) f1: vec2<i32>,
+  @location(1) f2: vec3<u32>,
+  @location(7) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(a0: S21, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(2) a0: vec4<f32>, @builtin(vertex_index) a1: u32, @location(1) a2: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let texture82 = device3.createTexture({
+label: '\ufd15\u632b\u{1f897}\u324b\u3e87\uf6dd\u9263\ud0da\uf367',
+size: {width: 40, height: 15, depthOrArrayLayers: 65},
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['depth16unorm', 'depth16unorm', 'depth16unorm'],
+});
+let renderBundleEncoder47 = device3.createRenderBundleEncoder({
+  label: '\u9191\u486d\u836f\uf483\u9474\u0d63\u0b9f\u92a8\u02fe\u00f7',
+  colorFormats: ['rg8sint'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder47.setVertexBuffer(5, buffer21, 48904, 7680);
+} catch {}
+try {
+device3.pushErrorScope('internal');
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture77,
+  mipLevel: 0,
+  origin: { x: 339, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(2176), /* required buffer size: 2176 */
+{offset: 836, rowsPerImage: 258}, {width: 335, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let textureView68 = texture72.createView({label: '\u{1ff7f}\u{1ff33}\uec90', dimension: '2d', baseMipLevel: 1, mipLevelCount: 2, baseArrayLayer: 114});
+try {
+computePassEncoder33.setPipeline(pipeline38);
+} catch {}
+try {
+renderBundleEncoder32.setPipeline(pipeline36);
+} catch {}
+try {
+device3.queue.submit([
+commandBuffer9,
+]);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 0,
+  origin: { x: 934, y: 0, z: 0 },
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(80)), /* required buffer size: 2396 */
+{offset: 480}, {width: 479, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let promise28 = device3.queue.onSubmittedWorkDone();
+try {
+  await promise28;
+} catch {}
+let offscreenCanvas9 = new OffscreenCanvas(103, 611);
+try {
+offscreenCanvas9.getContext('webgl');
+} catch {}
+let texture83 = device3.createTexture({
+label: '\u0d5d\ub5ab\u502c\u7cb1\u7f54\u1f38\ud36c\u{1f832}\u07e5\u{1fddc}',
+size: [384],
+dimension: '1d',
+format: 'rg16uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16uint', 'rg16uint'],
+});
+let textureView69 = texture72.createView({label: '\u{1fd8e}\u804e\u12a8', format: 'r32uint', baseMipLevel: 3, baseArrayLayer: 201, arrayLayerCount: 16});
+try {
+computePassEncoder33.setPipeline(pipeline38);
+} catch {}
+try {
+renderBundleEncoder32.draw(16, 16, 48, 80);
+} catch {}
+try {
+renderBundleEncoder32.setPipeline(pipeline32);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 19329 */
+{offset: 238, bytesPerRow: 117, rowsPerImage: 163}, {width: 5, height: 1, depthOrArrayLayers: 2});
+} catch {}
+try {
+adapter4.label = '\u{1f6e3}\u0273\u0a7d\u{1fa87}\uee9e\u0d37\u3366\u6364\u9fcd\u04a6\u5a42';
+} catch {}
+let imageBitmap12 = await createImageBitmap(offscreenCanvas3);
+offscreenCanvas0.height = 173;
+let video12 = await videoWithData();
+let commandEncoder50 = device3.createCommandEncoder();
+let querySet34 = device3.createQuerySet({
+type: 'occlusion',
+count: 3736,
+});
+let texture84 = device3.createTexture({
+label: '\u{1fb0c}\u6802\u08dc\u38d1\uc23f\u93c5\u0c15\u0dff',
+size: {width: 256, height: 80, depthOrArrayLayers: 652},
+mipLevelCount: 9,
+dimension: '3d',
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [],
+});
+let textureView70 = texture82.createView({label: '\u051c\u0fd8', baseArrayLayer: 3, arrayLayerCount: 27});
+try {
+renderBundleEncoder32.draw(80, 8, 56, 8);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(5, buffer21, 4396, 38844);
+} catch {}
+let pipeline51 = await device3.createRenderPipelineAsync({
+label: '\u09f4\u1be7\u6585\u01ec\u0e7d\u01dd\ub9fb\u87c2',
+layout: pipelineLayout13,
+fragment: {module: shaderModule19, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'replace',
+},
+stencilReadMask: 254,
+depthBias: 51,
+depthBiasSlopeScale: 89,
+depthBiasClamp: 91,
+},
+vertex: {
+  module: shaderModule19,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 2144,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint16x4',
+offset: 348,
+shaderLocation: 5,
+}, {
+format: 'float16x2',
+offset: 180,
+shaderLocation: 10,
+}, {
+format: 'snorm16x2',
+offset: 44,
+shaderLocation: 15,
+}, {
+format: 'float32',
+offset: 1488,
+shaderLocation: 12,
+}, {
+format: 'sint32x2',
+offset: 556,
+shaderLocation: 9,
+}, {
+format: 'uint32x2',
+offset: 876,
+shaderLocation: 14,
+}, {
+format: 'snorm16x4',
+offset: 796,
+shaderLocation: 6,
+}, {
+format: 'sint32x4',
+offset: 1900,
+shaderLocation: 11,
+}, {
+format: 'snorm8x4',
+offset: 1780,
+shaderLocation: 0,
+}, {
+format: 'sint32x3',
+offset: 1032,
+shaderLocation: 3,
+}, {
+format: 'float16x2',
+offset: 84,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 1324,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x3',
+offset: 224,
+shaderLocation: 13,
+}, {
+format: 'snorm8x2',
+offset: 918,
+shaderLocation: 7,
+}, {
+format: 'unorm10-10-10-2',
+offset: 784,
+shaderLocation: 4,
+}, {
+format: 'uint32x4',
+offset: 576,
+shaderLocation: 2,
+}, {
+format: 'sint32',
+offset: 200,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 4012,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 464,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 3396,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 676,
+shaderLocation: 8,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let buffer26 = device2.createBuffer({label: '\u0cf6\u2ec7\u0cde\u0ded\u48cf\uff1b', size: 17112, usage: GPUBufferUsage.INDEX});
+let querySet35 = device2.createQuerySet({
+type: 'occlusion',
+count: 2190,
+});
+try {
+buffer17.unmap();
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(buffer14, 13348, buffer17, 712, 1844);
+dissociateBuffer(device2, buffer14);
+dissociateBuffer(device2, buffer17);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer17, 2140, new Float32Array(38937), 11184, 172);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline52 = device2.createRenderPipeline({
+label: '\u{1fc3c}\u{1fb8a}\u0b12\u4356\ue0f0\u2827\uf620',
+layout: pipelineLayout11,
+multisample: {
+count: 4,
+mask: 0x70ac6f17,
+},
+fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  targets: [{format: 'bgra8unorm'}, {format: 'r16uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {format: 'r32uint', writeMask: 0}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}]
+},
+vertex: {
+  module: shaderModule20,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 22300,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x3',
+offset: 12260,
+shaderLocation: 21,
+}, {
+format: 'sint8x2',
+offset: 21790,
+shaderLocation: 9,
+}, {
+format: 'uint32x4',
+offset: 7792,
+shaderLocation: 7,
+}, {
+format: 'uint32',
+offset: 968,
+shaderLocation: 2,
+}, {
+format: 'float16x2',
+offset: 17976,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 8692,
+shaderLocation: 15,
+}, {
+format: 'uint32x4',
+offset: 24,
+shaderLocation: 11,
+}, {
+format: 'sint8x2',
+offset: 3900,
+shaderLocation: 1,
+}, {
+format: 'unorm10-10-10-2',
+offset: 20776,
+shaderLocation: 3,
+}, {
+format: 'sint16x4',
+offset: 6388,
+shaderLocation: 18,
+}, {
+format: 'float16x4',
+offset: 4648,
+shaderLocation: 4,
+}, {
+format: 'float16x4',
+offset: 8096,
+shaderLocation: 8,
+}, {
+format: 'unorm8x4',
+offset: 22040,
+shaderLocation: 14,
+}, {
+format: 'uint32x3',
+offset: 17308,
+shaderLocation: 16,
+}, {
+format: 'uint32x3',
+offset: 18236,
+shaderLocation: 19,
+}, {
+format: 'uint32x4',
+offset: 21200,
+shaderLocation: 6,
+}, {
+format: 'uint8x2',
+offset: 12930,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 44712,
+attributes: [{
+format: 'uint8x2',
+offset: 34644,
+shaderLocation: 10,
+}, {
+format: 'float16x4',
+offset: 28020,
+shaderLocation: 20,
+}, {
+format: 'unorm10-10-10-2',
+offset: 13800,
+shaderLocation: 17,
+}],
+},
+{
+arrayStride: 33344,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 29312,
+shaderLocation: 0,
+}, {
+format: 'float32',
+offset: 16308,
+shaderLocation: 13,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+gc();
+let bindGroup19 = device2.createBindGroup({
+label: '\u014f\ua7ed\u05e2',
+layout: bindGroupLayout16,
+entries: [],
+});
+let commandBuffer10 = commandEncoder46.finish({
+label: '\u9066\u0159\ue674\u2759\u3265\u2271\u64fe\u0212',
+});
+let promise29 = device2.popErrorScope();
+let pipeline53 = device2.createRenderPipeline({
+label: '\u{1fe2f}\u{1f65a}\u{1ff17}',
+layout: pipelineLayout8,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'src-alpha'},
+alpha: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'one-minus-dst'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE}, undefined, {
+  format: 'bgra8unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r32uint'}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'zero',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 1858,
+stencilWriteMask: 78,
+depthBias: 8,
+depthBiasSlopeScale: 70,
+depthBiasClamp: 33,
+},
+vertex: {
+  module: shaderModule20,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 27352,
+attributes: [{
+format: 'uint8x4',
+offset: 26472,
+shaderLocation: 5,
+}, {
+format: 'uint32x3',
+offset: 2376,
+shaderLocation: 16,
+}, {
+format: 'uint32',
+offset: 6564,
+shaderLocation: 6,
+}, {
+format: 'float32x2',
+offset: 22176,
+shaderLocation: 13,
+}, {
+format: 'uint32x2',
+offset: 16676,
+shaderLocation: 10,
+}, {
+format: 'unorm8x2',
+offset: 15094,
+shaderLocation: 17,
+}, {
+format: 'sint32x3',
+offset: 17564,
+shaderLocation: 21,
+}, {
+format: 'float32x3',
+offset: 2192,
+shaderLocation: 4,
+}, {
+format: 'sint8x4',
+offset: 8812,
+shaderLocation: 0,
+}, {
+format: 'sint32',
+offset: 22476,
+shaderLocation: 1,
+}, {
+format: 'snorm16x2',
+offset: 2308,
+shaderLocation: 8,
+}, {
+format: 'uint32x3',
+offset: 16960,
+shaderLocation: 15,
+}, {
+format: 'uint16x4',
+offset: 9160,
+shaderLocation: 7,
+}, {
+format: 'snorm8x2',
+offset: 19844,
+shaderLocation: 14,
+}, {
+format: 'sint16x2',
+offset: 25020,
+shaderLocation: 18,
+}],
+},
+{
+arrayStride: 55420,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 3884,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 0,
+attributes: [],
+},
+{
+arrayStride: 17452,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x2',
+offset: 16804,
+shaderLocation: 3,
+}, {
+format: 'float32x2',
+offset: 7876,
+shaderLocation: 20,
+}, {
+format: 'uint32x3',
+offset: 9528,
+shaderLocation: 11,
+}, {
+format: 'uint32x4',
+offset: 12592,
+shaderLocation: 2,
+}, {
+format: 'sint8x4',
+offset: 4948,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 32872,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 17860,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x2',
+offset: 10628,
+shaderLocation: 19,
+}],
+}
+]
+},
+});
+try {
+  await promise29;
+} catch {}
+let canvas11 = document.createElement('canvas');
+try {
+canvas11.getContext('2d');
+} catch {}
+try {
+window.someLabel = commandEncoder43.label;
+} catch {}
+try {
+computePassEncoder39.setBindGroup(6, bindGroup19);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let device4 = await promise15;
+let sampler48 = device3.createSampler({
+label: '\u02e2\uc6d1\u0987',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 62.799,
+lodMaxClamp: 99.665,
+});
+try {
+renderBundleEncoder46.setPipeline(pipeline36);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let device5 = await adapter5.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+});
+let bindGroup20 = device2.createBindGroup({
+layout: bindGroupLayout16,
+entries: [],
+});
+try {
+device2.queue.writeTexture({
+  texture: texture80,
+  mipLevel: 2,
+  origin: { x: 610, y: 10, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 643 */
+{offset: 643}, {width: 150, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video8.width = 210;
+let canvas12 = document.createElement('canvas');
+try {
+await adapter7.requestAdapterInfo();
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+document.body.prepend(video10);
+let texture85 = device5.createTexture({
+label: '\u0b83\u6013\u01b5\u02aa',
+size: {width: 1582, height: 160, depthOrArrayLayers: 1939},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg32sint', 'rg32sint'],
+});
+try {
+device5.queue.writeTexture({
+  texture: texture85,
+  mipLevel: 1,
+  origin: { x: 22, y: 0, z: 842 },
+  aspect: 'all',
+}, new ArrayBuffer(541), /* required buffer size: 541 */
+{offset: 541, bytesPerRow: 6092}, {width: 739, height: 79, depthOrArrayLayers: 0});
+} catch {}
+try {
+await adapter2.requestAdapterInfo();
+} catch {}
+let commandEncoder51 = device3.createCommandEncoder({});
+let querySet36 = device3.createQuerySet({
+label: '\u{1f763}\u0630\u{1fdb1}\uebee\u1872\ud88f\u{1fcfc}\ua8c5',
+type: 'occlusion',
+count: 1218,
+});
+let renderBundle65 = renderBundleEncoder46.finish({label: '\u0521\u067d\u52de\u8236\u0dd1\ua6ac'});
+try {
+renderBundleEncoder32.drawIndexed(56, 0);
+} catch {}
+gc();
+let texture86 = device5.createTexture({
+label: '\u0b2f\u{1fe00}\u0e89',
+size: {width: 6330, height: 640, depthOrArrayLayers: 199},
+mipLevelCount: 10,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [],
+});
+let sampler49 = device5.createSampler({
+label: '\u{1ff71}\u{1fda9}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 95.686,
+});
+let device6 = await adapter8.requestDevice({
+label: '\uf093\u0a16\u{1ff4b}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 45,
+maxVertexAttributes: 28,
+maxVertexBufferArrayStride: 15668,
+maxStorageTexturesPerShaderStage: 22,
+maxStorageBuffersPerShaderStage: 33,
+maxDynamicStorageBuffersPerPipelineLayout: 46085,
+maxBindingsPerBindGroup: 1191,
+maxTextureDimension1D: 14834,
+maxTextureDimension2D: 8450,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 111987824,
+maxUniformBuffersPerShaderStage: 39,
+maxInterStageShaderVariables: 60,
+maxInterStageShaderComponents: 61,
+maxSamplersPerShaderStage: 20,
+},
+});
+document.body.prepend(canvas9);
+try {
+canvas12.getContext('bitmaprenderer');
+} catch {}
+gc();
+let commandEncoder52 = device3.createCommandEncoder();
+let renderBundle66 = renderBundleEncoder42.finish({label: '\uba20\u04d0\u4dd6\ub379\u09ba\u0ac9\u0f2e\u0055\u{1fad0}\u073c'});
+let renderBundleEncoder48 = device6.createRenderBundleEncoder({
+  label: '\u{1fddd}\u0d40\ub1ca\u07f6\u03b7\u087d\u66ea',
+  colorFormats: ['rg32float', undefined],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+let renderBundle67 = renderBundleEncoder48.finish();
+let imageData13 = new ImageData(128, 156);
+let querySet37 = device5.createQuerySet({
+label: '\u{1f98d}\u59ae',
+type: 'occlusion',
+count: 278,
+});
+let sampler50 = device5.createSampler({
+label: '\u{1f90f}\u27b1\u8b8f\u03a0',
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 73.550,
+lodMaxClamp: 95.083,
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer27 = device2.createBuffer({size: 36885, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let commandEncoder53 = device2.createCommandEncoder({});
+let querySet38 = device2.createQuerySet({
+label: '\u18b3\u4d77\u0306\u634c\u47e5\u0594\uaff5\ucfd8\u00ba\u0c7a',
+type: 'occlusion',
+count: 2070,
+});
+let commandBuffer11 = commandEncoder53.finish({
+});
+pseudoSubmit(device2, commandEncoder24);
+try {
+computePassEncoder32.setBindGroup(2, bindGroup19, []);
+} catch {}
+let pipeline54 = await device2.createComputePipelineAsync({
+label: '\ue019\u86c1\u0b39\u{1fc0b}\u{1f73a}',
+layout: 'auto',
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let img11 = await imageWithData(1, 295, '#5063270b', '#e2506f7e');
+let video13 = await videoWithData();
+try {
+  await promise23;
+} catch {}
+let texture87 = device5.createTexture({
+label: '\u0c10\u641d\ude38\u0aaa\ub7d2\u1ca1\u00c6\u{1f78c}',
+size: [954],
+dimension: '1d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+device5.addEventListener('uncapturederror', e => { log('device5.uncapturederror'); log(e); e.label = device5.label; });
+} catch {}
+let commandEncoder54 = device4.createCommandEncoder();
+let computePassEncoder42 = commandEncoder54.beginComputePass({label: '\ua00c\u{1f9d2}\u76bd'});
+let imageData14 = new ImageData(172, 132);
+try {
+device1.label = '\u5240\u513e';
+} catch {}
+let commandEncoder55 = device3.createCommandEncoder({label: '\u06b8\u004d\uaa44\udbeb\u{1f9bf}\u0c8b'});
+let querySet39 = device3.createQuerySet({
+label: '\u{1fd26}\ua4b8\u{1f6ed}\u099f\u01b4\u0fa5\ude77\ub75d\u0cbb\u{1f90f}\u0643',
+type: 'occlusion',
+count: 3258,
+});
+let texture88 = device3.createTexture({
+label: '\uda26\u{1fe2f}\u0be3\ua93d\u{1fe0a}\u0bc2',
+size: {width: 1536, height: 1, depthOrArrayLayers: 216},
+mipLevelCount: 7,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+});
+let sampler51 = device2.createSampler({
+label: '\u1c87\u619b\u7c46\u0a84\u153f',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 51.768,
+lodMaxClamp: 73.209,
+compare: 'always',
+maxAnisotropy: 19,
+});
+try {
+device2.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: { x: 19, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 704 */
+{offset: 704, bytesPerRow: 1885}, {width: 936, height: 44, depthOrArrayLayers: 0});
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline55 = device2.createRenderPipeline({
+label: '\u{1f854}\u{1fe95}\u6652\udb61\u{1fbd3}\u5512\u{1f69b}\ucc42\u0ff3\u5a74\u1acb',
+layout: pipelineLayout8,
+fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+}
+}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, undefined, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}]
+},
+vertex: {
+  module: shaderModule20,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 51896,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint16x4',
+offset: 21292,
+shaderLocation: 0,
+}, {
+format: 'uint16x4',
+offset: 28864,
+shaderLocation: 5,
+}, {
+format: 'snorm8x4',
+offset: 9356,
+shaderLocation: 13,
+}, {
+format: 'snorm16x4',
+offset: 18076,
+shaderLocation: 3,
+}, {
+format: 'unorm8x4',
+offset: 3616,
+shaderLocation: 17,
+}, {
+format: 'float16x2',
+offset: 41408,
+shaderLocation: 4,
+}, {
+format: 'sint8x4',
+offset: 39956,
+shaderLocation: 1,
+}, {
+format: 'uint32x2',
+offset: 33396,
+shaderLocation: 7,
+}, {
+format: 'uint32x3',
+offset: 6760,
+shaderLocation: 11,
+}, {
+format: 'unorm8x4',
+offset: 45096,
+shaderLocation: 14,
+}, {
+format: 'uint16x4',
+offset: 9752,
+shaderLocation: 15,
+}, {
+format: 'unorm8x4',
+offset: 50076,
+shaderLocation: 20,
+}],
+},
+{
+arrayStride: 47624,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 46988,
+shaderLocation: 12,
+}, {
+format: 'uint32',
+offset: 35752,
+shaderLocation: 16,
+}, {
+format: 'unorm16x4',
+offset: 42304,
+shaderLocation: 8,
+}, {
+format: 'uint16x4',
+offset: 46732,
+shaderLocation: 19,
+}, {
+format: 'uint8x4',
+offset: 15144,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 27504,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32',
+offset: 18188,
+shaderLocation: 18,
+}, {
+format: 'uint32x2',
+offset: 5736,
+shaderLocation: 2,
+}, {
+format: 'sint16x2',
+offset: 14944,
+shaderLocation: 9,
+}, {
+format: 'uint16x4',
+offset: 26632,
+shaderLocation: 10,
+}, {
+format: 'sint16x2',
+offset: 11828,
+shaderLocation: 21,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let device7 = await adapter6.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 34,
+maxVertexAttributes: 22,
+maxVertexBufferArrayStride: 27572,
+maxStorageTexturesPerShaderStage: 30,
+maxStorageBuffersPerShaderStage: 27,
+maxDynamicStorageBuffersPerPipelineLayout: 60111,
+maxBindingsPerBindGroup: 1488,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 15153,
+maxTextureDimension2D: 12972,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 110536082,
+maxUniformBuffersPerShaderStage: 21,
+maxInterStageShaderVariables: 65,
+maxInterStageShaderComponents: 119,
+maxSamplersPerShaderStage: 20,
+},
+});
+canvas5.width = 222;
+let canvas13 = document.createElement('canvas');
+let offscreenCanvas10 = new OffscreenCanvas(851, 280);
+let renderBundleEncoder49 = device3.createRenderBundleEncoder({
+  label: '\u3d95\u9483\u0c16',
+  colorFormats: ['r16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder32.draw(48, 72, 80);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(4, buffer21);
+} catch {}
+try {
+commandEncoder55.copyBufferToTexture({
+/* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 3740 */
+offset: 3720,
+buffer: buffer23,
+}, {
+  texture: texture73,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 2 },
+  aspect: 'all',
+}, {width: 5, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer23);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let commandEncoder56 = device6.createCommandEncoder({});
+let texture89 = device6.createTexture({
+label: '\u0238\u0a9e\u{1f95c}\ubf21\uc01a\u1867',
+size: {width: 12, height: 24, depthOrArrayLayers: 73},
+mipLevelCount: 3,
+format: 'rg32uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rg32uint', 'rg32uint', 'rg32uint'],
+});
+try {
+gpuCanvasContext8.configure({
+device: device6,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'stencil8', 'rgba16float'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder57 = device3.createCommandEncoder({label: '\ua5f9\ufc96\u019c\uf899'});
+let querySet40 = device3.createQuerySet({
+label: '\u014d\u5e16\u43cd\u4586\uaf2f\u1b4a',
+type: 'occlusion',
+count: 2028,
+});
+let texture90 = device3.createTexture({
+label: '\u0d74\u0068\u67ae\u{1fd6b}\u10c0\u731e\udf2d',
+size: {width: 32, height: 10, depthOrArrayLayers: 1},
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['depth32float-stencil8', 'depth32float-stencil8', 'depth32float-stencil8'],
+});
+let computePassEncoder43 = commandEncoder52.beginComputePass({label: '\uebc6\u068d\udb18\uef33\u271e\u0c0c\u{1ff38}\ud036'});
+let sampler52 = device3.createSampler({
+label: '\u0d77\ud1d6',
+addressModeU: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 16.588,
+lodMaxClamp: 38.076,
+compare: 'less-equal',
+maxAnisotropy: 10,
+});
+try {
+renderBundleEncoder32.drawIndexed(48, 40, 48, 568, 56);
+} catch {}
+let arrayBuffer6 = buffer21.getMappedRange(37936, 21828);
+try {
+gpuCanvasContext9.configure({
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+});
+} catch {}
+let gpuCanvasContext10 = offscreenCanvas10.getContext('webgpu');
+try {
+  await promise26;
+} catch {}
+let texture91 = device5.createTexture({
+label: '\u5531\u0df9\ub1aa\u{1ff96}\u0b4c\u{1ffb6}\u0e6f\uf8af\u016b\u5e51',
+size: {width: 3165},
+dimension: '1d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let texture92 = gpuCanvasContext1.getCurrentTexture();
+let promise30 = device5.queue.onSubmittedWorkDone();
+try {
+device5.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas8,
+  origin: { x: 465, y: 74 },
+  flipY: true,
+}, {
+  texture: texture92,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let canvas14 = document.createElement('canvas');
+let commandEncoder58 = device3.createCommandEncoder({});
+let renderBundle68 = renderBundleEncoder39.finish({});
+let sampler53 = device3.createSampler({
+label: '\u016e\ufc7e\u{1f96b}\ubbdb\u06b7\u{1f690}\u17ac\u05f5\u0cdf\u94d4',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+});
+try {
+renderBundleEncoder47.setVertexBuffer(4, buffer21);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16float', 'r8sint'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let promise31 = device3.createComputePipelineAsync({
+label: '\u0e9e\u{1f806}\u0798\u5387',
+layout: pipelineLayout13,
+compute: {
+module: shaderModule16,
+entryPoint: 'compute0',
+},
+});
+let bindGroupLayout27 = device2.createBindGroupLayout({
+label: '\u06eb\u0a75\u061c\u7d31',
+entries: [],
+});
+let textureView71 = texture62.createView({label: '\u0e68\u07cf', format: 'etc2-rgba8unorm', baseMipLevel: 2, baseArrayLayer: 110, arrayLayerCount: 31});
+try {
+renderBundleEncoder38.setBindGroup(8, bindGroup19, new Uint32Array(697), 375, 0);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+device2.queue.writeBuffer(buffer17, 1408, new DataView(new ArrayBuffer(6186)), 2246, 308);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageData15 = new ImageData(132, 180);
+let buffer28 = device4.createBuffer({size: 29223, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let commandEncoder59 = device4.createCommandEncoder({label: '\u0b17\u45e2\u4494\uc8e4\u041c\u22c3\u{1fdcb}'});
+let imageBitmap13 = await createImageBitmap(img10);
+let querySet41 = device7.createQuerySet({
+label: '\u0288\ud865\u{1ff5b}\u{1f77b}\u20bb\u{1f795}\u{1fbc1}\u00f0',
+type: 'occlusion',
+count: 692,
+});
+let canvas15 = document.createElement('canvas');
+let textureView72 = texture85.createView({baseMipLevel: 1, mipLevelCount: 3, baseArrayLayer: 0});
+gc();
+let bindGroupLayout28 = device2.createBindGroupLayout({
+label: '\ua854\u3e38\u06b8\u6ad3\u{1fc33}\uc62d\u0bd5\u0d05\u9287\u{1fea5}',
+entries: [{
+binding: 4718,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 1940,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+let texture93 = device2.createTexture({
+size: [240, 11, 2],
+mipLevelCount: 8,
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView73 = texture93.createView({label: '\u59ec\u0cd6', dimension: '2d', baseMipLevel: 2, mipLevelCount: 2});
+try {
+device2.queue.writeTexture({
+  texture: texture93,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(993), /* required buffer size: 993 */
+{offset: 993}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let imageData16 = new ImageData(220, 36);
+try {
+gpuCanvasContext5.configure({
+device: device4,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba16float', 'rgba16float'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let imageBitmap14 = await createImageBitmap(offscreenCanvas10);
+let imageData17 = new ImageData(244, 140);
+let renderBundleEncoder50 = device7.createRenderBundleEncoder({
+  label: '\u41d6\u{1ff0a}\u{1fc8c}\u3f0f\u0bb3\u{1f85b}\u{1fe7c}',
+  colorFormats: ['r8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let querySet42 = device7.createQuerySet({
+label: '\u0f8d\u{1fb0c}',
+type: 'occlusion',
+count: 2861,
+});
+let texture94 = device7.createTexture({
+size: [320, 120, 138],
+mipLevelCount: 3,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundle69 = renderBundleEncoder50.finish({});
+let sampler54 = device7.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 74.753,
+maxAnisotropy: 11,
+});
+try {
+gpuCanvasContext6.configure({
+device: device7,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg32uint'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+gc();
+try {
+device6.pushErrorScope('out-of-memory');
+} catch {}
+let promise32 = device6.queue.onSubmittedWorkDone();
+gc();
+let gpuCanvasContext11 = canvas14.getContext('webgpu');
+document.body.prepend(video7);
+let offscreenCanvas11 = new OffscreenCanvas(723, 1011);
+let commandEncoder60 = device5.createCommandEncoder({label: '\u{1fd96}\u{1fdea}\u{1fbb7}\ue260\u0d4e\u{1ff21}\u539b'});
+let textureView74 = texture87.createView({});
+try {
+device5.queue.writeTexture({
+  texture: texture85,
+  mipLevel: 1,
+  origin: { x: 9, y: 42, z: 326 },
+  aspect: 'all',
+}, new Int32Array(arrayBuffer5), /* required buffer size: 2524467 */
+{offset: 756, bytesPerRow: 5789, rowsPerImage: 199}, {width: 687, height: 38, depthOrArrayLayers: 3});
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData2,
+  origin: { x: 10, y: 117 },
+  flipY: true,
+}, {
+  texture: texture92,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder61 = device6.createCommandEncoder();
+let querySet43 = device6.createQuerySet({
+type: 'occlusion',
+count: 3598,
+});
+let renderBundle70 = renderBundleEncoder48.finish();
+try {
+computePassEncoder42.end();
+} catch {}
+try {
+commandEncoder59.clearBuffer(buffer28, 156, 28156);
+dissociateBuffer(device4, buffer28);
+} catch {}
+document.body.prepend(img5);
+try {
+adapter1.label = '\u{1faec}\uba99\u{1f77e}\ufeda\u{1ff5b}\ua4e8\uf266\ua798\u072a';
+} catch {}
+let gpuCanvasContext12 = canvas15.getContext('webgpu');
+let offscreenCanvas12 = new OffscreenCanvas(997, 213);
+let texture95 = device4.createTexture({
+label: '\u{1fbcd}\u58d0\u{1fa2c}\ub0df\u8e94',
+size: [320, 40, 215],
+mipLevelCount: 6,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+commandEncoder54.clearBuffer(buffer28, 5432, 12612);
+dissociateBuffer(device4, buffer28);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer28, 940, new DataView(new ArrayBuffer(33525)), 23058, 8840);
+} catch {}
+let gpuCanvasContext13 = canvas13.getContext('webgpu');
+try {
+  await promise20;
+} catch {}
+let canvas16 = document.createElement('canvas');
+try {
+offscreenCanvas12.getContext('2d');
+} catch {}
+let sampler55 = device2.createSampler({
+label: '\u09b8\u014a\u1039\u03b1\u1468\u{1fd62}\u{1fc1d}\u4b61\ue80c\u0227\u2bed',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+lodMinClamp: 64.021,
+lodMaxClamp: 97.358,
+});
+try {
+computePassEncoder32.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline54);
+} catch {}
+try {
+renderBundleEncoder38.setPipeline(pipeline52);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture93,
+  mipLevel: 3,
+  origin: { x: 6, y: 0, z: 1 },
+  aspect: 'all',
+}, new Int16Array(arrayBuffer1), /* required buffer size: 774 */
+{offset: 774, rowsPerImage: 58}, {width: 17, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise30;
+} catch {}
+try {
+canvas16.getContext('bitmaprenderer');
+} catch {}
+try {
+renderBundleEncoder32.drawIndexed(64, 32);
+} catch {}
+try {
+commandEncoder57.copyBufferToTexture({
+/* bytesInLastRow: 2744 widthInBlocks: 686 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 34700 */
+offset: 34700,
+buffer: buffer23,
+}, {
+  texture: texture77,
+  mipLevel: 0,
+  origin: { x: 41, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 686, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer23);
+} catch {}
+let pipeline56 = await device3.createRenderPipelineAsync({
+label: '\u450f\u568a\u9664\u6090',
+layout: pipelineLayout10,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  blend: {
+color: {operation: 'add', srcFactor: 'one', dstFactor: 'one-minus-dst-alpha'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8unorm-srgb'}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'replace',
+},
+stencilReadMask: 1813,
+stencilWriteMask: 75,
+depthBias: 26,
+depthBiasClamp: 8,
+},
+vertex: {
+  module: shaderModule16,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 60,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32',
+offset: 40,
+shaderLocation: 4,
+}, {
+format: 'sint32x3',
+offset: 40,
+shaderLocation: 13,
+}, {
+format: 'sint16x2',
+offset: 40,
+shaderLocation: 7,
+}, {
+format: 'snorm16x2',
+offset: 4,
+shaderLocation: 6,
+}, {
+format: 'float32x2',
+offset: 8,
+shaderLocation: 15,
+}, {
+format: 'snorm16x2',
+offset: 44,
+shaderLocation: 12,
+}, {
+format: 'uint8x2',
+offset: 32,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 2636,
+attributes: [{
+format: 'unorm8x2',
+offset: 622,
+shaderLocation: 10,
+}, {
+format: 'uint8x2',
+offset: 386,
+shaderLocation: 14,
+}, {
+format: 'uint32',
+offset: 1148,
+shaderLocation: 11,
+}, {
+format: 'uint16x2',
+offset: 1208,
+shaderLocation: 0,
+}, {
+format: 'uint32',
+offset: 272,
+shaderLocation: 1,
+}],
+}
+]
+},
+});
+let buffer29 = device5.createBuffer({
+  label: '\u0f99\ub3ce\u{1fc49}\ue5b9\ubfe9\u{1fe46}\ucca4\u{1f8a0}\u3ac7\u{1fb6f}',
+  size: 24165,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false
+});
+let querySet44 = device5.createQuerySet({
+label: '\ud9b0\ua29d\uac4f',
+type: 'occlusion',
+count: 2622,
+});
+let renderBundleEncoder51 = device5.createRenderBundleEncoder({colorFormats: ['r8uint'], stencilReadOnly: true});
+try {
+device5.queue.writeTexture({
+  texture: texture92,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer5), /* required buffer size: 516 */
+{offset: 508}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let video14 = await videoWithData();
+let commandEncoder62 = device6.createCommandEncoder({label: '\ubd2b\ua1cb\ua4ef\u0cd9\ud0aa\u0b9f\u009b\uf5cf\u{1fd3a}\u0751\ub58c'});
+let externalTexture8 = device6.importExternalTexture({
+source: video6,
+colorSpace: 'display-p3',
+});
+try {
+commandEncoder56.insertDebugMarker('\u0d2c');
+} catch {}
+try {
+  await promise25;
+} catch {}
+let promise33 = adapter5.requestAdapterInfo();
+let querySet45 = device5.createQuerySet({
+label: '\u0486\uf167\u{1fe40}',
+type: 'occlusion',
+count: 1334,
+});
+let renderBundle71 = renderBundleEncoder51.finish();
+let querySet46 = device4.createQuerySet({
+label: '\u3ecc\u{1f8cf}',
+type: 'occlusion',
+count: 2219,
+});
+let texture96 = device4.createTexture({
+label: '\u{1fcfb}\u{1fa02}\u{1f709}\u6ffa\uca70\u{1f894}\u9fe5',
+size: [40, 60, 249],
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x5-unorm-srgb'],
+});
+let renderBundleEncoder52 = device7.createRenderBundleEncoder({
+  label: '\u08b9\u12cd\u0cdf\uc51b\u{1ff0e}\u{1f7d9}\uf0c1\u{1fbb1}\u01a1\udbf3\ucfaf',
+  colorFormats: ['r8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+  await promise33;
+} catch {}
+let bindGroupLayout29 = device6.createBindGroupLayout({
+label: '\u091b\u6b43\ud5b6\ud03f',
+entries: [{
+binding: 574,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 498,
+visibility: 0,
+texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+}, {
+binding: 379,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+}],
+});
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+try {
+offscreenCanvas11.getContext('webgpu');
+} catch {}
+let querySet47 = device5.createQuerySet({
+label: '\ufb4d\u0918\u0eec\u0092\u07f7\u1567\u3162\u{1f94e}\u5299\u0bbd',
+type: 'occlusion',
+count: 192,
+});
+let renderBundleEncoder53 = device5.createRenderBundleEncoder({colorFormats: ['r8uint']});
+try {
+renderBundleEncoder53.setVertexBuffer(0, buffer29, 13644, 3834);
+} catch {}
+let textureView75 = texture63.createView({label: '\u0137\uab05', dimension: '1d'});
+let sampler56 = device2.createSampler({
+label: '\u3e15\ufb14\u{1fbc7}\u06a0',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 26.334,
+lodMaxClamp: 91.711,
+});
+try {
+computePassEncoder39.setPipeline(pipeline49);
+} catch {}
+let promise34 = device2.queue.onSubmittedWorkDone();
+let bindGroupLayout30 = device7.createBindGroupLayout({
+label: '\u5410\u0c0c',
+entries: [{
+binding: 1217,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+}, {
+binding: 35,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}],
+});
+let querySet48 = device7.createQuerySet({
+label: '\u0166\u0cc8\u008c\u5d21\uc542\u{1ffd3}\u{1f785}\u{1fba5}\u0adb\u67a7\u5b65',
+type: 'occlusion',
+count: 3416,
+});
+let texture97 = device7.createTexture({
+size: [7040],
+sampleCount: 1,
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg32sint', 'rg32sint'],
+});
+try {
+renderBundleEncoder52.setVertexBuffer(21, undefined, 3371936576, 272778353);
+} catch {}
+try {
+device7.pushErrorScope('out-of-memory');
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let video15 = await videoWithData();
+let pipelineLayout15 = device7.createPipelineLayout({
+  label: '\udb50\u7e98\u0551\ufdc3\u811e\u53ca\u7e55',
+  bindGroupLayouts: [bindGroupLayout30, bindGroupLayout30, bindGroupLayout30, bindGroupLayout30, bindGroupLayout30, bindGroupLayout30]
+});
+let commandEncoder63 = device7.createCommandEncoder({label: '\udbaa\u{1fb37}\u{1f957}\u0d82\u8787\ud768\u54d0\u0304'});
+try {
+device7.pushErrorScope('out-of-memory');
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let offscreenCanvas13 = new OffscreenCanvas(677, 965);
+let imageBitmap15 = await createImageBitmap(video13);
+let computePassEncoder44 = commandEncoder63.beginComputePass({label: '\u0f6b\u705c\u{1f9a0}'});
+pseudoSubmit(device3, commandEncoder58);
+let renderBundle72 = renderBundleEncoder42.finish({label: '\u{1f66a}\ue1cf\u18cd\u17ad\u0176\u{1f7de}\uf20a\u013d\ub832\u6d5b'});
+try {
+renderBundleEncoder32.drawIndexed(8, 16, 32, 40, 56);
+} catch {}
+try {
+renderBundleEncoder32.setPipeline(pipeline36);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+device: device3,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float'],
+alphaMode: 'opaque',
+});
+} catch {}
+document.body.prepend(canvas7);
+gc();
+let offscreenCanvas14 = new OffscreenCanvas(36, 739);
+let arrayBuffer7 = buffer21.getMappedRange(60600, 444);
+let textureView76 = texture73.createView({label: '\u{1f761}\u699d\ub981', baseMipLevel: 1, mipLevelCount: 3});
+let renderBundle73 = renderBundleEncoder35.finish();
+try {
+computePassEncoder41.setPipeline(pipeline50);
+} catch {}
+try {
+renderBundleEncoder32.drawIndexed(16);
+} catch {}
+try {
+renderBundleEncoder32.setPipeline(pipeline32);
+} catch {}
+let arrayBuffer8 = buffer21.getMappedRange(61496, 244);
+try {
+buffer22.unmap();
+} catch {}
+let pipeline57 = device3.createRenderPipeline({
+layout: 'auto',
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8unorm-srgb', writeMask: 0}, {format: 'r8sint'}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'one-minus-constant'},
+alpha: {operation: 'subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'zero'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}]
+},
+vertex: {
+  module: shaderModule14,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 4316,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 1912,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 2992,
+attributes: [{
+format: 'unorm16x4',
+offset: 2532,
+shaderLocation: 6,
+}, {
+format: 'sint32x2',
+offset: 172,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 2868,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 3380,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 2280,
+shaderLocation: 2,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let shaderModule22 = device3.createShaderModule({
+label: '\u0233\u5685\ubce8\u0597\u{1fcc3}\u0145',
+code: `@group(3) @binding(1812)
+var<storage, read_write> function23: array<u32>;
+@group(1) @binding(1812)
+var<storage, read_write> type28: array<u32>;
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S23 {
+  @location(35) f0: vec4<f32>,
+  @location(4) f1: vec4<f32>,
+  @location(21) f2: vec2<u32>,
+  @location(1) f3: vec2<u32>,
+  @builtin(sample_mask) f4: u32,
+  @location(42) f5: vec2<f32>,
+  @location(23) f6: vec4<u32>,
+  @location(5) f7: vec3<i32>,
+  @location(37) f8: vec2<u32>,
+  @location(36) f9: vec3<u32>,
+  @builtin(front_facing) f10: bool,
+  @location(28) f11: vec4<i32>,
+  @location(31) f12: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(2) a0: vec4<f16>, @location(25) a1: vec4<i32>, @builtin(sample_index) a2: u32, @location(12) a3: vec3<f32>, @builtin(position) a4: vec4<f32>, a5: S23, @location(40) a6: f32, @location(22) a7: vec3<f32>, @location(16) a8: vec2<f16>, @location(38) a9: vec3<u32>) -> @location(200) vec3<u32> {
+return vec3<u32>();
+}
+
+struct S22 {
+  @location(11) f0: vec3<f32>,
+  @location(16) f1: vec2<i32>,
+  @location(15) f2: f16,
+  @location(6) f3: vec4<f32>,
+  @location(13) f4: vec2<f16>,
+  @location(14) f5: vec2<i32>
+}
+struct VertexOutput0 {
+  @location(42) f297: vec2<f32>,
+  @location(18) f298: vec4<f32>,
+  @location(28) f299: vec4<i32>,
+  @location(37) f300: vec2<u32>,
+  @location(35) f301: vec4<f32>,
+  @location(38) f302: vec3<u32>,
+  @location(2) f303: vec4<f16>,
+  @location(40) f304: f32,
+  @location(12) f305: vec3<f32>,
+  @location(4) f306: vec4<f32>,
+  @location(16) f307: vec2<f16>,
+  @location(13) f308: vec2<f32>,
+  @location(23) f309: vec4<u32>,
+  @location(1) f310: vec2<u32>,
+  @location(33) f311: vec3<f16>,
+  @location(31) f312: vec4<i32>,
+  @location(22) f313: vec3<f32>,
+  @location(5) f314: vec3<i32>,
+  @location(27) f315: vec2<i32>,
+  @builtin(position) f316: vec4<f32>,
+  @location(21) f317: vec2<u32>,
+  @location(25) f318: vec4<i32>,
+  @location(36) f319: vec3<u32>,
+  @location(29) f320: f16
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec3<u32>, @location(12) a1: vec3<u32>, @location(7) a2: vec3<i32>, @location(3) a3: vec2<f32>, @location(4) a4: vec2<u32>, @location(0) a5: vec2<i32>, a6: S22, @location(10) a7: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+});
+let bindGroupLayout31 = device3.createBindGroupLayout({
+label: '\u046c\u8ab0\u06f6\ufca2',
+entries: [],
+});
+let sampler57 = device3.createSampler({
+label: '\ua32b\u4eeb\u94fd\u03b1\u7de5\u{1fe61}\u34cc\u628a',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 64.057,
+lodMaxClamp: 66.297,
+});
+try {
+renderBundleEncoder32.drawIndexed(48, 80, 16, -456, 40);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(1, buffer21, 20436, 2120);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+let pipeline58 = await device3.createRenderPipelineAsync({
+layout: pipelineLayout13,
+fragment: {module: shaderModule22, entryPoint: 'fragment0', constants: {}, targets: [{format: 'r16uint'}]},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+},
+stencilReadMask: 3159,
+stencilWriteMask: 2718,
+depthBiasSlopeScale: 42,
+depthBiasClamp: 41,
+},
+vertex: {
+  module: shaderModule22,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 3704,
+shaderLocation: 13,
+}, {
+format: 'float32x3',
+offset: 3324,
+shaderLocation: 3,
+}, {
+format: 'uint8x2',
+offset: 1520,
+shaderLocation: 8,
+}, {
+format: 'uint16x4',
+offset: 4580,
+shaderLocation: 12,
+}, {
+format: 'uint8x2',
+offset: 878,
+shaderLocation: 4,
+}, {
+format: 'snorm16x4',
+offset: 1368,
+shaderLocation: 11,
+}, {
+format: 'sint32x2',
+offset: 628,
+shaderLocation: 0,
+}, {
+format: 'float16x2',
+offset: 2728,
+shaderLocation: 15,
+}, {
+format: 'sint32',
+offset: 3488,
+shaderLocation: 7,
+}, {
+format: 'sint32x3',
+offset: 864,
+shaderLocation: 16,
+}, {
+format: 'sint32x4',
+offset: 3864,
+shaderLocation: 14,
+}, {
+format: 'unorm16x4',
+offset: 3968,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 2380,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 2984,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x4',
+offset: 1876,
+shaderLocation: 10,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'none',
+unclippedDepth: true,
+},
+});
+let texture98 = device3.createTexture({
+label: '\u{1fe78}\u575d\u616a\uda35\u54a0\u0fac\ufbea\u92e4\ue685',
+size: [64, 20, 1],
+mipLevelCount: 6,
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rgba32float', 'rgba32float', 'rgba32float'],
+});
+try {
+commandEncoder51.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 624 */
+offset: 624,
+bytesPerRow: 0,
+buffer: buffer23,
+}, {
+  texture: texture73,
+  mipLevel: 3,
+  origin: { x: 10, y: 1, z: 2 },
+  aspect: 'all',
+}, {width: 0, height: 2, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer23);
+} catch {}
+let gpuCanvasContext14 = offscreenCanvas13.getContext('webgpu');
+let bindGroupLayout32 = device5.createBindGroupLayout({
+entries: [],
+});
+let bindGroup21 = device5.createBindGroup({
+label: '\u0b12\ude63\u01c4\u{1f680}',
+layout: bindGroupLayout32,
+entries: [],
+});
+let pipelineLayout16 = device5.createPipelineLayout({label: '\u{1f7c3}\u3243', bindGroupLayouts: [bindGroupLayout32, bindGroupLayout32, bindGroupLayout32]});
+let buffer30 = device5.createBuffer({
+  label: '\u12d8\u060e\ud892\u7691\u36c9\u0aef\u{1fc7d}\u{1f92d}',
+  size: 49061,
+  usage: GPUBufferUsage.QUERY_RESOLVE
+});
+let sampler58 = device5.createSampler({
+label: '\u0841\u07ca\u{1f849}\u{1ffb9}\u633c\u{1fd08}\u9704\u0255\uf255',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 20.139,
+maxAnisotropy: 5,
+});
+try {
+commandEncoder60.resolveQuerySet(querySet45, 688, 107, buffer30, 17408);
+} catch {}
+try {
+device5.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 5,
+  origin: { x: 80, y: 0, z: 135 },
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 2032893 */
+{offset: 411, bytesPerRow: 154, rowsPerImage: 249}, {width: 90, height: 10, depthOrArrayLayers: 54});
+} catch {}
+let commandEncoder64 = device4.createCommandEncoder({});
+pseudoSubmit(device4, commandEncoder59);
+let offscreenCanvas15 = new OffscreenCanvas(216, 480);
+try {
+await adapter9.requestAdapterInfo();
+} catch {}
+let shaderModule23 = device7.createShaderModule({
+code: `@group(4) @binding(1217)
+var<storage, read_write> i26: array<u32>;
+@group(1) @binding(35)
+var<storage, read_write> local26: array<u32>;
+@group(3) @binding(1217)
+var<storage, read_write> local27: array<u32>;
+@group(3) @binding(35)
+var<storage, read_write> local28: array<u32>;
+@group(5) @binding(1217)
+var<storage, read_write> parameter25: array<u32>;
+@group(4) @binding(35)
+var<storage, read_write> global20: array<u32>;
+@group(2) @binding(1217)
+var<storage, read_write> type29: array<u32>;
+@group(5) @binding(35)
+var<storage, read_write> function24: array<u32>;
+@group(2) @binding(35)
+var<storage, read_write> i27: array<u32>;
+@group(0) @binding(35)
+var<storage, read_write> parameter26: array<u32>;
+@group(0) @binding(1217)
+var<storage, read_write> i28: array<u32>;
+
+@compute @workgroup_size(3, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S25 {
+  @location(16) f0: vec4<f16>,
+  @location(41) f1: f16,
+  @location(60) f2: u32,
+  @location(18) f3: vec3<i32>,
+  @location(6) f4: u32,
+  @location(48) f5: vec2<i32>,
+  @location(40) f6: vec2<f16>,
+  @location(23) f7: vec2<f16>,
+  @location(45) f8: vec3<f32>,
+  @builtin(position) f9: vec4<f32>,
+  @location(25) f10: vec3<f16>,
+  @location(38) f11: vec3<f16>,
+  @location(21) f12: vec2<i32>,
+  @location(63) f13: vec4<f16>,
+  @location(31) f14: vec4<f16>,
+  @location(42) f15: vec2<u32>,
+  @location(57) f16: vec4<f16>,
+  @location(15) f17: u32,
+  @location(47) f18: vec3<f32>,
+  @location(3) f19: vec4<f16>,
+  @location(39) f20: f32,
+  @location(46) f21: vec4<i32>,
+  @location(34) f22: vec2<f32>,
+  @location(51) f23: u32,
+  @location(44) f24: i32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec3<u32>,
+  @location(5) f1: vec2<i32>,
+  @builtin(frag_depth) f2: f32
+}
+
+@fragment
+fn fragment0(@location(59) a0: vec4<u32>, @location(7) a1: vec3<u32>, @location(36) a2: vec4<f16>, @builtin(front_facing) a3: bool, @location(56) a4: vec3<u32>, @location(10) a5: vec3<u32>, @location(8) a6: vec2<u32>, @location(29) a7: vec2<f32>, @location(17) a8: f32, @location(32) a9: i32, @location(58) a10: f16, @location(52) a11: vec2<f32>, @builtin(sample_index) a12: u32, @location(11) a13: vec2<f32>, @location(22) a14: f32, @location(5) a15: vec2<f32>, @location(54) a16: vec2<u32>, @location(19) a17: vec3<u32>, @location(20) a18: vec4<f16>, @location(50) a19: vec4<i32>, @location(14) a20: u32, @location(64) a21: vec3<u32>, @location(0) a22: vec3<f32>, @location(1) a23: vec2<i32>, @location(49) a24: vec3<u32>, @location(9) a25: f32, @location(35) a26: vec3<f32>, @location(37) a27: f32, a28: S25, @builtin(sample_mask) a29: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S24 {
+  @builtin(vertex_index) f0: u32,
+  @location(9) f1: i32
+}
+struct VertexOutput0 {
+  @location(34) f321: vec2<f32>,
+  @location(50) f322: vec4<i32>,
+  @location(15) f323: u32,
+  @location(14) f324: u32,
+  @location(17) f325: f32,
+  @location(29) f326: vec2<f32>,
+  @location(40) f327: vec2<f16>,
+  @location(59) f328: vec4<u32>,
+  @location(11) f329: vec2<f32>,
+  @location(54) f330: vec2<u32>,
+  @location(47) f331: vec3<f32>,
+  @location(0) f332: vec3<f32>,
+  @location(25) f333: vec3<f16>,
+  @location(3) f334: vec4<f16>,
+  @location(44) f335: i32,
+  @location(60) f336: u32,
+  @location(1) f337: vec2<i32>,
+  @builtin(position) f338: vec4<f32>,
+  @location(52) f339: vec2<f32>,
+  @location(49) f340: vec3<u32>,
+  @location(38) f341: vec3<f16>,
+  @location(16) f342: vec4<f16>,
+  @location(23) f343: vec2<f16>,
+  @location(20) f344: vec4<f16>,
+  @location(35) f345: vec3<f32>,
+  @location(42) f346: vec2<u32>,
+  @location(37) f347: f32,
+  @location(48) f348: vec2<i32>,
+  @location(32) f349: i32,
+  @location(45) f350: vec3<f32>,
+  @location(21) f351: vec2<i32>,
+  @location(7) f352: vec3<u32>,
+  @location(5) f353: vec2<f32>,
+  @location(9) f354: f32,
+  @location(36) f355: vec4<f16>,
+  @location(51) f356: u32,
+  @location(39) f357: f32,
+  @location(41) f358: f16,
+  @location(22) f359: f32,
+  @location(19) f360: vec3<u32>,
+  @location(64) f361: vec3<u32>,
+  @location(8) f362: vec2<u32>,
+  @location(6) f363: u32,
+  @location(56) f364: vec3<u32>,
+  @location(31) f365: vec4<f16>,
+  @location(18) f366: vec3<i32>,
+  @location(10) f367: vec3<u32>,
+  @location(57) f368: vec4<f16>,
+  @location(63) f369: vec4<f16>,
+  @location(58) f370: f16,
+  @location(46) f371: vec4<i32>
+}
+
+@vertex
+fn vertex0(a0: S24, @builtin(instance_index) a1: u32, @location(14) a2: vec3<f16>, @location(12) a3: vec4<f32>, @location(0) a4: vec4<f32>, @location(6) a5: vec3<f32>, @location(2) a6: vec2<u32>, @location(20) a7: vec4<u32>, @location(18) a8: vec2<u32>, @location(11) a9: vec4<f32>, @location(5) a10: f32, @location(13) a11: vec3<u32>, @location(19) a12: u32, @location(8) a13: u32, @location(16) a14: vec3<f16>, @location(21) a15: vec3<f16>, @location(1) a16: i32, @location(7) a17: vec2<f32>, @location(4) a18: i32, @location(17) a19: vec4<u32>, @location(15) a20: vec4<f16>, @location(10) a21: vec4<f32>, @location(3) a22: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+});
+let texture99 = device7.createTexture({
+label: '\u4315\u{1f962}\uec88\u762e',
+size: {width: 880, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 9,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+  await promise32;
+} catch {}
+let querySet49 = device4.createQuerySet({
+label: '\u0890\u{1f826}\ubd6d\u1175\ud219\ub48e',
+type: 'occlusion',
+count: 33,
+});
+let texture100 = device4.createTexture({
+label: '\u0a87\u{1f85d}\ufa45\ud89a\ubeaa\u039c\ud633\u{1fead}',
+size: [160, 240, 1],
+dimension: '2d',
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x5-unorm-srgb', 'astc-8x5-unorm-srgb', 'astc-8x5-unorm-srgb'],
+});
+let img12 = await imageWithData(170, 246, '#8dc96ec6', '#b0add378');
+let bindGroupLayout33 = device7.createBindGroupLayout({
+label: '\ua75e\uf953\u0613\u0603\u21e6\u097c',
+entries: [],
+});
+try {
+gpuCanvasContext11.configure({
+device: device7,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'etc2-rgb8a1unorm', 'rg16float'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let pipeline59 = await device7.createComputePipelineAsync({
+label: '\u8d05\u7dfd\u0598\u5be8\u0d10\u{1fd8d}\u3680',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule23,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline60 = device7.createRenderPipeline({
+label: '\u{1f8ee}\u06b3\u{1f821}\u7794\u04af\uf2c4\u{1f9d2}',
+layout: pipelineLayout15,
+fragment: {
+  module: shaderModule23,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+failOp: 'invert',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 128,
+stencilWriteMask: 3670,
+depthBiasSlopeScale: 74,
+},
+vertex: {
+  module: shaderModule23,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 27180,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 7012,
+shaderLocation: 14,
+}, {
+format: 'unorm8x4',
+offset: 17760,
+shaderLocation: 11,
+}, {
+format: 'sint8x4',
+offset: 10296,
+shaderLocation: 9,
+}, {
+format: 'uint8x4',
+offset: 22296,
+shaderLocation: 2,
+}, {
+format: 'unorm10-10-10-2',
+offset: 24200,
+shaderLocation: 7,
+}, {
+format: 'unorm16x4',
+offset: 19908,
+shaderLocation: 10,
+}, {
+format: 'uint32x2',
+offset: 8648,
+shaderLocation: 8,
+}, {
+format: 'unorm16x4',
+offset: 24208,
+shaderLocation: 6,
+}, {
+format: 'float16x2',
+offset: 24416,
+shaderLocation: 21,
+}, {
+format: 'snorm8x4',
+offset: 9608,
+shaderLocation: 3,
+}, {
+format: 'sint16x4',
+offset: 13460,
+shaderLocation: 1,
+}, {
+format: 'float32x3',
+offset: 26964,
+shaderLocation: 15,
+}, {
+format: 'uint32x3',
+offset: 23452,
+shaderLocation: 18,
+}, {
+format: 'float32x4',
+offset: 7864,
+shaderLocation: 12,
+}, {
+format: 'sint16x4',
+offset: 23436,
+shaderLocation: 4,
+}, {
+format: 'uint16x2',
+offset: 25600,
+shaderLocation: 19,
+}, {
+format: 'float32x3',
+offset: 4984,
+shaderLocation: 5,
+}, {
+format: 'float32',
+offset: 3080,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 6344,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 17316,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x2',
+offset: 11328,
+shaderLocation: 13,
+}, {
+format: 'uint32x2',
+offset: 13864,
+shaderLocation: 17,
+}],
+},
+{
+arrayStride: 18552,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 10180,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 3732,
+shaderLocation: 20,
+}, {
+format: 'snorm8x4',
+offset: 9400,
+shaderLocation: 16,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let bindGroupLayout34 = pipeline59.getBindGroupLayout(3);
+let renderBundle74 = renderBundleEncoder52.finish({label: '\u2f2a\u{1fff8}\u0467\u4bad\u{1f646}\u5e77\uba7d\u42bd\ub4a3\u6ad0\u0410'});
+let sampler59 = device7.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 13.337,
+lodMaxClamp: 36.030,
+});
+let pipelineLayout17 = device2.createPipelineLayout({
+  label: '\u72f6\u{1fa67}\u0d05\u3c9c\u{1fc23}\u09d5\ub80a\u0be7\ucd92',
+  bindGroupLayouts: [bindGroupLayout28, bindGroupLayout16, bindGroupLayout13, bindGroupLayout21, bindGroupLayout21, bindGroupLayout16]
+});
+let texture101 = gpuCanvasContext6.getCurrentTexture();
+let textureView77 = texture101.createView({
+  label: '\u0812\u1b60\u0d16\u4f66\u{1f86a}\u9b53\ued7e\uc921\u0702\ua40a',
+  dimension: '2d-array',
+  format: 'rg32uint'
+});
+let renderBundleEncoder54 = device2.createRenderBundleEncoder({
+  label: '\u0a59\ucc77\ua05a',
+  colorFormats: ['bgra8unorm', 'r16uint', undefined, 'bgra8unorm', 'r32uint', 'rgb10a2uint'],
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let renderBundle75 = renderBundleEncoder26.finish({});
+try {
+renderBundleEncoder38.drawIndexed(32, 16);
+} catch {}
+try {
+device2.pushErrorScope('validation');
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let offscreenCanvas16 = new OffscreenCanvas(915, 640);
+let videoFrame7 = new VideoFrame(imageBitmap6, {timestamp: 0});
+let bindGroupLayout35 = device4.createBindGroupLayout({
+label: '\u{1f728}\u7681\ua28e\u3ee5\u0859\u{1fe76}\u03f1\u{1fbdd}\u{1f7f7}',
+entries: [{
+binding: 316,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+}],
+});
+let querySet50 = device4.createQuerySet({
+label: '\u7848\u336f\u0129\u{1fa71}\u022d',
+type: 'occlusion',
+count: 2616,
+});
+let texture102 = device4.createTexture({
+label: '\ub0c6\u7be0',
+size: [640, 80, 1],
+mipLevelCount: 10,
+sampleCount: 1,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-8x8-unorm'],
+});
+let computePassEncoder45 = commandEncoder64.beginComputePass({label: '\u02fa\u{1fbd2}\u32bc'});
+try {
+device4.queue.writeTexture({
+  texture: texture100,
+  mipLevel: 0,
+  origin: { x: 112, y: 30, z: 1 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 784 */
+{offset: 784, bytesPerRow: 132}, {width: 16, height: 135, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext15 = offscreenCanvas14.getContext('webgpu');
+let device8 = await adapter9.requestDevice({
+label: '\u{1feb8}\u2568\u0a2b\u3592\u0108\u9846\u022b\ue4c6\u973c\u7b8e\u7a76',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+});
+let videoFrame8 = new VideoFrame(canvas15, {timestamp: 0});
+try {
+offscreenCanvas16.getContext('webgpu');
+} catch {}
+let texture103 = device4.createTexture({
+label: '\uaf29\ue9d5\u0004\u{1f626}\u0cea\u0253\ub873\u9adb\u0aa7\u7e0d',
+size: [80],
+dimension: '1d',
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_SRC,
+});
+let promise35 = adapter4.requestAdapterInfo();
+let bindGroupLayout36 = device3.createBindGroupLayout({
+label: '\u67fd\u9aa6\u{1fe61}',
+entries: [{
+binding: 1300,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+}],
+});
+let renderBundleEncoder55 = device3.createRenderBundleEncoder({
+  label: '\u{1fad7}\u8697\u0ae7\u{1fbf3}',
+  colorFormats: ['r16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let externalTexture9 = device3.importExternalTexture({
+source: videoFrame7,
+colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder32.drawIndexed(0, 48, 56, -536, 48);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 0,
+  origin: { x: 446, y: 1, z: 0 },
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer8), /* required buffer size: 552 */
+{offset: 552}, {width: 366, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline61 = await promise31;
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+computePassEncoder44.insertDebugMarker('\u09a6');
+} catch {}
+gc();
+let video16 = await videoWithData();
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+video3.height = 140;
+let texture104 = device6.createTexture({
+label: '\u{1f6fc}\ud464\u{1fe96}\u00a0',
+size: [480, 160, 120],
+mipLevelCount: 8,
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['eac-r11snorm'],
+});
+let textureView78 = texture104.createView({label: '\u287f\u4ca3\u86b8\uf14e\uf1bb', baseMipLevel: 7, baseArrayLayer: 50, arrayLayerCount: 37});
+try {
+commandEncoder56.copyTextureToTexture({
+  texture: texture104,
+  mipLevel: 2,
+  origin: { x: 8, y: 28, z: 2 },
+  aspect: 'all',
+}, {
+  texture: texture104,
+  mipLevel: 4,
+  origin: { x: 8, y: 0, z: 8 },
+  aspect: 'all',
+}, {width: 4, height: 4, depthOrArrayLayers: 111});
+} catch {}
+try {
+gpuCanvasContext11.configure({
+device: device6,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16uint'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture104,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 63 },
+  aspect: 'all',
+}, new ArrayBuffer(452373), /* required buffer size: 452373 */
+{offset: 173, bytesPerRow: 76, rowsPerImage: 170}, {width: 28, height: 0, depthOrArrayLayers: 36});
+} catch {}
+try {
+  await promise35;
+} catch {}
+let canvas17 = document.createElement('canvas');
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let sampler60 = device3.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 59.735,
+lodMaxClamp: 66.170,
+});
+try {
+computePassEncoder40.setPipeline(pipeline44);
+} catch {}
+try {
+renderBundleEncoder32.draw(16);
+} catch {}
+let renderBundleEncoder56 = device3.createRenderBundleEncoder({
+  label: '\u{1fb84}\u1637\u{1f6b1}',
+  colorFormats: ['r32uint', 'rgba8sint', 'rgba8unorm-srgb', 'rg32float', 'rg32sint', 'rgba16sint', 'r8unorm', undefined]
+});
+let sampler61 = device3.createSampler({
+label: '\u439c\ude50',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 73.005,
+lodMaxClamp: 81.558,
+maxAnisotropy: 15,
+});
+try {
+renderBundleEncoder32.draw(8);
+} catch {}
+let arrayBuffer9 = buffer21.getMappedRange(60376, 44);
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let querySet51 = device7.createQuerySet({
+label: '\u0c60\u32ed\u854a\u3c67',
+type: 'occlusion',
+count: 1415,
+});
+let textureView79 = texture97.createView({label: '\u05a7\u22b1\u055e\u0cc3\u{1f9d6}\u4b34\u{1f893}\ub821\ua929\u{1f736}'});
+let renderBundleEncoder57 = device7.createRenderBundleEncoder({
+  label: '\ua8c3\u1c12\u0cc2\u{1f8f9}',
+  colorFormats: ['r8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true
+});
+let renderBundle76 = renderBundleEncoder52.finish({label: '\u0421\u84a0\u8a50\u136c\u0daa\ub209\u7ee8\u{1feb6}\u451e\ubdd4\ueb50'});
+try {
+computePassEncoder44.setPipeline(pipeline59);
+} catch {}
+try {
+renderBundleEncoder57.setVertexBuffer(75, undefined, 2026015468);
+} catch {}
+try {
+querySet48.destroy();
+} catch {}
+let pipeline62 = device7.createComputePipeline({
+label: '\u{1fe69}\u9872\u07ba\u0320\ua13c\ua875\u0b79',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule23,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+querySet15.label = '\u0678\ubbf1\u05fd\u{1ff0f}\ue77e\u535d\ue82e\ufd52\u0d74\u{1fd8a}';
+} catch {}
+try {
+  await promise24;
+} catch {}
+let bindGroupLayout37 = device8.createBindGroupLayout({
+label: '\u0585\u0218\u781e\u{1fcf3}\u{1ffcb}\ua844\u04e7\u{1ff78}\u05b4',
+entries: [],
+});
+let renderBundleEncoder58 = device8.createRenderBundleEncoder({
+  label: '\u{1fd5c}\ue0a0\u992b\u0cff\u1c0f\ufcc9\u{1f642}\u{1f9dc}\u5e8f\u4980\u02eb',
+  colorFormats: ['bgra8unorm', 'rg32uint'],
+  depthReadOnly: true
+});
+let renderBundle77 = renderBundleEncoder58.finish({label: '\u729c\u0417\u033c\u{1fa6c}\u046b\u448b\u{1fb90}\u1305'});
+let pipelineLayout18 = device4.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout35, bindGroupLayout35, bindGroupLayout35, bindGroupLayout35, bindGroupLayout35, bindGroupLayout35, bindGroupLayout35, bindGroupLayout35]
+});
+let commandBuffer12 = commandEncoder54.finish({
+label: '\ub94b\u41f9\u0430',
+});
+let renderBundleEncoder59 = device4.createRenderBundleEncoder({
+  label: '\u0ef9\u3407\u3b5d\u1fda\u8bd3',
+  colorFormats: ['r16float', 'bgra8unorm', 'rg32float', 'rg16sint', 'r32uint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true
+});
+let shaderModule24 = device4.createShaderModule({
+label: '\u7092\u{1fc0b}\u7b0e\u{1fb37}',
+code: `@group(7) @binding(316)
+var<storage, read_write> i29: array<u32>;
+@group(2) @binding(316)
+var<storage, read_write> global21: array<u32>;
+@group(4) @binding(316)
+var<storage, read_write> i30: array<u32>;
+@group(0) @binding(316)
+var<storage, read_write> type30: array<u32>;
+@group(6) @binding(316)
+var<storage, read_write> type31: array<u32>;
+@group(5) @binding(316)
+var<storage, read_write> function25: array<u32>;
+
+@compute @workgroup_size(7, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S27 {
+  @location(25) f0: vec3<f32>,
+  @location(41) f1: u32,
+  @location(10) f2: vec3<u32>,
+  @builtin(position) f3: vec4<f32>,
+  @location(21) f4: vec3<f32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec3<f32>,
+  @builtin(frag_depth) f1: f32,
+  @location(5) f2: vec3<i32>,
+  @location(4) f3: vec3<u32>,
+  @location(3) f4: vec3<i32>,
+  @location(2) f5: vec2<f32>,
+  @location(1) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(45) a0: i32, @location(18) a1: vec2<u32>, @location(24) a2: f16, @location(2) a3: vec3<i32>, @location(56) a4: u32, @location(47) a5: vec4<f16>, @builtin(front_facing) a6: bool, @location(27) a7: i32, @location(16) a8: f32, @location(64) a9: vec3<u32>, @location(67) a10: f32, @location(17) a11: vec3<i32>, @builtin(sample_index) a12: u32, @location(38) a13: vec4<i32>, @location(36) a14: vec2<i32>, @location(70) a15: vec2<i32>, @location(3) a16: f16, a17: S27, @location(62) a18: vec3<u32>, @location(58) a19: vec2<i32>, @location(8) a20: vec4<i32>, @location(22) a21: vec4<i32>, @location(33) a22: vec2<i32>, @location(51) a23: vec4<f16>, @location(13) a24: i32, @location(20) a25: vec3<f32>, @location(72) a26: vec4<i32>, @location(75) a27: vec2<i32>, @location(52) a28: vec3<u32>, @location(74) a29: vec4<f16>, @location(15) a30: vec4<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S26 {
+  @location(5) f0: i32,
+  @location(0) f1: vec4<f16>,
+  @location(6) f2: vec2<f16>,
+  @location(2) f3: vec2<f16>,
+  @location(3) f4: i32,
+  @location(26) f5: vec3<f32>
+}
+struct VertexOutput0 {
+  @location(18) f372: vec2<u32>,
+  @location(56) f373: u32,
+  @location(72) f374: vec4<i32>,
+  @location(19) f375: vec4<f32>,
+  @location(38) f376: vec4<i32>,
+  @location(67) f377: f32,
+  @location(27) f378: i32,
+  @location(45) f379: i32,
+  @location(41) f380: u32,
+  @location(22) f381: vec4<i32>,
+  @location(74) f382: vec4<f16>,
+  @location(36) f383: vec2<i32>,
+  @location(3) f384: f16,
+  @location(7) f385: vec4<i32>,
+  @location(17) f386: vec3<i32>,
+  @location(64) f387: vec3<u32>,
+  @location(58) f388: vec2<i32>,
+  @location(75) f389: vec2<i32>,
+  @location(70) f390: vec2<i32>,
+  @location(21) f391: vec3<f32>,
+  @location(8) f392: vec4<i32>,
+  @location(33) f393: vec2<i32>,
+  @builtin(position) f394: vec4<f32>,
+  @location(47) f395: vec4<f16>,
+  @location(24) f396: f16,
+  @location(25) f397: vec3<f32>,
+  @location(52) f398: vec3<u32>,
+  @location(16) f399: f32,
+  @location(10) f400: vec3<u32>,
+  @location(15) f401: vec4<u32>,
+  @location(62) f402: vec3<u32>,
+  @location(20) f403: vec3<f32>,
+  @location(51) f404: vec4<f16>,
+  @location(2) f405: vec3<i32>,
+  @location(13) f406: i32
+}
+
+@vertex
+fn vertex0(a0: S26, @location(22) a1: vec3<f32>, @location(16) a2: vec2<u32>, @location(25) a3: u32, @location(24) a4: vec4<i32>, @location(9) a5: vec3<f16>, @builtin(instance_index) a6: u32, @location(14) a7: vec2<f16>, @location(18) a8: vec2<u32>, @location(4) a9: vec2<i32>, @location(23) a10: vec4<f16>, @location(17) a11: vec2<f16>, @location(27) a12: vec3<f16>, @location(19) a13: f16, @location(13) a14: vec3<i32>, @location(12) a15: vec3<u32>, @location(11) a16: vec3<i32>, @location(7) a17: f16, @location(21) a18: i32, @location(15) a19: f16, @location(10) a20: vec2<i32>, @location(8) a21: vec4<f16>, @location(1) a22: f32, @location(20) a23: vec4<i32>, @builtin(vertex_index) a24: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let buffer31 = device4.createBuffer({
+  label: '\u06b1\u35f5\u4e67',
+  size: 51144,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false
+});
+let renderBundle78 = renderBundleEncoder59.finish({label: '\u{1f673}\ua28a\u0acc\ua803\ud5a7\uca01\u08e4\u{1fdff}'});
+try {
+computePassEncoder45.pushDebugGroup('\u79c5');
+} catch {}
+try {
+device4.queue.submit([
+commandBuffer12,
+]);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture95,
+  mipLevel: 2,
+  origin: { x: 24, y: 0, z: 124 },
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer5), /* required buffer size: 2145401 */
+{offset: 252, bytesPerRow: 125, rowsPerImage: 286}, {width: 12, height: 8, depthOrArrayLayers: 61});
+} catch {}
+let pipeline63 = device4.createComputePipeline({
+label: '\u8059\u{1ff3c}',
+layout: pipelineLayout18,
+compute: {
+module: shaderModule24,
+entryPoint: 'compute0',
+},
+});
+gc();
+pseudoSubmit(device7, commandEncoder63);
+let renderBundle79 = renderBundleEncoder52.finish({});
+let sampler62 = device7.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 43.199,
+lodMaxClamp: 74.248,
+});
+try {
+gpuCanvasContext14.configure({
+device: device7,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba32float', 'astc-10x10-unorm-srgb', 'r32uint', 'rgba8unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture94,
+  mipLevel: 0,
+  origin: { x: 60, y: 30, z: 38 },
+  aspect: 'all',
+}, new ArrayBuffer(579949), /* required buffer size: 579949 */
+{offset: 997, bytesPerRow: 391, rowsPerImage: 211}, {width: 170, height: 40, depthOrArrayLayers: 8});
+} catch {}
+try {
+  await promise34;
+} catch {}
+let buffer32 = device3.createBuffer({
+  label: '\uaf8d\u0770\u{1ffb3}\u0834\u3ca5\uc54e\u0d49\ud832\u0612\u0a42',
+  size: 4195,
+  usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX
+});
+let sampler63 = device3.createSampler({
+label: '\u{1fb90}\u{1f796}\ue5af',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMaxClamp: 65.829,
+});
+try {
+computePassEncoder33.setPipeline(pipeline38);
+} catch {}
+try {
+renderBundleEncoder32.drawIndexed(72, 64, 72, -416, 8);
+} catch {}
+let adapter10 = await navigator.gpu.requestAdapter();
+let canvas18 = document.createElement('canvas');
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let adapter11 = await navigator.gpu.requestAdapter();
+let buffer33 = device8.createBuffer({
+  label: '\u8b8b\u{1fdd9}\u03e7\ude56\u{1f8c6}\u{1fc78}\u{1f6d2}\u2f69\u0029',
+  size: 61483,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE
+});
+let commandEncoder65 = device8.createCommandEncoder({label: '\u195c\u0909\u{1fb75}\u09c0\u3d5d\u5be8\u0146\u0f5e'});
+let renderBundleEncoder60 = device8.createRenderBundleEncoder({label: '\u0748\ud72f\uf9a9', colorFormats: ['bgra8unorm', 'rg32uint'], depthReadOnly: false});
+let gpuCanvasContext16 = canvas18.getContext('webgpu');
+let img13 = await imageWithData(267, 100, '#81bf07e8', '#051a9b11');
+try {
+await adapter2.requestAdapterInfo();
+} catch {}
+let renderBundleEncoder61 = device2.createRenderBundleEncoder({
+  label: '\ue8ed\u0eba\u81cf\u0805\ud98c\ue707\u5b77',
+  colorFormats: ['bgra8unorm', 'r16uint', undefined, 'bgra8unorm', 'r32uint', 'rgb10a2uint'],
+  sampleCount: 4,
+  depthReadOnly: false
+});
+let renderBundle80 = renderBundleEncoder25.finish({label: '\u{1ff07}\u0760'});
+try {
+renderBundleEncoder54.setBindGroup(8, bindGroup20, new Uint32Array(5741), 708, 0);
+} catch {}
+try {
+renderBundleEncoder38.draw(24, 24, 8, 0);
+} catch {}
+gc();
+let videoFrame9 = new VideoFrame(offscreenCanvas15, {timestamp: 0});
+let commandEncoder66 = device8.createCommandEncoder({label: '\u0bd3\u34d9\ue9a5\u0ae8\u9b23\u1a6c\u0fba\u2df7\ud0fa'});
+let querySet52 = device8.createQuerySet({
+label: '\u{1f874}\uf508\u{1fc29}\u0e3a\u0617\u0b92\u0c1d\u6c63\u385d',
+type: 'occlusion',
+count: 1212,
+});
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/LayoutTests/fast/webgpu/fuzz-273570-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-273570-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-273570.html
+++ b/LayoutTests/fast/webgpu/fuzz-273570.html
@@ -1,0 +1,26002 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter({
+});
+let device0 = await adapter0.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 57,
+maxVertexAttributes: 20,
+maxVertexBufferArrayStride: 14219,
+maxStorageTexturesPerShaderStage: 7,
+maxStorageBuffersPerShaderStage: 12,
+maxDynamicStorageBuffersPerPipelineLayout: 52383,
+maxBindingsPerBindGroup: 6778,
+maxTextureDimension1D: 10211,
+maxTextureDimension2D: 14968,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 70996102,
+maxUniformBuffersPerShaderStage: 43,
+maxInterStageShaderVariables: 84,
+maxInterStageShaderComponents: 110,
+},
+});
+let img0 = await imageWithData(115, 147, '#374f85c4', '#6c943550');
+let texture0 = device0.createTexture({
+size: [360, 60, 207],
+mipLevelCount: 9,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-5x5-unorm-srgb', 'astc-5x5-unorm', 'astc-5x5-unorm-srgb'],
+});
+try {
+texture0.label = '\u1b34\u{1fc30}\u{1ffeb}\u8e59\udcbf\u{1fafa}';
+} catch {}
+let texture1 = device0.createTexture({
+label: '\uf29e\u{1fb14}\u8417\u032e\u1754',
+size: [180],
+dimension: '1d',
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8unorm', 'r8unorm'],
+});
+let textureView0 = texture0.createView({label: '\u1f32\u25ff\ua2a0', dimension: '2d', baseMipLevel: 3, mipLevelCount: 3, baseArrayLayer: 108});
+let textureView1 = texture0.createView({
+  label: '\u1b5e\uf590\u0a7a\u4d19\u{1ff65}\udc48\u6fbb\ufbf7\u694e',
+  dimension: '2d',
+  mipLevelCount: 3,
+  baseArrayLayer: 7
+});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\uafbf\u{1f988}',
+  colorFormats: ['rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let textureView2 = texture0.createView({
+  label: '\u1cff\ue825\u3c4c\u{1ff93}\u02a8\u0d2e\u6085\u0e4f',
+  baseMipLevel: 2,
+  mipLevelCount: 5,
+  baseArrayLayer: 70,
+  arrayLayerCount: 75
+});
+let img1 = await imageWithData(43, 157, '#b907cc79', '#5bd65f75');
+let texture2 = device0.createTexture({
+size: [360, 60, 28],
+mipLevelCount: 7,
+sampleCount: 1,
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let canvas0 = document.createElement('canvas');
+let imageData0 = new ImageData(196, 60);
+let videoFrame0 = new VideoFrame(img1, {timestamp: 0});
+let textureView3 = texture0.createView({
+  label: '\u{1fea6}\u2d88\u{1fddc}\u4aa5\u{1fc57}',
+  mipLevelCount: 6,
+  baseArrayLayer: 83,
+  arrayLayerCount: 68
+});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let texture3 = device0.createTexture({
+label: '\u0147\u537c',
+size: {width: 183, height: 3, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+sampleCount: 1,
+dimension: '3d',
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let sampler0 = device0.createSampler({
+label: '\uab7a\u746c\ua186\uc68a\u1d9b\u15f3\u0281\u767d',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 64.090,
+lodMaxClamp: 81.796,
+});
+let querySet0 = device0.createQuerySet({
+label: '\u{1fd40}\u0ad1\u3577\u2ae6',
+type: 'occlusion',
+count: 3701,
+});
+let renderBundle0 = renderBundleEncoder0.finish({label: '\u{1fe08}\ub489\u1ca4\u3f69\u{1f7e4}\u5405\u0652\ue6e8\u968a'});
+let commandEncoder0 = device0.createCommandEncoder({label: '\u07f4\u191c\u0790\u3db7\u51dc\uce9d\u9f77'});
+let textureView4 = texture1.createView({label: '\u6746\u{1fe3b}'});
+let offscreenCanvas0 = new OffscreenCanvas(1010, 284);
+let commandEncoder1 = device0.createCommandEncoder();
+let texture4 = device0.createTexture({
+size: [1440, 240, 71],
+mipLevelCount: 7,
+sampleCount: 1,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-10x10-unorm', 'astc-10x10-unorm'],
+});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['rgba16sint'], depthStencilFormat: 'depth32float-stencil8', sampleCount: 4});
+try {
+renderBundleEncoder2.setVertexBuffer(22, undefined, 3713960814, 112388966);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 9, y: 0, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 699 */
+{offset: 699, rowsPerImage: 39}, {width: 63, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let querySet1 = device0.createQuerySet({
+label: '\u134b\u2329\ua087\u1721\uec3e\u094e\u4540',
+type: 'occlusion',
+count: 3872,
+});
+let texture5 = device0.createTexture({
+label: '\uf043\u22f7\u092f\u0a82\udafd',
+size: [180, 30, 1],
+mipLevelCount: 2,
+sampleCount: 1,
+format: 'astc-10x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-10x10-unorm', 'astc-10x10-unorm-srgb', 'astc-10x10-unorm-srgb'],
+});
+let renderBundle1 = renderBundleEncoder2.finish();
+try {
+renderBundleEncoder1.setVertexBuffer(22, undefined);
+} catch {}
+let commandEncoder2 = device0.createCommandEncoder({label: '\u{1f69b}\ufecb\u22a1\u0b08\u3a62\u11f8'});
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 98, y: 1, z: 0 },
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(16)), /* required buffer size: 2 */
+{offset: 2}, {width: 61, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise0 = device0.queue.onSubmittedWorkDone();
+let commandEncoder3 = device0.createCommandEncoder();
+try {
+renderBundleEncoder1.setVertexBuffer(60, undefined, 542890090);
+} catch {}
+let commandEncoder4 = device0.createCommandEncoder({});
+let querySet2 = device0.createQuerySet({
+label: '\uffa3\u49b6',
+type: 'occlusion',
+count: 2006,
+});
+let texture6 = device0.createTexture({
+label: '\u2767\u721d\u9ea0',
+size: {width: 1470},
+dimension: '1d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST,
+});
+let textureView5 = texture4.createView({label: '\u026e\u087d', dimension: '2d', baseMipLevel: 6, mipLevelCount: 1, baseArrayLayer: 52});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\uf1bc\u{1fbf8}\u22ea\ua05b\u54f7\ueb67\u{1f9fe}\u25da\u2096\u08c9',
+  colorFormats: ['rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+adapter0.label = '\u{1fdc0}\u02dd';
+} catch {}
+pseudoSubmit(device0, commandEncoder1);
+let computePassEncoder0 = commandEncoder4.beginComputePass({label: '\u0dc7\u63b1\u2cba\u{1f666}\u6329\u2067\ucc19\u{1f7a2}\uca2f\u17d0\u8e53'});
+try {
+await device0.popErrorScope();
+} catch {}
+let adapter1 = await navigator.gpu.requestAdapter({
+});
+let texture7 = device0.createTexture({
+label: '\u05ac\u0211\u{1fdbd}\u0106',
+size: {width: 5880, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r32sint', 'r32sint'],
+});
+try {
+commandEncoder0.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 1,
+  origin: { x: 30, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture5,
+  mipLevel: 1,
+  origin: { x: 30, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 50, height: 10, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 121, y: 3, z: 1 },
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(32)), /* required buffer size: 429 */
+{offset: 429}, {width: 57, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet3 = device0.createQuerySet({
+type: 'occlusion',
+count: 190,
+});
+let computePassEncoder1 = commandEncoder3.beginComputePass();
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\u675e\u3b22\u{1ff00}\u0766\uff3f',
+  colorFormats: ['rg8sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+let offscreenCanvas1 = new OffscreenCanvas(297, 893);
+try {
+adapter1.label = '\u0f31\uf4fb';
+} catch {}
+try {
+canvas0.getContext('webgpu');
+} catch {}
+let computePassEncoder2 = commandEncoder0.beginComputePass({label: '\ub7b5\u3173\ua7d2\u6c22\u593b\u856a\ubfb0\u024b'});
+try {
+renderBundleEncoder4.setVertexBuffer(59, undefined, 2072460661, 1172130707);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer0 = device0.createBuffer({label: '\u12c6\u7ecf\ub82c\u6ca7\u{1f776}\u5db4\u786c', size: 9441, usage: GPUBufferUsage.MAP_WRITE});
+let querySet4 = device0.createQuerySet({
+label: '\u7933\u59e4\u47dc',
+type: 'occlusion',
+count: 2375,
+});
+try {
+computePassEncoder0.insertDebugMarker('\u{1fc5c}');
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder();
+let textureView6 = texture6.createView({});
+let querySet5 = device0.createQuerySet({
+label: '\u0463\u0971\ucd63\ub298\u1ca6\u0606\u05c7',
+type: 'occlusion',
+count: 1611,
+});
+let renderBundle2 = renderBundleEncoder4.finish({label: '\u682a\u02d1\ue397\u85dc\u0dfd\u428b'});
+let promise1 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext0 = offscreenCanvas1.getContext('webgpu');
+let imageBitmap0 = await createImageBitmap(offscreenCanvas0);
+let imageData1 = new ImageData(236, 100);
+let bindGroupLayout0 = device0.createBindGroupLayout({
+label: '\u64ad\uf517\u011d\u{1f962}\u{1f8e7}',
+entries: [{
+binding: 4710,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 496180, hasDynamicOffset: true },
+}],
+});
+let texture8 = device0.createTexture({
+label: '\u0f29\ubbd1\u{1ffb7}\ubb46\uc057\u02fe\ue4cb\u1924\ufe9d\u04db\u{1f97b}',
+size: [1440, 240, 122],
+mipLevelCount: 8,
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let gpuCanvasContext1 = offscreenCanvas0.getContext('webgpu');
+try {
+  await promise1;
+} catch {}
+let imageData2 = new ImageData(136, 96);
+let querySet6 = device0.createQuerySet({
+label: '\ua2f3\u{1f8ff}\u51e1',
+type: 'occlusion',
+count: 1496,
+});
+let textureView7 = texture2.createView({label: '\uf5ea\ua43b\uc617\u04ef', dimension: '2d', baseMipLevel: 3, mipLevelCount: 2, baseArrayLayer: 8});
+let sampler1 = device0.createSampler({
+addressModeV: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 70.747,
+lodMaxClamp: 97.511,
+});
+try {
+commandEncoder2.insertDebugMarker('\uda33');
+} catch {}
+let canvas1 = document.createElement('canvas');
+try {
+canvas1.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder6 = device0.createCommandEncoder({label: '\u0610\u026f\u3ba8\u50c3'});
+let querySet7 = device0.createQuerySet({
+label: '\u5818\udb11\u4696\u{1f8e9}\u0c92\u5f6b\u5f06\u0796',
+type: 'occlusion',
+count: 372,
+});
+pseudoSubmit(device0, commandEncoder6);
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  label: '\u4548\u4e1d\u{1fa6a}\u0051\u5071',
+  colorFormats: ['rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+let commandEncoder7 = device0.createCommandEncoder({label: '\ud500\u6010\uf7bd\u7760\u1593\u3b48\ua90c'});
+try {
+commandEncoder2.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 96, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 43, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 10, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let imageData3 = new ImageData(160, 152);
+let videoFrame1 = new VideoFrame(canvas1, {timestamp: 0});
+let texture9 = device0.createTexture({
+label: '\u0eb3\u3575\u92f4\u{1f6ef}\ua7c0\u3371\u2656',
+size: {width: 112, height: 5, depthOrArrayLayers: 87},
+mipLevelCount: 2,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let computePassEncoder3 = commandEncoder7.beginComputePass({label: '\u02b9\u6599\u{1faae}\uf826\uca9a\u{1f6bf}\u{1f917}'});
+let computePassEncoder4 = commandEncoder2.beginComputePass({label: '\u065b\u3b2b\u{1ff9e}\u3c39\u059f'});
+let computePassEncoder5 = commandEncoder5.beginComputePass({label: '\u0400\u9d06\u23de\u{1fc24}\u4d46\u5356\u{1fc18}\u0472\u11d4'});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  label: '\u{1f61b}\u0c92\u8fa3\u529a\u0a83\u0434\u{1ff12}',
+  colorFormats: ['rg8sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+  await buffer0.mapAsync(GPUMapMode.WRITE, 4144, 4648);
+} catch {}
+let arrayBuffer0 = buffer0.getMappedRange(6440, 492);
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+offscreenCanvas1.width = 704;
+let imageData4 = new ImageData(92, 72);
+let renderBundle3 = renderBundleEncoder6.finish({});
+let sampler2 = device0.createSampler({
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 92.915,
+lodMaxClamp: 99.014,
+maxAnisotropy: 10,
+});
+try {
+renderBundleEncoder1.setVertexBuffer(11, undefined, 3398495130, 126258958);
+} catch {}
+let arrayBuffer1 = buffer0.getMappedRange(4144, 1428);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let querySet8 = device0.createQuerySet({
+label: '\u{1fd59}\u{1fac2}\u0dfa\u4c28\u83f3\u{1f66a}',
+type: 'occlusion',
+count: 3543,
+});
+let textureView8 = texture9.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 37});
+let renderBundle4 = renderBundleEncoder6.finish({label: '\uc6ce\u5ea9\u070b\ue5f2\u{1f649}\u{1f73b}\ud606\u{1fa0a}\u{1f685}\u3ecb'});
+let sampler3 = device0.createSampler({
+label: '\uca55\ub544\u0185\u730c',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMaxClamp: 85.324,
+});
+let renderBundle5 = renderBundleEncoder6.finish({label: '\u4d09\ud849\ub233'});
+let sampler4 = device0.createSampler({
+label: '\uf6da\ubcc2\u0df7\u6dbc\u5209\u5442',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 85.532,
+maxAnisotropy: 3,
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let buffer1 = device0.createBuffer({size: 9500, usage: GPUBufferUsage.MAP_READ, mappedAtCreation: true});
+let commandEncoder8 = device0.createCommandEncoder();
+let renderBundle6 = renderBundleEncoder4.finish({label: '\u9241\ub0a2\u89f9\u3eb2\u0ee3\u03ca\u0aad\uc1c6\u{1ffbb}\u8dc3\u3d0b'});
+try {
+renderBundleEncoder3.setVertexBuffer(74, undefined, 2732569864, 738451134);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 6,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(56)), /* required buffer size: 1327 */
+{offset: 991}, {width: 84, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(50, undefined);
+} catch {}
+canvas0.width = 765;
+let texture10 = device0.createTexture({
+label: '\u011a\u{1fb10}\u9eb0\u046d\u0d6a',
+size: {width: 576, height: 12, depthOrArrayLayers: 1},
+mipLevelCount: 10,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+renderBundleEncoder5.setVertexBuffer(28, undefined, 1304550158, 1831937090);
+} catch {}
+try {
+renderBundleEncoder5.insertDebugMarker('\u{1ff79}');
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+offscreenCanvas0.width = 695;
+let offscreenCanvas2 = new OffscreenCanvas(647, 213);
+let textureView9 = texture4.createView({dimension: '2d', format: 'astc-10x10-unorm', baseMipLevel: 5, mipLevelCount: 2, baseArrayLayer: 7});
+let sampler5 = device0.createSampler({
+label: '\u1132\u6f3e\u{1fa12}\ud5c1\uecc7\u08d5\u5088\u{1fedc}\u0fa0\u{1fdd6}\u63ba',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 15.119,
+lodMaxClamp: 25.095,
+});
+try {
+renderBundleEncoder1.setVertexBuffer(98, undefined);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 6,
+  origin: { x: 6, y: 0, z: 1 },
+  aspect: 'all',
+}, new Int16Array(arrayBuffer1), /* required buffer size: 345 */
+{offset: 345, rowsPerImage: 96}, {width: 14, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder9 = device0.createCommandEncoder({label: '\u{1f649}\uf872\u{1fb3f}\u9512\uf8d0\u5653\u{1f6e1}\ueb48\ufbbc\u0c62'});
+let arrayBuffer2 = buffer1.getMappedRange(0, 6116);
+let querySet9 = device0.createQuerySet({
+type: 'occlusion',
+count: 3027,
+});
+let texture11 = device0.createTexture({
+size: {width: 2400, height: 8, depthOrArrayLayers: 1},
+mipLevelCount: 12,
+format: 'etc2-rgb8a1unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8a1unorm', 'etc2-rgb8a1unorm-srgb'],
+});
+let computePassEncoder6 = commandEncoder9.beginComputePass({label: '\u{1f7e7}\uc69c\u06ef\u6d61\u7533\u0a11\u2bf2\u0e1d\uf0fd\u02e5\u0a70'});
+let renderBundle7 = renderBundleEncoder4.finish({label: '\u5125\u0c73\uf251\u9778\ua100'});
+let arrayBuffer3 = buffer1.getMappedRange(8688, 128);
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 2,
+  origin: { x: 84, y: 48, z: 117 },
+  aspect: 'all',
+}, {
+  texture: texture8,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 70 },
+  aspect: 'all',
+}, {width: 4, height: 4, depthOrArrayLayers: 5});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 9,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 842 */
+{offset: 842, rowsPerImage: 64}, {width: 0, height: 4, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let imageData5 = new ImageData(256, 228);
+try {
+offscreenCanvas2.getContext('webgl2');
+} catch {}
+let pipelineLayout0 = device0.createPipelineLayout({
+  label: '\u{1fe54}\u0c8f\ua338\u0903\u60b8\u6d75\u19b2\u{1f67f}\u{1ffbc}',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0]
+});
+let commandEncoder10 = device0.createCommandEncoder({label: '\u{1f94e}\u03b4\u08c4\u3faf\udd8d\uc906\u{1f949}'});
+let querySet10 = device0.createQuerySet({
+label: '\u70ba\u0905',
+type: 'occlusion',
+count: 2744,
+});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u72cd\uff37\u{1f6c5}\ua6fb\u7c0d\u7441\u7a0a',
+  colorFormats: ['rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder7.setVertexBuffer(55, undefined, 2600802974, 759794962);
+} catch {}
+try {
+  await promise2;
+} catch {}
+let querySet11 = device0.createQuerySet({
+label: '\uaa5c\u00f8\u7ed9\u409e\u{1f7e6}\ubdef\u0aec\ue2ae\ucbc2\u{1fc7a}',
+type: 'occlusion',
+count: 2125,
+});
+let texture12 = device0.createTexture({
+label: '\u51a9\uceba\ua5eb\ue228\u0998\u9314\u0ed8',
+size: {width: 288, height: 6, depthOrArrayLayers: 15},
+dimension: '3d',
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba32sint', 'rgba32sint'],
+});
+let textureView10 = texture4.createView({
+  label: '\u{1fa12}\uc949',
+  format: 'astc-10x10-unorm',
+  mipLevelCount: 2,
+  baseArrayLayer: 69,
+  arrayLayerCount: 2
+});
+let renderBundle8 = renderBundleEncoder3.finish({label: '\uc830\u{1f7ea}\u{1fe92}\udbc7\u03e2\u24b2\u726d\u2854'});
+let sampler6 = device0.createSampler({
+label: '\u77a4\u0df5\u77d0\u2795\u{1fb7d}\u840a\ud366\u1f17\u0650\u08c0\uc747',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 69.992,
+lodMaxClamp: 80.926,
+maxAnisotropy: 18,
+});
+try {
+texture3.destroy();
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder({label: '\u498c\u3e81'});
+let texture13 = device0.createTexture({
+size: [720, 120, 249],
+mipLevelCount: 7,
+sampleCount: 1,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundle9 = renderBundleEncoder3.finish({label: '\u9824\uf88f\u{1f985}\u0865\ud250\uc184'});
+try {
+buffer0.destroy();
+} catch {}
+document.body.prepend(canvas0);
+let imageData6 = new ImageData(116, 76);
+let buffer2 = device0.createBuffer({label: '\u{1f8eb}\u{1f69d}\ua382\u{1fa87}\ub455\u0064', size: 37000, usage: GPUBufferUsage.QUERY_RESOLVE});
+let sampler7 = device0.createSampler({
+label: '\u0751\u0b6d\u249d\u48c4\u0c73',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 87.663,
+lodMaxClamp: 98.975,
+maxAnisotropy: 17,
+});
+let texture14 = device0.createTexture({
+label: '\u{1fdee}\uc4d4\u0d10\u8ff7',
+size: {width: 180, height: 30, depthOrArrayLayers: 23},
+dimension: '3d',
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r32sint'],
+});
+let renderBundle10 = renderBundleEncoder7.finish({label: '\u025e\u05df'});
+try {
+commandEncoder10.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: { x: 135, y: 9, z: 7 },
+  aspect: 'all',
+}, {
+  texture: texture7,
+  mipLevel: 6,
+  origin: { x: 17, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder8.resolveQuerySet(querySet0, 2587, 111, buffer2, 25600);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(216), /* required buffer size: 216 */
+{offset: 216, rowsPerImage: 41}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+label: '\u06c1\ud0b0',
+code: `@group(3) @binding(4710)
+var<storage, read_write> parameter0: array<u32>;
+@group(4) @binding(4710)
+var<storage, read_write> global0: array<u32>;
+@group(0) @binding(4710)
+var<storage, read_write> global1: array<u32>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @builtin(frag_depth) f1: f32
+}
+
+@fragment
+fn fragment0(@location(31) a0: vec2<u32>, @location(27) a1: vec2<u32>, @location(42) a2: vec3<f16>, @location(80) a3: vec4<i32>, @location(34) a4: vec3<f16>, @location(68) a5: vec2<f32>, @builtin(front_facing) a6: bool, @location(21) a7: u32, @builtin(sample_mask) a8: u32, @location(77) a9: vec3<f32>, @location(41) a10: vec3<u32>, @location(9) a11: f32, @location(65) a12: vec3<i32>, @location(3) a13: i32, @location(28) a14: f32, @location(60) a15: vec2<i32>, @location(35) a16: vec3<f16>, @location(74) a17: vec4<f32>, @location(79) a18: vec4<f16>, @location(82) a19: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S0 {
+  @location(9) f0: vec2<f16>,
+  @location(6) f1: vec4<f32>,
+  @location(19) f2: vec4<i32>,
+  @builtin(instance_index) f3: u32,
+  @location(3) f4: vec2<f32>,
+  @location(13) f5: vec4<u32>,
+  @location(4) f6: vec2<f16>
+}
+struct VertexOutput0 {
+  @location(42) f0: vec3<f16>,
+  @location(65) f1: vec3<i32>,
+  @location(27) f2: vec2<u32>,
+  @location(81) f3: vec2<f16>,
+  @location(68) f4: vec2<f32>,
+  @location(25) f5: vec3<u32>,
+  @location(80) f6: vec4<i32>,
+  @location(79) f7: vec4<f16>,
+  @location(28) f8: f32,
+  @location(40) f9: f32,
+  @location(29) f10: u32,
+  @builtin(position) f11: vec4<f32>,
+  @location(82) f12: u32,
+  @location(12) f13: f32,
+  @location(72) f14: f32,
+  @location(74) f15: vec4<f32>,
+  @location(77) f16: vec3<f32>,
+  @location(31) f17: vec2<u32>,
+  @location(15) f18: vec3<u32>,
+  @location(34) f19: vec3<f16>,
+  @location(59) f20: vec2<f16>,
+  @location(37) f21: vec3<i32>,
+  @location(3) f22: i32,
+  @location(21) f23: u32,
+  @location(35) f24: vec3<f16>,
+  @location(41) f25: vec3<u32>,
+  @location(4) f26: vec4<f16>,
+  @location(60) f27: vec2<i32>,
+  @location(9) f28: f32
+}
+
+@vertex
+fn vertex0(@location(7) a0: u32, @location(17) a1: vec3<u32>, @location(18) a2: vec4<f32>, @location(12) a3: vec4<f16>, @location(16) a4: vec4<i32>, @builtin(vertex_index) a5: u32, @location(5) a6: vec4<u32>, @location(15) a7: i32, @location(10) a8: vec4<f16>, @location(14) a9: vec4<u32>, a10: S0, @location(11) a11: vec4<f32>, @location(1) a12: vec4<f16>, @location(8) a13: vec3<i32>, @location(2) a14: vec2<f32>, @location(0) a15: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let buffer3 = device0.createBuffer({
+  label: '\ua22a\u7a0f\u0966\ub809\u{1f9d3}\uce7b\u95b4\ud900',
+  size: 60969,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let textureView11 = texture1.createView({label: '\u00b8\u{1fa92}\u56dc'});
+try {
+commandEncoder8.clearBuffer(buffer3, 36736, 652);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline0 = device0.createComputePipeline({
+label: '\u2371\u0b44\u{1fff4}\u017f',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroupLayout1 = pipeline0.getBindGroupLayout(0);
+let commandEncoder12 = device0.createCommandEncoder({label: '\u21a1\u02b2\u6141\ub350\uf5a8'});
+let texture15 = device0.createTexture({
+label: '\u0665\u{1f7ed}\u03c7',
+size: {width: 1440, height: 240, depthOrArrayLayers: 202},
+mipLevelCount: 3,
+dimension: '2d',
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView12 = texture5.createView({aspect: 'all'});
+try {
+renderBundleEncoder1.setVertexBuffer(4, undefined, 181742902, 1965708471);
+} catch {}
+try {
+commandEncoder12.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 332, y: 28, z: 92 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 736 widthInBlocks: 92 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 15648 */
+offset: 1088,
+bytesPerRow: 768,
+buffer: buffer3,
+}, {width: 368, height: 76, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 28, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 8, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 22, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline1 = device0.createComputePipeline({
+label: '\u9d06\u0bc1\u8f22\u0ff0',
+layout: 'auto',
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+renderBundle6.label = '\u451a\u{1f9ec}';
+} catch {}
+let commandEncoder13 = device0.createCommandEncoder({label: '\udca0\uf63a\u{1fc8b}\u0c95\u920b\u{1f6cf}\u0320\u6fe7\u0699\u1a3c\uf4e3'});
+let textureView13 = texture7.createView({label: '\u10e1\u0a3a\ue7cb\u{1fdde}\ufa07\u05cc\u0cba\u6f3b\u013d', baseMipLevel: 3});
+let renderBundle11 = renderBundleEncoder6.finish({label: '\uccc5\u0dc9'});
+try {
+buffer0.unmap();
+} catch {}
+let video0 = await videoWithData();
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder11.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 7,
+  origin: { x: 16, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 1256 */
+offset: 1256,
+rowsPerImage: 122,
+buffer: buffer3,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder12.clearBuffer(buffer3, 55968, 4344);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 3,
+  origin: { x: 191, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 590 */
+{offset: 590, bytesPerRow: 581, rowsPerImage: 210}, {width: 87, height: 1, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let videoFrame2 = new VideoFrame(img1, {timestamp: 0});
+let buffer4 = device0.createBuffer({label: '\u337f\u0d99', size: 25448, usage: GPUBufferUsage.VERTEX, mappedAtCreation: true});
+let renderBundle12 = renderBundleEncoder5.finish({label: '\u{1f7da}\u0c1b\u{1fa36}\u790d\u{1ff67}\ub01f\u6ad1\uc9a9\u1ee6\uc751\u553f'});
+try {
+computePassEncoder6.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(8, buffer4, 19336, 3928);
+} catch {}
+try {
+commandEncoder13.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 136, y: 12, z: 74 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 928 widthInBlocks: 116 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 53800 */
+offset: 27272,
+bytesPerRow: 1024,
+buffer: buffer3,
+}, {width: 464, height: 104, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder8.resolveQuerySet(querySet10, 1917, 450, buffer2, 13824);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm-srgb', 'rgba8snorm', 'r8unorm', 'rg16uint'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 2,
+  origin: { x: 256, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(220), /* required buffer size: 220 */
+{offset: 220}, {width: 493, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline2 = await device0.createComputePipelineAsync({
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let textureView14 = texture4.createView({
+  label: '\u{1fbef}\u059f\u{1ff8c}\u9b62\ue501\u{1fbe3}\u044a',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 27
+});
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder8.clearBuffer(buffer3, 13584, 15152);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 3,
+  origin: { x: 11, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer3), /* required buffer size: 3529 */
+{offset: 949}, {width: 645, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline3 = device0.createComputePipeline({
+label: '\ud03f\u02e1\udf6a\u9fce\u{1ffae}\u0ed5\u062b\u3567\u794a',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+});
+let buffer5 = device0.createBuffer({size: 9432, usage: GPUBufferUsage.MAP_READ});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  label: '\u06c4\u0f41\u0850\ub7c5\u03f8\u{1f735}\u6218\u{1ff0a}\u5d99',
+  colorFormats: ['rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: { x: 29, y: 15, z: 8 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 494894 */
+{offset: 629, bytesPerRow: 535, rowsPerImage: 304}, {width: 115, height: 12, depthOrArrayLayers: 4});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline4 = device0.createRenderPipeline({
+label: '\uda4e\u0b47\u05bb\uea62',
+layout: pipelineLayout0,
+multisample: {
+mask: 0x3ff54c70,
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16sint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'invert',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 3643,
+stencilWriteMask: 87,
+depthBias: 20,
+depthBiasSlopeScale: 17,
+depthBiasClamp: 10,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 3672,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x4',
+offset: 580,
+shaderLocation: 5,
+}, {
+format: 'unorm16x4',
+offset: 1016,
+shaderLocation: 0,
+}, {
+format: 'snorm16x2',
+offset: 612,
+shaderLocation: 11,
+}, {
+format: 'sint32',
+offset: 2924,
+shaderLocation: 19,
+}, {
+format: 'uint32x4',
+offset: 700,
+shaderLocation: 14,
+}, {
+format: 'sint8x2',
+offset: 3224,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 4488,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 228,
+shaderLocation: 9,
+}, {
+format: 'sint32x4',
+offset: 880,
+shaderLocation: 15,
+}, {
+format: 'sint16x4',
+offset: 1396,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 5144,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x4',
+offset: 3572,
+shaderLocation: 18,
+}, {
+format: 'unorm16x2',
+offset: 4952,
+shaderLocation: 4,
+}, {
+format: 'float16x4',
+offset: 2124,
+shaderLocation: 1,
+}, {
+format: 'snorm16x2',
+offset: 784,
+shaderLocation: 2,
+}, {
+format: 'snorm16x2',
+offset: 996,
+shaderLocation: 10,
+}, {
+format: 'float32',
+offset: 3904,
+shaderLocation: 12,
+}, {
+format: 'uint32x4',
+offset: 4292,
+shaderLocation: 13,
+}, {
+format: 'uint16x2',
+offset: 3844,
+shaderLocation: 17,
+}, {
+format: 'uint32x2',
+offset: 2556,
+shaderLocation: 7,
+}, {
+format: 'unorm10-10-10-2',
+offset: 5036,
+shaderLocation: 3,
+}, {
+format: 'snorm8x2',
+offset: 3246,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+document.body.prepend(canvas0);
+let videoFrame3 = new VideoFrame(img0, {timestamp: 0});
+try {
+computePassEncoder0.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 10600, new Float32Array(4932), 3427, 48);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 2,
+  origin: { x: 190, y: 10, z: 39 },
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 179995 */
+{offset: 65, bytesPerRow: 366, rowsPerImage: 49}, {width: 140, height: 20, depthOrArrayLayers: 11});
+} catch {}
+let pipeline5 = await device0.createRenderPipelineAsync({
+label: '\u99d8\u{1fc99}\u{1f8c9}\uf0ec\u1dfd\ua623\u03b5\ub7e7\ucd23\udcd0',
+layout: pipelineLayout0,
+multisample: {
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'invert',
+},
+stencilBack: {
+failOp: 'zero',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilReadMask: 2667,
+stencilWriteMask: 1282,
+depthBias: 66,
+depthBiasSlopeScale: 59,
+depthBiasClamp: 57,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 10380,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 6716,
+shaderLocation: 16,
+}, {
+format: 'unorm8x2',
+offset: 3960,
+shaderLocation: 6,
+}, {
+format: 'float32',
+offset: 9076,
+shaderLocation: 18,
+}, {
+format: 'uint32',
+offset: 4468,
+shaderLocation: 17,
+}, {
+format: 'sint32x4',
+offset: 7472,
+shaderLocation: 15,
+}, {
+format: 'unorm16x4',
+offset: 1904,
+shaderLocation: 2,
+}, {
+format: 'uint32',
+offset: 8348,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 7012,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 2868,
+shaderLocation: 9,
+}, {
+format: 'sint32x4',
+offset: 8,
+shaderLocation: 19,
+}, {
+format: 'float32',
+offset: 1608,
+shaderLocation: 10,
+}, {
+format: 'uint32x3',
+offset: 4560,
+shaderLocation: 5,
+}, {
+format: 'unorm16x2',
+offset: 6344,
+shaderLocation: 3,
+}, {
+format: 'unorm16x4',
+offset: 900,
+shaderLocation: 0,
+}, {
+format: 'float32x3',
+offset: 6256,
+shaderLocation: 1,
+}, {
+format: 'sint8x4',
+offset: 2280,
+shaderLocation: 8,
+}, {
+format: 'snorm8x4',
+offset: 1300,
+shaderLocation: 11,
+}, {
+format: 'float16x4',
+offset: 684,
+shaderLocation: 12,
+}, {
+format: 'unorm16x2',
+offset: 2844,
+shaderLocation: 4,
+}, {
+format: 'uint16x2',
+offset: 3732,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x4',
+offset: 9444,
+shaderLocation: 13,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let device1 = await adapter1.requestDevice({
+label: '\ue975\u5d8d',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 36,
+maxVertexAttributes: 27,
+maxVertexBufferArrayStride: 35977,
+maxStorageTexturesPerShaderStage: 7,
+maxStorageBuffersPerShaderStage: 18,
+maxDynamicStorageBuffersPerPipelineLayout: 25456,
+maxBindingsPerBindGroup: 3699,
+maxTextureDimension1D: 11913,
+maxTextureDimension2D: 9489,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 155105638,
+maxUniformBuffersPerShaderStage: 30,
+maxInterStageShaderVariables: 50,
+maxInterStageShaderComponents: 91,
+maxSamplersPerShaderStage: 17,
+},
+});
+let imageBitmap1 = await createImageBitmap(imageData3);
+try {
+computePassEncoder5.setPipeline(pipeline0);
+} catch {}
+let promise3 = device0.createRenderPipelineAsync({
+label: '\u01eb\uacf4\u0070\uc7f5\u{1fd52}\u4990\u5a7a',
+layout: pipelineLayout0,
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'invert',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'invert',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilReadMask: 943,
+stencilWriteMask: 1064,
+depthBias: 76,
+depthBiasSlopeScale: 63,
+depthBiasClamp: 27,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 8060,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x2',
+offset: 3688,
+shaderLocation: 1,
+}, {
+format: 'unorm16x4',
+offset: 4688,
+shaderLocation: 4,
+}, {
+format: 'snorm16x2',
+offset: 3416,
+shaderLocation: 10,
+}, {
+format: 'snorm16x2',
+offset: 284,
+shaderLocation: 3,
+}, {
+format: 'sint8x2',
+offset: 5626,
+shaderLocation: 16,
+}, {
+format: 'float32x2',
+offset: 1996,
+shaderLocation: 2,
+}, {
+format: 'uint32x4',
+offset: 4000,
+shaderLocation: 5,
+}, {
+format: 'uint16x2',
+offset: 3736,
+shaderLocation: 17,
+}],
+},
+{
+arrayStride: 4692,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 2380,
+shaderLocation: 11,
+}, {
+format: 'snorm16x2',
+offset: 1712,
+shaderLocation: 9,
+}, {
+format: 'uint32',
+offset: 508,
+shaderLocation: 7,
+}, {
+format: 'sint8x2',
+offset: 3812,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 7320,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 8956,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x4',
+offset: 4840,
+shaderLocation: 19,
+}, {
+format: 'float32x3',
+offset: 4356,
+shaderLocation: 12,
+}, {
+format: 'sint8x4',
+offset: 3292,
+shaderLocation: 15,
+}, {
+format: 'snorm8x2',
+offset: 7000,
+shaderLocation: 18,
+}],
+},
+{
+arrayStride: 604,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 172,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 11344,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x2',
+offset: 5788,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 10188,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32',
+offset: 7924,
+shaderLocation: 0,
+}, {
+format: 'uint8x4',
+offset: 6048,
+shaderLocation: 13,
+}],
+}
+]
+},
+});
+let video1 = await videoWithData();
+let commandEncoder14 = device0.createCommandEncoder({});
+try {
+commandEncoder10.clearBuffer(buffer3, 44556, 13960);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(querySet11, 2019, 76, buffer2, 15616);
+} catch {}
+let video2 = await videoWithData();
+let renderBundleEncoder9 = device1.createRenderBundleEncoder({
+  label: '\u0b97\uc374',
+  colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle13 = renderBundleEncoder9.finish({label: '\u9547\uc74a\u08c1\u02e8\u4efe\u{1ff95}\ua939\u649d'});
+video0.height = 208;
+let renderBundle14 = renderBundleEncoder2.finish({});
+let sampler8 = device0.createSampler({
+label: '\u9939\u048c\uadf1\u{1fd15}',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 17.760,
+maxAnisotropy: 6,
+});
+try {
+commandEncoder12.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 128, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 42, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder15 = device1.createCommandEncoder();
+let computePassEncoder7 = commandEncoder15.beginComputePass({label: '\uc1d5\ueb8a\u04e8\u712a\u0803\u0dcd\u0567'});
+let imageBitmap2 = await createImageBitmap(img0);
+let commandEncoder16 = device0.createCommandEncoder({label: '\u5449\u0ed9\u8a60\u9b2b\uf6f2\u4b4f\u93a9\u7011\u0c1a\u3bf8'});
+let texture16 = device0.createTexture({
+label: '\u069c\u0c9e\u{1fe23}\u{1fd85}',
+size: [2400, 8, 1],
+mipLevelCount: 7,
+format: 'astc-5x4-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView15 = texture1.createView({label: '\uf9b6\u0924\u6d66\uf880\u4338\u05eb\u0625\u8c93\uc15e'});
+try {
+commandEncoder14.clearBuffer(buffer3, 26420, 34484);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline6 = device0.createComputePipeline({
+label: '\u91da\u284b\ud5af\u{1fd23}\u0609\u{1f881}\u074d\uc997\u6727',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipelineLayout1 = device0.createPipelineLayout({
+  label: '\u08bc\u{1fd8b}\u7be7\u9605\u06f7\uf2ec\ub260\u{1fe66}',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout1, bindGroupLayout0, bindGroupLayout1]
+});
+let buffer6 = device0.createBuffer({
+  label: '\u0887\u01c2\u0510\u{1ff2d}\u533b\u827d\ua87a\uebf7\u{1fda5}',
+  size: 5256,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true
+});
+let commandEncoder17 = device0.createCommandEncoder({});
+let textureView16 = texture9.createView({baseMipLevel: 1, baseArrayLayer: 56, arrayLayerCount: 6});
+let renderBundle15 = renderBundleEncoder7.finish({label: '\ufdbc\u0b7a\ud456'});
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(72)), /* required buffer size: 792 */
+{offset: 792}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline7 = device0.createRenderPipeline({
+label: '\u7f5d\u8799\u9ead\u7782\uffea\u4691\u{1f664}\u8633\u49df\u572a\u7456',
+layout: pipelineLayout1,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'equal',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+},
+stencilReadMask: 2760,
+stencilWriteMask: 319,
+depthBias: 78,
+depthBiasSlopeScale: 60,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 13500,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x4',
+offset: 12504,
+shaderLocation: 19,
+}, {
+format: 'float32x4',
+offset: 11068,
+shaderLocation: 11,
+}, {
+format: 'unorm10-10-10-2',
+offset: 9244,
+shaderLocation: 9,
+}, {
+format: 'unorm16x4',
+offset: 5360,
+shaderLocation: 18,
+}, {
+format: 'unorm16x2',
+offset: 3156,
+shaderLocation: 4,
+}, {
+format: 'uint8x2',
+offset: 6406,
+shaderLocation: 5,
+}, {
+format: 'sint8x2',
+offset: 1708,
+shaderLocation: 15,
+}, {
+format: 'snorm8x2',
+offset: 1456,
+shaderLocation: 10,
+}, {
+format: 'uint32x2',
+offset: 6656,
+shaderLocation: 13,
+}, {
+format: 'uint32x3',
+offset: 5308,
+shaderLocation: 17,
+}, {
+format: 'float32',
+offset: 9540,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 2412,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x4',
+offset: 1432,
+shaderLocation: 1,
+}, {
+format: 'float16x2',
+offset: 148,
+shaderLocation: 2,
+}, {
+format: 'snorm8x4',
+offset: 1612,
+shaderLocation: 6,
+}, {
+format: 'unorm8x2',
+offset: 2350,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 12512,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 8180,
+shaderLocation: 3,
+}, {
+format: 'sint16x2',
+offset: 6588,
+shaderLocation: 16,
+}, {
+format: 'sint32',
+offset: 1560,
+shaderLocation: 8,
+}, {
+format: 'uint32x4',
+offset: 4516,
+shaderLocation: 14,
+}, {
+format: 'uint32x2',
+offset: 4568,
+shaderLocation: 7,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let commandEncoder18 = device0.createCommandEncoder({});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\u01da\u2bfc\u07df\u09ec',
+  colorFormats: ['rg8sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle16 = renderBundleEncoder10.finish({label: '\udd9e\uba34\u0a6f\u5092\u52b3\u0e67\u0384\u3989'});
+try {
+commandEncoder18.resolveQuerySet(querySet7, 317, 51, buffer2, 7936);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let texture17 = device1.createTexture({
+label: '\u2c1f\u03cf\u9383\u04bd\u0dc9\u2627\u0a33',
+size: {width: 108, height: 768, depthOrArrayLayers: 223},
+mipLevelCount: 3,
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['r16sint'],
+});
+try {
+device1.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 1,
+  origin: { x: 22, y: 35, z: 3 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 363459 */
+{offset: 562, bytesPerRow: 109, rowsPerImage: 257}, {width: 18, height: 246, depthOrArrayLayers: 13});
+} catch {}
+document.body.prepend(canvas0);
+let imageData7 = new ImageData(16, 212);
+let commandEncoder19 = device1.createCommandEncoder({label: '\u7537\uee27\u{1f6af}\ufcc8\uaac4\u44ac\u{1ffe9}\u07fe\u2359'});
+pseudoSubmit(device1, commandEncoder19);
+let textureView17 = texture17.createView({
+  label: '\u9f87\u{1f7e2}\u2f5d\u{1f8fc}\uf08e\u{1ff5d}\u{1f817}\u4c7f',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 143
+});
+let commandEncoder20 = device1.createCommandEncoder({label: '\u9173\u{1fe41}\u0484'});
+let querySet12 = device1.createQuerySet({
+label: '\u9adf\u073a',
+type: 'occlusion',
+count: 122,
+});
+let computePassEncoder8 = commandEncoder20.beginComputePass();
+let sampler9 = device1.createSampler({
+label: '\u3d1f\uc3bd\u73dc\u3671\ue6cc\ud96e\u48ab\u{1ffab}\u{1f799}\u09e3',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+lodMinClamp: 56.885,
+lodMaxClamp: 85.067,
+});
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let texture18 = device0.createTexture({
+label: '\u096e\u{1fbde}\u4439\u{1ff69}\u0925\u{1fe5a}\u08e8',
+size: {width: 4800},
+dimension: '1d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rg11b10ufloat'],
+});
+let renderBundle17 = renderBundleEncoder4.finish({});
+try {
+commandEncoder8.resolveQuerySet(querySet2, 1434, 57, buffer2, 19456);
+} catch {}
+try {
+  await promise0;
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder();
+let querySet13 = device0.createQuerySet({
+label: '\u4ea0\u00d5\u0001\uaf0f\u{1fda2}',
+type: 'occlusion',
+count: 3437,
+});
+try {
+commandEncoder8.clearBuffer(buffer3, 18424, 14620);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['stencil8'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 30236, new BigUint64Array(19765), 91, 2156);
+} catch {}
+offscreenCanvas0.height = 949;
+let buffer7 = device1.createBuffer({label: '\u8961\uf8b3\u01a5', size: 34656, usage: GPUBufferUsage.INDEX});
+let querySet14 = device1.createQuerySet({
+type: 'occlusion',
+count: 2798,
+});
+let textureView18 = texture17.createView({
+  label: '\uc3b1\u0cbf\u095b',
+  dimension: '2d',
+  aspect: 'all',
+  format: 'r16sint',
+  mipLevelCount: 1,
+  baseArrayLayer: 87
+});
+let buffer8 = device1.createBuffer({
+  label: '\ud157\u{1fef0}\u048b\uef79\u95ef\u3914\u0cf5\u4897\udd93\u4fdc',
+  size: 11791,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let texture19 = gpuCanvasContext1.getCurrentTexture();
+let textureView19 = texture19.createView({label: '\u0886\ud602\u265d\u456c\u{1fdac}', dimension: '2d-array', baseMipLevel: 0, baseArrayLayer: 0});
+try {
+  await buffer8.mapAsync(GPUMapMode.READ, 0, 2028);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+try {
+adapter0.label = '\u2e0b\u44d7\uc102\uf1de\u034f\u{1fa50}\ubd97\ud233\udb01\u12ac\u8318';
+} catch {}
+let texture20 = device0.createTexture({
+label: '\u8b8f\u0507',
+size: {width: 1470, height: 1, depthOrArrayLayers: 152},
+mipLevelCount: 9,
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16sint'],
+});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({
+  label: '\ud47d\ua224\u4da3',
+  colorFormats: ['rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let renderBundle18 = renderBundleEncoder2.finish();
+try {
+renderBundleEncoder8.setVertexBuffer(2, buffer4, 19620, 3356);
+} catch {}
+try {
+renderBundleEncoder11.insertDebugMarker('\u2b8c');
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout({label: '\u39cb\ua0d4\u1eb6', bindGroupLayouts: []});
+let querySet15 = device0.createQuerySet({
+label: '\udec4\u{1fb4b}\u05ba\u0903\u50c2\u8102\u1eb9\u5950',
+type: 'occlusion',
+count: 2215,
+});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  label: '\u1f79\u7324\uac33\uc233',
+  colorFormats: ['rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder1.setVertexBuffer(1, buffer4, 1364, 22803);
+} catch {}
+try {
+querySet5.destroy();
+} catch {}
+try {
+commandEncoder21.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 10,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture11,
+  mipLevel: 4,
+  origin: { x: 112, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let texture21 = device0.createTexture({
+label: '\ua7f0\u03e7\u{1fe52}',
+size: {width: 144, height: 3, depthOrArrayLayers: 7},
+mipLevelCount: 8,
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let computePassEncoder9 = commandEncoder12.beginComputePass({label: '\u0c0c\u{1f818}'});
+try {
+renderBundleEncoder11.setVertexBuffer(4, buffer4, 12144);
+} catch {}
+try {
+  await buffer5.mapAsync(GPUMapMode.READ);
+} catch {}
+let pipeline8 = device0.createRenderPipeline({
+label: '\uba10\u8f42\ub3da\u0d81\u4cee\u{1f66a}',
+layout: pipelineLayout0,
+multisample: {
+mask: 0xc48871c2,
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2546,
+stencilWriteMask: 513,
+depthBias: 36,
+depthBiasSlopeScale: 89,
+depthBiasClamp: 45,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 6168,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 4244,
+shaderLocation: 9,
+}, {
+format: 'snorm8x4',
+offset: 3716,
+shaderLocation: 18,
+}, {
+format: 'float32x2',
+offset: 4400,
+shaderLocation: 6,
+}, {
+format: 'snorm8x2',
+offset: 2998,
+shaderLocation: 1,
+}, {
+format: 'float32x3',
+offset: 2552,
+shaderLocation: 10,
+}, {
+format: 'unorm8x4',
+offset: 4816,
+shaderLocation: 11,
+}, {
+format: 'sint32',
+offset: 3892,
+shaderLocation: 15,
+}, {
+format: 'uint8x4',
+offset: 4896,
+shaderLocation: 7,
+}, {
+format: 'snorm16x2',
+offset: 196,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 1736,
+shaderLocation: 17,
+}, {
+format: 'snorm8x4',
+offset: 2032,
+shaderLocation: 4,
+}, {
+format: 'sint16x4',
+offset: 28,
+shaderLocation: 19,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 13548,
+shaderLocation: 13,
+}, {
+format: 'unorm10-10-10-2',
+offset: 9496,
+shaderLocation: 2,
+}, {
+format: 'sint8x4',
+offset: 11972,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 2484,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32',
+offset: 1004,
+shaderLocation: 14,
+}, {
+format: 'sint32x2',
+offset: 588,
+shaderLocation: 16,
+}, {
+format: 'unorm8x2',
+offset: 550,
+shaderLocation: 0,
+}, {
+format: 'uint16x4',
+offset: 108,
+shaderLocation: 5,
+}, {
+format: 'snorm8x4',
+offset: 1376,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let querySet16 = device1.createQuerySet({
+label: '\ua291\u9cb4\u02b0\u3c6d\u01b4\u{1f80d}\u2d9f\u8caa\u0542\ue9f9\u1be1',
+type: 'occlusion',
+count: 935,
+});
+canvas0.width = 678;
+let commandEncoder22 = device0.createCommandEncoder({label: '\u0f7f\u{1fd07}\u{1fc43}\ueb7f\ud009\u4756\u{1fd3b}\u0bc5'});
+let querySet17 = device0.createQuerySet({
+label: '\u{1f874}\ub1f4\u925f\u{1fe7d}\ube1e\uc561\ub143\u399e',
+type: 'occlusion',
+count: 3814,
+});
+try {
+commandEncoder13.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 0,
+  origin: { x: 139, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 10580 widthInBlocks: 2645 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 56932 */
+offset: 56932,
+bytesPerRow: 10752,
+buffer: buffer3,
+}, {width: 2645, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline9 = await promise3;
+let renderBundle19 = renderBundleEncoder10.finish({});
+try {
+renderBundleEncoder1.setVertexBuffer(3, buffer4, 24916, 497);
+} catch {}
+try {
+commandEncoder10.resolveQuerySet(querySet3, 173, 15, buffer2, 15104);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: { x: 2117, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer3), /* required buffer size: 15225 */
+{offset: 557, bytesPerRow: 14719}, {width: 3667, height: 1, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(canvas0);
+let texture22 = device0.createTexture({
+label: '\u1224\u716d\u{1ff7e}\ueb84\u{1f7f4}\u{1fe79}\ucf5d\u39a7',
+size: {width: 720, height: 120, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-8x6-unorm'],
+});
+try {
+commandEncoder14.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 90 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 37696 */
+offset: 37696,
+bytesPerRow: 0,
+rowsPerImage: 226,
+buffer: buffer3,
+}, {width: 0, height: 5, depthOrArrayLayers: 29});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let commandBuffer0 = commandEncoder8.finish({
+label: '\ua99f\u0763\u0e1c\ubb92\u0a39',
+});
+let renderBundle20 = renderBundleEncoder0.finish({label: '\u{1f65a}\u191c\u4ca3\u2d0b\u{1f901}\ufcb6\u{1f997}\u0b5d\u092e\u{1f737}\u{1fc92}'});
+let promise4 = device0.popErrorScope();
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 34, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 145, y: 2, z: 1 },
+  aspect: 'all',
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 152, y: 0, z: 94 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 44962689 */
+{offset: 723, bytesPerRow: 3837, rowsPerImage: 217}, {width: 904, height: 0, depthOrArrayLayers: 55});
+} catch {}
+let textureView20 = texture8.createView({
+  label: '\u1466\u{1f67b}\ufd85\u0168\uaded\ubf74\u{1f609}',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 95
+});
+try {
+commandEncoder10.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let pipeline10 = await device0.createComputePipelineAsync({
+label: '\uca17\u09fd\u0112\u0f30\u5578\u8872\ua9cd\u86cc\u{1fed2}\u06e8',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let sampler10 = device1.createSampler({
+label: '\u6588\u8e37\u{1f6dc}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+maxAnisotropy: 1,
+});
+let externalTexture0 = device1.importExternalTexture({
+label: '\u6a97\u2bef\u179b\uf4e5\uc954\ua5dc\u0f5d\u9517\u878f\u7fda\u{1f9ad}',
+source: videoFrame3,
+colorSpace: 'srgb',
+});
+try {
+buffer7.unmap();
+} catch {}
+let imageBitmap3 = await createImageBitmap(img1);
+let textureView21 = texture17.createView({
+  label: '\u736e\u022d\ua680\u3ad6\u0682\u0ea5\u2656',
+  baseMipLevel: 2,
+  baseArrayLayer: 211,
+  arrayLayerCount: 8
+});
+let arrayBuffer4 = buffer8.getMappedRange(0, 1036);
+let adapter2 = await navigator.gpu.requestAdapter({
+powerPreference: 'high-performance',
+});
+let img2 = await imageWithData(255, 293, '#12f693d2', '#b25972c8');
+let textureView22 = texture17.createView({
+  label: '\udc0b\uda64\ub229\ua63d\u7977\u40f9',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 164
+});
+let renderBundle21 = renderBundleEncoder9.finish({label: '\ufd3b\u0f86\u364c\uf464\u31f5\ue156\u0664'});
+let arrayBuffer5 = buffer8.getMappedRange(1656, 116);
+let sampler11 = device1.createSampler({
+label: '\ub07f\u0d54',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 37.319,
+lodMaxClamp: 48.763,
+});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+pseudoSubmit(device0, commandEncoder13);
+let renderBundle22 = renderBundleEncoder6.finish({});
+let pipeline11 = device0.createRenderPipeline({
+label: '\u0842\ude3a\u0843\u0718\u8ecd',
+layout: pipelineLayout2,
+fragment: {module: shaderModule0, entryPoint: 'fragment0', targets: [{format: 'rgba16sint'}]},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'keep',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 2332,
+stencilWriteMask: 3425,
+depthBias: 2,
+depthBiasSlopeScale: 35,
+depthBiasClamp: 42,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 6256,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x3',
+offset: 2492,
+shaderLocation: 14,
+}, {
+format: 'float32x4',
+offset: 3596,
+shaderLocation: 1,
+}, {
+format: 'uint8x2',
+offset: 6068,
+shaderLocation: 17,
+}, {
+format: 'sint8x2',
+offset: 5980,
+shaderLocation: 15,
+}, {
+format: 'unorm8x4',
+offset: 3532,
+shaderLocation: 11,
+}, {
+format: 'unorm16x2',
+offset: 6168,
+shaderLocation: 2,
+}, {
+format: 'unorm16x2',
+offset: 952,
+shaderLocation: 3,
+}, {
+format: 'float32x2',
+offset: 5768,
+shaderLocation: 0,
+}, {
+format: 'sint32x3',
+offset: 4616,
+shaderLocation: 16,
+}, {
+format: 'uint8x4',
+offset: 6116,
+shaderLocation: 13,
+}, {
+format: 'float32x3',
+offset: 5508,
+shaderLocation: 9,
+}, {
+format: 'uint8x2',
+offset: 3050,
+shaderLocation: 5,
+}, {
+format: 'unorm16x2',
+offset: 6076,
+shaderLocation: 4,
+}, {
+format: 'snorm16x4',
+offset: 3888,
+shaderLocation: 6,
+}, {
+format: 'float32x3',
+offset: 4072,
+shaderLocation: 18,
+}, {
+format: 'sint32x4',
+offset: 1516,
+shaderLocation: 8,
+}, {
+format: 'sint32',
+offset: 5948,
+shaderLocation: 19,
+}, {
+format: 'snorm16x4',
+offset: 5384,
+shaderLocation: 10,
+}, {
+format: 'uint8x2',
+offset: 3072,
+shaderLocation: 7,
+}, {
+format: 'snorm8x2',
+offset: 5930,
+shaderLocation: 12,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let bindGroupLayout2 = device1.createBindGroupLayout({
+label: '\u4f66\u75df\u0d79\u0cfe\ubfae\u71a6\ufa7f\u302f\u{1f8d8}',
+entries: [{
+binding: 704,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}, {
+binding: 1300,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+}],
+});
+let texture23 = device1.createTexture({
+size: [96, 4, 1],
+mipLevelCount: 7,
+format: 'eac-rg11unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['eac-rg11unorm', 'eac-rg11unorm'],
+});
+let textureView23 = texture23.createView({label: '\u0c6c\u{1f7a5}\ubb7a\u74a9\uc751\u06b4\u05cf\u{1fe16}', baseMipLevel: 0, mipLevelCount: 4});
+let sampler12 = device1.createSampler({
+label: '\u058d\u0f63\u527b\u7db8\u4c96\ubd84\ue339',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 95.585,
+maxAnisotropy: 14,
+});
+try {
+window.someLabel = querySet11.label;
+} catch {}
+let commandEncoder23 = device0.createCommandEncoder({label: '\u6efc\u0e75\u{1ff7a}\u0448\u{1fc07}\u0613\ucb5d\u{1fb98}\u01ca\ua621\u0895'});
+let texture24 = device0.createTexture({
+label: '\u04c6\u03cb\u3b5e\u4310\u3905\ub718',
+size: [1440, 240, 1],
+mipLevelCount: 6,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x12-unorm', 'astc-12x12-unorm', 'astc-12x12-unorm'],
+});
+let renderBundle23 = renderBundleEncoder1.finish({label: '\u38e5\u{1f79b}\ufb6c\u{1f9c4}\u8061\u0a01\u018d\u0970\u{1fc1c}\u{1fad7}'});
+gc();
+try {
+renderBundleEncoder12.setVertexBuffer(1, buffer4, 15940, 488);
+} catch {}
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: { x: 72, y: 1, z: 17 },
+  aspect: 'all',
+}, {
+  texture: texture7,
+  mipLevel: 4,
+  origin: { x: 161, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 101, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'astc-6x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-4x4-unorm', 'astc-6x5-unorm', 'r16sint'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 46112, new Int16Array(10746), 1753, 5208);
+} catch {}
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  label: '\u{1f99d}\u03ac\u0071\u{1fdf4}\u049c\u{1f9e2}\u1c5b\u1590\u{1f6e7}\u{1fafe}',
+  colorFormats: ['r8sint', 'rg16float', 'rgba16float'],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+try {
+commandEncoder11.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let pipeline12 = await device0.createRenderPipelineAsync({
+label: '\u4d2e\u{1fda1}\u6f2c\u{1f65e}\u0b4c',
+layout: 'auto',
+multisample: {
+mask: 0x9303a3e9,
+},
+fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rgba16sint'}]},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'keep',
+passOp: 'replace',
+},
+stencilReadMask: 1750,
+depthBiasSlopeScale: 48,
+depthBiasClamp: 57,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1596,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 1336,
+shaderLocation: 5,
+}, {
+format: 'uint32',
+offset: 48,
+shaderLocation: 13,
+}, {
+format: 'uint8x4',
+offset: 240,
+shaderLocation: 17,
+}, {
+format: 'unorm10-10-10-2',
+offset: 312,
+shaderLocation: 12,
+}, {
+format: 'uint16x4',
+offset: 1252,
+shaderLocation: 7,
+}, {
+format: 'float16x2',
+offset: 1524,
+shaderLocation: 4,
+}, {
+format: 'unorm16x4',
+offset: 1416,
+shaderLocation: 2,
+}, {
+format: 'float32x4',
+offset: 1328,
+shaderLocation: 10,
+}, {
+format: 'uint8x4',
+offset: 152,
+shaderLocation: 14,
+}, {
+format: 'sint16x4',
+offset: 1376,
+shaderLocation: 15,
+}, {
+format: 'sint32',
+offset: 1256,
+shaderLocation: 19,
+}, {
+format: 'sint32x4',
+offset: 592,
+shaderLocation: 8,
+}, {
+format: 'sint16x4',
+offset: 980,
+shaderLocation: 16,
+}, {
+format: 'unorm8x4',
+offset: 1012,
+shaderLocation: 3,
+}, {
+format: 'snorm16x2',
+offset: 1012,
+shaderLocation: 11,
+}, {
+format: 'snorm8x4',
+offset: 24,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 6532,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 3436,
+shaderLocation: 0,
+}, {
+format: 'snorm8x4',
+offset: 2124,
+shaderLocation: 9,
+}, {
+format: 'snorm8x4',
+offset: 5604,
+shaderLocation: 18,
+}, {
+format: 'float16x2',
+offset: 212,
+shaderLocation: 1,
+}],
+}
+]
+},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let img3 = await imageWithData(11, 70, '#d0ba2374', '#1e86ba42');
+let commandEncoder24 = device1.createCommandEncoder();
+let texture25 = device1.createTexture({
+label: '\u7223\ube5e\ua49a\u0bf9\ufd99\u01c8\u704a\uf321\u{1f702}\u02bb\u430e',
+size: [7664, 192, 1],
+mipLevelCount: 3,
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView24 = texture19.createView({label: '\u{1f8ec}\u{1f74b}\u9853\u7bb8\uce12\u069d\ue10c\u9cd8\u0683\u137d\u09db'});
+let videoFrame4 = new VideoFrame(videoFrame1, {timestamp: 0});
+pseudoSubmit(device0, commandEncoder9);
+try {
+commandEncoder21.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 1,
+  origin: { x: 530, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 520, y: 4, z: 0 },
+  aspect: 'all',
+}, {width: 505, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder23.resolveQuerySet(querySet0, 75, 640, buffer2, 1536);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 50432, new Float32Array(58569), 32493, 668);
+} catch {}
+let pipeline13 = await device0.createComputePipelineAsync({
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+});
+let pipeline14 = device0.createRenderPipeline({
+label: '\u0422\u0a1d\uf247\ud447\u0e28\u91f8',
+layout: pipelineLayout0,
+fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rgba16sint'}]},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater',
+depthFailOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2452,
+stencilWriteMask: 1484,
+depthBiasSlopeScale: 13,
+depthBiasClamp: 93,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 11996,
+shaderLocation: 11,
+}, {
+format: 'snorm8x2',
+offset: 7526,
+shaderLocation: 6,
+}, {
+format: 'uint32',
+offset: 8828,
+shaderLocation: 7,
+}, {
+format: 'float32x3',
+offset: 5628,
+shaderLocation: 18,
+}],
+},
+{
+arrayStride: 11868,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x4',
+offset: 500,
+shaderLocation: 15,
+}, {
+format: 'snorm8x2',
+offset: 3506,
+shaderLocation: 9,
+}, {
+format: 'sint32x2',
+offset: 5572,
+shaderLocation: 8,
+}, {
+format: 'uint8x4',
+offset: 3308,
+shaderLocation: 17,
+}, {
+format: 'uint8x4',
+offset: 10908,
+shaderLocation: 14,
+}, {
+format: 'unorm16x4',
+offset: 8040,
+shaderLocation: 2,
+}, {
+format: 'float16x2',
+offset: 1704,
+shaderLocation: 0,
+}, {
+format: 'uint32x3',
+offset: 1760,
+shaderLocation: 5,
+}, {
+format: 'float16x2',
+offset: 10396,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 5700,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x2',
+offset: 4576,
+shaderLocation: 16,
+}, {
+format: 'uint32x2',
+offset: 4144,
+shaderLocation: 13,
+}, {
+format: 'sint16x4',
+offset: 1760,
+shaderLocation: 19,
+}, {
+format: 'float32x2',
+offset: 3860,
+shaderLocation: 12,
+}, {
+format: 'float16x4',
+offset: 2348,
+shaderLocation: 1,
+}, {
+format: 'float32',
+offset: 3408,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 7984,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x2',
+offset: 56,
+shaderLocation: 10,
+}],
+}
+]
+},
+});
+let videoFrame5 = new VideoFrame(canvas0, {timestamp: 0});
+let buffer9 = device0.createBuffer({label: '\ua383\ud302\u839c\u82f9', size: 6632, usage: GPUBufferUsage.MAP_READ});
+let arrayBuffer6 = buffer6.getMappedRange();
+let promise5 = device0.queue.onSubmittedWorkDone();
+gc();
+let canvas2 = document.createElement('canvas');
+let bindGroupLayout3 = device0.createBindGroupLayout({
+label: '\ucf15\u{1fccf}\u032d\u757b\u7e9c\u77cf\u{1fbe6}\u4b28\ub027',
+entries: [{
+binding: 5542,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+let commandEncoder25 = device0.createCommandEncoder();
+let texture26 = device0.createTexture({
+label: '\u{1f8d1}\u02bc\u058f\u{1f68a}\ubef8',
+size: [144, 3, 7],
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let pipeline15 = await device0.createComputePipelineAsync({
+label: '\u60ef\u26e5\ufadf\u9445\uf41e\ub569',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+});
+let gpuCanvasContext2 = canvas2.getContext('webgpu');
+let imageBitmap4 = await createImageBitmap(imageData0);
+let texture27 = device1.createTexture({
+label: '\uc8fb\u091b\u2d11\ub2c3\u2196\u{1f8d8}\u035c\u6dd3\u21ba\ua039',
+size: {width: 2800, height: 6, depthOrArrayLayers: 177},
+mipLevelCount: 11,
+format: 'astc-10x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x6-unorm-srgb', 'astc-10x6-unorm-srgb'],
+});
+let computePassEncoder10 = commandEncoder24.beginComputePass();
+let renderBundleEncoder14 = device1.createRenderBundleEncoder({
+  label: '\u1b2d\uf7b7\uee9b\u{1f6f2}\u0b76',
+  colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint']
+});
+let renderBundle24 = renderBundleEncoder14.finish({label: '\u06bd\u{1f9a5}\u6fc3\ud90f\ufca0\ue555'});
+try {
+  await promise4;
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(696, 148);
+let pipelineLayout3 = device1.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout2, bindGroupLayout2, bindGroupLayout2, bindGroupLayout2, bindGroupLayout2]
+});
+let texture28 = device1.createTexture({
+label: '\ub23d\u949f\udddf\u{1fbf2}\u80ca\u865e\u6e23',
+size: [48, 2, 1],
+dimension: '3d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let sampler13 = device1.createSampler({
+label: '\u00c5\ue0c3\u3a27\u0055\ub289\u1f61\u{1fa6a}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 78.511,
+lodMaxClamp: 93.644,
+});
+let externalTexture1 = device1.importExternalTexture({
+source: videoFrame5,
+colorSpace: 'display-p3',
+});
+try {
+gpuCanvasContext1.configure({
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 7, y: 129 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 12, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 30, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder({label: '\u{1f8a2}\uc341\u40d2\uacef\u021d\u{1fadc}\uda4f\ud70e\uec7e\u77b5\ue42f'});
+let textureView25 = texture5.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 1});
+let computePassEncoder11 = commandEncoder23.beginComputePass({label: '\u4871\u{1fdbc}\u9fc3\uf80b'});
+let renderBundle25 = renderBundleEncoder11.finish();
+try {
+renderBundleEncoder8.setVertexBuffer(7, buffer4);
+} catch {}
+try {
+buffer6.destroy();
+} catch {}
+try {
+commandEncoder26.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 1,
+  origin: { x: 70, y: 10, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 35488 */
+offset: 35488,
+buffer: buffer3,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer0,
+]);
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+let renderBundle26 = renderBundleEncoder9.finish({label: '\u132d\u2e70\u0dfc\u67d6\u{1f670}\u3633\u{1f659}\u2504\u93a0'});
+try {
+buffer7.unmap();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 17, y: 1, z: 0 },
+  aspect: 'all',
+}, new DataView(arrayBuffer4), /* required buffer size: 176 */
+{offset: 96}, {width: 20, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext3 = offscreenCanvas3.getContext('webgpu');
+gc();
+let bindGroupLayout4 = device0.createBindGroupLayout({
+label: '\u0e09\ua783\u8874\uccca\u{1f703}\u09a9\u40e3\u{1f9ee}\u05ad\u127e\u8210',
+entries: [{
+binding: 1816,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 5759,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+}],
+});
+let commandBuffer1 = commandEncoder17.finish({
+label: '\u{1f854}\u0c17\u{1fe97}\u3c10\u{1f630}\u41b6\ud4a9\ucc49\u099c',
+});
+let texture29 = device0.createTexture({
+label: '\uaba9\ud3a1\u{1fde2}\u0de1\u03a9\u02a6\u{1ff64}\u0e94\u{1fe54}\u{1fe1a}',
+size: {width: 735, height: 15, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r32sint', 'r32sint', 'r32sint'],
+});
+let textureView26 = texture23.createView({
+  label: '\u509b\u{1fd24}\u04c8\u{1f88b}\u1d51\u50e9',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  mipLevelCount: 1
+});
+let renderBundle27 = renderBundleEncoder9.finish({});
+try {
+gpuCanvasContext3.configure({
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb'],
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas2,
+  origin: { x: 157, y: 47 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 37, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule1 = device1.createShaderModule({
+label: '\u86f2\u5f9c\ue2f9\u297a\ud61d\ucb0a\u43d9\u5785\ufb10',
+code: `@group(1) @binding(704)
+var<storage, read_write> function0: array<u32>;
+@group(2) @binding(704)
+var<storage, read_write> type0: array<u32>;
+@group(3) @binding(1300)
+var<storage, read_write> i0: array<u32>;
+@group(3) @binding(704)
+var<storage, read_write> parameter1: array<u32>;
+@group(4) @binding(704)
+var<storage, read_write> local0: array<u32>;
+@group(0) @binding(1300)
+var<storage, read_write> i1: array<u32>;
+@group(4) @binding(1300)
+var<storage, read_write> type1: array<u32>;
+
+@compute @workgroup_size(4, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(5) f0: vec4<i32>,
+  @location(6) f1: vec3<f32>,
+  @location(3) f2: vec2<f32>,
+  @location(1) f3: vec4<u32>,
+  @builtin(frag_depth) f4: f32,
+  @location(4) f5: vec3<u32>,
+  @location(0) f6: vec3<f32>,
+  @location(2) f7: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S1 {
+  @location(8) f0: vec3<f32>,
+  @location(15) f1: vec3<i32>,
+  @location(25) f2: vec4<i32>,
+  @location(24) f3: vec2<u32>,
+  @location(2) f4: vec2<f16>,
+  @location(5) f5: vec4<i32>,
+  @location(21) f6: f16,
+  @location(20) f7: vec2<f32>,
+  @location(4) f8: f32,
+  @location(17) f9: vec4<u32>,
+  @location(7) f10: f32,
+  @builtin(vertex_index) f11: u32,
+  @location(12) f12: vec2<u32>,
+  @location(22) f13: u32,
+  @location(14) f14: vec2<u32>,
+  @location(26) f15: vec4<u32>,
+  @builtin(instance_index) f16: u32,
+  @location(1) f17: vec3<f16>,
+  @location(0) f18: f16
+}
+
+@vertex
+fn vertex0(@location(16) a0: vec4<i32>, @location(10) a1: vec2<u32>, @location(6) a2: vec2<f32>, @location(13) a3: vec4<i32>, a4: S1) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+pseudoSubmit(device1, commandEncoder24);
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 1,
+  origin: { x: 330, y: 0, z: 129 },
+  aspect: 'all',
+}, new ArrayBuffer(246), /* required buffer size: 246 */
+{offset: 246, bytesPerRow: 1288}, {width: 720, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 106 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 39, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline16 = device1.createRenderPipeline({
+label: '\ue7f6\u{1f85d}\u3bd5\u{1f767}\u03c2',
+layout: pipelineLayout3,
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'r32uint'}, {format: 'rg8sint'}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r32sint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'replace',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'always',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'zero',
+},
+stencilReadMask: 1598,
+stencilWriteMask: 860,
+depthBias: 22,
+depthBiasSlopeScale: 6,
+depthBiasClamp: 39,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 6148,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x2',
+offset: 1954,
+shaderLocation: 15,
+}, {
+format: 'uint16x2',
+offset: 2708,
+shaderLocation: 26,
+}, {
+format: 'uint32x4',
+offset: 1608,
+shaderLocation: 14,
+}, {
+format: 'unorm8x2',
+offset: 2600,
+shaderLocation: 21,
+}, {
+format: 'unorm16x4',
+offset: 3288,
+shaderLocation: 0,
+}, {
+format: 'uint32x3',
+offset: 2224,
+shaderLocation: 12,
+}, {
+format: 'sint8x2',
+offset: 5718,
+shaderLocation: 16,
+}, {
+format: 'sint32x3',
+offset: 4728,
+shaderLocation: 5,
+}, {
+format: 'snorm8x2',
+offset: 246,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 21560,
+attributes: [{
+format: 'snorm16x4',
+offset: 6928,
+shaderLocation: 2,
+}, {
+format: 'sint8x2',
+offset: 2734,
+shaderLocation: 25,
+}, {
+format: 'unorm16x4',
+offset: 16872,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x2',
+offset: 30930,
+shaderLocation: 8,
+}, {
+format: 'float32',
+offset: 24468,
+shaderLocation: 1,
+}, {
+format: 'uint32x4',
+offset: 3320,
+shaderLocation: 22,
+}, {
+format: 'snorm16x4',
+offset: 31376,
+shaderLocation: 20,
+}, {
+format: 'uint32',
+offset: 22920,
+shaderLocation: 24,
+}, {
+format: 'uint16x2',
+offset: 31328,
+shaderLocation: 10,
+}, {
+format: 'uint32x4',
+offset: 29784,
+shaderLocation: 17,
+}, {
+format: 'float16x2',
+offset: 30136,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 4440,
+attributes: [],
+},
+{
+arrayStride: 8412,
+attributes: [],
+},
+{
+arrayStride: 14876,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 25056,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x2',
+offset: 24832,
+shaderLocation: 13,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let imageBitmap5 = await createImageBitmap(offscreenCanvas0);
+let bindGroupLayout5 = pipeline16.getBindGroupLayout(0);
+let sampler14 = device1.createSampler({
+label: '\u8cc3\u1def\u00cd\u3b92\u4c47',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 87.160,
+compare: 'equal',
+maxAnisotropy: 1,
+});
+let videoFrame6 = new VideoFrame(imageBitmap2, {timestamp: 0});
+let buffer10 = device0.createBuffer({
+  label: '\u{1f6fc}\ud1ee',
+  size: 1191,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: false
+});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({
+  label: '\u19fd\u036b\ucca2\u09b6\u4831\u5b5e\u0875\u0f74\u{1f77c}\u{1f818}\u0c42',
+  colorFormats: ['rg8sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 50, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 15, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 21, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 1,
+  origin: { x: 200, y: 30, z: 12 },
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer2), /* required buffer size: 7054 */
+{offset: 477, bytesPerRow: 823}, {width: 510, height: 80, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline17 = await device0.createComputePipelineAsync({
+label: '\ufa75\u80b2\u15c7\u04eb\u5e21\u06fb',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+});
+try {
+  await promise5;
+} catch {}
+let texture30 = device1.createTexture({
+label: '\u0927\u00dd\u0f92\ue9ca\u88b4\u{1f8f1}\u09e0\ucc3e\u8be6\u{1f63f}',
+size: {width: 220, height: 42, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'astc-10x6-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x6-unorm', 'astc-10x6-unorm', 'astc-10x6-unorm-srgb'],
+});
+let textureView27 = texture28.createView({label: '\u{1f65e}\ueb09\u04e3\ufc0c\uf744\u0855\u151f\u35c5\u{1fff1}\u0742'});
+try {
+buffer8.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-6x6-unorm-srgb', 'rg16uint', 'rg11b10ufloat'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let texture31 = device0.createTexture({
+label: '\u8a4c\u0467\u{1f743}\u0a98\u54b1\u04e7\u0678',
+size: {width: 576, height: 12, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  label: '\u01ed\u4a9b\u{1fca0}\u{1f622}',
+  colorFormats: ['rgba8unorm-srgb', 'rg8uint', 'r32sint', undefined, 'rg8uint', 'rgba8uint', 'rg11b10ufloat', 'r32sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 1,
+  depthReadOnly: false
+});
+try {
+computePassEncoder1.setPipeline(pipeline15);
+} catch {}
+try {
+commandEncoder10.resolveQuerySet(querySet0, 862, 2821, buffer2, 5888);
+} catch {}
+try {
+  await promise6;
+} catch {}
+let video3 = await videoWithData();
+let bindGroupLayout6 = pipeline16.getBindGroupLayout(3);
+pseudoSubmit(device1, commandEncoder20);
+let sampler15 = device1.createSampler({
+label: '\u32c2\u483a\uf105\u62fc\u{1fc78}\u064c\u1bd9\uae76\u0da0',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 25.414,
+lodMaxClamp: 54.941,
+});
+let offscreenCanvas4 = new OffscreenCanvas(639, 892);
+let imageData8 = new ImageData(128, 156);
+let bindGroupLayout7 = pipeline9.getBindGroupLayout(2);
+let querySet18 = device0.createQuerySet({
+label: '\ud99c\u940c\u0b85\u46d3\u{1fb85}\u03f8\u0d64\uba31\u02dc\u025d',
+type: 'occlusion',
+count: 809,
+});
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder14.clearBuffer(buffer3, 27716, 24528);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let texture32 = device1.createTexture({
+label: '\u{1f6f6}\u{1fe19}\u0ea5',
+size: [48, 1, 26],
+mipLevelCount: 6,
+format: 'rg8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle28 = renderBundleEncoder9.finish({label: '\u94be\u0813\u{1fdec}'});
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer8, 5784, new DataView(new ArrayBuffer(49733)), 7350, 5484);
+} catch {}
+let gpuCanvasContext4 = offscreenCanvas4.getContext('webgpu');
+let commandBuffer2 = commandEncoder14.finish({
+label: '\u0299\u949c\uf91a\u05d2\u0d9d\ucff3\u8ba8\u0d55\ub91f\ufad2',
+});
+try {
+commandEncoder16.insertDebugMarker('\u589c');
+} catch {}
+let device2 = await adapter2.requestDevice({
+label: '\u0c7c\uf39e\u0515\u138b\u{1f707}\ub965\u{1fc32}',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 48,
+maxVertexBufferArrayStride: 47628,
+maxStorageTexturesPerShaderStage: 34,
+maxStorageBuffersPerShaderStage: 36,
+maxDynamicStorageBuffersPerPipelineLayout: 1946,
+maxBindingsPerBindGroup: 3079,
+maxTextureDimension1D: 12729,
+maxTextureDimension2D: 15478,
+maxVertexBuffers: 10,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 233911788,
+maxUniformBuffersPerShaderStage: 23,
+maxInterStageShaderVariables: 99,
+maxInterStageShaderComponents: 91,
+maxSamplersPerShaderStage: 19,
+},
+});
+let imageBitmap6 = await createImageBitmap(videoFrame6);
+let commandEncoder27 = device2.createCommandEncoder({label: '\uc433\u0abb\u785f\uf1e1\u0eff\u{1ffb4}\u12fa\u{1f612}'});
+let texture33 = device2.createTexture({
+label: '\u{1fde4}\u4a6a\uedc9\u{1f6b7}\udadc\uc0ec\u2fdf\ub28f\u007f\u06f4\u{1fb4e}',
+size: {width: 9776, height: 25, depthOrArrayLayers: 210},
+mipLevelCount: 5,
+dimension: '2d',
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x5-unorm-srgb', 'astc-8x5-unorm-srgb', 'astc-8x5-unorm'],
+});
+let textureView28 = texture33.createView({
+  label: '\u2a7a\u0043\ua34a\u000c\u6c43\u4f7b\u091a\u866e\u045b\uc4ca',
+  format: 'astc-8x5-unorm-srgb',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 21,
+  arrayLayerCount: 145
+});
+let imageBitmap7 = await createImageBitmap(imageData0);
+let imageData9 = new ImageData(112, 20);
+let commandEncoder28 = device0.createCommandEncoder({label: '\u4457\ub59e'});
+let textureView29 = texture0.createView({
+  label: '\u{1f7fd}\uc907\ua7c7\ude47\u0b1a\u45a6\ua1ff\u0b54\ub360\uafb0',
+  format: 'astc-5x5-unorm-srgb',
+  baseMipLevel: 6,
+  mipLevelCount: 3,
+  baseArrayLayer: 120,
+  arrayLayerCount: 66
+});
+let computePassEncoder12 = commandEncoder10.beginComputePass({});
+try {
+computePassEncoder5.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder28.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 7, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 155 widthInBlocks: 155 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 43619 */
+offset: 43208,
+bytesPerRow: 256,
+buffer: buffer3,
+}, {width: 155, height: 2, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+renderBundleEncoder15.insertDebugMarker('\u02f7');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 864, new DataView(new ArrayBuffer(46003)), 41500, 2768);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 1,
+  origin: { x: 228, y: 48, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 200 */
+{offset: 200, bytesPerRow: 153}, {width: 0, height: 60, depthOrArrayLayers: 0});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(224, 64);
+let video4 = await videoWithData();
+let commandEncoder29 = device2.createCommandEncoder({label: '\u4f25\u07a2\ua619\u0b56\u8015\uec37\u09a9\u{1f76a}'});
+try {
+commandEncoder27.insertDebugMarker('\u06c3');
+} catch {}
+try {
+commandEncoder28.resolveQuerySet(querySet18, 466, 272, buffer2, 3840);
+} catch {}
+try {
+computePassEncoder1.insertDebugMarker('\u{1f8c8}');
+} catch {}
+let pipeline18 = device0.createComputePipeline({
+label: '\u0988\ufaf0\ua635\uffe5\u2d0d\u06cc',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline19 = await device0.createRenderPipelineAsync({
+label: '\u{1ff22}\u{1f898}\u04af\u{1fe93}\u9d30\u{1faa0}\u2dad\u17c1\u4867\u{1f63d}\u83d7',
+layout: pipelineLayout0,
+fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rgba16sint'}]},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less-equal',
+depthFailOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 3292,
+stencilWriteMask: 2067,
+depthBias: 94,
+depthBiasSlopeScale: 11,
+depthBiasClamp: 44,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 6288,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 2212,
+shaderLocation: 19,
+}, {
+format: 'float32',
+offset: 2676,
+shaderLocation: 2,
+}, {
+format: 'unorm8x4',
+offset: 1576,
+shaderLocation: 1,
+}, {
+format: 'float32x3',
+offset: 220,
+shaderLocation: 9,
+}, {
+format: 'sint16x2',
+offset: 28,
+shaderLocation: 15,
+}, {
+format: 'float32x3',
+offset: 3108,
+shaderLocation: 10,
+}, {
+format: 'sint32x4',
+offset: 3576,
+shaderLocation: 16,
+}, {
+format: 'unorm16x2',
+offset: 3932,
+shaderLocation: 4,
+}, {
+format: 'sint16x4',
+offset: 280,
+shaderLocation: 8,
+}, {
+format: 'snorm16x2',
+offset: 6168,
+shaderLocation: 3,
+}, {
+format: 'uint8x2',
+offset: 2720,
+shaderLocation: 14,
+}, {
+format: 'uint32x3',
+offset: 4652,
+shaderLocation: 13,
+}, {
+format: 'float32x3',
+offset: 392,
+shaderLocation: 6,
+}, {
+format: 'unorm16x2',
+offset: 5584,
+shaderLocation: 0,
+}, {
+format: 'snorm8x2',
+offset: 4800,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 3156,
+shaderLocation: 5,
+}, {
+format: 'float32x2',
+offset: 3484,
+shaderLocation: 18,
+}, {
+format: 'uint8x4',
+offset: 744,
+shaderLocation: 7,
+}, {
+format: 'uint32x3',
+offset: 5916,
+shaderLocation: 17,
+}, {
+format: 'unorm10-10-10-2',
+offset: 544,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+cullMode: 'front',
+unclippedDepth: false,
+},
+});
+try {
+offscreenCanvas5.getContext('webgl2');
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder({label: '\u{1f743}\u{1f933}\ue518\u3303'});
+let querySet19 = device0.createQuerySet({
+label: '\u0993\u24cf\ud020\ub56b\u01b6\u1fec\u1306\u8856\udb84',
+type: 'occlusion',
+count: 407,
+});
+let texture34 = device0.createTexture({
+label: '\u4244\ua2c6\u04f6\u{1fb18}\u02b4\uf897\u0199\u0913',
+size: [56, 2, 87],
+mipLevelCount: 4,
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r16float', 'r16float'],
+});
+let sampler16 = device0.createSampler({
+label: '\u47b0\ub148\ub610\ubc06\u{1f9cb}\u0bfe\udb76\u9295\uf508\u0a53\u45b2',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 88.844,
+lodMaxClamp: 91.207,
+maxAnisotropy: 15,
+});
+try {
+computePassEncoder3.setPipeline(pipeline13);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 780, new Int16Array(27649), 25265, 60);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let img4 = await imageWithData(128, 54, '#8f8fddf9', '#4915edcb');
+let bindGroupLayout8 = device2.createBindGroupLayout({
+label: '\u8549\u643c\uf03c\u0cd1',
+entries: [{
+binding: 1847,
+visibility: 0,
+sampler: { type: 'filtering' },
+}, {
+binding: 958,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+try {
+  await buffer3.mapAsync(GPUMapMode.READ, 7272, 28800);
+} catch {}
+let buffer11 = device2.createBuffer({label: '\u23e2\u03bd\u4576\u095c\u02ca\u0428\udc3b\u0110', size: 50488, usage: GPUBufferUsage.INDEX});
+let texture35 = device2.createTexture({
+label: '\u9748\u0815\u8e81\u0573\u58dd',
+size: {width: 288, height: 48, depthOrArrayLayers: 237},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView30 = texture33.createView({format: 'astc-8x5-unorm-srgb', baseMipLevel: 3, baseArrayLayer: 192, arrayLayerCount: 9});
+let texture36 = device2.createTexture({
+size: {width: 160, height: 100, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'astc-10x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+});
+let bindGroupLayout9 = device2.createBindGroupLayout({
+label: '\u1848\u{1fdd5}',
+entries: [{
+binding: 1877,
+visibility: 0,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+}, {
+binding: 2892,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+}],
+});
+let commandEncoder31 = device2.createCommandEncoder();
+let texture37 = device2.createTexture({
+label: '\u0cf7\u0a0a\u2184',
+size: [3720, 210, 1],
+dimension: '2d',
+format: 'astc-10x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-10x6-unorm-srgb', 'astc-10x6-unorm'],
+});
+let textureView31 = texture35.createView({baseMipLevel: 2, arrayLayerCount: 1});
+document.body.prepend(canvas2);
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline20 = device1.createRenderPipeline({
+label: '\u0145\u{1f99e}\uc58e',
+layout: pipelineLayout3,
+multisample: {
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-constant'},
+alpha: {operation: 'subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'dst'},
+},
+  writeMask: 0
+}, {format: 'r32uint', writeMask: GPUColorWrite.RED}, {format: 'rg8sint'}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'one-minus-constant'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {format: 'r32uint', writeMask: 0}, {format: 'r32sint'}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'invert',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 1289,
+stencilWriteMask: 1060,
+depthBias: 69,
+depthBiasSlopeScale: 56,
+depthBiasClamp: 98,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+attributes: [{
+format: 'sint32',
+offset: 27776,
+shaderLocation: 15,
+}, {
+format: 'sint32x4',
+offset: 7272,
+shaderLocation: 13,
+}, {
+format: 'sint32x3',
+offset: 19680,
+shaderLocation: 16,
+}, {
+format: 'uint32x3',
+offset: 1476,
+shaderLocation: 24,
+}, {
+format: 'sint32x4',
+offset: 20452,
+shaderLocation: 25,
+}, {
+format: 'uint32x4',
+offset: 2652,
+shaderLocation: 17,
+}, {
+format: 'unorm16x2',
+offset: 15132,
+shaderLocation: 2,
+}, {
+format: 'snorm16x2',
+offset: 9968,
+shaderLocation: 1,
+}, {
+format: 'uint8x4',
+offset: 32284,
+shaderLocation: 22,
+}],
+},
+{
+arrayStride: 15040,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm16x2',
+offset: 11196,
+shaderLocation: 8,
+}, {
+format: 'uint32',
+offset: 664,
+shaderLocation: 14,
+}, {
+format: 'unorm16x4',
+offset: 13804,
+shaderLocation: 7,
+}, {
+format: 'uint32',
+offset: 1576,
+shaderLocation: 12,
+}, {
+format: 'snorm8x4',
+offset: 7428,
+shaderLocation: 6,
+}, {
+format: 'uint32x2',
+offset: 3204,
+shaderLocation: 10,
+}, {
+format: 'sint8x4',
+offset: 8120,
+shaderLocation: 5,
+}, {
+format: 'snorm8x4',
+offset: 2744,
+shaderLocation: 21,
+}, {
+format: 'uint32x4',
+offset: 5860,
+shaderLocation: 26,
+}, {
+format: 'unorm8x4',
+offset: 9332,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 29636,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 19782,
+shaderLocation: 20,
+}, {
+format: 'float32x2',
+offset: 3144,
+shaderLocation: 4,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let commandEncoder32 = device0.createCommandEncoder();
+try {
+commandEncoder25.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 10, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 48, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 35, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 1124, new DataView(new ArrayBuffer(61305)), 22959, 56);
+} catch {}
+let promise7 = device0.createComputePipelineAsync({
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipelineLayout4 = device2.createPipelineLayout({label: '\u{1ff03}\ua47a\u0509\u69d6\u06c0\u{1f784}\u{1fcdc}\u{1f737}\uecca', bindGroupLayouts: []});
+let querySet20 = device1.createQuerySet({
+type: 'occlusion',
+count: 1396,
+});
+let texture38 = device1.createTexture({
+size: [96, 1, 1],
+mipLevelCount: 4,
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba8unorm'],
+});
+try {
+commandEncoder15.copyTextureToBuffer({
+  texture: texture27,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 8 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 5424 */
+offset: 5424,
+bytesPerRow: 0,
+rowsPerImage: 94,
+buffer: buffer8,
+}, {width: 0, height: 0, depthOrArrayLayers: 166});
+dissociateBuffer(device1, buffer8);
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout({
+label: '\u45aa\u923b\u{1ffa4}\u02a4',
+entries: [{
+binding: 4290,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}, {
+binding: 5366,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+}, {
+binding: 6107,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}],
+});
+let commandBuffer3 = commandEncoder21.finish({
+label: '\u{1fca8}\u410f\u0554\u04a7\uec00\u522f\u0fe0\ua51c\u0de2\u38e8\u{1fbb3}',
+});
+let sampler17 = device0.createSampler({
+label: '\u09a6\u0db4\u184b\ud8ea\u{1f850}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+lodMinClamp: 53.051,
+lodMaxClamp: 53.062,
+compare: 'always',
+});
+let pipeline21 = device0.createRenderPipeline({
+label: '\ud587\u{1fa33}\ue21b\u0b93\u0f94\u0347\u05a0',
+layout: 'auto',
+multisample: {
+mask: 0x7a86ba35,
+},
+fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rgba16sint'}]},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 1149,
+stencilWriteMask: 3340,
+depthBias: 54,
+depthBiasSlopeScale: 41,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 14132,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 7992,
+shaderLocation: 3,
+}, {
+format: 'snorm8x2',
+offset: 2432,
+shaderLocation: 10,
+}, {
+format: 'sint8x4',
+offset: 9036,
+shaderLocation: 16,
+}, {
+format: 'uint32',
+offset: 2628,
+shaderLocation: 14,
+}, {
+format: 'snorm16x2',
+offset: 8132,
+shaderLocation: 11,
+}, {
+format: 'snorm8x2',
+offset: 11114,
+shaderLocation: 2,
+}, {
+format: 'float32x2',
+offset: 4504,
+shaderLocation: 12,
+}, {
+format: 'sint16x2',
+offset: 6988,
+shaderLocation: 8,
+}, {
+format: 'uint16x2',
+offset: 13268,
+shaderLocation: 7,
+}, {
+format: 'sint32x3',
+offset: 7272,
+shaderLocation: 19,
+}, {
+format: 'float32',
+offset: 10140,
+shaderLocation: 0,
+}, {
+format: 'uint32x3',
+offset: 9404,
+shaderLocation: 17,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x4',
+offset: 5572,
+shaderLocation: 15,
+}, {
+format: 'uint32x2',
+offset: 10636,
+shaderLocation: 13,
+}, {
+format: 'float16x2',
+offset: 8488,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 564,
+shaderLocation: 5,
+}, {
+format: 'snorm8x2',
+offset: 922,
+shaderLocation: 1,
+}, {
+format: 'unorm16x4',
+offset: 12352,
+shaderLocation: 6,
+}, {
+format: 'snorm8x2',
+offset: 8244,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 5656,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32',
+offset: 2836,
+shaderLocation: 18,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let buffer12 = device1.createBuffer({label: '\u6673\ue232\u0397\ud7e0\ue6e8', size: 1032, usage: GPUBufferUsage.INDEX, mappedAtCreation: true});
+let renderBundleEncoder17 = device1.createRenderBundleEncoder({
+  label: '\u0d0d\u0dbc',
+  colorFormats: ['r8unorm', 'r32uint', 'rg8sint', 'rg8unorm', 'r32uint', 'r32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1,
+  stencilReadOnly: false
+});
+let sampler18 = device1.createSampler({
+label: '\ucf3a\u08a4\u0909\u0b33\u{1fa6e}',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 12.677,
+maxAnisotropy: 9,
+});
+try {
+commandEncoder15.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 9,
+  origin: { x: 0, y: 0, z: 73 },
+  aspect: 'all',
+}, {
+  texture: texture27,
+  mipLevel: 1,
+  origin: { x: 1060, y: 6, z: 92 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 6});
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer8, 9392, 1476);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer8, 4420, new Int16Array(22555), 6517, 2172);
+} catch {}
+let pipeline22 = device1.createComputePipeline({
+label: '\u0de8\u66a0',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipelineLayout5 = device0.createPipelineLayout({
+  label: '\u08f7\ud609\u3a64\u0195\u971d\u{1f8cc}\u{1fa19}',
+  bindGroupLayouts: [bindGroupLayout4, bindGroupLayout7, bindGroupLayout1, bindGroupLayout0]
+});
+let buffer13 = device0.createBuffer({label: '\u2021\uaeab', size: 61068, usage: GPUBufferUsage.UNIFORM});
+let computePassEncoder13 = commandEncoder16.beginComputePass({label: '\u398a\u8316\u0798\u005d\u0136'});
+let externalTexture2 = device0.importExternalTexture({
+label: '\u{1ff1d}\ud820\u0c68\u{1fc2d}',
+source: video3,
+colorSpace: 'srgb',
+});
+try {
+commandEncoder32.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 2,
+  origin: { x: 90, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture16,
+  mipLevel: 6,
+  origin: { x: 5, y: 4, z: 1 },
+  aspect: 'all',
+}, {width: 35, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder30.resolveQuerySet(querySet18, 190, 97, buffer2, 2560);
+} catch {}
+video1.height = 294;
+let bindGroupLayout11 = device1.createBindGroupLayout({
+label: '\u5733\u28a2\u70f8\u2485\ud703\uffe9\u9152\u0833\u007c',
+entries: [{
+binding: 542,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+}],
+});
+let textureView32 = texture17.createView({dimension: '2d', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 60});
+let renderBundleEncoder18 = device1.createRenderBundleEncoder({
+  label: '\u0b50\u{1fb51}\u6435\u{1f7f5}\u{1fa5b}\u0804',
+  colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint'],
+  depthReadOnly: true
+});
+let renderBundle29 = renderBundleEncoder14.finish({label: '\u{1fa9f}\u01e1\u5131\u{1fda9}\u0e2e\u457f\u2913\u{1faa6}\u{1f826}\u5fc2'});
+let promise8 = buffer8.mapAsync(GPUMapMode.READ, 6664, 2504);
+try {
+computePassEncoder8.insertDebugMarker('\u04e8');
+} catch {}
+let commandEncoder33 = device1.createCommandEncoder();
+let textureView33 = texture25.createView({label: '\u8a84\ufb6d\u7996', format: 'astc-8x6-unorm', mipLevelCount: 2});
+let renderBundle30 = renderBundleEncoder18.finish();
+try {
+commandEncoder15.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 1,
+  origin: { x: 250, y: 0, z: 76 },
+  aspect: 'all',
+}, {
+  texture: texture27,
+  mipLevel: 6,
+  origin: { x: 10, y: 0, z: 12 },
+  aspect: 'all',
+}, {width: 10, height: 0, depthOrArrayLayers: 87});
+} catch {}
+let promise9 = device1.createRenderPipelineAsync({
+label: '\u7e26\u{1f716}\u069a\u{1fdc3}\u94c0\u0635\u0514\u0b18\ud2a5\u0f42',
+layout: pipelineLayout3,
+multisample: {
+mask: 0x7c90a4b5,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'src-alpha-saturated'},
+},
+  writeMask: 0
+}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'subtract', srcFactor: 'one', dstFactor: 'src-alpha'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less',
+failOp: 'keep',
+depthFailOp: 'decrement-wrap',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+},
+stencilReadMask: 1437,
+stencilWriteMask: 2003,
+depthBias: 37,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 19192,
+attributes: [{
+format: 'sint32x3',
+offset: 15348,
+shaderLocation: 15,
+}, {
+format: 'uint16x2',
+offset: 6160,
+shaderLocation: 24,
+}, {
+format: 'uint8x2',
+offset: 12252,
+shaderLocation: 10,
+}, {
+format: 'sint32x2',
+offset: 6420,
+shaderLocation: 25,
+}, {
+format: 'unorm16x2',
+offset: 7392,
+shaderLocation: 2,
+}, {
+format: 'sint16x4',
+offset: 10964,
+shaderLocation: 13,
+}, {
+format: 'float32x3',
+offset: 968,
+shaderLocation: 1,
+}, {
+format: 'float16x2',
+offset: 19068,
+shaderLocation: 8,
+}, {
+format: 'uint32',
+offset: 12556,
+shaderLocation: 26,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 14364,
+shaderLocation: 12,
+}, {
+format: 'snorm16x4',
+offset: 30240,
+shaderLocation: 4,
+}, {
+format: 'uint8x4',
+offset: 35144,
+shaderLocation: 14,
+}, {
+format: 'snorm8x2',
+offset: 7708,
+shaderLocation: 7,
+}, {
+format: 'unorm16x2',
+offset: 27148,
+shaderLocation: 21,
+}, {
+format: 'snorm8x4',
+offset: 9004,
+shaderLocation: 6,
+}, {
+format: 'sint8x2',
+offset: 22138,
+shaderLocation: 5,
+}, {
+format: 'uint8x4',
+offset: 22596,
+shaderLocation: 22,
+}, {
+format: 'sint32x3',
+offset: 336,
+shaderLocation: 16,
+}, {
+format: 'uint8x2',
+offset: 23656,
+shaderLocation: 17,
+}],
+},
+{
+arrayStride: 8476,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x2',
+offset: 7250,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 23088,
+attributes: [{
+format: 'float32x2',
+offset: 17548,
+shaderLocation: 20,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: false,
+},
+});
+let canvas3 = document.createElement('canvas');
+let offscreenCanvas6 = new OffscreenCanvas(300, 216);
+try {
+gpuCanvasContext0.configure({
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let buffer14 = device2.createBuffer({label: '\u{1f82a}\u{1f641}', size: 63543, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let querySet21 = device2.createQuerySet({
+label: '\ud463\u5cad\ud8f7\ub21d\u7a82',
+type: 'occlusion',
+count: 530,
+});
+let textureView34 = texture33.createView({dimension: '2d', baseMipLevel: 2, mipLevelCount: 2, baseArrayLayer: 41});
+let sampler19 = device2.createSampler({
+label: '\u6eda\ufc58\u27da\u8c49\u9069\u6086\u0871\u030f\u8c33\ufccc\ufc3a',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 71.163,
+});
+try {
+  await promise8;
+} catch {}
+let imageBitmap8 = await createImageBitmap(canvas1);
+let textureView35 = texture27.createView({
+  label: '\u6334\u{1f9d9}\u4293\u06b2',
+  dimension: '2d',
+  baseMipLevel: 4,
+  mipLevelCount: 3,
+  baseArrayLayer: 133,
+  arrayLayerCount: 1
+});
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas0,
+  origin: { x: 238, y: 91 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 25, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 13, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext5 = canvas3.getContext('webgpu');
+let canvas4 = document.createElement('canvas');
+let texture39 = device2.createTexture({
+label: '\u352c\u0d36\u{1ffe2}\u{1fe0f}\u2e61\u{1fae8}\u0e0c\u0462\u59f0',
+size: {width: 180, height: 10, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-12x10-unorm', 'astc-12x10-unorm-srgb', 'astc-12x10-unorm-srgb'],
+});
+try {
+commandEncoder31.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 1,
+  origin: { x: 63, y: 3, z: 70 },
+  aspect: 'all',
+}, {
+  texture: texture35,
+  mipLevel: 2,
+  origin: { x: 37, y: 5, z: 23 },
+  aspect: 'all',
+}, {width: 22, height: 4, depthOrArrayLayers: 23});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: { x: 1640, y: 150, z: 0 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 346 */
+{offset: 346}, {width: 2030, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let adapter3 = await navigator.gpu.requestAdapter({
+});
+let querySet22 = device1.createQuerySet({
+label: '\u0681\u63b4\u0aed\u{1faae}\ubdd9\u{1f88f}',
+type: 'occlusion',
+count: 2793,
+});
+let renderBundle31 = renderBundleEncoder9.finish();
+try {
+device1.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 1,
+  origin: { x: 28, y: 69, z: 187 },
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(56)), /* required buffer size: 116933 */
+{offset: 764, bytesPerRow: 53, rowsPerImage: 186}, {width: 23, height: 146, depthOrArrayLayers: 12});
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas1,
+  origin: { x: 64, y: 33 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 42, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let textureView36 = texture34.createView({
+  label: '\u09c4\u{1f66e}\u04b7\u{1f6e4}\uf887\u026a\ucfa4\u5362\u7e0a\u0d67',
+  baseMipLevel: 3,
+  baseArrayLayer: 86
+});
+try {
+renderBundleEncoder16.setVertexBuffer(8, buffer4, 9132, 9268);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 1,
+  origin: { x: 96, y: 2, z: 0 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 758 */
+{offset: 758, bytesPerRow: 1034}, {width: 238, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let pipeline23 = await device0.createComputePipelineAsync({
+label: '\u01b1\u2ab1\ud57e\u{1fae1}\u93ba\u8a38\u7d30\u8c56\u4f4a',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let commandEncoder34 = device0.createCommandEncoder({label: '\u0f80\u097f\u0ef7\ua806\u094f\u2bb4\ua4fb\u454f\u8877'});
+let texture40 = device0.createTexture({
+label: '\u0813\u07c5\uff25\u0be4\u{1fbfe}\u0dbe\uec0d\u1d89',
+size: [735],
+dimension: '1d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({
+  label: '\u9cfd\u05f8\u3976',
+  colorFormats: ['rg8sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let commandBuffer4 = commandEncoder33.finish();
+let textureView37 = texture23.createView({baseMipLevel: 3});
+try {
+renderBundleEncoder17.setVertexBuffer(36, undefined, 3190219956);
+} catch {}
+let pipeline24 = device1.createRenderPipeline({
+label: '\u85d4\uae42\u9d78\u01ee\u5649\uebcb\u0612\u0e10',
+layout: pipelineLayout3,
+multisample: {
+mask: 0x9272c6ec,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {format: 'r32uint'}, {format: 'rg8sint', writeMask: 0}, {format: 'rg8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'equal',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 1819,
+stencilWriteMask: 2891,
+depthBias: 50,
+depthBiasSlopeScale: 28,
+depthBiasClamp: 77,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 13792,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 754,
+shaderLocation: 17,
+}, {
+format: 'float32x4',
+offset: 7688,
+shaderLocation: 1,
+}, {
+format: 'sint16x2',
+offset: 7084,
+shaderLocation: 16,
+}, {
+format: 'uint32x2',
+offset: 12384,
+shaderLocation: 22,
+}, {
+format: 'unorm10-10-10-2',
+offset: 60,
+shaderLocation: 21,
+}, {
+format: 'sint32x3',
+offset: 13116,
+shaderLocation: 25,
+}, {
+format: 'sint8x4',
+offset: 13224,
+shaderLocation: 15,
+}, {
+format: 'snorm8x2',
+offset: 6150,
+shaderLocation: 6,
+}, {
+format: 'snorm16x2',
+offset: 2044,
+shaderLocation: 8,
+}, {
+format: 'sint32x2',
+offset: 7200,
+shaderLocation: 5,
+}, {
+format: 'uint32',
+offset: 9532,
+shaderLocation: 14,
+}, {
+format: 'uint32x3',
+offset: 4068,
+shaderLocation: 12,
+}, {
+format: 'float16x2',
+offset: 4832,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 20556,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm16x4',
+offset: 10068,
+shaderLocation: 20,
+}, {
+format: 'sint32',
+offset: 10592,
+shaderLocation: 13,
+}, {
+format: 'unorm8x4',
+offset: 14768,
+shaderLocation: 0,
+}, {
+format: 'uint32x4',
+offset: 6224,
+shaderLocation: 26,
+}, {
+format: 'uint32x4',
+offset: 8756,
+shaderLocation: 24,
+}, {
+format: 'unorm8x4',
+offset: 3692,
+shaderLocation: 4,
+}, {
+format: 'float32x3',
+offset: 17140,
+shaderLocation: 2,
+}, {
+format: 'uint32x2',
+offset: 2620,
+shaderLocation: 10,
+}],
+}
+]
+},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+pseudoSubmit(device2, commandEncoder29);
+let renderBundleEncoder20 = device2.createRenderBundleEncoder({
+  label: '\ueb03\u1985\u729d',
+  colorFormats: ['rgba32sint', 'r8unorm', 'rg8uint', undefined, undefined, 'rgba8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let video5 = await videoWithData();
+let querySet23 = device2.createQuerySet({
+type: 'occlusion',
+count: 3897,
+});
+let texture41 = device2.createTexture({
+label: '\u1d1c\u9b52\u{1fb82}\u{1fa46}\ue271\u019f\u6fb7',
+size: {width: 72, height: 12, depthOrArrayLayers: 216},
+mipLevelCount: 7,
+dimension: '2d',
+format: 'etc2-rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['etc2-rgba8unorm-srgb', 'etc2-rgba8unorm'],
+});
+let textureView38 = texture41.createView({dimension: '2d', aspect: 'all', baseMipLevel: 5, baseArrayLayer: 66});
+let renderBundleEncoder21 = device2.createRenderBundleEncoder({
+  label: '\u19f0\u7c6a\u0cf3\uba4d',
+  colorFormats: ['rgba32sint', 'r8unorm', 'rg8uint', undefined, undefined, 'rgba8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder21.setIndexBuffer(buffer11, 'uint16', 21822);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 1,
+  origin: { x: 3, y: 15, z: 13 },
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 2482919 */
+{offset: 299, bytesPerRow: 492, rowsPerImage: 71}, {width: 120, height: 5, depthOrArrayLayers: 72});
+} catch {}
+pseudoSubmit(device0, commandEncoder10);
+let texture42 = device0.createTexture({
+label: '\ucb77\ucc8f\ue6b8\u00ac',
+size: [1200, 4, 1],
+mipLevelCount: 10,
+format: 'astc-4x4-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-4x4-unorm-srgb', 'astc-4x4-unorm-srgb', 'astc-4x4-unorm'],
+});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({
+  label: '\ua9c4\u{1fa60}\u97c9\u3c59\u20d7',
+  colorFormats: ['rgb10a2unorm', 'rgba32uint', 'bgra8unorm-srgb'],
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let sampler20 = device0.createSampler({
+label: '\u0a2d\u04f9\u{1f956}\u337a',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 30.323,
+});
+try {
+computePassEncoder13.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(7, buffer4, 10696, 13661);
+} catch {}
+try {
+commandEncoder18.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 1,
+  origin: { x: 0, y: 10, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: { x: 140, y: 10, z: 0 },
+  aspect: 'all',
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder26.clearBuffer(buffer3, 58524, 1716);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 340, new DataView(new ArrayBuffer(11199)), 10737, 328);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(9, undefined, 2316541694);
+} catch {}
+try {
+renderBundleEncoder17.insertDebugMarker('\u5ede');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 149, y: 60 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 25, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 2, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder35 = device2.createCommandEncoder({label: '\ufaca\u7b75\ua71f\u13a3'});
+let querySet24 = device2.createQuerySet({
+label: '\u081e\u72e5\u{1fa23}\ua6e7\u00b4\ubf6a\u07e0\u0b92\uadbb\u3c6b',
+type: 'occlusion',
+count: 2768,
+});
+let renderBundleEncoder23 = device2.createRenderBundleEncoder({
+  label: '\u30c7\u5b53\u8466\u645e\u069c\uc19b\u09d1\u970b\u{1f733}\ufa22\u0d42',
+  colorFormats: ['rgba32sint', 'r8unorm', 'rg8uint', undefined, undefined, 'rgba8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+gc();
+let textureView39 = texture17.createView({
+  label: '\u075f\u09e0\u0509\u8660\uaff0\u{1fbb9}\ub036\u032d\u4f92\u04b5',
+  format: 'r16sint',
+  mipLevelCount: 2,
+  baseArrayLayer: 105,
+  arrayLayerCount: 69
+});
+try {
+renderBundleEncoder17.setPipeline(pipeline16);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 5,
+  origin: { x: 40, y: 6, z: 5 },
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 2648789 */
+{offset: 89, bytesPerRow: 75, rowsPerImage: 218}, {width: 20, height: 0, depthOrArrayLayers: 163});
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+/* bytesInLastRow: 3600 widthInBlocks: 225 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 33024 */
+offset: 33024,
+buffer: buffer14,
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: { x: 1110, y: 150, z: 0 },
+  aspect: 'all',
+}, {width: 2250, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer14);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: { x: 0, y: 90, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: { x: 110, y: 24, z: 1 },
+  aspect: 'all',
+}, {width: 3540, height: 18, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext6 = canvas4.getContext('webgpu');
+let textureView40 = texture2.createView({label: '\u7eb4\u8294\u3d8c\u{1fcae}', dimension: '2d', baseMipLevel: 3, mipLevelCount: 2, baseArrayLayer: 20});
+let sampler21 = device0.createSampler({
+label: '\ua94b\u{1ff97}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMaxClamp: 48.211,
+maxAnisotropy: 1,
+});
+try {
+computePassEncoder13.setPipeline(pipeline18);
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(querySet10, 983, 1094, buffer2, 23552);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 576, new Int16Array(54428), 5213, 184);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 755 */
+{offset: 755, bytesPerRow: 320}, {width: 68, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder24 = device1.createRenderBundleEncoder({
+  colorFormats: ['r8unorm', 'r32uint', 'rg8sint', 'rg8unorm', 'r32uint', 'r32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder17.setPipeline(pipeline24);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let device3 = await adapter3.requestDevice({
+label: '\u0384\u9e97\u7441\u00c7\u{1f852}\u{1ffb9}\ubf07\u06f4\u{1fa95}\u7b90\u6053',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 38,
+maxVertexAttributes: 26,
+maxVertexBufferArrayStride: 28734,
+maxStorageBuffersPerShaderStage: 30,
+maxDynamicStorageBuffersPerPipelineLayout: 4675,
+maxBindingsPerBindGroup: 8595,
+maxTextureDimension1D: 8433,
+maxTextureDimension2D: 14738,
+maxVertexBuffers: 11,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 156416686,
+maxUniformBuffersPerShaderStage: 26,
+maxInterStageShaderVariables: 83,
+maxInterStageShaderComponents: 100,
+maxSamplersPerShaderStage: 21,
+},
+});
+let commandBuffer5 = commandEncoder15.finish();
+try {
+renderBundleEncoder17.setPipeline(pipeline20);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new Int32Array(arrayBuffer2), /* required buffer size: 733 */
+{offset: 733, rowsPerImage: 159}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let querySet25 = device1.createQuerySet({
+label: '\u0ed2\u{1fb7a}\ub23a\u13f5\u{1fb53}\u{1ff67}\u{1f85d}\u{1fead}\u970f',
+type: 'occlusion',
+count: 2082,
+});
+let renderBundleEncoder25 = device1.createRenderBundleEncoder({
+  label: '\u0d3e\u09a2\u035e\u0e2c\u{1f878}\u{1f93e}\u349a\u5256',
+  colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let textureView41 = texture27.createView({label: '\u85ce\uedd0\u19f1\u{1fe98}', dimension: '2d', baseMipLevel: 4, mipLevelCount: 5, baseArrayLayer: 60});
+let buffer15 = device0.createBuffer({size: 12520, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: true});
+let querySet26 = device0.createQuerySet({
+label: '\u02bd\u057f\u7d7d\ub0c1\u0eab\u4ff8',
+type: 'occlusion',
+count: 2834,
+});
+let textureView42 = texture29.createView({label: '\u42c0\u050e\u0306\u7760\u1312\u0d2e\u{1f8cf}\u{1fcc6}\u0e9c', aspect: 'all', baseMipLevel: 3});
+try {
+  await buffer5.mapAsync(GPUMapMode.READ, 5688);
+} catch {}
+try {
+commandEncoder22.clearBuffer(buffer3, 40532, 19896);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 1,
+  origin: { x: 30, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 741 */
+{offset: 741}, {width: 50, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame7 = new VideoFrame(imageBitmap5, {timestamp: 0});
+let querySet27 = device1.createQuerySet({
+label: '\u47d5\u{1f6bb}\u2f96\u257e\u{1f79a}\u8efa\u0439\u0f6a\u{1ff8f}\u024c',
+type: 'occlusion',
+count: 120,
+});
+let renderBundleEncoder26 = device1.createRenderBundleEncoder({
+  label: '\u{1f9ec}\u0013\u6270\u0e73\u{1f73a}\u{1f8d3}\ud055\u52eb\u1c6e\u{1fc1b}\u7571',
+  colorFormats: ['r8unorm', 'r32uint', 'rg8sint', 'rg8unorm', 'r32uint', 'r32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+let sampler22 = device1.createSampler({
+label: '\u0a22\u{1fea0}\u378c\u0934\u30a3\u523e\u{1fb3c}\u{1f8dd}\uaff7\u6877\u1a4a',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 93.673,
+lodMaxClamp: 97.197,
+maxAnisotropy: 9,
+});
+let offscreenCanvas7 = new OffscreenCanvas(131, 199);
+let buffer16 = device0.createBuffer({label: '\u2bb2\u17be\u0b3c\u0ef7', size: 16606, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let texture43 = device0.createTexture({
+label: '\u4076\u2510\u{1f7a3}\u0d10\ud2a7\u0952\u0e98\u{1f8eb}\uac2e\u08c2',
+size: [2940, 1, 1],
+mipLevelCount: 9,
+dimension: '2d',
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView43 = texture40.createView({label: '\u{1fe06}\ub7db\udfc6'});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({
+  colorFormats: ['r8sint', 'rg16float', 'rgba16float'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+let sampler23 = device0.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 27.887,
+lodMaxClamp: 99.113,
+});
+try {
+renderBundleEncoder19.setVertexBuffer(3, buffer4, 5604, 9004);
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: { x: 74, y: 11, z: 10 },
+  aspect: 'all',
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: { x: 208, y: 1, z: 1 },
+  aspect: 'all',
+}, {width: 52, height: 14, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg8unorm'],
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let canvas5 = document.createElement('canvas');
+let texture44 = device3.createTexture({
+size: [1008, 120, 878],
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['r8uint', 'r8uint', 'r8uint'],
+});
+let textureView44 = texture44.createView({label: '\u3aeb\u0035\u488f\ub068\u73a7\u0512'});
+let adapter4 = await navigator.gpu.requestAdapter({
+});
+let texture45 = device1.createTexture({
+label: '\u0032\u9dc0\ufc43\u6e26\u07d8\u{1fe3c}\u{1f88f}\u038f\u8a64\u63af',
+size: [96, 1, 1],
+mipLevelCount: 7,
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderBundleEncoder17.draw(64, 40, 8, 56);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(32, 40);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(9, undefined, 3138964128, 489204560);
+} catch {}
+try {
+buffer12.destroy();
+} catch {}
+let commandEncoder36 = device2.createCommandEncoder({});
+let sampler24 = device2.createSampler({
+label: '\u0bf4\uc844\u069d',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+lodMinClamp: 42.943,
+lodMaxClamp: 57.732,
+});
+document.body.prepend(img3);
+try {
+renderBundleEncoder17.draw(32, 32, 0, 8);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 508, y: 121 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 11, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 37, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let querySet28 = device2.createQuerySet({
+label: '\uc652\u{1f70f}\u505c\u{1f714}\u56a3\u4f78\ud462\uaf0f\u23dd\u022b',
+type: 'occlusion',
+count: 1520,
+});
+let texture46 = device2.createTexture({
+label: '\u5e23\ud3b1\u{1f979}\uc221',
+size: [8052, 1, 1],
+mipLevelCount: 8,
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let computePassEncoder14 = commandEncoder35.beginComputePass({label: '\u80c0\u4091\u0c66'});
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+let texture47 = gpuCanvasContext2.getCurrentTexture();
+try {
+gpuCanvasContext6.configure({
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x10-unorm-srgb', 'depth32float-stencil8', 'astc-10x8-unorm-srgb', 'rgba8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let imageData10 = new ImageData(256, 112);
+let querySet29 = device3.createQuerySet({
+label: '\u0e2f\u03fb\uefcd\ud05d\u06df\u5abe\u7729',
+type: 'occlusion',
+count: 2834,
+});
+let texture48 = device3.createTexture({
+label: '\u3241\u0b1c\u0443\u80cb\u453a\u{1f9dc}\u{1fd2a}\u691a\u{1ff6e}\u{1fbc6}\u0380',
+size: {width: 240, height: 960, depthOrArrayLayers: 1},
+mipLevelCount: 10,
+format: 'astc-6x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-6x6-unorm'],
+});
+let renderBundleEncoder28 = device3.createRenderBundleEncoder({
+  colorFormats: ['r8uint', undefined, 'r32sint', 'rgba8uint', 'rg8unorm', 'rg8uint', 'rg32uint', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let sampler25 = device3.createSampler({
+label: '\u{1f659}\ueba5\u0322',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 47.141,
+lodMaxClamp: 83.304,
+});
+try {
+await device3.popErrorScope();
+} catch {}
+let textureView45 = texture4.createView({
+  label: '\u88f8\u3789\u3b98\u7699\ua705',
+  dimension: '2d',
+  baseMipLevel: 3,
+  mipLevelCount: 2,
+  baseArrayLayer: 29,
+  arrayLayerCount: 1
+});
+try {
+computePassEncoder11.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(1, buffer4, 16316, 1806);
+} catch {}
+let arrayBuffer7 = buffer3.getMappedRange(27888, 5756);
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 10,
+  origin: { x: 4, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture11,
+  mipLevel: 6,
+  origin: { x: 28, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let adapter5 = await navigator.gpu.requestAdapter({
+});
+try {
+canvas5.getContext('webgl2');
+} catch {}
+pseudoSubmit(device2, commandEncoder35);
+let texture49 = device2.createTexture({
+label: '\u05a8\ufae1\u1cc9',
+size: [8750, 168, 173],
+mipLevelCount: 7,
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView46 = texture46.createView({dimension: '2d-array', baseMipLevel: 6, mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder15 = commandEncoder27.beginComputePass({label: '\u60f9\ue158'});
+let renderBundleEncoder29 = device2.createRenderBundleEncoder({
+  colorFormats: ['rgba32sint', 'r8unorm', 'rg8uint', undefined, undefined, 'rgba8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler26 = device2.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 61.873,
+lodMaxClamp: 79.091,
+});
+try {
+renderBundleEncoder23.setIndexBuffer(buffer11, 'uint16', 28266, 2489);
+} catch {}
+let querySet30 = device2.createQuerySet({
+label: '\u0107\u4558\u0f38\u6691\u0ca7\u0d34\u9cb5\u7aca\u0d4a',
+type: 'occlusion',
+count: 2962,
+});
+pseudoSubmit(device2, commandEncoder36);
+try {
+device2.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: { x: 320, y: 36, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 21637 */
+{offset: 667, bytesPerRow: 5246}, {width: 3270, height: 24, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(canvas3);
+let commandEncoder37 = device2.createCommandEncoder({label: '\ub412\uc15c\u5c7e\u019b\u8031'});
+let querySet31 = device2.createQuerySet({
+label: '\uaf79\ud472\u{1fc4f}\u{1fdf4}\u0875\u{1feba}',
+type: 'occlusion',
+count: 2343,
+});
+let promise10 = device2.queue.onSubmittedWorkDone();
+try {
+offscreenCanvas7.getContext('2d');
+} catch {}
+let pipelineLayout6 = device2.createPipelineLayout({label: '\u0474\u6ccc\u6da9\u3d24\u454e\u2488', bindGroupLayouts: [bindGroupLayout9, bindGroupLayout8]});
+let renderBundleEncoder30 = device2.createRenderBundleEncoder({
+  label: '\u02b6\u{1fb58}\u791e\u7188\u1b54',
+  colorFormats: ['rgba32sint', 'r8unorm', 'rg8uint', undefined, undefined, 'rgba8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+let sampler27 = device2.createSampler({
+label: '\u3e49\u{1f66d}\uead5\u{1fadb}\uc7ef',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 93.225,
+lodMaxClamp: 95.827,
+});
+try {
+device2.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 2,
+  origin: { x: 6, y: 5, z: 3 },
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 1904676 */
+{offset: 778, bytesPerRow: 445, rowsPerImage: 186}, {width: 47, height: 1, depthOrArrayLayers: 24});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(957, 2);
+try {
+offscreenCanvas8.getContext('webgl2');
+} catch {}
+let texture50 = device2.createTexture({
+size: [576, 96, 231],
+mipLevelCount: 9,
+sampleCount: 1,
+format: 'etc2-rgb8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['etc2-rgb8unorm-srgb', 'etc2-rgb8unorm-srgb', 'etc2-rgb8unorm'],
+});
+let textureView47 = texture39.createView({
+  label: '\u25d8\u{1ff84}\u01a5\u{1feb7}\u{1fb8d}\u85c6\ua728\u4082\u6911\ub99b\u0051',
+  aspect: 'all',
+  format: 'astc-12x10-unorm-srgb',
+  baseMipLevel: 3,
+  arrayLayerCount: 1
+});
+try {
+renderBundleEncoder29.pushDebugGroup('\u8cb3');
+} catch {}
+try {
+renderBundleEncoder29.popDebugGroup();
+} catch {}
+let commandEncoder38 = device0.createCommandEncoder({label: '\ue220\u{1f94d}\u4ce5\u0a6d'});
+let commandBuffer6 = commandEncoder26.finish({
+label: '\u08b7\u03c9\u002b\ufb3e\u{1fc9f}\u9117\u59b6\u003c\u0709\ue04b\u3ea9',
+});
+let sampler28 = device0.createSampler({
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 34.907,
+lodMaxClamp: 40.361,
+});
+try {
+device0.queue.submit([
+commandBuffer2,
+commandBuffer6,
+]);
+} catch {}
+try {
+renderBundleEncoder17.draw(8);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['bgra8unorm', 'bgra8unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder39 = device1.createCommandEncoder({label: '\u{1fafd}\u042a\u045f\u25f8\uf300\ud4bd\ufde3\u0430\u0986\uea98\u0540'});
+let querySet32 = device1.createQuerySet({
+label: '\uf2cf\u4ebb\u03dc\ue06d\u9916\u{1fea0}\u{1ff6a}\u9861\ua8e7\u0531',
+type: 'occlusion',
+count: 2126,
+});
+let renderBundleEncoder31 = device1.createRenderBundleEncoder({
+  colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder17.drawIndexed(8, 0, 16, 752, 64);
+} catch {}
+try {
+commandEncoder39.clearBuffer(buffer8, 5040, 688);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 5, y: 7 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 11, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 23, height: 2, depthOrArrayLayers: 1});
+} catch {}
+let pipeline25 = device1.createComputePipeline({
+label: '\ub331\u{1fd8c}\ud5e0\u023e\u66d2\u0fd9\ucbbd\u5a7c\u0e9b',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let commandEncoder40 = device1.createCommandEncoder({label: '\u8c6e\u5211\u0963\ubbad\u0949\u{1f672}\u{1fa06}\u0f45'});
+let texture51 = device1.createTexture({
+size: {width: 108, height: 768, depthOrArrayLayers: 176},
+mipLevelCount: 2,
+format: 'astc-4x4-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-4x4-unorm-srgb', 'astc-4x4-unorm-srgb', 'astc-4x4-unorm'],
+});
+let textureView48 = texture45.createView({label: '\ucaac\ub085\uf90f\u0db9\u2516\u520a\u{1ff7b}\u5747\u0a44', format: 'r32sint', baseMipLevel: 6});
+try {
+renderBundleEncoder17.draw(64);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(80, 32, 16);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: video1,
+  origin: { x: 5, y: 8 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 6, y: 2, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let bindGroupLayout12 = device0.createBindGroupLayout({
+label: '\u{1fa6a}\u{1fea3}\ud2b2\u62df',
+entries: [],
+});
+let buffer17 = device0.createBuffer({
+  label: '\u0200\u{1fe41}',
+  size: 26628,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM
+});
+let shaderModule2 = device1.createShaderModule({
+code: `@group(3) @binding(704)
+var<storage, read_write> local1: array<u32>;
+@group(0) @binding(1300)
+var<storage, read_write> type2: array<u32>;
+@group(4) @binding(1300)
+var<storage, read_write> field0: array<u32>;
+@group(3) @binding(1300)
+var<storage, read_write> field1: array<u32>;
+@group(2) @binding(1300)
+var<storage, read_write> i2: array<u32>;
+@group(1) @binding(1300)
+var<storage, read_write> local2: array<u32>;
+@group(1) @binding(704)
+var<storage, read_write> local3: array<u32>;
+@group(4) @binding(704)
+var<storage, read_write> local4: array<u32>;
+@group(2) @binding(704)
+var<storage, read_write> parameter2: array<u32>;
+
+@compute @workgroup_size(4, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<i32>,
+  @location(0) f1: vec4<i32>,
+  @location(4) f2: vec2<f32>,
+  @location(2) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S2 {
+  @location(9) f0: vec3<u32>,
+  @location(14) f1: vec4<i32>,
+  @location(12) f2: vec3<f16>,
+  @location(20) f3: vec2<u32>,
+  @location(7) f4: vec3<i32>,
+  @location(16) f5: vec3<f32>,
+  @location(4) f6: f32,
+  @location(21) f7: vec2<u32>,
+  @location(13) f8: f32,
+  @location(1) f9: vec2<u32>,
+  @location(2) f10: vec2<u32>,
+  @location(26) f11: vec3<f32>,
+  @location(19) f12: vec3<f16>,
+  @location(3) f13: vec2<u32>,
+  @location(10) f14: vec3<i32>,
+  @location(11) f15: vec2<u32>,
+  @location(0) f16: vec3<f16>,
+  @location(22) f17: vec2<i32>,
+  @location(6) f18: vec3<u32>,
+  @location(23) f19: vec2<f16>,
+  @location(5) f20: u32,
+  @location(25) f21: vec4<i32>,
+  @location(8) f22: vec4<u32>,
+  @builtin(vertex_index) f23: u32
+}
+
+@vertex
+fn vertex0(@location(18) a0: f16, @location(17) a1: vec2<i32>, @location(15) a2: vec4<f32>, @location(24) a3: vec4<f32>, a4: S2, @builtin(instance_index) a5: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let buffer18 = device1.createBuffer({size: 55321, usage: GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let renderBundleEncoder32 = device1.createRenderBundleEncoder({
+  label: '\u0d87\uc61f\u086c\u0d3c\u2790\u383d\u{1fbab}\u0ec2',
+  colorFormats: ['rgba32sint', 'rg8sint', 'rgba32uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder17.draw(56, 24, 56);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(7, buffer18, 44212);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: video3,
+  origin: { x: 2, y: 7 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 19, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 13, height: 2, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas9 = new OffscreenCanvas(358, 24);
+let img5 = await imageWithData(27, 89, '#fcbf870f', '#9c55cd8f');
+let commandEncoder41 = device2.createCommandEncoder({label: '\u0112\u{1fb3b}\uf81b\u2b6c\ue878\u039b\u001e\u317c'});
+pseudoSubmit(device2, commandEncoder37);
+let canvas6 = document.createElement('canvas');
+let sampler29 = device3.createSampler({
+label: '\uf92e\u0092\u{1f9ab}\u0044',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 71.766,
+lodMaxClamp: 77.356,
+maxAnisotropy: 18,
+});
+try {
+renderBundleEncoder28.setVertexBuffer(84, undefined, 3091826145, 763781219);
+} catch {}
+let bindGroupLayout13 = device0.createBindGroupLayout({
+label: '\u53f5\u5f46\u0af8\u0510',
+entries: [{
+binding: 2828,
+visibility: 0,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}, {
+binding: 869,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+let commandEncoder42 = device0.createCommandEncoder({label: '\uc73f\u0eee\u8677\u0d61\ud74b'});
+let texture52 = gpuCanvasContext0.getCurrentTexture();
+try {
+commandEncoder32.clearBuffer(buffer10, 372, 684);
+dissociateBuffer(device0, buffer10);
+} catch {}
+let pipeline26 = await device0.createRenderPipelineAsync({
+label: '\u095a\u0e1c\u0ee6\u09d8\u948f\u{1fbc1}\ud349\ub878\u{1fec5}\u{1f752}',
+layout: pipelineLayout0,
+multisample: {
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16sint', writeMask: GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 544,
+depthBiasSlopeScale: 84,
+depthBiasClamp: 30,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 13888,
+attributes: [{
+format: 'snorm8x4',
+offset: 9284,
+shaderLocation: 6,
+}, {
+format: 'snorm16x4',
+offset: 1512,
+shaderLocation: 0,
+}, {
+format: 'unorm16x2',
+offset: 10420,
+shaderLocation: 11,
+}, {
+format: 'sint32x3',
+offset: 9116,
+shaderLocation: 15,
+}, {
+format: 'uint32',
+offset: 4688,
+shaderLocation: 13,
+}, {
+format: 'float16x2',
+offset: 7128,
+shaderLocation: 2,
+}, {
+format: 'snorm16x4',
+offset: 7464,
+shaderLocation: 18,
+}, {
+format: 'snorm8x4',
+offset: 8364,
+shaderLocation: 9,
+}, {
+format: 'uint32x3',
+offset: 1968,
+shaderLocation: 7,
+}, {
+format: 'uint16x4',
+offset: 4600,
+shaderLocation: 17,
+}, {
+format: 'uint32x2',
+offset: 12012,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 12712,
+attributes: [{
+format: 'float32x3',
+offset: 11320,
+shaderLocation: 4,
+}, {
+format: 'unorm10-10-10-2',
+offset: 3012,
+shaderLocation: 3,
+}, {
+format: 'sint8x4',
+offset: 11832,
+shaderLocation: 19,
+}, {
+format: 'unorm8x4',
+offset: 3892,
+shaderLocation: 12,
+}, {
+format: 'snorm8x4',
+offset: 4232,
+shaderLocation: 1,
+}, {
+format: 'float32x4',
+offset: 3088,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 7048,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x4',
+offset: 584,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 456,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x2',
+offset: 100,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 10992,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32',
+offset: 10116,
+shaderLocation: 16,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+offscreenCanvas6.getContext('webgl2');
+} catch {}
+let shaderModule3 = device1.createShaderModule({
+code: `@group(0) @binding(1300)
+var<storage, read_write> global2: array<u32>;
+@group(0) @binding(704)
+var<storage, read_write> local5: array<u32>;
+@group(3) @binding(1300)
+var<storage, read_write> function1: array<u32>;
+@group(4) @binding(704)
+var<storage, read_write> field2: array<u32>;
+@group(2) @binding(704)
+var<storage, read_write> parameter3: array<u32>;
+@group(1) @binding(1300)
+var<storage, read_write> type3: array<u32>;
+
+@compute @workgroup_size(2, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S4 {
+  @builtin(sample_index) f0: u32,
+  @location(32) f1: vec2<f16>,
+  @location(39) f2: vec4<f16>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @location(2) f1: vec3<i32>,
+  @location(3) f2: vec2<f32>,
+  @location(4) f3: vec3<u32>,
+  @location(0) f4: vec3<f32>,
+  @location(5) f5: i32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @location(17) a1: vec3<u32>, @location(1) a2: vec3<i32>, a3: S4, @location(24) a4: vec2<f16>, @location(11) a5: vec2<i32>, @location(49) a6: vec2<u32>, @location(28) a7: vec4<i32>, @location(5) a8: vec3<i32>, @location(8) a9: vec3<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S3 {
+  @location(1) f0: vec3<u32>,
+  @location(3) f1: vec3<f32>,
+  @location(24) f2: vec3<f32>,
+  @location(15) f3: vec3<u32>,
+  @location(8) f4: u32,
+  @location(25) f5: vec3<f32>,
+  @location(20) f6: vec3<f16>,
+  @location(23) f7: vec4<u32>,
+  @location(9) f8: vec4<i32>,
+  @location(4) f9: vec4<u32>,
+  @location(11) f10: f16,
+  @location(12) f11: vec2<i32>,
+  @location(2) f12: vec3<u32>,
+  @location(0) f13: vec4<f16>
+}
+struct VertexOutput0 {
+  @location(25) f29: vec3<i32>,
+  @location(34) f30: f16,
+  @location(17) f31: vec3<u32>,
+  @location(27) f32: vec2<u32>,
+  @location(24) f33: vec2<f16>,
+  @location(46) f34: vec2<u32>,
+  @location(8) f35: vec3<u32>,
+  @location(1) f36: vec3<i32>,
+  @location(2) f37: f32,
+  @location(14) f38: vec3<f16>,
+  @location(13) f39: u32,
+  @location(6) f40: f16,
+  @location(5) f41: vec3<i32>,
+  @location(16) f42: vec3<u32>,
+  @location(15) f43: f32,
+  @location(47) f44: vec2<f16>,
+  @location(45) f45: vec3<f32>,
+  @location(37) f46: f16,
+  @location(0) f47: vec4<f16>,
+  @location(18) f48: vec2<f32>,
+  @location(40) f49: vec3<f16>,
+  @location(30) f50: vec4<i32>,
+  @location(29) f51: vec2<f16>,
+  @location(28) f52: vec4<i32>,
+  @location(35) f53: vec4<f32>,
+  @location(42) f54: vec2<u32>,
+  @location(23) f55: f16,
+  @location(7) f56: f32,
+  @location(22) f57: vec2<f32>,
+  @location(33) f58: vec2<u32>,
+  @location(38) f59: f16,
+  @builtin(position) f60: vec4<f32>,
+  @location(39) f61: vec4<f16>,
+  @location(49) f62: vec2<u32>,
+  @location(3) f63: vec4<f32>,
+  @location(32) f64: vec2<f16>,
+  @location(11) f65: vec2<i32>,
+  @location(36) f66: vec2<f32>,
+  @location(19) f67: vec4<u32>,
+  @location(44) f68: u32
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(22) a1: vec2<i32>, @location(6) a2: vec4<f32>, @location(17) a3: f32, @builtin(instance_index) a4: u32, @location(10) a5: vec3<i32>, a6: S3, @location(18) a7: vec3<f32>, @location(16) a8: vec4<f32>, @location(26) a9: vec4<i32>, @location(7) a10: vec2<i32>, @location(19) a11: vec3<f16>, @location(14) a12: f32, @location(13) a13: vec3<f32>, @location(5) a14: vec2<i32>, @location(21) a15: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroupLayout14 = device1.createBindGroupLayout({
+label: '\u{1fc8d}\u{1fa51}\ue8cb\u6719\ubf72\u3927\u4cc5\u{1f726}',
+entries: [{
+binding: 1723,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}],
+});
+let pipelineLayout7 = device1.createPipelineLayout({
+  label: '\u03d8\u19da\u{1f653}\u{1f988}\u61cb\u1ffd',
+  bindGroupLayouts: [bindGroupLayout11, bindGroupLayout6, bindGroupLayout14]
+});
+let texture53 = gpuCanvasContext0.getCurrentTexture();
+let textureView49 = texture27.createView({
+  label: '\ub1ae\u5f3c\ua0e7\u3d6f\ue566',
+  dimension: '2d',
+  baseMipLevel: 4,
+  mipLevelCount: 4,
+  baseArrayLayer: 87
+});
+let sampler30 = device1.createSampler({
+label: '\u{1ff77}\ub2c1\u455c\uf49b',
+addressModeU: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 5.350,
+lodMaxClamp: 59.220,
+maxAnisotropy: 20,
+});
+try {
+renderBundleEncoder17.drawIndexed(80, 48, 80, 136, 32);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(3, buffer18, 2280, 24328);
+} catch {}
+try {
+commandEncoder40.clearBuffer(buffer8, 9544, 1404);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+video5.height = 135;
+let bindGroup0 = device0.createBindGroup({
+layout: bindGroupLayout4,
+entries: [{
+binding: 5759,
+resource: externalTexture2
+}, {
+binding: 1816,
+resource: externalTexture2
+}],
+});
+let commandEncoder43 = device0.createCommandEncoder();
+let texture54 = device0.createTexture({
+label: '\uf70f\uc508\u209f\ub9b4\u03fb\u6b88\ucefb\u{1f688}\u{1f9fa}',
+size: [4800, 16, 1],
+dimension: '2d',
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x8-unorm', 'astc-10x8-unorm-srgb'],
+});
+let renderBundleEncoder33 = device0.createRenderBundleEncoder({
+  label: '\u0992\u001c',
+  colorFormats: ['r8unorm', 'rgba16sint', 'rg8sint', 'rgba32float', 'r32uint', undefined],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle32 = renderBundleEncoder7.finish({label: '\u3d38\u{1fe85}\ufecb\u542e\u47b6\u2b27'});
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder38.clearBuffer(buffer10, 864, 292);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer1,
+commandBuffer3,
+]);
+} catch {}
+let imageData11 = new ImageData(120, 76);
+let bindGroupLayout15 = device2.createBindGroupLayout({
+label: '\u0d96\u533d',
+entries: [],
+});
+let sampler31 = device2.createSampler({
+label: '\u{1f6ef}\u0480\u0d3e\u2d83\u070f\u{1feb4}\u01de\u0a78\u52e2\ube40',
+addressModeU: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 51.328,
+lodMaxClamp: 93.927,
+maxAnisotropy: 18,
+});
+try {
+commandEncoder31.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 3296 */
+offset: 3296,
+buffer: buffer14,
+}, {
+  texture: texture39,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer14);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let texture55 = device0.createTexture({
+label: '\u6c21\ueb90\u0ad5\u{1fd34}\u07be\u{1fde7}\u0d78\u{1fc59}',
+size: [1200, 4, 1],
+mipLevelCount: 9,
+format: 'rg32uint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rg32uint', 'rg32uint', 'rg32uint'],
+});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2unorm', 'r16float', 'rg8uint', 'r8uint'],
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder0.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(3, buffer4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 1,
+  origin: { x: 28, y: 0, z: 0 },
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer4), /* required buffer size: 1231 */
+{offset: 919, bytesPerRow: 470}, {width: 156, height: 4, depthOrArrayLayers: 1});
+} catch {}
+let pipeline27 = device0.createComputePipeline({
+layout: pipelineLayout5,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline28 = device0.createRenderPipeline({
+label: '\u04a4\uf631\uea82\udce3\u5519\u4cec\u4acc',
+layout: pipelineLayout2,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 1803,
+stencilWriteMask: 303,
+depthBias: 29,
+depthBiasSlopeScale: 10,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 456,
+attributes: [{
+format: 'uint16x2',
+offset: 272,
+shaderLocation: 5,
+}, {
+format: 'uint16x4',
+offset: 12,
+shaderLocation: 13,
+}, {
+format: 'float32',
+offset: 124,
+shaderLocation: 4,
+}, {
+format: 'snorm8x4',
+offset: 428,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 1332,
+attributes: [{
+format: 'snorm16x2',
+offset: 692,
+shaderLocation: 9,
+}, {
+format: 'sint32x4',
+offset: 568,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 8924,
+attributes: [{
+format: 'unorm8x2',
+offset: 8268,
+shaderLocation: 1,
+}, {
+format: 'uint16x4',
+offset: 1272,
+shaderLocation: 17,
+}, {
+format: 'snorm8x4',
+offset: 5488,
+shaderLocation: 3,
+}, {
+format: 'uint8x2',
+offset: 6274,
+shaderLocation: 14,
+}, {
+format: 'uint32',
+offset: 6040,
+shaderLocation: 7,
+}, {
+format: 'sint16x4',
+offset: 304,
+shaderLocation: 19,
+}, {
+format: 'snorm16x4',
+offset: 3508,
+shaderLocation: 2,
+}, {
+format: 'sint32x4',
+offset: 1160,
+shaderLocation: 16,
+}, {
+format: 'unorm8x4',
+offset: 3392,
+shaderLocation: 12,
+}, {
+format: 'unorm10-10-10-2',
+offset: 5936,
+shaderLocation: 0,
+}, {
+format: 'unorm16x2',
+offset: 3328,
+shaderLocation: 18,
+}, {
+format: 'float32x2',
+offset: 3520,
+shaderLocation: 6,
+}, {
+format: 'sint32',
+offset: 3464,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 5900,
+attributes: [],
+},
+{
+arrayStride: 3644,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 11028,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 5532,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 5364,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 12496,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 5184,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+try {
+  await promise10;
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas3,
+  origin: { x: 246, y: 68 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 6, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 39, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline29 = await device1.createComputePipelineAsync({
+label: '\u{1f795}\u0d9a\uc375\ude22\u7ec3\u15d7\u33e3',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let buffer19 = device3.createBuffer({
+  label: '\u{1fe46}\u0158\u633c\u01cc\uaceb\u0bfa\u2fa8',
+  size: 14797,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM
+});
+let renderBundle33 = renderBundleEncoder28.finish({label: '\u7ee7\u7118\ubb42\u0442\u3f2a\u299b\uc4ad'});
+document.body.prepend(img1);
+try {
+buffer19.destroy();
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext7 = offscreenCanvas9.getContext('webgpu');
+let commandEncoder44 = device3.createCommandEncoder({});
+let querySet33 = device3.createQuerySet({
+label: '\u09b2\uf59d\u08b7',
+type: 'occlusion',
+count: 2165,
+});
+try {
+buffer19.destroy();
+} catch {}
+try {
+gpuCanvasContext4.configure({
+device: device3,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+});
+} catch {}
+let commandEncoder45 = device3.createCommandEncoder({label: '\u{1f978}\u1413\u0a61'});
+let commandBuffer7 = commandEncoder44.finish({
+label: '\u{1fa92}\u0331',
+});
+pseudoSubmit(device3, commandEncoder45);
+let renderBundle34 = renderBundleEncoder28.finish({label: '\u017d\u01c5\ub551\u9b6c\u072c\u054e\u{1ffe2}'});
+let querySet34 = device3.createQuerySet({
+label: '\u4cd5\u344b\u3f62\u{1fd80}\u0091\u0bd0',
+type: 'occlusion',
+count: 1574,
+});
+let texture56 = device3.createTexture({
+label: '\uffb6\u0b78\u{1fed6}\u{1f64d}\u2b29\u{1f6c1}\u{1f815}\u4182\u6363\u058c\u314a',
+size: {width: 504, height: 60, depthOrArrayLayers: 193},
+mipLevelCount: 4,
+format: 'astc-6x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder32.setVertexBuffer(7, buffer18);
+} catch {}
+let pipeline30 = device1.createComputePipeline({
+label: '\u{1f916}\u1bb3\ud5d4\u2ecf\u4b18',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+},
+});
+let pipeline31 = device1.createRenderPipeline({
+label: '\u84f9\u3352\u58a0\u781b\ud2aa\ud692\u0bbf\u0fdc\u036f',
+layout: pipelineLayout7,
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {format: 'r32uint'}, {format: 'rg8sint', writeMask: 0}, {format: 'rg8unorm'}, {
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {format: 'r32sint'}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+},
+depthBias: 25,
+depthBiasSlopeScale: 13,
+depthBiasClamp: 19,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1996,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 13064,
+attributes: [{
+format: 'float16x2',
+offset: 8488,
+shaderLocation: 2,
+}, {
+format: 'sint8x2',
+offset: 8890,
+shaderLocation: 15,
+}, {
+format: 'uint32x2',
+offset: 1552,
+shaderLocation: 22,
+}, {
+format: 'unorm16x2',
+offset: 4036,
+shaderLocation: 21,
+}, {
+format: 'uint32',
+offset: 10432,
+shaderLocation: 12,
+}, {
+format: 'snorm8x4',
+offset: 5584,
+shaderLocation: 20,
+}, {
+format: 'sint32',
+offset: 4480,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 10412,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x3',
+offset: 1388,
+shaderLocation: 10,
+}, {
+format: 'snorm16x2',
+offset: 4952,
+shaderLocation: 6,
+}, {
+format: 'uint32x2',
+offset: 8784,
+shaderLocation: 26,
+}, {
+format: 'sint32',
+offset: 6836,
+shaderLocation: 16,
+}, {
+format: 'sint32',
+offset: 5360,
+shaderLocation: 25,
+}, {
+format: 'uint8x4',
+offset: 6512,
+shaderLocation: 17,
+}, {
+format: 'unorm8x2',
+offset: 6698,
+shaderLocation: 7,
+}, {
+format: 'float32x4',
+offset: 9244,
+shaderLocation: 8,
+}, {
+format: 'sint32x4',
+offset: 5196,
+shaderLocation: 5,
+}, {
+format: 'uint32',
+offset: 6952,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 5016,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x4',
+offset: 1500,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 1844,
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x2',
+offset: 11700,
+shaderLocation: 24,
+}],
+},
+{
+arrayStride: 11632,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 11288,
+shaderLocation: 0,
+}, {
+format: 'snorm16x4',
+offset: 7568,
+shaderLocation: 1,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+},
+});
+let bindGroup1 = device0.createBindGroup({
+label: '\u1001\u0707\ucb97',
+layout: bindGroupLayout13,
+entries: [{
+binding: 2828,
+resource: {
+buffer: buffer13,
+offset: 43808,
+size: 17076,
+}
+}, {
+binding: 869,
+resource: externalTexture2
+}],
+});
+let commandEncoder46 = device0.createCommandEncoder({label: '\u{1fdfe}\uf206\u8b93\u0c14\u9205'});
+let querySet35 = device0.createQuerySet({
+type: 'occlusion',
+count: 1386,
+});
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({
+  label: '\u321d\u9197\ua07e\u05b9\u08c1\u0e83\u{1f93b}\u03ca\ucf2f',
+  colorFormats: ['rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder3.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer3, 54036, 6092);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 308, new BigUint64Array(55676), 48230, 36);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 55, y: 1, z: 0 },
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer6), /* required buffer size: 14952252 */
+{offset: 111, bytesPerRow: 3681, rowsPerImage: 290}, {width: 225, height: 2, depthOrArrayLayers: 15});
+} catch {}
+let pipeline32 = device0.createComputePipeline({
+label: '\u0489\u7a06\u38a9\u07d3\u7c62',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let offscreenCanvas10 = new OffscreenCanvas(792, 590);
+let commandEncoder47 = device2.createCommandEncoder({label: '\u07ba\u8b15\u6339\u{1fa45}\ucd96\u0546\ue2c5\u7423\ua14e'});
+let promise11 = device2.queue.onSubmittedWorkDone();
+gc();
+let commandEncoder48 = device3.createCommandEncoder();
+let textureView50 = texture47.createView({dimension: '2d-array', format: 'astc-6x6-unorm-srgb'});
+let sampler32 = device3.createSampler({
+label: '\uaba8\ua806',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 47.632,
+lodMaxClamp: 84.322,
+});
+try {
+commandEncoder48.clearBuffer(buffer19, 5624, 8016);
+dissociateBuffer(device3, buffer19);
+} catch {}
+let videoFrame8 = new VideoFrame(canvas5, {timestamp: 0});
+let textureView51 = texture37.createView({label: '\u2640\uceda'});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let img6 = await imageWithData(130, 23, '#4bb77525', '#7adaec30');
+let buffer20 = device1.createBuffer({
+  label: '\u{1f9df}\u0752\u034f\udb0b\u4bd5\u0b1a\u{1fc20}\u{1ff4f}\ue780\ude9c\u0e07',
+  size: 1261,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC
+});
+let textureView52 = texture27.createView({
+  label: '\u06e5\u708d\ubbdc\u05d5\uad90\u9f21\u0e5e\u0376\u8214',
+  format: 'astc-10x6-unorm-srgb',
+  baseMipLevel: 5,
+  mipLevelCount: 5,
+  baseArrayLayer: 168,
+  arrayLayerCount: 5
+});
+try {
+renderBundleEncoder17.drawIndexed(16, 8, 64);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 28, y: 0, z: 0 },
+  aspect: 'all',
+}, new DataView(arrayBuffer2), /* required buffer size: 1058 */
+{offset: 722, bytesPerRow: 284, rowsPerImage: 268}, {width: 13, height: 2, depthOrArrayLayers: 1});
+} catch {}
+let pipeline33 = await device1.createComputePipelineAsync({
+layout: 'auto',
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline34 = device1.createRenderPipeline({
+label: '\u466d\u5c39\u0eab\u{1fd33}',
+layout: pipelineLayout3,
+multisample: {
+mask: 0x20ea4d18,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-src'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r32uint'}, {format: 'r32sint', writeMask: GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-clamp',
+},
+stencilReadMask: 2415,
+stencilWriteMask: 2320,
+depthBias: 26,
+depthBiasSlopeScale: 24,
+depthBiasClamp: 74,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 31444,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 8144,
+shaderLocation: 21,
+}, {
+format: 'float32x4',
+offset: 1720,
+shaderLocation: 6,
+}, {
+format: 'float32x3',
+offset: 6628,
+shaderLocation: 4,
+}, {
+format: 'uint32',
+offset: 26764,
+shaderLocation: 22,
+}, {
+format: 'uint8x4',
+offset: 29280,
+shaderLocation: 17,
+}, {
+format: 'uint16x4',
+offset: 5328,
+shaderLocation: 14,
+}, {
+format: 'sint32',
+offset: 4388,
+shaderLocation: 16,
+}, {
+format: 'uint8x2',
+offset: 27680,
+shaderLocation: 10,
+}, {
+format: 'sint16x4',
+offset: 8736,
+shaderLocation: 5,
+}, {
+format: 'snorm16x4',
+offset: 19592,
+shaderLocation: 1,
+}, {
+format: 'unorm16x4',
+offset: 7900,
+shaderLocation: 2,
+}, {
+format: 'sint32x2',
+offset: 28504,
+shaderLocation: 13,
+}, {
+format: 'uint32',
+offset: 5236,
+shaderLocation: 12,
+}, {
+format: 'snorm8x4',
+offset: 4760,
+shaderLocation: 20,
+}, {
+format: 'uint16x2',
+offset: 368,
+shaderLocation: 24,
+}, {
+format: 'unorm8x4',
+offset: 10420,
+shaderLocation: 8,
+}, {
+format: 'snorm16x2',
+offset: 24584,
+shaderLocation: 7,
+}, {
+format: 'sint16x4',
+offset: 8660,
+shaderLocation: 25,
+}, {
+format: 'uint8x4',
+offset: 9192,
+shaderLocation: 26,
+}],
+},
+{
+arrayStride: 10044,
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint16x2',
+offset: 14392,
+shaderLocation: 15,
+}, {
+format: 'snorm8x4',
+offset: 29028,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let shaderModule4 = device2.createShaderModule({
+label: '\u711b\u{1fa25}\u78b3\u{1f90c}',
+code: `@group(1) @binding(1847)
+var<storage, read_write> local6: array<u32>;
+@group(0) @binding(2892)
+var<storage, read_write> local7: array<u32>;
+@group(1) @binding(958)
+var<storage, read_write> parameter4: array<u32>;
+
+@compute @workgroup_size(1, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S6 {
+  @location(83) f0: vec3<f16>,
+  @location(21) f1: vec3<f32>,
+  @location(32) f2: vec4<u32>,
+  @builtin(front_facing) f3: bool,
+  @location(10) f4: vec2<i32>,
+  @location(49) f5: vec4<f32>,
+  @location(38) f6: vec2<u32>,
+  @location(91) f7: vec3<u32>,
+  @location(42) f8: vec2<i32>
+}
+struct FragmentOutput0 {
+  @location(5) f0: vec4<u32>,
+  @location(2) f1: vec3<u32>,
+  @location(1) f2: vec2<f32>,
+  @location(3) f3: u32,
+  @location(6) f4: f32,
+  @location(0) f5: vec4<i32>,
+  @builtin(frag_depth) f6: f32
+}
+
+@fragment
+fn fragment0(a0: S6, @location(89) a1: vec3<f32>, @location(2) a2: vec2<u32>, @location(69) a3: vec3<f16>, @location(77) a4: f16, @location(65) a5: vec3<f16>, @location(5) a6: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S5 {
+  @builtin(vertex_index) f0: u32,
+  @builtin(instance_index) f1: u32,
+  @location(12) f2: vec2<f16>,
+  @location(13) f3: vec2<i32>,
+  @location(8) f4: vec3<f32>,
+  @location(1) f5: i32,
+  @location(7) f6: vec4<f32>,
+  @location(15) f7: u32,
+  @location(6) f8: vec4<u32>,
+  @location(5) f9: vec4<i32>,
+  @location(14) f10: vec3<u32>,
+  @location(2) f11: i32,
+  @location(9) f12: vec3<i32>,
+  @location(10) f13: vec3<i32>,
+  @location(3) f14: vec2<i32>
+}
+struct VertexOutput0 {
+  @location(91) f69: vec3<u32>,
+  @location(49) f70: vec4<f32>,
+  @builtin(position) f71: vec4<f32>,
+  @location(32) f72: vec4<u32>,
+  @location(38) f73: vec2<u32>,
+  @location(42) f74: vec2<i32>,
+  @location(21) f75: vec3<f32>,
+  @location(10) f76: vec2<i32>,
+  @location(77) f77: f16,
+  @location(83) f78: vec3<f16>,
+  @location(65) f79: vec3<f16>,
+  @location(69) f80: vec3<f16>,
+  @location(89) f81: vec3<f32>,
+  @location(5) f82: vec4<f32>,
+  @location(2) f83: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(0) a0: vec4<f32>, a1: S5, @location(11) a2: f16, @location(4) a3: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let gpuCanvasContext8 = offscreenCanvas10.getContext('webgpu');
+let commandEncoder49 = device0.createCommandEncoder();
+let pipeline35 = device0.createComputePipeline({
+label: '\u09b8\u10bf',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let canvas7 = document.createElement('canvas');
+let bindGroupLayout16 = device2.createBindGroupLayout({
+label: '\u5311\u8a20',
+entries: [],
+});
+let computePassEncoder16 = commandEncoder47.beginComputePass();
+try {
+device2.pushErrorScope('out-of-memory');
+} catch {}
+try {
+buffer11.destroy();
+} catch {}
+try {
+commandEncoder31.copyBufferToTexture({
+/* bytesInLastRow: 304 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 48624 */
+offset: 48624,
+bytesPerRow: 512,
+buffer: buffer14,
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: { x: 1560, y: 96, z: 1 },
+  aspect: 'all',
+}, {width: 190, height: 102, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer14);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 5,
+  origin: { x: 4, y: 0, z: 30 },
+  aspect: 'all',
+}, new ArrayBuffer(827498), /* required buffer size: 827498 */
+{offset: 938, bytesPerRow: 246, rowsPerImage: 168}, {width: 4, height: 0, depthOrArrayLayers: 21});
+} catch {}
+let pipeline36 = await device2.createRenderPipelineAsync({
+label: '\u{1ff0d}\u{1fff3}\uc925\u0060\u19a5\u6c0d\u12d4\udfbb',
+layout: pipelineLayout6,
+fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: 0}, {format: 'r8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rg8uint'}, undefined, undefined, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'keep',
+depthFailOp: 'decrement-clamp',
+passOp: 'keep',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2196,
+stencilWriteMask: 2135,
+depthBias: 62,
+depthBiasClamp: 32,
+},
+vertex: {
+  module: shaderModule4,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 37892,
+attributes: [{
+format: 'sint32',
+offset: 6412,
+shaderLocation: 10,
+}, {
+format: 'float32x2',
+offset: 21108,
+shaderLocation: 4,
+}, {
+format: 'sint32x4',
+offset: 24316,
+shaderLocation: 13,
+}, {
+format: 'float32',
+offset: 27528,
+shaderLocation: 11,
+}, {
+format: 'sint32x3',
+offset: 27788,
+shaderLocation: 3,
+}, {
+format: 'unorm10-10-10-2',
+offset: 30572,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 14692,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 10868,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 5796,
+shaderLocation: 6,
+}, {
+format: 'sint32x3',
+offset: 1904,
+shaderLocation: 1,
+}, {
+format: 'sint32',
+offset: 4976,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 29628,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x4',
+offset: 8044,
+shaderLocation: 0,
+}, {
+format: 'uint32x2',
+offset: 8888,
+shaderLocation: 14,
+}, {
+format: 'snorm16x4',
+offset: 14300,
+shaderLocation: 8,
+}, {
+format: 'sint32x2',
+offset: 21144,
+shaderLocation: 5,
+}, {
+format: 'sint8x2',
+offset: 16988,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 26160,
+attributes: [{
+format: 'snorm8x2',
+offset: 5010,
+shaderLocation: 7,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+},
+});
+try {
+device2.destroy();
+} catch {}
+let gpuCanvasContext9 = canvas7.getContext('webgpu');
+let texture57 = device0.createTexture({
+label: '\u06a4\u{1f94a}\u8aef\u{1fddb}\u6efb\u5945\u344d',
+size: {width: 4800, height: 16, depthOrArrayLayers: 1},
+mipLevelCount: 12,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let computePassEncoder17 = commandEncoder43.beginComputePass({});
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({
+  label: '\u0825\u{1f9ac}\u0035\u0c7a\u6931\u0620\u1645\ucc22\u097b\u5bdf\u0f36',
+  colorFormats: ['rgb10a2unorm', 'r16float', 'rg8uint', 'r8uint'],
+  depthReadOnly: true
+});
+try {
+computePassEncoder2.setPipeline(pipeline1);
+} catch {}
+try {
+texture3.destroy();
+} catch {}
+let pipeline37 = await device0.createComputePipelineAsync({
+label: '\u03bb\u1c1c\u050d\u56ec\u02af\ua199\u{1f658}\u8474',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let video6 = await videoWithData();
+let texture58 = device3.createTexture({
+label: '\u0f65\u8cd8\u6ed5\ud218\u{1f7fe}',
+size: {width: 4032, height: 480, depthOrArrayLayers: 193},
+mipLevelCount: 2,
+format: 'astc-12x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x10-unorm'],
+});
+let computePassEncoder18 = commandEncoder48.beginComputePass({label: '\u{1f789}\u0141\u3c0f\u88ee\u{1fb27}\u0c73\u690e\u5973\u89a5'});
+try {
+computePassEncoder18.pushDebugGroup('\u6c4e');
+} catch {}
+let textureView53 = texture44.createView({mipLevelCount: 1});
+let renderBundle35 = renderBundleEncoder28.finish({label: '\ua39a\u1ae4\u{1f819}\u3d5a\u1a79\u0bc6\u06a2\u011e'});
+try {
+gpuCanvasContext1.configure({
+device: device3,
+format: 'rgba16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise11;
+} catch {}
+canvas3.width = 886;
+let textureView54 = texture0.createView({format: 'astc-5x5-unorm-srgb', baseMipLevel: 2, mipLevelCount: 2, baseArrayLayer: 27, arrayLayerCount: 162});
+let renderBundle36 = renderBundleEncoder3.finish();
+try {
+renderBundleEncoder27.setVertexBuffer(6, buffer4, 8860, 13866);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 664, new Int16Array(60950), 30882, 244);
+} catch {}
+let video7 = await videoWithData();
+try {
+canvas6.getContext('bitmaprenderer');
+} catch {}
+let computePassEncoder19 = commandEncoder42.beginComputePass({label: '\ue88d\u3c10\u3a48\uc1af\u86e5\udd76\u22e3\u{1f9ff}'});
+let imageBitmap9 = await createImageBitmap(videoFrame3);
+let querySet36 = device3.createQuerySet({
+label: '\ua46f\u73b5\u{1fbb0}\u9e89\uea74\u{1fc0f}',
+type: 'occlusion',
+count: 1546,
+});
+try {
+gpuCanvasContext1.configure({
+device: device3,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'stencil8', 'rgba16float', 'rgba16float'],
+});
+} catch {}
+document.body.prepend(img1);
+video1.height = 111;
+let texture59 = device3.createTexture({
+label: '\u{1fbfc}\u7df9\u{1ffda}',
+size: {width: 60, height: 240, depthOrArrayLayers: 227},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8snorm', 'rgba8snorm'],
+});
+let renderBundle37 = renderBundleEncoder28.finish({label: '\u{1fba7}\u9fe0\u{1f675}\u06a6\ufeaa\ue976\u1dcb\ub91c\u4a6a'});
+try {
+device2.label = '\u0f89\u{1fdf8}\u0f34';
+} catch {}
+let shaderModule5 = device1.createShaderModule({
+label: '\ue905\u0519\u02d3\uc9d9\u{1fb44}\u0437\u593c\ud382\u0e74',
+code: `@group(1) @binding(704)
+var<storage, read_write> local8: array<u32>;
+@group(1) @binding(1300)
+var<storage, read_write> global3: array<u32>;
+
+@compute @workgroup_size(7, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S7 {
+  @location(44) f0: vec4<f32>,
+  @location(17) f1: u32,
+  @location(38) f2: vec4<f16>
+}
+struct FragmentOutput0 {
+  @location(4) f0: vec4<u32>,
+  @location(2) f1: vec4<i32>,
+  @builtin(sample_mask) f2: u32,
+  @location(0) f3: vec3<f32>,
+  @location(1) f4: vec2<u32>,
+  @location(5) f5: vec3<i32>,
+  @location(3) f6: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(8) a0: vec2<i32>, @location(39) a1: f32, @location(33) a2: u32, @location(1) a3: vec2<f32>, a4: S7, @location(15) a5: vec4<f32>, @location(14) a6: vec4<f32>, @location(24) a7: vec2<f32>, @location(31) a8: vec4<u32>, @builtin(position) a9: vec4<f32>, @location(37) a10: vec2<i32>, @location(20) a11: f16, @location(9) a12: vec2<f16>, @location(46) a13: vec4<u32>, @location(16) a14: vec3<i32>, @location(49) a15: u32, @location(5) a16: i32, @location(6) a17: vec2<u32>, @location(29) a18: vec3<f16>, @location(21) a19: vec3<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(44) f84: vec4<f32>,
+  @location(5) f85: i32,
+  @location(21) f86: vec3<f16>,
+  @location(20) f87: f16,
+  @location(16) f88: vec3<i32>,
+  @location(15) f89: vec4<f32>,
+  @location(39) f90: f32,
+  @builtin(position) f91: vec4<f32>,
+  @location(33) f92: u32,
+  @location(8) f93: vec2<i32>,
+  @location(17) f94: u32,
+  @location(49) f95: u32,
+  @location(24) f96: vec2<f32>,
+  @location(14) f97: vec4<f32>,
+  @location(9) f98: vec2<f16>,
+  @location(38) f99: vec4<f16>,
+  @location(1) f100: vec2<f32>,
+  @location(29) f101: vec3<f16>,
+  @location(6) f102: vec2<u32>,
+  @location(37) f103: vec2<i32>,
+  @location(31) f104: vec4<u32>,
+  @location(46) f105: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec3<u32>, @location(6) a1: vec4<f16>, @location(22) a2: vec3<i32>, @builtin(vertex_index) a3: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder50 = device1.createCommandEncoder({label: '\u0083\uaf75\u{1fae2}\u{1f7e0}\u5d26\u043b\u{1fadb}\u043d\u0c4c\u0df6'});
+let commandBuffer8 = commandEncoder39.finish({
+});
+let computePassEncoder20 = commandEncoder40.beginComputePass({});
+try {
+renderBundleEncoder32.setVertexBuffer(6, buffer18, 23428, 30271);
+} catch {}
+try {
+commandEncoder50.copyBufferToBuffer(buffer20, 1080, buffer8, 11200, 80);
+dissociateBuffer(device1, buffer20);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 136, new BigUint64Array(45884), 44010, 100);
+} catch {}
+let promise12 = device1.createComputePipelineAsync({
+label: '\u{1fac1}\u{1fd8c}\uaa35\udc82\u{1fe8c}\u{1ff11}\uf8c8\udb59',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let promise13 = device1.createRenderPipelineAsync({
+label: '\u02d2\u951a\u07d3\u20e4\u3e3c\u7801\u{1fe60}\u064d\u06c7',
+layout: pipelineLayout3,
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'never',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'replace',
+passOp: 'invert',
+},
+stencilReadMask: 916,
+stencilWriteMask: 1116,
+depthBias: 54,
+depthBiasSlopeScale: 75,
+depthBiasClamp: 34,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 2268,
+attributes: [],
+},
+{
+arrayStride: 8204,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 5168,
+shaderLocation: 0,
+}, {
+format: 'snorm8x2',
+offset: 4940,
+shaderLocation: 26,
+}, {
+format: 'uint16x2',
+offset: 1192,
+shaderLocation: 6,
+}, {
+format: 'float32x2',
+offset: 2704,
+shaderLocation: 16,
+}, {
+format: 'sint16x4',
+offset: 2032,
+shaderLocation: 17,
+}, {
+format: 'uint8x4',
+offset: 5360,
+shaderLocation: 20,
+}, {
+format: 'uint32',
+offset: 404,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 27248,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x2',
+offset: 21348,
+shaderLocation: 3,
+}, {
+format: 'sint16x4',
+offset: 19316,
+shaderLocation: 22,
+}, {
+format: 'sint32x3',
+offset: 25896,
+shaderLocation: 14,
+}, {
+format: 'snorm16x2',
+offset: 4588,
+shaderLocation: 12,
+}, {
+format: 'snorm8x4',
+offset: 22100,
+shaderLocation: 4,
+}, {
+format: 'float16x4',
+offset: 96,
+shaderLocation: 23,
+}, {
+format: 'float32x3',
+offset: 7772,
+shaderLocation: 13,
+}, {
+format: 'float32x2',
+offset: 3136,
+shaderLocation: 18,
+}, {
+format: 'sint8x2',
+offset: 7860,
+shaderLocation: 25,
+}, {
+format: 'uint32x4',
+offset: 28,
+shaderLocation: 21,
+}, {
+format: 'float16x2',
+offset: 14532,
+shaderLocation: 24,
+}, {
+format: 'uint32x3',
+offset: 17044,
+shaderLocation: 5,
+}, {
+format: 'uint32x4',
+offset: 24056,
+shaderLocation: 1,
+}, {
+format: 'uint32x4',
+offset: 16748,
+shaderLocation: 8,
+}, {
+format: 'uint32',
+offset: 14108,
+shaderLocation: 11,
+}, {
+format: 'sint32x2',
+offset: 19912,
+shaderLocation: 7,
+}, {
+format: 'uint16x2',
+offset: 23612,
+shaderLocation: 9,
+}, {
+format: 'sint16x4',
+offset: 11812,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 25748,
+attributes: [],
+},
+{
+arrayStride: 5548,
+attributes: [{
+format: 'float16x4',
+offset: 272,
+shaderLocation: 15,
+}, {
+format: 'unorm10-10-10-2',
+offset: 5448,
+shaderLocation: 19,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+let buffer21 = device1.createBuffer({
+  label: '\u310f\uf07d\u021e',
+  size: 22472,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true
+});
+let computePassEncoder21 = commandEncoder50.beginComputePass({});
+let renderBundleEncoder37 = device1.createRenderBundleEncoder({
+  colorFormats: ['r8unorm', 'r32uint', 'rg8sint', 'rg8unorm', 'r32uint', 'r32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+try {
+buffer18.destroy();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas8,
+  origin: { x: 305, y: 1 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 21, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 6, height: 0, depthOrArrayLayers: 1});
+} catch {}
+gc();
+try {
+sampler12.label = '\u{1ffdc}\u0a99\u05c0\u0c37\u057b\u1896\u1677\u{1f881}\u{1f87a}\ud7a0';
+} catch {}
+let shaderModule6 = device1.createShaderModule({
+label: '\u3a71\u8c9a\u59db\u043e\u0341',
+code: `@group(2) @binding(1723)
+var<storage, read_write> global4: array<u32>;
+@group(1) @binding(704)
+var<storage, read_write> local9: array<u32>;
+@group(0) @binding(542)
+var<storage, read_write> type4: array<u32>;
+@group(1) @binding(1300)
+var<storage, read_write> field3: array<u32>;
+
+@compute @workgroup_size(5, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<i32>,
+  @location(1) f1: f32,
+  @location(0) f2: vec3<f32>,
+  @location(2) f3: vec2<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S8 {
+  @location(9) f0: vec3<u32>,
+  @location(12) f1: vec2<f32>,
+  @location(3) f2: vec3<u32>,
+  @location(22) f3: vec2<f16>,
+  @location(14) f4: f16,
+  @location(5) f5: vec2<f32>,
+  @location(6) f6: vec4<f16>,
+  @location(21) f7: u32,
+  @location(19) f8: f32
+}
+
+@vertex
+fn vertex0(@location(8) a0: f32, @location(23) a1: vec4<i32>, @builtin(instance_index) a2: u32, @location(1) a3: vec4<f32>, @location(11) a4: vec2<f16>, @location(24) a5: vec4<i32>, @location(0) a6: vec3<i32>, @location(13) a7: vec3<f16>, @location(7) a8: vec3<i32>, @location(26) a9: vec2<f32>, @location(10) a10: f16, @location(4) a11: f32, @location(17) a12: f32, @location(20) a13: vec2<f32>, @location(16) a14: f32, @location(25) a15: i32, @location(15) a16: vec2<u32>, @location(2) a17: u32, @location(18) a18: vec4<i32>, a19: S8, @builtin(vertex_index) a20: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+try {
+computePassEncoder20.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(8);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 56, y: 173, z: 38 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer7), /* required buffer size: 365178 */
+{offset: 426, bytesPerRow: 296, rowsPerImage: 689}, {width: 40, height: 544, depthOrArrayLayers: 2});
+} catch {}
+let video8 = await videoWithData();
+let videoFrame9 = new VideoFrame(imageBitmap9, {timestamp: 0});
+let promise14 = adapter1.requestAdapterInfo();
+let querySet37 = device0.createQuerySet({
+type: 'occlusion',
+count: 3587,
+});
+let commandBuffer9 = commandEncoder32.finish();
+let renderBundleEncoder38 = device0.createRenderBundleEncoder({
+  label: '\u0cea\u0200\ufe5c\u0c4b\u{1ff1f}\ua6e0\u95a4\u{1f968}\u0cdf\u06db',
+  colorFormats: ['rgba16uint', undefined, 'r8sint', 'rg16sint', 'rgba16sint', 'rgba16float', 'rg32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+let renderBundle38 = renderBundleEncoder36.finish({label: '\u23da\u06d8\u0d5f\u{1f72d}\u{1f947}\u4742\u{1ff0a}\u0dd1\u0a8e\u1716\u8ba3'});
+try {
+  await buffer1.mapAsync(GPUMapMode.READ, 0, 7460);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm', 'depth32float', 'r8sint'],
+alphaMode: 'opaque',
+});
+} catch {}
+let buffer22 = device0.createBuffer({
+  label: '\u08ca\u3a67\ud79c\u{1f73b}\u2e7c',
+  size: 32580,
+  usage: GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true
+});
+let renderBundleEncoder39 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rg8uint', 'r32sint', undefined, 'rg8uint', 'rgba8uint', 'rg11b10ufloat', 'r32sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+let sampler33 = device0.createSampler({
+label: '\u986d\ub70b',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 47.856,
+lodMaxClamp: 75.179,
+maxAnisotropy: 11,
+});
+try {
+computePassEncoder13.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder25.copyBufferToBuffer(buffer15, 6512, buffer3, 10980, 5460);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder30.resolveQuerySet(querySet5, 1540, 57, buffer2, 28416);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let canvas8 = document.createElement('canvas');
+try {
+canvas8.getContext('webgl2');
+} catch {}
+try {
+device3.queue.submit([
+]);
+} catch {}
+let renderBundle39 = renderBundleEncoder31.finish({label: '\u9665\u{1f8b9}\ud426\u0f8e\u{1f97a}\u2062\u0aa5'});
+try {
+renderBundleEncoder17.setVertexBuffer(20, undefined, 3837774951, 451065409);
+} catch {}
+let promise15 = device1.queue.onSubmittedWorkDone();
+let adapter6 = await navigator.gpu.requestAdapter();
+let commandEncoder51 = device3.createCommandEncoder();
+let textureView55 = texture59.createView({baseMipLevel: 1, mipLevelCount: 1, arrayLayerCount: 1});
+let renderBundleEncoder40 = device3.createRenderBundleEncoder({label: '\u256f\u0a9d\u05e7', colorFormats: ['rg32sint'], depthReadOnly: true});
+try {
+buffer19.unmap();
+} catch {}
+try {
+commandEncoder51.clearBuffer(buffer19, 11856, 1740);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+  await promise15;
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.prepend(canvas3);
+let offscreenCanvas11 = new OffscreenCanvas(369, 672);
+let computePassEncoder22 = commandEncoder28.beginComputePass({label: '\ua118\uef20\u0d20\u0447\u{1f7ec}\u{1f918}\u02cb\u0741\ufe1f\ub12b'});
+let renderBundle40 = renderBundleEncoder4.finish({label: '\u4897\ub51f\ub265\u{1fbde}\ua9b5\ua58e\ub8e1\u0cc6\u{1fdb2}\uaaa8'});
+let sampler34 = device0.createSampler({
+label: '\u{1fa46}\u5ba8\u3d73\u0032\u0f7a\u6075\u0bd1\u820f\uc4d6',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 45.992,
+maxAnisotropy: 18,
+});
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline15);
+} catch {}
+try {
+commandEncoder38.resolveQuerySet(querySet13, 582, 696, buffer2, 19968);
+} catch {}
+let pipeline38 = await device0.createRenderPipelineAsync({
+label: '\u0968\u0c70\u21f1\ub814\u0303',
+layout: pipelineLayout1,
+fragment: {module: shaderModule0, entryPoint: 'fragment0', targets: [{format: 'rgba16sint'}]},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'zero',
+passOp: 'replace',
+},
+stencilReadMask: 3781,
+depthBias: 38,
+depthBiasSlopeScale: 16,
+depthBiasClamp: 19,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 2848,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 1476,
+shaderLocation: 5,
+}, {
+format: 'uint8x2',
+offset: 1246,
+shaderLocation: 17,
+}, {
+format: 'unorm8x2',
+offset: 568,
+shaderLocation: 9,
+}, {
+format: 'float32x2',
+offset: 2328,
+shaderLocation: 11,
+}, {
+format: 'uint16x4',
+offset: 2212,
+shaderLocation: 13,
+}, {
+format: 'float32x2',
+offset: 2336,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 5336,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm16x4',
+offset: 2552,
+shaderLocation: 12,
+}, {
+format: 'uint32',
+offset: 3704,
+shaderLocation: 7,
+}, {
+format: 'unorm8x2',
+offset: 2486,
+shaderLocation: 0,
+}, {
+format: 'float32x2',
+offset: 3272,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 2896,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 1268,
+shaderLocation: 4,
+}, {
+format: 'float16x2',
+offset: 244,
+shaderLocation: 18,
+}, {
+format: 'sint32x4',
+offset: 936,
+shaderLocation: 16,
+}, {
+format: 'uint16x4',
+offset: 1584,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 10212,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x2',
+offset: 916,
+shaderLocation: 8,
+}, {
+format: 'unorm16x4',
+offset: 8992,
+shaderLocation: 1,
+}, {
+format: 'sint32x3',
+offset: 8580,
+shaderLocation: 19,
+}, {
+format: 'snorm16x4',
+offset: 2932,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 4488,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 8612,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32',
+offset: 6896,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 780,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+offscreenCanvas11.getContext('webgl');
+} catch {}
+try {
+window.someLabel = device2.queue.label;
+} catch {}
+try {
+  await promise14;
+} catch {}
+let buffer23 = device0.createBuffer({
+  label: '\u{1fc9f}\u0c22\uc284\u0b3c\u5072\u4362\u5441\u0a47',
+  size: 25276,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let textureView56 = texture2.createView({
+  label: '\u{1fa33}\u331f',
+  dimension: '2d',
+  format: 'eac-rg11snorm',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+  baseArrayLayer: 12
+});
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 2,
+  origin: { x: 84, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(999), /* required buffer size: 999 */
+{offset: 239, bytesPerRow: 424}, {width: 252, height: 24, depthOrArrayLayers: 1});
+} catch {}
+let shaderModule7 = device0.createShaderModule({
+label: '\u6551\u{1fce8}\u6fc3\ub8c1\ua4e1\u7d88\u81bf\ucef1\u7844\u052b',
+code: `@group(1) @binding(4710)
+var<storage, read_write> type5: array<u32>;
+@group(0) @binding(5759)
+var<storage, read_write> parameter5: array<u32>;
+
+@compute @workgroup_size(6, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<i32>,
+  @location(1) f1: vec4<i32>,
+  @location(0) f2: vec4<f32>,
+  @location(4) f3: vec2<u32>,
+  @builtin(sample_mask) f4: u32,
+  @location(3) f5: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(36) a0: vec3<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S9 {
+  @builtin(vertex_index) f0: u32,
+  @location(2) f1: vec3<u32>,
+  @location(14) f2: vec4<f32>,
+  @location(6) f3: vec3<i32>,
+  @location(13) f4: vec2<f32>,
+  @location(19) f5: vec3<f16>,
+  @builtin(instance_index) f6: u32,
+  @location(1) f7: vec4<f32>,
+  @location(18) f8: i32,
+  @location(8) f9: vec3<f32>,
+  @location(9) f10: vec2<f16>
+}
+struct VertexOutput0 {
+  @location(47) f106: vec3<u32>,
+  @location(55) f107: vec2<i32>,
+  @location(60) f108: vec2<i32>,
+  @location(28) f109: vec4<f16>,
+  @location(19) f110: vec4<i32>,
+  @location(0) f111: vec2<i32>,
+  @location(32) f112: vec3<i32>,
+  @location(73) f113: vec3<i32>,
+  @location(34) f114: u32,
+  @location(7) f115: i32,
+  @location(67) f116: u32,
+  @location(71) f117: vec4<u32>,
+  @location(49) f118: vec2<f32>,
+  @location(37) f119: u32,
+  @location(38) f120: vec4<f32>,
+  @location(20) f121: vec3<f32>,
+  @location(15) f122: vec3<f16>,
+  @location(33) f123: vec2<f16>,
+  @location(12) f124: vec2<f32>,
+  @location(21) f125: vec4<i32>,
+  @location(68) f126: f32,
+  @location(22) f127: f16,
+  @location(50) f128: f16,
+  @builtin(position) f129: vec4<f32>,
+  @location(58) f130: vec4<f16>,
+  @location(25) f131: vec4<u32>,
+  @location(2) f132: vec4<f16>,
+  @location(11) f133: u32,
+  @location(43) f134: vec3<f16>,
+  @location(18) f135: vec3<u32>,
+  @location(77) f136: vec4<i32>,
+  @location(13) f137: vec3<f32>,
+  @location(52) f138: u32,
+  @location(3) f139: vec2<u32>,
+  @location(82) f140: vec2<f32>,
+  @location(17) f141: vec3<f32>,
+  @location(9) f142: vec3<i32>,
+  @location(51) f143: vec2<f32>,
+  @location(53) f144: f32,
+  @location(16) f145: vec4<f16>,
+  @location(39) f146: vec4<i32>,
+  @location(81) f147: i32,
+  @location(45) f148: i32,
+  @location(36) f149: vec3<f32>,
+  @location(72) f150: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: u32, a1: S9, @location(7) a2: u32, @location(4) a3: vec2<u32>, @location(10) a4: vec3<i32>, @location(5) a5: vec2<i32>, @location(3) a6: vec2<f32>, @location(17) a7: vec2<f16>, @location(16) a8: vec3<u32>, @location(0) a9: vec3<f32>, @location(15) a10: vec2<f32>, @location(12) a11: f16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+});
+let texture60 = device0.createTexture({
+size: {width: 1200, height: 4, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'etc2-rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['etc2-rgba8unorm'],
+});
+let renderBundleEncoder41 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba16uint', undefined, 'r8sint', 'rg16sint', 'rgba16sint', 'rgba16float', 'rg32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder27.setVertexBuffer(7, buffer4);
+} catch {}
+try {
+commandEncoder0.copyBufferToBuffer(buffer15, 2200, buffer3, 27628, 7408);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder25.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 8,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(308), /* required buffer size: 308 */
+{offset: 308}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline39 = await device0.createRenderPipelineAsync({
+label: '\ucefc\u{1faad}\ub84e\u{1fc3a}\u363c\uf013\uae1d\u09f2',
+layout: pipelineLayout5,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 543,
+stencilWriteMask: 2219,
+depthBias: 87,
+depthBiasSlopeScale: 61,
+depthBiasClamp: 5,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 6264,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 176,
+shaderLocation: 9,
+}, {
+format: 'snorm8x4',
+offset: 5556,
+shaderLocation: 10,
+}, {
+format: 'uint16x4',
+offset: 5836,
+shaderLocation: 17,
+}, {
+format: 'sint16x2',
+offset: 4712,
+shaderLocation: 16,
+}, {
+format: 'float16x2',
+offset: 5076,
+shaderLocation: 1,
+}, {
+format: 'snorm8x2',
+offset: 4612,
+shaderLocation: 0,
+}, {
+format: 'uint32x4',
+offset: 3000,
+shaderLocation: 5,
+}, {
+format: 'sint8x4',
+offset: 1276,
+shaderLocation: 15,
+}, {
+format: 'float32x4',
+offset: 4104,
+shaderLocation: 3,
+}, {
+format: 'snorm16x2',
+offset: 5044,
+shaderLocation: 11,
+}, {
+format: 'sint32',
+offset: 4828,
+shaderLocation: 19,
+}, {
+format: 'uint32x4',
+offset: 776,
+shaderLocation: 14,
+}, {
+format: 'unorm16x2',
+offset: 4916,
+shaderLocation: 6,
+}, {
+format: 'unorm8x4',
+offset: 1236,
+shaderLocation: 2,
+}, {
+format: 'uint32x3',
+offset: 2580,
+shaderLocation: 13,
+}, {
+format: 'float16x4',
+offset: 2628,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 12576,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x3',
+offset: 10464,
+shaderLocation: 8,
+}, {
+format: 'snorm16x2',
+offset: 4920,
+shaderLocation: 4,
+}, {
+format: 'uint32x4',
+offset: 3952,
+shaderLocation: 7,
+}, {
+format: 'unorm8x2',
+offset: 2594,
+shaderLocation: 18,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+let textureView57 = texture11.createView({
+  label: '\u2f74\u1517\u0627\u3142\u00b8\u{1f81e}\u{1f7ef}\u8b75\ub639',
+  dimension: '2d-array',
+  baseMipLevel: 4,
+  mipLevelCount: 4
+});
+let renderBundle41 = renderBundleEncoder0.finish();
+try {
+renderBundleEncoder22.setVertexBuffer(3, buffer4, 14432, 5287);
+} catch {}
+try {
+commandEncoder46.clearBuffer(buffer10, 732, 440);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+renderBundleEncoder15.insertDebugMarker('\u{1fbfb}');
+} catch {}
+document.body.prepend(img5);
+let texture61 = device3.createTexture({
+size: [1008, 120, 193],
+mipLevelCount: 9,
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['r8uint'],
+});
+let textureView58 = texture56.createView({
+  label: '\u{1fbb2}\u01ca\ueef4\ue426\u0642\u0b44\u9f98\u{1fb85}',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 176,
+  arrayLayerCount: 14
+});
+let renderBundle42 = renderBundleEncoder28.finish();
+try {
+commandEncoder51.copyTextureToTexture({
+  texture: texture48,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture48,
+  mipLevel: 2,
+  origin: { x: 30, y: 156, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder52 = device3.createCommandEncoder();
+let texture62 = device3.createTexture({
+label: '\u1aa3\uc530\u0def\udc10\uaf90\u126f\uab84',
+size: [32, 60, 45],
+mipLevelCount: 3,
+format: 'astc-4x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+try {
+commandEncoder51.clearBuffer(buffer19, 2364, 11620);
+dissociateBuffer(device3, buffer19);
+} catch {}
+let promise16 = device3.queue.onSubmittedWorkDone();
+let renderBundleEncoder42 = device1.createRenderBundleEncoder({colorFormats: ['rgba32sint', 'rg8sint', 'rgba32uint'], sampleCount: 4, stencilReadOnly: true});
+let renderBundle43 = renderBundleEncoder26.finish({label: '\uddf5\u0ad3\u0a7e'});
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 1,
+  origin: { x: 530, y: 0, z: 113 },
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(40)), /* required buffer size: 5136720 */
+{offset: 820, bytesPerRow: 805, rowsPerImage: 110}, {width: 370, height: 0, depthOrArrayLayers: 59});
+} catch {}
+let pipeline40 = await device1.createComputePipelineAsync({
+label: '\u0ffa\u{1f94d}\u{1f6b6}\u{1fc72}\u9b10',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+},
+});
+document.body.prepend(video3);
+gc();
+try {
+  await promise16;
+} catch {}
+gc();
+let canvas9 = document.createElement('canvas');
+let bindGroup2 = device0.createBindGroup({
+label: '\u2c27\u{1f666}\u1994',
+layout: bindGroupLayout13,
+entries: [{
+binding: 869,
+resource: externalTexture2
+}, {
+binding: 2828,
+resource: {
+buffer: buffer13,
+offset: 6144,
+size: 45416,
+}
+}],
+});
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder0.clearBuffer(buffer3, 22872, 6396);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder38.resolveQuerySet(querySet6, 545, 283, buffer2, 6400);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 916, new Float32Array(2135), 1562, 36);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 2,
+  origin: { x: 4, y: 0, z: 63 },
+  aspect: 'all',
+}, new Float32Array(arrayBuffer4), /* required buffer size: 640349 */
+{offset: 299, bytesPerRow: 251, rowsPerImage: 170}, {width: 3, height: 0, depthOrArrayLayers: 16});
+} catch {}
+let commandEncoder53 = device0.createCommandEncoder({label: '\u093f\ua1c3\ue307\uc084\uaa09\u0387\u0ec7\u01c9\u0e7a\ue8fa'});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup1, [18112]);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(4, bindGroup1, [17760]);
+} catch {}
+let arrayBuffer8 = buffer1.getMappedRange(0, 3664);
+try {
+commandEncoder22.resolveQuerySet(querySet11, 357, 1170, buffer2, 15104);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 9,
+  origin: { x: 6, y: 1, z: 1 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 35 */
+{offset: 35, bytesPerRow: 219}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(2, bindGroup1, [32128]);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(5, buffer4);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let querySet38 = device3.createQuerySet({
+label: '\ua79e\u893e\u4d4f\u0122\udaf6\u0e5c\u{1f924}',
+type: 'occlusion',
+count: 2210,
+});
+let textureView59 = texture62.createView({label: '\uaa47\ue895\uefb2', dimension: '2d', baseMipLevel: 1, baseArrayLayer: 7});
+try {
+device3.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 1,
+  origin: { x: 5, y: 16, z: 70 },
+  aspect: 'all',
+}, new Float32Array(arrayBuffer7), /* required buffer size: 1990526 */
+{offset: 426, bytesPerRow: 398, rowsPerImage: 160}, {width: 25, height: 41, depthOrArrayLayers: 32});
+} catch {}
+document.body.prepend(video4);
+let renderBundle44 = renderBundleEncoder42.finish({label: '\u706f\ue22f'});
+try {
+device1.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 1,
+  origin: { x: 24, y: 0, z: 1 },
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer5), /* required buffer size: 435 */
+{offset: 435}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+canvas9.getContext('webgl2');
+} catch {}
+let offscreenCanvas12 = new OffscreenCanvas(7, 954);
+let commandEncoder54 = device1.createCommandEncoder({label: '\u0e8f\u0cd8'});
+try {
+renderBundleEncoder17.setVertexBuffer(28, undefined, 2514210788, 218179234);
+} catch {}
+try {
+commandEncoder54.clearBuffer(buffer8, 9676, 1792);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+computePassEncoder21.insertDebugMarker('\u2811');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: video6,
+  origin: { x: 8, y: 10 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 17, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise17 = device1.createRenderPipelineAsync({
+label: '\ud2b8\u0ac5\uf2f8\u88b1\uffed\ue8ce',
+layout: pipelineLayout3,
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32float', writeMask: 0}, {
+  format: 'r16float',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-dst'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {format: 'r16uint', writeMask: 0}, {format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r8uint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 1518,
+depthBias: 74,
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 12856,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x3',
+offset: 4880,
+shaderLocation: 11,
+}, {
+format: 'snorm16x4',
+offset: 9988,
+shaderLocation: 22,
+}, {
+format: 'float32',
+offset: 11532,
+shaderLocation: 4,
+}, {
+format: 'uint16x2',
+offset: 8744,
+shaderLocation: 9,
+}, {
+format: 'float32x2',
+offset: 5224,
+shaderLocation: 16,
+}, {
+format: 'sint16x2',
+offset: 12840,
+shaderLocation: 0,
+}, {
+format: 'float16x2',
+offset: 3424,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 29592,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 14544,
+shaderLocation: 1,
+}, {
+format: 'unorm16x4',
+offset: 3936,
+shaderLocation: 17,
+}, {
+format: 'float16x4',
+offset: 28208,
+shaderLocation: 14,
+}, {
+format: 'unorm16x2',
+offset: 7384,
+shaderLocation: 26,
+}, {
+format: 'uint32',
+offset: 27124,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 17632,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x4',
+offset: 3632,
+shaderLocation: 20,
+}, {
+format: 'unorm16x4',
+offset: 8532,
+shaderLocation: 13,
+}, {
+format: 'uint32x2',
+offset: 1504,
+shaderLocation: 3,
+}, {
+format: 'float32x4',
+offset: 13724,
+shaderLocation: 10,
+}, {
+format: 'sint8x4',
+offset: 9360,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 28100,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint16x2',
+offset: 12168,
+shaderLocation: 24,
+}, {
+format: 'sint8x4',
+offset: 17196,
+shaderLocation: 18,
+}, {
+format: 'float32x4',
+offset: 632,
+shaderLocation: 8,
+}, {
+format: 'float32x4',
+offset: 7276,
+shaderLocation: 12,
+}, {
+format: 'uint32x4',
+offset: 11992,
+shaderLocation: 21,
+}],
+},
+{
+arrayStride: 3168,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x2',
+offset: 20,
+shaderLocation: 5,
+}, {
+format: 'float16x2',
+offset: 960,
+shaderLocation: 19,
+}],
+},
+{
+arrayStride: 16928,
+attributes: [{
+format: 'sint32',
+offset: 9236,
+shaderLocation: 23,
+}, {
+format: 'sint16x4',
+offset: 988,
+shaderLocation: 25,
+}],
+},
+{
+arrayStride: 21448,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x3',
+offset: 9432,
+shaderLocation: 2,
+}],
+}
+]
+},
+});
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let commandEncoder55 = device1.createCommandEncoder({label: '\ufaf9\u9476\uc07e\ufb84\u0e50\u0c50\ufdc9'});
+let texture63 = device1.createTexture({
+label: '\u0e76\u06a2\u036c\u0e7d\u{1f8a7}\u08ff\u4280',
+size: {width: 384, height: 16, depthOrArrayLayers: 187},
+sampleCount: 1,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x8-unorm', 'astc-8x8-unorm', 'astc-8x8-unorm'],
+});
+try {
+renderBundleEncoder17.draw(40, 24, 72);
+} catch {}
+try {
+commandEncoder55.clearBuffer(buffer21);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+computePassEncoder21.insertDebugMarker('\ucf73');
+} catch {}
+let gpuCanvasContext10 = offscreenCanvas12.getContext('webgpu');
+document.body.prepend(video5);
+try {
+renderBundleEncoder15.setVertexBuffer(6, buffer4);
+} catch {}
+try {
+commandEncoder11.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 6,
+  origin: { x: 12, y: 0, z: 33 },
+  aspect: 'all',
+}, {
+  texture: texture8,
+  mipLevel: 6,
+  origin: { x: 4, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 4, height: 4, depthOrArrayLayers: 32});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 2,
+  origin: { x: 70, y: 40, z: 22 },
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 325165 */
+{offset: 941, bytesPerRow: 247, rowsPerImage: 32}, {width: 100, height: 10, depthOrArrayLayers: 42});
+} catch {}
+try {
+buffer19.destroy();
+} catch {}
+try {
+computePassEncoder18.insertDebugMarker('\u42fd');
+} catch {}
+canvas5.width = 470;
+canvas4.width = 7;
+let img7 = await imageWithData(235, 30, '#ff4a4e4d', '#42e4f65a');
+let querySet39 = device1.createQuerySet({
+type: 'occlusion',
+count: 2910,
+});
+let texture64 = device1.createTexture({
+size: {width: 384, height: 16, depthOrArrayLayers: 103},
+mipLevelCount: 3,
+format: 'etc2-rgb8a1unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['etc2-rgb8a1unorm', 'etc2-rgb8a1unorm-srgb'],
+});
+let computePassEncoder23 = commandEncoder54.beginComputePass({label: '\u0bce\u6c5b\u3aa4\ua3b7\ubedf\u0f25\u{1ff2c}'});
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 61, y: 129 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 40, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline41 = device1.createRenderPipeline({
+label: '\ue963\u2e38\u0354\ucd07\uf240\uac5d\u{1ff74}\uf16f\ue8ad',
+layout: pipelineLayout7,
+multisample: {
+count: 4,
+mask: 0xafb85aeb,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rg8sint', writeMask: GPUColorWrite.GREEN}, {format: 'rg8unorm', writeMask: 0}, {format: 'r32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+failOp: 'invert',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'keep',
+},
+stencilReadMask: 1450,
+stencilWriteMask: 1313,
+depthBiasSlopeScale: 65,
+depthBiasClamp: 74,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 22664,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x2',
+offset: 20268,
+shaderLocation: 13,
+}, {
+format: 'snorm16x4',
+offset: 220,
+shaderLocation: 4,
+}, {
+format: 'uint8x2',
+offset: 9186,
+shaderLocation: 24,
+}, {
+format: 'uint16x4',
+offset: 18536,
+shaderLocation: 14,
+}, {
+format: 'uint16x2',
+offset: 7564,
+shaderLocation: 26,
+}, {
+format: 'sint32x2',
+offset: 10936,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 30748,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 7472,
+shaderLocation: 22,
+}, {
+format: 'sint16x4',
+offset: 11636,
+shaderLocation: 5,
+}, {
+format: 'unorm10-10-10-2',
+offset: 16448,
+shaderLocation: 1,
+}, {
+format: 'uint16x2',
+offset: 21584,
+shaderLocation: 17,
+}, {
+format: 'float16x2',
+offset: 24328,
+shaderLocation: 7,
+}, {
+format: 'snorm8x4',
+offset: 6252,
+shaderLocation: 8,
+}, {
+format: 'unorm16x2',
+offset: 15412,
+shaderLocation: 0,
+}, {
+format: 'unorm10-10-10-2',
+offset: 27272,
+shaderLocation: 21,
+}, {
+format: 'sint16x4',
+offset: 14108,
+shaderLocation: 25,
+}, {
+format: 'unorm16x2',
+offset: 26660,
+shaderLocation: 6,
+}, {
+format: 'uint8x2',
+offset: 25356,
+shaderLocation: 12,
+}, {
+format: 'float32',
+offset: 20220,
+shaderLocation: 20,
+}, {
+format: 'uint8x4',
+offset: 1700,
+shaderLocation: 10,
+}, {
+format: 'unorm16x2',
+offset: 5836,
+shaderLocation: 2,
+}, {
+format: 'sint32x4',
+offset: 22624,
+shaderLocation: 16,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let bindGroupLayout17 = device0.createBindGroupLayout({
+label: '\u0879\u055f\u7766\u{1f999}\uaa8b\u0646\ub077\u43cc',
+entries: [],
+});
+let commandEncoder56 = device0.createCommandEncoder();
+let texture65 = device0.createTexture({
+label: '\u26cf\u5997\u0d31\u56c1\u8131\uef19\u{1fb2b}\uef93\uf7b0\u{1fc03}\u0c75',
+size: {width: 735, height: 1, depthOrArrayLayers: 20},
+sampleCount: 1,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView60 = texture55.createView({
+  label: '\u4f21\u{1f977}\u{1f983}\u47d5\u{1fc95}\ud9ab\u6d1b\u0c0f\u9ae0\u0927',
+  aspect: 'all',
+  format: 'rg32uint',
+  baseMipLevel: 7
+});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup1, [17280]);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(8, buffer4, 7192, 14878);
+} catch {}
+try {
+commandEncoder18.copyBufferToTexture({
+/* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 17836 */
+offset: 14232,
+bytesPerRow: 256,
+buffer: buffer23,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: { x: 264, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 5, height: 15, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer23);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba16float'],
+});
+} catch {}
+let bindGroup3 = device0.createBindGroup({
+layout: bindGroupLayout4,
+entries: [{
+binding: 5759,
+resource: externalTexture2
+}, {
+binding: 1816,
+resource: externalTexture2
+}],
+});
+let querySet40 = device0.createQuerySet({
+label: '\u0672\udfa7\u6315\u{1f6aa}\u77ab\ua264\u0df9\ub30b\u71de',
+type: 'occlusion',
+count: 3254,
+});
+let texture66 = gpuCanvasContext2.getCurrentTexture();
+let textureView61 = texture20.createView({
+  label: '\u9b26\u003a\u3244\uf812\u711b\u{1ffe6}',
+  baseMipLevel: 3,
+  mipLevelCount: 2,
+  baseArrayLayer: 6,
+  arrayLayerCount: 80
+});
+let renderBundleEncoder43 = device0.createRenderBundleEncoder({
+  label: '\u{1f831}\ua8be\u{1f767}\uf15d',
+  colorFormats: ['rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let renderBundle45 = renderBundleEncoder35.finish({});
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(0, buffer4, 6504, 5961);
+} catch {}
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 1,
+  origin: { x: 7, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 20, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 16, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(querySet17, 2791, 106, buffer2, 35072);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer9,
+]);
+} catch {}
+let imageData12 = new ImageData(40, 208);
+let querySet41 = device0.createQuerySet({
+type: 'occlusion',
+count: 3258,
+});
+let texture67 = device0.createTexture({
+label: '\ub489\u0ee7\u0382\u8386\u06ef\u0374',
+size: {width: 576, height: 12, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['eac-rg11snorm', 'eac-rg11snorm', 'eac-rg11snorm'],
+});
+let sampler35 = device0.createSampler({
+label: '\u{1f728}\u42ce\uc6d8\u6ca2\u4855\u0987\u702e',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 27.503,
+compare: 'greater',
+});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup3, new Uint32Array(3441), 2570, 0);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup3);
+} catch {}
+let promise18 = buffer23.mapAsync(GPUMapMode.WRITE, 24608, 208);
+try {
+commandEncoder46.copyBufferToBuffer(buffer15, 7432, buffer3, 29272, 492);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer3);
+} catch {}
+video0.height = 258;
+let texture68 = device0.createTexture({
+size: {width: 720, height: 120, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x8-unorm', 'astc-8x8-unorm'],
+});
+let renderBundleEncoder44 = device0.createRenderBundleEncoder({
+  label: '\u3d02\u{1fffc}\u{1fe48}\u7e01\u00a5\uc1d8',
+  colorFormats: ['r8unorm', 'rgba16sint', 'rg8sint', 'rgba32float', 'r32uint', undefined],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let promise19 = device0.queue.onSubmittedWorkDone();
+canvas4.height = 221;
+let videoFrame10 = new VideoFrame(imageBitmap7, {timestamp: 0});
+let computePassEncoder24 = commandEncoder52.beginComputePass({label: '\u3532\ueca6\u00bd\u0065\u{1f8a0}'});
+let renderBundle46 = renderBundleEncoder40.finish();
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+pseudoSubmit(device1, commandEncoder50);
+let renderBundleEncoder45 = device1.createRenderBundleEncoder({
+  colorFormats: ['rgba32sint', 'rg8sint', 'rgba32uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder23.setPipeline(pipeline22);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer2), /* required buffer size: 495 */
+{offset: 495, bytesPerRow: 136}, {width: 8, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+label: '\u0556\u7b80\u9656\u0c9d',
+code: `@group(3) @binding(4710)
+var<storage, read_write> function2: array<u32>;
+@group(1) @binding(4710)
+var<storage, read_write> parameter6: array<u32>;
+@group(4) @binding(4710)
+var<storage, read_write> i3: array<u32>;
+
+@compute @workgroup_size(5, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S11 {
+  @location(39) f0: vec3<f32>,
+  @location(65) f1: i32,
+  @location(57) f2: vec4<f32>,
+  @location(41) f3: f16,
+  @location(27) f4: vec4<f32>,
+  @location(71) f5: vec3<f32>,
+  @location(63) f6: i32,
+  @location(32) f7: vec4<f16>,
+  @location(20) f8: vec4<f32>,
+  @location(24) f9: vec2<f16>,
+  @location(33) f10: vec4<f32>,
+  @location(13) f11: vec2<u32>,
+  @location(67) f12: f16,
+  @location(2) f13: f32,
+  @location(11) f14: vec4<i32>,
+  @location(73) f15: vec4<u32>,
+  @location(79) f16: vec2<f16>,
+  @location(9) f17: vec4<f32>,
+  @location(31) f18: vec2<f16>,
+  @location(25) f19: vec4<f16>,
+  @location(38) f20: vec2<f32>,
+  @location(82) f21: u32,
+  @location(1) f22: vec4<f16>,
+  @location(7) f23: vec2<i32>,
+  @location(0) f24: vec4<u32>,
+  @builtin(sample_index) f25: u32,
+  @location(43) f26: vec3<f32>,
+  @location(74) f27: vec4<f32>,
+  @location(75) f28: vec3<f16>,
+  @location(17) f29: f16,
+  @location(35) f30: vec3<f16>,
+  @location(59) f31: vec3<f32>,
+  @location(5) f32: f32,
+  @location(45) f33: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(1) f1: vec4<u32>,
+  @builtin(sample_mask) f2: u32,
+  @location(2) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(36) a0: vec4<u32>, @location(46) a1: vec4<f32>, @location(28) a2: vec3<i32>, a3: S11, @builtin(front_facing) a4: bool, @location(12) a5: vec2<f32>, @location(72) a6: i32, @location(50) a7: vec2<f16>, @location(22) a8: vec3<f16>, @location(54) a9: f32, @builtin(sample_mask) a10: u32, @builtin(position) a11: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S10 {
+  @location(18) f0: i32,
+  @location(6) f1: vec2<u32>,
+  @location(19) f2: vec2<f32>,
+  @location(1) f3: vec2<f16>,
+  @location(11) f4: f16,
+  @location(14) f5: vec2<u32>,
+  @location(4) f6: i32,
+  @location(16) f7: vec4<f16>,
+  @location(9) f8: vec2<f16>,
+  @location(10) f9: vec4<f32>,
+  @location(3) f10: vec4<u32>,
+  @location(0) f11: vec4<i32>
+}
+struct VertexOutput0 {
+  @location(11) f151: vec4<i32>,
+  @location(74) f152: vec4<f32>,
+  @location(57) f153: vec4<f32>,
+  @location(79) f154: vec2<f16>,
+  @location(73) f155: vec4<u32>,
+  @location(0) f156: vec4<u32>,
+  @location(41) f157: f16,
+  @location(71) f158: vec3<f32>,
+  @location(32) f159: vec4<f16>,
+  @location(38) f160: vec2<f32>,
+  @location(75) f161: vec3<f16>,
+  @location(22) f162: vec3<f16>,
+  @location(43) f163: vec3<f32>,
+  @location(33) f164: vec4<f32>,
+  @location(25) f165: vec4<f16>,
+  @location(50) f166: vec2<f16>,
+  @location(24) f167: vec2<f16>,
+  @location(82) f168: u32,
+  @location(39) f169: vec3<f32>,
+  @builtin(position) f170: vec4<f32>,
+  @location(63) f171: i32,
+  @location(12) f172: vec2<f32>,
+  @location(17) f173: f16,
+  @location(35) f174: vec3<f16>,
+  @location(67) f175: f16,
+  @location(27) f176: vec4<f32>,
+  @location(28) f177: vec3<i32>,
+  @location(1) f178: vec4<f16>,
+  @location(72) f179: i32,
+  @location(13) f180: vec2<u32>,
+  @location(36) f181: vec4<u32>,
+  @location(31) f182: vec2<f16>,
+  @location(7) f183: vec2<i32>,
+  @location(54) f184: f32,
+  @location(65) f185: i32,
+  @location(20) f186: vec4<f32>,
+  @location(45) f187: vec4<f32>,
+  @location(46) f188: vec4<f32>,
+  @location(9) f189: vec4<f32>,
+  @location(5) f190: f32,
+  @location(59) f191: vec3<f32>,
+  @location(2) f192: f32
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec2<f16>, @location(2) a1: u32, @location(7) a2: vec4<i32>, a3: S10, @location(13) a4: vec2<f32>, @location(5) a5: vec4<f16>, @location(12) a6: u32, @location(17) a7: vec2<u32>, @location(15) a8: vec3<i32>, @builtin(vertex_index) a9: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let renderBundle47 = renderBundleEncoder15.finish();
+try {
+buffer6.unmap();
+} catch {}
+let querySet42 = device3.createQuerySet({
+label: '\u{1f6b9}\u0554\u0bc9\u{1f83b}',
+type: 'occlusion',
+count: 3538,
+});
+let texture69 = device3.createTexture({
+label: '\u9c37\u{1faed}\uaa6a\u004e\u060b\uecaa',
+size: {width: 30},
+sampleCount: 1,
+dimension: '1d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+});
+let textureView62 = texture47.createView({label: '\u86e8\udbb2', baseMipLevel: 0});
+let computePassEncoder25 = commandEncoder51.beginComputePass({label: '\udfd8\u24a1\u0219'});
+let renderBundle48 = renderBundleEncoder40.finish({label: '\u79f4\u060c\u0f7e\u{1fc6f}\ud8ae\u0de3\u0f3c'});
+let sampler36 = device3.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 54.162,
+lodMaxClamp: 71.866,
+compare: 'less-equal',
+maxAnisotropy: 11,
+});
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let videoFrame11 = new VideoFrame(img6, {timestamp: 0});
+let computePassEncoder26 = commandEncoder55.beginComputePass({label: '\u{1fa6b}\ud2e4\u0069\u9615\ued8d'});
+try {
+renderBundleEncoder17.draw(40, 16, 0, 8);
+} catch {}
+try {
+buffer8.destroy();
+} catch {}
+try {
+  await promise18;
+} catch {}
+let device4 = await adapter6.requestDevice({
+label: '\u2b7c\u765f\udd19\u{1f967}\udb3f\uecc7\u{1fdf5}\ued54\u8d17\u{1f60c}\u3d1a',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxColorAttachmentBytesPerSample: 39,
+maxVertexAttributes: 19,
+maxVertexBufferArrayStride: 19567,
+maxStorageTexturesPerShaderStage: 15,
+maxStorageBuffersPerShaderStage: 16,
+maxDynamicStorageBuffersPerPipelineLayout: 54670,
+maxBindingsPerBindGroup: 2341,
+maxTextureDimension1D: 9883,
+maxTextureDimension2D: 15366,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 256,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 178727275,
+maxUniformBuffersPerShaderStage: 37,
+maxInterStageShaderVariables: 55,
+maxInterStageShaderComponents: 108,
+maxSamplersPerShaderStage: 18,
+},
+});
+try {
+adapter5.label = '\u2752\u18e2\ud805\ub832\ua672';
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let commandEncoder57 = device3.createCommandEncoder({label: '\uf8c9\u562c'});
+try {
+texture48.destroy();
+} catch {}
+let querySet43 = device1.createQuerySet({
+label: '\uaf0b\u425a\u2907\u{1fb55}\u67e2\u{1fd4f}\u039d\u4bda\u{1fc5f}\u{1fe53}\u7159',
+type: 'occlusion',
+count: 3622,
+});
+let renderBundleEncoder46 = device1.createRenderBundleEncoder({label: '\u4f83\u77f3\u087a', colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint']});
+try {
+renderBundleEncoder17.setPipeline(pipeline34);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 772, new BigUint64Array(15992), 2392, 56);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let video9 = await videoWithData();
+let buffer24 = device3.createBuffer({
+  label: '\u027c\u0ea8\u{1fff9}\u{1fb03}\u03c7',
+  size: 9579,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE
+});
+let texture70 = gpuCanvasContext0.getCurrentTexture();
+try {
+buffer19.unmap();
+} catch {}
+try {
+commandEncoder57.clearBuffer(buffer19, 11624, 2544);
+dissociateBuffer(device3, buffer19);
+} catch {}
+let canvas10 = document.createElement('canvas');
+let commandEncoder58 = device3.createCommandEncoder({label: '\u{1fb75}\ucafe\u06b6\u{1f97a}\u0076\ueb94\u0586\u9da2'});
+let computePassEncoder27 = commandEncoder58.beginComputePass({label: '\u0501\u9840\u9daa\u01c6\ua1a8\u{1f80b}'});
+let renderBundle49 = renderBundleEncoder28.finish({label: '\u27fa\u{1f838}\u8ec9\u0005\u{1f60e}'});
+try {
+device3.queue.writeBuffer(buffer24, 7052, new DataView(new ArrayBuffer(13280)), 6812, 2116);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+canvas10.getContext('webgl');
+} catch {}
+let pipelineLayout8 = device1.createPipelineLayout({label: '\ua538\u41f3\u018b\u{1ffbc}', bindGroupLayouts: [bindGroupLayout11, bindGroupLayout14]});
+let renderBundle50 = renderBundleEncoder31.finish({label: '\u1bc4\u17e0\u{1faf6}\u2512\ubb2b\u8890\u0fe1\ueca9\u6a82'});
+let sampler37 = device1.createSampler({
+label: '\uadc7\uad37\u5d48\u{1fbce}\u85a3\u1eb1',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 44.403,
+lodMaxClamp: 70.097,
+});
+try {
+renderBundleEncoder17.draw(48, 16, 16, 8);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 22, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 816 */
+{offset: 816, bytesPerRow: 310}, {width: 21, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder59 = device1.createCommandEncoder({label: '\u{1fd9d}\u06a9\u{1fb35}\u8cdb\u11c0\u0e89\u7edf\u18e0\uf37a\u{1f9a6}\u61ee'});
+let textureView63 = texture25.createView({label: '\u{1fcf0}\u098c\uc2af\u{1f716}\u8d10\u0e92\ucb21\u{1f914}\u9cb4\ub981\u0db6', baseMipLevel: 2});
+try {
+renderBundleEncoder17.draw(0, 24, 80);
+} catch {}
+let video10 = await videoWithData();
+let querySet44 = device1.createQuerySet({
+label: '\u{1f883}\u1c36\u{1fa36}\u5171\u979e',
+type: 'occlusion',
+count: 2506,
+});
+try {
+renderBundleEncoder17.draw(8, 72, 80, 0);
+} catch {}
+let arrayBuffer9 = buffer21.getMappedRange();
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture45,
+  mipLevel: 1,
+  origin: { x: 29, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: { x: 75, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 8, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderBundleEncoder37.pushDebugGroup('\u0e07');
+} catch {}
+let pipeline42 = device1.createRenderPipeline({
+label: '\u0328\u5be0\u6981\u6a16\u6c3f\u1acd\u3bcb\uda39',
+layout: pipelineLayout8,
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32float', writeMask: 0}, {format: 'r16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r16uint', writeMask: 0}, {format: 'r16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8uint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilReadMask: 1213,
+depthBias: 5,
+depthBiasSlopeScale: 41,
+depthBiasClamp: 17,
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x4',
+offset: 13484,
+shaderLocation: 23,
+}, {
+format: 'sint16x4',
+offset: 28012,
+shaderLocation: 18,
+}, {
+format: 'unorm16x4',
+offset: 23028,
+shaderLocation: 6,
+}, {
+format: 'float16x4',
+offset: 28656,
+shaderLocation: 13,
+}, {
+format: 'sint32',
+offset: 2948,
+shaderLocation: 25,
+}, {
+format: 'uint32x3',
+offset: 22700,
+shaderLocation: 2,
+}, {
+format: 'snorm8x2',
+offset: 11394,
+shaderLocation: 11,
+}, {
+format: 'snorm16x4',
+offset: 35132,
+shaderLocation: 12,
+}, {
+format: 'unorm8x2',
+offset: 2072,
+shaderLocation: 4,
+}, {
+format: 'sint8x4',
+offset: 4068,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 2424,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x4',
+offset: 1192,
+shaderLocation: 14,
+}, {
+format: 'unorm10-10-10-2',
+offset: 1572,
+shaderLocation: 17,
+}, {
+format: 'unorm8x2',
+offset: 2180,
+shaderLocation: 1,
+}, {
+format: 'unorm8x2',
+offset: 1380,
+shaderLocation: 8,
+}, {
+format: 'uint16x4',
+offset: 2276,
+shaderLocation: 3,
+}, {
+format: 'snorm8x4',
+offset: 2148,
+shaderLocation: 20,
+}, {
+format: 'unorm8x4',
+offset: 620,
+shaderLocation: 5,
+}, {
+format: 'float16x4',
+offset: 1816,
+shaderLocation: 19,
+}, {
+format: 'uint16x4',
+offset: 736,
+shaderLocation: 9,
+}, {
+format: 'float32x3',
+offset: 280,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 27632,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x2',
+offset: 10500,
+shaderLocation: 21,
+}, {
+format: 'sint16x4',
+offset: 16920,
+shaderLocation: 7,
+}, {
+format: 'snorm16x4',
+offset: 10544,
+shaderLocation: 22,
+}, {
+format: 'sint8x2',
+offset: 236,
+shaderLocation: 24,
+}, {
+format: 'uint16x2',
+offset: 25632,
+shaderLocation: 15,
+}, {
+format: 'float32x4',
+offset: 20728,
+shaderLocation: 26,
+}, {
+format: 'unorm16x4',
+offset: 9092,
+shaderLocation: 16,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'none',
+},
+});
+let texture71 = device4.createTexture({
+label: '\u23c8\u{1fee8}\u082b',
+size: [2020, 1, 220],
+mipLevelCount: 8,
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+});
+let textureView64 = texture71.createView({label: '\u1d52\u8167', dimension: '2d', baseMipLevel: 3, baseArrayLayer: 194});
+try {
+  await promise19;
+} catch {}
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+let bindGroupLayout18 = device0.createBindGroupLayout({
+label: '\u03e3\u086a\ue06c\ue9c2\u{1f914}\u{1f7e6}',
+entries: [{
+binding: 5556,
+visibility: 0,
+storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '2d' },
+}, {
+binding: 1953,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}],
+});
+try {
+computePassEncoder3.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(3, buffer4, 20508);
+} catch {}
+try {
+commandEncoder49.clearBuffer(buffer3, 43352, 12972);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let renderBundleEncoder47 = device0.createRenderBundleEncoder({
+  label: '\u7e67\u{1fc87}',
+  colorFormats: ['rgba16uint', undefined, 'r8sint', 'rg16sint', 'rgba16sint', 'rgba16float', 'rg32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+let renderBundle51 = renderBundleEncoder16.finish({});
+try {
+computePassEncoder4.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(3, bindGroup0, new Uint32Array(3749), 3649, 0);
+} catch {}
+try {
+commandEncoder53.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 2,
+  origin: { x: 290, y: 4, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture16,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 75, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder11.clearBuffer(buffer3, 26096, 1552);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder49.resolveQuerySet(querySet41, 3156, 28, buffer2, 8960);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 384, new BigUint64Array(46502), 1041, 24);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 18, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData12,
+  origin: { x: 38, y: 34 },
+  flipY: false,
+}, {
+  texture: texture57,
+  mipLevel: 8,
+  origin: { x: 8, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline43 = device0.createComputePipeline({
+label: '\ufb26\u0cf1\u251d\u091c\ua776\u0d25\ue5bc',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+},
+});
+document.body.prepend(canvas6);
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap10 = await createImageBitmap(offscreenCanvas6);
+let pipelineLayout9 = device0.createPipelineLayout({
+  label: '\u55ac\u9425\u95d0\ue4df\u{1f643}',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout4, bindGroupLayout12, bindGroupLayout7, bindGroupLayout3]
+});
+let buffer25 = device0.createBuffer({label: '\u0fc9\udf2b', size: 5734, usage: GPUBufferUsage.QUERY_RESOLVE});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup2, new Uint32Array(2711), 1456, 1);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+try {
+commandEncoder22.clearBuffer(buffer3, 16884, 42632);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder16.resolveQuerySet(querySet41, 1248, 346, buffer2, 9216);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video9,
+  origin: { x: 1, y: 3 },
+  flipY: true,
+}, {
+  texture: texture57,
+  mipLevel: 11,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout19 = device4.createBindGroupLayout({
+label: '\u8008\u{1f9b9}\u7854',
+entries: [{
+binding: 115,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+}, {
+binding: 1245,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+}, {
+binding: 1223,
+visibility: 0,
+sampler: { type: 'non-filtering' },
+}],
+});
+let texture72 = device4.createTexture({
+size: {width: 4740, height: 1, depthOrArrayLayers: 240},
+mipLevelCount: 2,
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgb10a2uint', 'rgb10a2uint', 'rgb10a2uint'],
+});
+let renderBundleEncoder48 = device4.createRenderBundleEncoder({
+  label: '\u{1ff5f}\u25a7\uf826\u4b73\u734d\u08dc\u1684\u0855\u85d3\ue039',
+  colorFormats: ['r32uint', undefined, 'rgba32float', 'rg16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+document.body.prepend(img2);
+let bindGroupLayout20 = device0.createBindGroupLayout({
+entries: [{
+binding: 4281,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+}, {
+binding: 3997,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}, {
+binding: 1641,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+}],
+});
+let commandEncoder60 = device0.createCommandEncoder({});
+let querySet45 = device0.createQuerySet({
+label: '\ub7f9\u{1f89b}\u2f4b\u{1fdbd}\u0523\u1eff\u5bc4\u0e06\u0264\u0a41\u7b8e',
+type: 'occlusion',
+count: 4078,
+});
+let computePassEncoder28 = commandEncoder53.beginComputePass({label: '\u0fff\u7879\u{1f96a}\u0a47\u43e4\u0403\ua9f5\u0f69\u{1f9af}\u0f82\u0217'});
+try {
+renderBundleEncoder27.setBindGroup(0, bindGroup1, [35264]);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(3, bindGroup3, new Uint32Array(2607), 1190, 0);
+} catch {}
+try {
+commandEncoder25.copyBufferToBuffer(buffer15, 3676, buffer10, 912, 196);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder30.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder34.resolveQuerySet(querySet35, 633, 406, buffer25, 2304);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video7,
+  origin: { x: 6, y: 0 },
+  flipY: true,
+}, {
+  texture: texture57,
+  mipLevel: 4,
+  origin: { x: 232, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let video11 = await videoWithData();
+let commandEncoder61 = device3.createCommandEncoder({label: '\u0b2d\u{1feec}\u0d27\u0ce0\u{1feb3}\u9f54\u4424\u{1ff20}\u{1f758}\u{1ff82}'});
+let computePassEncoder29 = commandEncoder61.beginComputePass({label: '\u{1ff09}\u{1f6d3}\u{1f88d}\u2794\u51ea\u3c85'});
+try {
+device3.queue.writeBuffer(buffer24, 4168, new Float32Array(4109), 203, 616);
+} catch {}
+let querySet46 = device4.createQuerySet({
+label: '\u0fba\u5cb8\u{1fe56}\u13af\u0112\u4d5f\u95a8\u35ab',
+type: 'occlusion',
+count: 528,
+});
+let texture73 = device4.createTexture({
+label: '\u{1fb53}\u0c55\u87f0',
+size: [160, 320, 1],
+mipLevelCount: 7,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-5x5-unorm-srgb', 'astc-5x5-unorm-srgb'],
+});
+let sampler38 = device4.createSampler({
+label: '\u000f\ucb5d\u{1ff20}\u7a5f\uecfa\u{1fbf2}\ub729\u055f\u0b9e\u{1feb4}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 43.763,
+lodMaxClamp: 74.934,
+});
+let buffer26 = device4.createBuffer({label: '\u003c\uc0f3\u{1f90a}', size: 54936, usage: GPUBufferUsage.INDIRECT, mappedAtCreation: true});
+let commandEncoder62 = device4.createCommandEncoder();
+let texture74 = device4.createTexture({
+label: '\u0327\u73d0\u02fd\u0738\u16ac\ub058',
+size: {width: 160, height: 320, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+sampleCount: 1,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x8-unorm-srgb'],
+});
+let texture75 = gpuCanvasContext2.getCurrentTexture();
+let textureView65 = texture74.createView({
+  label: '\u0e2d\ufd06\u67ea\u4014',
+  aspect: 'all',
+  format: 'astc-8x8-unorm-srgb',
+  baseMipLevel: 1,
+  mipLevelCount: 1
+});
+try {
+device4.destroy();
+} catch {}
+let querySet47 = device1.createQuerySet({
+type: 'occlusion',
+count: 3517,
+});
+let renderBundleEncoder49 = device1.createRenderBundleEncoder({
+  label: '\u4b83\uddae\u2e10\u0aa1\u01dd',
+  colorFormats: [undefined, 'rg8sint', 'rgba8uint', 'bgra8unorm-srgb', 'rg16sint', 'rg16float', 'rg8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+try {
+computePassEncoder23.end();
+} catch {}
+try {
+renderBundleEncoder17.draw(16, 24);
+} catch {}
+try {
+renderBundleEncoder46.setIndexBuffer(buffer7, 'uint16', 19500, 5825);
+} catch {}
+try {
+commandEncoder54.copyTextureToTexture({
+  texture: texture45,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture45,
+  mipLevel: 4,
+  origin: { x: 3, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder54.clearBuffer(buffer21);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 85, y: 99 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 30, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 17, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame12 = new VideoFrame(video2, {timestamp: 0});
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let texture76 = device0.createTexture({
+size: [180, 30, 1],
+format: 'astc-10x6-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView66 = texture43.createView({
+  label: '\u7af2\u3791\u{1f780}\ufb48\u04f3\u255e',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseMipLevel: 6,
+  mipLevelCount: 3
+});
+try {
+computePassEncoder19.setBindGroup(4, bindGroup2, new Uint32Array(9149), 822, 1);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(4, buffer4, 23932, 644);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 352, new BigUint64Array(54955), 51022, 88);
+} catch {}
+let img8 = await imageWithData(54, 142, '#dd2d3567', '#bb7317af');
+let sampler39 = device1.createSampler({
+label: '\ue836\u5fb2\u{1f7a4}',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 6.290,
+lodMaxClamp: 60.933,
+compare: 'not-equal',
+maxAnisotropy: 9,
+});
+try {
+renderBundleEncoder17.draw(8, 64, 56, 56);
+} catch {}
+try {
+renderBundleEncoder37.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let commandEncoder63 = device3.createCommandEncoder();
+let querySet48 = device3.createQuerySet({
+label: '\ue9bd\u00e6\u{1fcdf}\u{1fc54}\u0666\u0cb8\ub7e1\u4528\u{1fe07}\u2046',
+type: 'occlusion',
+count: 424,
+});
+let sampler40 = device3.createSampler({
+label: '\ub578\uc2ba\u085b\u33db\u{1f723}\u0a2d\u2c4e\u1aad\u04ac',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 49.289,
+lodMaxClamp: 93.929,
+});
+try {
+device3.queue.submit([
+]);
+} catch {}
+let img9 = await imageWithData(69, 188, '#851227b3', '#db9ce1f0');
+let promise20 = adapter3.requestAdapterInfo();
+let texture77 = device3.createTexture({
+label: '\u31e0\u654d\u300a',
+size: [912, 20, 163],
+mipLevelCount: 8,
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x10-unorm', 'astc-12x10-unorm', 'astc-12x10-unorm-srgb'],
+});
+let computePassEncoder30 = commandEncoder63.beginComputePass();
+try {
+device3.queue.submit([
+commandBuffer7,
+]);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 1,
+  origin: { x: 0, y: 25, z: 62 },
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 1716688 */
+{offset: 838, bytesPerRow: 837, rowsPerImage: 50}, {width: 210, height: 0, depthOrArrayLayers: 42});
+} catch {}
+let commandEncoder64 = device0.createCommandEncoder({label: '\u0690\ub036\u2592\u0ecf\ub257\u{1f997}'});
+let texture78 = device0.createTexture({
+label: '\u587b\u{1f659}\u0f21\uf11c\u09eb\u55fd\u06dc',
+size: [360, 60, 200],
+mipLevelCount: 9,
+format: 'astc-4x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-4x4-unorm', 'astc-4x4-unorm-srgb'],
+});
+let renderBundle52 = renderBundleEncoder6.finish({label: '\u{1feb8}\u24f8'});
+try {
+renderBundleEncoder22.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 4,
+  origin: { x: 20, y: 0, z: 0 },
+  aspect: 'all',
+}, new DataView(arrayBuffer1), /* required buffer size: 13 */
+{offset: 13}, {width: 128, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture79 = device3.createTexture({
+label: '\u0a53\u7e7d\u6710\ua5b1\u0dcd\u2f86',
+size: {width: 60, height: 240, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder31 = commandEncoder57.beginComputePass({label: '\uf9a6\u{1fa97}\u0c50\u4d29\uebd7\u9d61'});
+let sampler41 = device3.createSampler({
+label: '\u{1f978}\ubacf\u5bc6',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 68.497,
+lodMaxClamp: 72.893,
+});
+offscreenCanvas3.height = 730;
+let canvas11 = document.createElement('canvas');
+let renderBundleEncoder50 = device3.createRenderBundleEncoder({
+  label: '\u089e\u8968\u0a46\u0f01\ubcb2\u{1f926}\u765f\u0abf\u6fcd\u56e9',
+  colorFormats: ['rg32sint'],
+  stencilReadOnly: true
+});
+let renderBundle53 = renderBundleEncoder50.finish({label: '\u{1fc40}\ue886'});
+let shaderModule9 = device0.createShaderModule({
+label: '\u8e66\ucbf8\u07ff\u448f',
+code: `@group(0) @binding(5759)
+var<storage, read_write> local10: array<u32>;
+@group(3) @binding(4710)
+var<storage, read_write> global5: array<u32>;
+
+@compute @workgroup_size(7, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: f32,
+  @location(2) f1: vec2<u32>,
+  @location(3) f2: u32,
+  @location(0) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool, @builtin(sample_mask) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S12 {
+  @location(16) f0: vec2<i32>,
+  @location(10) f1: f16,
+  @location(18) f2: vec4<i32>,
+  @location(4) f3: i32,
+  @location(6) f4: vec2<f32>,
+  @location(3) f5: vec4<i32>,
+  @location(14) f6: vec2<f16>,
+  @location(19) f7: vec4<u32>,
+  @location(5) f8: vec3<i32>,
+  @location(12) f9: vec4<f16>,
+  @location(11) f10: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec4<f16>, @location(8) a1: f16, @builtin(vertex_index) a2: u32, @location(1) a3: u32, @location(7) a4: vec4<u32>, @location(13) a5: vec4<f16>, @builtin(instance_index) a6: u32, @location(0) a7: i32, @location(9) a8: vec4<i32>, @location(17) a9: vec2<f32>, a10: S12, @location(2) a11: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder65 = device0.createCommandEncoder();
+let querySet49 = device0.createQuerySet({
+label: '\u{1f652}\u{1f8fa}\u0740\u9652\u0f5b\ube06\u07ab\u{1fee2}',
+type: 'occlusion',
+count: 1464,
+});
+let renderBundleEncoder51 = device0.createRenderBundleEncoder({
+  label: '\u0fdb\u3b7c\u{1fe94}\u026a\u1370\u0223\u{1fe20}\u{1fe2d}',
+  colorFormats: ['r8sint', 'rg16float', 'rgba16float'],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+let sampler42 = device0.createSampler({
+label: '\uef30\u0d85\uf37f\ua175\u{1febd}\u0e86\u390d\u{1fb71}\u073e\u0ae2\u0a0f',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 73.945,
+lodMaxClamp: 97.370,
+maxAnisotropy: 8,
+});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup3, new Uint32Array(3189), 654, 0);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline27);
+} catch {}
+try {
+commandEncoder34.copyBufferToBuffer(buffer23, 1828, buffer3, 46752, 12760);
+dissociateBuffer(device0, buffer23);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder0.clearBuffer(buffer3, 6516, 9284);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 219, y: 2, z: 1 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 414017 */
+{offset: 968, bytesPerRow: 1003, rowsPerImage: 82}, {width: 51, height: 2, depthOrArrayLayers: 6});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let querySet50 = device3.createQuerySet({
+label: '\u0a9b\u{1fb1d}\u0e63\u0c02\u7da4\u0950\u{1fc67}',
+type: 'occlusion',
+count: 3974,
+});
+let textureView67 = texture77.createView({label: '\u0f5b\ua544\ud602', baseMipLevel: 5, mipLevelCount: 2, baseArrayLayer: 98, arrayLayerCount: 8});
+let sampler43 = device3.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 63.184,
+lodMaxClamp: 93.476,
+});
+try {
+canvas11.getContext('bitmaprenderer');
+} catch {}
+let img10 = await imageWithData(104, 275, '#088358bb', '#ffdf3b9b');
+try {
+window.someLabel = device4.label;
+} catch {}
+let renderBundle54 = renderBundleEncoder43.finish({label: '\ud681\u0d68\udec2\ueeec'});
+try {
+renderBundleEncoder12.setBindGroup(3, bindGroup0, new Uint32Array(6845), 376, 0);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(7, buffer4, 7220, 7816);
+} catch {}
+let promise21 = device0.createComputePipelineAsync({
+label: '\u07b2\u004b\u4503',
+layout: 'auto',
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+  await promise20;
+} catch {}
+let textureView68 = texture58.createView({label: '\u9977\ue4cf\u{1f97f}', baseMipLevel: 1, baseArrayLayer: 24, arrayLayerCount: 91});
+let sampler44 = device3.createSampler({
+label: '\u09c8\uc537\u1ec6\u{1f661}',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMaxClamp: 50.495,
+});
+try {
+device3.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 3,
+  origin: { x: 12, y: 5, z: 4 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 2949205 */
+{offset: 190, bytesPerRow: 235, rowsPerImage: 267}, {width: 24, height: 0, depthOrArrayLayers: 48});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+gc();
+let buffer27 = device1.createBuffer({size: 20756, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let querySet51 = device1.createQuerySet({
+label: '\u8db7\u8763\u0e36\u{1fa02}\u6691\ue15f\u62d3\u0b06\u07e8',
+type: 'occlusion',
+count: 3274,
+});
+let textureView69 = texture64.createView({
+  label: '\ue51b\uc1b1\u93f3\ud072\u{1fd9c}\u{1faa5}\u4759\u3fd0\u0e61\ue37c\u3ba6',
+  format: 'etc2-rgb8a1unorm',
+  mipLevelCount: 2,
+  baseArrayLayer: 71,
+  arrayLayerCount: 11
+});
+let renderBundle55 = renderBundleEncoder24.finish();
+try {
+renderBundleEncoder49.setVertexBuffer(72, undefined, 2332263278, 1260032284);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer27, 19336, new Int16Array(31330), 23825, 56);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData5,
+  origin: { x: 147, y: 104 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 45, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let bindGroupLayout21 = device1.createBindGroupLayout({
+label: '\u0461\u{1fca7}\u0796',
+entries: [{
+binding: 3399,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}, {
+binding: 1145,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '3d' },
+}, {
+binding: 3240,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}],
+});
+let bindGroup4 = device1.createBindGroup({
+label: '\uf5f8\u049d\ud89a\uf83b\u7b3c\u{1f7e9}\u{1faa3}',
+layout: bindGroupLayout14,
+entries: [{
+binding: 1723,
+resource: sampler22
+}],
+});
+let renderBundle56 = renderBundleEncoder9.finish({label: '\u0122\u601f\u7579\u30fc\u{1fd85}\u{1fcd8}\u1dbe\u0cd3'});
+let sampler45 = device1.createSampler({
+label: '\u898c\ucbf5\u{1fff3}\u{1fa53}\ubcbc\ud255\u4cc6',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 65.488,
+lodMaxClamp: 93.194,
+maxAnisotropy: 15,
+});
+try {
+renderBundleEncoder25.setVertexBuffer(23, undefined, 1690392923, 1421406778);
+} catch {}
+try {
+computePassEncoder21.insertDebugMarker('\u0fdb');
+} catch {}
+let canvas12 = document.createElement('canvas');
+let offscreenCanvas13 = new OffscreenCanvas(331, 539);
+let textureView70 = texture31.createView({label: '\u{1fcee}\u{1f714}\uf822\u{1fd8e}\u0033', dimension: '2d-array', mipLevelCount: 3});
+let computePassEncoder32 = commandEncoder65.beginComputePass({label: '\u68c3\u7f38\u{1fdac}\u0882\u0f3a\u{1f609}'});
+let renderBundle57 = renderBundleEncoder7.finish({label: '\u0f63\u29f8\u0693\ufee3\u7bac\u1f67\u{1ffaa}\u{1fc3d}\u0b28\u{1f87f}\u{1ff77}'});
+try {
+commandEncoder34.copyBufferToBuffer(buffer23, 3044, buffer10, 1104, 72);
+dissociateBuffer(device0, buffer23);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 300, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video4,
+  origin: { x: 5, y: 14 },
+  flipY: false,
+}, {
+  texture: texture57,
+  mipLevel: 4,
+  origin: { x: 228, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline44 = await promise7;
+try {
+computePassEncoder5.setPipeline(pipeline37);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 4,
+  origin: { x: 30, y: 0, z: 4 },
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 892401 */
+{offset: 373, bytesPerRow: 311, rowsPerImage: 47}, {width: 50, height: 20, depthOrArrayLayers: 62});
+} catch {}
+let pipeline45 = await promise21;
+let gpuCanvasContext11 = canvas12.getContext('webgpu');
+let img11 = await imageWithData(50, 103, '#01e5a3e1', '#562fb65b');
+let querySet52 = device0.createQuerySet({
+label: '\u{1f911}\u0edb\u2396\u9413\u0970\u8fa8',
+type: 'occlusion',
+count: 2414,
+});
+let computePassEncoder33 = commandEncoder64.beginComputePass({});
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 75, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas6,
+  origin: { x: 53, y: 89 },
+  flipY: false,
+}, {
+  texture: texture57,
+  mipLevel: 6,
+  origin: { x: 33, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 18, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline46 = await device0.createComputePipelineAsync({
+layout: pipelineLayout5,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let videoFrame13 = videoFrame2.clone();
+let bindGroup5 = device0.createBindGroup({
+label: '\u0fbf\u00d8\ua9b5\u0d4a',
+layout: bindGroupLayout13,
+entries: [{
+binding: 2828,
+resource: {
+buffer: buffer13,
+offset: 31040,
+size: 10860,
+}
+}, {
+binding: 869,
+resource: externalTexture2
+}],
+});
+let buffer28 = device0.createBuffer({
+  label: '\udee5\uaacc',
+  size: 48792,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX
+});
+let querySet53 = device0.createQuerySet({
+label: '\u{1ff29}\ua179\u0628\uf727\u04c4\u0502',
+type: 'occlusion',
+count: 1029,
+});
+try {
+renderBundleEncoder39.setBindGroup(2, bindGroup5, new Uint32Array(5503), 4008, 1);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(3, buffer28, 28708, 6516);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+alphaMode: 'premultiplied',
+});
+} catch {}
+let videoFrame14 = new VideoFrame(video3, {timestamp: 0});
+let querySet54 = device2.createQuerySet({
+label: '\uc7a6\u64d1',
+type: 'occlusion',
+count: 1100,
+});
+let computePassEncoder34 = commandEncoder31.beginComputePass();
+let renderBundle58 = renderBundleEncoder30.finish({label: '\u9802\u{1fd02}\ub092\uc073\u126d\u053b\u677c\u{1ff67}\u{1f800}\u0740'});
+try {
+renderBundleEncoder21.setVertexBuffer(22, undefined, 3047368825, 1106745983);
+} catch {}
+let offscreenCanvas14 = new OffscreenCanvas(961, 658);
+document.body.prepend(video3);
+let textureView71 = texture12.createView({label: '\u086c\u11fe\ua0f5\u4ba4\u4312\u{1f824}\u0e66'});
+try {
+commandEncoder22.copyBufferToBuffer(buffer23, 15516, buffer6, 1300, 3600);
+dissociateBuffer(device0, buffer23);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let gpuCanvasContext12 = offscreenCanvas13.getContext('webgpu');
+let canvas13 = document.createElement('canvas');
+try {
+offscreenCanvas14.getContext('webgl2');
+} catch {}
+document.body.prepend(img11);
+let img12 = await imageWithData(3, 196, '#7a8e74ba', '#4ebd7861');
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+video6.height = 226;
+let promise22 = adapter5.requestDevice({
+});
+let querySet55 = device0.createQuerySet({
+type: 'occlusion',
+count: 1853,
+});
+let textureView72 = texture57.createView({dimension: '2d-array', baseMipLevel: 4, mipLevelCount: 4});
+let computePassEncoder35 = commandEncoder49.beginComputePass({label: '\ubd81\ud121'});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup3, new Uint32Array(3384), 1291, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 940, new Int16Array(14604), 4522, 84);
+} catch {}
+let imageBitmap11 = await createImageBitmap(canvas2);
+let imageData13 = new ImageData(124, 240);
+let commandEncoder66 = device3.createCommandEncoder({});
+try {
+window.someLabel = sampler29.label;
+} catch {}
+let bindGroupLayout22 = device3.createBindGroupLayout({
+label: '\ub376\u{1f6ac}\uc8ce\u06da\u0be3\u{1fc34}\u8c11\u09d0\ua967\u{1fbc9}',
+entries: [],
+});
+let pipelineLayout10 = device3.createPipelineLayout({label: '\u025c\u{1fdb4}\u{1f73a}\u1e60\ufb6b\u0dda\u0292', bindGroupLayouts: []});
+let commandEncoder67 = device3.createCommandEncoder({label: '\u582a\u2cb4\ud470\ubf7a'});
+let renderBundleEncoder52 = device3.createRenderBundleEncoder({
+  label: '\u{1f878}\u63d2\uc7ea\uf395\uf16c\u026c\u3360\u0ba7',
+  colorFormats: ['rg32sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler46 = device3.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 45.088,
+lodMaxClamp: 64.438,
+compare: 'equal',
+});
+let externalTexture3 = device3.importExternalTexture({
+label: '\u{1ffdc}\u0296\u{1f6aa}\u24d2\u2db9\u0afa\uf4e1\u08d0',
+source: video2,
+colorSpace: 'srgb',
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let shaderModule10 = device0.createShaderModule({
+code: `@group(3) @binding(4710)
+var<storage, read_write> parameter7: array<u32>;
+@group(4) @binding(4710)
+var<storage, read_write> local11: array<u32>;
+@group(0) @binding(4710)
+var<storage, read_write> type6: array<u32>;
+@group(2) @binding(4710)
+var<storage, read_write> type7: array<u32>;
+@group(1) @binding(4710)
+var<storage, read_write> global6: array<u32>;
+
+@compute @workgroup_size(6, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S13 {
+  @location(11) f0: vec2<u32>,
+  @builtin(sample_mask) f1: u32,
+  @location(65) f2: vec3<f16>,
+  @location(1) f3: f32,
+  @location(57) f4: vec3<f16>,
+  @location(6) f5: vec2<f32>,
+  @location(62) f6: u32,
+  @builtin(sample_index) f7: u32,
+  @location(18) f8: vec2<u32>
+}
+struct FragmentOutput0 {
+  @builtin(frag_depth) f0: f32,
+  @builtin(sample_mask) f1: u32,
+  @location(0) f2: u32,
+  @location(5) f3: i32
+}
+
+@fragment
+fn fragment0(a0: S13, @location(12) a1: vec3<f32>, @builtin(position) a2: vec4<f32>, @location(44) a3: f16, @location(8) a4: vec2<f32>, @location(66) a5: f32, @location(82) a6: i32, @location(72) a7: vec3<f32>, @location(46) a8: i32, @location(64) a9: u32, @location(16) a10: vec2<i32>, @location(17) a11: vec3<i32>, @location(48) a12: vec4<i32>, @location(60) a13: f32, @location(73) a14: vec2<i32>, @location(67) a15: f32, @location(28) a16: vec2<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(46) f193: i32,
+  @location(64) f194: u32,
+  @location(3) f195: vec4<i32>,
+  @location(48) f196: vec4<i32>,
+  @location(28) f197: vec2<i32>,
+  @location(29) f198: vec3<f32>,
+  @location(62) f199: u32,
+  @location(82) f200: i32,
+  @location(65) f201: vec3<f16>,
+  @location(76) f202: vec2<f32>,
+  @location(72) f203: vec3<f32>,
+  @location(1) f204: f32,
+  @location(18) f205: vec2<u32>,
+  @location(12) f206: vec3<f32>,
+  @location(6) f207: vec2<f32>,
+  @location(11) f208: vec2<u32>,
+  @location(67) f209: f32,
+  @location(60) f210: f32,
+  @location(10) f211: vec4<u32>,
+  @location(57) f212: vec3<f16>,
+  @location(66) f213: f32,
+  @builtin(position) f214: vec4<f32>,
+  @location(44) f215: f16,
+  @location(8) f216: vec2<f32>,
+  @location(23) f217: vec4<f16>,
+  @location(73) f218: vec2<i32>,
+  @location(16) f219: vec2<i32>,
+  @location(17) f220: vec3<i32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroupLayout23 = device0.createBindGroupLayout({
+label: '\u1730\u{1f73e}\u4c49\u0089',
+entries: [],
+});
+let renderBundleEncoder53 = device0.createRenderBundleEncoder({label: '\u2811\u0b95', colorFormats: ['rgb10a2unorm', 'r16float', 'rg8uint', 'r8uint']});
+let renderBundle59 = renderBundleEncoder0.finish();
+try {
+computePassEncoder32.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(0, buffer28);
+} catch {}
+try {
+  await buffer9.mapAsync(GPUMapMode.READ, 0, 340);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 344, new Float32Array(15832), 12383, 156);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 2,
+  origin: { x: 12, y: 0, z: 11 },
+  aspect: 'all',
+}, new Int16Array(arrayBuffer6), /* required buffer size: 1279435 */
+{offset: 157, bytesPerRow: 142, rowsPerImage: 143}, {width: 0, height: 1, depthOrArrayLayers: 64});
+} catch {}
+let bindGroupLayout24 = device3.createBindGroupLayout({
+entries: [],
+});
+let buffer29 = device3.createBuffer({label: '\u0fbb\u8fef', size: 4288, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let commandEncoder68 = device3.createCommandEncoder({label: '\u{1fb69}\u97ee\ubb79\u0dde\u9b2d'});
+let texture80 = device3.createTexture({
+label: '\ub7f4\u0fad\u{1feba}\u{1faf1}\ucd75',
+size: {width: 64, height: 120, depthOrArrayLayers: 94},
+mipLevelCount: 4,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let renderBundleEncoder54 = device3.createRenderBundleEncoder({colorFormats: ['rg32sint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundleEncoder55 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba16uint', undefined, 'r8sint', 'rg16sint', 'rgba16sint', 'rgba16float', 'rg32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true
+});
+let sampler47 = device0.createSampler({
+label: '\u8b43\u0b4c\uba32\ud032\u{1ffef}\ub79f',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 1.311,
+lodMaxClamp: 56.673,
+maxAnisotropy: 6,
+});
+try {
+commandEncoder30.clearBuffer(buffer10, 604, 208);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder34.resolveQuerySet(querySet7, 312, 32, buffer25, 512);
+} catch {}
+try {
+commandEncoder34.insertDebugMarker('\u5b36');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4800, height: 16, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 114, y: 9 },
+  flipY: false,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: { x: 1558, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 80, height: 14, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext13 = canvas13.getContext('webgpu');
+document.body.prepend(video6);
+let bindGroup6 = device3.createBindGroup({
+layout: bindGroupLayout24,
+entries: [],
+});
+let pipelineLayout11 = device3.createPipelineLayout({
+  label: '\u434c\uc5d4\u{1f71d}\u0906\u3584\u8508\u4eb7\u56d9',
+  bindGroupLayouts: [bindGroupLayout24, bindGroupLayout24, bindGroupLayout22, bindGroupLayout22, bindGroupLayout22]
+});
+let querySet56 = device3.createQuerySet({
+label: '\udb1e\u{1f991}\u{1fe25}\uf2d3\u{1ffd1}\u07d2\ud88d\ub090\u0693',
+type: 'occlusion',
+count: 1982,
+});
+let computePassEncoder36 = commandEncoder67.beginComputePass({label: '\u0c06\u0f72\u0feb\u0d87'});
+let renderBundleEncoder56 = device3.createRenderBundleEncoder({
+  label: '\u6918\u9ad2\u9f72\u4f47',
+  colorFormats: ['r8uint', undefined, 'r32sint', 'rgba8uint', 'rg8unorm', 'rg8uint', 'rg32uint', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+commandEncoder68.copyTextureToTexture({
+  texture: texture80,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 14 },
+  aspect: 'all',
+}, {
+  texture: texture80,
+  mipLevel: 1,
+  origin: { x: 0, y: 32, z: 13 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 73});
+} catch {}
+try {
+device3.queue.writeBuffer(buffer24, 8644, new Int16Array(32954), 18717, 64);
+} catch {}
+try {
+device1.queue.label = '\u01e0\u17c5\ud932\u{1fb8e}\u0708\ufeeb\u0317\u0420\u0d3a\u0c4a';
+} catch {}
+let texture81 = gpuCanvasContext6.getCurrentTexture();
+let renderBundleEncoder57 = device1.createRenderBundleEncoder({colorFormats: ['rgba32sint', 'rg8sint', 'rgba32uint'], sampleCount: 4, stencilReadOnly: true});
+try {
+computePassEncoder26.setBindGroup(3, bindGroup4, new Uint32Array(7567), 1997, 0);
+} catch {}
+try {
+renderBundleEncoder17.draw(8, 80, 48, 64);
+} catch {}
+try {
+commandEncoder54.copyBufferToBuffer(buffer20, 876, buffer8, 10480, 28);
+dissociateBuffer(device1, buffer20);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder54.clearBuffer(buffer20, 1060, 168);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 23, y: 71 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 12, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 32, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.label = '\u38fe\u747a\ue402';
+} catch {}
+let textureView73 = texture25.createView({label: '\uf68a\u86c2\ubcb0\u1297\u{1f73d}\u0f88\u2ab7\u83b7', dimension: '2d-array', baseMipLevel: 2});
+let renderBundle60 = renderBundleEncoder9.finish({});
+try {
+renderBundleEncoder17.draw(16, 80);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(72, 32);
+} catch {}
+let pipeline47 = await device1.createRenderPipelineAsync({
+label: '\u0eb6\u074b\u0f74',
+layout: pipelineLayout3,
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3617,
+stencilWriteMask: 3684,
+depthBiasSlopeScale: 83,
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 10548,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 8652,
+shaderLocation: 19,
+}, {
+format: 'uint32',
+offset: 412,
+shaderLocation: 21,
+}, {
+format: 'snorm16x2',
+offset: 912,
+shaderLocation: 20,
+}, {
+format: 'snorm8x4',
+offset: 4324,
+shaderLocation: 11,
+}, {
+format: 'uint16x2',
+offset: 9172,
+shaderLocation: 9,
+}, {
+format: 'float32x4',
+offset: 9732,
+shaderLocation: 26,
+}, {
+format: 'uint16x2',
+offset: 6848,
+shaderLocation: 3,
+}, {
+format: 'sint16x4',
+offset: 3484,
+shaderLocation: 7,
+}, {
+format: 'snorm8x4',
+offset: 6904,
+shaderLocation: 14,
+}, {
+format: 'unorm10-10-10-2',
+offset: 6212,
+shaderLocation: 4,
+}, {
+format: 'sint16x2',
+offset: 9816,
+shaderLocation: 23,
+}, {
+format: 'sint32x2',
+offset: 7044,
+shaderLocation: 25,
+}, {
+format: 'snorm16x4',
+offset: 5408,
+shaderLocation: 5,
+}, {
+format: 'sint16x2',
+offset: 7644,
+shaderLocation: 18,
+}, {
+format: 'snorm16x4',
+offset: 5372,
+shaderLocation: 12,
+}, {
+format: 'snorm16x2',
+offset: 10244,
+shaderLocation: 22,
+}, {
+format: 'sint16x4',
+offset: 2516,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 12960,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm16x2',
+offset: 1724,
+shaderLocation: 17,
+}, {
+format: 'unorm8x4',
+offset: 1748,
+shaderLocation: 8,
+}, {
+format: 'float16x4',
+offset: 808,
+shaderLocation: 13,
+}, {
+format: 'snorm16x2',
+offset: 7396,
+shaderLocation: 1,
+}, {
+format: 'uint8x4',
+offset: 8080,
+shaderLocation: 15,
+}, {
+format: 'float32x2',
+offset: 12228,
+shaderLocation: 16,
+}, {
+format: 'unorm8x4',
+offset: 7380,
+shaderLocation: 6,
+}, {
+format: 'uint32x4',
+offset: 6616,
+shaderLocation: 2,
+}, {
+format: 'sint8x4',
+offset: 4936,
+shaderLocation: 24,
+}, {
+format: 'float16x2',
+offset: 6624,
+shaderLocation: 10,
+}],
+}
+]
+},
+});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let bindGroupLayout25 = device1.createBindGroupLayout({
+entries: [],
+});
+let buffer30 = device1.createBuffer({
+  label: '\uc9b5\u44e7\u94eb\u4d15\u{1f8c1}\uf9bd\u0efb\u6443\u{1fc2e}\u{1febf}\ueaea',
+  size: 46974,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let querySet57 = device1.createQuerySet({
+label: '\uc169\ueeaf\u96e4\u63e9\u3c42\ud88a\u5fd7\u0822\uaee1\u2e91',
+type: 'occlusion',
+count: 1994,
+});
+let commandBuffer10 = commandEncoder54.finish({
+label: '\ueb4c\u0285\u0840\u9c32\u0d57\u0982',
+});
+let textureView74 = texture19.createView({label: '\u682d\udcb9\ub4bc\u03f1\u{1fdb3}\u4faf', dimension: '2d-array'});
+let sampler48 = device1.createSampler({
+label: '\u6248\u1071\ucc2a\ufc12\u3100\ucca9',
+addressModeU: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 54.763,
+lodMaxClamp: 62.559,
+});
+try {
+device1.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 1,
+  origin: { x: 24, y: 86, z: 95 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer6), /* required buffer size: 647 */
+{offset: 647, bytesPerRow: 295}, {width: 23, height: 167, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData13,
+  origin: { x: 94, y: 207 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 19, y: 2, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 13, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline48 = device1.createComputePipeline({
+label: '\u{1ffa1}\u25c7\u{1f815}\u00dc\ua9ef\u99d3',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+renderBundleEncoder17.draw(40);
+} catch {}
+try {
+commandEncoder59.copyBufferToBuffer(buffer20, 896, buffer27, 16712, 84);
+dissociateBuffer(device1, buffer20);
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 2,
+  origin: { x: 2, y: 0, z: 51 },
+  aspect: 'all',
+}, {
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 49, y: 623, z: 157 },
+  aspect: 'all',
+}, {width: 23, height: 5, depthOrArrayLayers: 38});
+} catch {}
+let pipeline49 = device1.createRenderPipeline({
+layout: pipelineLayout8,
+fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg8sint'}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-constant'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-src-alpha'},
+},
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r32uint'}, {
+  format: 'r32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater',
+failOp: 'keep',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-wrap',
+depthFailOp: 'invert',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 3250,
+stencilWriteMask: 1730,
+depthBias: 89,
+depthBiasSlopeScale: 31,
+depthBiasClamp: 34,
+},
+vertex: {
+  module: shaderModule5,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 26772,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 1896,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 22376,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 32196,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x2',
+offset: 29876,
+shaderLocation: 6,
+}, {
+format: 'sint8x2',
+offset: 29118,
+shaderLocation: 22,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+video11.width = 188;
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageBitmap12 = await createImageBitmap(imageBitmap3);
+canvas2.height = 900;
+let video12 = await videoWithData();
+let img13 = await imageWithData(100, 183, '#01982809', '#05505431');
+let imageData14 = new ImageData(28, 232);
+let commandBuffer11 = commandEncoder11.finish();
+let renderBundleEncoder58 = device0.createRenderBundleEncoder({
+  label: '\u2551\ue57f\ud343\ud658\u{1fe37}\ue33e\u37bf\u406c\u0fff\u0e3e\ud69b',
+  colorFormats: ['r8unorm', 'rgba16sint', 'rg8sint', 'rgba32float', 'r32uint', undefined],
+  sampleCount: 4
+});
+try {
+renderBundleEncoder22.setBindGroup(3, bindGroup5, new Uint32Array(2075), 1840, 1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 600, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: video4,
+  origin: { x: 3, y: 4 },
+  flipY: false,
+}, {
+  texture: texture57,
+  mipLevel: 3,
+  origin: { x: 460, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let pipelineLayout12 = device1.createPipelineLayout({
+  label: '\u789e\ub72a\uc979\u4375\ub9b3\u185b\u4278\u02c9\u81eb',
+  bindGroupLayouts: [bindGroupLayout5, bindGroupLayout2, bindGroupLayout21, bindGroupLayout6, bindGroupLayout21, bindGroupLayout2, bindGroupLayout25]
+});
+let buffer31 = device1.createBuffer({label: '\u1bdb\u0661\u{1fda2}\u154f\ueec2', size: 28513, usage: GPUBufferUsage.MAP_READ});
+let querySet58 = device1.createQuerySet({
+type: 'occlusion',
+count: 2382,
+});
+let texture82 = device1.createTexture({
+label: '\u{1fd8c}\u1bb6\ue316\u{1f861}\u{1f788}\uea1e',
+size: {width: 27, height: 192, depthOrArrayLayers: 141},
+dimension: '2d',
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['depth16unorm', 'depth16unorm', 'depth16unorm'],
+});
+try {
+renderBundleEncoder17.drawIndexed(56, 40, 56, 24, 8);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 2,
+  origin: { x: 0, y: 6, z: 106 },
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 171385 */
+{offset: 556, bytesPerRow: 275, rowsPerImage: 457}, {width: 27, height: 165, depthOrArrayLayers: 2});
+} catch {}
+let texture83 = device3.createTexture({
+label: '\u8e8c\uad34\u0875\ucea1',
+size: [4032, 480, 193],
+mipLevelCount: 10,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x8-unorm', 'astc-8x8-unorm-srgb', 'astc-8x8-unorm-srgb'],
+});
+let textureView75 = texture77.createView({mipLevelCount: 4, baseArrayLayer: 53, arrayLayerCount: 30});
+let renderBundle61 = renderBundleEncoder40.finish({});
+try {
+device3.queue.writeBuffer(buffer24, 9204, new BigUint64Array(36709), 9812, 16);
+} catch {}
+let bindGroup7 = device1.createBindGroup({
+label: '\u3ee7\u41fb\ue80b\uf323\u13cd\u4825\u{1fb3c}\ud4e9\uf8d7\ue67e\uec90',
+layout: bindGroupLayout14,
+entries: [{
+binding: 1723,
+resource: sampler30
+}],
+});
+let pipelineLayout13 = device1.createPipelineLayout({label: '\uc8ad\u47bb\udd5b\u0c8c\u{1f9c4}\u3b83', bindGroupLayouts: [bindGroupLayout2]});
+try {
+renderBundleEncoder45.setVertexBuffer(85, undefined, 808455806, 1852397215);
+} catch {}
+let promise23 = device1.popErrorScope();
+try {
+device1.queue.writeBuffer(buffer30, 36488, new Float32Array(57234), 3015, 308);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline50 = await device1.createRenderPipelineAsync({
+label: '\u{1f968}\u{1f80a}',
+layout: pipelineLayout3,
+multisample: {
+mask: 0x3abeffce,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'r32uint'}, {format: 'rg8sint'}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-dst-alpha'},
+alpha: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-dst-alpha'},
+},
+  writeMask: GPUColorWrite.GREEN
+}, {
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilWriteMask: 993,
+depthBias: 10,
+depthBiasSlopeScale: 42,
+depthBiasClamp: 19,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 17296,
+attributes: [{
+format: 'uint16x2',
+offset: 9924,
+shaderLocation: 10,
+}, {
+format: 'float32x3',
+offset: 14160,
+shaderLocation: 4,
+}, {
+format: 'uint32x2',
+offset: 8660,
+shaderLocation: 26,
+}, {
+format: 'float32x3',
+offset: 10912,
+shaderLocation: 20,
+}, {
+format: 'sint16x2',
+offset: 10988,
+shaderLocation: 16,
+}, {
+format: 'unorm8x2',
+offset: 13754,
+shaderLocation: 0,
+}, {
+format: 'sint32',
+offset: 13392,
+shaderLocation: 5,
+}, {
+format: 'float32x3',
+offset: 848,
+shaderLocation: 21,
+}, {
+format: 'float32',
+offset: 10996,
+shaderLocation: 6,
+}, {
+format: 'uint32x3',
+offset: 13916,
+shaderLocation: 24,
+}, {
+format: 'unorm8x4',
+offset: 5960,
+shaderLocation: 7,
+}, {
+format: 'sint8x2',
+offset: 4638,
+shaderLocation: 25,
+}, {
+format: 'sint32x3',
+offset: 416,
+shaderLocation: 13,
+}, {
+format: 'uint8x4',
+offset: 13792,
+shaderLocation: 22,
+}, {
+format: 'uint16x4',
+offset: 7396,
+shaderLocation: 14,
+}, {
+format: 'unorm8x2',
+offset: 15230,
+shaderLocation: 1,
+}, {
+format: 'uint16x2',
+offset: 16260,
+shaderLocation: 12,
+}, {
+format: 'sint32x4',
+offset: 14124,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 31400,
+attributes: [{
+format: 'float16x2',
+offset: 12688,
+shaderLocation: 8,
+}, {
+format: 'uint16x2',
+offset: 22416,
+shaderLocation: 17,
+}, {
+format: 'snorm8x2',
+offset: 28690,
+shaderLocation: 2,
+}],
+}
+]
+},
+});
+let bindGroupLayout26 = device3.createBindGroupLayout({
+label: '\u08e3\u094a\uecc5\u{1f71a}\u0796\ufffa',
+entries: [{
+binding: 846,
+visibility: 0,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}],
+});
+let renderBundle62 = renderBundleEncoder50.finish({});
+try {
+computePassEncoder27.setBindGroup(4, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(9, buffer29, 2448, 1333);
+} catch {}
+try {
+commandEncoder66.copyTextureToTexture({
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 20, y: 24, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture79,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 711 */
+{offset: 711}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame15 = new VideoFrame(video1, {timestamp: 0});
+try {
+computePassEncoder30.setBindGroup(7, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder56.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(7, bindGroup6, new Uint32Array(4410), 2833, 0);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(video12);
+let canvas14 = document.createElement('canvas');
+let gpuCanvasContext14 = canvas14.getContext('webgpu');
+let bindGroup8 = device3.createBindGroup({
+label: '\u4852\u046c\u993a\u0c77\u8ee2\ucb49\uc0ce\u{1feb1}\u06d7\u{1f78f}\u02c4',
+layout: bindGroupLayout22,
+entries: [],
+});
+let texture84 = device3.createTexture({
+label: '\u087a\u414d\u0e86\u6112',
+size: {width: 240, height: 960, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+dimension: '2d',
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder37 = commandEncoder68.beginComputePass();
+try {
+renderBundleEncoder54.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer24, 2440, new BigUint64Array(54946), 40038, 48);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture80,
+  mipLevel: 2,
+  origin: { x: 8, y: 8, z: 57 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer7), /* required buffer size: 1955550 */
+{offset: 735, bytesPerRow: 285, rowsPerImage: 254}, {width: 0, height: 16, depthOrArrayLayers: 28});
+} catch {}
+let video13 = await videoWithData();
+document.body.prepend(img2);
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let bindGroupLayout27 = device3.createBindGroupLayout({
+label: '\u5ac4\u{1fb01}\uff43\u2f0d',
+entries: [{
+binding: 7747,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '1d' },
+}, {
+binding: 2070,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}],
+});
+let bindGroup9 = device3.createBindGroup({
+label: '\u{1fd8f}\ubdaa\uca4f\u01b3\u08f1\u{1fdba}\u09e8\ua59b\u08d3',
+layout: bindGroupLayout24,
+entries: [],
+});
+try {
+renderBundleEncoder56.setVertexBuffer(3, buffer29, 36, 1418);
+} catch {}
+try {
+commandEncoder66.clearBuffer(buffer19, 9356, 3752);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+renderBundleEncoder54.insertDebugMarker('\u{1fd41}');
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 1,
+  origin: { x: 42, y: 5, z: 96 },
+  aspect: 'all',
+}, new Int32Array(arrayBuffer0), /* required buffer size: 5656192 */
+{offset: 32, bytesPerRow: 429, rowsPerImage: 269}, {width: 84, height: 20, depthOrArrayLayers: 50});
+} catch {}
+let textureView76 = texture69.createView({label: '\uf836\u{1fe7d}\u3cf6\ue1b4\ufcbb\u3e1c\u2c35\u0b28\u17dc', format: 'rgba8unorm-srgb'});
+let sampler49 = device3.createSampler({
+label: '\u{1f9c6}\u7443\u7216',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 82.254,
+lodMaxClamp: 90.901,
+});
+try {
+computePassEncoder29.setBindGroup(5, bindGroup9, []);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(5, buffer29, 2132, 583);
+} catch {}
+try {
+commandEncoder66.clearBuffer(buffer19, 11092, 912);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 3,
+  origin: { x: 0, y: 8, z: 1 },
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 197 */
+{offset: 197, bytesPerRow: 102}, {width: 0, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = commandEncoder52.label;
+} catch {}
+let computePassEncoder38 = commandEncoder66.beginComputePass();
+let renderBundleEncoder59 = device1.createRenderBundleEncoder({
+  label: '\ua247\u0c6b\u99f7\u{1fa36}\u2671\u6deb\u{1f684}\u8c01\ucfc3\u{1fdb8}',
+  colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint'],
+  depthReadOnly: true
+});
+try {
+computePassEncoder26.setBindGroup(3, bindGroup4, []);
+} catch {}
+let promise24 = device1.queue.onSubmittedWorkDone();
+document.body.prepend(img13);
+let shaderModule11 = device0.createShaderModule({
+label: '\ua806\u3cc7\u{1fb18}',
+code: `@group(2) @binding(4710)
+var<storage, read_write> i4: array<u32>;
+@group(4) @binding(4710)
+var<storage, read_write> field4: array<u32>;
+@group(3) @binding(4710)
+var<storage, read_write> i5: array<u32>;
+@group(1) @binding(4710)
+var<storage, read_write> type8: array<u32>;
+@group(0) @binding(4710)
+var<storage, read_write> type9: array<u32>;
+
+@compute @workgroup_size(3, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S15 {
+  @builtin(sample_mask) f0: u32,
+  @location(38) f1: vec2<u32>,
+  @location(57) f2: vec3<i32>,
+  @location(50) f3: vec4<f16>,
+  @location(31) f4: vec2<i32>,
+  @location(63) f5: vec2<i32>,
+  @builtin(position) f6: vec4<f32>,
+  @builtin(sample_index) f7: u32,
+  @location(49) f8: vec2<u32>,
+  @location(83) f9: vec2<f16>,
+  @location(29) f10: vec4<f16>,
+  @location(54) f11: vec4<u32>,
+  @location(33) f12: vec4<f32>,
+  @location(80) f13: vec3<f32>,
+  @location(28) f14: vec4<f16>,
+  @location(55) f15: vec3<u32>,
+  @location(40) f16: vec4<i32>,
+  @location(62) f17: vec3<f16>,
+  @location(20) f18: i32,
+  @location(52) f19: u32,
+  @location(41) f20: u32,
+  @location(71) f21: vec2<u32>,
+  @builtin(front_facing) f22: bool,
+  @location(0) f23: f16,
+  @location(34) f24: i32,
+  @location(77) f25: vec3<f16>,
+  @location(44) f26: f32,
+  @location(68) f27: vec2<i32>,
+  @location(66) f28: f32,
+  @location(56) f29: vec3<f32>,
+  @location(46) f30: vec2<u32>,
+  @location(60) f31: f32,
+  @location(61) f32: vec3<f32>,
+  @location(1) f33: vec3<f32>,
+  @location(22) f34: vec4<u32>,
+  @location(65) f35: f32,
+  @location(17) f36: vec2<f16>,
+  @location(79) f37: vec3<u32>,
+  @location(51) f38: vec4<f16>,
+  @location(18) f39: vec3<i32>,
+  @location(7) f40: vec3<i32>,
+  @location(3) f41: vec3<f16>,
+  @location(53) f42: u32
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec3<u32>,
+  @builtin(frag_depth) f1: f32
+}
+
+@fragment
+fn fragment0(@location(70) a0: f16, @location(45) a1: i32, @location(67) a2: vec2<i32>, @location(47) a3: f32, @location(19) a4: vec2<i32>, a5: S15, @location(9) a6: i32, @location(48) a7: vec4<f32>, @location(24) a8: vec2<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S14 {
+  @location(18) f0: vec4<f32>,
+  @location(0) f1: vec2<u32>,
+  @location(1) f2: i32,
+  @location(6) f3: vec2<f32>,
+  @location(2) f4: vec3<i32>,
+  @location(10) f5: vec2<u32>,
+  @location(5) f6: vec4<u32>,
+  @location(13) f7: vec4<f32>,
+  @location(8) f8: vec3<i32>,
+  @location(19) f9: vec4<f16>,
+  @location(15) f10: i32,
+  @location(11) f11: vec3<f32>,
+  @location(4) f12: vec2<f32>,
+  @location(7) f13: vec3<f16>,
+  @location(12) f14: f32,
+  @location(3) f15: i32
+}
+struct VertexOutput0 {
+  @location(17) f221: vec2<f16>,
+  @location(41) f222: u32,
+  @location(62) f223: vec3<f16>,
+  @location(51) f224: vec4<f16>,
+  @location(24) f225: vec2<f32>,
+  @location(66) f226: f32,
+  @location(63) f227: vec2<i32>,
+  @location(47) f228: f32,
+  @location(49) f229: vec2<u32>,
+  @location(28) f230: vec4<f16>,
+  @location(31) f231: vec2<i32>,
+  @location(52) f232: u32,
+  @location(45) f233: i32,
+  @location(18) f234: vec3<i32>,
+  @location(40) f235: vec4<i32>,
+  @location(44) f236: f32,
+  @location(55) f237: vec3<u32>,
+  @builtin(position) f238: vec4<f32>,
+  @location(29) f239: vec4<f16>,
+  @location(50) f240: vec4<f16>,
+  @location(0) f241: f16,
+  @location(53) f242: u32,
+  @location(56) f243: vec3<f32>,
+  @location(48) f244: vec4<f32>,
+  @location(79) f245: vec3<u32>,
+  @location(60) f246: f32,
+  @location(22) f247: vec4<u32>,
+  @location(9) f248: i32,
+  @location(70) f249: f16,
+  @location(80) f250: vec3<f32>,
+  @location(83) f251: vec2<f16>,
+  @location(67) f252: vec2<i32>,
+  @location(33) f253: vec4<f32>,
+  @location(7) f254: vec3<i32>,
+  @location(34) f255: i32,
+  @location(54) f256: vec4<u32>,
+  @location(38) f257: vec2<u32>,
+  @location(65) f258: f32,
+  @location(61) f259: vec3<f32>,
+  @location(77) f260: vec3<f16>,
+  @location(57) f261: vec3<i32>,
+  @location(20) f262: i32,
+  @location(71) f263: vec2<u32>,
+  @location(1) f264: vec3<f32>,
+  @location(3) f265: vec3<f16>,
+  @location(19) f266: vec2<i32>,
+  @location(46) f267: vec2<u32>,
+  @location(68) f268: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec4<u32>, a1: S14, @location(14) a2: vec3<f32>, @location(16) a3: vec2<u32>, @location(17) a4: vec4<u32>, @builtin(instance_index) a5: u32, @builtin(vertex_index) a6: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandBuffer12 = commandEncoder25.finish({
+});
+try {
+renderBundleEncoder22.setVertexBuffer(0, buffer4, 1116, 8287);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 524, new DataView(new ArrayBuffer(60830)), 31812, 232);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: { x: 789, y: 0, z: 0 },
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(72)), /* required buffer size: 7758 */
+{offset: 534}, {width: 1806, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 18, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img8,
+  origin: { x: 35, y: 30 },
+  flipY: true,
+}, {
+  texture: texture57,
+  mipLevel: 8,
+  origin: { x: 7, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+try {
+window.someLabel = renderBundleEncoder26.label;
+} catch {}
+let commandEncoder69 = device1.createCommandEncoder();
+let renderBundle63 = renderBundleEncoder14.finish();
+try {
+renderBundleEncoder17.draw(32, 80);
+} catch {}
+let pipeline51 = device1.createComputePipeline({
+label: '\u23a6\u8d2b',
+layout: pipelineLayout12,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroup10 = device0.createBindGroup({
+layout: bindGroupLayout12,
+entries: [],
+});
+let commandBuffer13 = commandEncoder34.finish({
+label: '\u1286\u0868\u4eea\ud109\u0337\u3a04',
+});
+let textureView77 = texture31.createView({
+  label: '\u{1fa10}\u0982\u0a20\u01ac\u05be\uf5a5\u0dc6\u0e19\u61f4\u015f',
+  baseMipLevel: 3,
+  baseArrayLayer: 0
+});
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+commandEncoder18.copyBufferToTexture({
+/* bytesInLastRow: 1744 widthInBlocks: 436 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 25680 */
+offset: 25680,
+buffer: buffer28,
+}, {
+  texture: texture7,
+  mipLevel: 1,
+  origin: { x: 1559, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 436, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer28);
+} catch {}
+try {
+device0.destroy();
+} catch {}
+gc();
+let video14 = await videoWithData();
+let canvas15 = document.createElement('canvas');
+let bindGroup11 = device3.createBindGroup({
+layout: bindGroupLayout24,
+entries: [],
+});
+let externalTexture4 = device3.importExternalTexture({
+label: '\u8f57\ua56f\u{1f7a8}\ud30c\u{1f8e9}\ud0cf\u440c\u4716',
+source: video11,
+colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder54.pushDebugGroup('\u{1fac5}');
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let texture85 = device3.createTexture({
+label: '\u{1f6b2}\u1f50\u0288\ua43f\u0de6\u0762\u9e89\u65e0',
+size: {width: 504, height: 60, depthOrArrayLayers: 193},
+mipLevelCount: 7,
+format: 'astc-6x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView78 = texture59.createView({label: '\u49d3\u18a5\u01f9\u7fbc\ufa4a\ubb71\u12fa\u00fb', aspect: 'all', mipLevelCount: 2});
+let renderBundle64 = renderBundleEncoder52.finish({});
+try {
+device3.queue.writeBuffer(buffer24, 668, new DataView(new ArrayBuffer(20654)), 10640, 3176);
+} catch {}
+gc();
+let commandEncoder70 = device1.createCommandEncoder();
+let textureView79 = texture30.createView({
+  label: '\u09ec\u{1fc4a}\ua7ba\uf5e2\u{1f909}\u3222\u19cf\ub5ea\u55fd\u0f51\uf407',
+  dimension: '2d-array',
+  mipLevelCount: 1
+});
+let sampler50 = device1.createSampler({
+label: '\u{1f6d0}\uae38\u490d\u{1fb93}\u08a1\u0747\u{1fa3f}\u0199\u005d',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 30.285,
+lodMaxClamp: 57.535,
+compare: 'greater-equal',
+});
+let externalTexture5 = device1.importExternalTexture({
+label: '\u256d\u000e\ud6b9\u0f3a\u0d3b',
+source: videoFrame14,
+colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder45.setVertexBuffer(46, undefined, 1752803767);
+} catch {}
+let pipeline52 = await device1.createComputePipelineAsync({
+layout: pipelineLayout13,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let imageBitmap13 = await createImageBitmap(offscreenCanvas7);
+try {
+canvas15.getContext('webgl');
+} catch {}
+let commandEncoder71 = device1.createCommandEncoder({label: '\ua240\u508b\u41d7\u0a21\ub070'});
+let textureView80 = texture38.createView({
+  label: '\ufeaa\u0856\u{1fa53}\u3a91',
+  format: 'rgba8unorm',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  arrayLayerCount: 1
+});
+let computePassEncoder39 = commandEncoder59.beginComputePass({label: '\u3a68\u4732\u7514'});
+let sampler51 = device1.createSampler({
+label: '\uc4fd\ufc8c\ub90c\u0b86\u0b35\u{1f666}\uf516\u60c6\ud88d\u06bb',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMaxClamp: 97.947,
+});
+try {
+renderBundleEncoder46.setVertexBuffer(0, undefined, 2058900679, 1639589443);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'r32float', 'astc-8x8-unorm-srgb', 'rgba16float'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let canvas16 = document.createElement('canvas');
+let offscreenCanvas15 = new OffscreenCanvas(835, 269);
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+  await promise23;
+} catch {}
+let adapter7 = await navigator.gpu.requestAdapter({
+});
+let img14 = await imageWithData(70, 116, '#cb015cdd', '#89414115');
+let pipelineLayout14 = device3.createPipelineLayout({
+  label: '\u0a95\u5b93\uf254\uc694\u00d3\u08ac\u5552\ub256',
+  bindGroupLayouts: [bindGroupLayout26, bindGroupLayout24, bindGroupLayout22, bindGroupLayout22, bindGroupLayout26, bindGroupLayout22, bindGroupLayout22]
+});
+let querySet59 = device3.createQuerySet({
+label: '\u{1fe8e}\u3b1f\u{1fe65}\u0e63\u{1f7c9}\u0ccd\ue103\u57e9\u0fe1\u8a10',
+type: 'occlusion',
+count: 1025,
+});
+let renderBundle65 = renderBundleEncoder50.finish({});
+try {
+computePassEncoder31.setBindGroup(8, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(7, buffer29);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 2,
+  origin: { x: 1, y: 27, z: 14 },
+  aspect: 'all',
+}, new Float32Array(arrayBuffer4), /* required buffer size: 285079 */
+{offset: 837, bytesPerRow: 134, rowsPerImage: 141}, {width: 7, height: 7, depthOrArrayLayers: 16});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+canvas16.getContext('webgl2');
+} catch {}
+let querySet60 = device3.createQuerySet({
+type: 'occlusion',
+count: 544,
+});
+let buffer32 = device1.createBuffer({
+  label: '\u0662\u02ae\u{1f98c}\u1fb7\uc627\u0715\u483b\ub92d\ubd70\ub62c\u9afd',
+  size: 16206,
+  usage: GPUBufferUsage.INDEX
+});
+let commandEncoder72 = device1.createCommandEncoder({label: '\u0a87\u0dd0\udb18\u{1fec5}\u0ff3\u9594\u{1ff53}\u18d1\uf27b\ua572'});
+let querySet61 = device1.createQuerySet({
+label: '\u304b\uea8a\u5684\u3c58\u72c0\u{1f887}\u{1f76a}\uf418\u0aa1',
+type: 'occlusion',
+count: 1864,
+});
+try {
+renderBundleEncoder45.setBindGroup(4, bindGroup4, new Uint32Array(3366), 880, 0);
+} catch {}
+try {
+commandEncoder69.copyBufferToBuffer(buffer20, 372, buffer27, 1892, 496);
+dissociateBuffer(device1, buffer20);
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+commandEncoder71.clearBuffer(buffer30, 5264, 8564);
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer5,
+commandBuffer10,
+]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 10,
+  origin: { x: 0, y: 6, z: 83 },
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 1169411 */
+{offset: 803, bytesPerRow: 282, rowsPerImage: 112}, {width: 0, height: 0, depthOrArrayLayers: 38});
+} catch {}
+let pipeline53 = device1.createRenderPipeline({
+label: '\u{1f8f9}\u0937\u{1fe02}\u{1fbc5}\u5389\u6f1f\u0039\u{1f675}\u0420\u0e90',
+layout: pipelineLayout12,
+fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'r32uint'}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rg8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32sint'}]
+},
+vertex: {
+  module: shaderModule5,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 27644,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 18312,
+shaderLocation: 22,
+}, {
+format: 'snorm16x4',
+offset: 21028,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 7116,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 18788,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x3',
+offset: 4872,
+shaderLocation: 8,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'back',
+},
+});
+try {
+  await promise24;
+} catch {}
+let imageBitmap14 = await createImageBitmap(imageData14);
+let sampler52 = device3.createSampler({
+label: '\u0057\ua201\u{1feac}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 88.403,
+lodMaxClamp: 92.355,
+});
+try {
+renderBundleEncoder56.setBindGroup(4, bindGroup11);
+} catch {}
+let shaderModule12 = device3.createShaderModule({
+label: '\u{1f9ad}\u82f5\udbcf\u033c\u87a7',
+code: `@group(0) @binding(846)
+var<storage, read_write> parameter8: array<u32>;
+@group(4) @binding(846)
+var<storage, read_write> local12: array<u32>;
+
+@compute @workgroup_size(5, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<f32>,
+  @location(1) f1: vec4<f32>,
+  @location(0) f2: vec4<f32>,
+  @location(2) f3: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(34) a0: vec4<f16>, @location(2) a1: vec4<f16>, @location(54) a2: vec3<f16>, @location(8) a3: vec3<f32>, @location(75) a4: f32, @builtin(sample_index) a5: u32, @location(48) a6: vec2<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S16 {
+  @location(25) f0: vec4<i32>,
+  @builtin(instance_index) f1: u32,
+  @location(7) f2: vec4<i32>,
+  @location(24) f3: vec4<u32>,
+  @location(22) f4: vec3<f32>,
+  @location(16) f5: vec2<f16>,
+  @location(18) f6: vec3<f16>,
+  @location(8) f7: vec4<f32>,
+  @location(1) f8: vec3<i32>,
+  @location(13) f9: vec2<u32>,
+  @location(21) f10: vec3<f32>,
+  @location(17) f11: vec3<f32>,
+  @location(15) f12: vec3<f32>,
+  @location(12) f13: vec4<u32>,
+  @location(9) f14: vec4<f16>,
+  @location(3) f15: vec2<f16>
+}
+struct VertexOutput0 {
+  @location(24) f269: vec4<u32>,
+  @location(63) f270: vec3<f32>,
+  @location(37) f271: vec3<f16>,
+  @location(29) f272: f16,
+  @location(60) f273: vec2<f16>,
+  @location(0) f274: i32,
+  @location(77) f275: u32,
+  @location(11) f276: vec4<f32>,
+  @builtin(position) f277: vec4<f32>,
+  @location(1) f278: vec4<i32>,
+  @location(19) f279: vec3<f32>,
+  @location(73) f280: vec4<f16>,
+  @location(8) f281: vec3<f32>,
+  @location(5) f282: vec4<i32>,
+  @location(48) f283: vec2<f16>,
+  @location(4) f284: vec2<u32>,
+  @location(23) f285: vec4<f16>,
+  @location(13) f286: vec3<f32>,
+  @location(54) f287: vec3<f16>,
+  @location(71) f288: vec2<f16>,
+  @location(21) f289: vec4<u32>,
+  @location(75) f290: f32,
+  @location(76) f291: f16,
+  @location(17) f292: vec4<u32>,
+  @location(7) f293: i32,
+  @location(6) f294: vec2<i32>,
+  @location(34) f295: vec4<f16>,
+  @location(32) f296: vec4<u32>,
+  @location(65) f297: f32,
+  @location(58) f298: f16,
+  @location(51) f299: vec4<i32>,
+  @location(74) f300: vec4<u32>,
+  @location(38) f301: f16,
+  @location(41) f302: f16,
+  @location(16) f303: vec2<i32>,
+  @location(12) f304: vec2<f16>,
+  @location(2) f305: vec4<f16>,
+  @location(56) f306: vec2<u32>,
+  @location(42) f307: vec4<i32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(20) a1: vec3<u32>, @location(4) a2: vec4<u32>, @location(5) a3: vec2<f32>, @location(10) a4: vec2<f16>, @location(0) a5: vec3<f32>, a6: S16, @location(14) a7: vec4<u32>, @location(19) a8: vec2<f16>, @location(11) a9: vec4<i32>, @location(23) a10: vec2<f16>, @location(6) a11: vec2<i32>, @location(2) a12: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder73 = device3.createCommandEncoder({label: '\u0f15\u305a\u7cc2\u628b'});
+let querySet62 = device3.createQuerySet({
+label: '\u2afa\ud24d\u51dc\u01ad\u{1f67a}\uc280',
+type: 'occlusion',
+count: 2179,
+});
+let sampler53 = device3.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 79.907,
+lodMaxClamp: 83.222,
+});
+gc();
+let canvas17 = document.createElement('canvas');
+try {
+canvas17.getContext('bitmaprenderer');
+} catch {}
+let bindGroupLayout28 = device3.createBindGroupLayout({
+label: '\u0abd\u{1f700}',
+entries: [],
+});
+let commandEncoder74 = device3.createCommandEncoder({label: '\u{1f918}\u{1fd23}\u04be\u9d25\u7a1e\u3dd0\u289c'});
+let pipeline54 = device3.createComputePipeline({
+label: '\u{1fc33}\ud579\ueb32\u54ab\u{1f8c4}\u1c41\u0c1e\ub764\ue8b3',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+gc();
+let videoFrame16 = new VideoFrame(video8, {timestamp: 0});
+let gpuCanvasContext15 = offscreenCanvas15.getContext('webgpu');
+let texture86 = device3.createTexture({
+label: '\u7c0c\ucd2f\u2185\u26dd\u04b4\u110f',
+size: [2016],
+dimension: '1d',
+format: 'r32float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r32float'],
+});
+try {
+renderBundleEncoder54.setBindGroup(9, bindGroup8, new Uint32Array(6384), 4932, 0);
+} catch {}
+let pipeline55 = await device3.createComputePipelineAsync({
+label: '\u0a98\u081b\u{1fbac}\u022d\uaa4e\u0ba0\u007e\u1b89\u02ed\u{1f725}\uab16',
+layout: 'auto',
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let bindGroup12 = device1.createBindGroup({
+label: '\u{1fa04}\u{1f8ef}\u{1fe9e}\u5c68\u0f90\u0e03\ua9e0\u0f81',
+layout: bindGroupLayout25,
+entries: [],
+});
+let renderBundle66 = renderBundleEncoder24.finish({label: '\u0863\u0053\u0678\u7f3f'});
+try {
+  await buffer31.mapAsync(GPUMapMode.READ, 0, 5676);
+} catch {}
+try {
+renderBundleEncoder46.insertDebugMarker('\u0d0c');
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16sint', 'rg8sint', 'rgba8unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline56 = device1.createRenderPipeline({
+label: '\u0da6\uce01\u2722\uf23e\u{1fe12}\u383a\u{1f955}',
+layout: pipelineLayout3,
+multisample: {
+count: 4,
+mask: 0x5a0313bc,
+},
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32float'}, {format: 'r16float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r16uint', writeMask: 0}, {format: 'r16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r8uint', writeMask: 0}]
+},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilReadMask: 96,
+stencilWriteMask: 100,
+depthBias: 82,
+depthBiasSlopeScale: 93,
+depthBiasClamp: 97,
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 13240,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x2',
+offset: 6124,
+shaderLocation: 7,
+}, {
+format: 'float16x4',
+offset: 12724,
+shaderLocation: 10,
+}, {
+format: 'float32x2',
+offset: 4244,
+shaderLocation: 13,
+}, {
+format: 'unorm8x4',
+offset: 11344,
+shaderLocation: 26,
+}, {
+format: 'float32x3',
+offset: 13092,
+shaderLocation: 20,
+}, {
+format: 'unorm16x4',
+offset: 7308,
+shaderLocation: 1,
+}, {
+format: 'snorm8x4',
+offset: 11744,
+shaderLocation: 6,
+}, {
+format: 'snorm16x4',
+offset: 3572,
+shaderLocation: 17,
+}, {
+format: 'sint32x2',
+offset: 10596,
+shaderLocation: 25,
+}, {
+format: 'snorm8x2',
+offset: 12376,
+shaderLocation: 16,
+}, {
+format: 'uint16x4',
+offset: 11408,
+shaderLocation: 9,
+}, {
+format: 'uint8x2',
+offset: 9036,
+shaderLocation: 3,
+}, {
+format: 'float32x4',
+offset: 3656,
+shaderLocation: 19,
+}, {
+format: 'uint32x2',
+offset: 7636,
+shaderLocation: 21,
+}, {
+format: 'float32x2',
+offset: 2868,
+shaderLocation: 22,
+}, {
+format: 'uint16x4',
+offset: 12132,
+shaderLocation: 15,
+}, {
+format: 'float16x2',
+offset: 2376,
+shaderLocation: 11,
+}, {
+format: 'sint16x2',
+offset: 12060,
+shaderLocation: 0,
+}, {
+format: 'unorm16x4',
+offset: 9896,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x3',
+offset: 5764,
+shaderLocation: 18,
+}, {
+format: 'unorm8x4',
+offset: 4428,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 27360,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 17224,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 17116,
+shaderLocation: 14,
+}, {
+format: 'snorm8x4',
+offset: 10496,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 3836,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 28396,
+attributes: [{
+format: 'uint16x4',
+offset: 260,
+shaderLocation: 2,
+}, {
+format: 'sint8x4',
+offset: 14476,
+shaderLocation: 24,
+}, {
+format: 'sint8x4',
+offset: 20168,
+shaderLocation: 23,
+}],
+},
+{
+arrayStride: 0,
+attributes: [],
+},
+{
+arrayStride: 30220,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 19372,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 23888,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 7196,
+shaderLocation: 8,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+unclippedDepth: true,
+},
+});
+let buffer33 = device3.createBuffer({
+  label: '\u{1fd53}\u06a4\u0092\u0a2e\u{1f937}\u0df3\u0ec5\u{1f969}',
+  size: 40275,
+  usage: GPUBufferUsage.QUERY_RESOLVE
+});
+try {
+renderBundleEncoder54.setVertexBuffer(1, buffer29, 1688, 2456);
+} catch {}
+let img15 = await imageWithData(91, 146, '#562babac', '#925ab510');
+let querySet63 = device1.createQuerySet({
+label: '\u77f9\u2aa2\u{1f9e4}\u0a17',
+type: 'occlusion',
+count: 875,
+});
+let texture87 = device1.createTexture({
+size: [205, 100, 1],
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-5x5-unorm-srgb'],
+});
+let pipeline57 = await device1.createRenderPipelineAsync({
+label: '\u0d23\u68a1\u6cb3\u0bf3',
+layout: pipelineLayout3,
+multisample: {
+count: 4,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'r32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+}
+}, {format: 'r32uint'}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'invert',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilWriteMask: 2196,
+depthBias: 31,
+depthBiasSlopeScale: 36,
+depthBiasClamp: 20,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 18904,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32',
+offset: 12616,
+shaderLocation: 21,
+}, {
+format: 'uint16x4',
+offset: 1948,
+shaderLocation: 26,
+}, {
+format: 'uint8x4',
+offset: 544,
+shaderLocation: 14,
+}, {
+format: 'uint16x2',
+offset: 14800,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 16972,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 10928,
+shaderLocation: 20,
+}, {
+format: 'snorm16x2',
+offset: 14804,
+shaderLocation: 4,
+}, {
+format: 'uint32x2',
+offset: 14488,
+shaderLocation: 24,
+}],
+},
+{
+arrayStride: 2500,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 160,
+shaderLocation: 7,
+}, {
+format: 'uint32',
+offset: 2156,
+shaderLocation: 22,
+}, {
+format: 'snorm16x2',
+offset: 848,
+shaderLocation: 0,
+}, {
+format: 'unorm16x4',
+offset: 1432,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 11668,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x2',
+offset: 2336,
+shaderLocation: 16,
+}, {
+format: 'uint16x2',
+offset: 10884,
+shaderLocation: 17,
+}, {
+format: 'sint32x2',
+offset: 6196,
+shaderLocation: 15,
+}, {
+format: 'sint16x4',
+offset: 6348,
+shaderLocation: 13,
+}, {
+format: 'unorm16x4',
+offset: 8736,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 11280,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 9032,
+shaderLocation: 25,
+}, {
+format: 'snorm16x2',
+offset: 7520,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 27900,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 5632,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 12340,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 3872,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 3636,
+attributes: [{
+format: 'sint8x4',
+offset: 2208,
+shaderLocation: 5,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+offscreenCanvas0.height = 904;
+let img16 = await imageWithData(278, 118, '#cbb8cd74', '#a539470e');
+let commandEncoder75 = device3.createCommandEncoder({label: '\uf3f6\u{1f760}\u2351\uac13\u1c31\u9c30'});
+let commandBuffer14 = commandEncoder73.finish({
+label: '\udd6f\u0f50\u0e07\u{1f70d}\u9343\u2e5f\uf13e',
+});
+let computePassEncoder40 = commandEncoder75.beginComputePass({label: '\uc4f2\u0b48\u{1fdfd}'});
+let renderBundle67 = renderBundleEncoder28.finish({label: '\ua1df\ub1f2\uf37e\uac53\u0c32\u01de\u0b44\u28c3\u8272\ubbff'});
+try {
+renderBundleEncoder56.setVertexBuffer(9, buffer29);
+} catch {}
+try {
+commandEncoder74.clearBuffer(buffer19, 4892, 7784);
+dissociateBuffer(device3, buffer19);
+} catch {}
+let promise25 = device3.queue.onSubmittedWorkDone();
+offscreenCanvas10.width = 649;
+gc();
+let canvas18 = document.createElement('canvas');
+let promise26 = adapter3.requestAdapterInfo();
+try {
+renderBundleEncoder56.setVertexBuffer(5, buffer29, 212, 232);
+} catch {}
+try {
+commandEncoder74.copyTextureToBuffer({
+  texture: texture84,
+  mipLevel: 2,
+  origin: { x: 16, y: 24, z: 1 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 7040 */
+offset: 7040,
+bytesPerRow: 256,
+buffer: buffer19,
+}, {width: 40, height: 204, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+commandEncoder74.clearBuffer(buffer24, 2040, 2124);
+dissociateBuffer(device3, buffer24);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer24, 4056, new Float32Array(23550), 259, 404);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: { x: 186, y: 15, z: 30 },
+  aspect: 'all',
+}, new Int8Array(arrayBuffer2), /* required buffer size: 8069391 */
+{offset: 767, bytesPerRow: 272, rowsPerImage: 223}, {width: 6, height: 30, depthOrArrayLayers: 134});
+} catch {}
+try {
+adapter5.label = '\ufc81\udfff\u{1f74b}\u1637\ub460\ub00f\u02bf';
+} catch {}
+try {
+  await promise25;
+} catch {}
+let querySet64 = device1.createQuerySet({
+label: '\u{1ff0c}\ubaeb',
+type: 'occlusion',
+count: 1084,
+});
+let computePassEncoder41 = commandEncoder72.beginComputePass({label: '\u{1f647}\u{1fbbe}\u39d4\u6dd2\u6fa7\u04d3\u46a5\u{1fd7c}\u3c46\u09f5'});
+try {
+computePassEncoder20.setPipeline(pipeline30);
+} catch {}
+try {
+renderBundleEncoder57.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder17.draw(16, 48, 40, 8);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(24, 8, 72, 728, 0);
+} catch {}
+try {
+commandEncoder70.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 2,
+  origin: { x: 23, y: 35, z: 44 },
+  aspect: 'all',
+}, {
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 92, y: 146, z: 12 },
+  aspect: 'all',
+}, {width: 3, height: 10, depthOrArrayLayers: 178});
+} catch {}
+try {
+commandEncoder70.clearBuffer(buffer30, 612, 40092);
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba8unorm-srgb', 'rgba8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer8,
+]);
+} catch {}
+let pipeline58 = device1.createComputePipeline({
+label: '\u{1fad3}\u940b\u{1f6a5}\u343d\u{1ffe2}\u4ccc\u70e2\u0a91\ub170',
+layout: pipelineLayout13,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let videoFrame17 = new VideoFrame(videoFrame12, {timestamp: 0});
+let bindGroupLayout29 = pipeline55.getBindGroupLayout(3);
+let querySet65 = device3.createQuerySet({
+label: '\u37fa\u543f\u0aae\u{1f907}\u503f\u{1fd27}\u{1fd1a}\uc0c0\u00cf',
+type: 'occlusion',
+count: 850,
+});
+try {
+renderBundleEncoder56.setVertexBuffer(10, buffer29, 3744, 49);
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(buffer29, 3604, buffer24, 6192, 324);
+dissociateBuffer(device3, buffer29);
+dissociateBuffer(device3, buffer24);
+} catch {}
+let imageData15 = new ImageData(112, 116);
+let gpuCanvasContext16 = canvas18.getContext('webgpu');
+canvas6.width = 888;
+gc();
+try {
+window.someLabel = externalTexture5.label;
+} catch {}
+let bindGroup13 = device1.createBindGroup({
+label: '\u1496\ubb0d',
+layout: bindGroupLayout14,
+entries: [{
+binding: 1723,
+resource: sampler12
+}],
+});
+let buffer34 = device1.createBuffer({
+  label: '\uc18f\u02ba\u38ec',
+  size: 23246,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM
+});
+let commandEncoder76 = device1.createCommandEncoder({});
+pseudoSubmit(device1, commandEncoder70);
+let texture88 = device1.createTexture({
+label: '\u0b47\u{1fc84}\u{1fa71}\u050d\u6390\u0e1a\u0b56\u4755\u{1fdfc}\u{1f69d}',
+size: {width: 384, height: 5, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+dimension: '2d',
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView81 = texture63.createView({label: '\u0f9b\u66f5\u031d\ucb52\ue4fd', dimension: '2d', baseArrayLayer: 162});
+let computePassEncoder42 = commandEncoder71.beginComputePass({label: '\u703e\uc272\u0c3f'});
+let renderBundle68 = renderBundleEncoder32.finish({});
+try {
+computePassEncoder39.setPipeline(pipeline30);
+} catch {}
+try {
+renderBundleEncoder17.draw(80, 56, 72);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(16);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline49);
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer4,
+]);
+} catch {}
+let pipeline59 = await promise12;
+let offscreenCanvas16 = new OffscreenCanvas(103, 560);
+let imageData16 = new ImageData(36, 256);
+let videoFrame18 = new VideoFrame(offscreenCanvas13, {timestamp: 0});
+let commandEncoder77 = device3.createCommandEncoder({label: '\ud18e\uf8a9\uabbf'});
+let texture89 = device3.createTexture({
+label: '\u0a6b\u0038\u08fc\u6f5a\u617c',
+size: [504, 60, 193],
+mipLevelCount: 9,
+sampleCount: 1,
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16sint', 'rg16sint', 'rg16sint'],
+});
+let computePassEncoder43 = commandEncoder74.beginComputePass({label: '\u0c27\u5248\u061e'});
+let sampler54 = device3.createSampler({
+label: '\ue231\u0eb4',
+addressModeU: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 11.572,
+lodMaxClamp: 82.223,
+maxAnisotropy: 16,
+});
+try {
+computePassEncoder24.setPipeline(pipeline54);
+} catch {}
+let renderBundle69 = renderBundleEncoder46.finish({label: '\u{1fb3d}\udff0\ub249\u{1ff0e}\ua507\u0e05\u0edb'});
+try {
+renderBundleEncoder17.drawIndexed(40, 72, 72, 400, 0);
+} catch {}
+try {
+  await buffer27.mapAsync(GPUMapMode.READ);
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let offscreenCanvas17 = new OffscreenCanvas(90, 457);
+let bindGroup14 = device3.createBindGroup({
+label: '\u{1ff66}\u{1f9b6}\u8321\u0951\ubd5c\u07bb\u0745\u661e',
+layout: bindGroupLayout22,
+entries: [],
+});
+let renderBundleEncoder60 = device3.createRenderBundleEncoder({colorFormats: ['rg32sint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderBundleEncoder56.setVertexBuffer(10, buffer29);
+} catch {}
+try {
+commandEncoder77.clearBuffer(buffer19, 3536, 6428);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+offscreenCanvas17.getContext('webgpu');
+} catch {}
+let computePassEncoder44 = commandEncoder77.beginComputePass({label: '\u01d9\u0655\u0973\u4fd8\u81de'});
+let renderBundle70 = renderBundleEncoder28.finish({label: '\u08d3\u713a\ua500\u9113\u0607\u{1faba}'});
+try {
+computePassEncoder25.setBindGroup(8, bindGroup11, new Uint32Array(9924), 4619, 0);
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline54);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(6, buffer29);
+} catch {}
+try {
+device3.queue.submit([
+]);
+} catch {}
+try {
+  await promise26;
+} catch {}
+canvas13.height = 496;
+try {
+commandEncoder76.clearBuffer(buffer20, 120, 412);
+dissociateBuffer(device1, buffer20);
+} catch {}
+document.body.prepend(video9);
+try {
+offscreenCanvas16.getContext('webgl');
+} catch {}
+let texture90 = device1.createTexture({
+label: '\u{1ffd8}\u935a\ua8a3\u{1fbb7}\u{1f703}\ufb43\u0cf6\u09fb\ua9ad',
+size: {width: 108, height: 768, depthOrArrayLayers: 1321},
+mipLevelCount: 7,
+sampleCount: 1,
+dimension: '3d',
+format: 'rg8uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg8uint', 'rg8uint', 'rg8uint'],
+});
+try {
+computePassEncoder26.setBindGroup(2, bindGroup13, new Uint32Array(1983), 1632, 0);
+} catch {}
+try {
+commandEncoder69.clearBuffer(buffer21, 5792);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 363 */
+{offset: 363}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise27 = device1.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let offscreenCanvas18 = new OffscreenCanvas(95, 237);
+let querySet66 = device3.createQuerySet({
+label: '\u89a2\u09f1\u0080\u0d5a\uf875',
+type: 'occlusion',
+count: 353,
+});
+try {
+  await promise27;
+} catch {}
+let offscreenCanvas19 = new OffscreenCanvas(52, 72);
+let computePassEncoder45 = commandEncoder62.beginComputePass({label: '\u0fce\u1c14\u0358\u89d4\u1066\u927b\u7f11\u80e2\ub6ec\u919b\u0c56'});
+document.body.prepend(canvas16);
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let offscreenCanvas20 = new OffscreenCanvas(76, 179);
+let adapter8 = await navigator.gpu.requestAdapter({
+});
+let offscreenCanvas21 = new OffscreenCanvas(729, 905);
+let video15 = await videoWithData();
+let imageBitmap15 = await createImageBitmap(imageBitmap6);
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let videoFrame19 = new VideoFrame(canvas13, {timestamp: 0});
+try {
+renderBundle48.label = '\u0e42\u076b\udea8\u{1f724}\u46d8\uf970\u{1f89f}\u51ea\u667d\u3b41';
+} catch {}
+let textureView82 = texture85.createView({baseMipLevel: 0, mipLevelCount: 6, baseArrayLayer: 9, arrayLayerCount: 18});
+let renderBundleEncoder61 = device3.createRenderBundleEncoder({label: '\u0ed3\u{1fa07}\u04fb\u08a5\u{1f746}\ue6eb\u0967', colorFormats: ['r16uint', 'rg16uint']});
+let sampler55 = device3.createSampler({
+label: '\u3078\u{1fd08}\u4999\u0eb3\u6587\u9aa7\ue417\u{1fa95}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 9.472,
+lodMaxClamp: 50.989,
+maxAnisotropy: 12,
+});
+try {
+renderBundleEncoder54.setBindGroup(8, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder56.setBindGroup(2, bindGroup6, new Uint32Array(363), 54, 0);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer24, 8028, new BigUint64Array(49562), 18503, 128);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: { x: 30, y: 104, z: 95 },
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 1685809 */
+{offset: 437, bytesPerRow: 164, rowsPerImage: 283}, {width: 27, height: 89, depthOrArrayLayers: 37});
+} catch {}
+let adapter9 = await navigator.gpu.requestAdapter({
+});
+try {
+offscreenCanvas21.getContext('2d');
+} catch {}
+let texture91 = device3.createTexture({
+label: '\u9d1c\u1bed',
+size: [1024],
+dimension: '1d',
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundle71 = renderBundleEncoder40.finish({});
+let sampler56 = device3.createSampler({
+label: '\uec6f\u{1f6d5}\u06a9\u6411\u1723\u09f7\u8053\ue7f8\u2f05\u37e9',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 36.607,
+lodMaxClamp: 38.306,
+maxAnisotropy: 6,
+});
+try {
+renderBundleEncoder60.setVertexBuffer(6, buffer29, 24);
+} catch {}
+let imageBitmap16 = await createImageBitmap(canvas2);
+let imageData17 = new ImageData(24, 156);
+document.body.prepend(canvas2);
+let buffer35 = device3.createBuffer({
+  label: '\u04f6\u0100',
+  size: 54882,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM
+});
+let texture92 = device3.createTexture({
+size: {width: 456},
+dimension: '1d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8uint'],
+});
+let renderBundleEncoder62 = device3.createRenderBundleEncoder({
+  label: '\u{1fe8f}\u17c5\u{1f88c}\uc981\u0560\u7e90\u0149\u{1fa49}\u0718\u3d52',
+  colorFormats: ['r8uint', undefined, 'r32sint', 'rgba8uint', 'rg8unorm', 'rg8uint', 'rg32uint', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+try {
+renderBundleEncoder62.setVertexBuffer(10, buffer29, 512, 1161);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer24, 3740, new BigUint64Array(19812), 18496, 440);
+} catch {}
+let promise28 = device3.createComputePipelineAsync({
+label: '\u7cea\u33dc\u77be\u01c7\u{1ff94}\u0678\u0ec0',
+layout: pipelineLayout14,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+},
+});
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let bindGroup15 = device3.createBindGroup({
+layout: bindGroupLayout22,
+entries: [],
+});
+let texture93 = device3.createTexture({
+label: '\u442f\u1a16\u23b9\uaa1b',
+size: [1024, 12, 13],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba32float'],
+});
+let renderBundle72 = renderBundleEncoder28.finish({});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(3, buffer29, 180);
+} catch {}
+try {
+buffer35.unmap();
+} catch {}
+try {
+renderBundleEncoder54.popDebugGroup();
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 0,
+  origin: { x: 424, y: 264, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(21530), /* required buffer size: 21530 */
+{offset: 730, bytesPerRow: 4172}, {width: 2056, height: 40, depthOrArrayLayers: 1});
+} catch {}
+let pipeline60 = await device3.createRenderPipelineAsync({
+label: '\u4fc1\u05f6\u815e\u2626',
+layout: pipelineLayout10,
+fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r32sint', writeMask: 0}, {
+  format: 'bgra8unorm-srgb',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilWriteMask: 509,
+depthBias: 48,
+depthBiasSlopeScale: 38,
+depthBiasClamp: 22,
+},
+vertex: {
+  module: shaderModule12,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 5988,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32',
+offset: 2764,
+shaderLocation: 20,
+}, {
+format: 'float16x2',
+offset: 2872,
+shaderLocation: 15,
+}, {
+format: 'unorm8x4',
+offset: 1956,
+shaderLocation: 22,
+}, {
+format: 'uint32x2',
+offset: 648,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 3684,
+shaderLocation: 14,
+}, {
+format: 'snorm8x2',
+offset: 5648,
+shaderLocation: 8,
+}, {
+format: 'unorm16x2',
+offset: 4320,
+shaderLocation: 19,
+}, {
+format: 'sint16x2',
+offset: 3048,
+shaderLocation: 7,
+}, {
+format: 'unorm16x4',
+offset: 3552,
+shaderLocation: 0,
+}, {
+format: 'uint32x4',
+offset: 5796,
+shaderLocation: 24,
+}, {
+format: 'sint32',
+offset: 916,
+shaderLocation: 6,
+}, {
+format: 'float32x2',
+offset: 5680,
+shaderLocation: 17,
+}, {
+format: 'snorm16x4',
+offset: 2896,
+shaderLocation: 5,
+}, {
+format: 'uint32x4',
+offset: 4216,
+shaderLocation: 4,
+}, {
+format: 'float32x2',
+offset: 2140,
+shaderLocation: 18,
+}, {
+format: 'sint16x2',
+offset: 3052,
+shaderLocation: 1,
+}, {
+format: 'uint8x4',
+offset: 3616,
+shaderLocation: 2,
+}, {
+format: 'unorm8x2',
+offset: 5888,
+shaderLocation: 23,
+}, {
+format: 'float32x2',
+offset: 2944,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 22844,
+attributes: [],
+},
+{
+arrayStride: 12164,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 12108,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint16x2',
+offset: 3464,
+shaderLocation: 25,
+}, {
+format: 'unorm10-10-10-2',
+offset: 25200,
+shaderLocation: 10,
+}, {
+format: 'unorm16x4',
+offset: 18704,
+shaderLocation: 21,
+}, {
+format: 'uint32',
+offset: 26132,
+shaderLocation: 13,
+}, {
+format: 'snorm8x4',
+offset: 2832,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 22836,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x2',
+offset: 158,
+shaderLocation: 16,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let img17 = await imageWithData(43, 126, '#bc5cb327', '#e0b41d34');
+try {
+offscreenCanvas18.getContext('2d');
+} catch {}
+try {
+offscreenCanvas20.getContext('bitmaprenderer');
+} catch {}
+let texture94 = device1.createTexture({
+size: [96, 1, 318],
+mipLevelCount: 8,
+dimension: '3d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderBundleEncoder17.drawIndexed(8, 64, 40, 784, 72);
+} catch {}
+let arrayBuffer10 = buffer31.getMappedRange(4336, 96);
+try {
+commandEncoder76.copyBufferToBuffer(buffer34, 17652, buffer30, 32564, 636);
+dissociateBuffer(device1, buffer34);
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+commandEncoder76.resolveQuerySet(querySet44, 475, 1184, buffer34, 9472);
+} catch {}
+let promise29 = device1.queue.onSubmittedWorkDone();
+let bindGroupLayout30 = device1.createBindGroupLayout({
+label: '\u6cd5\udc4a\u0022\u2fe2\u296c\u01ff\u{1f974}',
+entries: [{
+binding: 3524,
+visibility: 0,
+buffer: { type: 'uniform', minBindingSize: 558476, hasDynamicOffset: true },
+}],
+});
+let buffer36 = device1.createBuffer({
+  label: '\u{1fa67}\u0adb\u737a\ua35a\u5d9e\u5007',
+  size: 34627,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let querySet67 = device1.createQuerySet({
+label: '\u80d2\u{1f93a}\u{1f845}\uc3eb',
+type: 'occlusion',
+count: 1547,
+});
+let texture95 = device1.createTexture({
+size: [384],
+dimension: '1d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST,
+});
+try {
+renderBundleEncoder49.setBindGroup(8, bindGroup12);
+} catch {}
+try {
+  await buffer36.mapAsync(GPUMapMode.WRITE, 12744, 12452);
+} catch {}
+try {
+commandEncoder69.clearBuffer(buffer21, 7052);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture88,
+  mipLevel: 1,
+  origin: { x: 24, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 105 */
+{offset: 105}, {width: 72, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext17 = offscreenCanvas19.getContext('webgpu');
+let renderBundleEncoder63 = device1.createRenderBundleEncoder({
+  label: '\u{1fad5}\udcc7\u{1faad}',
+  colorFormats: [undefined, 'rg8sint', 'rgba8uint', 'bgra8unorm-srgb', 'rg16sint', 'rg16float', 'rg8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle73 = renderBundleEncoder17.finish({});
+try {
+computePassEncoder26.end();
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline59);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(6, bindGroup4);
+} catch {}
+try {
+commandEncoder76.copyBufferToBuffer(buffer20, 108, buffer27, 15832, 452);
+dissociateBuffer(device1, buffer20);
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+device: device1,
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgb10a2unorm', 'astc-5x4-unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame19,
+  origin: { x: 8, y: 69 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 13, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 32, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let video16 = await videoWithData();
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let renderBundleEncoder64 = device3.createRenderBundleEncoder({
+  label: '\u4fe4\u{1fc64}',
+  colorFormats: ['r8uint', undefined, 'r32sint', 'rgba8uint', 'rg8unorm', 'rg8uint', 'rg32uint', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder56.setVertexBuffer(10, buffer29, 2752, 1403);
+} catch {}
+let offscreenCanvas22 = new OffscreenCanvas(544, 320);
+let video17 = await videoWithData();
+let imageBitmap17 = await createImageBitmap(offscreenCanvas17);
+let commandEncoder78 = device3.createCommandEncoder({label: '\u0fd3\u{1f946}\ua246'});
+let textureView83 = texture89.createView({
+  label: '\u066a\ufa19\u{1fa5e}\u69c4\u{1fa0e}\u{1f7f8}\u7d6b\u{1f925}',
+  dimension: '2d',
+  baseMipLevel: 7,
+  mipLevelCount: 1,
+  baseArrayLayer: 121
+});
+try {
+computePassEncoder38.setPipeline(pipeline54);
+} catch {}
+try {
+renderBundleEncoder62.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+commandEncoder78.copyBufferToTexture({
+/* bytesInLastRow: 528 widthInBlocks: 33 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 33872 */
+offset: 33872,
+bytesPerRow: 768,
+buffer: buffer35,
+}, {
+  texture: texture48,
+  mipLevel: 0,
+  origin: { x: 18, y: 288, z: 0 },
+  aspect: 'all',
+}, {width: 198, height: 294, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer35);
+} catch {}
+let gpuCanvasContext18 = offscreenCanvas22.getContext('webgpu');
+let adapter10 = await navigator.gpu.requestAdapter({
+});
+let renderBundleEncoder65 = device3.createRenderBundleEncoder({
+  label: '\u08fc\uaa6f\u99cb\u78e6\uaecd\u0653\udb24\ue06b\u0ef0\u301c\ua63b',
+  colorFormats: ['rg8unorm'],
+  sampleCount: 1,
+  stencilReadOnly: false
+});
+try {
+commandEncoder78.clearBuffer(buffer24, 3572, 4992);
+dissociateBuffer(device3, buffer24);
+} catch {}
+try {
+  await promise29;
+} catch {}
+let adapter11 = await navigator.gpu.requestAdapter();
+let video18 = await videoWithData();
+let imageData18 = new ImageData(136, 232);
+try {
+renderBundleEncoder63.setVertexBuffer(41, undefined, 1617249828, 145364569);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer34, 22768, new DataView(new ArrayBuffer(37481)), 18976, 188);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas13,
+  origin: { x: 181, y: 440 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 41, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let promise30 = adapter11.requestAdapterInfo();
+let commandEncoder79 = device1.createCommandEncoder({label: '\uf84e\uc770\u{1f9a8}'});
+let commandBuffer15 = commandEncoder55.finish({
+label: '\u5c14\u{1fbb7}\uc8fb\ue2bc\u7a74\u65b5',
+});
+let texture96 = device1.createTexture({
+size: {width: 192, height: 8, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['etc2-rgb8unorm-srgb', 'etc2-rgb8unorm-srgb'],
+});
+let computePassEncoder46 = commandEncoder69.beginComputePass({label: '\uef83\u{1fc00}\u{1f621}\u{1fc96}'});
+try {
+computePassEncoder41.setPipeline(pipeline22);
+} catch {}
+try {
+commandEncoder79.copyBufferToBuffer(buffer34, 13904, buffer20, 188, 632);
+dissociateBuffer(device1, buffer34);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+  await promise30;
+} catch {}
+let img18 = await imageWithData(220, 166, '#7ec73c67', '#1cbe589c');
+let imageData19 = new ImageData(176, 224);
+canvas11.height = 455;
+let img19 = await imageWithData(103, 213, '#01fafc84', '#cbf180cb');
+let shaderModule13 = device1.createShaderModule({
+label: '\u0ba9\ueae2\u752d\u469c\u0d06\u7fe9\u08ee\u{1fcb6}\u{1f6ad}\u07cc\u08cb',
+code: `@group(0) @binding(542)
+var<storage, read_write> type10: array<u32>;
+@group(1) @binding(1723)
+var<storage, read_write> type11: array<u32>;
+
+@compute @workgroup_size(3, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec2<i32>,
+  @location(0) f1: vec3<f32>,
+  @location(4) f2: vec3<u32>,
+  @location(1) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4<f32>, @builtin(sample_mask) a2: u32, @builtin(sample_index) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S17 {
+  @location(23) f0: vec4<u32>,
+  @location(13) f1: vec4<i32>,
+  @location(4) f2: u32,
+  @location(15) f3: f16,
+  @location(2) f4: vec4<i32>,
+  @location(3) f5: vec4<f16>,
+  @location(0) f6: vec3<i32>,
+  @location(25) f7: vec4<f16>,
+  @location(11) f8: i32,
+  @location(19) f9: u32,
+  @location(6) f10: f16,
+  @location(1) f11: vec3<u32>,
+  @location(24) f12: f32,
+  @location(22) f13: vec4<u32>
+}
+
+@vertex
+fn vertex0(a0: S17, @location(20) a1: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+let renderBundle74 = renderBundleEncoder46.finish({});
+let externalTexture6 = device1.importExternalTexture({
+label: '\u0c13\ua860\u0320\u{1faf8}\u9a79\ue8b0\ud509',
+source: videoFrame5,
+colorSpace: 'srgb',
+});
+try {
+computePassEncoder20.setBindGroup(5, bindGroup12, new Uint32Array(9327), 1649, 0);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline52);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(5, bindGroup4);
+} catch {}
+try {
+commandEncoder76.clearBuffer(buffer21);
+dissociateBuffer(device1, buffer21);
+} catch {}
+let promise31 = device1.createComputePipelineAsync({
+label: '\u04f7\u06e2\u9db1\u{1fcd9}\u{1febc}',
+layout: 'auto',
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let commandEncoder80 = device1.createCommandEncoder({label: '\uf4b8\u0280\u6028\u1c5c\u07ed\u1282\u0785\ud62b\ue627'});
+let textureView84 = texture32.createView({baseMipLevel: 3, mipLevelCount: 2, baseArrayLayer: 7, arrayLayerCount: 13});
+let renderBundle75 = renderBundleEncoder26.finish({});
+try {
+computePassEncoder39.end();
+} catch {}
+try {
+commandEncoder76.clearBuffer(buffer34, 9532, 6320);
+dissociateBuffer(device1, buffer34);
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(querySet25, 1512, 121, buffer34, 3840);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 576, new BigUint64Array(42271), 3712, 68);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: video11,
+  origin: { x: 4, y: 6 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 33, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let adapter12 = await navigator.gpu.requestAdapter({
+});
+canvas12.height = 644;
+let img20 = await imageWithData(55, 83, '#553664a0', '#8b160ec9');
+try {
+renderBundle29.label = '\u58d6\u7a98';
+} catch {}
+pseudoSubmit(device1, commandEncoder69);
+let texture97 = device1.createTexture({
+size: {width: 48, height: 2, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder41.setPipeline(pipeline40);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(1, bindGroup13, new Uint32Array(3896), 1804, 0);
+} catch {}
+try {
+commandEncoder80.resolveQuerySet(querySet25, 272, 1297, buffer34, 7936);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 1,
+  origin: { x: 36, y: 4, z: 0 },
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 389 */
+{offset: 389}, {width: 4, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline61 = device1.createComputePipeline({
+label: '\u6304\u{1f86d}\u27c5',
+layout: 'auto',
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let querySet68 = device1.createQuerySet({
+label: '\u075b\u0e60\u1d92\u97a4\uf4a0\u{1fe9d}\u115a\u0eb6',
+type: 'occlusion',
+count: 1927,
+});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+computePassEncoder42.setBindGroup(8, bindGroup4, new Uint32Array(1069), 1033, 0);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline22);
+} catch {}
+try {
+commandEncoder76.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 9,
+  origin: { x: 0, y: 6, z: 127 },
+  aspect: 'all',
+}, {
+  texture: texture27,
+  mipLevel: 10,
+  origin: { x: 0, y: 0, z: 123 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 21});
+} catch {}
+try {
+commandEncoder79.resolveQuerySet(querySet39, 2401, 207, buffer34, 12288);
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer15,
+]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture88,
+  mipLevel: 4,
+  origin: { x: 8, y: 5, z: 1 },
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer1), /* required buffer size: 127 */
+{offset: 127}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout15 = device1.createPipelineLayout({
+  label: '\uacce\uffe7\ud685',
+  bindGroupLayouts: [bindGroupLayout11, bindGroupLayout30, bindGroupLayout2, bindGroupLayout25, bindGroupLayout6, bindGroupLayout6, bindGroupLayout21, bindGroupLayout11, bindGroupLayout14, bindGroupLayout21, bindGroupLayout21]
+});
+let texture98 = device1.createTexture({
+label: '\u7469\u4179\u{1f720}\u71de\u02c9\u1d6b\u9ad3\u07a1\u00c5\u065a\u6e1a',
+size: [96, 4, 2],
+mipLevelCount: 3,
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [],
+});
+let renderBundleEncoder66 = device1.createRenderBundleEncoder({
+  label: '\u884d\u1455\u3fac\u7612\u{1fda6}\ua0d1\u9b22',
+  colorFormats: [undefined, 'rg8sint', 'rgba8uint', 'bgra8unorm-srgb', 'rg16sint', 'rg16float', 'rg8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: false
+});
+try {
+computePassEncoder41.setBindGroup(5, bindGroup12, new Uint32Array(1653), 375, 0);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline30);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(62, undefined, 1392713464, 1571660599);
+} catch {}
+let arrayBuffer11 = buffer31.getMappedRange(4432, 580);
+try {
+commandEncoder76.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 10,
+  origin: { x: 0, y: 0, z: 41 },
+  aspect: 'all',
+}, {
+  texture: texture27,
+  mipLevel: 10,
+  origin: { x: 0, y: 0, z: 110 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 60});
+} catch {}
+try {
+gpuCanvasContext7.configure({
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['r8uint'],
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: img19,
+  origin: { x: 2, y: 35 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 5, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 35, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline62 = device1.createComputePipeline({
+label: '\u7720\u{1fd74}',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let video19 = await videoWithData();
+let renderBundleEncoder67 = device3.createRenderBundleEncoder({label: '\u{1f95b}\u7b0d\u{1f7a6}', colorFormats: ['rg8unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder40.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder64.setVertexBuffer(8, buffer29, 3704, 107);
+} catch {}
+let promise32 = device3.createRenderPipelineAsync({
+label: '\u308d\uf238\u{1fbb5}',
+layout: 'auto',
+fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'one-minus-dst-alpha'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r32sint', writeMask: 0}, {format: 'bgra8unorm-srgb'}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 2614,
+stencilWriteMask: 3105,
+depthBiasSlopeScale: 33,
+depthBiasClamp: 29,
+},
+vertex: {
+  module: shaderModule12,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1588,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x2',
+offset: 856,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 28524,
+attributes: [{
+format: 'sint16x2',
+offset: 28288,
+shaderLocation: 1,
+}, {
+format: 'sint16x4',
+offset: 12220,
+shaderLocation: 6,
+}, {
+format: 'unorm10-10-10-2',
+offset: 468,
+shaderLocation: 22,
+}, {
+format: 'float16x4',
+offset: 21012,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 11184,
+attributes: [{
+format: 'uint32',
+offset: 9964,
+shaderLocation: 24,
+}, {
+format: 'sint16x4',
+offset: 9920,
+shaderLocation: 7,
+}, {
+format: 'float32x2',
+offset: 6312,
+shaderLocation: 21,
+}, {
+format: 'float32x4',
+offset: 10200,
+shaderLocation: 9,
+}, {
+format: 'float16x4',
+offset: 9732,
+shaderLocation: 5,
+}, {
+format: 'float32x4',
+offset: 9448,
+shaderLocation: 19,
+}, {
+format: 'snorm16x4',
+offset: 508,
+shaderLocation: 8,
+}, {
+format: 'uint8x4',
+offset: 3224,
+shaderLocation: 12,
+}, {
+format: 'uint16x2',
+offset: 7360,
+shaderLocation: 14,
+}, {
+format: 'uint32x3',
+offset: 10092,
+shaderLocation: 13,
+}, {
+format: 'unorm8x2',
+offset: 6466,
+shaderLocation: 23,
+}, {
+format: 'uint8x4',
+offset: 9048,
+shaderLocation: 20,
+}, {
+format: 'uint16x4',
+offset: 188,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 10064,
+attributes: [{
+format: 'snorm16x4',
+offset: 3920,
+shaderLocation: 17,
+}],
+},
+{
+arrayStride: 7064,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x2',
+offset: 2188,
+shaderLocation: 16,
+}, {
+format: 'unorm16x4',
+offset: 4900,
+shaderLocation: 18,
+}, {
+format: 'sint32x3',
+offset: 4928,
+shaderLocation: 25,
+}, {
+format: 'float16x4',
+offset: 6388,
+shaderLocation: 0,
+}, {
+format: 'snorm16x4',
+offset: 5104,
+shaderLocation: 15,
+}, {
+format: 'uint16x2',
+offset: 6844,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 14168,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 6728,
+attributes: [],
+},
+{
+arrayStride: 0,
+attributes: [],
+},
+{
+arrayStride: 15572,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 1472,
+shaderLocation: 10,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+},
+});
+gc();
+let canvas19 = document.createElement('canvas');
+let imageData20 = new ImageData(132, 12);
+let bindGroup16 = device3.createBindGroup({
+label: '\u058d\u{1fa58}\u0d90\u2756\u0652\u{1f8a3}\u05cc\u050a',
+layout: bindGroupLayout29,
+entries: [],
+});
+let texture99 = device3.createTexture({
+label: '\u6dca\ub32d\u40b5\u{1fb6e}\uf9ae\u00a6\ue830\u6f01\u2943',
+size: [512],
+dimension: '1d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16float', 'rg16float', 'rg16float'],
+});
+let textureView85 = texture56.createView({label: '\uff91\u{1fabd}', dimension: '2d', aspect: 'all', baseMipLevel: 2, baseArrayLayer: 15});
+let computePassEncoder47 = commandEncoder78.beginComputePass({label: '\u8f6d\u0b42'});
+let renderBundleEncoder68 = device3.createRenderBundleEncoder({label: '\u0e75\u0d04\u0f6e', colorFormats: ['rg32sint'], depthReadOnly: true, stencilReadOnly: true});
+let sampler57 = device3.createSampler({
+label: '\u06ea\u4378\u39af\u{1f605}\u934d\u7573\u35d6\u5d8c',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 50.308,
+lodMaxClamp: 74.036,
+compare: 'equal',
+maxAnisotropy: 8,
+});
+try {
+device3.queue.writeBuffer(buffer24, 1124, new Int16Array(5759), 1211, 1556);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 9,
+  origin: { x: 0, y: 0, z: 81 },
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 96235 */
+{offset: 867, bytesPerRow: 131, rowsPerImage: 8}, {width: 0, height: 0, depthOrArrayLayers: 92});
+} catch {}
+offscreenCanvas11.width = 439;
+try {
+await adapter6.requestAdapterInfo();
+} catch {}
+try {
+computePassEncoder20.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer32, 'uint16', 15418);
+} catch {}
+try {
+commandEncoder76.copyTextureToTexture({
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 145, y: 20, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 140, y: 5, z: 0 },
+  aspect: 'all',
+}, {width: 5, height: 20, depthOrArrayLayers: 0});
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext19 = canvas19.getContext('webgpu');
+document.body.prepend(canvas5);
+try {
+window.someLabel = texture75.label;
+} catch {}
+let imageData21 = new ImageData(188, 228);
+let adapter13 = await navigator.gpu.requestAdapter({
+});
+let commandEncoder81 = device3.createCommandEncoder();
+let texture100 = device3.createTexture({
+label: '\udba1\u041f\u3e37\u{1fd2f}\u0216\uc110\u048e\u8a2b\u{1fa16}\uaab4',
+size: {width: 504, height: 60, depthOrArrayLayers: 193},
+mipLevelCount: 7,
+format: 'eac-rg11unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView86 = texture47.createView({
+  label: '\u0883\u0135\u0703\u8cef\uf904\u4385\u0eb2\uf9a2',
+  format: 'astc-6x6-unorm-srgb',
+  baseMipLevel: 0
+});
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+commandEncoder81.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 45808 */
+offset: 45808,
+bytesPerRow: 0,
+rowsPerImage: 227,
+buffer: buffer35,
+}, {
+  texture: texture85,
+  mipLevel: 6,
+  origin: { x: 6, y: 0, z: 73 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 38});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder81.resolveQuerySet(querySet48, 202, 94, buffer33, 18688);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer24, 2748, new DataView(new ArrayBuffer(33008)), 20049, 2044);
+} catch {}
+let bindGroupLayout31 = device3.createBindGroupLayout({
+entries: [{
+binding: 2662,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+}, {
+binding: 6976,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'filtering' },
+}],
+});
+let commandBuffer16 = commandEncoder81.finish();
+try {
+renderBundleEncoder65.setBindGroup(9, bindGroup14, []);
+} catch {}
+try {
+renderBundleEncoder67.setVertexBuffer(6, buffer29, 428, 1690);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 348, y: 20, z: 122 },
+  aspect: 'all',
+}, new ArrayBuffer(195035), /* required buffer size: 195035 */
+{offset: 905, bytesPerRow: 454, rowsPerImage: 84}, {width: 102, height: 40, depthOrArrayLayers: 6});
+} catch {}
+let imageBitmap18 = await createImageBitmap(video12);
+pseudoSubmit(device1, commandEncoder40);
+let textureView87 = texture63.createView({dimension: '2d', format: 'astc-8x8-unorm', baseArrayLayer: 4});
+let sampler58 = device1.createSampler({
+label: '\u2077\u0b0c\u3d5a\uadcf\uab45\u1fd8\u1943\u9005\uc08e',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 82.894,
+lodMaxClamp: 84.448,
+maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder66.setBindGroup(0, bindGroup12, []);
+} catch {}
+try {
+  await buffer30.mapAsync(GPUMapMode.READ, 21208, 3216);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC,
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 95 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 442301 */
+{offset: 43, bytesPerRow: 119, rowsPerImage: 235}, {width: 27, height: 192, depthOrArrayLayers: 16});
+} catch {}
+let pipeline63 = device1.createRenderPipeline({
+label: '\u0f81\u{1f63b}\u0b43\u01e8\u{1fd60}\u1308',
+layout: pipelineLayout3,
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'constant'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rg8sint', writeMask: 0}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one', dstFactor: 'one-minus-src'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.RED
+}, {format: 'r32uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r32sint'}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilWriteMask: 1799,
+depthBias: 51,
+depthBiasSlopeScale: 3,
+depthBiasClamp: 23,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 20128,
+attributes: [{
+format: 'unorm8x4',
+offset: 12692,
+shaderLocation: 2,
+}, {
+format: 'sint32',
+offset: 2936,
+shaderLocation: 16,
+}, {
+format: 'uint8x2',
+offset: 4246,
+shaderLocation: 17,
+}, {
+format: 'unorm16x4',
+offset: 9896,
+shaderLocation: 4,
+}, {
+format: 'float16x4',
+offset: 17864,
+shaderLocation: 0,
+}, {
+format: 'uint16x2',
+offset: 4740,
+shaderLocation: 12,
+}, {
+format: 'float16x4',
+offset: 13424,
+shaderLocation: 20,
+}, {
+format: 'uint8x4',
+offset: 4696,
+shaderLocation: 14,
+}, {
+format: 'uint16x4',
+offset: 1456,
+shaderLocation: 22,
+}, {
+format: 'unorm16x4',
+offset: 7664,
+shaderLocation: 1,
+}, {
+format: 'sint32x3',
+offset: 5420,
+shaderLocation: 25,
+}, {
+format: 'uint16x2',
+offset: 2388,
+shaderLocation: 26,
+}, {
+format: 'uint32x3',
+offset: 5772,
+shaderLocation: 10,
+}, {
+format: 'sint8x4',
+offset: 3040,
+shaderLocation: 5,
+}, {
+format: 'float32x4',
+offset: 18012,
+shaderLocation: 21,
+}, {
+format: 'sint16x4',
+offset: 18184,
+shaderLocation: 13,
+}, {
+format: 'float16x4',
+offset: 14068,
+shaderLocation: 6,
+}, {
+format: 'snorm8x2',
+offset: 476,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 34044,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 5324,
+shaderLocation: 7,
+}, {
+format: 'sint16x2',
+offset: 13320,
+shaderLocation: 15,
+}, {
+format: 'uint32x4',
+offset: 17588,
+shaderLocation: 24,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let img21 = await imageWithData(142, 252, '#57835747', '#cda85e9a');
+let videoFrame20 = new VideoFrame(canvas7, {timestamp: 0});
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let offscreenCanvas23 = new OffscreenCanvas(412, 161);
+let sampler59 = device3.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMaxClamp: 67.204,
+});
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(video6);
+try {
+device3.label = '\u{1fc41}\u028f\uf5f5\ud213\u30ad\u517f\u{1fc3b}\ud0e3\uebdf\u1299';
+} catch {}
+let bindGroupLayout32 = device3.createBindGroupLayout({
+label: '\u{1f75d}\u0828\ufc75\u28c3\u062f\u034d\u07f1',
+entries: [],
+});
+try {
+renderBundleEncoder64.setVertexBuffer(9, buffer29, 3740, 215);
+} catch {}
+let pipeline64 = await promise32;
+let canvas20 = document.createElement('canvas');
+let renderBundleEncoder69 = device1.createRenderBundleEncoder({
+  label: '\ue92b\u{1f63f}\u1954\u0bb0',
+  colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+try {
+renderBundleEncoder63.setIndexBuffer(buffer32, 'uint16');
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(querySet39, 1947, 272, buffer34, 20736);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 24, y: 176, z: 70 },
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(80)), /* required buffer size: 750002 */
+{offset: 30, bytesPerRow: 286, rowsPerImage: 289}, {width: 20, height: 88, depthOrArrayLayers: 10});
+} catch {}
+let promise33 = device1.queue.onSubmittedWorkDone();
+let imageData22 = new ImageData(228, 208);
+try {
+canvas20.getContext('webgl2');
+} catch {}
+try {
+offscreenCanvas23.getContext('webgl2');
+} catch {}
+offscreenCanvas11.width = 782;
+let offscreenCanvas24 = new OffscreenCanvas(343, 632);
+let gpuCanvasContext20 = offscreenCanvas24.getContext('webgpu');
+gc();
+let imageBitmap19 = await createImageBitmap(img19);
+let videoFrame21 = new VideoFrame(canvas17, {timestamp: 0});
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+try {
+  await promise33;
+} catch {}
+let renderBundle76 = renderBundleEncoder28.finish({label: '\u28a8\ub213\ue55c\uc1ce\uc1be\u{1fa1c}'});
+try {
+computePassEncoder37.setBindGroup(9, bindGroup16, new Uint32Array(6429), 1681, 0);
+} catch {}
+try {
+renderBundleEncoder67.setVertexBuffer(2, buffer29, 860, 2599);
+} catch {}
+let pipeline65 = device3.createComputePipeline({
+layout: 'auto',
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+document.body.prepend(canvas4);
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let querySet69 = device1.createQuerySet({
+label: '\ud02a\u9b63\u4317\u{1fdaf}\u0748\u0fe2\u0d42\u0896',
+type: 'occlusion',
+count: 4058,
+});
+let texture101 = device1.createTexture({
+size: [192, 8, 5],
+mipLevelCount: 8,
+dimension: '3d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba16uint', 'rgba16uint'],
+});
+let textureView88 = texture95.createView({label: '\ufb0e\udbaf', baseMipLevel: 0});
+try {
+computePassEncoder41.end();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: { x: 0, y: 30, z: 81 },
+  aspect: 'depth-only',
+}, arrayBuffer2, /* required buffer size: 1521146 */
+{offset: 821, bytesPerRow: 233, rowsPerImage: 145}, {width: 27, height: 0, depthOrArrayLayers: 46});
+} catch {}
+let texture102 = device2.createTexture({
+size: {width: 576, height: 96, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'eac-r11unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['eac-r11unorm', 'eac-r11unorm'],
+});
+let textureView89 = texture35.createView({label: '\u8845\u3aca\u3b68\uc797\ua2b4\u3762', mipLevelCount: 2});
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 2,
+  origin: { x: 16, y: 6, z: 16 },
+  aspect: 'all',
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 106, y: 41, z: 105 },
+  aspect: 'all',
+}, {width: 41, height: 3, depthOrArrayLayers: 10});
+} catch {}
+document.body.prepend(img11);
+let renderBundleEncoder70 = device1.createRenderBundleEncoder({
+  label: '\ua10e\u811d\u0fb0\uf9c9\u02dc\u04f1\u8598\u0b96\u{1ffe0}\u{1fad7}\u505e',
+  colorFormats: ['rg8sint', 'r16uint', 'r32sint', 'rg16sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder66.setBindGroup(8, bindGroup4);
+} catch {}
+let arrayBuffer12 = buffer27.getMappedRange(0, 8632);
+try {
+device1.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: { x: 0, y: 4, z: 41 },
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 2973485 */
+{offset: 863, bytesPerRow: 599, rowsPerImage: 121}, {width: 192, height: 8, depthOrArrayLayers: 42});
+} catch {}
+let promise34 = device1.createComputePipelineAsync({
+layout: pipelineLayout7,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let adapter14 = await navigator.gpu.requestAdapter();
+let buffer37 = device3.createBuffer({
+  label: '\u47b8\u{1fa3e}\u6bad\ub389\u9292\ube99\udacf\u{1f9f9}\ufef5\u0c21',
+  size: 41660,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let commandEncoder82 = device3.createCommandEncoder();
+let computePassEncoder48 = commandEncoder82.beginComputePass({label: '\u760a\u{1fc33}\u090a\u{1fbd4}\u04f8\u6ea7\u52c3\u0b2c'});
+try {
+renderBundleEncoder64.setBindGroup(2, bindGroup11);
+} catch {}
+let pipeline66 = await device3.createComputePipelineAsync({
+label: '\u{1ff13}\u0e1a',
+layout: 'auto',
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+window.someLabel = commandBuffer5.label;
+} catch {}
+let textureView90 = texture95.createView({label: '\ue1d5\u0713\ufdd8\u{1f732}\ubefc\ued04', aspect: 'all', mipLevelCount: 1});
+let computePassEncoder49 = commandEncoder79.beginComputePass();
+try {
+computePassEncoder42.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(35, undefined, 503102045, 1586376843);
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+try {
+commandEncoder72.resolveQuerySet(querySet16, 843, 51, buffer34, 4352);
+} catch {}
+try {
+renderBundleEncoder59.insertDebugMarker('\ub1b7');
+} catch {}
+let pipeline67 = await device1.createRenderPipelineAsync({
+label: '\u{1f8c6}\u0ba6\ub943\u{1ffcd}\u00c7',
+layout: pipelineLayout3,
+multisample: {
+count: 4,
+},
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg32float'}, {
+  format: 'r16float',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'zero'},
+}
+}, {format: 'r16uint', writeMask: 0}, {format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r8uint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'equal',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 3692,
+depthBias: 5,
+depthBiasSlopeScale: 29,
+depthBiasClamp: 19,
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 21068,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 21736,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 15750,
+shaderLocation: 5,
+}, {
+format: 'unorm8x2',
+offset: 962,
+shaderLocation: 13,
+}, {
+format: 'sint8x2',
+offset: 15480,
+shaderLocation: 7,
+}, {
+format: 'unorm16x2',
+offset: 7004,
+shaderLocation: 4,
+}, {
+format: 'uint8x4',
+offset: 18584,
+shaderLocation: 15,
+}, {
+format: 'unorm8x2',
+offset: 2594,
+shaderLocation: 19,
+}, {
+format: 'uint32',
+offset: 17984,
+shaderLocation: 2,
+}, {
+format: 'float32',
+offset: 21156,
+shaderLocation: 6,
+}, {
+format: 'unorm16x4',
+offset: 17852,
+shaderLocation: 10,
+}, {
+format: 'sint8x4',
+offset: 2260,
+shaderLocation: 23,
+}, {
+format: 'unorm16x4',
+offset: 20376,
+shaderLocation: 22,
+}, {
+format: 'sint32x4',
+offset: 6636,
+shaderLocation: 25,
+}, {
+format: 'float32x2',
+offset: 17020,
+shaderLocation: 16,
+}, {
+format: 'unorm10-10-10-2',
+offset: 10936,
+shaderLocation: 8,
+}, {
+format: 'float16x2',
+offset: 12916,
+shaderLocation: 1,
+}, {
+format: 'uint8x4',
+offset: 1932,
+shaderLocation: 3,
+}, {
+format: 'uint16x4',
+offset: 16228,
+shaderLocation: 21,
+}, {
+format: 'sint8x2',
+offset: 12902,
+shaderLocation: 0,
+}, {
+format: 'float16x2',
+offset: 7948,
+shaderLocation: 20,
+}, {
+format: 'uint8x2',
+offset: 6590,
+shaderLocation: 9,
+}, {
+format: 'sint32x4',
+offset: 11976,
+shaderLocation: 18,
+}, {
+format: 'float32',
+offset: 2260,
+shaderLocation: 17,
+}, {
+format: 'sint8x4',
+offset: 8180,
+shaderLocation: 24,
+}, {
+format: 'float16x4',
+offset: 4832,
+shaderLocation: 12,
+}, {
+format: 'snorm8x4',
+offset: 3084,
+shaderLocation: 26,
+}, {
+format: 'snorm8x4',
+offset: 10272,
+shaderLocation: 11,
+}, {
+format: 'unorm16x4',
+offset: 8304,
+shaderLocation: 14,
+}],
+}
+]
+},
+});
+gc();
+let imageBitmap20 = await createImageBitmap(video16);
+let querySet70 = device3.createQuerySet({
+label: '\u008a\u3eca\u0637',
+type: 'occlusion',
+count: 1792,
+});
+let sampler60 = device3.createSampler({
+label: '\u{1ff76}\ub858\ua99b\u{1f78c}\u0463\u16ef\u037a',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 43.724,
+maxAnisotropy: 15,
+});
+try {
+computePassEncoder27.end();
+} catch {}
+try {
+renderBundleEncoder68.setVertexBuffer(0, buffer29, 684);
+} catch {}
+try {
+commandEncoder58.copyTextureToBuffer({
+  texture: texture58,
+  mipLevel: 0,
+  origin: { x: 168, y: 170, z: 15 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 4304 widthInBlocks: 269 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 10016 */
+offset: 10016,
+bytesPerRow: 4608,
+buffer: buffer19,
+}, {width: 3228, height: 30, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer19);
+} catch {}
+let pipeline68 = await device3.createRenderPipelineAsync({
+label: '\u{1fec4}\u1048\u03a7\u{1f758}\u7fed\u09db',
+layout: pipelineLayout14,
+fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one', dstFactor: 'dst'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+vertex: {
+  module: shaderModule12,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 20788,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 4032,
+shaderLocation: 25,
+}, {
+format: 'float32x3',
+offset: 18132,
+shaderLocation: 19,
+}, {
+format: 'sint16x4',
+offset: 14160,
+shaderLocation: 1,
+}, {
+format: 'sint16x2',
+offset: 17416,
+shaderLocation: 11,
+}, {
+format: 'unorm10-10-10-2',
+offset: 1500,
+shaderLocation: 3,
+}, {
+format: 'snorm8x4',
+offset: 9024,
+shaderLocation: 10,
+}, {
+format: 'uint16x4',
+offset: 13660,
+shaderLocation: 20,
+}, {
+format: 'uint8x2',
+offset: 15222,
+shaderLocation: 2,
+}, {
+format: 'snorm16x4',
+offset: 4224,
+shaderLocation: 5,
+}, {
+format: 'unorm16x4',
+offset: 15440,
+shaderLocation: 17,
+}, {
+format: 'sint32',
+offset: 948,
+shaderLocation: 6,
+}, {
+format: 'float16x2',
+offset: 11172,
+shaderLocation: 8,
+}, {
+format: 'uint32x2',
+offset: 2688,
+shaderLocation: 13,
+}, {
+format: 'sint32x4',
+offset: 9900,
+shaderLocation: 7,
+}, {
+format: 'uint8x4',
+offset: 7912,
+shaderLocation: 4,
+}, {
+format: 'snorm8x2',
+offset: 6546,
+shaderLocation: 21,
+}, {
+format: 'uint32x4',
+offset: 7516,
+shaderLocation: 24,
+}, {
+format: 'float32x3',
+offset: 16908,
+shaderLocation: 22,
+}, {
+format: 'uint8x2',
+offset: 6204,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 10904,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 9688,
+attributes: [{
+format: 'unorm16x4',
+offset: 8712,
+shaderLocation: 0,
+}, {
+format: 'float32x4',
+offset: 3128,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 25168,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 1612,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 15936,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 14252,
+shaderLocation: 18,
+}, {
+format: 'unorm8x2',
+offset: 13458,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 25732,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 26924,
+attributes: [],
+},
+{
+arrayStride: 22880,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 22652,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 18320,
+shaderLocation: 23,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let canvas21 = document.createElement('canvas');
+let shaderModule14 = device3.createShaderModule({
+label: '\ufc76\uf7c8\u3e51\u{1fe9f}\u5d87\u26f9\u0884\u234c\u7bc0\ud027',
+code: `@group(0) @binding(846)
+var<storage, read_write> field5: array<u32>;
+
+@compute @workgroup_size(3, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S19 {
+  @builtin(sample_index) f0: u32,
+  @builtin(position) f1: vec4<f32>,
+  @location(24) f2: f16,
+  @location(33) f3: vec4<i32>,
+  @location(12) f4: vec3<f16>,
+  @location(58) f5: vec4<u32>,
+  @location(73) f6: u32,
+  @location(40) f7: vec4<u32>,
+  @location(15) f8: f16,
+  @location(37) f9: vec4<f16>,
+  @location(42) f10: vec3<i32>,
+  @location(44) f11: u32,
+  @location(81) f12: f32,
+  @location(74) f13: vec3<f32>,
+  @location(2) f14: f16,
+  @location(3) f15: vec4<i32>,
+  @location(79) f16: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: i32,
+  @location(0) f1: vec2<u32>,
+  @location(5) f2: vec3<u32>,
+  @location(3) f3: vec4<u32>,
+  @location(6) f4: vec3<u32>,
+  @location(4) f5: vec2<f32>,
+  @location(7) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(59) a0: vec2<f32>, @location(66) a1: vec2<u32>, @location(56) a2: vec4<f32>, @location(7) a3: vec4<f16>, @builtin(front_facing) a4: bool, @location(80) a5: vec3<f32>, @location(43) a6: f16, @location(11) a7: f32, @location(28) a8: vec2<f32>, @builtin(sample_mask) a9: u32, @location(0) a10: vec4<f16>, @location(27) a11: vec3<u32>, @location(16) a12: vec3<f16>, @location(60) a13: f32, a14: S19, @location(52) a15: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S18 {
+  @location(14) f0: f16,
+  @location(11) f1: i32,
+  @location(7) f2: vec3<u32>,
+  @location(4) f3: f32,
+  @location(18) f4: vec4<f16>,
+  @location(0) f5: vec2<f32>,
+  @location(19) f6: vec2<u32>
+}
+struct VertexOutput0 {
+  @location(12) f308: vec3<f16>,
+  @location(37) f309: vec4<f16>,
+  @location(59) f310: vec2<f32>,
+  @location(80) f311: vec3<f32>,
+  @builtin(position) f312: vec4<f32>,
+  @location(11) f313: f32,
+  @location(44) f314: u32,
+  @location(56) f315: vec4<f32>,
+  @location(3) f316: vec4<i32>,
+  @location(27) f317: vec3<u32>,
+  @location(40) f318: vec4<u32>,
+  @location(79) f319: vec4<f32>,
+  @location(2) f320: f16,
+  @location(58) f321: vec4<u32>,
+  @location(24) f322: f16,
+  @location(74) f323: vec3<f32>,
+  @location(66) f324: vec2<u32>,
+  @location(52) f325: u32,
+  @location(33) f326: vec4<i32>,
+  @location(28) f327: vec2<f32>,
+  @location(0) f328: vec4<f16>,
+  @location(81) f329: f32,
+  @location(73) f330: u32,
+  @location(60) f331: f32,
+  @location(16) f332: vec3<f16>,
+  @location(7) f333: vec4<f16>,
+  @location(43) f334: f16,
+  @location(15) f335: f16,
+  @location(42) f336: vec3<i32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @builtin(instance_index) a1: u32, a2: S18, @location(25) a3: vec2<f16>, @location(21) a4: vec3<i32>, @location(3) a5: vec4<f32>, @location(20) a6: vec2<u32>, @location(17) a7: vec3<f32>, @location(13) a8: vec2<u32>, @location(23) a9: vec4<i32>, @location(15) a10: vec2<f32>, @location(12) a11: vec2<f16>, @location(9) a12: u32, @location(8) a13: vec4<f32>, @location(22) a14: i32, @location(1) a15: i32, @location(10) a16: vec2<u32>, @location(24) a17: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+});
+let bindGroup17 = device3.createBindGroup({
+label: '\u{1fc3c}\ub79a\u02d6\uee5a\u0852\u039f\ue263\uea40\u072d',
+layout: bindGroupLayout22,
+entries: [],
+});
+let texture103 = device3.createTexture({
+label: '\u000f\u085c\u7099',
+size: {width: 1824},
+sampleCount: 1,
+dimension: '1d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['bgra8unorm'],
+});
+let computePassEncoder50 = commandEncoder58.beginComputePass({label: '\u0cb8\udb80\u5543\u{1fd90}\ucab4\uf36c\u{1fedc}\u{1f83c}\u12e8\u7a67\u0c76'});
+let renderBundleEncoder71 = device3.createRenderBundleEncoder({
+  label: '\u0cf7\u1c9b\ub429\u9375\u3f1c\u2fa3\u8401\u2fe2\u0a0c\u{1fe94}\ufd05',
+  colorFormats: ['rg32sint'],
+  stencilReadOnly: true
+});
+let renderBundle77 = renderBundleEncoder61.finish();
+let externalTexture7 = device3.importExternalTexture({
+label: '\u4d32\u258d\u0c58\ufa94\u{1f8d5}\u07f6\u{1f716}\ub83c\u0241',
+source: videoFrame16,
+});
+try {
+buffer19.unmap();
+} catch {}
+try {
+device3.queue.writeBuffer(buffer24, 2132, new Float32Array(60630), 55866, 452);
+} catch {}
+let pipeline69 = await device3.createRenderPipelineAsync({
+label: '\u6d5f\u0d4b\u{1ff44}\u33b8',
+layout: pipelineLayout11,
+fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: GPUColorWrite.ALPHA}, undefined, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8uint', writeMask: 0}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rg8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rg32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgb10a2unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'src-alpha'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.RED
+}]
+},
+vertex: {
+  module: shaderModule14,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 14616,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x4',
+offset: 8544,
+shaderLocation: 15,
+}, {
+format: 'unorm8x2',
+offset: 10502,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 14844,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 10856,
+shaderLocation: 7,
+}, {
+format: 'snorm16x4',
+offset: 3360,
+shaderLocation: 17,
+}, {
+format: 'uint16x2',
+offset: 7692,
+shaderLocation: 9,
+}, {
+format: 'sint16x4',
+offset: 2240,
+shaderLocation: 1,
+}, {
+format: 'float32x4',
+offset: 6316,
+shaderLocation: 14,
+}, {
+format: 'uint8x4',
+offset: 4176,
+shaderLocation: 10,
+}, {
+format: 'unorm10-10-10-2',
+offset: 13304,
+shaderLocation: 18,
+}, {
+format: 'sint16x4',
+offset: 4264,
+shaderLocation: 11,
+}, {
+format: 'sint16x4',
+offset: 6000,
+shaderLocation: 21,
+}, {
+format: 'float32x3',
+offset: 4784,
+shaderLocation: 3,
+}, {
+format: 'uint16x2',
+offset: 9128,
+shaderLocation: 19,
+}, {
+format: 'sint16x4',
+offset: 14280,
+shaderLocation: 22,
+}, {
+format: 'float32',
+offset: 4060,
+shaderLocation: 25,
+}, {
+format: 'uint16x4',
+offset: 1496,
+shaderLocation: 20,
+}, {
+format: 'unorm8x4',
+offset: 13548,
+shaderLocation: 4,
+}, {
+format: 'sint8x4',
+offset: 14444,
+shaderLocation: 23,
+}, {
+format: 'snorm16x2',
+offset: 8672,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 19536,
+attributes: [{
+format: 'uint32x3',
+offset: 6412,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 21828,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 13728,
+attributes: [{
+format: 'float32',
+offset: 1660,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 720,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 10196,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 23876,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 4360,
+attributes: [{
+format: 'sint16x4',
+offset: 2844,
+shaderLocation: 24,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+let offscreenCanvas25 = new OffscreenCanvas(89, 393);
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let adapter15 = await navigator.gpu.requestAdapter();
+let gpuCanvasContext21 = canvas21.getContext('webgpu');
+let canvas22 = document.createElement('canvas');
+let textureView91 = texture97.createView({label: '\u00e4\u44da\u0342\u{1f759}\ub23e\u0ca9\u3990\u3e95\u{1fb8b}\u1cda'});
+let renderBundleEncoder72 = device1.createRenderBundleEncoder({
+  label: '\uc733\u0365\u3439\u6415\u0ccb\u{1f7e8}\ua7e6\u{1fd81}\ufc3e\u0440',
+  colorFormats: ['r8unorm', 'r32uint', 'rg8sint', 'rg8unorm', 'r32uint', 'r32sint'],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+let renderBundle78 = renderBundleEncoder45.finish();
+try {
+computePassEncoder42.setPipeline(pipeline58);
+} catch {}
+gc();
+pseudoSubmit(device3, commandEncoder67);
+let texture104 = device3.createTexture({
+label: '\u8e76\u043c\u{1f6fd}\ua59b',
+size: {width: 120, height: 480, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'astc-10x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-10x6-unorm-srgb'],
+});
+try {
+computePassEncoder18.setBindGroup(5, bindGroup15, new Uint32Array(9563), 1229, 0);
+} catch {}
+try {
+device3.queue.submit([
+commandBuffer16,
+commandBuffer14,
+]);
+} catch {}
+document.body.prepend(canvas0);
+let adapter16 = await navigator.gpu.requestAdapter({
+});
+let offscreenCanvas26 = new OffscreenCanvas(962, 609);
+let video20 = await videoWithData();
+let texture105 = device3.createTexture({
+label: '\uca46\u0982\u{1fb31}\u0c27\u2b60\u9968\u{1f885}',
+size: [60, 240, 173],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rg16uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView92 = texture86.createView({label: '\u5215\u07b9\u0289\u0756\u074f\u{1fb9f}\u1650', aspect: 'all'});
+try {
+computePassEncoder18.setBindGroup(6, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder71.setIndexBuffer(buffer35, 'uint32', 9896);
+} catch {}
+let pipeline70 = await device3.createRenderPipelineAsync({
+label: '\u2c36\u04c5',
+layout: pipelineLayout14,
+multisample: {
+},
+fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined, {format: 'r32sint', writeMask: GPUColorWrite.BLUE}, {format: 'rgba8uint', writeMask: 0}, {format: 'rg8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg8uint'}, {format: 'rg32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rgb10a2unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'one-minus-src'},
+alpha: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-dst'},
+},
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED
+}]
+},
+vertex: {
+  module: shaderModule14,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 22820,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 20188,
+shaderLocation: 17,
+}, {
+format: 'snorm16x2',
+offset: 11996,
+shaderLocation: 14,
+}, {
+format: 'sint32x4',
+offset: 19532,
+shaderLocation: 21,
+}, {
+format: 'sint8x2',
+offset: 2858,
+shaderLocation: 24,
+}, {
+format: 'float32x3',
+offset: 6504,
+shaderLocation: 15,
+}, {
+format: 'snorm8x4',
+offset: 22228,
+shaderLocation: 18,
+}, {
+format: 'uint16x2',
+offset: 2592,
+shaderLocation: 20,
+}, {
+format: 'unorm10-10-10-2',
+offset: 14652,
+shaderLocation: 0,
+}, {
+format: 'float32x3',
+offset: 632,
+shaderLocation: 4,
+}, {
+format: 'float32x2',
+offset: 7348,
+shaderLocation: 3,
+}, {
+format: 'sint8x2',
+offset: 20790,
+shaderLocation: 11,
+}, {
+format: 'uint32x2',
+offset: 10776,
+shaderLocation: 10,
+}, {
+format: 'sint16x2',
+offset: 10160,
+shaderLocation: 23,
+}, {
+format: 'uint32x3',
+offset: 15452,
+shaderLocation: 7,
+}, {
+format: 'uint32x2',
+offset: 4248,
+shaderLocation: 19,
+}],
+},
+{
+arrayStride: 12696,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 12596,
+shaderLocation: 13,
+}, {
+format: 'sint32x3',
+offset: 3596,
+shaderLocation: 22,
+}, {
+format: 'uint16x2',
+offset: 5700,
+shaderLocation: 9,
+}, {
+format: 'sint8x4',
+offset: 12200,
+shaderLocation: 1,
+}, {
+format: 'unorm10-10-10-2',
+offset: 3736,
+shaderLocation: 12,
+}, {
+format: 'unorm10-10-10-2',
+offset: 3576,
+shaderLocation: 25,
+}, {
+format: 'float32x3',
+offset: 8824,
+shaderLocation: 8,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let imageData23 = new ImageData(124, 220);
+let querySet71 = device1.createQuerySet({
+type: 'occlusion',
+count: 1936,
+});
+let textureView93 = texture82.createView({label: '\u08e0\u{1f92e}\u{1f8d7}\u0fcc\u{1feee}\u1e7d', baseArrayLayer: 103, arrayLayerCount: 33});
+try {
+computePassEncoder49.setBindGroup(7, bindGroup13);
+} catch {}
+try {
+computePassEncoder49.setBindGroup(0, bindGroup12, new Uint32Array(6198), 3277, 0);
+} catch {}
+try {
+commandEncoder76.copyBufferToBuffer(buffer36, 10560, buffer21, 20744, 684);
+dissociateBuffer(device1, buffer36);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 2,
+  origin: { x: 5, y: 29, z: 59 },
+  aspect: 'all',
+}, {
+  texture: texture17,
+  mipLevel: 2,
+  origin: { x: 2, y: 14, z: 156 },
+  aspect: 'all',
+}, {width: 18, height: 32, depthOrArrayLayers: 2});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 380, new Int16Array(40779), 15830, 324);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame18,
+  origin: { x: 157, y: 307 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 31, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline71 = await device1.createRenderPipelineAsync({
+label: '\ubee7\u2829\u{1f657}\ub88b\u02ff',
+layout: pipelineLayout7,
+multisample: {
+mask: 0x32eec057,
+},
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'rg8sint'}, {format: 'rgba32uint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'invert',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 1043,
+stencilWriteMask: 2828,
+depthBias: 67,
+depthBiasSlopeScale: 16,
+depthBiasClamp: 19,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 11460,
+attributes: [{
+format: 'sint16x2',
+offset: 4336,
+shaderLocation: 22,
+}, {
+format: 'float32x4',
+offset: 3324,
+shaderLocation: 16,
+}, {
+format: 'float16x2',
+offset: 120,
+shaderLocation: 18,
+}, {
+format: 'snorm16x4',
+offset: 9316,
+shaderLocation: 4,
+}, {
+format: 'uint16x4',
+offset: 3464,
+shaderLocation: 3,
+}, {
+format: 'uint32x3',
+offset: 7296,
+shaderLocation: 8,
+}, {
+format: 'unorm8x2',
+offset: 11016,
+shaderLocation: 13,
+}, {
+format: 'unorm16x4',
+offset: 8292,
+shaderLocation: 24,
+}, {
+format: 'snorm16x2',
+offset: 2992,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 8248,
+shaderLocation: 20,
+}, {
+format: 'sint16x4',
+offset: 7580,
+shaderLocation: 10,
+}, {
+format: 'sint16x4',
+offset: 5400,
+shaderLocation: 7,
+}, {
+format: 'float32x2',
+offset: 7664,
+shaderLocation: 19,
+}, {
+format: 'sint32x4',
+offset: 10636,
+shaderLocation: 14,
+}, {
+format: 'unorm8x2',
+offset: 9714,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 0,
+attributes: [{
+format: 'sint32x3',
+offset: 19716,
+shaderLocation: 25,
+}, {
+format: 'uint8x4',
+offset: 9448,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 34316,
+attributes: [{
+format: 'unorm16x2',
+offset: 22464,
+shaderLocation: 23,
+}, {
+format: 'uint32x2',
+offset: 30800,
+shaderLocation: 6,
+}, {
+format: 'uint32',
+offset: 21444,
+shaderLocation: 5,
+}, {
+format: 'uint8x4',
+offset: 4860,
+shaderLocation: 2,
+}, {
+format: 'snorm8x4',
+offset: 19396,
+shaderLocation: 15,
+}, {
+format: 'sint8x4',
+offset: 14484,
+shaderLocation: 17,
+}],
+},
+{
+arrayStride: 16408,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 4728,
+shaderLocation: 26,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x2',
+offset: 15116,
+shaderLocation: 1,
+}, {
+format: 'uint8x4',
+offset: 20296,
+shaderLocation: 21,
+}],
+},
+{
+arrayStride: 6608,
+attributes: [],
+},
+{
+arrayStride: 35784,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 22640,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x2',
+offset: 16592,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let gpuCanvasContext22 = canvas22.getContext('webgpu');
+let video21 = await videoWithData();
+let imageBitmap21 = await createImageBitmap(offscreenCanvas7);
+gc();
+try {
+adapter2.label = '\uae9b\u0feb\u25d0\u{1f721}\ufcf9';
+} catch {}
+let offscreenCanvas27 = new OffscreenCanvas(283, 291);
+try {
+offscreenCanvas26.getContext('webgl2');
+} catch {}
+try {
+device2.queue.label = '\u0611\uff55\u095d\u{1f851}\u0087\u4bd0';
+} catch {}
+let renderBundle79 = renderBundleEncoder45.finish({label: '\u46b1\u1eb5\u29f3\u348e\u{1fcce}\u2c9c\u0456\u{1fe13}\u045a'});
+try {
+computePassEncoder42.setBindGroup(10, bindGroup7, new Uint32Array(1524), 831, 0);
+} catch {}
+try {
+renderBundleEncoder72.setBindGroup(1, bindGroup4, new Uint32Array(1731), 1434, 0);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let imageData24 = new ImageData(164, 24);
+let querySet72 = device4.createQuerySet({
+type: 'occlusion',
+count: 1086,
+});
+let textureView94 = texture74.createView({label: '\u{1f8ee}\u0d35', arrayLayerCount: 1});
+let canvas23 = document.createElement('canvas');
+let video22 = await videoWithData();
+let imageBitmap22 = await createImageBitmap(videoFrame15);
+try {
+offscreenCanvas27.getContext('webgl2');
+} catch {}
+let pipelineLayout16 = device3.createPipelineLayout({
+  label: '\u0acf\ueb73',
+  bindGroupLayouts: [bindGroupLayout32, bindGroupLayout24, bindGroupLayout28, bindGroupLayout32, bindGroupLayout31, bindGroupLayout22, bindGroupLayout31, bindGroupLayout28, bindGroupLayout27]
+});
+try {
+computePassEncoder38.setPipeline(pipeline55);
+} catch {}
+try {
+renderBundleEncoder68.setVertexBuffer(10, buffer29);
+} catch {}
+let video23 = await videoWithData();
+let buffer38 = device1.createBuffer({
+  label: '\u1a7f\u1a65\u8217\u23e4\ucdcb\u{1fe19}\u8cf0\u{1fb0a}\ue852\u{1ffec}\u53fd',
+  size: 2691,
+  usage: GPUBufferUsage.UNIFORM
+});
+let commandEncoder83 = device1.createCommandEncoder({});
+let renderBundle80 = renderBundleEncoder69.finish();
+try {
+renderBundleEncoder59.setVertexBuffer(88, undefined, 1220253945, 2659901091);
+} catch {}
+try {
+commandEncoder80.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 1,
+  origin: { x: 26, y: 4, z: 96 },
+  aspect: 'all',
+}, {
+  texture: texture17,
+  mipLevel: 1,
+  origin: { x: 36, y: 74, z: 146 },
+  aspect: 'all',
+}, {width: 18, height: 274, depthOrArrayLayers: 5});
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(querySet58, 1960, 322, buffer34, 5888);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer34, 5548, new BigUint64Array(34066), 17094, 24);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 84, y: 260, z: 31 },
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer10), /* required buffer size: 8030704 */
+{offset: 8, bytesPerRow: 243, rowsPerImage: 273}, {width: 8, height: 64, depthOrArrayLayers: 122});
+} catch {}
+try {
+offscreenCanvas25.getContext('webgpu');
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+offscreenCanvas6.height = 440;
+let offscreenCanvas28 = new OffscreenCanvas(404, 356);
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+gc();
+let commandEncoder84 = device3.createCommandEncoder({label: '\u8ebf\u041e\ubc92\u0629\u0c12\ub1ac\u0e79\u0695\u1bd6'});
+let texture106 = device3.createTexture({
+label: '\u{1fa41}\ubbb0\u3b76\u9442\u{1faa5}\u7985\u{1fbf9}\ue7e0',
+size: {width: 1024, height: 12, depthOrArrayLayers: 13},
+mipLevelCount: 9,
+sampleCount: 1,
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let renderBundleEncoder73 = device3.createRenderBundleEncoder({
+  label: '\ue309\u{1fb44}\u5ae6\ued4f',
+  colorFormats: ['rg32sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+commandEncoder84.copyBufferToBuffer(buffer29, 676, buffer37, 2260, 1092);
+dissociateBuffer(device3, buffer29);
+dissociateBuffer(device3, buffer37);
+} catch {}
+try {
+commandEncoder84.resolveQuerySet(querySet33, 2051, 69, buffer33, 4608);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline72 = await device3.createComputePipelineAsync({
+label: '\u{1f6ea}\u8ea1\u08c9\u638a\uc484\u9d14\ueeaf\ue949\ubd8a\u07c6',
+layout: pipelineLayout10,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+},
+});
+let buffer39 = device1.createBuffer({
+  label: '\u0029\u{1f918}\u490a\u0e95\ue4c2\u0e93\ucba6\ucfcb\u{1f650}',
+  size: 63080,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let querySet73 = device1.createQuerySet({
+label: '\u56b8\u{1fc65}\ua3ac\u{1fc30}',
+type: 'occlusion',
+count: 1726,
+});
+let sampler61 = device1.createSampler({
+label: '\ueae0\u0a12\u0ead\u0e88\u{1f969}\u0c2a\u92be\u5c92\u{1f721}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMaxClamp: 88.112,
+compare: 'less',
+});
+try {
+renderBundleEncoder37.setIndexBuffer(buffer12, 'uint16', 450, 282);
+} catch {}
+try {
+commandEncoder59.copyTextureToBuffer({
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 65, y: 10, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 336 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 55120 */
+offset: 50176,
+bytesPerRow: 512,
+buffer: buffer39,
+}, {width: 105, height: 50, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 2,
+  origin: { x: 4, y: 28, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture17,
+  mipLevel: 1,
+  origin: { x: 35, y: 134, z: 1 },
+  aspect: 'all',
+}, {width: 4, height: 113, depthOrArrayLayers: 221});
+} catch {}
+try {
+computePassEncoder10.insertDebugMarker('\u1caa');
+} catch {}
+let promise35 = device1.createComputePipelineAsync({
+layout: pipelineLayout12,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let buffer40 = device3.createBuffer({
+  label: '\u6df0\u{1fd85}\u24c9\u7178\ua4ac\u7515\u02ee\u{1ff1c}\u{1fe14}',
+  size: 40563,
+  usage: GPUBufferUsage.COPY_DST
+});
+let texture107 = device3.createTexture({
+label: '\u{1fe62}\u{1f952}\u0002\u2d43',
+size: [228],
+dimension: '1d',
+format: 'r32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture108 = gpuCanvasContext6.getCurrentTexture();
+try {
+commandEncoder84.clearBuffer(buffer19, 9488, 420);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+commandEncoder84.resolveQuerySet(querySet70, 458, 35, buffer33, 4864);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline73 = await promise28;
+let promise36 = device3.createRenderPipelineAsync({
+label: '\u{1fafc}\u77ad',
+layout: pipelineLayout10,
+fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, undefined, {format: 'r32sint'}, {format: 'rgba8uint', writeMask: 0}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'dst-alpha'},
+},
+  writeMask: GPUColorWrite.GREEN
+}, {format: 'rg8uint', writeMask: 0}, {format: 'rg32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+vertex: {
+  module: shaderModule14,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 3884,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 2214,
+shaderLocation: 23,
+}, {
+format: 'uint16x4',
+offset: 1224,
+shaderLocation: 9,
+}, {
+format: 'float32x2',
+offset: 1384,
+shaderLocation: 25,
+}],
+},
+{
+arrayStride: 4968,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 438,
+shaderLocation: 10,
+}, {
+format: 'snorm8x2',
+offset: 1442,
+shaderLocation: 4,
+}, {
+format: 'snorm16x2',
+offset: 3036,
+shaderLocation: 3,
+}, {
+format: 'float32x2',
+offset: 2612,
+shaderLocation: 17,
+}, {
+format: 'sint32x2',
+offset: 568,
+shaderLocation: 21,
+}, {
+format: 'snorm8x4',
+offset: 3160,
+shaderLocation: 12,
+}, {
+format: 'unorm16x2',
+offset: 4220,
+shaderLocation: 18,
+}, {
+format: 'sint32x3',
+offset: 1856,
+shaderLocation: 24,
+}, {
+format: 'uint8x4',
+offset: 3124,
+shaderLocation: 13,
+}, {
+format: 'sint8x2',
+offset: 2262,
+shaderLocation: 22,
+}, {
+format: 'unorm8x4',
+offset: 1848,
+shaderLocation: 15,
+}, {
+format: 'float32x4',
+offset: 2684,
+shaderLocation: 8,
+}, {
+format: 'sint16x4',
+offset: 2708,
+shaderLocation: 1,
+}, {
+format: 'float32x4',
+offset: 4384,
+shaderLocation: 0,
+}, {
+format: 'sint16x2',
+offset: 368,
+shaderLocation: 11,
+}, {
+format: 'uint32x2',
+offset: 2712,
+shaderLocation: 20,
+}, {
+format: 'float32',
+offset: 4608,
+shaderLocation: 14,
+}, {
+format: 'uint8x4',
+offset: 2076,
+shaderLocation: 19,
+}],
+},
+{
+arrayStride: 3056,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x3',
+offset: 7204,
+shaderLocation: 7,
+}],
+}
+]
+},
+});
+try {
+externalTexture2.label = '\u03bd\ucae6';
+} catch {}
+let adapter17 = await navigator.gpu.requestAdapter({
+});
+try {
+computePassEncoder44.setBindGroup(7, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder68.setBindGroup(4, bindGroup6);
+} catch {}
+try {
+commandEncoder84.copyTextureToBuffer({
+  texture: texture99,
+  mipLevel: 0,
+  origin: { x: 234, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 388 widthInBlocks: 97 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 3068 */
+offset: 2680,
+buffer: buffer19,
+}, {width: 97, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+canvas23.getContext('webgl2');
+} catch {}
+let commandEncoder85 = device3.createCommandEncoder({label: '\u{1fc8d}\u7ce2\ud9f8\u01c9\u009a'});
+let computePassEncoder51 = commandEncoder85.beginComputePass({label: '\u064b\u03fe\u0d5e\u8c32\u0b58\u{1feb9}\u18ae\u0dff\u0b68\u7490'});
+let renderBundleEncoder74 = device3.createRenderBundleEncoder({
+  label: '\u{1ff0c}\u{1f99d}\u55be',
+  colorFormats: ['r8uint', undefined, 'r32sint', 'rgba8uint', 'rg8unorm', 'rg8uint', 'rg32uint', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+try {
+computePassEncoder18.popDebugGroup();
+} catch {}
+try {
+device3.queue.writeBuffer(buffer40, 22528, new Int16Array(65522), 65117, 204);
+} catch {}
+let pipeline74 = await device3.createComputePipelineAsync({
+label: '\u050e\u{1fefb}\uf8f5\u05d2\ua628\u06f2\u{1f9e9}',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let videoFrame22 = new VideoFrame(videoFrame9, {timestamp: 0});
+try {
+offscreenCanvas28.getContext('bitmaprenderer');
+} catch {}
+let bindGroupLayout33 = device1.createBindGroupLayout({
+label: '\u085f\udfed\u754c\u1681\u{1fd30}\u{1fefe}\u8a7a\u8651',
+entries: [{
+binding: 1265,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+let commandEncoder86 = device1.createCommandEncoder({label: '\u007d\u0a41\ub4ca\u2ae2\u{1f7fc}\ub946\u{1ffb6}\u{1fda0}\u0ae0\u8945\u20be'});
+let textureView95 = texture87.createView({label: '\u06d3\ub571\ub139\u{1fc57}', dimension: '2d-array', format: 'astc-5x5-unorm-srgb'});
+let renderBundleEncoder75 = device1.createRenderBundleEncoder({
+  label: '\uf67c\ucb8b\ua9bd',
+  colorFormats: ['r8uint', 'r16float', 'rg32sint', 'rgba16sint', 'rgba32uint'],
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder49.end();
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 102, y: 850 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 11, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 36, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame23 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let bindGroupLayout34 = pipeline64.getBindGroupLayout(2);
+let commandEncoder87 = device3.createCommandEncoder();
+let renderBundleEncoder76 = device3.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle81 = renderBundleEncoder60.finish({label: '\u{1fae2}\u87b9\u0c81\u0e0c\udc2d\ue9eb\u0950\u0c43'});
+try {
+computePassEncoder50.setPipeline(pipeline55);
+} catch {}
+let pipelineLayout17 = device1.createPipelineLayout({
+  label: '\u91eb\u0bff\u0520\u0717\u0e90\u{1fe8a}\ueffa\u{1f61a}\u0f86\u{1f6d8}',
+  bindGroupLayouts: [bindGroupLayout21, bindGroupLayout11]
+});
+let textureView96 = texture95.createView({mipLevelCount: 1});
+let renderBundle82 = renderBundleEncoder17.finish();
+try {
+texture97.destroy();
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+commandEncoder72.copyBufferToBuffer(buffer34, 16996, buffer8, 3684, 2012);
+dissociateBuffer(device1, buffer34);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder86.resolveQuerySet(querySet51, 578, 1863, buffer34, 1792);
+} catch {}
+let canvas24 = document.createElement('canvas');
+try {
+canvas24.getContext('webgpu');
+} catch {}
+let imageBitmap23 = await createImageBitmap(img11);
+let buffer41 = device3.createBuffer({
+  label: '\u51b9\u282f\u0c98\ua371',
+  size: 8177,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE
+});
+let querySet74 = device3.createQuerySet({
+label: '\ucfc2\u{1f817}\u3bef\u{1fe9d}\uace6\u{1f983}\u{1fe72}\u044a',
+type: 'occlusion',
+count: 3491,
+});
+let texture109 = device3.createTexture({
+label: '\u1963\u0f67\ubf4c\u01a3\u932e\u1d98',
+size: {width: 1824, height: 40, depthOrArrayLayers: 1264},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['r8snorm'],
+});
+let computePassEncoder52 = commandEncoder84.beginComputePass({label: '\u0bce\u0977\u{1fe31}\u48cc\u8244\u0f12\ud7b0\ub08a\u9a6d\u00bb\u91e8'});
+let renderBundle83 = renderBundleEncoder40.finish({label: '\u{1fc2a}\u0e07\u{1f78d}\u11da\u063d\ua4f3\u2f3e\u{1fdd6}\u06b0'});
+try {
+commandEncoder87.clearBuffer(buffer24, 1388, 3976);
+dissociateBuffer(device3, buffer24);
+} catch {}
+let imageData25 = new ImageData(184, 220);
+let computePassEncoder53 = commandEncoder87.beginComputePass({label: '\u03e5\ufcbb\u{1f71b}\u41b0\u6792\u{1f902}\u0039\u0275'});
+let renderBundle84 = renderBundleEncoder60.finish({label: '\u066d\u1602\u4178\u{1f86f}\u014e\u183d\u6c94\u436c\u374f'});
+try {
+computePassEncoder24.setBindGroup(8, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder67.setBindGroup(8, bindGroup14);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let imageData26 = new ImageData(48, 144);
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let offscreenCanvas29 = new OffscreenCanvas(582, 572);
+video0.height = 85;
+let buffer42 = device3.createBuffer({
+  label: '\u1520\u62ea\u0673\u33c1\u09e0\u0e9c\u147b\ud527\u02dc\u0793',
+  size: 3858,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+pseudoSubmit(device3, commandEncoder66);
+try {
+renderBundleEncoder64.setBindGroup(8, bindGroup9, []);
+} catch {}
+let pipeline75 = await device3.createComputePipelineAsync({
+label: '\u04e4\u{1fd07}\u{1f6da}',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline76 = device3.createRenderPipeline({
+label: '\ua9e9\u0066\ue061',
+layout: pipelineLayout11,
+multisample: {
+count: 4,
+mask: 0x53992fa9,
+},
+fragment: {
+  module: shaderModule12,
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'src'},
+},
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'r32sint', writeMask: GPUColorWrite.RED}, {format: 'bgra8unorm-srgb'}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'keep',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilBack: {
+failOp: 'replace',
+passOp: 'replace',
+},
+stencilReadMask: 3560,
+depthBias: 92,
+depthBiasSlopeScale: 63,
+depthBiasClamp: 15,
+},
+vertex: {
+  module: shaderModule12,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 14760,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 12616,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x3',
+offset: 8812,
+shaderLocation: 14,
+}, {
+format: 'unorm8x2',
+offset: 6650,
+shaderLocation: 16,
+}, {
+format: 'unorm8x4',
+offset: 3044,
+shaderLocation: 17,
+}, {
+format: 'sint32x3',
+offset: 10628,
+shaderLocation: 7,
+}, {
+format: 'uint32x4',
+offset: 11172,
+shaderLocation: 13,
+}, {
+format: 'sint8x4',
+offset: 12076,
+shaderLocation: 6,
+}, {
+format: 'unorm8x2',
+offset: 10362,
+shaderLocation: 8,
+}, {
+format: 'unorm8x4',
+offset: 4228,
+shaderLocation: 3,
+}, {
+format: 'uint16x4',
+offset: 2300,
+shaderLocation: 4,
+}, {
+format: 'uint32x2',
+offset: 1292,
+shaderLocation: 20,
+}, {
+format: 'snorm8x4',
+offset: 8312,
+shaderLocation: 5,
+}, {
+format: 'float32x4',
+offset: 11588,
+shaderLocation: 21,
+}, {
+format: 'float32x4',
+offset: 7388,
+shaderLocation: 10,
+}, {
+format: 'snorm8x4',
+offset: 4096,
+shaderLocation: 9,
+}, {
+format: 'float16x2',
+offset: 5428,
+shaderLocation: 22,
+}, {
+format: 'uint16x2',
+offset: 6000,
+shaderLocation: 24,
+}, {
+format: 'float32x3',
+offset: 8932,
+shaderLocation: 0,
+}, {
+format: 'snorm16x4',
+offset: 1880,
+shaderLocation: 19,
+}, {
+format: 'unorm8x4',
+offset: 1816,
+shaderLocation: 23,
+}, {
+format: 'uint32x4',
+offset: 10112,
+shaderLocation: 12,
+}, {
+format: 'float32',
+offset: 10052,
+shaderLocation: 18,
+}],
+},
+{
+arrayStride: 13496,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 11020,
+shaderLocation: 15,
+}, {
+format: 'sint32',
+offset: 7020,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 9480,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 14188,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+attributes: [],
+},
+{
+arrayStride: 28588,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x4',
+offset: 13048,
+shaderLocation: 2,
+}, {
+format: 'sint32x4',
+offset: 22144,
+shaderLocation: 25,
+}, {
+format: 'sint8x2',
+offset: 10080,
+shaderLocation: 1,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let adapter18 = await navigator.gpu.requestAdapter({
+});
+try {
+offscreenCanvas29.getContext('webgl2');
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let promise37 = navigator.gpu.requestAdapter();
+let sampler62 = device3.createSampler({
+label: '\u6584\u094e\u05b1\u{1fb89}\u73a4\u{1f79d}\uec75',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 31.547,
+lodMaxClamp: 91.351,
+});
+try {
+renderBundleEncoder65.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture106,
+  mipLevel: 7,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(867), /* required buffer size: 867 */
+{offset: 867}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas26.height = 93;
+let img22 = await imageWithData(209, 100, '#2deb1b58', '#6e349a58');
+let img23 = await imageWithData(294, 250, '#3dea45be', '#d3e5aa15');
+offscreenCanvas16.height = 230;
+let imageBitmap24 = await createImageBitmap(offscreenCanvas13);
+let videoFrame24 = new VideoFrame(videoFrame23, {timestamp: 0});
+let promise38 = adapter15.requestAdapterInfo();
+let querySet75 = device3.createQuerySet({
+label: '\u8cf4\u{1fb19}\u{1f725}\uc861\u3501\u0561\u{1faa9}\u{1fcf0}',
+type: 'occlusion',
+count: 3269,
+});
+try {
+renderBundleEncoder65.setVertexBuffer(5, buffer29, 64, 139);
+} catch {}
+let commandEncoder88 = device1.createCommandEncoder({label: '\u14dd\u02ac\u6c02\ua95b\u0bcf\ue59c\u40c4\u0cf8\u6988\u18fd'});
+let querySet76 = device1.createQuerySet({
+type: 'occlusion',
+count: 208,
+});
+let renderBundle85 = renderBundleEncoder18.finish();
+try {
+renderBundleEncoder49.setBindGroup(6, bindGroup13);
+} catch {}
+try {
+commandEncoder59.copyTextureToBuffer({
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 80, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 96 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 53968 */
+offset: 53968,
+bytesPerRow: 256,
+buffer: buffer39,
+}, {width: 30, height: 65, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer39);
+} catch {}
+let buffer43 = device1.createBuffer({
+  label: '\u74ac\u03cb\u{1fb61}\uf210\u{1fb36}\u549d\u71d4\ufd76\u{1fcc5}\ua55b\u{1fab7}',
+  size: 42626,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM
+});
+let computePassEncoder54 = commandEncoder83.beginComputePass({});
+try {
+computePassEncoder42.setPipeline(pipeline51);
+} catch {}
+try {
+renderBundleEncoder66.pushDebugGroup('\u08a1');
+} catch {}
+document.body.prepend(video2);
+let shaderModule15 = device1.createShaderModule({
+code: `@group(1) @binding(1300)
+var<storage, read_write> parameter9: array<u32>;
+@group(2) @binding(1723)
+var<storage, read_write> i6: array<u32>;
+
+@compute @workgroup_size(7, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S20 {
+  @location(4) f0: vec2<f32>,
+  @location(47) f1: f32,
+  @location(8) f2: i32,
+  @location(35) f3: vec2<i32>,
+  @location(23) f4: vec2<f32>,
+  @location(20) f5: vec4<u32>,
+  @location(13) f6: vec3<f16>,
+  @location(43) f7: i32,
+  @location(45) f8: vec3<u32>,
+  @builtin(position) f9: vec4<f32>,
+  @location(46) f10: u32,
+  @location(41) f11: vec3<u32>,
+  @location(32) f12: vec4<u32>,
+  @location(10) f13: vec2<f16>,
+  @location(44) f14: f16,
+  @location(9) f15: vec3<u32>,
+  @location(27) f16: u32,
+  @location(1) f17: vec4<u32>,
+  @location(11) f18: u32,
+  @location(5) f19: vec2<f16>,
+  @location(30) f20: u32,
+  @location(31) f21: f16,
+  @location(0) f22: u32,
+  @location(38) f23: f16,
+  @location(29) f24: vec3<f32>,
+  @builtin(sample_index) f25: u32,
+  @location(6) f26: i32,
+  @builtin(front_facing) f27: bool,
+  @location(17) f28: vec2<i32>,
+  @location(40) f29: vec4<u32>,
+  @builtin(sample_mask) f30: u32,
+  @location(49) f31: u32,
+  @location(19) f32: vec4<f16>,
+  @location(12) f33: vec4<i32>,
+  @location(36) f34: u32,
+  @location(26) f35: f16,
+  @location(28) f36: vec3<f16>,
+  @location(33) f37: vec3<u32>,
+  @location(48) f38: vec3<f32>,
+  @location(2) f39: vec3<f16>,
+  @location(37) f40: vec4<i32>,
+  @location(22) f41: f32
+}
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(1) f1: vec4<i32>,
+  @location(6) f2: vec4<u32>,
+  @location(2) f3: vec4<u32>,
+  @location(4) f4: vec4<i32>,
+  @builtin(frag_depth) f5: f32,
+  @location(5) f6: vec2<f32>,
+  @location(3) f7: vec4<f32>
+}
+
+@fragment
+fn fragment0(a0: S20, @location(16) a1: vec4<i32>, @location(24) a2: i32, @location(25) a3: vec3<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(36) f337: u32,
+  @location(38) f338: f16,
+  @location(0) f339: u32,
+  @location(35) f340: vec2<i32>,
+  @location(47) f341: f32,
+  @location(37) f342: vec4<i32>,
+  @location(32) f343: vec4<u32>,
+  @location(11) f344: u32,
+  @location(43) f345: i32,
+  @location(25) f346: vec3<i32>,
+  @location(23) f347: vec2<f32>,
+  @location(49) f348: u32,
+  @location(30) f349: u32,
+  @location(31) f350: f16,
+  @location(44) f351: f16,
+  @location(16) f352: vec4<i32>,
+  @location(4) f353: vec2<f32>,
+  @location(5) f354: vec2<f16>,
+  @location(45) f355: vec3<u32>,
+  @location(20) f356: vec4<u32>,
+  @location(27) f357: u32,
+  @location(2) f358: vec3<f16>,
+  @location(17) f359: vec2<i32>,
+  @location(8) f360: i32,
+  @location(28) f361: vec3<f16>,
+  @location(6) f362: i32,
+  @location(22) f363: f32,
+  @location(19) f364: vec4<f16>,
+  @location(29) f365: vec3<f32>,
+  @location(48) f366: vec3<f32>,
+  @location(9) f367: vec3<u32>,
+  @location(33) f368: vec3<u32>,
+  @location(26) f369: f16,
+  @location(13) f370: vec3<f16>,
+  @location(12) f371: vec4<i32>,
+  @location(40) f372: vec4<u32>,
+  @location(24) f373: i32,
+  @builtin(position) f374: vec4<f32>,
+  @location(46) f375: u32,
+  @location(10) f376: vec2<f16>,
+  @location(1) f377: vec4<u32>,
+  @location(41) f378: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(26) a0: i32, @location(18) a1: vec3<u32>, @location(15) a2: vec2<f16>, @location(9) a3: vec3<u32>, @location(24) a4: f16, @location(23) a5: vec2<f32>, @location(5) a6: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let querySet77 = device1.createQuerySet({
+type: 'occlusion',
+count: 3641,
+});
+let texture110 = device1.createTexture({
+size: {width: 384, height: 5, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x5-unorm', 'astc-8x5-unorm'],
+});
+let textureView97 = texture87.createView({dimension: '2d-array', format: 'astc-5x5-unorm-srgb'});
+let renderBundleEncoder77 = device1.createRenderBundleEncoder({
+  label: '\u154f\u075f\u48d7\u0c38\u{1fbce}\uea05',
+  colorFormats: ['r8unorm', 'r32uint', 'rg8sint', 'rg8unorm', 'r32uint', 'r32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1
+});
+try {
+computePassEncoder54.setBindGroup(10, bindGroup13);
+} catch {}
+let pipeline77 = device1.createComputePipeline({
+label: '\u2a0a\u7b81\u{1f671}\u4093\u84bd\u{1ff01}\u8739\u{1fd4c}\u0f58',
+layout: pipelineLayout17,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let imageBitmap25 = await createImageBitmap(videoFrame2);
+let promise39 = navigator.gpu.requestAdapter({
+});
+try {
+computePassEncoder24.setPipeline(pipeline75);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer37, 15496, new Int16Array(7904));
+} catch {}
+let shaderModule16 = device1.createShaderModule({
+label: '\u0733\u0b2e\u3a58\ua83b\u0863',
+code: `@group(0) @binding(542)
+var<storage, read_write> parameter10: array<u32>;
+@group(5) @binding(704)
+var<storage, read_write> local13: array<u32>;
+@group(6) @binding(1145)
+var<storage, read_write> i7: array<u32>;
+@group(9) @binding(1145)
+var<storage, read_write> local14: array<u32>;
+@group(2) @binding(704)
+var<storage, read_write> type12: array<u32>;
+@group(1) @binding(3524)
+var<storage, read_write> field6: array<u32>;
+@group(6) @binding(3399)
+var<storage, read_write> field7: array<u32>;
+@group(10) @binding(1145)
+var<storage, read_write> function3: array<u32>;
+@group(10) @binding(3399)
+var<storage, read_write> field8: array<u32>;
+@group(10) @binding(3240)
+var<storage, read_write> i8: array<u32>;
+@group(2) @binding(1300)
+var<storage, read_write> field9: array<u32>;
+@group(8) @binding(1723)
+var<storage, read_write> local15: array<u32>;
+@group(9) @binding(3240)
+var<storage, read_write> type13: array<u32>;
+@group(4) @binding(704)
+var<storage, read_write> i9: array<u32>;
+@group(4) @binding(1300)
+var<storage, read_write> parameter11: array<u32>;
+@group(5) @binding(1300)
+var<storage, read_write> i10: array<u32>;
+
+@compute @workgroup_size(1, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec3<i32>,
+  @location(3) f1: vec3<i32>,
+  @location(1) f2: vec2<u32>,
+  @builtin(sample_mask) f3: u32,
+  @location(0) f4: vec4<i32>,
+  @builtin(frag_depth) f5: f32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(front_facing) a2: bool, @builtin(sample_mask) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S21 {
+  @location(21) f0: u32,
+  @location(12) f1: vec4<i32>,
+  @location(4) f2: vec2<f16>,
+  @location(20) f3: vec3<f32>,
+  @location(24) f4: vec4<u32>,
+  @location(1) f5: vec4<f32>,
+  @location(9) f6: vec4<i32>,
+  @location(11) f7: vec3<u32>,
+  @location(7) f8: u32,
+  @location(16) f9: vec3<f32>,
+  @location(22) f10: vec2<u32>,
+  @location(15) f11: vec3<i32>,
+  @location(3) f12: vec3<f16>,
+  @location(5) f13: vec3<f16>,
+  @location(26) f14: i32,
+  @location(19) f15: vec2<u32>,
+  @location(8) f16: vec2<f16>,
+  @location(23) f17: vec3<f16>
+}
+
+@vertex
+fn vertex0(a0: S21, @location(18) a1: f16, @location(0) a2: vec3<u32>, @location(2) a3: f32, @location(6) a4: vec4<u32>, @location(13) a5: vec3<i32>, @location(17) a6: vec3<f16>, @location(10) a7: vec3<i32>, @location(14) a8: vec4<i32>, @location(25) a9: vec4<i32>, @builtin(vertex_index) a10: u32, @builtin(instance_index) a11: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+try {
+computePassEncoder8.insertDebugMarker('\ubde7');
+} catch {}
+let pipeline78 = await promise17;
+let bindGroupLayout35 = pipeline3.getBindGroupLayout(4);
+let commandEncoder89 = device0.createCommandEncoder({label: '\ueba4\u8761\u4525\u{1f9be}\u{1fcbb}'});
+let renderBundle86 = renderBundleEncoder36.finish({label: '\uaf66\u0c4c\u0b68\u70e5\u0f2f\uc951\u7b10'});
+let externalTexture8 = device0.importExternalTexture({
+label: '\uffa9\u0544\u{1f798}',
+source: video15,
+colorSpace: 'srgb',
+});
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: { x: 36, y: 4, z: 1 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 772 */
+{offset: 772, bytesPerRow: 451}, {width: 208, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 150, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 116, y: 23 },
+  flipY: true,
+}, {
+  texture: texture57,
+  mipLevel: 5,
+  origin: { x: 82, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 14, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline79 = await device0.createComputePipelineAsync({
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+});
+let bindGroup18 = device3.createBindGroup({
+label: '\u677b\u0e61\u{1fe37}\uf4e4\ub97e',
+layout: bindGroupLayout34,
+entries: [],
+});
+let buffer44 = device3.createBuffer({
+  label: '\u{1f70b}\u{1fe89}\u497d\u8be5\u0e4f\uec5e\u0f63\u3d9c\u833b\u0a39\ub09a',
+  size: 62797,
+  usage: GPUBufferUsage.VERTEX
+});
+let texture111 = device3.createTexture({
+label: '\u{1fe94}\u04a6\u1c79\u59a1\u{1fe15}\u8f24\u05ec',
+size: {width: 60, height: 240, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView98 = texture59.createView({baseArrayLayer: 0});
+let renderBundle87 = renderBundleEncoder65.finish({});
+try {
+gpuCanvasContext11.configure({
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let pipeline80 = device3.createRenderPipeline({
+layout: pipelineLayout14,
+multisample: {
+count: 4,
+mask: 0x743108f5,
+},
+fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, undefined, {format: 'r32sint'}, {format: 'rgba8uint', writeMask: 0}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'zero', dstFactor: 'zero'},
+alpha: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'src-alpha'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {
+  format: 'rg8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rg32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgb10a2unorm', writeMask: 0}]
+},
+vertex: {
+  module: shaderModule14,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 5584,
+shaderLocation: 23,
+}, {
+format: 'float32x3',
+offset: 5708,
+shaderLocation: 0,
+}, {
+format: 'unorm16x4',
+offset: 5956,
+shaderLocation: 4,
+}, {
+format: 'sint16x2',
+offset: 5172,
+shaderLocation: 22,
+}, {
+format: 'unorm10-10-10-2',
+offset: 24568,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 14388,
+shaderLocation: 19,
+}, {
+format: 'unorm8x2',
+offset: 19012,
+shaderLocation: 14,
+}, {
+format: 'float32',
+offset: 14280,
+shaderLocation: 3,
+}, {
+format: 'sint8x4',
+offset: 10568,
+shaderLocation: 21,
+}, {
+format: 'sint32x4',
+offset: 1376,
+shaderLocation: 24,
+}, {
+format: 'unorm16x2',
+offset: 10328,
+shaderLocation: 15,
+}, {
+format: 'sint16x2',
+offset: 17700,
+shaderLocation: 1,
+}, {
+format: 'uint16x2',
+offset: 8304,
+shaderLocation: 7,
+}, {
+format: 'uint16x2',
+offset: 9336,
+shaderLocation: 13,
+}, {
+format: 'float16x2',
+offset: 6848,
+shaderLocation: 17,
+}, {
+format: 'sint32x4',
+offset: 22752,
+shaderLocation: 11,
+}, {
+format: 'uint32x4',
+offset: 12592,
+shaderLocation: 10,
+}, {
+format: 'uint8x2',
+offset: 17524,
+shaderLocation: 9,
+}, {
+format: 'float32',
+offset: 23816,
+shaderLocation: 18,
+}, {
+format: 'float32x4',
+offset: 27720,
+shaderLocation: 8,
+}, {
+format: 'unorm16x2',
+offset: 5224,
+shaderLocation: 25,
+}],
+},
+{
+arrayStride: 8324,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 6136,
+attributes: [{
+format: 'uint8x4',
+offset: 2084,
+shaderLocation: 20,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+try {
+  await promise38;
+} catch {}
+canvas0.width = 968;
+let videoFrame25 = new VideoFrame(offscreenCanvas5, {timestamp: 0});
+let canvas25 = document.createElement('canvas');
+let video24 = await videoWithData();
+let imageBitmap26 = await createImageBitmap(videoFrame11);
+let commandEncoder90 = device1.createCommandEncoder({});
+try {
+computePassEncoder54.setPipeline(pipeline52);
+} catch {}
+try {
+renderBundleEncoder70.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder57.setVertexBuffer(1, undefined, 1370987002, 890272743);
+} catch {}
+try {
+commandEncoder72.clearBuffer(buffer34, 16488, 3220);
+dissociateBuffer(device1, buffer34);
+} catch {}
+let pipeline81 = await device1.createRenderPipelineAsync({
+label: '\u0bee\u050a\u0fcf\u88c6\uc9a7\u0380\u8afd\u{1ff52}\uef50',
+layout: pipelineLayout13,
+multisample: {
+count: 4,
+mask: 0x93b11935,
+},
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {format: 'rgba32uint', writeMask: 0}]
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 24852,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x4',
+offset: 4288,
+shaderLocation: 7,
+}, {
+format: 'snorm8x4',
+offset: 10368,
+shaderLocation: 0,
+}, {
+format: 'sint32',
+offset: 15328,
+shaderLocation: 10,
+}, {
+format: 'uint16x2',
+offset: 7340,
+shaderLocation: 9,
+}, {
+format: 'sint32',
+offset: 18868,
+shaderLocation: 14,
+}, {
+format: 'uint32x2',
+offset: 17920,
+shaderLocation: 5,
+}, {
+format: 'uint32',
+offset: 4788,
+shaderLocation: 2,
+}, {
+format: 'unorm8x2',
+offset: 7990,
+shaderLocation: 13,
+}, {
+format: 'uint32',
+offset: 16152,
+shaderLocation: 8,
+}, {
+format: 'unorm8x4',
+offset: 5052,
+shaderLocation: 18,
+}, {
+format: 'uint32x4',
+offset: 17224,
+shaderLocation: 3,
+}, {
+format: 'uint32x4',
+offset: 19436,
+shaderLocation: 20,
+}, {
+format: 'sint8x4',
+offset: 21096,
+shaderLocation: 25,
+}, {
+format: 'uint32x3',
+offset: 19152,
+shaderLocation: 21,
+}, {
+format: 'float32x2',
+offset: 11080,
+shaderLocation: 4,
+}, {
+format: 'sint32',
+offset: 17148,
+shaderLocation: 22,
+}, {
+format: 'snorm8x4',
+offset: 20448,
+shaderLocation: 24,
+}, {
+format: 'float32x2',
+offset: 14460,
+shaderLocation: 12,
+}, {
+format: 'float32x3',
+offset: 22448,
+shaderLocation: 16,
+}, {
+format: 'uint8x4',
+offset: 9472,
+shaderLocation: 1,
+}, {
+format: 'snorm16x2',
+offset: 892,
+shaderLocation: 19,
+}, {
+format: 'float32x4',
+offset: 4980,
+shaderLocation: 23,
+}, {
+format: 'uint32x3',
+offset: 22748,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 14616,
+attributes: [{
+format: 'unorm8x4',
+offset: 1832,
+shaderLocation: 26,
+}, {
+format: 'unorm8x4',
+offset: 480,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 524,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 26608,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x4',
+offset: 15032,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 7340,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 460,
+attributes: [{
+format: 'sint32',
+offset: 344,
+shaderLocation: 17,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let imageBitmap27 = await createImageBitmap(canvas3);
+let buffer45 = device2.createBuffer({
+  label: '\u{1f819}\u46db\u5cc2\u0d42\u027d',
+  size: 62642,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let sampler63 = device2.createSampler({
+label: '\u092f\u{1fd6c}\u02f6',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 81.856,
+lodMaxClamp: 97.823,
+maxAnisotropy: 2,
+});
+let bindGroup19 = device1.createBindGroup({
+label: '\u059d\u{1fa49}\u{1f837}\u{1fcac}\u{1fbf3}\u05f6\u{1f785}',
+layout: bindGroupLayout11,
+entries: [{
+binding: 542,
+resource: textureView91
+}],
+});
+pseudoSubmit(device1, commandEncoder71);
+let textureView99 = texture97.createView({
+  label: '\uf9f3\u5cb0\u07bc\ub044\u4152\u01c0\u457a\u07bd\u1ff5\ucdf7\ube99',
+  baseMipLevel: 1,
+  mipLevelCount: 1
+});
+try {
+commandEncoder90.copyBufferToBuffer(buffer20, 12, buffer27, 1224, 16);
+dissociateBuffer(device1, buffer20);
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+commandEncoder88.copyTextureToBuffer({
+  texture: texture53,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 59712 */
+offset: 59712,
+buffer: buffer39,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+commandEncoder88.clearBuffer(buffer34, 7236, 900);
+dissociateBuffer(device1, buffer34);
+} catch {}
+try {
+gpuCanvasContext21.configure({
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+});
+} catch {}
+let video25 = await videoWithData();
+try {
+canvas25.getContext('2d');
+} catch {}
+let shaderModule17 = device1.createShaderModule({
+label: '\ubbec\u0ef2\u0ec0\u7fe4\ubb49\ub2f9\u5ce2',
+code: `@group(8) @binding(1723)
+var<storage, read_write> type14: array<u32>;
+@group(9) @binding(1145)
+var<storage, read_write> parameter12: array<u32>;
+@group(6) @binding(3399)
+var<storage, read_write> type15: array<u32>;
+@group(0) @binding(542)
+var<storage, read_write> type16: array<u32>;
+@group(9) @binding(3240)
+var<storage, read_write> parameter13: array<u32>;
+@group(4) @binding(704)
+var<storage, read_write> function4: array<u32>;
+@group(4) @binding(1300)
+var<storage, read_write> function5: array<u32>;
+@group(2) @binding(704)
+var<storage, read_write> type17: array<u32>;
+@group(9) @binding(3399)
+var<storage, read_write> type18: array<u32>;
+@group(6) @binding(3240)
+var<storage, read_write> field10: array<u32>;
+@group(1) @binding(3524)
+var<storage, read_write> global7: array<u32>;
+@group(7) @binding(542)
+var<storage, read_write> i11: array<u32>;
+@group(10) @binding(3399)
+var<storage, read_write> type19: array<u32>;
+@group(5) @binding(1300)
+var<storage, read_write> global8: array<u32>;
+@group(6) @binding(1145)
+var<storage, read_write> type20: array<u32>;
+@group(10) @binding(3240)
+var<storage, read_write> parameter14: array<u32>;
+@group(10) @binding(1145)
+var<storage, read_write> function6: array<u32>;
+
+@compute @workgroup_size(1, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S22 {
+  @location(44) f0: vec4<f32>,
+  @location(37) f1: u32,
+  @location(14) f2: vec4<f32>,
+  @location(43) f3: vec2<f16>,
+  @builtin(position) f4: vec4<f32>,
+  @location(20) f5: vec2<i32>,
+  @location(13) f6: vec2<u32>,
+  @location(28) f7: f16,
+  @location(34) f8: vec4<f16>,
+  @location(47) f9: vec3<i32>,
+  @location(42) f10: vec2<f16>,
+  @location(32) f11: vec2<i32>,
+  @location(25) f12: vec2<f32>,
+  @location(21) f13: f16,
+  @location(27) f14: vec2<f32>
+}
+struct FragmentOutput0 {
+  @location(5) f0: vec4<i32>,
+  @location(1) f1: vec3<u32>,
+  @location(2) f2: vec3<i32>,
+  @location(3) f3: vec3<f32>,
+  @location(4) f4: u32,
+  @location(0) f5: vec3<f32>,
+  @builtin(sample_mask) f6: u32
+}
+
+@fragment
+fn fragment0(a0: S22, @location(41) a1: vec2<f16>, @location(12) a2: vec2<f32>, @location(48) a3: vec2<f32>, @location(6) a4: vec2<u32>, @builtin(sample_mask) a5: u32, @location(40) a6: i32, @location(46) a7: vec3<f16>, @location(23) a8: f16, @location(16) a9: vec2<i32>, @location(39) a10: vec3<i32>, @location(49) a11: i32, @location(19) a12: vec2<f32>, @location(4) a13: i32, @location(5) a14: vec4<u32>, @location(35) a15: f16, @location(2) a16: vec2<f32>, @location(15) a17: vec2<i32>, @location(8) a18: vec3<f16>, @location(26) a19: u32, @location(33) a20: i32, @location(18) a21: vec2<u32>, @location(29) a22: vec4<i32>, @location(1) a23: vec2<i32>, @location(31) a24: vec4<f32>, @location(38) a25: vec4<f32>, @location(22) a26: vec3<u32>, @location(9) a27: vec3<u32>, @builtin(front_facing) a28: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(40) f379: i32,
+  @location(22) f380: vec3<u32>,
+  @location(42) f381: vec2<f16>,
+  @location(48) f382: vec2<f32>,
+  @location(21) f383: f16,
+  @location(39) f384: vec3<i32>,
+  @location(12) f385: vec2<f32>,
+  @location(25) f386: vec2<f32>,
+  @location(6) f387: vec2<u32>,
+  @location(2) f388: vec2<f32>,
+  @location(19) f389: vec2<f32>,
+  @location(33) f390: i32,
+  @location(13) f391: vec2<u32>,
+  @location(27) f392: vec2<f32>,
+  @location(43) f393: vec2<f16>,
+  @location(41) f394: vec2<f16>,
+  @location(20) f395: vec2<i32>,
+  @location(15) f396: vec2<i32>,
+  @location(9) f397: vec3<u32>,
+  @location(14) f398: vec4<f32>,
+  @location(16) f399: vec2<i32>,
+  @location(47) f400: vec3<i32>,
+  @location(46) f401: vec3<f16>,
+  @location(31) f402: vec4<f32>,
+  @location(1) f403: vec2<i32>,
+  @location(18) f404: vec2<u32>,
+  @location(44) f405: vec4<f32>,
+  @location(23) f406: f16,
+  @location(4) f407: i32,
+  @location(8) f408: vec3<f16>,
+  @location(5) f409: vec4<u32>,
+  @location(38) f410: vec4<f32>,
+  @location(35) f411: f16,
+  @location(32) f412: vec2<i32>,
+  @location(37) f413: u32,
+  @location(34) f414: vec4<f16>,
+  @location(28) f415: f16,
+  @location(49) f416: i32,
+  @location(29) f417: vec4<i32>,
+  @builtin(position) f418: vec4<f32>,
+  @location(26) f419: u32
+}
+
+@vertex
+fn vertex0(@location(23) a0: f16, @location(1) a1: vec4<u32>, @location(19) a2: vec3<u32>, @location(8) a3: vec3<f32>, @location(22) a4: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let renderBundle88 = renderBundleEncoder14.finish();
+try {
+computePassEncoder54.setPipeline(pipeline61);
+} catch {}
+try {
+renderBundleEncoder70.setBindGroup(6, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder49.setVertexBuffer(44, undefined, 877063511);
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(querySet43, 1029, 966, buffer34, 3328);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 1148, new BigUint64Array(25723), 14370, 8);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: video6,
+  origin: { x: 3, y: 13 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 15, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline82 = device1.createRenderPipeline({
+label: '\u2029\u{1fda0}\u{1fe5c}\u72c4\u{1fbfd}\u6802\uea32\u0832\u4ffe',
+layout: pipelineLayout15,
+fragment: {
+  module: shaderModule13,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32float'}, {format: 'r16float', writeMask: GPUColorWrite.ALL}, {format: 'r16uint', writeMask: 0}, {format: 'r16sint', writeMask: 0}, {format: 'r8uint', writeMask: 0}]
+},
+vertex: {
+  module: shaderModule13,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 5756,
+attributes: [],
+},
+{
+arrayStride: 26812,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x2',
+offset: 13962,
+shaderLocation: 24,
+}, {
+format: 'uint8x4',
+offset: 16288,
+shaderLocation: 22,
+}, {
+format: 'uint32x2',
+offset: 7632,
+shaderLocation: 1,
+}, {
+format: 'sint32',
+offset: 3700,
+shaderLocation: 0,
+}, {
+format: 'uint8x2',
+offset: 19156,
+shaderLocation: 4,
+}, {
+format: 'snorm8x2',
+offset: 22262,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 32968,
+attributes: [{
+format: 'uint16x2',
+offset: 28500,
+shaderLocation: 19,
+}, {
+format: 'sint16x2',
+offset: 3272,
+shaderLocation: 2,
+}, {
+format: 'snorm16x2',
+offset: 19296,
+shaderLocation: 15,
+}, {
+format: 'uint8x2',
+offset: 14402,
+shaderLocation: 23,
+}, {
+format: 'float16x2',
+offset: 4240,
+shaderLocation: 6,
+}, {
+format: 'sint16x2',
+offset: 20180,
+shaderLocation: 20,
+}, {
+format: 'sint8x4',
+offset: 32080,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 25220,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 5708,
+shaderLocation: 13,
+}, {
+format: 'snorm16x2',
+offset: 18836,
+shaderLocation: 25,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+unclippedDepth: true,
+},
+});
+let imageBitmap28 = await createImageBitmap(videoFrame19);
+let textureView100 = texture87.createView({
+  label: '\u{1fd58}\u88c9\u{1f8a2}\u2937\ubc0e\u0922\u0b16\ue080',
+  dimension: '2d-array',
+  format: 'astc-5x5-unorm-srgb'
+});
+let computePassEncoder55 = commandEncoder80.beginComputePass();
+let sampler64 = device1.createSampler({
+label: '\udda4\u786f\u{1ff13}\u{1fa42}\u0ee5\u7dc5\udca0\uc1fc\u{1fd5d}\u073b\u8f5b',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 5.143,
+lodMaxClamp: 72.836,
+});
+try {
+renderBundleEncoder77.setBindGroup(8, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder77.setVertexBuffer(37, undefined, 577394612);
+} catch {}
+try {
+commandEncoder88.clearBuffer(buffer39);
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas13,
+  origin: { x: 152, y: 208 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 23, y: 2, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let texture112 = device3.createTexture({
+label: '\u{1f746}\u0beb\u0346\u1e7e\u2dd6\u{1fa9f}',
+size: [1008, 120, 193],
+mipLevelCount: 10,
+format: 'astc-4x4-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-4x4-unorm-srgb', 'astc-4x4-unorm-srgb'],
+});
+let textureView101 = texture86.createView({label: '\u1ba5\u0d78\u08ac\u0917\u7b0a\u{1f7ec}'});
+try {
+renderBundleEncoder74.setBindGroup(2, bindGroup6);
+} catch {}
+document.body.prepend(video13);
+let canvas26 = document.createElement('canvas');
+try {
+window.someLabel = device4.queue.label;
+} catch {}
+try {
+texture74.label = '\u0c8c\ue5ec\u0c8b\ud455\u0997\u01a4\u5ace\udc67\u8654\u95e2';
+} catch {}
+let offscreenCanvas30 = new OffscreenCanvas(135, 624);
+try {
+canvas26.getContext('webgpu');
+} catch {}
+let textureView102 = texture82.createView({label: '\uf540\u0221', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 123});
+try {
+computePassEncoder55.setBindGroup(9, bindGroup4, new Uint32Array(2321), 442, 0);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+let adapter19 = await promise39;
+let imageData27 = new ImageData(200, 12);
+let canvas27 = document.createElement('canvas');
+let video26 = await videoWithData();
+let bindGroupLayout36 = device3.createBindGroupLayout({
+label: '\u{1fd75}\u0f88',
+entries: [{
+binding: 1662,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+}],
+});
+try {
+renderBundleEncoder56.setBindGroup(3, bindGroup16, []);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let pipeline83 = await device3.createComputePipelineAsync({
+label: '\uf124\u0d20',
+layout: 'auto',
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let gpuCanvasContext23 = offscreenCanvas30.getContext('webgpu');
+let gpuCanvasContext24 = canvas27.getContext('webgpu');
+try {
+gpuCanvasContext21.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let renderBundle89 = renderBundleEncoder63.finish({label: '\u0ad2\u0c81\u{1ffe3}\ud58f\u3e34\uba6d'});
+let sampler65 = device1.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 76.583,
+lodMaxClamp: 90.894,
+});
+try {
+device1.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 63 },
+  aspect: 'depth-only',
+}, new Uint32Array(new ArrayBuffer(8)), /* required buffer size: 652194 */
+{offset: 104, bytesPerRow: 308, rowsPerImage: 321}, {width: 27, height: 192, depthOrArrayLayers: 7});
+} catch {}
+let promise40 = device1.queue.onSubmittedWorkDone();
+gc();
+try {
+  await promise40;
+} catch {}
+let bindGroupLayout37 = device3.createBindGroupLayout({
+label: '\ubc70\u0fad',
+entries: [{
+binding: 3821,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}, {
+binding: 416,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+}, {
+binding: 7473,
+visibility: 0,
+externalTexture: {},
+}],
+});
+let renderBundle90 = renderBundleEncoder68.finish({label: '\ub53e\u1922\u45a6\u0081\u{1f9d0}\u012f\u1bc5\u{1fcd2}\u0ac8\uf033'});
+try {
+renderBundleEncoder56.setVertexBuffer(5, buffer29, 2716, 790);
+} catch {}
+offscreenCanvas0.width = 453;
+let offscreenCanvas31 = new OffscreenCanvas(219, 938);
+let commandEncoder91 = device3.createCommandEncoder({label: '\ud289\u{1fb1d}\u{1f6be}\u4102\u0819\ue54d'});
+let texture113 = device3.createTexture({
+size: {width: 120, height: 480, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView103 = texture62.createView({aspect: 'all', baseMipLevel: 1, baseArrayLayer: 9, arrayLayerCount: 28});
+let renderBundleEncoder78 = device3.createRenderBundleEncoder({
+  colorFormats: ['r32float', 'rgb10a2uint', 'r32uint', 'rg8unorm', 'rg8sint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle91 = renderBundleEncoder40.finish({});
+try {
+commandEncoder91.clearBuffer(buffer37);
+dissociateBuffer(device3, buffer37);
+} catch {}
+let promise41 = device3.queue.onSubmittedWorkDone();
+let pipelineLayout18 = device4.createPipelineLayout({
+  label: '\u{1f6e4}\u{1fb08}\uac18',
+  bindGroupLayouts: [bindGroupLayout19, bindGroupLayout19, bindGroupLayout19, bindGroupLayout19]
+});
+let buffer46 = device4.createBuffer({label: '\u3aa8\u9fe2\u2b92\u{1fd61}\u{1fd11}', size: 51578, usage: GPUBufferUsage.MAP_READ});
+let commandEncoder92 = device4.createCommandEncoder({label: '\u2ffb\ud14e\u{1faed}\u3ffa\u019c\u0ddb\u8a12'});
+let commandBuffer17 = commandEncoder92.finish({
+});
+let renderBundle92 = renderBundleEncoder48.finish({label: '\u00a5\u0d19\u2f63'});
+let adapter20 = await navigator.gpu.requestAdapter({
+});
+let commandEncoder93 = device1.createCommandEncoder({label: '\ud4be\ub629\u0256\u0559\u0cf0\ua43d\u6dd4\u0d6f\u621e'});
+let texture114 = device1.createTexture({
+label: '\u06c7\u{1ff95}\u56ea\u{1ff8f}\u{1fe71}\ub461\u{1f94d}\u5504\uff36\u{1fb3f}\u3b82',
+size: [192],
+dimension: '1d',
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+let computePassEncoder56 = commandEncoder90.beginComputePass({label: '\ud525\ufe00\u{1fef1}\u06fa\u09c2\u1530\u{1fb42}'});
+let renderBundle93 = renderBundleEncoder69.finish({label: '\u01b1\ufb40\u063c\u{1f6c8}\uc374\u{1f7b2}\u0468\u0f8a\u34ff\u3106\uaca1'});
+let sampler66 = device1.createSampler({
+label: '\ubb29\u0d34\ua64e\u056c\u4d79',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMaxClamp: 68.570,
+});
+try {
+renderBundleEncoder66.popDebugGroup();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: video9,
+  origin: { x: 2, y: 12 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 15, y: 2, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+let texture115 = device3.createTexture({
+label: '\u7e0e\ucfef',
+size: [30, 120, 1],
+format: 'astc-10x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView104 = texture105.createView({label: '\u9e5a\u4cff', dimension: '3d', baseMipLevel: 3});
+try {
+renderBundleEncoder71.setBindGroup(4, bindGroup18);
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(3, bindGroup18, new Uint32Array(9386), 5892, 0);
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+commandEncoder91.copyTextureToTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: { x: 12, y: 98, z: 158 },
+  aspect: 'all',
+}, {
+  texture: texture59,
+  mipLevel: 1,
+  origin: { x: 1, y: 14, z: 25 },
+  aspect: 'all',
+}, {width: 28, height: 65, depthOrArrayLayers: 36});
+} catch {}
+try {
+commandEncoder91.clearBuffer(buffer24, 2956, 4928);
+dissociateBuffer(device3, buffer24);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline84 = await device3.createComputePipelineAsync({
+label: '\u087b\u0799\u229a',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+video22.height = 121;
+let canvas28 = document.createElement('canvas');
+let bindGroupLayout38 = device3.createBindGroupLayout({
+label: '\u{1f7c5}\u0893\u0712\u{1f607}\u07fd\u0f66\u0565\u{1f652}',
+entries: [],
+});
+let commandEncoder94 = device3.createCommandEncoder();
+try {
+computePassEncoder50.end();
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline83);
+} catch {}
+try {
+renderBundleEncoder64.setIndexBuffer(buffer35, 'uint32', 41048, 12232);
+} catch {}
+let adapter21 = await promise37;
+document.body.prepend(img0);
+let gpuCanvasContext25 = canvas28.getContext('webgpu');
+let buffer47 = device1.createBuffer({size: 31468, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let textureView105 = texture30.createView({
+  label: '\u056d\ua0a7\u348f\uc4ba\u{1fc5c}\u8617\u{1fc37}\u{1f788}',
+  dimension: '2d-array',
+  baseMipLevel: 1
+});
+let computePassEncoder57 = commandEncoder76.beginComputePass({label: '\uf5d4\u{1ff87}\u54ea\u{1f6c9}\u8c44\u03bc\u0daf\u{1f851}\u{1fb11}\u6372\u253e'});
+try {
+buffer47.unmap();
+} catch {}
+try {
+commandEncoder86.copyBufferToBuffer(buffer34, 11392, buffer39, 45880, 3692);
+dissociateBuffer(device1, buffer34);
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer39, 23556, new Int16Array(9402), 6738);
+} catch {}
+let commandEncoder95 = device0.createCommandEncoder({label: '\u6cea\ud168\uad17\u5059\ua9d2\u5b82\ua961'});
+let computePassEncoder58 = commandEncoder0.beginComputePass({label: '\u9d68\u16ce\ue5c0\u062a'});
+let sampler67 = device0.createSampler({
+label: '\u0320\u73ca\u1939\u{1f93b}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 50.178,
+lodMaxClamp: 65.833,
+});
+try {
+renderBundleEncoder34.setBindGroup(0, bindGroup2, [3744]);
+} catch {}
+try {
+commandEncoder56.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 20, new Float32Array(43228), 15701, 192);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise42 = device0.createComputePipelineAsync({
+label: '\u0a46\u7157',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let textureView106 = texture79.createView({
+  label: '\uef85\u{1fb4b}\u416a\u{1f741}\u{1f6ca}\u0618\u{1fe94}\u0347\u2195\u72e0\u{1f77c}',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+  mipLevelCount: 4,
+  arrayLayerCount: 1
+});
+let sampler68 = device3.createSampler({
+label: '\uca14\u00c3\u070e\u{1fdf2}\u{1fffb}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 88.295,
+lodMaxClamp: 96.666,
+maxAnisotropy: 1,
+});
+try {
+commandEncoder58.clearBuffer(buffer37);
+dissociateBuffer(device3, buffer37);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer37, 6584, new Float32Array(16036), 11778);
+} catch {}
+let promise43 = device3.queue.onSubmittedWorkDone();
+let pipeline85 = device3.createComputePipeline({
+label: '\ufea9\u0111\u8cd9\u95c7\u{1f8f2}\u8d93',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let imageData28 = new ImageData(128, 36);
+try {
+renderBundleEncoder66.setVertexBuffer(83, undefined, 3085687169, 290474724);
+} catch {}
+try {
+commandEncoder93.copyTextureToTexture({
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 30, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 10, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 170, height: 65, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder93.clearBuffer(buffer8, 1832, 9060);
+dissociateBuffer(device1, buffer8);
+} catch {}
+let gpuCanvasContext26 = offscreenCanvas31.getContext('webgpu');
+let canvas29 = document.createElement('canvas');
+try {
+canvas29.getContext('2d');
+} catch {}
+let renderBundle94 = renderBundleEncoder72.finish({label: '\u00f3\uae90\u9401\u97e7'});
+try {
+computePassEncoder55.setBindGroup(6, bindGroup12, new Uint32Array(3639), 667, 0);
+} catch {}
+try {
+renderBundleEncoder77.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer12, 'uint32', 988, 44);
+} catch {}
+try {
+commandEncoder88.clearBuffer(buffer39);
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture98,
+  mipLevel: 0,
+  origin: { x: 59, y: 3, z: 0 },
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer3), /* required buffer size: 41 */
+{offset: 41}, {width: 10, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline86 = device1.createRenderPipeline({
+label: '\uedaf\u1ff1\ub187\u9620',
+layout: pipelineLayout15,
+fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'dst-alpha'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {format: 'rg8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'never',
+depthFailOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 158,
+depthBiasClamp: 65,
+},
+vertex: {
+  module: shaderModule5,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 15032,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x2',
+offset: 12502,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 13752,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 7272,
+shaderLocation: 22,
+}],
+},
+{
+arrayStride: 26964,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 14196,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x4',
+offset: 6984,
+shaderLocation: 8,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let canvas30 = document.createElement('canvas');
+let img24 = await imageWithData(206, 226, '#3b78c91f', '#a5ebd30a');
+try {
+adapter5.label = '\u97d1\u{1f6a8}\u0b0c\u262e\ua0e4\u5d1d\u8217\u{1fd6d}\u0a27';
+} catch {}
+let commandEncoder96 = device3.createCommandEncoder({});
+let computePassEncoder59 = commandEncoder58.beginComputePass({label: '\u6430\u0aef\u91a1\u{1fbe9}'});
+let renderBundle95 = renderBundleEncoder74.finish({label: '\u{1fa0b}\u0916\u{1ff4a}\ub292\u05a2\u0d62\u6054'});
+try {
+computePassEncoder53.setPipeline(pipeline75);
+} catch {}
+try {
+renderBundleEncoder62.setBindGroup(3, bindGroup17, new Uint32Array(3902), 3098, 0);
+} catch {}
+try {
+commandEncoder94.resolveQuerySet(querySet62, 1563, 282, buffer33, 22272);
+} catch {}
+let pipeline87 = await promise36;
+let textureView107 = texture23.createView({label: '\u0885\uc1e2', dimension: '2d-array', baseMipLevel: 2});
+let renderBundle96 = renderBundleEncoder45.finish({label: '\u07e5\u{1f980}\ud51f\u77a5\u0a6d\u0f9d\u0c9c\u01e6\u422f'});
+try {
+computePassEncoder57.setPipeline(pipeline59);
+} catch {}
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture45,
+  mipLevel: 5,
+  origin: { x: 1, y: 1, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: { x: 14, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder59.clearBuffer(buffer20, 588, 596);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 1,
+  origin: { x: 840, y: 0, z: 50 },
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer7), /* required buffer size: 797122 */
+{offset: 650, bytesPerRow: 808, rowsPerImage: 197}, {width: 370, height: 6, depthOrArrayLayers: 6});
+} catch {}
+try {
+  await promise43;
+} catch {}
+let bindGroup20 = device1.createBindGroup({
+label: '\u{1f931}\u062e',
+layout: bindGroupLayout11,
+entries: [{
+binding: 542,
+resource: textureView99
+}],
+});
+let commandEncoder97 = device1.createCommandEncoder({label: '\ue48e\uafe1\u6c36\u412d'});
+let querySet78 = device1.createQuerySet({
+label: '\u9201\u8b6a\u0709\u052e\u{1fd0c}\ubcea',
+type: 'occlusion',
+count: 2139,
+});
+let texture116 = device1.createTexture({
+label: '\u21f9\u{1fc01}\u02dd\u1164\ud6a3\u01ad\ub96a',
+size: {width: 48, height: 1, depthOrArrayLayers: 220},
+mipLevelCount: 6,
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['r8unorm', 'r8unorm'],
+});
+let textureView108 = texture101.createView({label: '\u0663\u0aab\ubf41', baseMipLevel: 6, mipLevelCount: 1});
+let computePassEncoder60 = commandEncoder59.beginComputePass({label: '\u7e93\u5259'});
+try {
+computePassEncoder60.setPipeline(pipeline59);
+} catch {}
+try {
+renderBundleEncoder57.setBindGroup(0, bindGroup4, new Uint32Array(7563), 3817, 0);
+} catch {}
+try {
+commandEncoder79.resolveQuerySet(querySet77, 3585, 16, buffer34, 18432);
+} catch {}
+let pipeline88 = device1.createComputePipeline({
+label: '\uf7dc\u2d72\u562b\u{1fbf2}',
+layout: pipelineLayout12,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+let img25 = await imageWithData(213, 58, '#3709908c', '#401670ee');
+let imageData29 = new ImageData(120, 72);
+gc();
+let img26 = await imageWithData(98, 49, '#9dadeb65', '#d87ec13c');
+let video27 = await videoWithData();
+let pipelineLayout19 = device1.createPipelineLayout({
+  label: '\uc1db\u093f\u7d04\u0074\u054f\u{1fcd7}\u09f1\u789c\u9dfc\u10d1',
+  bindGroupLayouts: [bindGroupLayout30, bindGroupLayout30, bindGroupLayout14, bindGroupLayout11, bindGroupLayout11, bindGroupLayout11, bindGroupLayout11]
+});
+let texture117 = device1.createTexture({
+label: '\u7421\u09b2\uc1ec\u3847\u24a1\u{1f66a}',
+size: [120, 115, 1],
+format: 'astc-10x5-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder59.setPipeline(pipeline82);
+} catch {}
+try {
+renderBundleEncoder57.setVertexBuffer(12, undefined, 14815892, 1516561928);
+} catch {}
+try {
+commandEncoder93.copyTextureToTexture({
+  texture: texture45,
+  mipLevel: 4,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture45,
+  mipLevel: 2,
+  origin: { x: 17, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap23,
+  origin: { x: 15, y: 52 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 33, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 2, depthOrArrayLayers: 1});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let canvas31 = document.createElement('canvas');
+try {
+renderBundle82.label = '\ub880\u0ec6\u{1ffd0}\u31fd\ua6f4\u0b0d\u07df';
+} catch {}
+let querySet79 = device1.createQuerySet({
+label: '\u{1fb36}\u{1f6ce}\u167c',
+type: 'occlusion',
+count: 578,
+});
+let computePassEncoder61 = commandEncoder72.beginComputePass({});
+try {
+renderBundleEncoder25.setBindGroup(8, bindGroup12, new Uint32Array(2017), 2002, 0);
+} catch {}
+try {
+renderBundleEncoder59.draw(16);
+} catch {}
+try {
+renderBundleEncoder37.setPipeline(pipeline31);
+} catch {}
+try {
+commandEncoder88.copyTextureToBuffer({
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 80, y: 5, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 176 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 51872 */
+offset: 50928,
+bytesPerRow: 256,
+buffer: buffer39,
+}, {width: 55, height: 20, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+commandEncoder79.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 1,
+  origin: { x: 9, y: 2, z: 109 },
+  aspect: 'all',
+}, {
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 16, y: 321, z: 90 },
+  aspect: 'all',
+}, {width: 36, height: 379, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder97.clearBuffer(buffer27);
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: video14,
+  origin: { x: 10, y: 4 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 35, y: 2, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.label = '\u0292\u3f71\u6df5\u0845\u94ed\udcdd\u{1f65b}\u1a08\ud062\u2fbd';
+} catch {}
+let videoFrame26 = new VideoFrame(imageBitmap25, {timestamp: 0});
+try {
+canvas31.getContext('2d');
+} catch {}
+let imageBitmap29 = await createImageBitmap(canvas31);
+try {
+  await promise41;
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+video8.height = 158;
+let adapter22 = await navigator.gpu.requestAdapter({
+});
+try {
+window.someLabel = device3.queue.label;
+} catch {}
+try {
+computePassEncoder30.setBindGroup(3, bindGroup16, new Uint32Array(4423), 4288, 0);
+} catch {}
+try {
+renderBundleEncoder71.setVertexBuffer(1, buffer29, 1692, 687);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: { x: 119, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 322 */
+{offset: 322, bytesPerRow: 1591, rowsPerImage: 192}, {width: 389, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let videoFrame27 = new VideoFrame(offscreenCanvas27, {timestamp: 0});
+try {
+canvas30.getContext('webgpu');
+} catch {}
+let textureView109 = texture99.createView({label: '\u5701\ub232'});
+let renderBundleEncoder79 = device3.createRenderBundleEncoder({
+  label: '\u05ed\u0547\ub2c8\u2e05\u{1f662}\u{1fcaa}\u{1f727}\u596f\u{1f64d}\u{1febb}\uf5ad',
+  colorFormats: ['rg32sint'],
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder62.setVertexBuffer(7, buffer29, 3660);
+} catch {}
+try {
+buffer35.unmap();
+} catch {}
+try {
+commandEncoder91.copyBufferToBuffer(buffer35, 44736, buffer19, 4568, 2572);
+dissociateBuffer(device3, buffer35);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+device: device3,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [],
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder98 = device3.createCommandEncoder();
+let querySet80 = device3.createQuerySet({
+label: '\uce57\u0c88',
+type: 'occlusion',
+count: 179,
+});
+let textureView110 = texture93.createView({label: '\u4623\u{1fadc}\ub1b1\u{1fb9e}\uffc7\u0cc6\u0e8b', mipLevelCount: 4, arrayLayerCount: 1});
+let computePassEncoder62 = commandEncoder96.beginComputePass({label: '\u554f\u{1f9b4}\ubc2b\u{1fcf9}\u0700\u1a41'});
+let renderBundle97 = renderBundleEncoder52.finish({label: '\u01ba\udf90\u{1fa8a}\ubbc0'});
+try {
+renderBundleEncoder54.setVertexBuffer(6, buffer29);
+} catch {}
+try {
+commandEncoder98.resolveQuerySet(querySet59, 549, 87, buffer41, 1792);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture83,
+  mipLevel: 5,
+  origin: { x: 0, y: 8, z: 86 },
+  aspect: 'all',
+}, arrayBuffer8, /* required buffer size: 3778212 */
+{offset: 438, bytesPerRow: 481, rowsPerImage: 187}, {width: 120, height: 0, depthOrArrayLayers: 43});
+} catch {}
+document.body.prepend(video19);
+document.body.prepend(canvas20);
+let commandEncoder99 = device1.createCommandEncoder({});
+let commandBuffer18 = commandEncoder86.finish({
+label: '\ud217\u{1f6fb}\u745a\u85c4\u3578\u{1fe88}\ue9d6\u{1f76f}\u0544\ub770',
+});
+let textureView111 = texture51.createView({
+  label: '\u5d58\u{1f7c2}\u678e\u0ed6\u{1fe4e}\u{1fcda}\u{1fc83}\ucdcd\ua00b\udd66\u19cb',
+  format: 'astc-4x4-unorm-srgb',
+  baseMipLevel: 1,
+  baseArrayLayer: 117,
+  arrayLayerCount: 44
+});
+try {
+renderBundleEncoder37.drawIndexed(80);
+} catch {}
+try {
+commandEncoder99.clearBuffer(buffer21);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: { x: 140, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(72), /* required buffer size: 2542711 */
+{offset: 303, bytesPerRow: 268, rowsPerImage: 279}, {width: 80, height: 4, depthOrArrayLayers: 35});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: img15,
+  origin: { x: 35, y: 63 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 5, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 41, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let imageBitmap30 = await createImageBitmap(video13);
+let texture118 = device3.createTexture({
+size: [1008, 120, 193],
+mipLevelCount: 9,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8unorm', 'etc2-rgb8unorm-srgb', 'etc2-rgb8unorm-srgb'],
+});
+let textureView112 = texture105.createView({baseMipLevel: 1, mipLevelCount: 1});
+try {
+renderBundleEncoder62.setIndexBuffer(buffer35, 'uint32', 11196, 27916);
+} catch {}
+try {
+renderBundleEncoder64.setVertexBuffer(7, buffer44, 28728);
+} catch {}
+try {
+commandEncoder91.clearBuffer(buffer37, 21400);
+dissociateBuffer(device3, buffer37);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(16)), /* required buffer size: 543 */
+{offset: 543, rowsPerImage: 118}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise44 = device3.queue.onSubmittedWorkDone();
+let pipeline89 = device3.createComputePipeline({
+label: '\u0f6a\u4232\u2c3d\u0fef\u{1ff36}\u{1fe9c}',
+layout: 'auto',
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+  await promise44;
+} catch {}
+let video28 = await videoWithData();
+let imageData30 = new ImageData(100, 56);
+let canvas32 = document.createElement('canvas');
+let texture119 = device2.createTexture({
+label: '\u088f\u0d37',
+size: [576, 96, 1],
+mipLevelCount: 3,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundleEncoder80 = device2.createRenderBundleEncoder({
+  colorFormats: ['rgba32sint', 'r8unorm', 'rg8uint', undefined, undefined, 'rgba8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+try {
+renderBundleEncoder21.setVertexBuffer(46, undefined, 1787199359, 1455784410);
+} catch {}
+let computePassEncoder63 = commandEncoder79.beginComputePass({label: '\u0c56\u6137\u{1fc43}\u7303'});
+try {
+renderBundleEncoder70.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder37.drawIndexed(8);
+} catch {}
+try {
+renderBundleEncoder49.setIndexBuffer(buffer47, 'uint16');
+} catch {}
+let arrayBuffer13 = buffer36.getMappedRange(24888, 256);
+try {
+device1.queue.writeBuffer(buffer20, 556, new Float32Array(32022), 14444, 28);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture116,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 10 },
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer4), /* required buffer size: 22226 */
+{offset: 449, bytesPerRow: 17, rowsPerImage: 61}, {width: 0, height: 1, depthOrArrayLayers: 22});
+} catch {}
+let pipeline90 = await promise34;
+let shaderModule18 = device1.createShaderModule({
+label: '\u076c\u{1f6c2}\u0035\u1f10\u{1f63a}',
+code: `@group(4) @binding(542)
+var<storage, read_write> global9: array<u32>;
+@group(3) @binding(542)
+var<storage, read_write> type21: array<u32>;
+@group(0) @binding(3524)
+var<storage, read_write> field11: array<u32>;
+@group(5) @binding(542)
+var<storage, read_write> global10: array<u32>;
+@group(2) @binding(1723)
+var<storage, read_write> global11: array<u32>;
+@group(6) @binding(542)
+var<storage, read_write> parameter15: array<u32>;
+
+@compute @workgroup_size(5, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(7) f0: vec2<u32>,
+  @location(0) f1: vec2<u32>,
+  @location(4) f2: vec4<u32>,
+  @location(3) f3: vec4<i32>,
+  @location(2) f4: vec2<i32>,
+  @location(1) f5: vec3<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S23 {
+  @location(18) f0: vec2<f16>,
+  @location(10) f1: vec3<i32>,
+  @location(26) f2: i32,
+  @location(21) f3: vec3<u32>,
+  @location(11) f4: vec4<i32>,
+  @location(13) f5: vec2<f16>,
+  @location(0) f6: vec2<f16>,
+  @location(23) f7: f16,
+  @location(3) f8: i32,
+  @location(19) f9: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: u32, @location(22) a1: vec2<u32>, @location(8) a2: vec4<u32>, @location(6) a3: u32, @location(25) a4: f16, @location(20) a5: vec4<f16>, @location(17) a6: f16, @location(2) a7: vec4<f16>, @location(24) a8: vec4<u32>, @location(15) a9: vec4<u32>, @location(14) a10: vec4<f32>, @location(7) a11: vec3<u32>, a12: S23, @location(4) a13: vec4<f16>, @location(16) a14: u32, @location(12) a15: vec4<u32>, @location(1) a16: vec2<u32>, @builtin(instance_index) a17: u32, @location(5) a18: vec4<u32>, @builtin(vertex_index) a19: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let textureView113 = texture94.createView({label: '\u070a\u04d2\ufc29', baseMipLevel: 5, mipLevelCount: 1, arrayLayerCount: 1});
+let renderBundleEncoder81 = device1.createRenderBundleEncoder({
+  label: '\u57c4\uff0d\u511e\u{1fd97}\u21ab\u{1fcb4}\u01a1\u{1f7e2}\u5595',
+  colorFormats: ['rgba32sint', 'rg8sint', 'rgba32uint'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle98 = renderBundleEncoder81.finish({});
+try {
+renderBundleEncoder77.setBindGroup(4, bindGroup4);
+} catch {}
+try {
+await device1.popErrorScope();
+} catch {}
+try {
+commandEncoder97.copyBufferToBuffer(buffer36, 8264, buffer20, 280, 284);
+dissociateBuffer(device1, buffer36);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas24,
+  origin: { x: 156, y: 136 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 10, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 38, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+document.body.prepend(img12);
+try {
+computePassEncoder44.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+computePassEncoder25.dispatchWorkgroupsIndirect(buffer41, 1272);
+} catch {}
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+commandEncoder94.copyBufferToBuffer(buffer29, 3528, buffer24, 9572, 0);
+dissociateBuffer(device3, buffer29);
+dissociateBuffer(device3, buffer24);
+} catch {}
+try {
+commandEncoder91.copyTextureToTexture({
+  texture: texture89,
+  mipLevel: 5,
+  origin: { x: 14, y: 0, z: 82 },
+  aspect: 'all',
+}, {
+  texture: texture89,
+  mipLevel: 2,
+  origin: { x: 90, y: 8, z: 36 },
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 62});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['bgra8unorm', 'rg11b10ufloat'],
+alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.prepend(video25);
+let canvas33 = document.createElement('canvas');
+let videoFrame28 = new VideoFrame(videoFrame6, {timestamp: 0});
+let videoFrame29 = new VideoFrame(img3, {timestamp: 0});
+let commandEncoder100 = device1.createCommandEncoder();
+let querySet81 = device1.createQuerySet({
+label: '\u1699\u08df\u5c12\u3669\u0d62\u{1fd63}\u039d\u00d0\u{1f858}',
+type: 'occlusion',
+count: 3462,
+});
+let computePassEncoder64 = commandEncoder99.beginComputePass();
+let sampler69 = device1.createSampler({
+label: '\u0594\u3c7d\u43c2\u055f\u0aa2\ubb2d\u7a74\u0163\u{1f892}\ub1c1',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 68.516,
+lodMaxClamp: 71.680,
+});
+try {
+renderBundleEncoder77.setIndexBuffer(buffer43, 'uint32', 38936, 1131);
+} catch {}
+try {
+commandEncoder97.copyBufferToBuffer(buffer34, 20340, buffer8, 456, 628);
+dissociateBuffer(device1, buffer34);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder93.copyBufferToTexture({
+/* bytesInLastRow: 96 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 672 */
+offset: 672,
+buffer: buffer34,
+}, {
+  texture: texture88,
+  mipLevel: 2,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 48, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer34);
+} catch {}
+try {
+commandEncoder88.copyTextureToBuffer({
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 37, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 44 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 3832 */
+offset: 3532,
+bytesPerRow: 256,
+rowsPerImage: 141,
+buffer: buffer39,
+}, {width: 11, height: 2, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+commandEncoder88.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 2,
+  origin: { x: 270, y: 0, z: 3 },
+  aspect: 'all',
+}, {
+  texture: texture27,
+  mipLevel: 6,
+  origin: { x: 10, y: 0, z: 19 },
+  aspect: 'all',
+}, {width: 20, height: 0, depthOrArrayLayers: 126});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 1, y: 8 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 40, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let imageData31 = new ImageData(168, 60);
+let canvas34 = document.createElement('canvas');
+let video29 = await videoWithData();
+let textureView114 = texture36.createView({label: '\u07f2\ufc5f\u05c3\u94ff', dimension: '2d-array', baseMipLevel: 5});
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+commandEncoder27.clearBuffer(buffer45, 49740, 8168);
+dissociateBuffer(device2, buffer45);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer45, 31900, new Float32Array(51781), 25220, 1512);
+} catch {}
+let pipeline91 = await device2.createRenderPipelineAsync({
+label: '\u{1f98e}\u2cdc\ubd48\uda59\ua8f1\u1d36\ub3b8\u0c8a',
+layout: pipelineLayout6,
+fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: 0}, {format: 'r8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg8uint', writeMask: GPUColorWrite.BLUE}, undefined, undefined, {format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'invert',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 3764,
+stencilWriteMask: 1963,
+depthBiasSlopeScale: 47,
+depthBiasClamp: 49,
+},
+vertex: {
+  module: shaderModule4,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 28152,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x4',
+offset: 16632,
+shaderLocation: 3,
+}, {
+format: 'uint32',
+offset: 3304,
+shaderLocation: 14,
+}, {
+format: 'float16x2',
+offset: 24268,
+shaderLocation: 11,
+}, {
+format: 'sint32x4',
+offset: 19004,
+shaderLocation: 13,
+}, {
+format: 'sint32',
+offset: 6444,
+shaderLocation: 5,
+}, {
+format: 'sint16x2',
+offset: 18484,
+shaderLocation: 10,
+}, {
+format: 'sint32',
+offset: 12416,
+shaderLocation: 1,
+}, {
+format: 'uint8x4',
+offset: 22132,
+shaderLocation: 6,
+}, {
+format: 'unorm8x4',
+offset: 23628,
+shaderLocation: 8,
+}, {
+format: 'uint8x4',
+offset: 9504,
+shaderLocation: 15,
+}, {
+format: 'snorm8x4',
+offset: 11664,
+shaderLocation: 12,
+}, {
+format: 'float32x3',
+offset: 21448,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 21884,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 13218,
+shaderLocation: 4,
+}, {
+format: 'sint32x4',
+offset: 19692,
+shaderLocation: 9,
+}, {
+format: 'float32x3',
+offset: 15728,
+shaderLocation: 7,
+}, {
+format: 'sint16x4',
+offset: 11108,
+shaderLocation: 2,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let commandEncoder101 = device3.createCommandEncoder({label: '\u0beb\uf9a8\u3e11\ue04e\u0e1f\u7847\u57ab\u0e31'});
+let texture120 = device3.createTexture({
+label: '\ua4db\u060e',
+size: {width: 30, height: 120, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rg32sint'],
+});
+let textureView115 = texture59.createView({
+  label: '\uf456\ud07c\u7f2b\u{1f933}\u076d\u{1fec1}\u0929\u8848\ufbd1\ud62f',
+  baseMipLevel: 1,
+  mipLevelCount: 1
+});
+let sampler70 = device3.createSampler({
+label: '\u9b83\u006d\u0fe5\u1faf',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 70.616,
+maxAnisotropy: 12,
+});
+try {
+commandEncoder91.copyBufferToTexture({
+/* bytesInLastRow: 192 widthInBlocks: 24 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 33832 */
+offset: 33832,
+bytesPerRow: 256,
+buffer: buffer35,
+}, {
+  texture: texture120,
+  mipLevel: 0,
+  origin: { x: 5, y: 17, z: 1 },
+  aspect: 'all',
+}, {width: 24, height: 99, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder91.copyTextureToTexture({
+  texture: texture59,
+  mipLevel: 1,
+  origin: { x: 10, y: 50, z: 53 },
+  aspect: 'all',
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: { x: 7, y: 133, z: 104 },
+  aspect: 'all',
+}, {width: 14, height: 51, depthOrArrayLayers: 45});
+} catch {}
+let pipeline92 = await device3.createRenderPipelineAsync({
+label: '\ue3e7\u{1fa61}\u{1fe6b}\u{1f6fa}\uf779\u7393\u04e3\udbf0\u7fa3\u16b1',
+layout: pipelineLayout10,
+fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALPHA}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one', dstFactor: 'one-minus-constant'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALPHA
+}]
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'never',
+failOp: 'keep',
+depthFailOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+depthBias: 11,
+depthBiasSlopeScale: 82,
+},
+vertex: {
+  module: shaderModule12,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 15720,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 14306,
+shaderLocation: 0,
+}, {
+format: 'uint32x3',
+offset: 8676,
+shaderLocation: 4,
+}, {
+format: 'unorm10-10-10-2',
+offset: 1044,
+shaderLocation: 19,
+}, {
+format: 'uint32',
+offset: 13900,
+shaderLocation: 20,
+}, {
+format: 'unorm8x2',
+offset: 2184,
+shaderLocation: 18,
+}, {
+format: 'float32',
+offset: 12332,
+shaderLocation: 9,
+}, {
+format: 'uint32x3',
+offset: 13412,
+shaderLocation: 14,
+}, {
+format: 'sint16x4',
+offset: 4464,
+shaderLocation: 1,
+}, {
+format: 'uint32x3',
+offset: 664,
+shaderLocation: 24,
+}, {
+format: 'unorm16x2',
+offset: 12236,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 27088,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 13772,
+shaderLocation: 17,
+}, {
+format: 'snorm8x4',
+offset: 8952,
+shaderLocation: 23,
+}, {
+format: 'unorm16x2',
+offset: 25500,
+shaderLocation: 21,
+}, {
+format: 'sint32x3',
+offset: 26788,
+shaderLocation: 6,
+}, {
+format: 'float16x2',
+offset: 12556,
+shaderLocation: 16,
+}, {
+format: 'sint8x4',
+offset: 14280,
+shaderLocation: 11,
+}, {
+format: 'unorm8x2',
+offset: 13348,
+shaderLocation: 22,
+}],
+},
+{
+arrayStride: 23004,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 18760,
+shaderLocation: 10,
+}, {
+format: 'uint16x4',
+offset: 4832,
+shaderLocation: 12,
+}, {
+format: 'float16x2',
+offset: 4976,
+shaderLocation: 15,
+}, {
+format: 'uint32x3',
+offset: 21708,
+shaderLocation: 2,
+}, {
+format: 'snorm16x2',
+offset: 20432,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 25788,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 16240,
+shaderLocation: 7,
+}, {
+format: 'sint8x4',
+offset: 10332,
+shaderLocation: 25,
+}, {
+format: 'uint16x4',
+offset: 4916,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 7768,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 20832,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x2',
+offset: 8156,
+shaderLocation: 8,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+},
+});
+let texture121 = device3.createTexture({
+label: '\u19b8\u{1fb86}\u{1fadd}\ucc60\u4d23\ue806\u{1f72b}\u{1fb38}\u0fb5',
+size: {width: 240, height: 960, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+sampleCount: 1,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder65 = commandEncoder91.beginComputePass({label: '\u1343\u0280\ufd9b\u{1f6bd}'});
+let renderBundle99 = renderBundleEncoder64.finish({});
+try {
+renderBundleEncoder78.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder79.setBindGroup(7, bindGroup15, new Uint32Array(2359), 2268, 0);
+} catch {}
+try {
+renderBundleEncoder76.setVertexBuffer(9, buffer44, 35384);
+} catch {}
+try {
+commandEncoder101.clearBuffer(buffer24, 3340, 2564);
+dissociateBuffer(device3, buffer24);
+} catch {}
+try {
+commandEncoder101.insertDebugMarker('\u2962');
+} catch {}
+let texture122 = device3.createTexture({
+label: '\u3d1d\u077d\u59a4\u08e2\u0765\u5b59\uc7df\u091f\ua9de\u0d8d',
+size: [256, 480, 1],
+mipLevelCount: 1,
+sampleCount: 1,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8unorm-srgb', 'etc2-rgb8unorm-srgb', 'etc2-rgb8unorm-srgb'],
+});
+let renderBundle100 = renderBundleEncoder60.finish();
+try {
+renderBundleEncoder56.setVertexBuffer(3, buffer44, 24708, 23584);
+} catch {}
+let pipeline93 = device3.createComputePipeline({
+label: '\u0f14\u0eac',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let renderBundleEncoder82 = device3.createRenderBundleEncoder({
+  label: '\ua1c6\u02b5\u03f1\u96e5\u0402\u{1f63d}\u{1fe37}\u390f\u03cb',
+  colorFormats: ['r32float', 'rgb10a2uint', 'r32uint', 'rg8unorm', 'rg8sint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+try {
+computePassEncoder37.end();
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(7, buffer29, 1208);
+} catch {}
+try {
+commandEncoder101.copyBufferToBuffer(buffer35, 17284, buffer24, 2088, 2252);
+dissociateBuffer(device3, buffer35);
+dissociateBuffer(device3, buffer24);
+} catch {}
+try {
+commandEncoder94.resolveQuerySet(querySet38, 1328, 15, buffer41, 3584);
+} catch {}
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+let imageData32 = new ImageData(84, 20);
+let commandEncoder102 = device1.createCommandEncoder();
+let querySet82 = device1.createQuerySet({
+label: '\uda21\u1f41\u{1fbb3}\ua944\u{1f92c}\u4e33',
+type: 'occlusion',
+count: 103,
+});
+try {
+renderBundleEncoder37.setBindGroup(10, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder37.draw(32, 48, 32, 32);
+} catch {}
+try {
+renderBundleEncoder70.setIndexBuffer(buffer18, 'uint32', 45624, 6102);
+} catch {}
+try {
+commandEncoder100.clearBuffer(buffer21, 20360);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture95,
+  mipLevel: 0,
+  origin: { x: 102, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(190), /* required buffer size: 190 */
+{offset: 25, rowsPerImage: 152}, {width: 165, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let offscreenCanvas32 = new OffscreenCanvas(448, 375);
+let device5 = await promise22;
+let commandEncoder103 = device5.createCommandEncoder({label: '\u930f\u0443\u0728\u09d6\u91eb'});
+try {
+gpuCanvasContext8.configure({
+device: device5,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth24plus'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let promise45 = device5.queue.onSubmittedWorkDone();
+let offscreenCanvas33 = new OffscreenCanvas(174, 873);
+let commandEncoder104 = device5.createCommandEncoder({label: '\u{1f62a}\u{1ff02}\u71f8\u943b\u0243\u0812\u095f\u{1f973}\u5a4b\u02a5\u0d3c'});
+let texture123 = device5.createTexture({
+size: {width: 624, height: 2, depthOrArrayLayers: 1723},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rgb10a2unorm', 'rgb10a2unorm'],
+});
+let computePassEncoder66 = commandEncoder103.beginComputePass();
+let sampler71 = device5.createSampler({
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 15.145,
+lodMaxClamp: 58.163,
+});
+let gpuCanvasContext27 = canvas32.getContext('webgpu');
+canvas21.width = 992;
+pseudoSubmit(device5, commandEncoder104);
+let renderBundleEncoder83 = device5.createRenderBundleEncoder({label: '\u8ecc\u{1fdbd}\u00a8\u08e6', colorFormats: ['rg16uint'], sampleCount: 4, depthReadOnly: true});
+let sampler72 = device5.createSampler({
+label: '\ua09f\u{1f9c2}',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 38.069,
+lodMaxClamp: 71.256,
+compare: 'less-equal',
+maxAnisotropy: 3,
+});
+try {
+device5.queue.writeTexture({
+  texture: texture123,
+  mipLevel: 1,
+  origin: { x: 4, y: 0, z: 34 },
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer4), /* required buffer size: 21560870 */
+{offset: 732, bytesPerRow: 862, rowsPerImage: 63}, {width: 164, height: 1, depthOrArrayLayers: 398});
+} catch {}
+let texture124 = device3.createTexture({
+label: '\u0d1a\u49b4\u7ade\u3e40\u7ecc',
+size: [120, 480, 1],
+mipLevelCount: 5,
+format: 'astc-6x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let sampler73 = device3.createSampler({
+label: '\u0349\uc971',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 57.405,
+lodMaxClamp: 91.881,
+});
+let promise46 = device3.popErrorScope();
+let pipeline94 = device3.createComputePipeline({
+label: '\u9cd8\u{1fb14}',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline95 = device3.createRenderPipeline({
+label: '\u08d8\u0404\ud4ed\u996f\u2369\uf6aa\ub5fa\u2bf5\u{1f75f}\u0f75\ua1be',
+layout: pipelineLayout14,
+fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-constant'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'src-alpha'},
+}
+}, {format: 'r32sint'}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'dst'},
+alpha: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-dst-alpha'},
+},
+  writeMask: GPUColorWrite.ALPHA
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 30,
+stencilWriteMask: 2867,
+depthBias: 20,
+depthBiasSlopeScale: 14,
+depthBiasClamp: 13,
+},
+vertex: {
+  module: shaderModule12,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 19340,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 11740,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint16x4',
+offset: 13720,
+shaderLocation: 7,
+}, {
+format: 'uint32x2',
+offset: 24852,
+shaderLocation: 2,
+}, {
+format: 'float32x2',
+offset: 1896,
+shaderLocation: 21,
+}, {
+format: 'unorm10-10-10-2',
+offset: 22512,
+shaderLocation: 17,
+}, {
+format: 'uint8x4',
+offset: 25896,
+shaderLocation: 20,
+}, {
+format: 'uint32x3',
+offset: 11360,
+shaderLocation: 13,
+}, {
+format: 'float16x4',
+offset: 5844,
+shaderLocation: 22,
+}, {
+format: 'snorm16x4',
+offset: 24452,
+shaderLocation: 18,
+}, {
+format: 'snorm8x2',
+offset: 6436,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 0,
+attributes: [{
+format: 'float32x3',
+offset: 1944,
+shaderLocation: 0,
+}, {
+format: 'float32x4',
+offset: 15292,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 19812,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x4',
+offset: 17192,
+shaderLocation: 15,
+}, {
+format: 'uint32x3',
+offset: 17368,
+shaderLocation: 12,
+}, {
+format: 'snorm16x2',
+offset: 1364,
+shaderLocation: 23,
+}, {
+format: 'sint32x2',
+offset: 16852,
+shaderLocation: 11,
+}, {
+format: 'float32x3',
+offset: 2964,
+shaderLocation: 8,
+}, {
+format: 'sint32x2',
+offset: 9752,
+shaderLocation: 25,
+}, {
+format: 'uint32x4',
+offset: 11680,
+shaderLocation: 4,
+}, {
+format: 'unorm16x4',
+offset: 7624,
+shaderLocation: 9,
+}, {
+format: 'sint32',
+offset: 5364,
+shaderLocation: 6,
+}, {
+format: 'snorm8x2',
+offset: 2092,
+shaderLocation: 19,
+}, {
+format: 'snorm8x2',
+offset: 8598,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 9020,
+attributes: [],
+},
+{
+arrayStride: 6072,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 28208,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x3',
+offset: 28180,
+shaderLocation: 14,
+}, {
+format: 'uint16x2',
+offset: 11720,
+shaderLocation: 24,
+}],
+},
+{
+arrayStride: 23896,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x2',
+offset: 15504,
+shaderLocation: 5,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+try {
+  await promise45;
+} catch {}
+let commandEncoder105 = device5.createCommandEncoder({label: '\ua50b\u0f71\u{1f9c2}\u587f\u3a58\uf67c\u0f23\ubb56\u10a7'});
+let querySet83 = device5.createQuerySet({
+label: '\u08eb\ua811\u20c3\u3916\ufc48\uba0c\u40c6\u0140',
+type: 'occlusion',
+count: 2415,
+});
+let commandBuffer19 = commandEncoder105.finish({
+label: '\u{1ff2e}\u32c1\uc7d5\ub695',
+});
+let renderBundle101 = renderBundleEncoder83.finish({label: '\ue4b6\u7317'});
+try {
+device5.queue.writeTexture({
+  texture: texture123,
+  mipLevel: 1,
+  origin: { x: 15, y: 0, z: 182 },
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer5), /* required buffer size: 33507332 */
+{offset: 288, bytesPerRow: 1385, rowsPerImage: 192}, {width: 281, height: 1, depthOrArrayLayers: 127});
+} catch {}
+canvas16.width = 429;
+let canvas35 = document.createElement('canvas');
+let img27 = await imageWithData(285, 54, '#e8568f35', '#dbf8368c');
+let promise47 = adapter13.requestAdapterInfo();
+let bindGroupLayout39 = device5.createBindGroupLayout({
+label: '\u84f0\u{1f916}',
+entries: [],
+});
+try {
+device5.addEventListener('uncapturederror', e => { log('device5.uncapturederror'); log(e); e.label = device5.label; });
+} catch {}
+let videoFrame30 = new VideoFrame(video29, {timestamp: 0});
+let texture125 = device1.createTexture({
+label: '\u0481\u1039\u076d\u0601',
+size: {width: 384, height: 5, depthOrArrayLayers: 113},
+format: 'astc-6x5-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder67 = commandEncoder100.beginComputePass({label: '\ub1e4\u5345'});
+try {
+renderBundleEncoder77.setBindGroup(9, bindGroup19, new Uint32Array(7870), 4783, 0);
+} catch {}
+try {
+renderBundleEncoder37.draw(8, 24, 24, 56);
+} catch {}
+try {
+commandEncoder88.resolveQuerySet(querySet39, 795, 957, buffer34, 14848);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer34, 20892, new DataView(new ArrayBuffer(2573)), 459, 1804);
+} catch {}
+let pipeline96 = device1.createComputePipeline({
+label: '\u4fa5\u97f6\u2fa8\u0d0f\u7635\uc73f\u05ea\u5a73\uce52\u0a61',
+layout: pipelineLayout12,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+  await promise46;
+} catch {}
+let textureView116 = texture123.createView({label: '\u0444\u0852\u4f4d\u64dd\u{1fb0d}\u701a\u89c9\uc840\u064e\u01e1', baseMipLevel: 1});
+let img28 = await imageWithData(280, 12, '#cbf75d42', '#b41f6082');
+let imageBitmap31 = await createImageBitmap(video0);
+let video30 = await videoWithData();
+try {
+  await promise47;
+} catch {}
+let img29 = await imageWithData(280, 277, '#6d958065', '#e5e56c48');
+let bindGroupLayout40 = device1.createBindGroupLayout({
+entries: [],
+});
+let querySet84 = device1.createQuerySet({
+label: '\uf691\ub85a',
+type: 'occlusion',
+count: 612,
+});
+try {
+renderBundleEncoder70.setBindGroup(5, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder59.setBindGroup(5, bindGroup7, new Uint32Array(816), 561, 0);
+} catch {}
+try {
+commandEncoder88.insertDebugMarker('\ufa06');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap27,
+  origin: { x: 404, y: 97 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 46, y: 2, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline97 = device1.createComputePipeline({
+label: '\u23dc\u{1f763}\ude1e\u{1fad5}\uc549\u066d\u2d64\u8226\u7d5c',
+layout: pipelineLayout8,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let gpuCanvasContext28 = canvas33.getContext('webgpu');
+let bindGroup21 = device5.createBindGroup({
+layout: bindGroupLayout39,
+entries: [],
+});
+let querySet85 = device5.createQuerySet({
+label: '\u{1feb0}\u0f47\u8beb\uf1ca\u844b\u8377\u0660\uf02b',
+type: 'occlusion',
+count: 1086,
+});
+let textureView117 = texture123.createView({label: '\u0cb3\ue8a7\u0d3f', mipLevelCount: 1});
+let renderBundleEncoder84 = device5.createRenderBundleEncoder({
+  label: '\u916b\u0f9a\u8297\u9591\u02ea\u0e89\u{1f62b}',
+  colorFormats: ['rg16uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let externalTexture9 = device5.importExternalTexture({
+label: '\ub358\u45c8\u{1febb}\u03f8\uf56f\u036d\u5584\u{1fc53}\uf9a5',
+source: videoFrame5,
+colorSpace: 'display-p3',
+});
+try {
+gpuCanvasContext8.configure({
+device: device5,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let promise48 = device5.queue.onSubmittedWorkDone();
+let img30 = await imageWithData(207, 274, '#8b04ccea', '#7da75b1c');
+try {
+canvas35.getContext('2d');
+} catch {}
+try {
+  await promise48;
+} catch {}
+let img31 = await imageWithData(146, 208, '#676ba080', '#1b130991');
+try {
+querySet1.label = '\u4873\u509f\u6f81\u076a\u{1f801}\u0934\udd4b\u0775\u{1fdc8}\u{1fc9c}\u886c';
+} catch {}
+try {
+renderBundleEncoder84.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+device5.queue.writeTexture({
+  texture: texture123,
+  mipLevel: 1,
+  origin: { x: 268, y: 1, z: 753 },
+  aspect: 'all',
+}, arrayBuffer12, /* required buffer size: 860081 */
+{offset: 697, bytesPerRow: 136, rowsPerImage: 71}, {width: 19, height: 0, depthOrArrayLayers: 90});
+} catch {}
+canvas17.width = 553;
+let renderBundle102 = renderBundleEncoder83.finish({label: '\ub9b0\u{1f8fe}\u15fe\u0bb3\u{1f8c3}\u07ba\u2b01\u5848\u6ec1\ue897\u9f77'});
+gc();
+let canvas36 = document.createElement('canvas');
+let imageData33 = new ImageData(248, 156);
+let renderBundle103 = renderBundleEncoder61.finish({label: '\u{1f99b}\u{1f822}\u8581\u{1f892}\u{1f8c9}\u11b1\uce47\u{1f97a}\u06a2\u9e70'});
+try {
+renderBundleEncoder56.setBindGroup(3, bindGroup14, new Uint32Array(6442), 2689, 0);
+} catch {}
+try {
+adapter11.label = '\u{1fd5e}\u1fd3\u1cd9\u19e1';
+} catch {}
+let device6 = await adapter4.requestDevice({
+label: '\uff4f\uabf4\u1ff3\u07a8\u{1f886}\u41c8\u6601',
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 35,
+maxVertexAttributes: 25,
+maxVertexBufferArrayStride: 31411,
+maxStorageTexturesPerShaderStage: 41,
+maxStorageBuffersPerShaderStage: 17,
+maxDynamicStorageBuffersPerPipelineLayout: 26203,
+maxBindingsPerBindGroup: 4663,
+maxTextureDimension1D: 9364,
+maxTextureDimension2D: 13488,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 40444181,
+maxUniformBuffersPerShaderStage: 14,
+maxInterStageShaderVariables: 38,
+maxInterStageShaderComponents: 62,
+maxSamplersPerShaderStage: 20,
+},
+});
+let computePassEncoder68 = commandEncoder94.beginComputePass({label: '\u3b1c\u817f\u7e46\u012e\u7f0e\uce2d\ud008\udc95\u0164\u6c8c\u{1f69e}'});
+let sampler74 = device3.createSampler({
+label: '\u548d\u{1feb3}',
+addressModeU: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 93.471,
+lodMaxClamp: 98.619,
+maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder79.setBindGroup(7, bindGroup8, new Uint32Array(9229), 6449, 0);
+} catch {}
+let pipeline98 = await device3.createComputePipelineAsync({
+label: '\u37de\u6795\ufcd9\u1a8e',
+layout: pipelineLayout10,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+},
+});
+let device7 = await adapter14.requestDevice({
+label: '\u{1fcd1}\ud0fc\u06aa\u9e40\u48fe\u85e0\u068a',
+requiredFeatures: [
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 6,
+maxColorAttachmentBytesPerSample: 52,
+maxVertexBufferArrayStride: 60076,
+maxStorageTexturesPerShaderStage: 26,
+maxStorageBuffersPerShaderStage: 25,
+maxDynamicStorageBuffersPerPipelineLayout: 39249,
+maxBindingsPerBindGroup: 8484,
+maxTextureDimension1D: 13922,
+maxTextureDimension2D: 10957,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 195871878,
+maxUniformBuffersPerShaderStage: 19,
+maxInterStageShaderVariables: 102,
+maxInterStageShaderComponents: 92,
+},
+});
+let imageBitmap32 = await createImageBitmap(img6);
+let texture126 = device1.createTexture({
+size: {width: 384, height: 16, depthOrArrayLayers: 243},
+mipLevelCount: 5,
+dimension: '2d',
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundleEncoder85 = device1.createRenderBundleEncoder({
+  label: '\ua26b\u8141\u79d1\u417a\u8a45\u{1f891}\u0b6e',
+  colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint']
+});
+try {
+renderBundleEncoder37.draw(72, 56, 72);
+} catch {}
+try {
+renderBundleEncoder59.drawIndexed(16, 40, 16);
+} catch {}
+try {
+renderBundleEncoder66.setIndexBuffer(buffer47, 'uint32', 15684, 9527);
+} catch {}
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+try {
+adapter3.label = '\ud696\udcb1\u02b7\u51bd\u0463\u{1fcc2}';
+} catch {}
+let device8 = await adapter8.requestDevice({
+label: '\uf393\u9cf4\u{1f869}\u{1fa62}\u1b7b\u2bbe',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 6,
+maxColorAttachmentBytesPerSample: 45,
+maxVertexAttributes: 17,
+maxVertexBufferArrayStride: 5510,
+maxStorageTexturesPerShaderStage: 39,
+maxStorageBuffersPerShaderStage: 39,
+maxDynamicStorageBuffersPerPipelineLayout: 26188,
+maxBindingsPerBindGroup: 4184,
+maxTextureDimension1D: 15929,
+maxTextureDimension2D: 13179,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 147110740,
+maxUniformBuffersPerShaderStage: 17,
+maxInterStageShaderVariables: 98,
+maxInterStageShaderComponents: 67,
+maxSamplersPerShaderStage: 17,
+},
+});
+let video31 = await videoWithData();
+try {
+gpuCanvasContext8.configure({
+device: device8,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16float', 'rg32float', 'rgba16float', 'rgba16float'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let offscreenCanvas34 = new OffscreenCanvas(655, 704);
+let sampler75 = device8.createSampler({
+label: '\u64e0\u{1fb19}\u{1f791}\u1252\u3d50',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 42.634,
+maxAnisotropy: 9,
+});
+try {
+gpuCanvasContext25.unconfigure();
+} catch {}
+let bindGroup22 = device1.createBindGroup({
+label: '\u89ca\u0014\ua3ee\udbcc\u{1fcf1}\u{1fb34}\u1890\u{1fea6}\u00be\u4e09\u7381',
+layout: bindGroupLayout25,
+entries: [],
+});
+let textureView118 = texture17.createView({label: '\u94c5\ua735\u0e44\u04d0\u6529', dimension: '2d', baseMipLevel: 2, baseArrayLayer: 200});
+try {
+device1.pushErrorScope('internal');
+} catch {}
+let pipeline99 = device1.createRenderPipeline({
+layout: pipelineLayout7,
+multisample: {
+mask: 0x6b45d840,
+},
+fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'r32uint', writeMask: GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'rg8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r32uint'}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'always',
+failOp: 'replace',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2703,
+depthBiasSlopeScale: 35,
+},
+vertex: {
+  module: shaderModule3,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 6104,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x4',
+offset: 4256,
+shaderLocation: 15,
+}, {
+format: 'sint16x4',
+offset: 3980,
+shaderLocation: 7,
+}, {
+format: 'sint32x3',
+offset: 140,
+shaderLocation: 10,
+}, {
+format: 'snorm8x4',
+offset: 3380,
+shaderLocation: 20,
+}, {
+format: 'uint32x2',
+offset: 1412,
+shaderLocation: 4,
+}, {
+format: 'uint16x4',
+offset: 920,
+shaderLocation: 2,
+}, {
+format: 'float32',
+offset: 3012,
+shaderLocation: 14,
+}, {
+format: 'sint16x4',
+offset: 1220,
+shaderLocation: 9,
+}, {
+format: 'unorm8x2',
+offset: 686,
+shaderLocation: 19,
+}, {
+format: 'unorm16x4',
+offset: 5036,
+shaderLocation: 18,
+}, {
+format: 'sint8x4',
+offset: 5724,
+shaderLocation: 5,
+}, {
+format: 'uint32x4',
+offset: 5532,
+shaderLocation: 23,
+}, {
+format: 'sint8x4',
+offset: 3908,
+shaderLocation: 26,
+}, {
+format: 'sint16x2',
+offset: 5184,
+shaderLocation: 22,
+}, {
+format: 'snorm8x2',
+offset: 366,
+shaderLocation: 16,
+}, {
+format: 'snorm16x2',
+offset: 3164,
+shaderLocation: 13,
+}, {
+format: 'snorm16x4',
+offset: 2636,
+shaderLocation: 17,
+}],
+},
+{
+arrayStride: 9888,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 5478,
+shaderLocation: 1,
+}, {
+format: 'sint8x2',
+offset: 7774,
+shaderLocation: 21,
+}, {
+format: 'uint32x3',
+offset: 8976,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 10152,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 31608,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 2098,
+shaderLocation: 0,
+}, {
+format: 'sint32x4',
+offset: 10460,
+shaderLocation: 12,
+}, {
+format: 'float16x4',
+offset: 23716,
+shaderLocation: 3,
+}, {
+format: 'float32x3',
+offset: 26992,
+shaderLocation: 24,
+}, {
+format: 'unorm8x4',
+offset: 2472,
+shaderLocation: 25,
+}],
+},
+{
+arrayStride: 15468,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 33628,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x4',
+offset: 23068,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 216,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 12,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let gpuCanvasContext29 = offscreenCanvas32.getContext('webgpu');
+document.body.prepend(video26);
+let offscreenCanvas35 = new OffscreenCanvas(641, 692);
+let querySet86 = device1.createQuerySet({
+label: '\u023c\u0cec\u{1f661}',
+type: 'occlusion',
+count: 3173,
+});
+pseudoSubmit(device1, commandEncoder90);
+let renderBundleEncoder86 = device1.createRenderBundleEncoder({
+  label: '\ue976\u094d\u0829\u0ddf\u795e\u6180\u9aca\ud573',
+  colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint'],
+  sampleCount: 1,
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+let sampler76 = device1.createSampler({
+label: '\u{1ffa0}\uef86\uae07',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 16.581,
+lodMaxClamp: 67.948,
+compare: 'always',
+});
+try {
+renderBundleEncoder37.drawIndexed(0, 72, 48, 376, 32);
+} catch {}
+try {
+renderBundleEncoder57.setPipeline(pipeline81);
+} catch {}
+try {
+commandEncoder93.copyBufferToBuffer(buffer47, 31104, buffer21, 8672, 324);
+dissociateBuffer(device1, buffer47);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+commandEncoder102.copyTextureToTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 8, y: 344, z: 41 },
+  aspect: 'all',
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: { x: 4, y: 32, z: 17 },
+  aspect: 'all',
+}, {width: 36, height: 244, depthOrArrayLayers: 4});
+} catch {}
+try {
+commandEncoder97.resolveQuerySet(querySet69, 2354, 1334, buffer34, 8448);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 936, new DataView(new ArrayBuffer(65467)), 38851, 28);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: { x: 0, y: 184, z: 60 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 525934 */
+{offset: 332, bytesPerRow: 74, rowsPerImage: 106}, {width: 27, height: 1, depthOrArrayLayers: 68});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas19,
+  origin: { x: 105, y: 82 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 7, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 40, height: 2, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let renderBundleEncoder87 = device6.createRenderBundleEncoder({
+  label: '\uc010\u{1f96b}\uc8ef\ub2b9\u{1f692}\ud033\u0d18\u4d57\u{1f83f}\ufad0',
+  colorFormats: ['r8uint', 'rg16uint', 'r32float', 'rgba8uint', 'rgba16float', 'rgb10a2unorm'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+document.body.prepend(img0);
+let textureView119 = texture123.createView({
+  label: '\u{1fab0}\u{1fdad}\u0375\ued00\u{1fa7e}\u9507\u0e8b\u068e\ubb98\u{1f667}\udc37',
+  mipLevelCount: 1
+});
+let renderBundleEncoder88 = device5.createRenderBundleEncoder({
+  label: '\u{1ff51}\u6ab2\u3cab\u0864\ud2d1\udff8\u88d3\ucf0e',
+  colorFormats: ['rg16uint'],
+  sampleCount: 4,
+  depthReadOnly: false
+});
+let computePassEncoder69 = commandEncoder93.beginComputePass();
+try {
+computePassEncoder67.setBindGroup(6, bindGroup4, []);
+} catch {}
+try {
+renderBundleEncoder77.setIndexBuffer(buffer43, 'uint16', 15544);
+} catch {}
+try {
+texture126.destroy();
+} catch {}
+try {
+buffer47.unmap();
+} catch {}
+try {
+commandEncoder97.copyBufferToBuffer(buffer34, 21984, buffer8, 6604, 832);
+dissociateBuffer(device1, buffer34);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder97.clearBuffer(buffer8, 5708, 5840);
+dissociateBuffer(device1, buffer8);
+} catch {}
+let video32 = await videoWithData();
+try {
+device5.label = '\u1878\u{1fc3a}\u005a\uaa23\uc993\u0101\ufddb\u916b\u0366';
+} catch {}
+let pipelineLayout20 = device5.createPipelineLayout({label: '\u0812\u{1fc92}\u{1f7db}', bindGroupLayouts: [bindGroupLayout39, bindGroupLayout39]});
+let renderBundleEncoder89 = device5.createRenderBundleEncoder({
+  label: '\ue2c8\ue67c\uc311\ua9eb\u9d34\u{1fd6d}\u{1fa02}\ub688\u06f5',
+  colorFormats: ['rg16uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+let renderBundle104 = renderBundleEncoder83.finish({label: '\u13f6\u0ed4\uec3c\u17e1\u8801\u09b7'});
+let sampler77 = device5.createSampler({
+label: '\u0416\u0d6f\ua86b\u047e\u4eb8\u4e99\uc507\u04ce\u1d4a',
+addressModeU: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 94.467,
+lodMaxClamp: 95.636,
+});
+try {
+renderBundleEncoder84.setBindGroup(2, bindGroup21);
+} catch {}
+let bindGroupLayout41 = device8.createBindGroupLayout({
+entries: [{
+binding: 4129,
+visibility: 0,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+}, {
+binding: 1813,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}],
+});
+let pipelineLayout21 = device8.createPipelineLayout({label: '\uc20b\u0887\u026b\u{1f642}\u0d7a\u0b47', bindGroupLayouts: []});
+let renderBundleEncoder90 = device8.createRenderBundleEncoder({label: '\ubdab\u473b', colorFormats: ['rg16sint'], sampleCount: 4, depthReadOnly: true});
+try {
+gpuCanvasContext28.configure({
+device: device8,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'depth24plus-stencil8'],
+alphaMode: 'premultiplied',
+});
+} catch {}
+let imageBitmap33 = await createImageBitmap(videoFrame14);
+let commandEncoder106 = device1.createCommandEncoder({label: '\u{1fd9d}\u24b2\u584c\u3849\u97c8\ue366\u051a\u021e\ud505\u24df\u307e'});
+let texture127 = device1.createTexture({
+label: '\u{1f740}\ueddd\u6604',
+size: {width: 192, height: 8, depthOrArrayLayers: 5},
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let sampler78 = device1.createSampler({
+label: '\u78d8\uc3bd\u146e\u385e\u33e9\u0589',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 73.534,
+lodMaxClamp: 85.891,
+maxAnisotropy: 12,
+});
+try {
+computePassEncoder63.setBindGroup(6, bindGroup12);
+} catch {}
+try {
+commandEncoder88.clearBuffer(buffer39);
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+device1.queue.submit([
+]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer39, 32856, new DataView(new ArrayBuffer(24032)));
+} catch {}
+let querySet87 = device7.createQuerySet({
+label: '\u5fc0\u02db',
+type: 'occlusion',
+count: 3175,
+});
+let texture128 = device7.createTexture({
+label: '\u{1ffdf}\u07e3\u4d29\u{1f775}\ub6ee',
+size: {width: 149, height: 2, depthOrArrayLayers: 47},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rg16sint', 'rg16sint'],
+});
+try {
+device7.queue.writeTexture({
+  texture: texture128,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 2 },
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 229 */
+{offset: 229}, {width: 9, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let img32 = await imageWithData(277, 150, '#bb7c3108', '#86461a73');
+let querySet88 = device5.createQuerySet({
+type: 'occlusion',
+count: 2643,
+});
+let texture129 = device5.createTexture({
+size: {width: 312, height: 1, depthOrArrayLayers: 244},
+mipLevelCount: 8,
+sampleCount: 1,
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundleEncoder91 = device5.createRenderBundleEncoder({label: '\ubf35\ude44\u{1ff94}\u3d12\u{1f627}\udce5', colorFormats: ['rg16uint'], sampleCount: 4});
+try {
+computePassEncoder66.setBindGroup(2, bindGroup21, new Uint32Array(3249), 2042, 0);
+} catch {}
+let imageBitmap34 = await createImageBitmap(canvas17);
+let renderBundleEncoder92 = device8.createRenderBundleEncoder({label: '\u5b68\uba41\u5712\u{1f804}', colorFormats: ['rg16sint'], sampleCount: 4});
+try {
+await device8.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundleEncoder93 = device6.createRenderBundleEncoder({
+  colorFormats: ['r8uint', 'rg16uint', 'r32float', 'rgba8uint', 'rgba16float', 'rgb10a2unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+let bindGroup23 = device1.createBindGroup({
+label: '\u{1f9be}\u5369\uc109\u3c84\u{1feae}\ufb1d\u2d12',
+layout: bindGroupLayout33,
+entries: [{
+binding: 1265,
+resource: externalTexture6
+}],
+});
+let commandEncoder107 = device1.createCommandEncoder({label: '\u{1f94d}\u{1fcc1}\uadd1'});
+let commandBuffer20 = commandEncoder106.finish({
+label: '\u{1ff2f}\u{1f608}\u01cc\u3cb7\u632e\uebfd\u{1f604}\u{1ffec}\u470a\u20c6',
+});
+try {
+renderBundleEncoder59.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+commandEncoder107.copyBufferToBuffer(buffer20, 660, buffer8, 1884, 508);
+dissociateBuffer(device1, buffer20);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder102.resolveQuerySet(querySet39, 2455, 199, buffer34, 3072);
+} catch {}
+try {
+commandEncoder107.insertDebugMarker('\u{1f8b0}');
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer20,
+commandBuffer18,
+]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 852, new DataView(new ArrayBuffer(49517)), 2042, 160);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 2,
+  origin: { x: 1, y: 16, z: 7 },
+  aspect: 'all',
+}, new DataView(arrayBuffer10), /* required buffer size: 18174504 */
+{offset: 736, bytesPerRow: 247, rowsPerImage: 373}, {width: 1, height: 98, depthOrArrayLayers: 198});
+} catch {}
+let pipeline100 = await device1.createComputePipelineAsync({
+label: '\u04b3\ud29a',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+},
+});
+let videoFrame31 = new VideoFrame(imageBitmap17, {timestamp: 0});
+let buffer48 = device7.createBuffer({
+  label: '\u{1f7ce}\u4105\u{1ff0e}\u{1f741}\ufa97',
+  size: 9948,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true
+});
+let texture130 = device7.createTexture({
+label: '\u0806\u198f\u65cd\u84e3\u{1fb2f}\u0bdf',
+size: [4858, 1, 174],
+mipLevelCount: 5,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['bgra8unorm-srgb'],
+});
+let textureView120 = texture128.createView({baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 0});
+let sampler79 = device7.createSampler({
+label: '\u{1fdea}\uaf23\u09a8\uf711\u0f23\uc986\u6cba\u0c31\u06cc',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 87.483,
+maxAnisotropy: 17,
+});
+let arrayBuffer14 = buffer48.getMappedRange(0, 9444);
+try {
+renderBundleEncoder87.setVertexBuffer(98, undefined, 110944318);
+} catch {}
+let gpuCanvasContext30 = offscreenCanvas35.getContext('webgpu');
+let offscreenCanvas36 = new OffscreenCanvas(346, 803);
+let imageBitmap35 = await createImageBitmap(imageData31);
+let commandEncoder108 = device5.createCommandEncoder({label: '\u7241\ub3eb\u{1f817}\u08c1\u063f\u{1ff5e}\ub70e\u{1fed8}\uf075\u0c1d'});
+let texture131 = device5.createTexture({
+label: '\ud487\u08d5\u2285\u8e96\u09e0',
+size: {width: 1248},
+dimension: '1d',
+format: 'rg32float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rg32float'],
+});
+let computePassEncoder70 = commandEncoder108.beginComputePass({});
+let promise49 = navigator.gpu.requestAdapter({
+});
+let imageData34 = new ImageData(16, 64);
+let videoFrame32 = new VideoFrame(video2, {timestamp: 0});
+let canvas37 = document.createElement('canvas');
+let gpuCanvasContext31 = canvas37.getContext('webgpu');
+let img33 = await imageWithData(156, 283, '#3a202db3', '#b225f877');
+let commandEncoder109 = device8.createCommandEncoder({});
+let texture132 = device8.createTexture({
+label: '\u010a\u029e\u{1fd71}\u0f2f\u323e\u0834\ub054\u62f4\u9b89',
+size: {width: 320, height: 24, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'r8snorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8snorm', 'r8snorm'],
+});
+try {
+renderBundleEncoder92.setVertexBuffer(22, undefined, 1724164326, 2202998771);
+} catch {}
+let texture133 = device6.createTexture({
+label: '\u781a\ucedb\ue4dd',
+size: {width: 140},
+dimension: '1d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView121 = texture133.createView({format: 'rgba8uint'});
+let renderBundleEncoder94 = device6.createRenderBundleEncoder({
+  label: '\u6016\u0a63\u09c5\uc83f\u0c12\u2352',
+  colorFormats: ['r8uint', 'rg16uint', 'r32float', 'rgba8uint', 'rgba16float', 'rgb10a2unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler80 = device6.createSampler({
+label: '\u4d0a\u{1f876}\ud73f\u0a9b\u64c5\uccff\u465c\u048d\u6600\u3e57\ue057',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 3.979,
+lodMaxClamp: 36.812,
+});
+try {
+gpuCanvasContext6.configure({
+device: device6,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['depth32float', 'r32float'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+gc();
+try {
+offscreenCanvas34.getContext('bitmaprenderer');
+} catch {}
+let textureView122 = texture51.createView({
+  label: '\u7ea6\u0847\u32d3\u{1fd9a}\u13b5\u9ab8\u0d64',
+  format: 'astc-4x4-unorm-srgb',
+  baseMipLevel: 1,
+  baseArrayLayer: 159,
+  arrayLayerCount: 8
+});
+try {
+computePassEncoder55.setBindGroup(1, bindGroup7, new Uint32Array(4184), 3952, 0);
+} catch {}
+try {
+renderBundleEncoder59.draw(32, 32, 80);
+} catch {}
+try {
+renderBundleEncoder59.drawIndexed(40);
+} catch {}
+try {
+renderBundleEncoder86.setPipeline(pipeline82);
+} catch {}
+try {
+buffer18.destroy();
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+try {
+commandEncoder88.copyBufferToTexture({
+/* bytesInLastRow: 112 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 23536 */
+offset: 23536,
+buffer: buffer47,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: { x: 4, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 28, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer47);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 48, new DataView(new ArrayBuffer(30751)), 18272, 332);
+} catch {}
+video23.width = 112;
+let commandBuffer21 = commandEncoder109.finish({
+label: '\ucc65\u09f6\u0329\u60ba\ufc70\u86e4\u{1fce6}',
+});
+let renderBundle105 = renderBundleEncoder92.finish({label: '\u421c\u6181\u06fa\u0e4a\u0bc5\udd7d'});
+let sampler81 = device8.createSampler({
+label: '\u0e11\u83cf\ubeab\u5a61\u{1fd81}\u6d46',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 32.612,
+compare: 'greater-equal',
+maxAnisotropy: 4,
+});
+try {
+await device8.queue.onSubmittedWorkDone();
+} catch {}
+let textureView123 = texture133.createView({label: '\u2ab1\u0614'});
+let buffer49 = device1.createBuffer({size: 3265, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let renderBundle106 = renderBundleEncoder14.finish();
+try {
+renderBundleEncoder66.setBindGroup(7, bindGroup4, new Uint32Array(9105), 7242, 0);
+} catch {}
+try {
+commandEncoder97.copyTextureToBuffer({
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 3, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 124 widthInBlocks: 31 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 592 */
+offset: 468,
+bytesPerRow: 256,
+rowsPerImage: 298,
+buffer: buffer39,
+}, {width: 31, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+gpuCanvasContext25.configure({
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float'],
+alphaMode: 'opaque',
+});
+} catch {}
+let pipeline101 = await device1.createComputePipelineAsync({
+label: '\u57da\u{1fc69}\u0a9a\u52db\u46e5\u7a9b\u4b9c\u0201',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let offscreenCanvas37 = new OffscreenCanvas(472, 299);
+try {
+adapter15.label = '\ud5f0\ue49e\u{1fa04}\u7bee\ua597\u{1f761}\u0195\u3808\u{1fe0d}\u6cd7\u0e9f';
+} catch {}
+let adapter23 = await promise49;
+let device9 = await adapter9.requestDevice({
+label: '\u5aa7\u4926\u8141\u085a\u32ed\u{1f70c}\uc8cd\u{1ffe4}\uf193',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 52,
+maxVertexAttributes: 29,
+maxVertexBufferArrayStride: 3582,
+maxStorageTexturesPerShaderStage: 17,
+maxStorageBuffersPerShaderStage: 43,
+maxDynamicStorageBuffersPerPipelineLayout: 45254,
+maxBindingsPerBindGroup: 1047,
+maxTextureDimension1D: 10333,
+maxTextureDimension2D: 12740,
+minStorageBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 78782145,
+maxUniformBuffersPerShaderStage: 19,
+maxInterStageShaderVariables: 30,
+maxInterStageShaderComponents: 65,
+maxSamplersPerShaderStage: 19,
+},
+});
+let commandEncoder110 = device3.createCommandEncoder({label: '\u0ba0\ua1e7\u3e76\u72a5\u0c01\u011a\u7fce\u3638\u61f5\u81e6'});
+let querySet89 = device3.createQuerySet({
+label: '\u{1fda9}\u1361\u{1fe57}\u{1f629}',
+type: 'occlusion',
+count: 3368,
+});
+try {
+renderBundleEncoder54.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder62.setVertexBuffer(3, buffer29, 3676, 538);
+} catch {}
+try {
+commandEncoder110.resolveQuerySet(querySet33, 861, 616, buffer33, 5632);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer37, 17808, new Int16Array(7572));
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture120,
+  mipLevel: 1,
+  origin: { x: 3, y: 3, z: 1 },
+  aspect: 'all',
+}, new DataView(arrayBuffer2), /* required buffer size: 285 */
+{offset: 285, bytesPerRow: 295}, {width: 5, height: 57, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder111 = device8.createCommandEncoder({label: '\u431b\u02a6\u{1fe34}\u5477\u8c04\u2d68\u701a\u85b9\u040c'});
+pseudoSubmit(device8, commandEncoder111);
+let texture134 = device8.createTexture({
+label: '\uc144\u4f8e\u07cb\u7e80\u08dd',
+size: [320, 24, 1],
+mipLevelCount: 6,
+format: 'etc2-rgb8a1unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8a1unorm'],
+});
+let textureView124 = texture132.createView({label: '\u{1f767}\u{1f983}\u6524\u{1fb4a}\u9544\u{1f7a6}\u6ee6', baseMipLevel: 3, mipLevelCount: 2});
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas37.getContext('webgl');
+} catch {}
+let renderBundleEncoder95 = device6.createRenderBundleEncoder({
+  label: '\u0f1d\udd97\uc340\u0ed4\u{1fb01}',
+  colorFormats: ['r8uint', 'rg16uint', 'r32float', 'rgba8uint', 'rgba16float', 'rgb10a2unorm'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder95.insertDebugMarker('\u869c');
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture133,
+  mipLevel: 0,
+  origin: { x: 78, y: 1, z: 1 },
+  aspect: 'all',
+}, arrayBuffer12, /* required buffer size: 357 */
+{offset: 357}, {width: 59, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas38 = new OffscreenCanvas(459, 88);
+let videoFrame33 = new VideoFrame(videoFrame28, {timestamp: 0});
+let buffer50 = device7.createBuffer({size: 54781, usage: GPUBufferUsage.INDEX});
+let commandEncoder112 = device7.createCommandEncoder({label: '\u{1f7e0}\u06c4\u7ba5\ue13c\u{1fa57}\uf70a'});
+let renderBundleEncoder96 = device7.createRenderBundleEncoder({
+  label: '\ufd5a\ud629\u5289\u02a9\u0876',
+  colorFormats: ['rgba16sint', 'rgba32sint', 'rgba32sint', 'rg16float', 'r16uint', undefined]
+});
+try {
+gpuCanvasContext31.configure({
+device: device7,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm', 'bgra8unorm', 'depth24plus-stencil8'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageData35 = new ImageData(76, 228);
+let gpuCanvasContext32 = offscreenCanvas33.getContext('webgpu');
+canvas3.width = 415;
+let img34 = await imageWithData(86, 265, '#b0c1807e', '#42beed73');
+let commandEncoder113 = device6.createCommandEncoder();
+let renderBundleEncoder97 = device6.createRenderBundleEncoder({
+  label: '\u{1fb46}\uef9c',
+  colorFormats: ['r8uint', 'rg16uint', 'r32float', 'rgba8uint', 'rgba16float', 'rgb10a2unorm'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder94.setVertexBuffer(44, undefined, 1563203222);
+} catch {}
+pseudoSubmit(device1, commandEncoder83);
+let sampler82 = device1.createSampler({
+label: '\uf868\u10b7\uddd8\ufb69\u2101\u5fa4\u0221\ucf54\u328d',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 63.872,
+lodMaxClamp: 75.938,
+});
+try {
+renderBundleEncoder57.drawIndexed(72);
+} catch {}
+try {
+renderBundleEncoder59.setVertexBuffer(47, undefined, 3919681797, 184618806);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: video14,
+  origin: { x: 1, y: 2 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 22, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas38 = document.createElement('canvas');
+let offscreenCanvas39 = new OffscreenCanvas(913, 886);
+let img35 = await imageWithData(162, 214, '#ef8d5ffa', '#7ef507b3');
+let bindGroupLayout42 = device1.createBindGroupLayout({
+entries: [{
+binding: 2984,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '1d' },
+}, {
+binding: 516,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}],
+});
+let texture135 = device1.createTexture({
+label: '\ufe66\ua339',
+size: {width: 96, height: 4, depthOrArrayLayers: 234},
+mipLevelCount: 3,
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['etc2-rgb8unorm', 'etc2-rgb8unorm-srgb'],
+});
+let textureView125 = texture135.createView({dimension: '2d', format: 'etc2-rgb8unorm', mipLevelCount: 1, baseArrayLayer: 68});
+let renderBundleEncoder98 = device1.createRenderBundleEncoder({
+  colorFormats: ['r32float', 'rgb10a2unorm', 'rg16sint', 'r32float'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder59.drawIndexed(16, 80, 8, 448);
+} catch {}
+try {
+commandEncoder107.resolveQuerySet(querySet57, 261, 533, buffer34, 15616);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer39, 37356, new DataView(new ArrayBuffer(25328)));
+} catch {}
+let commandEncoder114 = device8.createCommandEncoder({label: '\u9e7d\u0a04\u0fd8'});
+let renderBundle107 = renderBundleEncoder90.finish({label: '\uc76d\uaccb\u{1f60d}\u068c\u40be'});
+let sampler83 = device8.createSampler({
+label: '\u{1f69d}\uba0a\u2ffc\ubca4',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 74.998,
+maxAnisotropy: 15,
+});
+try {
+gpuCanvasContext29.configure({
+device: device8,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba8sint', 'rgba8unorm'],
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+gc();
+let img36 = await imageWithData(293, 131, '#935bea14', '#fd8c2002');
+let buffer51 = device6.createBuffer({label: '\u7a69\u6e3e\u6c7c\ucdfc\u2d5d', size: 48001, usage: GPUBufferUsage.COPY_SRC});
+let querySet90 = device9.createQuerySet({
+label: '\u50cf\ucc9c\u7bba',
+type: 'occlusion',
+count: 1815,
+});
+let renderBundleEncoder99 = device9.createRenderBundleEncoder({
+  label: '\u0d0d\u769b\u{1f71a}\u1959\u0dc7\udfec\u05c6\u52a9',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2unorm', 'rg32float', 'rgba8unorm', 'r8uint', 'rgba8unorm-srgb', 'rg8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle108 = renderBundleEncoder99.finish();
+let sampler84 = device9.createSampler({
+label: '\u9d30\u{1fdde}\ub546\u{1fad5}\u0e06\u{1f99c}\u0393',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 50.227,
+lodMaxClamp: 85.156,
+compare: 'greater',
+});
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+let video33 = await videoWithData();
+let renderBundle109 = renderBundleEncoder77.finish({label: '\ud248\uba4f\u057d\uc676\u038a\u9b13\u{1fd73}\u{1f787}\u09ad\u4ec0\u02f6'});
+let sampler85 = device1.createSampler({
+label: '\u0561\u2b8c\udb7d\u{1fd27}\u05dc\u94b8',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 99.716,
+lodMaxClamp: 99.840,
+});
+try {
+renderBundleEncoder25.setVertexBuffer(78, undefined, 1091144514, 1322593844);
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let videoFrame34 = new VideoFrame(img13, {timestamp: 0});
+let sampler86 = device1.createSampler({
+label: '\u5a74\u6e2a\u45de\u095f\u5f2e\u{1f8b1}\uee8b\u4a10\u3ec8\u2c29\u{1fa26}',
+addressModeU: 'mirror-repeat',
+magFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMaxClamp: 96.214,
+compare: 'not-equal',
+});
+try {
+renderBundleEncoder70.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder59.drawIndexed(24);
+} catch {}
+try {
+computePassEncoder60.pushDebugGroup('\u4cb5');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas10,
+  origin: { x: 171, y: 464 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 10, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 14, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video14);
+let buffer52 = device3.createBuffer({
+  label: '\u{1fb6e}\u0020\u0d61\u018b\u0354\u03f6\ub5b5\u292f\u0ee3\u071c',
+  size: 39369,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: false
+});
+let texture136 = device3.createTexture({
+label: '\u8be0\u9637\u372d\ud88e\u0696\uac06',
+size: [128, 240, 244],
+mipLevelCount: 7,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder51.setBindGroup(0, bindGroup9, new Uint32Array(6862), 4536, 0);
+} catch {}
+try {
+renderBundleEncoder79.setIndexBuffer(buffer35, 'uint16', 6126, 102);
+} catch {}
+try {
+commandEncoder110.copyBufferToBuffer(buffer35, 28928, buffer19, 10712, 2040);
+dissociateBuffer(device3, buffer35);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+commandEncoder110.clearBuffer(buffer37);
+dissociateBuffer(device3, buffer37);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 367 */
+{offset: 367}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline102 = device3.createRenderPipeline({
+layout: pipelineLayout11,
+multisample: {
+mask: 0x282d5a7a,
+},
+fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint'}, undefined, {format: 'r32sint', writeMask: GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: 0}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'src-alpha-saturated'},
+},
+  writeMask: GPUColorWrite.GREEN
+}, {format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rg32uint'}, {
+  format: 'rgb10a2unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 912,
+stencilWriteMask: 3536,
+depthBias: 87,
+depthBiasSlopeScale: 92,
+depthBiasClamp: 90,
+},
+vertex: {
+  module: shaderModule14,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 5988,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x3',
+offset: 2644,
+shaderLocation: 10,
+}, {
+format: 'float16x2',
+offset: 4768,
+shaderLocation: 25,
+}, {
+format: 'unorm16x2',
+offset: 2544,
+shaderLocation: 3,
+}, {
+format: 'uint8x2',
+offset: 2978,
+shaderLocation: 20,
+}, {
+format: 'snorm8x4',
+offset: 3096,
+shaderLocation: 12,
+}, {
+format: 'float16x2',
+offset: 1228,
+shaderLocation: 14,
+}, {
+format: 'unorm16x2',
+offset: 2344,
+shaderLocation: 18,
+}, {
+format: 'sint8x4',
+offset: 588,
+shaderLocation: 21,
+}, {
+format: 'sint16x2',
+offset: 1296,
+shaderLocation: 24,
+}, {
+format: 'unorm8x4',
+offset: 2508,
+shaderLocation: 17,
+}, {
+format: 'uint16x2',
+offset: 4440,
+shaderLocation: 19,
+}, {
+format: 'float32x2',
+offset: 3904,
+shaderLocation: 8,
+}, {
+format: 'sint16x4',
+offset: 5308,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 13084,
+attributes: [{
+format: 'snorm8x4',
+offset: 9696,
+shaderLocation: 4,
+}, {
+format: 'uint8x4',
+offset: 5796,
+shaderLocation: 9,
+}, {
+format: 'sint32x2',
+offset: 4540,
+shaderLocation: 22,
+}, {
+format: 'sint8x4',
+offset: 5824,
+shaderLocation: 23,
+}, {
+format: 'unorm16x4',
+offset: 11852,
+shaderLocation: 15,
+}, {
+format: 'uint32',
+offset: 1696,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 27420,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 3614,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 5784,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 10716,
+attributes: [{
+format: 'sint32x4',
+offset: 2500,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 14780,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 13408,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x2',
+offset: 10572,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+frontFace: 'cw',
+cullMode: 'back',
+},
+});
+let canvas39 = document.createElement('canvas');
+let sampler87 = device5.createSampler({
+label: '\u1685\u0bac\ufd49',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 23.006,
+});
+try {
+gpuCanvasContext8.configure({
+device: device5,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16float', 'rg8unorm', 'rgba8unorm'],
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let renderBundle110 = renderBundleEncoder92.finish({label: '\u02f1\u{1fc0e}\ufbcc\u{1ffaa}\u{1fffb}\u375a\u0680'});
+let sampler88 = device8.createSampler({
+label: '\ud47a\u0a8b\u021d\u06dd\u09a3\u{1ffa6}\ua78f\uef65',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMaxClamp: 94.311,
+});
+gc();
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandBuffer22 = commandEncoder114.finish({
+label: '\u547c\uc877\u5ea0\u1a1d',
+});
+let textureView126 = texture134.createView({label: '\u{1fd55}\u7c17\u{1fe3f}\u4bbf\u{1fe9a}\u0611\u08a2\uae66', baseMipLevel: 5});
+let sampler89 = device8.createSampler({
+label: '\u096d\uf487\uc2a3\uead6\ud76f\u5488\ube0b\u26c3',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 42.591,
+maxAnisotropy: 15,
+});
+let commandEncoder115 = device6.createCommandEncoder({});
+let computePassEncoder71 = commandEncoder115.beginComputePass({label: '\u0fd9\u348e'});
+let video34 = await videoWithData();
+let textureView127 = texture59.createView({baseMipLevel: 1});
+try {
+computePassEncoder51.setPipeline(pipeline84);
+} catch {}
+try {
+renderBundleEncoder71.setBindGroup(4, bindGroup14);
+} catch {}
+try {
+commandEncoder110.copyBufferToBuffer(buffer29, 68, buffer37, 9592, 1716);
+dissociateBuffer(device3, buffer29);
+dissociateBuffer(device3, buffer37);
+} catch {}
+let device10 = await adapter18.requestDevice({
+label: '\u{1fd44}\uab11\u{1f661}\u03fb',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 45,
+maxVertexAttributes: 27,
+maxVertexBufferArrayStride: 40432,
+maxStorageTexturesPerShaderStage: 18,
+maxStorageBuffersPerShaderStage: 19,
+maxDynamicStorageBuffersPerPipelineLayout: 12639,
+maxBindingsPerBindGroup: 7151,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 10393,
+maxTextureDimension2D: 12458,
+maxVertexBuffers: 12,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 156446444,
+maxUniformBuffersPerShaderStage: 38,
+maxInterStageShaderVariables: 85,
+maxInterStageShaderComponents: 90,
+},
+});
+try {
+gpuCanvasContext8.configure({
+device: device10,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+});
+} catch {}
+let device11 = await adapter13.requestDevice({
+label: '\u03d4\u752c\uc20d\u{1fc2b}',
+requiredFeatures: [
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 9,
+maxColorAttachmentBytesPerSample: 37,
+maxVertexAttributes: 27,
+maxVertexBufferArrayStride: 35717,
+maxStorageTexturesPerShaderStage: 8,
+maxStorageBuffersPerShaderStage: 23,
+maxDynamicStorageBuffersPerPipelineLayout: 9293,
+maxBindingsPerBindGroup: 6970,
+maxTextureDimension1D: 12367,
+maxTextureDimension2D: 16359,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 162668265,
+maxUniformBuffersPerShaderStage: 34,
+maxInterStageShaderVariables: 114,
+maxInterStageShaderComponents: 105,
+},
+});
+let offscreenCanvas40 = new OffscreenCanvas(403, 114);
+let imageBitmap36 = await createImageBitmap(imageBitmap15);
+let commandEncoder116 = device9.createCommandEncoder();
+let renderBundleEncoder100 = device9.createRenderBundleEncoder({
+  label: '\u0220\u{1fb89}\u0ef9\u0983\u0e24\ub5db',
+  colorFormats: ['r16float', 'r8sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+let renderBundle111 = renderBundleEncoder100.finish();
+let textureView128 = texture133.createView({label: '\u5ada\u020d\u4446\u8b9d\u0281\u2cf5\u0dbb\u023e'});
+let renderBundle112 = renderBundleEncoder93.finish({label: '\u472f\ue862'});
+try {
+computePassEncoder71.insertDebugMarker('\ufaf7');
+} catch {}
+let pipelineLayout22 = device3.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout27, bindGroupLayout22, bindGroupLayout32, bindGroupLayout32, bindGroupLayout34, bindGroupLayout32]
+});
+let querySet91 = device3.createQuerySet({
+label: '\udd90\u5e30\ufe1b\u06c5\u{1fbd1}\u{1f95c}\u055f',
+type: 'occlusion',
+count: 3589,
+});
+try {
+computePassEncoder53.setBindGroup(8, bindGroup14, new Uint32Array(5458), 36, 0);
+} catch {}
+try {
+device3.queue.writeBuffer(buffer40, 5212, new DataView(new ArrayBuffer(7341)), 5803, 1256);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 1,
+  origin: { x: 0, y: 24, z: 1 },
+  aspect: 'all',
+}, new Int16Array(arrayBuffer8), /* required buffer size: 707 */
+{offset: 707, bytesPerRow: 292, rowsPerImage: 195}, {width: 20, height: 64, depthOrArrayLayers: 0});
+} catch {}
+let promise50 = navigator.gpu.requestAdapter();
+let commandEncoder117 = device10.createCommandEncoder();
+let computePassEncoder72 = commandEncoder117.beginComputePass();
+try {
+await adapter19.requestAdapterInfo();
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let texture137 = device6.createTexture({
+size: {width: 140, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['bgra8unorm-srgb'],
+});
+let renderBundleEncoder101 = device6.createRenderBundleEncoder({
+  label: '\u0dd3\u0746\u09a2',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler90 = device6.createSampler({
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 38.530,
+lodMaxClamp: 39.529,
+});
+try {
+gpuCanvasContext23.configure({
+device: device6,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba8unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroupLayout43 = device11.createBindGroupLayout({
+label: '\u2e0b\ue339\ua58d\u8f30\u817c\u0db6\u54d1\u0d71\u0de0',
+entries: [{
+binding: 4677,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}, {
+binding: 772,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 5512,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '1d' },
+}],
+});
+let texture138 = device10.createTexture({
+size: [240, 80, 254],
+mipLevelCount: 3,
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x8-unorm-srgb'],
+});
+let renderBundleEncoder102 = device10.createRenderBundleEncoder({
+  label: '\u6a4d\u06b5\u{1f713}\u0dde\u29d1\u123d\u5f29\u3e34\u853c',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle113 = renderBundleEncoder102.finish();
+try {
+texture138.destroy();
+} catch {}
+try {
+await device10.queue.onSubmittedWorkDone();
+} catch {}
+let video35 = await videoWithData();
+try {
+canvas36.getContext('webgpu');
+} catch {}
+let imageBitmap37 = await createImageBitmap(videoFrame6);
+try {
+device9.queue.label = '\u{1fa50}\u{1fc06}\u{1f9d6}\u1652\u1349\u0a0c\u5580\ub6fa\ue5d9\u{1fa4e}';
+} catch {}
+let texture139 = device9.createTexture({
+label: '\u0ce6\u996f\ua25b\u{1fcc8}\ufd44\u8470\u431b\u{1ff43}',
+size: {width: 1633, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16uint'],
+});
+let textureView129 = texture139.createView({dimension: '2d-array', baseMipLevel: 1});
+let renderBundle114 = renderBundleEncoder99.finish({});
+try {
+gpuCanvasContext32.unconfigure();
+} catch {}
+document.body.prepend(canvas8);
+let querySet92 = device7.createQuerySet({
+label: '\ud61f\u0c81',
+type: 'occlusion',
+count: 2298,
+});
+let renderBundleEncoder103 = device7.createRenderBundleEncoder({
+  label: '\u0837\u{1fb9d}\u5daa\u7905\ue800\u0f8e\u7edf',
+  colorFormats: ['rgba16sint', 'rgba32sint', 'rgba32sint', 'rg16float', 'r16uint', undefined]
+});
+let renderBundle115 = renderBundleEncoder96.finish({label: '\u79e5\u401a\u{1f94b}\uc022\u576e\u2032\ued60\ue756\u0388\u0313'});
+try {
+buffer48.unmap();
+} catch {}
+let textureView130 = texture130.createView({
+  label: '\u32ec\u0a02',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 130,
+  arrayLayerCount: 43
+});
+let renderBundle116 = renderBundleEncoder103.finish({label: '\u{1fd95}\u59e3'});
+let promise51 = device7.queue.onSubmittedWorkDone();
+let promise52 = navigator.gpu.requestAdapter({
+});
+let texture140 = device1.createTexture({
+label: '\ud957\u4c18\ufd73\u007b\u0866\u{1f768}',
+size: [140, 10, 161],
+mipLevelCount: 7,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+renderBundleEncoder37.draw(64, 16);
+} catch {}
+try {
+renderBundleEncoder59.setIndexBuffer(buffer18, 'uint32', 7276, 46066);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+try {
+commandEncoder97.copyBufferToBuffer(buffer49, 904, buffer39, 25748, 1676);
+dissociateBuffer(device1, buffer49);
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+commandEncoder107.clearBuffer(buffer21);
+dissociateBuffer(device1, buffer21);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap27,
+  origin: { x: 412, y: 131 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 10, y: 2, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 33, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline103 = await device1.createComputePipelineAsync({
+label: '\u0261\u{1f865}\u{1f6a7}\u1967\u{1f957}\u02b9\u0e31\u{1fc47}\uc6c6\u751d\u5cae',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let videoFrame35 = new VideoFrame(video23, {timestamp: 0});
+let renderBundleEncoder104 = device5.createRenderBundleEncoder({
+  label: '\u7e0f\u{1fbfa}\u686f\uadd1\u33f5\u{1fa5b}\u{1fea1}\u05cc',
+  colorFormats: ['rg32float', 'r8sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+try {
+computePassEncoder66.setBindGroup(2, bindGroup21);
+} catch {}
+let promise53 = buffer48.mapAsync(GPUMapMode.READ, 3768, 4568);
+let gpuCanvasContext33 = offscreenCanvas40.getContext('webgpu');
+let gpuCanvasContext34 = offscreenCanvas39.getContext('webgpu');
+offscreenCanvas35.width = 407;
+let bindGroup24 = device5.createBindGroup({
+layout: bindGroupLayout39,
+entries: [],
+});
+let commandEncoder118 = device5.createCommandEncoder({label: '\u05c5\u0e5c\u9607\u5786\u{1f8fd}\u022f\u0235\u{1f665}\u01fa\u{1fcab}'});
+let texture141 = device5.createTexture({
+label: '\u1266\uc0d5\u4176',
+size: {width: 1248},
+dimension: '1d',
+format: 'rgba16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float'],
+});
+let sampler91 = device5.createSampler({
+label: '\u811c\u0257\u060e\u{1fe08}\u{1f6c8}\u{1fff8}\u65ab',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 32.059,
+lodMaxClamp: 77.499,
+compare: 'greater-equal',
+});
+let bindGroupLayout44 = device5.createBindGroupLayout({
+label: '\u{1fd3e}\u{1f7be}\u293e\ue651\u{1fd71}\u{1f70b}',
+entries: [{
+binding: 180,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}, {
+binding: 101,
+visibility: 0,
+storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '2d' },
+}, {
+binding: 251,
+visibility: 0,
+sampler: { type: 'comparison' },
+}],
+});
+let renderBundleEncoder105 = device5.createRenderBundleEncoder({
+  label: '\uee4e\u{1f8d1}\u0a3f\ube54\udfeb\ue9c1\u{1facc}\u{1f6d6}\uddff\u036b',
+  colorFormats: ['r32float', 'r8sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle117 = renderBundleEncoder84.finish({});
+let promise54 = device5.queue.onSubmittedWorkDone();
+try {
+  await promise53;
+} catch {}
+let gpuCanvasContext35 = canvas38.getContext('webgpu');
+try {
+  await promise54;
+} catch {}
+let img37 = await imageWithData(271, 183, '#a54da85f', '#54bbe7fc');
+let bindGroupLayout45 = device1.createBindGroupLayout({
+label: '\u0858\udb5e',
+entries: [{
+binding: 3389,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '1d' },
+}, {
+binding: 1057,
+visibility: 0,
+buffer: { type: 'uniform', minBindingSize: 859088, hasDynamicOffset: false },
+}, {
+binding: 2074,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+}],
+});
+let pipelineLayout23 = device1.createPipelineLayout({
+  label: '\u0f25\u0f60\u253e\u047a\u0dcc\u1421\u28a8\u02c6\uf7e7\u{1fa49}',
+  bindGroupLayouts: [bindGroupLayout11, bindGroupLayout21, bindGroupLayout6, bindGroupLayout45, bindGroupLayout2, bindGroupLayout2, bindGroupLayout25, bindGroupLayout6]
+});
+let buffer53 = device1.createBuffer({
+  label: '\u5d60\u4a46\u381e\u{1ff5d}\u04d2\u0a70\u04f1\u{1fe00}\u{1facb}',
+  size: 9228,
+  usage: GPUBufferUsage.STORAGE,
+  mappedAtCreation: false
+});
+let texture142 = device1.createTexture({
+label: '\u5ae8\u0fd0',
+size: [108, 768, 1],
+mipLevelCount: 5,
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.COPY_DST,
+});
+let textureView131 = texture140.createView({label: '\u0b48\uea70\u6ad1', baseMipLevel: 4, mipLevelCount: 2, baseArrayLayer: 39, arrayLayerCount: 29});
+try {
+renderBundleEncoder37.draw(24, 24, 80, 48);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer43, 'uint16');
+} catch {}
+let promise55 = buffer49.mapAsync(GPUMapMode.WRITE, 0, 3088);
+try {
+commandEncoder88.resolveQuerySet(querySet32, 983, 1000, buffer34, 5120);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture88,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer14, /* required buffer size: 613 */
+{offset: 613, bytesPerRow: 162}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline104 = device1.createRenderPipeline({
+label: '\ud9da\u{1fce6}\u9b12\u1853\u{1fdb6}',
+layout: pipelineLayout8,
+multisample: {
+count: 4,
+mask: 0xd2b430f7,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'r32uint', writeMask: 0}, {format: 'rg8sint', writeMask: 0}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'constant', dstFactor: 'one-minus-src'},
+alpha: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-constant'},
+},
+  writeMask: 0
+}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32sint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 256,
+stencilWriteMask: 1953,
+depthBiasSlopeScale: 52,
+depthBiasClamp: 61,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x2',
+offset: 30340,
+shaderLocation: 15,
+}, {
+format: 'unorm8x2',
+offset: 30388,
+shaderLocation: 6,
+}, {
+format: 'float32x4',
+offset: 9668,
+shaderLocation: 20,
+}, {
+format: 'sint8x2',
+offset: 12728,
+shaderLocation: 16,
+}, {
+format: 'uint32',
+offset: 24940,
+shaderLocation: 14,
+}, {
+format: 'sint16x4',
+offset: 12200,
+shaderLocation: 13,
+}, {
+format: 'snorm8x2',
+offset: 13692,
+shaderLocation: 1,
+}, {
+format: 'float32x2',
+offset: 18284,
+shaderLocation: 8,
+}, {
+format: 'uint16x2',
+offset: 21548,
+shaderLocation: 10,
+}, {
+format: 'uint32x4',
+offset: 456,
+shaderLocation: 22,
+}, {
+format: 'snorm8x2',
+offset: 16040,
+shaderLocation: 0,
+}, {
+format: 'float32x2',
+offset: 26220,
+shaderLocation: 7,
+}, {
+format: 'uint8x4',
+offset: 5736,
+shaderLocation: 24,
+}, {
+format: 'uint8x4',
+offset: 4060,
+shaderLocation: 12,
+}, {
+format: 'sint8x2',
+offset: 15996,
+shaderLocation: 5,
+}, {
+format: 'uint32x4',
+offset: 23492,
+shaderLocation: 26,
+}, {
+format: 'snorm8x2',
+offset: 32996,
+shaderLocation: 2,
+}, {
+format: 'sint16x2',
+offset: 22116,
+shaderLocation: 25,
+}],
+},
+{
+arrayStride: 16604,
+attributes: [{
+format: 'uint32x4',
+offset: 844,
+shaderLocation: 17,
+}, {
+format: 'unorm8x2',
+offset: 13168,
+shaderLocation: 4,
+}, {
+format: 'unorm16x4',
+offset: 2984,
+shaderLocation: 21,
+}],
+}
+]
+},
+});
+let buffer54 = device3.createBuffer({
+  label: '\uafc1\u0285\u733a\u3883\u1bcb\u{1f83a}',
+  size: 11482,
+  usage: GPUBufferUsage.VERTEX,
+  mappedAtCreation: false
+});
+try {
+renderBundleEncoder82.setBindGroup(5, bindGroup15, new Uint32Array(2014), 405, 0);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST,
+colorSpace: 'display-p3',
+});
+} catch {}
+let offscreenCanvas41 = new OffscreenCanvas(154, 947);
+let shaderModule19 = device1.createShaderModule({
+code: `@group(0) @binding(542)
+var<storage, read_write> parameter16: array<u32>;
+@group(8) @binding(1723)
+var<storage, read_write> parameter17: array<u32>;
+@group(5) @binding(1300)
+var<storage, read_write> global12: array<u32>;
+@group(10) @binding(3399)
+var<storage, read_write> function7: array<u32>;
+@group(10) @binding(3240)
+var<storage, read_write> local16: array<u32>;
+@group(6) @binding(3399)
+var<storage, read_write> type22: array<u32>;
+@group(5) @binding(704)
+var<storage, read_write> parameter18: array<u32>;
+@group(9) @binding(1145)
+var<storage, read_write> parameter19: array<u32>;
+@group(1) @binding(3524)
+var<storage, read_write> parameter20: array<u32>;
+@group(4) @binding(704)
+var<storage, read_write> global13: array<u32>;
+@group(7) @binding(542)
+var<storage, read_write> local17: array<u32>;
+@group(10) @binding(1145)
+var<storage, read_write> local18: array<u32>;
+@group(9) @binding(3399)
+var<storage, read_write> type23: array<u32>;
+@group(6) @binding(3240)
+var<storage, read_write> function8: array<u32>;
+
+@compute @workgroup_size(1, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S25 {
+  @location(24) f0: vec4<i32>,
+  @location(31) f1: vec2<i32>,
+  @location(38) f2: vec4<f32>,
+  @location(29) f3: vec2<f32>,
+  @location(28) f4: vec2<f16>,
+  @location(2) f5: vec3<f32>,
+  @location(6) f6: f32,
+  @location(18) f7: vec4<i32>,
+  @builtin(sample_index) f8: u32,
+  @location(1) f9: vec4<f16>,
+  @location(45) f10: i32,
+  @location(3) f11: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @location(1) f1: vec4<i32>,
+  @location(2) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(16) a0: vec3<u32>, @location(40) a1: vec4<u32>, @location(4) a2: vec4<f32>, @location(33) a3: u32, @location(36) a4: vec2<u32>, @location(30) a5: vec3<f16>, a6: S25, @location(13) a7: vec3<i32>, @location(7) a8: vec2<i32>, @location(5) a9: i32, @builtin(position) a10: vec4<f32>, @builtin(front_facing) a11: bool, @builtin(sample_mask) a12: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S24 {
+  @location(7) f0: vec4<i32>,
+  @location(3) f1: vec4<u32>,
+  @location(22) f2: f32,
+  @location(21) f3: f32,
+  @location(13) f4: vec3<f16>,
+  @builtin(vertex_index) f5: u32,
+  @builtin(instance_index) f6: u32,
+  @location(26) f7: vec4<f32>,
+  @location(5) f8: vec2<f16>,
+  @location(4) f9: vec4<i32>,
+  @location(20) f10: vec3<u32>,
+  @location(1) f11: vec3<i32>,
+  @location(15) f12: f16
+}
+struct VertexOutput0 {
+  @location(24) f420: vec4<i32>,
+  @location(3) f421: vec4<f32>,
+  @location(13) f422: vec3<i32>,
+  @location(33) f423: u32,
+  @location(36) f424: vec2<u32>,
+  @builtin(position) f425: vec4<f32>,
+  @location(28) f426: vec2<f16>,
+  @location(29) f427: vec2<f32>,
+  @location(31) f428: vec2<i32>,
+  @location(6) f429: f32,
+  @location(4) f430: vec4<f32>,
+  @location(30) f431: vec3<f16>,
+  @location(2) f432: vec3<f32>,
+  @location(16) f433: vec3<u32>,
+  @location(1) f434: vec4<f16>,
+  @location(5) f435: i32,
+  @location(7) f436: vec2<i32>,
+  @location(18) f437: vec4<i32>,
+  @location(45) f438: i32,
+  @location(40) f439: vec4<u32>,
+  @location(38) f440: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(25) a0: vec3<u32>, @location(11) a1: vec2<u32>, @location(24) a2: vec3<i32>, @location(10) a3: i32, @location(19) a4: f32, @location(18) a5: vec4<i32>, @location(9) a6: vec4<f16>, @location(2) a7: vec4<f16>, @location(16) a8: vec4<i32>, @location(17) a9: vec3<i32>, @location(23) a10: i32, @location(0) a11: i32, @location(12) a12: f16, @location(6) a13: f16, @location(8) a14: vec4<u32>, @location(14) a15: vec2<u32>, a16: S24) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+});
+let bindGroupLayout46 = device1.createBindGroupLayout({
+label: '\ub81d\uddf2\u4428\u0d03\u77ab\u3593\uf3fa\u{1f64c}',
+entries: [],
+});
+let querySet93 = device1.createQuerySet({
+label: '\u{1ff67}\u{1fb07}\u{1fb3f}\u6d36',
+type: 'occlusion',
+count: 1067,
+});
+let textureView132 = texture142.createView({label: '\u0923\u84b9\udb3a\u{1fbe1}', dimension: '2d-array', baseMipLevel: 1});
+try {
+renderBundleEncoder57.draw(8, 64);
+} catch {}
+try {
+commandEncoder97.copyBufferToBuffer(buffer36, 364, buffer20, 580, 132);
+dissociateBuffer(device1, buffer36);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame29,
+  origin: { x: 0, y: 50 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 39, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let imageData36 = new ImageData(192, 64);
+let videoFrame36 = new VideoFrame(offscreenCanvas23, {timestamp: 0});
+let texture143 = device1.createTexture({
+label: '\u02d8\u8b85\u5a9d\u0fc6\u0e86\u{1f7af}\uadb7',
+size: {width: 384, height: 5, depthOrArrayLayers: 1},
+format: 'astc-6x5-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+renderBundleEncoder57.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+commandEncoder88.copyBufferToBuffer(buffer20, 776, buffer8, 1176, 476);
+dissociateBuffer(device1, buffer20);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder97.clearBuffer(buffer27);
+dissociateBuffer(device1, buffer27);
+} catch {}
+let imageData37 = new ImageData(148, 104);
+let gpuCanvasContext36 = offscreenCanvas38.getContext('webgpu');
+gc();
+let videoFrame37 = new VideoFrame(img2, {timestamp: 0});
+let commandEncoder119 = device11.createCommandEncoder({label: '\u096a\u0db9'});
+let texture144 = device11.createTexture({
+label: '\u00c6\u35e2\u08e6\ucec2\u047d\u00f7\ufdb8\uf938',
+size: [1024],
+dimension: '1d',
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['r32sint', 'r32sint'],
+});
+let computePassEncoder73 = commandEncoder119.beginComputePass({label: '\u{1fd76}\u4448\u655f\u0fca\u433c\ue0fc\u0be6'});
+let promise56 = device11.queue.onSubmittedWorkDone();
+try {
+  await promise51;
+} catch {}
+let shaderModule20 = device3.createShaderModule({
+label: '\u737c\u{1fc0d}\ub5b6\u0fee\u2847\ucee0\u{1f62c}\u08aa\u985f\u{1fee3}',
+code: `@group(4) @binding(6976)
+var<storage, read_write> i12: array<u32>;
+@group(8) @binding(7747)
+var<storage, read_write> i13: array<u32>;
+@group(8) @binding(2070)
+var<storage, read_write> i14: array<u32>;
+@group(6) @binding(2662)
+var<storage, read_write> local19: array<u32>;
+
+@compute @workgroup_size(2, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(frag_depth) f0: f32,
+  @location(2) f1: vec4<u32>,
+  @location(7) f2: vec2<u32>,
+  @location(0) f3: vec2<f32>,
+  @location(3) f4: vec2<f32>,
+  @location(5) f5: vec4<u32>,
+  @location(1) f6: vec4<u32>,
+  @location(4) f7: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S26 {
+  @location(4) f0: vec3<u32>,
+  @builtin(instance_index) f1: u32,
+  @location(5) f2: i32,
+  @location(8) f3: vec4<f16>,
+  @location(9) f4: f32,
+  @builtin(vertex_index) f5: u32,
+  @location(13) f6: vec3<i32>,
+  @location(10) f7: u32,
+  @location(21) f8: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(16) a0: vec4<u32>, @location(3) a1: f16, @location(20) a2: vec4<u32>, a3: S26, @location(7) a4: vec2<f32>, @location(19) a5: u32, @location(0) a6: vec2<f32>, @location(24) a7: vec4<u32>, @location(12) a8: vec2<f16>, @location(6) a9: vec4<i32>, @location(11) a10: vec4<i32>, @location(18) a11: vec3<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+});
+let texture145 = device3.createTexture({
+label: '\u9cd4\u01e8\u09e9\u01ba\ud450\u7cd1\u0167\u{1fc83}',
+size: [60, 240, 1],
+mipLevelCount: 7,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+computePassEncoder52.insertDebugMarker('\u{1f95e}');
+} catch {}
+try {
+  await promise55;
+} catch {}
+let bindGroup25 = device3.createBindGroup({
+label: '\u0d27\u{1f9d6}\ue6d4\u2e93\u0466\u{1fcde}\u022c\u0e92\uf73f',
+layout: bindGroupLayout38,
+entries: [],
+});
+try {
+renderBundleEncoder82.setBindGroup(4, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder79.setVertexBuffer(0, buffer44, 47164, 2774);
+} catch {}
+try {
+commandEncoder51.clearBuffer(buffer37);
+dissociateBuffer(device3, buffer37);
+} catch {}
+try {
+gpuCanvasContext25.configure({
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['bgra8unorm', 'rgba8unorm'],
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device3.queue.writeBuffer(buffer37, 5204, new Float32Array(1085));
+} catch {}
+let textureView133 = texture61.createView({
+  label: '\u51b2\u315a\u{1fab2}\u0570\u{1f932}\ub4bd\u04bc\uca82\u0d55\u58d4',
+  dimension: '2d',
+  baseMipLevel: 3,
+  mipLevelCount: 4,
+  baseArrayLayer: 8
+});
+let renderBundle118 = renderBundleEncoder40.finish({label: '\u81d7\ufc57\u3a18'});
+try {
+computePassEncoder52.setBindGroup(3, bindGroup25, new Uint32Array(3709), 2522, 0);
+} catch {}
+try {
+commandEncoder68.copyBufferToTexture({
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 30036 */
+offset: 30036,
+bytesPerRow: 256,
+buffer: buffer35,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer35);
+} catch {}
+try {
+commandEncoder98.clearBuffer(buffer40, 6708, 8768);
+dissociateBuffer(device3, buffer40);
+} catch {}
+try {
+commandEncoder101.resolveQuerySet(querySet42, 3006, 133, buffer41, 4096);
+} catch {}
+pseudoSubmit(device11, commandEncoder119);
+let texture146 = device11.createTexture({
+label: '\u0891\u0f95\u0dbb',
+size: [1024],
+dimension: '1d',
+format: 'rg32float',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rg32float'],
+});
+let sampler92 = device3.createSampler({
+label: '\ufaac\u263b',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 97.040,
+maxAnisotropy: 5,
+});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup9, new Uint32Array(1915), 1736, 0);
+} catch {}
+let pipeline105 = device3.createComputePipeline({
+layout: pipelineLayout16,
+compute: {
+module: shaderModule20,
+entryPoint: 'compute0',
+},
+});
+let texture147 = device11.createTexture({
+label: '\u8bcc\ua6e6\u0b25\u0f5c\ud9f5\u1468\u08c3\ue7b4',
+size: [1024, 1, 1],
+mipLevelCount: 2,
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [],
+});
+let sampler93 = device11.createSampler({
+label: '\u{1fe8a}\u1fc8\u{1ffeb}\uf274\ua289\u9d25\u2561',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+lodMinClamp: 40.847,
+lodMaxClamp: 96.817,
+});
+let imageBitmap38 = await createImageBitmap(video18);
+let buffer55 = device8.createBuffer({
+  label: '\u0b09\ue76a\u83c5\u{1f793}\u1452\u1a6e\u{1fd76}\u6665\u3e41',
+  size: 16070,
+  usage: GPUBufferUsage.INDIRECT
+});
+let commandEncoder120 = device8.createCommandEncoder({label: '\u{1ff7e}\u0e18\uf73c\u22ce\u0c72'});
+let commandBuffer23 = commandEncoder120.finish({
+});
+let renderBundleEncoder106 = device8.createRenderBundleEncoder({label: '\u2dc3\u0289', colorFormats: ['rg16sint'], sampleCount: 4, depthReadOnly: true});
+let renderBundle119 = renderBundleEncoder90.finish({});
+let sampler94 = device8.createSampler({
+label: '\u871d\u{1fe70}\ufa5c',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 47.488,
+lodMaxClamp: 68.235,
+});
+try {
+renderBundleEncoder106.setVertexBuffer(67, undefined);
+} catch {}
+canvas7.width = 126;
+let renderBundleEncoder107 = device3.createRenderBundleEncoder({
+  label: '\u07c9\u097b\u{1fd97}\u06bc\ub125\u6fbf\u234c\ua2a1\uce10\ub5b8\uf3e0',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+try {
+computePassEncoder24.setBindGroup(6, bindGroup18, new Uint32Array(9793), 9737, 0);
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline94);
+} catch {}
+try {
+commandEncoder110.copyBufferToBuffer(buffer35, 33764, buffer37, 24332, 16396);
+dissociateBuffer(device3, buffer35);
+dissociateBuffer(device3, buffer37);
+} catch {}
+try {
+commandEncoder110.resolveQuerySet(querySet38, 1136, 569, buffer33, 17152);
+} catch {}
+let promise57 = device3.createComputePipelineAsync({
+label: '\u{1ff31}\ubeae\u{1fe7b}\u66cb\ub9aa\u7a92\u0631',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+offscreenCanvas36.getContext('bitmaprenderer');
+} catch {}
+pseudoSubmit(device1, commandEncoder102);
+let texture148 = device1.createTexture({
+label: '\ue719\u2f5c\u530e\u04f2\u{1fe98}\u099a\u{1f627}\u0b2c\u0960\u06e6\u54ce',
+size: [384, 5, 1275],
+dimension: '3d',
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler95 = device1.createSampler({
+label: '\u{1ff5f}\u1d58\ucb16\u9d34\u08af\u0717\u0b5e\u0074\ue469',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 95.181,
+lodMaxClamp: 99.136,
+});
+try {
+renderBundleEncoder59.draw(0, 56);
+} catch {}
+try {
+renderBundleEncoder59.setPipeline(pipeline82);
+} catch {}
+try {
+commandEncoder107.copyBufferToBuffer(buffer36, 5120, buffer27, 15848, 1116);
+dissociateBuffer(device1, buffer36);
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+commandEncoder107.copyTextureToTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 92, y: 328, z: 61 },
+  aspect: 'all',
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: { x: 16, y: 4, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 308, depthOrArrayLayers: 108});
+} catch {}
+try {
+commandEncoder107.clearBuffer(buffer8, 9508, 92);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder97.resolveQuerySet(querySet86, 790, 1800, buffer34, 3072);
+} catch {}
+try {
+computePassEncoder60.popDebugGroup();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture96,
+  mipLevel: 7,
+  origin: { x: 4, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer13, /* required buffer size: 390 */
+{offset: 390}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline106 = device1.createComputePipeline({
+layout: pipelineLayout15,
+compute: {
+module: shaderModule18,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+gpuCanvasContext28.unconfigure();
+} catch {}
+pseudoSubmit(device7, commandEncoder112);
+let texture149 = device7.createTexture({
+size: [240, 24, 1],
+mipLevelCount: 8,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-8x8-unorm'],
+});
+try {
+buffer48.unmap();
+} catch {}
+let canvas40 = document.createElement('canvas');
+try {
+  await promise56;
+} catch {}
+let device12 = await adapter19.requestDevice({
+label: '\u{1fc86}\uc104\ua33b',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxColorAttachmentBytesPerSample: 36,
+maxVertexAttributes: 21,
+maxVertexBufferArrayStride: 50053,
+maxStorageTexturesPerShaderStage: 36,
+maxStorageBuffersPerShaderStage: 36,
+maxDynamicStorageBuffersPerPipelineLayout: 63758,
+maxBindingsPerBindGroup: 3448,
+maxTextureDimension1D: 8424,
+maxTextureDimension2D: 15232,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 75117908,
+maxUniformBuffersPerShaderStage: 21,
+maxInterStageShaderVariables: 122,
+maxInterStageShaderComponents: 95,
+maxSamplersPerShaderStage: 19,
+},
+});
+let commandEncoder121 = device9.createCommandEncoder({label: '\u{1fe66}\ud0ab\u{1fea5}\u0297\u{1f8ea}'});
+let computePassEncoder74 = commandEncoder121.beginComputePass({label: '\ub788\u284f\u1ec8\u0b18'});
+let renderBundle120 = renderBundleEncoder99.finish({label: '\ufbdc\u015a\u{1fa93}\u{1f982}\u{1fc26}\udba6\u{1fd03}\u1aaf\udce8\ub28f'});
+let videoFrame38 = new VideoFrame(imageBitmap2, {timestamp: 0});
+let pipelineLayout24 = device11.createPipelineLayout({
+  label: '\u100f\u4b95\u9ed2\ufd2f\u00e1\u{1fa15}\u{1fbd0}\u02b2\u038e\u0cab\u4bdb',
+  bindGroupLayouts: [bindGroupLayout43, bindGroupLayout43, bindGroupLayout43, bindGroupLayout43, bindGroupLayout43, bindGroupLayout43, bindGroupLayout43, bindGroupLayout43]
+});
+let texture150 = device11.createTexture({
+label: '\u{1fc9a}\ua3cf\u{1fa76}\u{1f8c4}\u771a\ud932\u05fa\u3335',
+size: {width: 2550, height: 8, depthOrArrayLayers: 1},
+mipLevelCount: 9,
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-10x8-unorm-srgb'],
+});
+try {
+gpuCanvasContext34.configure({
+device: device11,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba32float', 'rgba16float'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let promise58 = device11.queue.onSubmittedWorkDone();
+let commandEncoder122 = device8.createCommandEncoder({});
+let querySet94 = device8.createQuerySet({
+label: '\u{1fc5f}\u2aa0',
+type: 'occlusion',
+count: 3158,
+});
+let externalTexture10 = device8.importExternalTexture({
+source: video13,
+colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder96.label = '\u0510\u6c09\u0663\u0441\u0ff5\u{1fee1}\u0638';
+} catch {}
+let textureView134 = texture130.createView({
+  label: '\u{1ff45}\u00e2\u{1f7f4}\uad4a\u00bc',
+  format: 'bgra8unorm-srgb',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 22,
+  arrayLayerCount: 138
+});
+let sampler96 = device7.createSampler({
+label: '\ud062\u0241\ua8ab\u0580\u0263',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 2.324,
+lodMaxClamp: 70.782,
+});
+try {
+texture130.destroy();
+} catch {}
+try {
+device7.queue.writeBuffer(buffer48, 4444, new Float32Array(58009), 30704, 980);
+} catch {}
+gc();
+try {
+  await promise58;
+} catch {}
+let commandEncoder123 = device12.createCommandEncoder();
+let sampler97 = device12.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 6.922,
+lodMaxClamp: 99.044,
+maxAnisotropy: 15,
+});
+let promise59 = adapter9.requestAdapterInfo();
+let commandEncoder124 = device10.createCommandEncoder({label: '\u{1fcce}\u094e\u76cd\u5db8\u0258\u0bca\ucf01\u0604\u{1fc3f}\u74bb'});
+let renderBundleEncoder108 = device10.createRenderBundleEncoder({
+  label: '\ua26c\ua884\u{1fc8a}\u8485\u{1ff68}',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+try {
+renderBundleEncoder108.setVertexBuffer(97, undefined);
+} catch {}
+let gpuCanvasContext37 = canvas34.getContext('webgpu');
+let commandEncoder125 = device12.createCommandEncoder({label: '\u22b2\uaa8b'});
+let texture151 = device12.createTexture({
+label: '\u518d\u25be\u0c07\u0765\u8f38\ub829\u6713',
+size: [176, 112, 1],
+mipLevelCount: 4,
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['eac-r11snorm'],
+});
+let shaderModule21 = device11.createShaderModule({
+label: '\u0dae\u71ce\u4f7f\u5e76\u035a\u7493\ua6e7\u5fc0\u{1fa00}\u029b',
+code: `@group(2) @binding(4677)
+var<storage, read_write> type24: array<u32>;
+@group(5) @binding(4677)
+var<storage, read_write> parameter21: array<u32>;
+@group(3) @binding(5512)
+var<storage, read_write> global14: array<u32>;
+@group(1) @binding(772)
+var<storage, read_write> parameter22: array<u32>;
+@group(4) @binding(772)
+var<storage, read_write> type25: array<u32>;
+@group(6) @binding(5512)
+var<storage, read_write> i15: array<u32>;
+@group(3) @binding(4677)
+var<storage, read_write> global15: array<u32>;
+@group(3) @binding(772)
+var<storage, read_write> parameter23: array<u32>;
+@group(5) @binding(5512)
+var<storage, read_write> local20: array<u32>;
+@group(7) @binding(4677)
+var<storage, read_write> local21: array<u32>;
+@group(4) @binding(4677)
+var<storage, read_write> local22: array<u32>;
+@group(7) @binding(772)
+var<storage, read_write> type26: array<u32>;
+@group(5) @binding(772)
+var<storage, read_write> local23: array<u32>;
+@group(0) @binding(772)
+var<storage, read_write> i16: array<u32>;
+@group(2) @binding(772)
+var<storage, read_write> type27: array<u32>;
+@group(7) @binding(5512)
+var<storage, read_write> parameter24: array<u32>;
+@group(1) @binding(4677)
+var<storage, read_write> local24: array<u32>;
+@group(6) @binding(772)
+var<storage, read_write> function9: array<u32>;
+@group(0) @binding(4677)
+var<storage, read_write> global16: array<u32>;
+@group(0) @binding(5512)
+var<storage, read_write> i17: array<u32>;
+
+@compute @workgroup_size(6, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S28 {
+  @location(30) f0: vec2<u32>,
+  @location(10) f1: vec2<f32>,
+  @location(77) f2: vec2<f16>,
+  @location(66) f3: vec3<i32>,
+  @location(76) f4: vec3<i32>,
+  @location(39) f5: vec2<f16>,
+  @location(22) f6: vec4<f16>,
+  @location(19) f7: vec3<u32>,
+  @location(32) f8: i32,
+  @location(101) f9: f32,
+  @location(27) f10: u32,
+  @location(82) f11: vec3<u32>,
+  @location(8) f12: vec3<f16>,
+  @location(20) f13: vec4<i32>,
+  @location(54) f14: vec2<f16>,
+  @location(69) f15: f16,
+  @builtin(front_facing) f16: bool,
+  @location(111) f17: vec2<f32>,
+  @location(49) f18: i32,
+  @location(97) f19: vec4<f32>,
+  @builtin(position) f20: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec3<u32>,
+  @location(7) f1: vec3<u32>,
+  @location(2) f2: vec4<u32>,
+  @location(0) f3: i32,
+  @location(5) f4: f32,
+  @location(3) f5: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(68) a0: vec4<f16>, @location(55) a1: vec4<u32>, @location(35) a2: vec2<u32>, @location(107) a3: f32, @location(40) a4: f16, @location(4) a5: vec2<i32>, @location(87) a6: vec4<u32>, @location(45) a7: i32, @location(89) a8: f16, @location(5) a9: vec4<f32>, @location(53) a10: u32, @location(88) a11: vec3<i32>, @location(104) a12: i32, @location(99) a13: vec3<f16>, @location(84) a14: vec3<u32>, @location(75) a15: vec3<f16>, @location(37) a16: vec4<f32>, @location(0) a17: f32, @location(92) a18: vec2<f16>, @location(94) a19: i32, @location(93) a20: i32, @location(33) a21: vec4<u32>, @location(65) a22: vec2<f16>, @location(23) a23: vec2<f32>, @builtin(sample_index) a24: u32, @location(110) a25: f16, @location(15) a26: vec2<i32>, @location(62) a27: vec3<i32>, a28: S28, @builtin(sample_mask) a29: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S27 {
+  @location(0) f0: f16,
+  @location(21) f1: vec3<f32>,
+  @location(4) f2: vec2<f16>,
+  @location(7) f3: vec2<i32>,
+  @location(5) f4: vec2<f32>,
+  @location(8) f5: vec2<u32>,
+  @location(22) f6: f16,
+  @location(2) f7: vec2<u32>,
+  @location(1) f8: i32,
+  @location(19) f9: f16,
+  @location(15) f10: vec2<i32>,
+  @location(13) f11: vec4<f16>
+}
+struct VertexOutput0 {
+  @location(65) f441: vec2<f16>,
+  @location(104) f442: i32,
+  @location(22) f443: vec4<f16>,
+  @location(111) f444: vec2<f32>,
+  @location(20) f445: vec4<i32>,
+  @location(87) f446: vec4<u32>,
+  @location(10) f447: vec2<f32>,
+  @location(45) f448: i32,
+  @location(53) f449: u32,
+  @location(94) f450: i32,
+  @location(89) f451: f16,
+  @location(35) f452: vec2<u32>,
+  @location(30) f453: vec2<u32>,
+  @location(82) f454: vec3<u32>,
+  @location(54) f455: vec2<f16>,
+  @location(23) f456: vec2<f32>,
+  @location(5) f457: vec4<f32>,
+  @location(15) f458: vec2<i32>,
+  @builtin(position) f459: vec4<f32>,
+  @location(0) f460: f32,
+  @location(37) f461: vec4<f32>,
+  @location(4) f462: vec2<i32>,
+  @location(62) f463: vec3<i32>,
+  @location(88) f464: vec3<i32>,
+  @location(49) f465: i32,
+  @location(97) f466: vec4<f32>,
+  @location(32) f467: i32,
+  @location(19) f468: vec3<u32>,
+  @location(39) f469: vec2<f16>,
+  @location(55) f470: vec4<u32>,
+  @location(101) f471: f32,
+  @location(75) f472: vec3<f16>,
+  @location(68) f473: vec4<f16>,
+  @location(76) f474: vec3<i32>,
+  @location(27) f475: u32,
+  @location(69) f476: f16,
+  @location(110) f477: f16,
+  @location(93) f478: i32,
+  @location(40) f479: f16,
+  @location(84) f480: vec3<u32>,
+  @location(8) f481: vec3<f16>,
+  @location(92) f482: vec2<f16>,
+  @location(33) f483: vec4<u32>,
+  @location(77) f484: vec2<f16>,
+  @location(107) f485: f32,
+  @location(66) f486: vec3<i32>,
+  @location(99) f487: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(24) a0: vec3<f32>, @location(17) a1: vec4<f16>, @builtin(vertex_index) a2: u32, @location(16) a3: i32, @location(10) a4: vec2<f32>, @location(9) a5: vec2<f32>, @location(14) a6: f32, @builtin(instance_index) a7: u32, @location(23) a8: vec4<f16>, @location(20) a9: vec4<f16>, @location(26) a10: vec4<u32>, @location(6) a11: vec2<u32>, a12: S27, @location(12) a13: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let textureView135 = texture146.createView({label: '\u3df1\u1e0d\ua087\u3b8f\u07a0\u38a5\u224e'});
+let sampler98 = device11.createSampler({
+addressModeV: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 58.707,
+lodMaxClamp: 78.570,
+});
+let pipeline107 = await device11.createRenderPipelineAsync({
+layout: pipelineLayout24,
+multisample: {
+},
+fragment: {
+  module: shaderModule21,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16sint'}, {format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgb10a2uint'}, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}]
+},
+vertex: {
+  module: shaderModule21,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 19872,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x4',
+offset: 2008,
+shaderLocation: 7,
+}, {
+format: 'float32x3',
+offset: 15372,
+shaderLocation: 21,
+}, {
+format: 'float32x2',
+offset: 15508,
+shaderLocation: 13,
+}, {
+format: 'unorm8x2',
+offset: 17982,
+shaderLocation: 19,
+}, {
+format: 'float32x4',
+offset: 3932,
+shaderLocation: 9,
+}, {
+format: 'unorm8x4',
+offset: 17548,
+shaderLocation: 17,
+}, {
+format: 'unorm10-10-10-2',
+offset: 3800,
+shaderLocation: 5,
+}, {
+format: 'sint16x2',
+offset: 5060,
+shaderLocation: 16,
+}, {
+format: 'float16x4',
+offset: 8768,
+shaderLocation: 4,
+}, {
+format: 'sint32x2',
+offset: 14568,
+shaderLocation: 1,
+}, {
+format: 'float32',
+offset: 5360,
+shaderLocation: 10,
+}, {
+format: 'uint32x3',
+offset: 4332,
+shaderLocation: 2,
+}, {
+format: 'float16x4',
+offset: 8012,
+shaderLocation: 14,
+}, {
+format: 'unorm10-10-10-2',
+offset: 852,
+shaderLocation: 22,
+}, {
+format: 'unorm8x2',
+offset: 3920,
+shaderLocation: 0,
+}, {
+format: 'snorm16x4',
+offset: 11952,
+shaderLocation: 24,
+}, {
+format: 'uint8x4',
+offset: 13104,
+shaderLocation: 26,
+}, {
+format: 'sint8x4',
+offset: 7928,
+shaderLocation: 15,
+}, {
+format: 'snorm8x4',
+offset: 6244,
+shaderLocation: 20,
+}, {
+format: 'float16x4',
+offset: 1744,
+shaderLocation: 12,
+}, {
+format: 'snorm16x4',
+offset: 7316,
+shaderLocation: 23,
+}, {
+format: 'uint8x2',
+offset: 11242,
+shaderLocation: 8,
+}, {
+format: 'uint16x2',
+offset: 5248,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+unclippedDepth: true,
+},
+});
+let texture152 = device6.createTexture({
+label: '\u8c43\u0abd\u8cc7\u0e5d',
+size: {width: 280},
+dimension: '1d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8snorm', 'r8snorm'],
+});
+let computePassEncoder75 = commandEncoder113.beginComputePass({label: '\u{1f6fc}\uad87\u0f33\u4f31\u06d7\uc586\u0aa6\u0ea4'});
+let renderBundle121 = renderBundleEncoder87.finish();
+try {
+device6.queue.writeTexture({
+  texture: texture133,
+  mipLevel: 0,
+  origin: { x: 8, y: 1, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 780 */
+{offset: 780}, {width: 108, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 4, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas24,
+  origin: { x: 133, y: 562 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 5,
+  origin: { x: 3, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+shaderModule17.label = '\u{1f856}\ue10d\u0482\u0252\uf528\u384d';
+} catch {}
+let buffer56 = device1.createBuffer({label: '\u1bd1\u665a', size: 57613, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC});
+let querySet95 = device1.createQuerySet({
+label: '\u{1f9cc}\ud38a',
+type: 'occlusion',
+count: 369,
+});
+pseudoSubmit(device1, commandEncoder72);
+let sampler99 = device1.createSampler({
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'linear',
+lodMinClamp: 66.301,
+lodMaxClamp: 72.350,
+});
+try {
+computePassEncoder64.setPipeline(pipeline77);
+} catch {}
+try {
+renderBundleEncoder66.setIndexBuffer(buffer32, 'uint32', 3944, 7267);
+} catch {}
+try {
+commandEncoder107.copyBufferToTexture({
+/* bytesInLastRow: 256 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 37584 */
+offset: 37584,
+bytesPerRow: 256,
+buffer: buffer56,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 55, y: 75, z: 1 },
+  aspect: 'all',
+}, {width: 80, height: 15, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer56);
+} catch {}
+try {
+commandEncoder97.resolveQuerySet(querySet81, 3446, 0, buffer34, 14336);
+} catch {}
+try {
+  await promise59;
+} catch {}
+let commandEncoder126 = device12.createCommandEncoder({label: '\ue8d2\u9f43\u0ad7\u4aca\u093b\u8e0d\u{1f9a0}\u{1fa9d}\u{1fb62}\ua5bc'});
+let gpuCanvasContext38 = canvas40.getContext('webgpu');
+try {
+offscreenCanvas41.getContext('bitmaprenderer');
+} catch {}
+let bindGroupLayout47 = device11.createBindGroupLayout({
+label: '\u5c1a\u{1f6b1}\u6035\u{1f94f}\u{1f621}\ue76a\u{1fd3c}',
+entries: [],
+});
+try {
+device11.queue.writeTexture({
+  texture: texture144,
+  mipLevel: 0,
+  origin: { x: 110, y: 1, z: 0 },
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer1), /* required buffer size: 296 */
+{offset: 296, bytesPerRow: 2091}, {width: 460, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise60 = device11.queue.onSubmittedWorkDone();
+try {
+  await promise60;
+} catch {}
+let imageData38 = new ImageData(220, 248);
+let querySet96 = device7.createQuerySet({
+label: '\u06bc\u269e\u{1f989}\ue4ac\u122f\u{1fa9c}\u0c65\u2f4d',
+type: 'occlusion',
+count: 3076,
+});
+try {
+canvas39.getContext('2d');
+} catch {}
+let computePassEncoder76 = commandEncoder116.beginComputePass({label: '\u{1f8a4}\u0d34\u0350\u8967\ub530\ud0f1\u0173\uae49\u03df\u{1f64c}\u{1fd59}'});
+let renderBundle122 = renderBundleEncoder99.finish({});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageBitmap39 = await createImageBitmap(canvas34);
+pseudoSubmit(device6, commandEncoder113);
+let texture153 = device6.createTexture({
+label: '\ufc18\u0ebc\u0ccd\u{1fb17}',
+size: [1035, 1, 1],
+mipLevelCount: 11,
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rg8uint', 'rg8uint'],
+});
+let renderBundleEncoder109 = device6.createRenderBundleEncoder({
+  label: '\u495c\u4547\u2320\ue474\u0574\u{1feb0}\u0551\ub801\ue600\u2e82',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 17, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas30,
+  origin: { x: 265, y: 71 },
+  flipY: false,
+}, {
+  texture: texture137,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 9, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let renderBundle123 = renderBundleEncoder100.finish();
+try {
+gpuCanvasContext10.configure({
+device: device9,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let texture154 = device1.createTexture({
+label: '\u8e01\ua642\u01fc\u08b7\u0f98\u6d43\u013c\u{1faf9}\uad8e\uc003',
+size: [7740, 10, 1],
+mipLevelCount: 5,
+sampleCount: 1,
+dimension: '2d',
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x10-unorm', 'astc-12x10-unorm-srgb'],
+});
+let textureView136 = texture143.createView({label: '\u0a37\u0f8f\uefe3\ud18f\u066b\u0b25\u0cb8\u453f\u138d\u09f9\u5a79'});
+let renderBundle124 = renderBundleEncoder18.finish({label: '\u079d\u0722\u5f8d'});
+try {
+  await buffer27.mapAsync(GPUMapMode.READ, 19544, 336);
+} catch {}
+try {
+commandEncoder107.copyBufferToBuffer(buffer47, 7736, buffer39, 53120, 9820);
+dissociateBuffer(device1, buffer47);
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+commandEncoder97.copyBufferToTexture({
+/* bytesInLastRow: 108 widthInBlocks: 27 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 23388 */
+offset: 23388,
+bytesPerRow: 256,
+buffer: buffer56,
+}, {
+  texture: texture45,
+  mipLevel: 1,
+  origin: { x: 14, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 27, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer56);
+} catch {}
+try {
+commandEncoder88.copyTextureToBuffer({
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 23, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 504 */
+offset: 504,
+bytesPerRow: 256,
+buffer: buffer8,
+}, {width: 2, height: 2, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder107.resolveQuerySet(querySet82, 102, 0, buffer34, 8448);
+} catch {}
+let pipeline108 = await device1.createRenderPipelineAsync({
+label: '\u0624\u0925\u0af4\u0071\ubfcc\u03c1\ueebe\u030e',
+layout: pipelineLayout7,
+multisample: {
+},
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32float'}, {
+  format: 'r16float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r16uint', writeMask: 0}, {format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r8uint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'invert',
+depthFailOp: 'keep',
+passOp: 'increment-clamp',
+},
+stencilWriteMask: 3076,
+depthBiasSlopeScale: 58,
+depthBiasClamp: 68,
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x2',
+offset: 29832,
+shaderLocation: 22,
+}, {
+format: 'uint32x3',
+offset: 21664,
+shaderLocation: 21,
+}, {
+format: 'unorm10-10-10-2',
+offset: 20020,
+shaderLocation: 17,
+}, {
+format: 'sint16x2',
+offset: 15460,
+shaderLocation: 25,
+}, {
+format: 'unorm16x4',
+offset: 23324,
+shaderLocation: 8,
+}, {
+format: 'snorm16x2',
+offset: 1768,
+shaderLocation: 12,
+}, {
+format: 'float32x4',
+offset: 1420,
+shaderLocation: 16,
+}, {
+format: 'unorm16x2',
+offset: 33584,
+shaderLocation: 20,
+}, {
+format: 'float32x4',
+offset: 11788,
+shaderLocation: 4,
+}, {
+format: 'snorm8x2',
+offset: 6796,
+shaderLocation: 5,
+}, {
+format: 'snorm16x2',
+offset: 10320,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 5548,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 4812,
+shaderLocation: 14,
+}, {
+format: 'uint16x2',
+offset: 3876,
+shaderLocation: 3,
+}, {
+format: 'sint16x2',
+offset: 5192,
+shaderLocation: 23,
+}, {
+format: 'sint8x4',
+offset: 868,
+shaderLocation: 0,
+}, {
+format: 'unorm16x2',
+offset: 3948,
+shaderLocation: 1,
+}, {
+format: 'float16x2',
+offset: 5308,
+shaderLocation: 26,
+}, {
+format: 'sint16x2',
+offset: 3948,
+shaderLocation: 18,
+}, {
+format: 'uint16x4',
+offset: 692,
+shaderLocation: 15,
+}, {
+format: 'uint32x2',
+offset: 1572,
+shaderLocation: 2,
+}, {
+format: 'unorm10-10-10-2',
+offset: 1904,
+shaderLocation: 10,
+}, {
+format: 'sint32x4',
+offset: 236,
+shaderLocation: 24,
+}, {
+format: 'uint32',
+offset: 3672,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 6392,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 3696,
+shaderLocation: 13,
+}, {
+format: 'float32x3',
+offset: 6040,
+shaderLocation: 19,
+}, {
+format: 'sint32',
+offset: 480,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 27100,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1196,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 30836,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 15096,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 19668,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 4600,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 6036,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 2832,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let img38 = await imageWithData(271, 277, '#5f6b48c0', '#961a98c1');
+let textureView137 = texture151.createView({label: '\u6c89\u53d0\u0d14\ucd19\u0cdb\u1ec4\uab68\u0cf2\u06e8', baseMipLevel: 2});
+try {
+gpuCanvasContext23.unconfigure();
+} catch {}
+let adapter24 = await promise52;
+let renderBundleEncoder110 = device1.createRenderBundleEncoder({
+  label: '\u0f52\u{1ff61}\u0833\u09f9\u{1f6d6}\u0596\u8f21\u{1f626}\u28d4\u022c',
+  colorFormats: ['rg8sint', 'r16uint', 'r32sint', 'rg16sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let sampler100 = device1.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 12.945,
+lodMaxClamp: 52.841,
+});
+try {
+renderBundleEncoder59.draw(72, 24, 24, 32);
+} catch {}
+try {
+renderBundleEncoder59.drawIndexed(72, 80, 8, 768);
+} catch {}
+try {
+commandEncoder97.copyBufferToBuffer(buffer56, 17748, buffer30, 14516, 14084);
+dissociateBuffer(device1, buffer56);
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+commandEncoder107.clearBuffer(buffer39);
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+commandEncoder88.resolveQuerySet(querySet43, 3213, 172, buffer34, 8704);
+} catch {}
+let commandEncoder127 = device10.createCommandEncoder();
+let texture155 = device10.createTexture({
+label: '\uc589\ua16b\u{1f65f}\u7ec3\u03cc',
+size: {width: 120, height: 40, depthOrArrayLayers: 254},
+mipLevelCount: 2,
+format: 'astc-5x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-5x4-unorm-srgb', 'astc-5x4-unorm', 'astc-5x4-unorm'],
+});
+let renderBundle125 = renderBundleEncoder102.finish({});
+let sampler101 = device10.createSampler({
+label: '\u{1fbdf}\u{1fa0f}\u0216\uc965\u0eed\u0481\u2747',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 37.039,
+lodMaxClamp: 50.901,
+});
+try {
+renderBundleEncoder108.insertDebugMarker('\u098b');
+} catch {}
+try {
+gpuCanvasContext37.unconfigure();
+} catch {}
+let adapter25 = await navigator.gpu.requestAdapter();
+let computePassEncoder77 = commandEncoder118.beginComputePass({});
+try {
+computePassEncoder66.pushDebugGroup('\u04e3');
+} catch {}
+try {
+device5.queue.writeTexture({
+  texture: texture131,
+  mipLevel: 0,
+  origin: { x: 319, y: 0, z: 1 },
+  aspect: 'all',
+}, new Uint16Array(new ArrayBuffer(32)), /* required buffer size: 86 */
+{offset: 86, bytesPerRow: 7422, rowsPerImage: 143}, {width: 901, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture156 = device6.createTexture({
+label: '\u5eab\u0d3b\u0a8f\u{1f6ca}\u017a\u5193\u{1f727}\u6d48\u04be',
+size: [640, 480, 1],
+mipLevelCount: 8,
+sampleCount: 1,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth32float', 'depth32float'],
+});
+try {
+renderBundleEncoder94.pushDebugGroup('\u9b40');
+} catch {}
+let imageData39 = new ImageData(236, 176);
+pseudoSubmit(device10, commandEncoder127);
+let renderBundleEncoder111 = device10.createRenderBundleEncoder({
+  label: '\u{1f814}\u9bc9\u{1ff9a}\u9d94\u463d\ub938\u6f85\u68cc',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle126 = renderBundleEncoder108.finish({});
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let promise61 = navigator.gpu.requestAdapter();
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend(video20);
+let sampler102 = device9.createSampler({
+label: '\u3273\u4bcf',
+addressModeU: 'repeat',
+addressModeW: 'mirror-repeat',
+lodMinClamp: 78.127,
+lodMaxClamp: 85.277,
+});
+let textureView138 = texture132.createView({
+  label: '\u154b\u0104\u0dec\u3953\u640b\u8a5b\ua08f\u2a29\ub74b\u55d2\u{1f935}',
+  dimension: '2d-array',
+  baseMipLevel: 5
+});
+try {
+renderBundleEncoder106.setVertexBuffer(5, undefined, 1278777758, 3011786311);
+} catch {}
+try {
+commandEncoder122.copyTextureToTexture({
+  texture: texture134,
+  mipLevel: 2,
+  origin: { x: 32, y: 4, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture134,
+  mipLevel: 5,
+  origin: { x: 4, y: 4, z: 1 },
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device8.queue.writeTexture({
+  texture: texture134,
+  mipLevel: 3,
+  origin: { x: 12, y: 0, z: 0 },
+  aspect: 'all',
+}, new Int8Array(arrayBuffer3), /* required buffer size: 44 */
+{offset: 44, rowsPerImage: 109}, {width: 24, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let texture157 = device3.createTexture({
+label: '\u6c88\udb03\uc708\u{1f6e4}\u0989\u{1fa5c}\u022d',
+size: {width: 2048, height: 24, depthOrArrayLayers: 1},
+mipLevelCount: 11,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder112 = device3.createRenderBundleEncoder({
+  label: '\u7173\u{1f9a2}\u{1ff5c}\u{1f96d}\u33c9\ub80c\u{1fb4b}\u50a1',
+  colorFormats: ['rgba32float', 'bgra8unorm-srgb', 'r32sint', 'bgra8unorm-srgb'],
+  stencilReadOnly: false
+});
+let renderBundle127 = renderBundleEncoder56.finish({});
+let sampler103 = device3.createSampler({
+label: '\u1c78\ue178\u6eb9\u0e00\u{1fd46}\u094e\u{1fe1b}\u2c13\u5b4b\u0695',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 6.486,
+lodMaxClamp: 93.868,
+compare: 'not-equal',
+});
+try {
+renderBundleEncoder82.setIndexBuffer(buffer35, 'uint32');
+} catch {}
+let imageData40 = new ImageData(92, 28);
+let bindGroup26 = device11.createBindGroup({
+layout: bindGroupLayout47,
+entries: [],
+});
+let texture158 = gpuCanvasContext29.getCurrentTexture();
+gc();
+let canvas41 = document.createElement('canvas');
+try {
+device6.queue.writeTexture({
+  texture: texture153,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 98 */
+{offset: 98}, {width: 32, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise62 = adapter12.requestAdapterInfo();
+let commandEncoder128 = device10.createCommandEncoder({label: '\u0d20\u4136\uda18\ud3e3\uf924\u15f5\u{1fe7e}\u6c75\u0ff7\u4de1\u0d72'});
+let querySet97 = device10.createQuerySet({
+label: '\u0cfb\u9664\u53de\u9021\u{1fc67}\u0ba5\u426a\u9f17\u97be\u537b\u6bd3',
+type: 'occlusion',
+count: 3091,
+});
+let renderBundleEncoder113 = device10.createRenderBundleEncoder({
+  label: '\u7132\u{1fd6d}\u2322\u5fbb\u00e2\u4df7\u1578',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let commandEncoder129 = device11.createCommandEncoder();
+let renderBundleEncoder114 = device11.createRenderBundleEncoder({
+  colorFormats: ['r16sint', 'rg16uint', 'rgb10a2uint', 'rg32float'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler104 = device11.createSampler({
+label: '\u90f8\u{1fe85}\u{1f6e6}\u3463\u7947\u{1f9ff}\u{1f895}\u04ca',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMaxClamp: 95.743,
+});
+let textureView139 = texture75.createView({format: 'rg11b10ufloat'});
+let renderBundle128 = renderBundleEncoder48.finish({});
+try {
+pipeline70.label = '\u{1fc00}\u{1f6e4}\u{1f707}\u4035\u0188\u5040\u2033';
+} catch {}
+let bindGroup27 = device3.createBindGroup({
+layout: bindGroupLayout34,
+entries: [],
+});
+let computePassEncoder78 = commandEncoder98.beginComputePass({label: '\uf9d7\u589c\u02a9\u{1f785}\u{1f9e9}\u5477\u2d0a'});
+let renderBundleEncoder115 = device3.createRenderBundleEncoder({
+  label: '\u0cb9\ub8c2\u0f10\ufc70\ub072\uc679\uce21\u{1fe69}',
+  colorFormats: ['r16uint', 'rg16uint'],
+  sampleCount: 1,
+  stencilReadOnly: true
+});
+try {
+commandEncoder68.copyTextureToBuffer({
+  texture: texture44,
+  mipLevel: 0,
+  origin: { x: 641, y: 10, z: 682 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 335 widthInBlocks: 335 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 9300 */
+offset: 9300,
+bytesPerRow: 768,
+buffer: buffer19,
+}, {width: 335, height: 103, depthOrArrayLayers: 0});
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+commandEncoder51.copyTextureToTexture({
+  texture: texture79,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture79,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise63 = device3.createComputePipelineAsync({
+layout: pipelineLayout16,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+canvas41.getContext('webgl');
+} catch {}
+let texture159 = device1.createTexture({
+label: '\u0a67\u0c64\u7293\ue2e7\u9697\u0dc2\u059b\uf5a3\uf795\u0437\u{1fe13}',
+size: {width: 96, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['depth24plus-stencil8'],
+});
+let textureView140 = texture117.createView({});
+try {
+gpuCanvasContext27.unconfigure();
+} catch {}
+let imageBitmap40 = await createImageBitmap(video21);
+let commandEncoder130 = device5.createCommandEncoder({label: '\u{1fe96}\u{1f9ed}\u250e\ub921\u0bbd\u0810\ub16a\ud37b'});
+let querySet98 = device5.createQuerySet({
+type: 'occlusion',
+count: 200,
+});
+let texture160 = device5.createTexture({
+label: '\u20e5\u0f8a\u156f\u2f85',
+size: {width: 624},
+mipLevelCount: 1,
+dimension: '1d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle129 = renderBundleEncoder104.finish();
+let externalTexture11 = device5.importExternalTexture({
+label: '\u146f\u031f\ufa79\ub45f\u5f3d\u059a\u080d\u5dcb',
+source: video15,
+colorSpace: 'display-p3',
+});
+try {
+computePassEncoder66.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+gpuCanvasContext20.configure({
+device: device5,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device5.queue.writeTexture({
+  texture: texture131,
+  mipLevel: 0,
+  origin: { x: 64, y: 1, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(225), /* required buffer size: 225 */
+{offset: 225}, {width: 1165, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device9.queue.label = '\u{1fe06}\uac70\uda41';
+} catch {}
+let texture161 = device9.createTexture({
+label: '\u7fa9\u0adf\u{1f859}\ua67c\u053d\ud073\u89f6\u52a7',
+size: {width: 2000, height: 480, depthOrArrayLayers: 172},
+mipLevelCount: 11,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x6-unorm-srgb', 'astc-8x6-unorm', 'astc-8x6-unorm-srgb'],
+});
+let sampler105 = device9.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 17.774,
+lodMaxClamp: 70.247,
+});
+let videoFrame39 = new VideoFrame(img21, {timestamp: 0});
+let bindGroupLayout48 = device11.createBindGroupLayout({
+entries: [{
+binding: 5789,
+visibility: GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}, {
+binding: 6176,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+}, {
+binding: 2668,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '1d' },
+}],
+});
+let pipelineLayout25 = device11.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout43, bindGroupLayout43, bindGroupLayout47, bindGroupLayout48, bindGroupLayout48, bindGroupLayout47, bindGroupLayout48, bindGroupLayout43]
+});
+let buffer57 = device11.createBuffer({
+  label: '\u0aab\u0926\u03ab\uc00a\uef99\ud7bd\u6148\u9399\u5ff4',
+  size: 14772,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let texture162 = device11.createTexture({
+label: '\ub553\u7432\u{1f6c4}\u{1fab1}\u{1f8db}',
+size: {width: 768, height: 12, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-4x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundle130 = renderBundleEncoder114.finish({label: '\u0d5f\uc3f0\u9a35\u2929\uc0fb\u09a6\u{1ff72}\u{1fd48}\u0034\udc4e\ua14a'});
+let promise64 = buffer57.mapAsync(GPUMapMode.WRITE, 3864, 1400);
+let shaderModule22 = device1.createShaderModule({
+label: '\u00ae\uc388\u0f47\u{1ffcf}',
+code: `@group(0) @binding(1300)
+var<storage, read_write> type28: array<u32>;
+@group(0) @binding(704)
+var<storage, read_write> field12: array<u32>;
+
+@compute @workgroup_size(3, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<i32>,
+  @location(1) f1: vec4<f32>,
+  @location(0) f2: vec2<f32>,
+  @location(3) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(19) a1: vec4<u32>, @location(21) a2: vec4<f16>, @location(4) a3: vec4<f32>, @location(3) a4: i32, @location(1) a5: vec3<f16>, @location(26) a6: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroup28 = device1.createBindGroup({
+label: '\u0fb2\u3a94',
+layout: bindGroupLayout25,
+entries: [],
+});
+let renderBundle131 = renderBundleEncoder98.finish({label: '\uc29e\uad3b\u5f32\ud9e9\u2d12\u035d'});
+let sampler106 = device1.createSampler({
+label: '\u3955\u0941\uf2f9\u{1ffaf}\u{1f7b0}\u{1fef9}\u6b3c\u326a\u0304\u060e',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 77.757,
+lodMaxClamp: 87.011,
+maxAnisotropy: 5,
+});
+try {
+renderBundleEncoder110.setVertexBuffer(6, undefined);
+} catch {}
+try {
+commandEncoder107.clearBuffer(buffer20, 452, 360);
+dissociateBuffer(device1, buffer20);
+} catch {}
+let img39 = await imageWithData(290, 251, '#161cb870', '#d0b8cf33');
+let commandBuffer24 = commandEncoder97.finish({
+label: '\u5a1b\u51ac\u168c\u3aec\u099b\u064a\u4ca3',
+});
+let texture163 = device1.createTexture({
+label: '\u0438\u369b\ubc76\u1d2f\u0bb2\uc5af\u70b0',
+size: {width: 192, height: 8, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+try {
+computePassEncoder67.setBindGroup(10, bindGroup28, new Uint32Array(2276), 1789, 0);
+} catch {}
+try {
+buffer43.destroy();
+} catch {}
+try {
+renderBundleEncoder49.insertDebugMarker('\ua014');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData17,
+  origin: { x: 3, y: 60 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 27, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet99 = device6.createQuerySet({
+type: 'occlusion',
+count: 3799,
+});
+try {
+renderBundleEncoder109.setVertexBuffer(96, undefined, 302323412, 1917246157);
+} catch {}
+let video36 = await videoWithData();
+let imageBitmap41 = await createImageBitmap(img30);
+let commandEncoder131 = device8.createCommandEncoder({label: '\u3db8\ua93d\u9942\u{1f76f}\uec94\ub200\u4782\u28b0\ub10c'});
+let querySet100 = device8.createQuerySet({
+label: '\u{1fbce}\ue255\u025d',
+type: 'occlusion',
+count: 3641,
+});
+let textureView141 = texture134.createView({label: '\u8966\ufbd3', dimension: '2d-array', format: 'etc2-rgb8a1unorm', baseMipLevel: 2, mipLevelCount: 3});
+try {
+device8.queue.writeTexture({
+  texture: texture134,
+  mipLevel: 1,
+  origin: { x: 72, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 1180 */
+{offset: 814, bytesPerRow: 206}, {width: 80, height: 8, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder132 = device7.createCommandEncoder({label: '\u{1f6a1}\u{1f8b9}\u0496\u2314\u{1f78a}\u1b2a\u00d6'});
+let texture164 = device7.createTexture({
+label: '\u01cb\u6cb1',
+size: {width: 1740, height: 131, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rgb9e5ufloat', 'rgb9e5ufloat', 'rgb9e5ufloat'],
+});
+try {
+commandEncoder132.clearBuffer(buffer48);
+dissociateBuffer(device7, buffer48);
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture164,
+  mipLevel: 1,
+  origin: { x: 8, y: 49, z: 0 },
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 59 */
+{offset: 59, bytesPerRow: 3417}, {width: 784, height: 9, depthOrArrayLayers: 0});
+} catch {}
+let video37 = await videoWithData();
+let querySet101 = device1.createQuerySet({
+label: '\u070a\ub292\u11be\ua374\u52df\u{1fffd}',
+type: 'occlusion',
+count: 883,
+});
+let texture165 = device1.createTexture({
+label: '\uaad5\u{1fed2}\uc6be\u0851\u6d95\uf0f6\uf687\u0adf\u0af2\u6a5e',
+size: {width: 108, height: 768, depthOrArrayLayers: 20},
+mipLevelCount: 5,
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let textureView142 = texture28.createView({label: '\u24b1\u5e87\u1299\u0f62\u{1f667}\u{1f8c2}\ucaa1\ud391\u3f2a\uc666'});
+let renderBundle132 = renderBundleEncoder57.finish({label: '\u0019\ufdd7\u5e04\u4dcb\u{1f601}\u{1f928}\ueeca'});
+try {
+computePassEncoder63.setPipeline(pipeline106);
+} catch {}
+try {
+renderBundleEncoder59.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder59.draw(56);
+} catch {}
+try {
+renderBundleEncoder86.drawIndexed(40, 80);
+} catch {}
+try {
+commandEncoder107.copyBufferToBuffer(buffer56, 51280, buffer8, 9516, 1092);
+dissociateBuffer(device1, buffer56);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+renderBundleEncoder54.setIndexBuffer(buffer35, 'uint16', 18560, 7695);
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+try {
+commandEncoder51.copyBufferToBuffer(buffer35, 9544, buffer37, 4056, 9208);
+dissociateBuffer(device3, buffer35);
+dissociateBuffer(device3, buffer37);
+} catch {}
+try {
+commandEncoder110.clearBuffer(buffer24, 4984, 3896);
+dissociateBuffer(device3, buffer24);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let buffer58 = device1.createBuffer({label: '\u557c\u4d13\u0e2b\ud793\u1200', size: 1230, usage: GPUBufferUsage.COPY_SRC});
+let renderBundle133 = renderBundleEncoder85.finish({label: '\u7d5a\u070d\u54ad\u6a32'});
+try {
+computePassEncoder60.setPipeline(pipeline25);
+} catch {}
+try {
+renderBundleEncoder70.setBindGroup(3, bindGroup12, []);
+} catch {}
+try {
+renderBundleEncoder37.drawIndexed(32);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(56, undefined, 1268510883, 1333941604);
+} catch {}
+try {
+commandEncoder107.resolveQuerySet(querySet95, 235, 55, buffer34, 17920);
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer24,
+]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture98,
+  mipLevel: 0,
+  origin: { x: 53, y: 2, z: 0 },
+  aspect: 'all',
+}, arrayBuffer12, /* required buffer size: 948 */
+{offset: 948, bytesPerRow: 28}, {width: 23, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend(video12);
+let adapter26 = await promise50;
+let offscreenCanvas42 = new OffscreenCanvas(281, 167);
+try {
+gpuCanvasContext18.configure({
+device: device9,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth24plus', 'bgra8unorm-srgb', 'bgra8unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let videoFrame40 = new VideoFrame(video3, {timestamp: 0});
+let bindGroup29 = device5.createBindGroup({
+label: '\u74c3\u2eff\u0096\ud4d6\u0ff5\udab2\uc9e0',
+layout: bindGroupLayout39,
+entries: [],
+});
+let texture166 = device5.createTexture({
+label: '\u240a\u519d\u2aef\u89d8\u8c48\u{1f7e2}',
+size: {width: 312, height: 1, depthOrArrayLayers: 244},
+mipLevelCount: 7,
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgb10a2unorm', 'rgb10a2unorm', 'rgb10a2unorm'],
+});
+try {
+  await promise62;
+} catch {}
+let videoFrame41 = new VideoFrame(img36, {timestamp: 0});
+offscreenCanvas28.width = 81;
+let imageData41 = new ImageData(4, 128);
+let videoFrame42 = new VideoFrame(canvas4, {timestamp: 0});
+let texture167 = device9.createTexture({
+label: '\uf2f0\ue08c\ucb5c\uc897\u042b\ucc45',
+size: {width: 11616, height: 160, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+dimension: '2d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r16sint'],
+});
+let renderBundleEncoder116 = device9.createRenderBundleEncoder({
+  label: '\ua3b4\u8def\u5245\ub854\u{1fff8}\u0bf5\u0742\u9b10\u0fae\u0e97\u0092',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2unorm', 'rg32float', 'rgba8unorm', 'r8uint', 'rgba8unorm-srgb', 'rg8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+let texture168 = device5.createTexture({
+label: '\u13fa\u{1f834}\u{1f7eb}\u0ee2\u{1f607}\u64b1\u0e3f\u{1fea0}',
+size: [312],
+dimension: '1d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_SRC,
+});
+let renderBundle134 = renderBundleEncoder89.finish({label: '\u0296\u0b91\u54e6\u18b4\u2763\u0256\u7b2d\u{1fcd9}'});
+try {
+renderBundleEncoder105.setVertexBuffer(74, undefined);
+} catch {}
+let gpuCanvasContext39 = offscreenCanvas42.getContext('webgpu');
+let texture169 = device5.createTexture({
+label: '\u0fa4\u07fe\ua34c\u653b\u7458\u{1fb08}',
+size: {width: 156, height: 1, depthOrArrayLayers: 1011},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8uint'],
+});
+let imageData42 = new ImageData(64, 152);
+let commandEncoder133 = device1.createCommandEncoder({label: '\u{1f9d2}\u2038\ud8bc'});
+try {
+commandEncoder88.clearBuffer(buffer30, 2516, 14700);
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+gpuCanvasContext39.configure({
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm', 'rgba8unorm', 'rgba8unorm-srgb'],
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 36, y: 484, z: 22 },
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(40)), /* required buffer size: 461261 */
+{offset: 718, bytesPerRow: 479, rowsPerImage: 115}, {width: 56, height: 168, depthOrArrayLayers: 9});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 48, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame11,
+  origin: { x: 84, y: 9 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 0, y: 2, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 45, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise64;
+} catch {}
+let videoFrame43 = new VideoFrame(videoFrame13, {timestamp: 0});
+pseudoSubmit(device10, commandEncoder117);
+let querySet102 = device3.createQuerySet({
+label: '\u{1fc33}\u3b38\u1aab\udee0\u0d9d\u8fdc',
+type: 'occlusion',
+count: 1402,
+});
+let texture170 = device3.createTexture({
+label: '\ud50e\u07a7\u02ba\u0438\uf1db\u44fa\u{1fb5c}\u1969\ufa0d',
+size: {width: 32, height: 60, depthOrArrayLayers: 179},
+mipLevelCount: 6,
+sampleCount: 1,
+format: 'r32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['r32float'],
+});
+let computePassEncoder79 = commandEncoder101.beginComputePass();
+let sampler107 = device3.createSampler({
+label: '\u{1fb20}\u{1fd1c}\u38af\u7b97\u169c\u0841\u0760\u76e9\ud072\u5c2d\u{1fc30}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 65.666,
+lodMaxClamp: 98.093,
+compare: 'always',
+maxAnisotropy: 1,
+});
+try {
+computePassEncoder68.setBindGroup(6, bindGroup27, new Uint32Array(9939), 125, 0);
+} catch {}
+try {
+commandEncoder51.copyTextureToTexture({
+  texture: texture79,
+  mipLevel: 7,
+  origin: { x: 10, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture79,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder110.resolveQuerySet(querySet29, 1847, 965, buffer33, 14336);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline109 = device3.createComputePipeline({
+layout: pipelineLayout11,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let textureView143 = texture151.createView({label: '\u3edf\u1374\u2461\u0508\ub9ed', dimension: '2d-array', baseMipLevel: 3});
+let renderBundleEncoder117 = device12.createRenderBundleEncoder({
+  label: '\u0e94\u{1fb30}\u{1fc5a}\u7145',
+  colorFormats: ['rg16uint', 'rg16sint'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle135 = renderBundleEncoder117.finish({label: '\u496c\ufb94\u996e'});
+try {
+gpuCanvasContext34.configure({
+device: device12,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['eac-r11snorm', 'etc2-rgb8a1unorm', 'bgra8unorm-srgb', 'rgba8unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+gc();
+let commandEncoder134 = device3.createCommandEncoder({label: '\u4dde\u{1fe56}\u3e03\u6fe5\u67b0\u0a48\u561c\u035c'});
+let renderBundleEncoder118 = device3.createRenderBundleEncoder({label: '\u5a6b\u205e\uf42c\u08e8', colorFormats: ['rg32sint'], stencilReadOnly: true});
+try {
+computePassEncoder78.setPipeline(pipeline109);
+} catch {}
+try {
+renderBundleEncoder107.setVertexBuffer(8, buffer54);
+} catch {}
+let promise65 = buffer37.mapAsync(GPUMapMode.READ, 0, 12056);
+try {
+commandEncoder68.copyTextureToTexture({
+  texture: texture145,
+  mipLevel: 3,
+  origin: { x: 0, y: 25, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture145,
+  mipLevel: 4,
+  origin: { x: 0, y: 5, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder134.resolveQuerySet(querySet74, 2631, 446, buffer41, 3840);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 8, height: 15, depthOrArrayLayers: 179}
+*/
+{
+  source: imageData4,
+  origin: { x: 85, y: 69 },
+  flipY: true,
+}, {
+  texture: texture170,
+  mipLevel: 2,
+  origin: { x: 1, y: 4, z: 40 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder135 = device9.createCommandEncoder({label: '\u1ad1\u826b\u{1fa7a}\u1bbf\ua785'});
+let textureView144 = texture161.createView({
+  label: '\u{1fc46}\uf90f\uc7b8\ua170\u0bf0\uf9e8\u3665\u0112\u0bb4\u7a07',
+  dimension: '2d',
+  baseMipLevel: 7,
+  mipLevelCount: 1,
+  baseArrayLayer: 17
+});
+let renderBundle136 = renderBundleEncoder99.finish({label: '\u0427\u{1fa5f}\u050a\uae36\u3e5e\u7d51\u439c'});
+try {
+renderBundleEncoder116.setVertexBuffer(70, undefined, 3266289223, 687296722);
+} catch {}
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let commandEncoder136 = device1.createCommandEncoder({});
+let sampler108 = device1.createSampler({
+label: '\uaef6\u20ef',
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 95.845,
+lodMaxClamp: 98.352,
+maxAnisotropy: 14,
+});
+try {
+renderBundleEncoder37.drawIndexed(16);
+} catch {}
+try {
+renderBundleEncoder86.setPipeline(pipeline82);
+} catch {}
+try {
+commandEncoder88.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 17672 */
+offset: 17672,
+bytesPerRow: 0,
+buffer: buffer47,
+}, {
+  texture: texture142,
+  mipLevel: 2,
+  origin: { x: 4, y: 16, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 152, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer47);
+} catch {}
+try {
+commandEncoder107.clearBuffer(buffer27);
+dissociateBuffer(device1, buffer27);
+} catch {}
+let promise66 = device1.queue.onSubmittedWorkDone();
+document.body.prepend(img32);
+let textureView145 = texture167.createView({
+  label: '\u3f61\u{1fa85}\u{1f728}\u4dad\u24bb\u4aa2\u4f6f\ubceb\u0d80\u009f\u0b5b',
+  format: 'r16sint',
+  baseMipLevel: 2,
+  mipLevelCount: 3
+});
+let sampler109 = device9.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 79.624,
+lodMaxClamp: 90.200,
+compare: 'less-equal',
+});
+try {
+device9.addEventListener('uncapturederror', e => { log('device9.uncapturederror'); log(e); e.label = device9.label; });
+} catch {}
+offscreenCanvas3.height = 682;
+let imageData43 = new ImageData(184, 32);
+let textureView146 = texture130.createView({label: '\ueb3c\u{1f6d0}\u664a', dimension: '2d', baseMipLevel: 3, baseArrayLayer: 170});
+let computePassEncoder80 = commandEncoder132.beginComputePass({label: '\u{1fa3d}\u0e8a\u{1ffbd}\u3b80\u{1ff07}'});
+try {
+device7.queue.writeTexture({
+  texture: texture128,
+  mipLevel: 2,
+  origin: { x: 21, y: 0, z: 0 },
+  aspect: 'all',
+}, new Float32Array(arrayBuffer14), /* required buffer size: 459280 */
+{offset: 280, bytesPerRow: 300, rowsPerImage: 153}, {width: 8, height: 0, depthOrArrayLayers: 11});
+} catch {}
+let canvas42 = document.createElement('canvas');
+let computePassEncoder81 = commandEncoder88.beginComputePass();
+let renderBundle137 = renderBundleEncoder42.finish({label: '\u0975\u0bfb'});
+try {
+computePassEncoder60.setPipeline(pipeline106);
+} catch {}
+try {
+commandEncoder136.copyTextureToTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 32, y: 468, z: 34 },
+  aspect: 'all',
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: { x: 20, y: 32, z: 49 },
+  aspect: 'all',
+}, {width: 36, height: 276, depthOrArrayLayers: 9});
+} catch {}
+try {
+commandEncoder136.resolveQuerySet(querySet27, 84, 0, buffer34, 512);
+} catch {}
+try {
+renderBundleEncoder94.popDebugGroup();
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture137,
+  mipLevel: 5,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 213 */
+{offset: 205}, {width: 2, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let imageBitmap42 = await createImageBitmap(canvas24);
+try {
+await adapter11.requestAdapterInfo();
+} catch {}
+try {
+canvas42.getContext('webgpu');
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture152,
+  mipLevel: 0,
+  origin: { x: 12, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 384 */
+{offset: 384, rowsPerImage: 234}, {width: 266, height: 1, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas36.height = 901;
+let texture171 = device9.createTexture({
+label: '\u4eca\u{1f725}\u33bf\u0d7e\u{1fe06}\u713e\u{1f77e}\ua19a\u0f9b\u5795\u9551',
+size: {width: 2688, height: 1, depthOrArrayLayers: 63},
+mipLevelCount: 3,
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+});
+let sampler110 = device9.createSampler({
+label: '\u0d62\u06e1\u0c6a',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 18.703,
+lodMaxClamp: 73.505,
+maxAnisotropy: 3,
+});
+try {
+renderBundleEncoder116.setVertexBuffer(6, undefined, 1101574973, 3150808641);
+} catch {}
+let texture172 = device10.createTexture({
+label: '\u467f\u73cd\u9b42\u48ca\u0075',
+size: [180, 204, 1],
+mipLevelCount: 7,
+format: 'astc-12x12-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-12x12-unorm', 'astc-12x12-unorm-srgb', 'astc-12x12-unorm'],
+});
+try {
+await device10.popErrorScope();
+} catch {}
+try {
+gpuCanvasContext32.unconfigure();
+} catch {}
+let offscreenCanvas43 = new OffscreenCanvas(247, 424);
+let video38 = await videoWithData();
+try {
+  await promise65;
+} catch {}
+let sampler111 = device6.createSampler({
+label: '\u{1f7fb}\u{1f63d}\uac37\u27d8\u9829\u4bb8\u04d7\u03ed',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 96.898,
+lodMaxClamp: 99.044,
+});
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 4, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap30,
+  origin: { x: 10, y: 11 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+offscreenCanvas43.getContext('webgpu');
+} catch {}
+let querySet103 = device1.createQuerySet({
+label: '\u{1f9ad}\u0bdd\u{1fef4}',
+type: 'occlusion',
+count: 641,
+});
+let textureView147 = texture30.createView({
+  label: '\udeea\u0d7c\u{1f7dc}\u330c\u764f\u7da1\ua699\u07d4\u6a96\ue983\u99a7',
+  dimension: '2d-array',
+  baseMipLevel: 1
+});
+let renderBundle138 = renderBundleEncoder37.finish({});
+try {
+computePassEncoder55.setPipeline(pipeline101);
+} catch {}
+try {
+renderBundleEncoder59.draw(72, 32, 48, 48);
+} catch {}
+try {
+commandEncoder107.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 1,
+  origin: { x: 3, y: 82, z: 6 },
+  aspect: 'all',
+}, {
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 29, y: 229, z: 30 },
+  aspect: 'all',
+}, {width: 48, height: 302, depthOrArrayLayers: 2});
+} catch {}
+try {
+commandEncoder136.insertDebugMarker('\u09c8');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture163,
+  mipLevel: 1,
+  origin: { x: 8, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 300 */
+{offset: 300, bytesPerRow: 335}, {width: 88, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let pipeline110 = device1.createComputePipeline({
+label: '\u{1fba1}\u954d\u58ae',
+layout: pipelineLayout13,
+compute: {
+module: shaderModule18,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+computePassEncoder48.setPipeline(pipeline98);
+} catch {}
+try {
+renderBundleEncoder76.setBindGroup(0, bindGroup25, []);
+} catch {}
+try {
+computePassEncoder51.insertDebugMarker('\u{1fec2}');
+} catch {}
+try {
+adapter22.label = '\u480c\u0f19\u01d3';
+} catch {}
+let bindGroup30 = device3.createBindGroup({
+label: '\u1c8d\u0ee5\u9188\u6d25\ub6e8',
+layout: bindGroupLayout32,
+entries: [],
+});
+let texture173 = device3.createTexture({
+label: '\u7133\u08cd\u1321\u00b9',
+size: {width: 240, height: 960, depthOrArrayLayers: 1455},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rg32sint'],
+});
+try {
+renderBundleEncoder78.setBindGroup(4, bindGroup27);
+} catch {}
+try {
+renderBundleEncoder79.setIndexBuffer(buffer35, 'uint32', 19648, 24844);
+} catch {}
+try {
+renderBundleEncoder78.setVertexBuffer(6, buffer54, 9996, 1479);
+} catch {}
+try {
+  await buffer42.mapAsync(GPUMapMode.WRITE, 1752, 896);
+} catch {}
+let adapter27 = await navigator.gpu.requestAdapter();
+let textureView148 = texture138.createView({
+  label: '\ua265\ud9a6\u0365\u{1ff09}\u{1fc2e}\u9997',
+  format: 'astc-10x8-unorm-srgb',
+  baseMipLevel: 1,
+  baseArrayLayer: 5,
+  arrayLayerCount: 163
+});
+try {
+renderBundleEncoder111.setVertexBuffer(58, undefined);
+} catch {}
+try {
+  await promise66;
+} catch {}
+let device13 = await adapter25.requestDevice({
+label: '\uca0a\ub7c3\u9fbf\ue63d\u{1ffd0}\u0c62\ue3cf\uab76',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 8,
+maxColorAttachmentBytesPerSample: 40,
+maxVertexAttributes: 25,
+maxVertexBufferArrayStride: 19828,
+maxStorageTexturesPerShaderStage: 26,
+maxStorageBuffersPerShaderStage: 43,
+maxDynamicStorageBuffersPerPipelineLayout: 9379,
+maxBindingsPerBindGroup: 4932,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 13804,
+maxTextureDimension2D: 14509,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 113391366,
+maxUniformBuffersPerShaderStage: 33,
+maxInterStageShaderVariables: 97,
+maxInterStageShaderComponents: 70,
+maxSamplersPerShaderStage: 22,
+},
+});
+let commandEncoder137 = device8.createCommandEncoder({label: '\u{1fc85}\u0655\u069e'});
+try {
+commandEncoder131.copyTextureToTexture({
+  texture: texture134,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture134,
+  mipLevel: 1,
+  origin: { x: 0, y: 4, z: 0 },
+  aspect: 'all',
+}, {width: 156, height: 8, depthOrArrayLayers: 0});
+} catch {}
+canvas3.width = 278;
+let computePassEncoder82 = commandEncoder125.beginComputePass({label: '\u{1fb9a}\u0d2b\ue58a\ub92e\u94e7\u0c92\u0d4e\u0de8\u{1ffb1}'});
+let renderBundle139 = renderBundleEncoder117.finish({label: '\u{1fdc7}\u{1f728}\u0fe9\u0650\u05ff\u026b\u{1f7d1}\u{1f6fe}\u6982\u05b9\u0c61'});
+document.body.prepend(canvas33);
+let imageData44 = new ImageData(88, 176);
+try {
+adapter18.label = '\u0f13\uf666';
+} catch {}
+let buffer59 = device7.createBuffer({
+  label: '\u{1f962}\u05d0\u3176\u{1fcde}\u1d8c\u6159',
+  size: 65359,
+  usage: GPUBufferUsage.MAP_READ,
+  mappedAtCreation: false
+});
+let textureView149 = texture164.createView({label: '\ua058\u866f\u5d8c\u38c5\u0541\uab0f\u2ae9\u8397\uf75f', baseMipLevel: 1, mipLevelCount: 2});
+try {
+computePassEncoder80.end();
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture149,
+  mipLevel: 3,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer9), /* required buffer size: 906 */
+{offset: 906}, {width: 16, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let img40 = await imageWithData(216, 225, '#138a02b5', '#7425111b');
+let promise67 = adapter3.requestAdapterInfo();
+document.body.prepend(canvas20);
+let renderBundle140 = renderBundleEncoder26.finish();
+try {
+computePassEncoder81.setBindGroup(5, bindGroup23, []);
+} catch {}
+try {
+computePassEncoder63.setBindGroup(0, bindGroup20, new Uint32Array(2579), 58, 0);
+} catch {}
+try {
+computePassEncoder81.end();
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline29);
+} catch {}
+try {
+commandEncoder136.copyBufferToBuffer(buffer58, 688, buffer20, 1144, 64);
+dissociateBuffer(device1, buffer58);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+commandEncoder107.clearBuffer(buffer27, 16676);
+dissociateBuffer(device1, buffer27);
+} catch {}
+let promise68 = device1.createRenderPipelineAsync({
+layout: pipelineLayout12,
+fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'r32uint', writeMask: GPUColorWrite.ALL}, {format: 'rg8sint', writeMask: GPUColorWrite.BLUE}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'dst-alpha'},
+}
+}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}]
+},
+vertex: {
+  module: shaderModule3,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 9228,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 8516,
+shaderLocation: 19,
+}, {
+format: 'float16x2',
+offset: 4908,
+shaderLocation: 3,
+}, {
+format: 'unorm16x4',
+offset: 2432,
+shaderLocation: 6,
+}, {
+format: 'uint32x3',
+offset: 3720,
+shaderLocation: 23,
+}],
+},
+{
+arrayStride: 13508,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 6780,
+shaderLocation: 22,
+}, {
+format: 'float16x4',
+offset: 4684,
+shaderLocation: 14,
+}, {
+format: 'uint16x2',
+offset: 8968,
+shaderLocation: 2,
+}, {
+format: 'uint32',
+offset: 11216,
+shaderLocation: 15,
+}, {
+format: 'float32x4',
+offset: 600,
+shaderLocation: 18,
+}, {
+format: 'uint32x4',
+offset: 13408,
+shaderLocation: 8,
+}, {
+format: 'sint8x4',
+offset: 4616,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 9432,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x4',
+offset: 4848,
+shaderLocation: 26,
+}, {
+format: 'sint8x4',
+offset: 6592,
+shaderLocation: 5,
+}, {
+format: 'snorm8x2',
+offset: 1638,
+shaderLocation: 13,
+}, {
+format: 'unorm10-10-10-2',
+offset: 1260,
+shaderLocation: 25,
+}, {
+format: 'float32x4',
+offset: 8812,
+shaderLocation: 0,
+}, {
+format: 'sint8x4',
+offset: 9100,
+shaderLocation: 9,
+}, {
+format: 'sint32x4',
+offset: 8080,
+shaderLocation: 12,
+}, {
+format: 'float32',
+offset: 2240,
+shaderLocation: 11,
+}, {
+format: 'float32x4',
+offset: 6232,
+shaderLocation: 16,
+}, {
+format: 'snorm16x4',
+offset: 2592,
+shaderLocation: 20,
+}],
+},
+{
+arrayStride: 27564,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 22096,
+shaderLocation: 17,
+}, {
+format: 'uint32',
+offset: 15764,
+shaderLocation: 4,
+}, {
+format: 'snorm8x4',
+offset: 9812,
+shaderLocation: 24,
+}, {
+format: 'sint16x4',
+offset: 4476,
+shaderLocation: 10,
+}, {
+format: 'uint8x2',
+offset: 4828,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 33696,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1500,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 1160,
+shaderLocation: 21,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let bindGroupLayout49 = device3.createBindGroupLayout({
+entries: [],
+});
+let commandEncoder138 = device3.createCommandEncoder({label: '\u{1fe05}\u6da2\u97dd\u{1f747}\ub7f8\u0c64\u{1ff2a}\u{1f847}\u8ea2'});
+let querySet104 = device3.createQuerySet({
+label: '\uf331\ue663',
+type: 'occlusion',
+count: 2137,
+});
+try {
+commandEncoder134.copyBufferToBuffer(buffer35, 30492, buffer24, 5036, 2136);
+dissociateBuffer(device3, buffer35);
+dissociateBuffer(device3, buffer24);
+} catch {}
+try {
+commandEncoder51.copyTextureToBuffer({
+  texture: texture79,
+  mipLevel: 4,
+  origin: { x: 10, y: 8, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 33488 */
+offset: 33488,
+buffer: buffer40,
+}, {width: 0, height: 8, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer40);
+} catch {}
+try {
+commandEncoder138.resolveQuerySet(querySet74, 1350, 837, buffer33, 33024);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 179}
+*/
+{
+  source: img27,
+  origin: { x: 56, y: 54 },
+  flipY: false,
+}, {
+  texture: texture170,
+  mipLevel: 5,
+  origin: { x: 0, y: 1, z: 94 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let bindGroupLayout50 = device12.createBindGroupLayout({
+label: '\u04a0\uefa5',
+entries: [],
+});
+let bindGroup31 = device12.createBindGroup({
+layout: bindGroupLayout50,
+entries: [],
+});
+let pipelineLayout26 = device12.createPipelineLayout({label: '\u9e0a\u47f7\u9957', bindGroupLayouts: [bindGroupLayout50]});
+let commandEncoder139 = device12.createCommandEncoder();
+let querySet105 = device12.createQuerySet({
+label: '\u{1feac}\u1e17\u057a\u1c30',
+type: 'occlusion',
+count: 3724,
+});
+let renderBundleEncoder119 = device12.createRenderBundleEncoder({
+  colorFormats: [undefined, 'rgba8uint', 'rgba16float', 'rgba16sint', 'bgra8unorm', 'rgba16sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder119.setBindGroup(2, bindGroup31);
+} catch {}
+try {
+renderBundleEncoder119.setVertexBuffer(39, undefined, 1521196456, 1576214910);
+} catch {}
+document.body.prepend(img4);
+let texture174 = device13.createTexture({
+label: '\uc20c\u02f4\u0337\uaae4',
+size: {width: 450, height: 5, depthOrArrayLayers: 66},
+format: 'astc-10x5-unorm',
+usage: GPUTextureUsage.COPY_DST,
+});
+let textureView150 = texture174.createView({baseArrayLayer: 13, arrayLayerCount: 17});
+let renderBundleEncoder120 = device13.createRenderBundleEncoder({
+  label: '\u8815\u{1f871}\u043a\ua944\u0690',
+  colorFormats: ['rgba32sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: false
+});
+let canvas43 = document.createElement('canvas');
+let shaderModule23 = device4.createShaderModule({
+label: '\ue775\u3b5c\ud873\u{1fd99}\u7948\ua33e',
+code: `@group(2) @binding(1245)
+var<storage, read_write> parameter25: array<u32>;
+@group(0) @binding(115)
+var<storage, read_write> global17: array<u32>;
+@group(3) @binding(115)
+var<storage, read_write> local25: array<u32>;
+@group(0) @binding(1223)
+var<storage, read_write> field13: array<u32>;
+@group(0) @binding(1245)
+var<storage, read_write> function10: array<u32>;
+@group(3) @binding(1223)
+var<storage, read_write> type29: array<u32>;
+@group(1) @binding(1245)
+var<storage, read_write> parameter26: array<u32>;
+@group(1) @binding(1223)
+var<storage, read_write> local26: array<u32>;
+
+@compute @workgroup_size(3, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S30 {
+  @builtin(position) f0: vec4<f32>,
+  @builtin(front_facing) f1: bool,
+  @builtin(sample_mask) f2: u32
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @builtin(frag_depth) f1: f32,
+  @location(0) f2: vec4<u32>,
+  @location(4) f3: u32,
+  @location(3) f4: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, a1: S30) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S29 {
+  @location(7) f0: vec2<f32>,
+  @location(15) f1: vec3<f32>,
+  @location(3) f2: vec4<f32>,
+  @location(12) f3: vec2<f16>,
+  @location(1) f4: vec3<f16>,
+  @location(0) f5: vec2<f32>,
+  @location(18) f6: vec3<i32>,
+  @location(2) f7: vec3<f32>,
+  @location(17) f8: i32,
+  @builtin(instance_index) f9: u32
+}
+
+@vertex
+fn vertex0(@location(11) a0: i32, @location(14) a1: vec4<f16>, @location(16) a2: vec3<i32>, @location(5) a3: vec2<i32>, a4: S29, @location(9) a5: vec4<u32>, @location(10) a6: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+let arrayBuffer15 = buffer26.getMappedRange(17824);
+let pipeline111 = await device4.createRenderPipelineAsync({
+layout: 'auto',
+multisample: {
+mask: 0xe842e253,
+},
+fragment: {
+  module: shaderModule23,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined, {format: 'rgba32float'}, {format: 'rg16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 1896,
+stencilWriteMask: 3397,
+depthBias: 60,
+depthBiasSlopeScale: 75,
+depthBiasClamp: 89,
+},
+vertex: {
+  module: shaderModule23,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 9208,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 7896,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 6040,
+shaderLocation: 1,
+}, {
+format: 'unorm16x2',
+offset: 1472,
+shaderLocation: 7,
+}, {
+format: 'sint16x2',
+offset: 3560,
+shaderLocation: 5,
+}, {
+format: 'sint8x4',
+offset: 2304,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 15172,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 1316,
+shaderLocation: 12,
+}, {
+format: 'unorm16x4',
+offset: 14272,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 11144,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 7656,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 1412,
+attributes: [{
+format: 'float32x3',
+offset: 152,
+shaderLocation: 14,
+}, {
+format: 'unorm16x2',
+offset: 788,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 0,
+attributes: [{
+format: 'sint32x4',
+offset: 15576,
+shaderLocation: 18,
+}, {
+format: 'uint8x2',
+offset: 19284,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 5748,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x4',
+offset: 1728,
+shaderLocation: 15,
+}, {
+format: 'uint32x2',
+offset: 1324,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 17832,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x2',
+offset: 2222,
+shaderLocation: 17,
+}],
+},
+{
+arrayStride: 4460,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x2',
+offset: 1112,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let promise69 = adapter13.requestAdapterInfo();
+let texture175 = gpuCanvasContext10.getCurrentTexture();
+try {
+commandEncoder122.copyTextureToTexture({
+  texture: texture175,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture175,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext40 = canvas43.getContext('webgpu');
+let commandEncoder140 = device12.createCommandEncoder({});
+let renderBundleEncoder121 = device10.createRenderBundleEncoder({
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler112 = device10.createSampler({
+label: '\u3ce4\u5362\u64cb\ucffd\uaa80',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 88.269,
+lodMaxClamp: 93.083,
+});
+try {
+device10.queue.writeTexture({
+  texture: texture172,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer14, /* required buffer size: 138 */
+{offset: 138, bytesPerRow: 280}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise70 = device10.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let imageData45 = new ImageData(180, 192);
+let videoFrame44 = new VideoFrame(canvas23, {timestamp: 0});
+let sampler113 = device4.createSampler({
+label: '\ue083\u443a\u{1ff75}',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 94.605,
+lodMaxClamp: 96.826,
+compare: 'always',
+});
+let video39 = await videoWithData();
+let imageBitmap43 = await createImageBitmap(img26);
+let videoFrame45 = new VideoFrame(imageBitmap24, {timestamp: 0});
+let offscreenCanvas44 = new OffscreenCanvas(985, 456);
+let querySet106 = device3.createQuerySet({
+label: '\u8829\u70ce',
+type: 'occlusion',
+count: 1274,
+});
+let textureView151 = texture92.createView({label: '\uf31d\ud42f\u2670', aspect: 'all'});
+let renderBundleEncoder122 = device3.createRenderBundleEncoder({
+  label: '\u{1f86a}\u2a0b\ubca7\u0b52\u0741\u{1f94b}\u0e2f\u{1fd45}\u2be3\u0ea9\u07c6',
+  colorFormats: ['bgra8unorm-srgb', 'rg32uint', 'rg32sint', 'rgb10a2unorm', undefined, 'rgba8uint']
+});
+try {
+renderBundleEncoder118.setVertexBuffer(0, buffer44);
+} catch {}
+try {
+commandEncoder138.copyTextureToTexture({
+  texture: texture69,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture106,
+  mipLevel: 5,
+  origin: { x: 2, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 30, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder110.clearBuffer(buffer40, 13472, 2952);
+dissociateBuffer(device3, buffer40);
+} catch {}
+try {
+commandEncoder68.resolveQuerySet(querySet91, 2178, 774, buffer41, 1280);
+} catch {}
+let offscreenCanvas45 = new OffscreenCanvas(465, 514);
+let gpuCanvasContext41 = offscreenCanvas44.getContext('webgpu');
+try {
+  await promise70;
+} catch {}
+let imageData46 = new ImageData(136, 96);
+let textureView152 = texture134.createView({format: 'etc2-rgb8a1unorm', baseMipLevel: 5});
+let renderBundle141 = renderBundleEncoder90.finish({label: '\u8119\u6038\ufbbe\u2208\ue077\u0f91\ude40'});
+let sampler114 = device8.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 19.705,
+lodMaxClamp: 40.554,
+});
+try {
+commandEncoder88.clearBuffer(buffer39);
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+commandEncoder133.resolveQuerySet(querySet67, 1354, 11, buffer34, 22272);
+} catch {}
+let commandEncoder141 = device1.createCommandEncoder({label: '\u{1f63a}\u0f65\u0680\u0a01\ucc0a\uc2ee\u0089\u014d'});
+let querySet107 = device1.createQuerySet({
+label: '\u{1f7a1}\u5802\u75f2\ucecb\u4710\u4d4f\u{1fa64}\uc763\udcf7\ua6a9',
+type: 'occlusion',
+count: 3435,
+});
+let computePassEncoder83 = commandEncoder141.beginComputePass({label: '\u3656\uf0c9\u63b3\u781c\ufab6\u{1f7f6}'});
+try {
+commandEncoder133.resolveQuerySet(querySet73, 760, 241, buffer34, 10752);
+} catch {}
+let bindGroup32 = device1.createBindGroup({
+label: '\u0f31\u{1fd1f}\ub3fe',
+layout: bindGroupLayout11,
+entries: [{
+binding: 542,
+resource: textureView99
+}],
+});
+let texture176 = device1.createTexture({
+label: '\u{1fb92}\u17b0\u0882\u2722\uace9\u6246\u{1f916}\ufc24\ua477\u0c32',
+size: [13, 96, 165],
+mipLevelCount: 3,
+dimension: '3d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['r16float', 'r16float', 'r16float'],
+});
+let texture177 = gpuCanvasContext34.getCurrentTexture();
+try {
+commandEncoder133.copyBufferToTexture({
+/* bytesInLastRow: 96 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 4720 */
+offset: 4720,
+buffer: buffer34,
+}, {
+  texture: texture154,
+  mipLevel: 3,
+  origin: { x: 576, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 72, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer34);
+} catch {}
+try {
+commandEncoder136.copyTextureToTexture({
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 100, y: 40, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 55, y: 70, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext42 = offscreenCanvas45.getContext('webgpu');
+let img41 = await imageWithData(271, 107, '#05fa5602', '#5f63cc6b');
+let imageBitmap44 = await createImageBitmap(img7);
+let bindGroup33 = device12.createBindGroup({
+layout: bindGroupLayout50,
+entries: [],
+});
+let commandEncoder142 = device12.createCommandEncoder({label: '\u8ad7\u{1fe8e}\u{1fcde}'});
+let renderBundle142 = renderBundleEncoder117.finish({label: '\uffd4\uec99\u821d\u042c\u8d30\ub50a\u{1f982}\u09e8\u9ff5\u008e\u{1f9aa}'});
+let externalTexture12 = device12.importExternalTexture({
+source: videoFrame27,
+colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder119.setBindGroup(2, bindGroup33, new Uint32Array(175), 76, 0);
+} catch {}
+let canvas44 = document.createElement('canvas');
+let video40 = await videoWithData();
+try {
+computePassEncoder47.setBindGroup(8, bindGroup9, new Uint32Array(2069), 694, 0);
+} catch {}
+try {
+renderBundleEncoder73.insertDebugMarker('\u{1fbe8}');
+} catch {}
+try {
+device3.queue.writeBuffer(buffer40, 6220, new Int16Array(42071), 29228, 4016);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: { x: 4, y: 1, z: 1 },
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer15), /* required buffer size: 670 */
+{offset: 670}, {width: 501, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline112 = device3.createComputePipeline({
+label: '\u666c\u0ac9\u{1f75d}\u{1fcc5}\u09a6\u{1fdbe}\udb22\u{1fc43}\u09f6',
+layout: pipelineLayout10,
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let canvas45 = document.createElement('canvas');
+let offscreenCanvas46 = new OffscreenCanvas(36, 932);
+let shaderModule24 = device3.createShaderModule({
+label: '\u7de4\u0328\u0a12\u5b56\u{1fe15}\u573d\u68a7\u06f8\u409b\uc0e2',
+code: `@group(0) @binding(846)
+var<storage, read_write> parameter27: array<u32>;
+@group(4) @binding(846)
+var<storage, read_write> function11: array<u32>;
+
+@compute @workgroup_size(8, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(5) f0: vec4<u32>,
+  @location(1) f1: vec4<u32>,
+  @location(0) f2: f32,
+  @location(2) f3: u32,
+  @location(4) f4: vec2<i32>,
+  @location(3) f5: vec4<f32>,
+  @builtin(sample_mask) f6: u32
+}
+
+@fragment
+fn fragment0(@location(57) a0: i32, @location(78) a1: vec4<i32>, @location(72) a2: vec4<f32>, @location(34) a3: vec4<u32>, @location(55) a4: vec3<f32>, @location(81) a5: f16, @location(60) a6: vec3<f16>, @location(38) a7: vec3<f32>, @location(54) a8: vec2<f32>, @location(40) a9: vec3<f16>, @location(62) a10: u32, @location(46) a11: vec2<u32>, @location(26) a12: vec2<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(70) f488: f32,
+  @location(53) f489: vec2<u32>,
+  @location(78) f490: vec4<i32>,
+  @location(50) f491: u32,
+  @location(18) f492: vec4<f16>,
+  @location(49) f493: f16,
+  @location(48) f494: vec4<f16>,
+  @location(21) f495: i32,
+  @location(34) f496: vec4<u32>,
+  @location(81) f497: f16,
+  @location(12) f498: vec2<i32>,
+  @location(68) f499: vec2<i32>,
+  @location(22) f500: vec2<u32>,
+  @location(80) f501: f32,
+  @builtin(position) f502: vec4<f32>,
+  @location(75) f503: vec2<f32>,
+  @location(2) f504: vec4<f16>,
+  @location(40) f505: vec3<f16>,
+  @location(60) f506: vec3<f16>,
+  @location(38) f507: vec3<f32>,
+  @location(67) f508: vec3<f16>,
+  @location(57) f509: i32,
+  @location(82) f510: vec3<f16>,
+  @location(43) f511: vec4<f32>,
+  @location(46) f512: vec2<u32>,
+  @location(76) f513: i32,
+  @location(32) f514: vec2<f32>,
+  @location(59) f515: vec4<u32>,
+  @location(31) f516: u32,
+  @location(54) f517: vec2<f32>,
+  @location(77) f518: u32,
+  @location(10) f519: vec2<i32>,
+  @location(69) f520: i32,
+  @location(62) f521: u32,
+  @location(72) f522: vec4<f32>,
+  @location(23) f523: vec2<i32>,
+  @location(17) f524: f16,
+  @location(26) f525: vec2<i32>,
+  @location(36) f526: vec4<f32>,
+  @location(65) f527: u32,
+  @location(55) f528: vec3<f32>,
+  @location(41) f529: u32,
+  @location(5) f530: vec4<f16>,
+  @location(8) f531: f16,
+  @location(7) f532: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(23) a0: vec4<f16>, @location(21) a1: vec3<f32>, @location(9) a2: f32, @location(11) a3: vec3<u32>, @location(22) a4: vec4<f32>, @location(7) a5: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder143 = device3.createCommandEncoder({label: '\u98c9\u076d\u{1f66e}\u0ee9\u0c17\u0f40'});
+let texture178 = device3.createTexture({
+label: '\ubda1\u{1f7af}\u46b0\u272b\uc864\u0315\u3f1b\u1de1\u{1fa1d}',
+size: {width: 30, height: 120, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+sampleCount: 1,
+format: 'astc-6x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-6x6-unorm-srgb', 'astc-6x6-unorm-srgb', 'astc-6x6-unorm'],
+});
+let renderBundle143 = renderBundleEncoder65.finish({label: '\u0283\u{1faea}\uf0e6'});
+try {
+computePassEncoder48.dispatchWorkgroups(2, 1);
+} catch {}
+try {
+renderBundleEncoder54.setVertexBuffer(0, buffer29, 1600, 1819);
+} catch {}
+try {
+commandEncoder68.copyTextureToTexture({
+  texture: texture157,
+  mipLevel: 5,
+  origin: { x: 5, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture157,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'depth-only',
+}, {width: 8, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder134.clearBuffer(buffer37);
+dissociateBuffer(device3, buffer37);
+} catch {}
+let gpuCanvasContext43 = canvas45.getContext('webgpu');
+let videoFrame46 = new VideoFrame(img21, {timestamp: 0});
+let computePassEncoder84 = commandEncoder132.beginComputePass();
+let renderBundleEncoder123 = device7.createRenderBundleEncoder({
+  label: '\uc377\u0931\u0ce3\u0ba0\u4af6',
+  colorFormats: ['rgba16sint', 'rgba32sint', 'rgba32sint', 'rg16float', 'r16uint', undefined],
+  stencilReadOnly: true
+});
+let sampler115 = device7.createSampler({
+label: '\u{1f62e}\uf8db\u63c4',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 81.457,
+lodMaxClamp: 93.220,
+maxAnisotropy: 6,
+});
+let buffer60 = device6.createBuffer({
+  label: '\ufcc2\u7bd2\u3406\u1612\u{1fc2d}\u{1fb63}\u4594\ue5b8',
+  size: 14163,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT
+});
+let querySet108 = device6.createQuerySet({
+label: '\u05a6\u21f5\u{1fb99}\u08fe\u4d5c\u0f79\ub10c',
+type: 'occlusion',
+count: 555,
+});
+let sampler116 = device6.createSampler({
+label: '\u5255\u{1f6ed}\u0f2e\u59d6\u{1f8bf}\u0f03\u{1fec6}\ubee2\u8b8a\ub61d\u0048',
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 75.006,
+lodMaxClamp: 75.599,
+maxAnisotropy: 12,
+});
+try {
+renderBundleEncoder109.insertDebugMarker('\ud1f6');
+} catch {}
+canvas25.height = 49;
+let offscreenCanvas47 = new OffscreenCanvas(508, 705);
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+document.body.prepend(canvas16);
+let gpuCanvasContext44 = offscreenCanvas47.getContext('webgpu');
+let bindGroupLayout51 = device3.createBindGroupLayout({
+label: '\u56b7\ud3ed\ucca0\u036f\uee9b\ub6cd\u0ce8\ud41d\u1d84\uf7f5',
+entries: [],
+});
+let renderBundleEncoder124 = device3.createRenderBundleEncoder({label: '\u{1fa83}\u06f9\u0420\u1de9\u1077\ubeb3\u348a', colorFormats: ['rg8unorm'], depthReadOnly: true});
+let renderBundle144 = renderBundleEncoder65.finish({label: '\ubd6e\u091f'});
+try {
+commandEncoder68.copyTextureToTexture({
+  texture: texture59,
+  mipLevel: 1,
+  origin: { x: 3, y: 32, z: 40 },
+  aspect: 'all',
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: { x: 1, y: 116, z: 188 },
+  aspect: 'all',
+}, {width: 5, height: 60, depthOrArrayLayers: 0});
+} catch {}
+let texture179 = device8.createTexture({
+label: '\u1844\ua14d\ub2aa\uf7a8\u5e60\u0409\ud3a2\u00c8\ubf09\u7b1e\u7528',
+size: {width: 320},
+dimension: '1d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba32float', 'rgba32float'],
+});
+try {
+commandEncoder137.copyTextureToTexture({
+  texture: texture175,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture175,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device8.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video38,
+  origin: { x: 13, y: 6 },
+  flipY: false,
+}, {
+  texture: texture175,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img42 = await imageWithData(83, 240, '#c718a3a4', '#c2870904');
+let video41 = await videoWithData();
+let commandEncoder144 = device3.createCommandEncoder();
+let textureView153 = texture44.createView({label: '\u35c8\u4d6c\u2374\u7e1a\u802c\u5d54\u3656\u5168\u6932', baseArrayLayer: 0});
+let computePassEncoder85 = commandEncoder134.beginComputePass();
+try {
+renderBundleEncoder78.setBindGroup(0, bindGroup15, new Uint32Array(14), 7, 0);
+} catch {}
+let pipeline113 = device3.createComputePipeline({
+label: '\u0026\u0421\u0442\u0789',
+layout: pipelineLayout14,
+compute: {
+module: shaderModule24,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+gc();
+let commandEncoder145 = device7.createCommandEncoder({label: '\u{1fb11}\u{1fe29}\u02a1\u{1ff7a}\u05f4\uf203\u0d24\u99c7'});
+let renderBundle145 = renderBundleEncoder103.finish({label: '\u09b2\ub9bc\u11a2\u01d1\u01a8\u2472'});
+gc();
+let commandEncoder146 = device10.createCommandEncoder({label: '\uc106\u0ab6\u011b\uf50a\u6994\u065d\ua9b3\u2b02\u84fc'});
+let querySet109 = device10.createQuerySet({
+label: '\u235f\u4bec\u{1fe86}\u{1f695}\u7e65\u7b65\u0353\u8b83\udec5\u0ca7',
+type: 'occlusion',
+count: 681,
+});
+let textureView154 = texture138.createView({
+  label: '\u0324\u{1f9df}\uc49a\u{1fa4a}\udb33\ueff8\u8629\ucf6b',
+  dimension: '2d',
+  baseMipLevel: 2,
+  baseArrayLayer: 240
+});
+let renderBundleEncoder125 = device10.createRenderBundleEncoder({
+  label: '\u3d41\u{1fd2c}\u04d9\u099a\u{1f845}\u09a0\u0103\u114c\u0ceb\u145f\u6b31',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let sampler117 = device10.createSampler({
+label: '\u6091\u{1ffc0}\u{1fa66}\u0f98\u786e',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+lodMaxClamp: 98.338,
+});
+try {
+  await promise67;
+} catch {}
+try {
+adapter12.label = '\ufb3e\u6399\u01cc\u04f4\u2501\u2c7f\u0aa0\u9316\ubf5a';
+} catch {}
+let texture180 = device6.createTexture({
+label: '\u{1f8af}\u2c24\u{1f62c}\u{1fa52}\u8f0b\u6efa\u53c6',
+size: [140, 1, 1],
+sampleCount: 4,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundleEncoder126 = device6.createRenderBundleEncoder({
+  label: '\u9d2e\u{1f79f}\uf26d',
+  colorFormats: ['r8uint', 'rg16uint', 'r32float', 'rgba8uint', 'rgba16float', 'rgb10a2unorm'],
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+computePassEncoder71.end();
+} catch {}
+try {
+commandEncoder115.copyTextureToTexture({
+  texture: texture180,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture156,
+  mipLevel: 0,
+  origin: { x: 47, y: 279, z: 0 },
+  aspect: 'depth-only',
+}, {width: 140, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder115.insertDebugMarker('\u2db1');
+} catch {}
+let offscreenCanvas48 = new OffscreenCanvas(327, 77);
+try {
+textureView150.label = '\u31f4\u309d\ud863\ub3a5\u{1f897}\u93e3';
+} catch {}
+let texture181 = gpuCanvasContext20.getCurrentTexture();
+video29.width = 259;
+let commandEncoder147 = device7.createCommandEncoder({});
+let texture182 = device7.createTexture({
+label: '\u286b\u171e\u020c\u9831\uca43\u3b3b\u0dd4\u08cd\u0e11\ue2b2\u{1f85a}',
+size: {width: 591, height: 1, depthOrArrayLayers: 1458},
+mipLevelCount: 8,
+dimension: '3d',
+format: 'r8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle146 = renderBundleEncoder96.finish({label: '\uc94e\u0ad8\u0355'});
+let sampler118 = device7.createSampler({
+label: '\u{1f664}\u2eca\u0dcd\u{1f9d9}\uf281\u4a7f\u0fa0',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 89.521,
+});
+try {
+renderBundleEncoder123.setVertexBuffer(94, undefined, 1298893487, 500963130);
+} catch {}
+let bindGroupLayout52 = device4.createBindGroupLayout({
+label: '\u0502\uc155\u5fea\uae36\u{1fd97}\u{1ffdd}\uade0\u0f11\u{1f949}\u0200',
+entries: [],
+});
+let textureView155 = texture73.createView({
+  label: '\u0705\u0b79\uccf9\u05c7\ud5c8\ud235\u0d50\ua326\u7612\udff5',
+  dimension: '2d-array',
+  format: 'astc-5x5-unorm-srgb',
+  baseMipLevel: 4,
+  mipLevelCount: 1
+});
+try {
+device4.queue.submit([
+]);
+} catch {}
+try {
+  await promise69;
+} catch {}
+let videoFrame47 = videoFrame33.clone();
+let bindGroupLayout53 = device8.createBindGroupLayout({
+label: '\u07e4\u9638\u12a7\u529d\uca45\u{1f985}\ud50b\u001d',
+entries: [{
+binding: 3148,
+visibility: 0,
+externalTexture: {},
+}, {
+binding: 603,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}, {
+binding: 4171,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}],
+});
+let querySet110 = device8.createQuerySet({
+label: '\ufbf7\u0656\u053d\uf7d1\u2e54',
+type: 'occlusion',
+count: 142,
+});
+try {
+device8.queue.submit([
+commandBuffer22,
+commandBuffer23,
+]);
+} catch {}
+let offscreenCanvas49 = new OffscreenCanvas(163, 351);
+let textureView156 = texture172.createView({
+  label: '\u0c33\u3c91\u{1fb19}\u4e5b\u1025\u870e\u8ed2\u4787\u3f1c\u0e94',
+  format: 'astc-12x12-unorm-srgb',
+  baseMipLevel: 3,
+  mipLevelCount: 1
+});
+let sampler119 = device10.createSampler({
+label: '\ub527\ub3cd\ufc83\u017f\u0fe7\u{1fdea}\u{1fbbf}\u6093',
+addressModeU: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMaxClamp: 74.194,
+});
+let bindGroupLayout54 = device10.createBindGroupLayout({
+label: '\u859a\u0d17\u{1f640}\u3684\u8567',
+entries: [{
+binding: 4499,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 424236, hasDynamicOffset: true },
+}, {
+binding: 2163,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}, {
+binding: 3588,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+}],
+});
+let querySet111 = device10.createQuerySet({
+label: '\u{1f797}\uf402\u76b9\u{1fe11}\u2d78',
+type: 'occlusion',
+count: 3276,
+});
+try {
+device10.queue.writeTexture({
+  texture: texture172,
+  mipLevel: 0,
+  origin: { x: 24, y: 96, z: 0 },
+  aspect: 'all',
+}, arrayBuffer8, /* required buffer size: 951 */
+{offset: 919}, {width: 24, height: 12, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup34 = device12.createBindGroup({
+label: '\u564d\u0296\uad4b\u097c\ua0ef\u{1f67e}\u04e8\u{1fc4e}\u06d8\u{1fc3a}\u0da6',
+layout: bindGroupLayout50,
+entries: [],
+});
+let shaderModule25 = device11.createShaderModule({
+label: '\ue987\uf088\u7e8b',
+code: `@group(1) @binding(5512)
+var<storage, read_write> field14: array<u32>;
+@group(1) @binding(4677)
+var<storage, read_write> i18: array<u32>;
+@group(3) @binding(5789)
+var<storage, read_write> local27: array<u32>;
+@group(4) @binding(5789)
+var<storage, read_write> i19: array<u32>;
+@group(7) @binding(4677)
+var<storage, read_write> i20: array<u32>;
+@group(0) @binding(772)
+var<storage, read_write> global18: array<u32>;
+@group(0) @binding(5512)
+var<storage, read_write> global19: array<u32>;
+@group(4) @binding(6176)
+var<storage, read_write> parameter28: array<u32>;
+@group(3) @binding(6176)
+var<storage, read_write> global20: array<u32>;
+@group(0) @binding(4677)
+var<storage, read_write> parameter29: array<u32>;
+@group(6) @binding(5789)
+var<storage, read_write> i21: array<u32>;
+@group(3) @binding(2668)
+var<storage, read_write> field15: array<u32>;
+@group(7) @binding(5512)
+var<storage, read_write> global21: array<u32>;
+@group(7) @binding(772)
+var<storage, read_write> field16: array<u32>;
+
+@compute @workgroup_size(2, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S32 {
+  @location(37) f0: vec3<f32>,
+  @location(97) f1: i32,
+  @location(72) f2: vec4<u32>,
+  @location(86) f3: vec2<i32>,
+  @location(4) f4: vec4<i32>,
+  @location(112) f5: u32,
+  @location(12) f6: vec3<f32>,
+  @location(58) f7: vec3<f32>,
+  @location(78) f8: vec3<f32>,
+  @location(55) f9: f16,
+  @location(76) f10: u32,
+  @builtin(position) f11: vec4<f32>,
+  @location(0) f12: u32,
+  @location(19) f13: vec2<u32>,
+  @location(106) f14: f16
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @location(2) f1: vec4<u32>,
+  @location(3) f2: vec2<f32>,
+  @location(0) f3: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(61) a0: vec2<u32>, a1: S32, @location(47) a2: vec3<f16>, @location(50) a3: vec3<f32>, @builtin(sample_mask) a4: u32, @location(63) a5: vec4<f16>, @location(54) a6: vec2<f32>, @location(96) a7: f16, @location(49) a8: vec2<f32>, @location(91) a9: vec4<f16>, @location(21) a10: vec3<u32>, @location(44) a11: vec4<f32>, @location(34) a12: vec4<u32>, @location(40) a13: f16, @location(77) a14: f16, @location(39) a15: vec3<i32>, @location(105) a16: vec3<u32>, @location(59) a17: vec4<i32>, @location(7) a18: vec3<i32>, @location(113) a19: vec2<u32>, @builtin(front_facing) a20: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S31 {
+  @location(8) f0: vec4<f32>,
+  @location(24) f1: f16,
+  @location(21) f2: f32,
+  @location(12) f3: vec3<u32>,
+  @location(25) f4: vec3<f16>,
+  @location(22) f5: vec2<f16>,
+  @location(5) f6: vec4<f16>,
+  @location(10) f7: u32,
+  @location(15) f8: vec2<u32>,
+  @location(6) f9: u32,
+  @location(2) f10: vec2<f16>,
+  @location(0) f11: vec3<f32>,
+  @location(26) f12: vec2<u32>,
+  @location(3) f13: u32,
+  @builtin(vertex_index) f14: u32
+}
+struct VertexOutput0 {
+  @location(59) f533: vec4<i32>,
+  @location(34) f534: vec4<u32>,
+  @location(76) f535: u32,
+  @location(55) f536: f16,
+  @location(93) f537: i32,
+  @location(49) f538: vec2<f32>,
+  @location(106) f539: f16,
+  @builtin(position) f540: vec4<f32>,
+  @location(7) f541: vec3<i32>,
+  @location(58) f542: vec3<f32>,
+  @location(105) f543: vec3<u32>,
+  @location(19) f544: vec2<u32>,
+  @location(47) f545: vec3<f16>,
+  @location(44) f546: vec4<f32>,
+  @location(78) f547: vec3<f32>,
+  @location(80) f548: vec4<f16>,
+  @location(50) f549: vec3<f32>,
+  @location(37) f550: vec3<f32>,
+  @location(86) f551: vec2<i32>,
+  @location(0) f552: u32,
+  @location(97) f553: i32,
+  @location(17) f554: i32,
+  @location(77) f555: f16,
+  @location(11) f556: vec3<f16>,
+  @location(43) f557: u32,
+  @location(5) f558: vec4<i32>,
+  @location(21) f559: vec3<u32>,
+  @location(40) f560: f16,
+  @location(36) f561: i32,
+  @location(16) f562: vec3<f32>,
+  @location(4) f563: vec4<i32>,
+  @location(113) f564: vec2<u32>,
+  @location(39) f565: vec3<i32>,
+  @location(72) f566: vec4<u32>,
+  @location(54) f567: vec2<f32>,
+  @location(2) f568: vec3<f16>,
+  @location(112) f569: u32,
+  @location(61) f570: vec2<u32>,
+  @location(63) f571: vec4<f16>,
+  @location(12) f572: vec3<f32>,
+  @location(73) f573: f32,
+  @location(103) f574: vec4<i32>,
+  @location(96) f575: f16,
+  @location(91) f576: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(14) a0: i32, @location(16) a1: vec4<u32>, @location(11) a2: vec3<i32>, @location(13) a3: u32, @location(4) a4: vec4<f32>, @location(20) a5: vec2<i32>, @location(19) a6: vec3<f32>, @location(1) a7: vec3<f16>, a8: S31, @location(23) a9: f32, @location(7) a10: vec2<i32>, @location(18) a11: vec4<i32>, @location(9) a12: vec3<u32>, @location(17) a13: vec3<f32>, @builtin(instance_index) a14: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+});
+let commandEncoder148 = device11.createCommandEncoder({label: '\u1001\u{1fcbd}\u45b6\u3467\u1d82\u0442\ub375'});
+let textureView157 = texture158.createView({format: 'rgba8unorm', baseMipLevel: 0});
+let renderBundleEncoder127 = device11.createRenderBundleEncoder({
+  label: '\ud4d0\u9f14\ub059\u0073\u6c56\u4f57\u{1f7f7}\u1f71',
+  colorFormats: ['r16sint', 'rg16uint', 'rgb10a2uint', 'rg32float'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let texture183 = device5.createTexture({
+size: {width: 312, height: 1, depthOrArrayLayers: 222},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+});
+let renderBundle147 = renderBundleEncoder104.finish({label: '\u162c\u7dc0\u0659\u6aee\u1662\u9b71'});
+try {
+device5.destroy();
+} catch {}
+let video42 = await videoWithData();
+let gpuCanvasContext45 = canvas44.getContext('webgpu');
+try {
+offscreenCanvas46.getContext('webgl2');
+} catch {}
+let gpuCanvasContext46 = offscreenCanvas48.getContext('webgpu');
+try {
+offscreenCanvas49.getContext('webgpu');
+} catch {}
+let commandEncoder149 = device9.createCommandEncoder({label: '\u019c\u{1f96c}\u59f6\uefeb'});
+let querySet112 = device9.createQuerySet({
+label: '\u0b9e\u05c6\uf496\u848f\u{1fb16}\u{1fa6d}\ud496\u{1fe2e}',
+type: 'occlusion',
+count: 2221,
+});
+let texture184 = device9.createTexture({
+label: '\u{1fc05}\ud542\u2dc5\uaa3a\u05bf\ub410\u3a3a\u5e48\u0286\u889b',
+size: {width: 1452, height: 20, depthOrArrayLayers: 1},
+mipLevelCount: 10,
+format: 'astc-6x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView158 = texture161.createView({
+  label: '\u{1faa9}\u0455\u27e2\ub2d6\u5959\u{1ff3d}',
+  dimension: '2d',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  baseArrayLayer: 93
+});
+let renderBundleEncoder128 = device9.createRenderBundleEncoder({
+  label: '\ub4c0\u531f\u{1fbb8}\u8fff\u{1fbb8}\u{1ffdc}',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2unorm', 'rg32float', 'rgba8unorm', 'r8uint', 'rgba8unorm-srgb', 'rg8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundle135.label = '\u0588\u{1fd6b}\u277d\uab1f\u1e91';
+} catch {}
+let commandEncoder150 = device12.createCommandEncoder({label: '\u{1fda7}\u{1f908}\uc30f'});
+let querySet113 = device12.createQuerySet({
+type: 'occlusion',
+count: 4095,
+});
+let texture185 = device12.createTexture({
+label: '\uf6ef\u0aeb\u265e\uc7ee\ub14b\u30ed\u39a4\uc5f5',
+size: [9368, 152, 179],
+mipLevelCount: 11,
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg32sint', 'rg32sint', 'rg32sint'],
+});
+let promise71 = navigator.gpu.requestAdapter();
+let imageData47 = new ImageData(112, 132);
+let canvas46 = document.createElement('canvas');
+let bindGroupLayout55 = device3.createBindGroupLayout({
+label: '\u8f5b\uca05',
+entries: [{
+binding: 688,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube', sampleType: 'float', multisampled: false },
+}, {
+binding: 7759,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '1d' },
+}, {
+binding: 3049,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+}],
+});
+let computePassEncoder86 = commandEncoder138.beginComputePass();
+let renderBundleEncoder129 = device3.createRenderBundleEncoder({
+  label: '\u0d1d\u0450',
+  colorFormats: ['r32float', 'rgb10a2uint', 'r32uint', 'rg8unorm', 'rg8sint', 'rgba32uint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let renderBundle148 = renderBundleEncoder68.finish({label: '\ub225\ub6dd\u3eff\u0d77\u{1faf8}\u0871\u01a8'});
+let sampler120 = device3.createSampler({
+label: '\u898b\u5394\ufc45\u6378\u4fdf',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 99.674,
+compare: 'greater-equal',
+});
+try {
+commandEncoder144.copyBufferToBuffer(buffer29, 3628, buffer19, 12176, 420);
+dissociateBuffer(device3, buffer29);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+commandEncoder68.resolveQuerySet(querySet106, 642, 505, buffer33, 12800);
+} catch {}
+let gpuCanvasContext47 = canvas46.getContext('webgpu');
+let commandEncoder151 = device9.createCommandEncoder({});
+let sampler121 = device9.createSampler({
+label: '\uebd9\ud991\u8a83\u4bb7\ub8dc\ud729\u{1fd74}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 80.486,
+lodMaxClamp: 95.118,
+});
+try {
+await adapter13.requestAdapterInfo();
+} catch {}
+try {
+adapter13.label = '\u0f60\u{1fe6d}\u351d\u4d2a';
+} catch {}
+try {
+window.someLabel = externalTexture10.label;
+} catch {}
+let renderBundle149 = renderBundleEncoder106.finish({label: '\ue0d4\u34bb\u0f82\u0531\u{1ffa1}\u2307\u04ae\u01d7\u{1fe37}\u0067\u{1fc3a}'});
+let sampler122 = device8.createSampler({
+label: '\uaa82\u70c9\u06f5\u0d35\u{1f7d5}\u01b5\u0364',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 21.835,
+compare: 'never',
+});
+let adapter28 = await navigator.gpu.requestAdapter({
+});
+try {
+gpuCanvasContext24.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let computePassEncoder87 = commandEncoder147.beginComputePass({label: '\u240e\u0cb2\u{1f7a7}\u0da1\u63b5\u352d\u7b38\ueb7f\u6fb2\u92fe\u0883'});
+try {
+  await buffer48.mapAsync(GPUMapMode.READ, 2480, 3924);
+} catch {}
+try {
+commandEncoder145.copyTextureToTexture({
+  texture: texture130,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 8 },
+  aspect: 'all',
+}, {
+  texture: texture130,
+  mipLevel: 3,
+  origin: { x: 175, y: 0, z: 24 },
+  aspect: 'all',
+}, {width: 258, height: 1, depthOrArrayLayers: 134});
+} catch {}
+try {
+gpuCanvasContext23.configure({
+device: device7,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float', 'rgb10a2unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let canvas47 = document.createElement('canvas');
+let img43 = await imageWithData(200, 59, '#16540b6e', '#6d78f799');
+let bindGroupLayout56 = device6.createBindGroupLayout({
+label: '\u{1fee5}\ucbf6\uc4c8\ue57f\u562b\u6e47\u2567\u0486\u80ef\uc47d\uf6fa',
+entries: [],
+});
+let pipelineLayout27 = device6.createPipelineLayout({
+  label: '\uf35a\u0f5e\u61e5\u6ea3\u72fb\u05ce\u5352\u{1fa01}\u{1ffda}',
+  bindGroupLayouts: [bindGroupLayout56, bindGroupLayout56, bindGroupLayout56, bindGroupLayout56]
+});
+pseudoSubmit(device6, commandEncoder115);
+let textureView159 = texture133.createView({label: '\u{1f950}\u{1fb49}\u74b8\u03ad\u{1f98a}\ucddd\u5a14\u0324'});
+try {
+device6.queue.writeBuffer(buffer60, 10596, new Float32Array(51651), 42782, 460);
+} catch {}
+let imageData48 = new ImageData(120, 256);
+let renderBundleEncoder130 = device11.createRenderBundleEncoder({
+  label: '\ue5f4\uba5e\ufb19\u6afe\uc545\u{1f8bc}\u5105\u0c77',
+  colorFormats: ['r16sint', 'rg16uint', 'rgb10a2uint', 'rg32float'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder127.setBindGroup(2, bindGroup26, new Uint32Array(1728), 1565, 0);
+} catch {}
+try {
+renderBundleEncoder130.pushDebugGroup('\uf2ee');
+} catch {}
+let pipeline114 = await device11.createRenderPipelineAsync({
+label: '\ube7b\u0a20\u0005\u056d\u0127\u{1f850}',
+layout: pipelineLayout24,
+fragment: {
+  module: shaderModule25,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rg32float'}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'not-equal',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2721,
+stencilWriteMask: 1039,
+depthBiasSlopeScale: 83,
+depthBiasClamp: 60,
+},
+vertex: {
+  module: shaderModule25,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 14012,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 31816,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32',
+offset: 5664,
+shaderLocation: 11,
+}, {
+format: 'snorm16x4',
+offset: 11052,
+shaderLocation: 25,
+}, {
+format: 'float16x2',
+offset: 3428,
+shaderLocation: 21,
+}, {
+format: 'float32',
+offset: 3468,
+shaderLocation: 4,
+}, {
+format: 'uint32x4',
+offset: 21624,
+shaderLocation: 12,
+}, {
+format: 'unorm8x4',
+offset: 4708,
+shaderLocation: 19,
+}, {
+format: 'snorm16x2',
+offset: 25172,
+shaderLocation: 1,
+}, {
+format: 'snorm16x2',
+offset: 12364,
+shaderLocation: 5,
+}, {
+format: 'uint32x4',
+offset: 16044,
+shaderLocation: 26,
+}, {
+format: 'uint32x4',
+offset: 8500,
+shaderLocation: 16,
+}, {
+format: 'float32x3',
+offset: 7452,
+shaderLocation: 23,
+}, {
+format: 'sint32',
+offset: 184,
+shaderLocation: 18,
+}, {
+format: 'uint16x2',
+offset: 26420,
+shaderLocation: 10,
+}, {
+format: 'uint16x4',
+offset: 3968,
+shaderLocation: 9,
+}, {
+format: 'sint8x2',
+offset: 23948,
+shaderLocation: 14,
+}, {
+format: 'float16x4',
+offset: 1224,
+shaderLocation: 22,
+}],
+},
+{
+arrayStride: 28004,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x3',
+offset: 8648,
+shaderLocation: 20,
+}, {
+format: 'uint8x4',
+offset: 21584,
+shaderLocation: 3,
+}, {
+format: 'unorm16x4',
+offset: 21868,
+shaderLocation: 17,
+}, {
+format: 'uint32x2',
+offset: 7408,
+shaderLocation: 6,
+}, {
+format: 'uint32x4',
+offset: 1880,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 19324,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 4176,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 31232,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x2',
+offset: 12208,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 29308,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 22732,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 20656,
+shaderLocation: 7,
+}, {
+format: 'unorm16x2',
+offset: 21964,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 25288,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 4036,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 30596,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x4',
+offset: 29344,
+shaderLocation: 24,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+window.someLabel = externalTexture8.label;
+} catch {}
+let offscreenCanvas50 = new OffscreenCanvas(500, 277);
+try {
+canvas47.getContext('webgl2');
+} catch {}
+let renderBundle150 = renderBundleEncoder95.finish({label: '\u{1fa77}\u0522\ud40d\u0ee2\u5673\ua16e\udd6f\u0d90'});
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 140, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img27,
+  origin: { x: 104, y: 44 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: { x: 37, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 80, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext25.unconfigure();
+} catch {}
+document.body.prepend(img12);
+canvas2.width = 754;
+let textureView160 = texture167.createView({
+  label: '\ub41b\u{1fed6}\ufac4\uc4bb',
+  dimension: '2d-array',
+  aspect: 'all',
+  baseMipLevel: 3,
+  mipLevelCount: 4
+});
+let sampler123 = device9.createSampler({
+label: '\u2502\u22de\uedd2\uc1e6',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 45.265,
+lodMaxClamp: 58.877,
+compare: 'less-equal',
+maxAnisotropy: 12,
+});
+try {
+computePassEncoder74.end();
+} catch {}
+try {
+renderBundleEncoder116.pushDebugGroup('\u{1faba}');
+} catch {}
+let bindGroupLayout57 = device6.createBindGroupLayout({
+label: '\u217f\u1ca1\ub266\u767b',
+entries: [{
+binding: 3160,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+}],
+});
+let commandEncoder152 = device6.createCommandEncoder({label: '\u0df0\u9ede\u0c84\u5200\u{1f651}\uf6f2\u1090\uf4d6\u8eef\ue5d4'});
+let computePassEncoder88 = commandEncoder152.beginComputePass({label: '\u0e6d\u4864\u05ff\u0a58\u078a\u{1f691}'});
+let renderBundle151 = renderBundleEncoder87.finish();
+try {
+renderBundleEncoder109.setVertexBuffer(90, undefined, 172136510, 3329050169);
+} catch {}
+document.body.prepend(canvas31);
+let textureView161 = texture180.createView({});
+try {
+renderBundleEncoder126.setVertexBuffer(19, undefined, 1255532346, 385676205);
+} catch {}
+try {
+gpuCanvasContext22.configure({
+device: device6,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8sint', 'bgra8unorm-srgb', 'r32sint'],
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device6.queue.writeBuffer(buffer60, 6156, new Float32Array(37269), 268, 384);
+} catch {}
+let gpuCanvasContext48 = offscreenCanvas50.getContext('webgpu');
+let commandEncoder153 = device7.createCommandEncoder({label: '\u4137\u0384\u4c9e\u5651'});
+try {
+computePassEncoder87.end();
+} catch {}
+try {
+await adapter2.requestAdapterInfo();
+} catch {}
+try {
+renderBundle3.label = '\u0053\u{1f775}\ua2d1\ub338\u0fb8\u203b\ue690\uf0a8';
+} catch {}
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+video23.width = 54;
+let commandEncoder154 = device1.createCommandEncoder({});
+let texture186 = device1.createTexture({
+label: '\ua337\u9c6b\u44e8\u{1fb6b}\uc77f\u7523\ud024\u04a4\u0865',
+size: [384, 16, 1],
+mipLevelCount: 9,
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder131 = device1.createRenderBundleEncoder({
+  label: '\u1228\u07a9\u664e\u3423\u3913\ufd04',
+  colorFormats: ['rg32float', 'r16float', 'r16uint', 'r16sint', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+let externalTexture13 = device1.importExternalTexture({
+label: '\u1e51\u095d\u25b2\u1338\u0683\u63d2\u2022\u012e\u9bfc\u5286',
+source: video22,
+colorSpace: 'display-p3',
+});
+let arrayBuffer16 = buffer21.getMappedRange(22472, 0);
+try {
+commandEncoder88.copyBufferToTexture({
+/* bytesInLastRow: 416 widthInBlocks: 26 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 18208 */
+offset: 18208,
+bytesPerRow: 512,
+buffer: buffer47,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 55, y: 45, z: 0 },
+  aspect: 'all',
+}, {width: 130, height: 35, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer47);
+} catch {}
+try {
+commandEncoder107.clearBuffer(buffer20, 1148, 0);
+dissociateBuffer(device1, buffer20);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer20, 1248, new Float32Array(32399), 10171, 0);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let promise72 = device1.createRenderPipelineAsync({
+label: '\ub8e3\u0421\u99b3\u3399',
+layout: pipelineLayout3,
+vertex: {
+  module: shaderModule22,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 2056,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 1692,
+shaderLocation: 26,
+}, {
+format: 'float16x2',
+offset: 60,
+shaderLocation: 4,
+}, {
+format: 'unorm10-10-10-2',
+offset: 72,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 1872,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 29028,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 21244,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 20116,
+shaderLocation: 3,
+}, {
+format: 'uint16x2',
+offset: 18700,
+shaderLocation: 19,
+}],
+},
+{
+arrayStride: 1288,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 8916,
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 14392,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 29740,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 13296,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 9620,
+shaderLocation: 21,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55) };
+} catch {}
+let adapter29 = await promise71;
+let renderBundle152 = renderBundleEncoder103.finish({label: '\u0ada\ubda8\uc648\u0034\u{1ff1d}\u7055'});
+let promise73 = adapter12.requestDevice({
+requiredLimits: {
+maxBindGroups: 8,
+maxColorAttachmentBytesPerSample: 47,
+maxVertexAttributes: 24,
+maxVertexBufferArrayStride: 41744,
+maxStorageTexturesPerShaderStage: 8,
+maxStorageBuffersPerShaderStage: 22,
+maxDynamicStorageBuffersPerPipelineLayout: 7299,
+maxBindingsPerBindGroup: 8089,
+maxTextureDimension1D: 9886,
+maxTextureDimension2D: 8673,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 50508974,
+maxUniformBuffersPerShaderStage: 38,
+maxInterStageShaderVariables: 50,
+maxInterStageShaderComponents: 77,
+},
+});
+let bindGroupLayout58 = device9.createBindGroupLayout({
+entries: [{
+binding: 291,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}, {
+binding: 979,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}],
+});
+let commandEncoder155 = device9.createCommandEncoder({});
+let textureView162 = texture139.createView({label: '\u0647\u6c77\u8041\ue253\u0e53\u8f1e', baseMipLevel: 6, mipLevelCount: 1, baseArrayLayer: 0});
+try {
+device9.pushErrorScope('internal');
+} catch {}
+let commandEncoder156 = device10.createCommandEncoder({label: '\ucede\ubc56\u{1f6aa}\u0e97'});
+let texture187 = device10.createTexture({
+label: '\u0685\u806b\u{1faa2}\u{1ff4e}',
+size: [408],
+dimension: '1d',
+format: 'rgba32uint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba32uint', 'rgba32uint', 'rgba32uint'],
+});
+let textureView163 = texture138.createView({aspect: 'all', mipLevelCount: 1, baseArrayLayer: 57, arrayLayerCount: 128});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let pipelineLayout28 = device3.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout38, bindGroupLayout55, bindGroupLayout51, bindGroupLayout27, bindGroupLayout32, bindGroupLayout26]
+});
+let texture188 = device3.createTexture({
+label: '\u6d5c\u{1f9b5}\u066d\u{1fdde}\u0d57\ud3c7',
+size: [1824, 40, 91],
+mipLevelCount: 11,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+});
+try {
+computePassEncoder48.dispatchWorkgroupsIndirect(buffer35, 32696);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(806), /* required buffer size: 806 */
+{offset: 806, bytesPerRow: 109}, {width: 0, height: 16, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder89 = commandEncoder137.beginComputePass({label: '\u8e51\u0c85\u363a'});
+let renderBundle153 = renderBundleEncoder90.finish({label: '\u4c1f\u{1fb89}\u550b\u115b\ub39b\u8f85\u2648\u53ff\u13b9'});
+try {
+commandEncoder131.copyTextureToTexture({
+  texture: texture134,
+  mipLevel: 1,
+  origin: { x: 32, y: 4, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture134,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 40, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device8.queue.onSubmittedWorkDone();
+} catch {}
+let video43 = await videoWithData();
+let querySet114 = device6.createQuerySet({
+label: '\u{1fdb9}\u025a\u{1fb07}\u{1f87d}\u47a2\u2f65\u91a4\u20a4\u9655\u2da9\u{1fb80}',
+type: 'occlusion',
+count: 3857,
+});
+let renderBundle154 = renderBundleEncoder95.finish({label: '\u{1ffca}\ua2aa\u982d\u0c0f'});
+try {
+texture181.destroy();
+} catch {}
+let videoFrame48 = new VideoFrame(offscreenCanvas20, {timestamp: 0});
+let pipelineLayout29 = device10.createPipelineLayout({label: '\ub38b\u04c8', bindGroupLayouts: [bindGroupLayout54, bindGroupLayout54, bindGroupLayout54]});
+let textureView164 = texture187.createView({label: '\u{1fa56}\udfc2\u0c70\u{1f9ab}'});
+let renderBundle155 = renderBundleEncoder113.finish({label: '\uf065\ud606\u{1f88d}\u0014\uee56\u{1ff82}\u{1fac9}\u01de\u5aba\uab79\u{1f6b7}'});
+let sampler124 = device10.createSampler({
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 67.932,
+lodMaxClamp: 92.338,
+});
+let promise74 = navigator.gpu.requestAdapter({
+});
+let imageBitmap45 = await createImageBitmap(canvas39);
+let commandEncoder157 = device6.createCommandEncoder({label: '\u0e1b\udad3\uf579\u0a5a\u201c'});
+try {
+gpuCanvasContext48.configure({
+device: device6,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rgba16float', 'rgba16float'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 17, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video11,
+  origin: { x: 3, y: 4 },
+  flipY: true,
+}, {
+  texture: texture137,
+  mipLevel: 3,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 9, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let textureView165 = texture133.createView({label: '\u{1fcc2}\u6dad\u{1fe16}\u4892\ub991'});
+let sampler125 = device6.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'linear',
+lodMinClamp: 82.018,
+lodMaxClamp: 90.217,
+});
+try {
+commandEncoder157.copyBufferToTexture({
+/* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 30336 */
+offset: 30336,
+buffer: buffer51,
+}, {
+  texture: texture133,
+  mipLevel: 0,
+  origin: { x: 127, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device6, buffer51);
+} catch {}
+try {
+commandEncoder157.clearBuffer(buffer60, 13216, 260);
+dissociateBuffer(device6, buffer60);
+} catch {}
+try {
+device6.queue.writeBuffer(buffer60, 12900, new DataView(new ArrayBuffer(24295)), 17354, 832);
+} catch {}
+let bindGroupLayout59 = device9.createBindGroupLayout({
+label: '\u0f3a\u{1faf9}\ubd10\ueb1f\u{1fe97}\u058f\u{1f860}',
+entries: [],
+});
+let bindGroupLayout60 = device13.createBindGroupLayout({
+label: '\u{1fb26}\ufd50\u{1fab6}',
+entries: [],
+});
+let buffer61 = device13.createBuffer({size: 11507, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let offscreenCanvas51 = new OffscreenCanvas(696, 698);
+let gpuCanvasContext49 = offscreenCanvas51.getContext('webgpu');
+let commandEncoder158 = device12.createCommandEncoder({label: '\uc3d6\u4a96\u{1f8a0}\u040b\u003b\u0fb1\u45a3\u{1fb1b}\u{1f795}'});
+let renderBundle156 = renderBundleEncoder117.finish({label: '\u0440\uecec\u0a03\u1663\u06c6\uc237\u{1f6da}\u8599'});
+try {
+computePassEncoder82.setBindGroup(3, bindGroup31);
+} catch {}
+try {
+computePassEncoder82.end();
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame40.close();
+videoFrame41.close();
+videoFrame42.close();
+videoFrame43.close();
+videoFrame44.close();
+videoFrame45.close();
+videoFrame46.close();
+videoFrame47.close();
+videoFrame48.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/LayoutTests/fast/webgpu/fuzz-273573-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-273573-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-273573.html
+++ b/LayoutTests/fast/webgpu/fuzz-273573.html
@@ -1,0 +1,24604 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let device0 = await adapter0.requestDevice({
+label: '\u{1fc65}\ufb7e\u1bf2\u71e7\u0c2f\u03f6\u0862\u0696\u0cc1\ua058\u6115',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 43,
+maxVertexAttributes: 19,
+maxVertexBufferArrayStride: 35280,
+maxStorageTexturesPerShaderStage: 29,
+maxStorageBuffersPerShaderStage: 27,
+maxDynamicStorageBuffersPerPipelineLayout: 30084,
+maxBindingsPerBindGroup: 8754,
+maxTextureDimension1D: 11229,
+maxTextureDimension2D: 11699,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 199721813,
+maxUniformBuffersPerShaderStage: 35,
+maxInterStageShaderVariables: 49,
+maxInterStageShaderComponents: 119,
+maxSamplersPerShaderStage: 21,
+},
+});
+let video0 = await videoWithData();
+let buffer0 = device0.createBuffer(
+{
+label: '\u2cea\u{1f6df}\u5535\ufa73\u0bd8\ub8fa\u2751\u7f94\u{1f863}',
+size: 11395,
+usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+let querySet0 = device0.createQuerySet({
+label: '\u0718\u{1fde6}\uedca\u0f9c\u32a6\u0e6d\u{1fee9}\u03a5\u0133\u{1f80e}\u{1fb19}',
+type: 'occlusion',
+count: 274,
+});
+let texture0 = device0.createTexture(
+{
+label: '\ua5d3\u01b9\u{1f6cd}\u075e\u0047\uc6c3',
+size: {width: 6145},
+dimension: '1d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16float'
+],
+}
+);
+let textureView0 = texture0.createView(
+{
+}
+);
+let videoFrame0 = new VideoFrame(video0, {timestamp: 0});
+try {
+adapter0.label = '\u8679\u{1f9b3}\u020c\u2e10\u{1f97c}\ucee1\ud1c9';
+} catch {}
+let sampler0 = device0.createSampler(
+{
+label: '\ue327\u09a0\u6321\u6a9c\ua9ad\u{1fc56}\u55f1\u0526\u{1f854}\u03e9\u0f53',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMaxClamp: 59.746,
+compare: 'equal',
+}
+);
+let textureView1 = texture0.createView(
+{
+label: '\u{1fd5b}\u6a17\u29a3',
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 366, y: 1, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(48),
+/* required buffer size: 304 */{
+offset: 304,
+},
+{width: 4990, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let buffer1 = device0.createBuffer(
+{
+label: '\ub4cf\u{1fac5}\u5573\u7004\ufe12\u933e\u23e3',
+size: 11420,
+usage: GPUBufferUsage.UNIFORM,
+mappedAtCreation: true,
+}
+);
+let renderBundleEncoder0 = device0.createRenderBundleEncoder(
+{
+label: '\u{1f962}\u{1fabe}',
+colorFormats: [
+'rg32float',
+'r16uint',
+'rg16sint',
+'rgba16sint',
+undefined,
+'rgba8unorm-srgb'
+],
+sampleCount: 675,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder0.setVertexBuffer(
+10,
+buffer0,
+5980,
+4631
+);
+} catch {}
+let bindGroupLayout0 = device0.createBindGroupLayout(
+{
+label: '\u0501\u049d\u043a\u0fc8\u{1f668}\u1ded\u5428\u66ee\u3a64',
+entries: [
+{
+binding: 2242,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+},
+{
+binding: 6973,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '3d' },
+},
+{
+binding: 6956,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+}
+],
+}
+);
+let renderBundle0 = renderBundleEncoder0.finish(
+{
+label: '\u672c\u{1fa51}\u0af1\ub5c6\u{1f727}\u33a8\u23ac\u034f\u46a2'
+}
+);
+let commandEncoder0 = device0.createCommandEncoder(
+{
+label: '\u0ae0\ud2c7',
+}
+);
+let renderBundle1 = renderBundleEncoder0.finish(
+{
+
+}
+);
+let promise0 = device0.popErrorScope();
+let imageData0 = new ImageData(140, 244);
+let videoFrame1 = new VideoFrame(video0, {timestamp: 0});
+let pipelineLayout0 = device0.createPipelineLayout(
+{
+label: '\u7c79\u0af6\ue8b6\u1889\u5b7f',
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout0
+]
+}
+);
+let textureView2 = texture0.createView(
+{
+label: '\uf80a\uef33',
+}
+);
+let computePassEncoder0 = commandEncoder0.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder1 = device0.createRenderBundleEncoder(
+{
+label: '\ud250\u077c\u3b84\u2b1d\u{1f6c8}\u0f5a\u522b\u0012\u8be8\u34c7\u5f5b',
+colorFormats: [
+'rg16uint',
+'r16float',
+'r8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 784,
+}
+);
+let img0 = await imageWithData(180, 280, '#2093da37', '#41ada33d');
+let shaderModule0 = device0.createShaderModule(
+{
+label: '\u0e92\u8873\u04eb\uc8ce\u9b98\u57ad\u{1fa9a}',
+code: `@group(4) @binding(2242)
+var<storage, read_write> function0: array<u32>;
+@group(0) @binding(6956)
+var<storage, read_write> field0: array<u32>;
+@group(5) @binding(6956)
+var<storage, read_write> i0: array<u32>;
+@group(3) @binding(2242)
+var<storage, read_write> function1: array<u32>;
+@group(5) @binding(2242)
+var<storage, read_write> type0: array<u32>;
+@group(6) @binding(6956)
+var<storage, read_write> i1: array<u32>;
+@group(8) @binding(6973)
+var<storage, read_write> global0: array<u32>;
+@group(7) @binding(2242)
+var<storage, read_write> field1: array<u32>;
+@group(0) @binding(2242)
+var<storage, read_write> i2: array<u32>;
+@group(4) @binding(6973)
+var<storage, read_write> local0: array<u32>;
+@group(2) @binding(6973)
+var<storage, read_write> function2: array<u32>;
+@group(7) @binding(6973)
+var<storage, read_write> i3: array<u32>;
+@group(7) @binding(6956)
+var<storage, read_write> function3: array<u32>;
+@group(6) @binding(6973)
+var<storage, read_write> parameter0: array<u32>;
+@group(6) @binding(2242)
+var<storage, read_write> parameter1: array<u32>;
+@group(2) @binding(6956)
+var<storage, read_write> type1: array<u32>;
+@group(1) @binding(6973)
+var<storage, read_write> type2: array<u32>;
+@group(3) @binding(6956)
+var<storage, read_write> local1: array<u32>;
+@group(0) @binding(6973)
+var<storage, read_write> global1: array<u32>;
+@group(4) @binding(6956)
+var<storage, read_write> type3: array<u32>;
+@group(1) @binding(6956)
+var<storage, read_write> parameter2: array<u32>;
+@group(1) @binding(2242)
+var<storage, read_write> function4: array<u32>;
+@group(3) @binding(6973)
+var<storage, read_write> global2: array<u32>;
+
+@compute @workgroup_size(6, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec2<f32>,
+@location(3) f1: u32,
+@builtin(sample_mask) f2: u32,
+@location(1) f3: f32,
+@location(5) f4: vec4<i32>,
+@location(2) f5: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S0 {
+@location(2) f0: vec2<u32>,
+@location(12) f1: vec4<u32>,
+@location(10) f2: vec3<i32>,
+@location(4) f3: i32,
+@builtin(vertex_index) f4: u32,
+@location(15) f5: vec4<i32>,
+@location(7) f6: vec3<u32>,
+@location(6) f7: vec2<u32>,
+@location(3) f8: vec2<u32>,
+@location(8) f9: vec3<f32>,
+@location(14) f10: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec4<u32>, @location(13) a1: vec4<u32>, @location(1) a2: vec4<f32>, @location(18) a3: vec2<u32>, @builtin(instance_index) a4: u32, @location(5) a5: f32, @location(9) a6: f32, @location(17) a7: vec3<f32>, a8: S0, @location(16) a9: vec2<u32>, @location(0) a10: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let renderBundleEncoder2 = device0.createRenderBundleEncoder(
+{
+label: '\u2ec7\u{1f653}\u0a1c\u661a\u081a\u000d\u{1f6e4}\u0355',
+colorFormats: [
+'rg16uint',
+undefined,
+'r16uint',
+'rg16uint',
+'r16float',
+'bgra8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 900,
+stencilReadOnly: true,
+}
+);
+let querySet1 = device0.createQuerySet({
+label: '\u{1f9e9}\u0cf4\u9680\u2385\u09e9\u8f5c\u6274\u{1fa68}\u0849\u80c7\u{1f63e}',
+type: 'occlusion',
+count: 1727,
+});
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 17, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(80),
+/* required buffer size: 12495 */{
+offset: 703,
+},
+{width: 5896, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let texture1 = device0.createTexture(
+{
+label: '\u{1f893}\u7e06\u08c3\u{1fa0c}',
+size: [1551, 157, 54],
+mipLevelCount: 5,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'depth16unorm'
+],
+}
+);
+let sampler1 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 53.273,
+lodMaxClamp: 62.635,
+}
+);
+try {
+buffer1.destroy();
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 263, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(new ArrayBuffer(64)),
+/* required buffer size: 10810 */{
+offset: 2,
+},
+{width: 5404, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let renderBundle2 = renderBundleEncoder1.finish(
+{
+label: '\u{1f98f}\u2c83\u0835\u0826'
+}
+);
+let externalTexture0 = device0.importExternalTexture(
+{
+label: '\u7c5b\u{1f60c}\u01c4\ud922\u759d',
+source: videoFrame1,
+colorSpace: 'srgb',
+}
+);
+try {
+buffer0.unmap();
+} catch {}
+let querySet2 = device0.createQuerySet({
+label: '\u1c4c\u05b9',
+type: 'occlusion',
+count: 3040,
+});
+let sampler2 = device0.createSampler(
+{
+label: '\u{1fc11}\u8c04\u6a12\u0e6b\u{1ffd2}\ua5d7\ueff5\u004f\u2334\u{1fa14}\u{1fff0}',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 92.224,
+maxAnisotropy: 3,
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture1,
+  mipLevel: 4,
+  origin: { x: 0, y: 4, z: 37 },
+  aspect: 'depth-only',
+},
+new ArrayBuffer(0),
+/* required buffer size: 258935 */{
+offset: 518,
+bytesPerRow: 313,
+rowsPerImage: 55,
+},
+{width: 96, height: 1, depthOrArrayLayers: 16}
+);
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+try {
+await promise1;
+} catch {}
+let videoFrame2 = new VideoFrame(video0, {timestamp: 0});
+let querySet3 = device0.createQuerySet({
+label: '\u{1f953}\u{1f78b}\ud443\u0c9c\u0d12\u0be3\ud280\u3c98\uf2a2\uae30\u{1f6b8}',
+type: 'occlusion',
+count: 3541,
+});
+let renderBundle3 = renderBundleEncoder1.finish(
+{
+
+}
+);
+let sampler3 = device0.createSampler(
+{
+label: '\u56b3\u38ae\u7b7b\u0a1e\u3f3e\ub3ec\u0653\u74b8\u{1f995}\u7637\u3fd0',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 86.159,
+lodMaxClamp: 87.507,
+}
+);
+try {
+renderBundleEncoder2.setVertexBuffer(
+5,
+buffer0
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture1,
+  mipLevel: 2,
+  origin: { x: 0, y: 7, z: 30 },
+  aspect: 'all',
+},
+new BigUint64Array(new ArrayBuffer(64)),
+/* required buffer size: 806032 */{
+offset: 674,
+bytesPerRow: 892,
+rowsPerImage: 41,
+},
+{width: 387, height: 1, depthOrArrayLayers: 23}
+);
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+let pipeline0 = await device0.createComputePipelineAsync(
+{
+label: '\u0d26\u0b7d\u9379\u01e4\u0ed1',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let video1 = await videoWithData();
+let renderBundleEncoder3 = device0.createRenderBundleEncoder(
+{
+label: '\ud5e5\u6f4b\u0395\u241f\u{1f7cc}\u8342',
+colorFormats: [
+'r32uint',
+undefined,
+'rgba8uint',
+'rgba16float',
+'rg8unorm'
+],
+sampleCount: 734,
+}
+);
+let renderBundle4 = renderBundleEncoder2.finish();
+try {
+computePassEncoder0.setPipeline(
+pipeline0
+);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(
+11,
+buffer0
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 436, y: 0, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(0),
+/* required buffer size: 154 */{
+offset: 154,
+},
+{width: 2473, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(941, 675);
+let imageBitmap0 = await createImageBitmap(imageData0);
+let texture2 = device0.createTexture(
+{
+size: [1923, 2, 5],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle5 = renderBundleEncoder1.finish(
+{
+label: '\u3fb3\uffc8'
+}
+);
+try {
+renderBundleEncoder3.setVertexBuffer(
+10,
+buffer0
+);
+} catch {}
+let shaderModule1 = device0.createShaderModule(
+{
+code: `@group(2) @binding(2242)
+var<storage, read_write> local2: array<u32>;
+@group(3) @binding(2242)
+var<storage, read_write> field2: array<u32>;
+@group(8) @binding(6956)
+var<storage, read_write> type4: array<u32>;
+@group(5) @binding(6973)
+var<storage, read_write> i4: array<u32>;
+@group(0) @binding(6956)
+var<storage, read_write> i5: array<u32>;
+@group(4) @binding(2242)
+var<storage, read_write> global3: array<u32>;
+@group(5) @binding(6956)
+var<storage, read_write> field3: array<u32>;
+@group(4) @binding(6973)
+var<storage, read_write> local3: array<u32>;
+@group(0) @binding(2242)
+var<storage, read_write> function5: array<u32>;
+@group(7) @binding(2242)
+var<storage, read_write> global4: array<u32>;
+@group(5) @binding(2242)
+var<storage, read_write> field4: array<u32>;
+@group(8) @binding(6973)
+var<storage, read_write> local4: array<u32>;
+@group(7) @binding(6973)
+var<storage, read_write> parameter3: array<u32>;
+@group(6) @binding(2242)
+var<storage, read_write> type5: array<u32>;
+@group(3) @binding(6956)
+var<storage, read_write> type6: array<u32>;
+@group(6) @binding(6973)
+var<storage, read_write> field5: array<u32>;
+@group(1) @binding(6973)
+var<storage, read_write> global5: array<u32>;
+@group(6) @binding(6956)
+var<storage, read_write> i6: array<u32>;
+@group(1) @binding(2242)
+var<storage, read_write> global6: array<u32>;
+@group(2) @binding(6973)
+var<storage, read_write> local5: array<u32>;
+@group(0) @binding(6973)
+var<storage, read_write> global7: array<u32>;
+@group(3) @binding(6973)
+var<storage, read_write> type7: array<u32>;
+
+@compute @workgroup_size(4, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec3<f32>,
+@location(1) f1: vec3<u32>,
+@location(3) f2: vec4<f32>,
+@location(5) f3: vec3<f32>,
+@location(7) f4: f32,
+@location(4) f5: vec4<u32>,
+@location(0) f6: u32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(17) a0: vec3<u32>, @location(2) a1: i32, @location(15) a2: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet4 = device0.createQuerySet({
+label: '\ueebe\u88c6\ud549\u116b\udf5a\u0693\u{1fa89}\uc21e\uf412\u7289\u7508',
+type: 'occlusion',
+count: 2874,
+});
+pseudoSubmit(device0, commandEncoder0);
+let textureView3 = texture0.createView(
+{
+label: '\u0446\ued95\u0c80\u6482\u808e\u0757',
+aspect: 'all',
+baseArrayLayer: 0,
+}
+);
+let sampler4 = device0.createSampler(
+{
+label: '\u0ae9\u{1fa59}\u8a60',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 94.207,
+lodMaxClamp: 97.398,
+compare: 'not-equal',
+maxAnisotropy: 1,
+}
+);
+let renderBundle6 = renderBundleEncoder0.finish(
+{
+label: '\u019c\uf653'
+}
+);
+try {
+renderBundleEncoder3.setVertexBuffer(
+4,
+buffer0,
+11156,
+24
+);
+} catch {}
+try {
+await promise2;
+} catch {}
+let renderBundleEncoder4 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg11b10ufloat',
+'rg8unorm',
+'rgba16uint',
+undefined,
+'rg8uint',
+'rgb10a2unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 365,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: { x: 118, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Float32Array(new ArrayBuffer(64)),
+/* required buffer size: 2583033 */{
+offset: 877,
+bytesPerRow: 8843,
+rowsPerImage: 292,
+},
+{width: 1098, height: 0, depthOrArrayLayers: 2}
+);
+} catch {}
+let pipeline1 = await device0.createRenderPipelineAsync(
+{
+label: '\u{1f60e}\u58aa\u0e80\u043e\u{1fcd3}\u0176\u{1f942}\u7794\u308a\ueb86\u{1fb35}',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 16420,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 9276,
+shaderLocation: 0,
+},
+{
+format: 'uint32x3',
+offset: 14048,
+shaderLocation: 12,
+},
+{
+format: 'sint16x4',
+offset: 10924,
+shaderLocation: 15,
+},
+{
+format: 'uint8x2',
+offset: 932,
+shaderLocation: 7,
+},
+{
+format: 'sint8x4',
+offset: 15888,
+shaderLocation: 4,
+},
+{
+format: 'uint8x2',
+offset: 828,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x2',
+offset: 980,
+shaderLocation: 17,
+},
+{
+format: 'unorm16x2',
+offset: 14700,
+shaderLocation: 5,
+},
+{
+format: 'uint32x2',
+offset: 10972,
+shaderLocation: 14,
+},
+{
+format: 'uint8x2',
+offset: 7716,
+shaderLocation: 3,
+},
+{
+format: 'uint8x2',
+offset: 6472,
+shaderLocation: 6,
+},
+{
+format: 'uint8x2',
+offset: 11772,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 35032,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 13136,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x4',
+offset: 32392,
+shaderLocation: 9,
+},
+{
+format: 'sint32x2',
+offset: 23196,
+shaderLocation: 10,
+},
+{
+format: 'uint32x4',
+offset: 15352,
+shaderLocation: 13,
+},
+{
+format: 'unorm8x2',
+offset: 25054,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 6604,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 4704,
+shaderLocation: 8,
+},
+{
+format: 'uint32x3',
+offset: 112,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x84c6f9db,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'keep',
+passOp: 'invert',
+},
+stencilWriteMask: 3212,
+depthBiasSlopeScale: 49,
+depthBiasClamp: 20,
+},
+}
+);
+try {
+adapter0.label = '\u03bd\u9784\u024a\u{1faf5}\u03a1\u{1f7f2}';
+} catch {}
+let texture3 = device0.createTexture(
+{
+label: '\u75df\u2ee5\u{1f75f}\ucbbb\u8423\u809a\u75bf\u00fe\u0e2b\u29da',
+size: {width: 2403, height: 2, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+await promise0;
+} catch {}
+gc();
+let promise3 = navigator.gpu.requestAdapter(
+{
+}
+);
+let renderBundle7 = renderBundleEncoder0.finish(
+{
+label: '\uc427\u{1fa37}\u{1f77a}\u2b9a\u0a23\u0a16\u74ba\u{1f6d2}\u{1fb51}\u0499\u3364'
+}
+);
+let sampler5 = device0.createSampler(
+{
+label: '\u{1f9a8}\u1058\ucc59\u{1fb41}',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 45.878,
+lodMaxClamp: 63.682,
+maxAnisotropy: 15,
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 5,
+  origin: { x: 21, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Float32Array(new ArrayBuffer(24)),
+/* required buffer size: 260 */{
+offset: 260,
+},
+{width: 4, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend(img0);
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+let commandEncoder1 = device0.createCommandEncoder(
+{
+label: '\u368c\u9883\u0db0\u0641\u22d7\ud6ff\u{1faf8}\u0ae5\u10c0\u13f9\u3a33',
+}
+);
+let sampler6 = device0.createSampler(
+{
+label: '\uf7f6\u07a8\u1f86\u1d38\u0ff9\ud084\u2148\u35be\u595b\u3fa0\u{1f962}',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 32.948,
+lodMaxClamp: 57.918,
+}
+);
+document.body.prepend(video0);
+let renderBundle8 = renderBundleEncoder0.finish();
+try {
+renderBundleEncoder3.setVertexBuffer(
+9,
+buffer0,
+10320,
+870
+);
+} catch {}
+gc();
+let imageData1 = new ImageData(120, 188);
+let sampler7 = device0.createSampler(
+{
+addressModeW: 'repeat',
+mipmapFilter: 'linear',
+lodMinClamp: 28.081,
+lodMaxClamp: 48.021,
+}
+);
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+computePassEncoder0.insertDebugMarker(
+'\u84b9'
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 5,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(new ArrayBuffer(64)),
+/* required buffer size: 496 */{
+offset: 400,
+rowsPerImage: 105,
+},
+{width: 12, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+let renderBundleEncoder5 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba32sint',
+undefined,
+'r32uint',
+'bgra8unorm-srgb',
+'rg32float'
+],
+sampleCount: 464,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder3.setVertexBuffer(
+11,
+buffer0,
+6292,
+4475
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture1,
+  mipLevel: 2,
+  origin: { x: 0, y: 37, z: 10 },
+  aspect: 'all',
+},
+new Int8Array(new ArrayBuffer(40)),
+/* required buffer size: 793 */{
+offset: 793,
+bytesPerRow: 1000,
+},
+{width: 387, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let bindGroupLayout1 = device0.createBindGroupLayout(
+{
+label: '\ua868\u7337\ub65f\u9ee1\u{1fe05}\u0731\u04e6\u68cc\u{1f717}\u{1f8f4}\u{1fd01}',
+entries: [
+{
+binding: 1109,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'storage', minBindingSize: 756003, hasDynamicOffset: false },
+},
+{
+binding: 5018,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+},
+{
+binding: 166,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+let texture4 = device0.createTexture(
+{
+label: '\uf35b\uf842\u{1fd63}\u0cfa',
+size: [6049, 1, 28],
+mipLevelCount: 5,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 1,
+  origin: { x: 7, y: 1, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(219255),
+/* required buffer size: 219255 */{
+offset: 267,
+bytesPerRow: 4977,
+rowsPerImage: 44,
+},
+{width: 606, height: 0, depthOrArrayLayers: 2}
+);
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+let pipeline2 = await device0.createComputePipelineAsync(
+{
+label: '\u0103\ub87c\u9280\u0fcd\u025f\u3876\u0329\u01e3',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+await promise4;
+} catch {}
+let commandEncoder2 = device0.createCommandEncoder(
+{
+label: '\ud309\u0b15\u705c\u{1f78f}',
+}
+);
+let querySet5 = device0.createQuerySet({
+label: '\u1751\u99d6\u{1f707}\u2756\u070b\u1b7b\u{1f8c8}\uf5f6\udd53',
+type: 'occlusion',
+count: 941,
+});
+pseudoSubmit(device0, commandEncoder1);
+offscreenCanvas0.height = 858;
+gc();
+let video2 = await videoWithData();
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let bindGroupLayout2 = device0.createBindGroupLayout(
+{
+label: '\u1e79\u50e3\u9971\u0b9c\u3a6b\u007c\u0e0e\u{1f92c}\u7181',
+entries: [
+{
+binding: 1894,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let buffer2 = device0.createBuffer(
+{
+label: '\u0bf8\ud3f4\u0c70\u{1f77f}\uedf5\u0ccb\ue727\u18d8',
+size: 37670,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let textureView4 = texture3.createView(
+{
+label: '\u{1f6b8}\u{1fa46}\u8f8d\ueaef',
+baseMipLevel: 3,
+}
+);
+let sampler8 = device0.createSampler(
+{
+label: '\u5da7\ub28b\ub2c6',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 97.639,
+lodMaxClamp: 97.918,
+}
+);
+let sampler9 = device0.createSampler(
+{
+label: '\u0901\u12e1\u7743\u{1f77d}\u01f2\ub9a6',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 21.994,
+lodMaxClamp: 53.935,
+}
+);
+try {
+renderBundleEncoder3.setVertexBuffer(
+7,
+buffer0,
+712,
+1092
+);
+} catch {}
+try {
+commandEncoder2.clearBuffer(
+buffer2,
+3556,
+31540
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+18816,
+new BigUint64Array(20106),
+15263,
+1376
+);
+} catch {}
+let querySet6 = device0.createQuerySet({
+label: '\uf515\u{1fb79}\u0200\u1ea8\u{1fd7d}',
+type: 'occlusion',
+count: 442,
+});
+let sampler10 = device0.createSampler(
+{
+label: '\u6b11\u{1fb68}\uf360\uef06\ue0b8\u{1f649}\ua090',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 97.884,
+lodMaxClamp: 98.800,
+maxAnisotropy: 11,
+}
+);
+let pipeline3 = device0.createRenderPipeline(
+{
+label: '\u5f26\ub5e9\u047e\u084d\u07b0\u{1ffd9}\u03db\ue149\u{1fbcb}',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 6676,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 3368,
+shaderLocation: 17,
+},
+{
+format: 'uint32x2',
+offset: 6248,
+shaderLocation: 14,
+},
+{
+format: 'uint32x2',
+offset: 408,
+shaderLocation: 18,
+},
+{
+format: 'uint16x2',
+offset: 3460,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 13352,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x4',
+offset: 2400,
+shaderLocation: 12,
+},
+{
+format: 'uint8x4',
+offset: 1564,
+shaderLocation: 13,
+},
+{
+format: 'unorm16x4',
+offset: 3228,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x2',
+offset: 3662,
+shaderLocation: 5,
+},
+{
+format: 'unorm8x2',
+offset: 654,
+shaderLocation: 1,
+},
+{
+format: 'unorm16x4',
+offset: 6324,
+shaderLocation: 0,
+},
+{
+format: 'sint8x2',
+offset: 12924,
+shaderLocation: 15,
+},
+{
+format: 'sint32',
+offset: 1384,
+shaderLocation: 4,
+},
+{
+format: 'uint16x4',
+offset: 3752,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 31496,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x2',
+offset: 824,
+shaderLocation: 3,
+},
+{
+format: 'uint8x4',
+offset: 17568,
+shaderLocation: 2,
+},
+{
+format: 'float32x4',
+offset: 15140,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 9740,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 2260,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 1916,
+shaderLocation: 11,
+},
+{
+format: 'sint32',
+offset: 2000,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'front',
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+{
+format: 'rg8sint',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'never',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'replace',
+},
+stencilWriteMask: 1295,
+depthBiasSlopeScale: 19,
+depthBiasClamp: 97,
+},
+}
+);
+let offscreenCanvas1 = new OffscreenCanvas(668, 789);
+let sampler11 = device0.createSampler(
+{
+label: '\u0e9b\udf1f\u{1fe39}\u095a\u8345\u54ad\u0d35\u37a7\u2acf\u{1f6e9}\u0a9d',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 94.275,
+lodMaxClamp: 94.669,
+maxAnisotropy: 6,
+}
+);
+try {
+renderBundleEncoder5.setVertexBuffer(
+3,
+buffer0,
+5964,
+4900
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 4,
+  origin: { x: 28, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int16Array(new ArrayBuffer(24)),
+/* required buffer size: 1462 */{
+offset: 830,
+},
+{width: 79, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let textureView5 = texture4.createView(
+{
+label: '\u96a1\u0d3a\ufbfd\ubc80\u5143\u5253\u0777',
+dimension: '2d',
+aspect: 'depth-only',
+baseMipLevel: 3,
+baseArrayLayer: 18,
+}
+);
+try {
+device0.queue.writeBuffer(
+buffer2,
+16160,
+new BigUint64Array(32124),
+9598,
+1532
+);
+} catch {}
+let buffer3 = device0.createBuffer(
+{
+label: '\u032c\u0fae\u{1f939}\u{1f9af}\u{1f744}',
+size: 58610,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let querySet7 = device0.createQuerySet({
+label: '\u0394\u5d94\ufaae\u6552\u336b\u0201',
+type: 'occlusion',
+count: 1117,
+});
+let texture5 = device0.createTexture(
+{
+label: '\u046e\u{1fd5e}\uf139\u{1fd9b}\u0a1e',
+size: {width: 2263, height: 141, depthOrArrayLayers: 254},
+mipLevelCount: 9,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'depth32float',
+'depth32float'
+],
+}
+);
+let textureView6 = texture0.createView(
+{
+label: '\u{1f9e3}\u85a6\u00e3\u7615',
+aspect: 'all',
+}
+);
+let renderPassEncoder0 = commandEncoder2.beginRenderPass(
+{
+label: '\ud3b2\u{1f876}\u0c93\ueb55\u0d18',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView4,
+depthClearValue: 0.15733808489520262,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+stencilClearValue: 16998,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet1,
+maxDrawCount: 256168,
+}
+);
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(
+0,
+buffer0
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rgba16float',
+'rgba16float',
+'rgba16float',
+'rgba16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let pipeline4 = await device0.createRenderPipelineAsync(
+{
+label: '\u7ce4\u024e\u1ce8\uce2a\u279b\u0102\u0fb4\u{1fe71}\u6336\u6367',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 6544,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 2248,
+shaderLocation: 11,
+},
+{
+format: 'uint32x3',
+offset: 3844,
+shaderLocation: 12,
+},
+{
+format: 'sint32x3',
+offset: 6512,
+shaderLocation: 4,
+},
+{
+format: 'uint8x2',
+offset: 500,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x4',
+offset: 3672,
+shaderLocation: 8,
+},
+{
+format: 'uint32',
+offset: 48,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x2',
+offset: 2364,
+shaderLocation: 0,
+},
+{
+format: 'uint8x2',
+offset: 5444,
+shaderLocation: 6,
+},
+{
+format: 'unorm16x2',
+offset: 1300,
+shaderLocation: 9,
+},
+{
+format: 'float32x4',
+offset: 5624,
+shaderLocation: 17,
+},
+{
+format: 'uint16x2',
+offset: 2184,
+shaderLocation: 2,
+},
+{
+format: 'uint32x2',
+offset: 1488,
+shaderLocation: 18,
+},
+{
+format: 'uint32',
+offset: 6232,
+shaderLocation: 13,
+},
+{
+format: 'sint8x2',
+offset: 3916,
+shaderLocation: 10,
+},
+{
+format: 'float32x2',
+offset: 6180,
+shaderLocation: 1,
+},
+{
+format: 'uint16x4',
+offset: 6008,
+shaderLocation: 16,
+},
+{
+format: 'uint8x2',
+offset: 2684,
+shaderLocation: 14,
+},
+{
+format: 'sint16x2',
+offset: 5856,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x2',
+offset: 894,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+},
+multisample: {
+mask: 0xc197a1d6,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.GREEN,
+},
+{
+format: 'r8uint',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+},
+stencilReadMask: 2709,
+stencilWriteMask: 1981,
+depthBias: 97,
+depthBiasSlopeScale: 12,
+depthBiasClamp: 17,
+},
+}
+);
+let buffer4 = device0.createBuffer(
+{
+label: '\u0aa6\uba12',
+size: 2276,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let commandEncoder3 = device0.createCommandEncoder(
+{
+label: '\u{1f838}\u416b\ua6e1\u8583',
+}
+);
+let renderPassEncoder1 = commandEncoder3.beginRenderPass(
+{
+label: '\ua2a1\u10f1\u7192\u0dc5\u0300\u{1ffb7}\u7032',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView4,
+depthClearValue: 0.832537604223622,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+depthReadOnly: false,
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet1,
+maxDrawCount: 1960,
+}
+);
+let sampler12 = device0.createSampler(
+{
+label: '\u0688\uc61c\u{1f821}\uf3f8\u{1feda}\u{1f65d}\u0c18\u1d00\u063a\uc4d3',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 82.401,
+maxAnisotropy: 12,
+}
+);
+try {
+renderPassEncoder1.setVertexBuffer(
+6,
+buffer0,
+2144
+);
+} catch {}
+document.body.prepend(video1);
+try {
+renderPassEncoder0.beginOcclusionQuery(374);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+298.7,
+0.08654,
+0.3991,
+0.06178,
+0.4545,
+0.9532
+);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(
+3,
+buffer0,
+704,
+5809
+);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+5852,
+new DataView(new ArrayBuffer(1120)),
+100,
+220
+);
+} catch {}
+let pipeline5 = device0.createComputePipeline(
+{
+label: '\u7dfb\uec28\u{1fd92}\u69be',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline6 = await device0.createRenderPipelineAsync(
+{
+label: '\ua803\u{1fab9}\u0354\uece9\u00e4\u4c96',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 8760,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 6904,
+shaderLocation: 15,
+},
+{
+format: 'uint32x4',
+offset: 1840,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 27164,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 21500,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x4e3281a6,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.RED,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rgba8unorm-srgb',
+},
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'src-alpha',
+dstFactor: 'constant'
+},
+},
+format: 'r16float',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2445,
+stencilWriteMask: 1116,
+depthBias: 91,
+depthBiasSlopeScale: 82,
+depthBiasClamp: 12,
+},
+}
+);
+let gpuCanvasContext1 = offscreenCanvas1.getContext('webgpu');
+let texture6 = device0.createTexture(
+{
+label: '\u0832\u013d',
+size: {width: 100, height: 236, depthOrArrayLayers: 151},
+mipLevelCount: 2,
+dimension: '2d',
+format: 'etc2-rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'etc2-rgba8unorm',
+'etc2-rgba8unorm'
+],
+}
+);
+let renderBundleEncoder6 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8uint',
+'rg16sint',
+'rg16float',
+'rgba16float',
+'r32float',
+'rg16sint',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 449,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+pseudoSubmit(device0, commandEncoder2);
+try {
+renderPassEncoder0.setScissorRect(
+40,
+1,
+9,
+0
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+37252,
+new BigUint64Array(6391),
+3653,
+40
+);
+} catch {}
+let imageBitmap1 = await createImageBitmap(video0);
+let texture7 = device0.createTexture(
+{
+label: '\ue72f\u{1fb14}\uf6b0\u0465\ud58a\u119e\u{1ff7f}\uc3d9\ue8aa\u0d65',
+size: {width: 7472},
+mipLevelCount: 1,
+dimension: '1d',
+format: 'rgba32uint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundleEncoder7 = device0.createRenderBundleEncoder(
+{
+label: '\u2d63\u{1f621}\ud87d\u0375\u1466\u0f15\ub287\ub51c\u5eb9\u0341',
+colorFormats: [
+'r8uint',
+'rgba8uint',
+'rg16float',
+'rg32uint'
+],
+sampleCount: 425,
+stencilReadOnly: true,
+}
+);
+let renderBundle9 = renderBundleEncoder5.finish(
+{
+label: '\u06cc\u9bf2\u0163\u013e\u6259\u7d11\u3c61\u5dbb\u5eab\u076a\ub4f7'
+}
+);
+let sampler13 = device0.createSampler(
+{
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 65.843,
+lodMaxClamp: 75.680,
+}
+);
+try {
+renderPassEncoder1.setScissorRect(
+101,
+1,
+180,
+0
+);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+1237
+);
+} catch {}
+try {
+computePassEncoder0.insertDebugMarker(
+'\u6f1a'
+);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+204,
+0,
+39,
+0
+);
+} catch {}
+try {
+renderBundleEncoder6.pushDebugGroup(
+'\u08b9'
+);
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout(
+{
+label: '\u1fa7\u0112\u0c62\u4f52\u0082',
+entries: [
+{
+binding: 2091,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let commandEncoder4 = device0.createCommandEncoder(
+{
+label: '\u0b0c\ud3f3\ubdce\u94d9',
+}
+);
+pseudoSubmit(device0, commandEncoder3);
+let texture8 = device0.createTexture(
+{
+label: '\u{1f8a5}\u04d1\u7066\u069b',
+size: {width: 111, height: 1, depthOrArrayLayers: 1356},
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rgba8unorm',
+'rgba8unorm-srgb',
+'rgba8unorm-srgb'
+],
+}
+);
+try {
+renderPassEncoder0.setViewport(
+253.0,
+0.6568,
+33.88,
+0.06573,
+0.3723,
+0.7845
+);
+} catch {}
+try {
+commandEncoder4.clearBuffer(
+buffer2,
+14384,
+16788
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let pipelineLayout1 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout2,
+bindGroupLayout3
+]
+}
+);
+let textureView7 = texture1.createView(
+{
+label: '\u0db4\u043e',
+dimension: '2d',
+baseMipLevel: 1,
+mipLevelCount: 1,
+baseArrayLayer: 52,
+}
+);
+try {
+renderPassEncoder0.setBlendConstant({ r: -203.9, g: 848.6, b: -317.5, a: -687.1, });
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(
+188,
+0,
+32,
+0
+);
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+270.0,
+0.4812,
+13.22,
+0.3565,
+0.9318,
+0.9379
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+2,
+buffer0,
+3752,
+499
+);
+} catch {}
+try {
+commandEncoder4.clearBuffer(
+buffer2,
+24944,
+11048
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let pipeline7 = await device0.createComputePipelineAsync(
+{
+label: '\u05fd\u812a\u{1ff41}\ud94c',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let computePassEncoder1 = commandEncoder4.beginComputePass(
+{
+label: '\u2ee3\u{1fc56}\u013c\u1a83\u{1f9df}'
+}
+);
+let renderBundle10 = renderBundleEncoder5.finish(
+{
+label: '\u67b5\u06a1\ub474\u0c9a\u0df9\u{1f743}\u0c58\u{1fe22}\ua51f\u15fd'
+}
+);
+let sampler14 = device0.createSampler(
+{
+label: '\ue14e\u922f\u{1f830}\u{1fc68}\ua181\u0c10\uf4d9',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 4.768,
+lodMaxClamp: 83.735,
+maxAnisotropy: 16,
+}
+);
+try {
+renderPassEncoder0.setVertexBuffer(
+9,
+buffer0,
+9256,
+1687
+);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(
+5,
+buffer0,
+6260,
+4588
+);
+} catch {}
+try {
+renderBundleEncoder6.popDebugGroup();
+} catch {}
+let adapter1 = await promise3;
+let offscreenCanvas2 = new OffscreenCanvas(802, 32);
+try {
+offscreenCanvas2.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder();
+let querySet8 = device0.createQuerySet({
+label: '\u00e0\u{1fe05}',
+type: 'occlusion',
+count: 815,
+});
+let computePassEncoder2 = commandEncoder5.beginComputePass(
+{
+label: '\ua9d3\u9a87'
+}
+);
+try {
+computePassEncoder2.setPipeline(
+pipeline0
+);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(797);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+2673
+);
+} catch {}
+let renderBundleEncoder8 = device0.createRenderBundleEncoder(
+{
+label: '\u0ef2\u{1f7eb}\u0f40\u{1f87a}\u0d35\u{1ff09}\ud700\u5263\ubc88\u05cf',
+colorFormats: [
+'rg8uint',
+undefined,
+'rgba32sint',
+'r8uint',
+'rgba32float',
+'r8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 779,
+stencilReadOnly: true,
+}
+);
+let sampler15 = device0.createSampler(
+{
+label: '\u8d85\u0877\u580d\u{1f9d9}\u{1fcf9}\u08e1\u3449\u{1fa9d}\u3eae\u6534',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 98.640,
+maxAnisotropy: 12,
+}
+);
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture1,
+  mipLevel: 1,
+  origin: { x: 0, y: 31, z: 26 },
+  aspect: 'depth-only',
+},
+new BigInt64Array(new ArrayBuffer(80)),
+/* required buffer size: 2827681 */{
+offset: 945,
+bytesPerRow: 1729,
+rowsPerImage: 86,
+},
+{width: 775, height: 1, depthOrArrayLayers: 20}
+);
+} catch {}
+gc();
+let querySet9 = device0.createQuerySet({
+type: 'occlusion',
+count: 577,
+});
+try {
+renderPassEncoder1.setScissorRect(
+255,
+0,
+18,
+0
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+11204,
+new Int16Array(24086),
+5725,
+8004
+);
+} catch {}
+gc();
+let textureView8 = texture7.createView(
+{
+label: '\u46ec\uc01b\u{1f9df}\u4402\ua28d\ue641',
+aspect: 'all',
+}
+);
+let renderBundle11 = renderBundleEncoder4.finish(
+{
+label: '\u{1fb4b}\u8790\u0afa'
+}
+);
+let sampler16 = device0.createSampler(
+{
+label: '\u{1ffda}\u44af\u{1f97c}\u4a85',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 56.125,
+lodMaxClamp: 99.094,
+}
+);
+let arrayBuffer0 = buffer4.getMappedRange(
+0,
+1976
+);
+try {
+computePassEncoder0.pushDebugGroup(
+'\u{1fdd3}'
+);
+} catch {}
+try {
+computePassEncoder0.popDebugGroup();
+} catch {}
+offscreenCanvas2.width = 3;
+let canvas0 = document.createElement('canvas');
+try {
+device0.queue.label = '\u3ccd\u{1fd09}\u{1fff6}\uaa29\u0c6b\u{1f909}\ufc73\ufa69\u011b';
+} catch {}
+let bindGroup0 = device0.createBindGroup({
+label: '\ue878\u837e\ue68a\u{1fc1f}\u{1f986}\u8021',
+layout: bindGroupLayout3,
+entries: [
+{
+binding: 2091,
+resource: externalTexture0
+}
+],
+});
+let textureView9 = texture3.createView(
+{
+dimension: '2d-array',
+baseMipLevel: 3,
+}
+);
+let sampler17 = device0.createSampler(
+{
+label: '\u1d55\u0da2\u04e8\u36db',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 53.930,
+lodMaxClamp: 78.740,
+maxAnisotropy: 12,
+}
+);
+try {
+computePassEncoder2.setBindGroup(
+10,
+bindGroup0,
+new Uint32Array(6516),
+2938,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: -951.3, g: -41.09, b: -812.8, a: -908.8, });
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+67,
+1,
+127,
+0
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+11,
+buffer0
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 2194, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer0),
+/* required buffer size: 83 */{
+offset: 83,
+},
+{width: 767, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(37, 809);
+let textureView10 = texture6.createView(
+{
+format: 'etc2-rgba8unorm',
+baseMipLevel: 1,
+baseArrayLayer: 87,
+arrayLayerCount: 47,
+}
+);
+try {
+renderPassEncoder1.setBindGroup(
+9,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+10,
+buffer0,
+3664,
+6615
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(472, 408);
+let pipelineLayout2 = device0.createPipelineLayout(
+{
+label: '\u719a\ub8ec\u064a\ub71d\u0e0d\u{1f985}\u{1f9a6}\u588a',
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout2,
+bindGroupLayout0,
+bindGroupLayout1
+]
+}
+);
+let commandEncoder6 = device0.createCommandEncoder();
+let texture9 = device0.createTexture(
+{
+label: '\u94c1\ucf98\u04d1\u0ea0\u0b3c\u0a06',
+size: {width: 7788, height: 1, depthOrArrayLayers: 210},
+mipLevelCount: 3,
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2unorm',
+'rgb10a2unorm',
+'rgb10a2unorm'
+],
+}
+);
+let computePassEncoder3 = commandEncoder6.beginComputePass(
+{
+label: '\u8637\u75af\u8eda\u{1ff7f}\u901f\ub63b\u0e9f\u{1fe50}\u07b9\ud8e4'
+}
+);
+let renderBundleEncoder9 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8unorm-srgb',
+'rgba8unorm-srgb',
+'r32float'
+],
+sampleCount: 289,
+depthReadOnly: true,
+}
+);
+let sampler18 = device0.createSampler(
+{
+label: '\u{1fe41}\u0585\u0358\u7fae\u{1fe36}\u005a\u0c91\u42d1\u0371',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 58.707,
+maxAnisotropy: 11,
+}
+);
+let videoFrame3 = new VideoFrame(video1, {timestamp: 0});
+let commandEncoder7 = device0.createCommandEncoder(
+{
+label: '\u{1f668}\udf31\u8e67\u78e9\u{1fcd1}\u{1fe38}\u0772\ufb51\u{1fcc7}\u21cf',
+}
+);
+let textureView11 = texture2.createView(
+{
+label: '\ue4ec\u0ee5\u{1f84d}\ud35e\u0e39\u2835\ua8dd\u{1f6df}\u0796',
+baseMipLevel: 1,
+mipLevelCount: 4,
+baseArrayLayer: 0,
+}
+);
+let renderBundle12 = renderBundleEncoder2.finish(
+{
+label: '\u6799\u{1fb2b}\u{1f9af}\u0294\u06c3\ucd2a\u{1f6ee}\u8804\u{1fa7a}'
+}
+);
+try {
+computePassEncoder3.setPipeline(
+pipeline0
+);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+3384
+);
+} catch {}
+try {
+commandEncoder7.clearBuffer(
+buffer2,
+26368,
+3820
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+externalTexture0.label = '\u6cc2\u0330\u{1fdc4}\u33e6\u091f\u6fa6\u0404';
+} catch {}
+pseudoSubmit(device0, commandEncoder7);
+let renderBundle13 = renderBundleEncoder9.finish();
+try {
+computePassEncoder3.setBindGroup(
+8,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+154,
+0,
+25,
+1
+);
+} catch {}
+try {
+renderBundleEncoder7.pushDebugGroup(
+'\u9a66'
+);
+} catch {}
+let pipeline8 = await device0.createComputePipelineAsync(
+{
+layout: pipelineLayout2,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let img1 = await imageWithData(251, 285, '#3c8ac767', '#3e9f2eda');
+let commandEncoder8 = device0.createCommandEncoder(
+{
+label: '\u0531\u07e6\u{1f922}\ud091\u37be\u8b82',
+}
+);
+let querySet10 = device0.createQuerySet({
+label: '\u0d1c\uffc8\u9c95\u3329\u{1f7eb}',
+type: 'occlusion',
+count: 109,
+});
+let textureView12 = texture6.createView(
+{
+label: '\u0bc8\u{1f819}',
+dimension: '2d',
+baseMipLevel: 1,
+baseArrayLayer: 38,
+}
+);
+let renderBundle14 = renderBundleEncoder4.finish(
+{
+label: '\u0298\u{1fff1}\u0079\u9a63\u0ed2'
+}
+);
+let sampler19 = device0.createSampler(
+{
+label: '\u0e24\u{1faae}\ucbbc\ub6f6\uc911\ud596\u{1ff6d}\u0df4\u01d3\u0d1b\ua753',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+lodMinClamp: 46.742,
+lodMaxClamp: 78.445,
+}
+);
+try {
+renderPassEncoder1.beginOcclusionQuery(1555);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+3,
+buffer0,
+1676,
+2505
+);
+} catch {}
+let shaderModule2 = device0.createShaderModule(
+{
+label: '\u4ad3\u{1fbb6}',
+code: `@group(2) @binding(2242)
+var<storage, read_write> type8: array<u32>;
+@group(2) @binding(6973)
+var<storage, read_write> parameter4: array<u32>;
+@group(0) @binding(6973)
+var<storage, read_write> function6: array<u32>;
+@group(3) @binding(1109)
+var<storage, read_write> field6: array<u32>;
+@group(1) @binding(1894)
+var<storage, read_write> i7: array<u32>;
+@group(0) @binding(6956)
+var<storage, read_write> function7: array<u32>;
+@group(3) @binding(5018)
+var<storage, read_write> parameter5: array<u32>;
+@group(3) @binding(166)
+var<storage, read_write> local6: array<u32>;
+@group(2) @binding(6956)
+var<storage, read_write> field7: array<u32>;
+
+@compute @workgroup_size(7, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: vec2<f32>,
+@location(2) f1: f32,
+@location(1) f2: vec3<u32>,
+@location(0) f3: vec2<i32>,
+@location(3) f4: f32,
+@location(5) f5: i32,
+@location(6) f6: vec4<f32>,
+@location(7) f7: i32,
+@builtin(sample_mask) f8: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(position) a2: vec4<f32>, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S1 {
+@location(14) f0: vec3<f32>,
+@location(5) f1: vec2<u32>,
+@location(1) f2: vec4<f32>,
+@location(15) f3: f16,
+@location(3) f4: vec4<u32>,
+@location(7) f5: vec3<f16>,
+@location(10) f6: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(2) a0: f32, @builtin(instance_index) a1: u32, @location(16) a2: vec4<i32>, @location(9) a3: vec4<f32>, @location(13) a4: vec3<f32>, @builtin(vertex_index) a5: u32, @location(6) a6: vec4<f16>, a7: S1, @location(0) a8: vec4<u32>, @location(17) a9: vec3<i32>, @location(11) a10: i32, @location(12) a11: vec3<u32>, @location(4) a12: vec4<u32>, @location(8) a13: vec2<i32>, @location(18) a14: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+}
+);
+let renderPassEncoder2 = commandEncoder8.beginRenderPass(
+{
+label: '\u{1f779}\u{1f87e}\u{1f81a}\u56e9\u6538',
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView4,
+depthClearValue: 0.42470479129491456,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+},
+occlusionQuerySet: querySet9,
+maxDrawCount: 14184,
+}
+);
+try {
+computePassEncoder1.setPipeline(
+pipeline5
+);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(100);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+4,
+buffer0
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageBitmap2 = await createImageBitmap(imageBitmap0);
+try {
+computePassEncoder2.setBindGroup(
+5,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+40,
+0,
+232,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+476
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+261.6,
+0.9086,
+21.63,
+0.04544,
+0.1062,
+0.9803
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+0,
+buffer0,
+7924,
+1182
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+6,
+buffer0,
+212,
+9207
+);
+} catch {}
+let sampler20 = device0.createSampler(
+{
+label: '\u9522\u{1f6cd}\u1e6a\u{1f9ed}\u05da\u6fcb\u7e48',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 12.162,
+lodMaxClamp: 14.953,
+compare: 'less-equal',
+}
+);
+try {
+renderBundleEncoder6.setBindGroup(
+8,
+bindGroup0
+);
+} catch {}
+try {
+computePassEncoder0.insertDebugMarker(
+'\uf9ce'
+);
+} catch {}
+let pipeline9 = device0.createRenderPipeline(
+{
+label: '\u7b94\u02dd\u{1f7a7}\u{1f864}\u{1f872}\u{1fc39}\u0552\u7d10\u{1fa72}\u3844',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 30256,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 22396,
+shaderLocation: 7,
+},
+{
+format: 'uint32x2',
+offset: 8528,
+shaderLocation: 4,
+},
+{
+format: 'float16x2',
+offset: 8692,
+shaderLocation: 18,
+},
+{
+format: 'unorm16x2',
+offset: 2044,
+shaderLocation: 14,
+},
+{
+format: 'uint8x2',
+offset: 8996,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 12224,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 1504,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 8232,
+shaderLocation: 3,
+},
+{
+format: 'uint16x2',
+offset: 17188,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x4',
+offset: 31092,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 31572,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x2',
+offset: 3818,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x4',
+offset: 27164,
+shaderLocation: 1,
+},
+{
+format: 'sint32x2',
+offset: 13140,
+shaderLocation: 11,
+},
+{
+format: 'uint8x4',
+offset: 1240,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x2',
+offset: 1498,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 1640,
+shaderLocation: 15,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 24604,
+shaderLocation: 13,
+},
+{
+format: 'sint32x2',
+offset: 24752,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x4',
+offset: 4928,
+shaderLocation: 10,
+},
+{
+format: 'float32x4',
+offset: 30592,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+multisample: {
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'invert',
+passOp: 'replace',
+},
+depthBias: 36,
+depthBiasSlopeScale: 83,
+depthBiasClamp: 2,
+},
+}
+);
+try {
+renderPassEncoder1.setScissorRect(
+158,
+1,
+134,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+1530
+);
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+166.4,
+0.4016,
+108.3,
+0.4899,
+0.9151,
+0.9951
+);
+} catch {}
+let pipeline10 = await device0.createRenderPipelineAsync(
+{
+label: '\ua23a\ueac4\u06cc\u08b0\u{1ffae}\u{1f8b5}\u1515\u0eea\u{1f998}\u0362',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 3008,
+shaderLocation: 6,
+},
+{
+format: 'sint32x3',
+offset: 34296,
+shaderLocation: 10,
+},
+{
+format: 'sint8x4',
+offset: 5456,
+shaderLocation: 15,
+},
+{
+format: 'uint32x3',
+offset: 23272,
+shaderLocation: 14,
+},
+{
+format: 'uint8x2',
+offset: 32328,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 8360,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x3',
+offset: 468,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x4',
+offset: 4764,
+shaderLocation: 1,
+},
+{
+format: 'unorm16x2',
+offset: 2932,
+shaderLocation: 17,
+},
+{
+format: 'sint32x2',
+offset: 2136,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x4',
+offset: 8160,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 10376,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 6826,
+shaderLocation: 7,
+},
+{
+format: 'uint32x3',
+offset: 2908,
+shaderLocation: 18,
+},
+{
+format: 'uint8x2',
+offset: 9866,
+shaderLocation: 13,
+},
+{
+format: 'snorm16x4',
+offset: 8080,
+shaderLocation: 8,
+},
+{
+format: 'uint16x2',
+offset: 612,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 27552,
+attributes: [
+{
+format: 'uint32',
+offset: 23964,
+shaderLocation: 16,
+},
+{
+format: 'uint32x4',
+offset: 4408,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x2',
+offset: 26284,
+shaderLocation: 0,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 23764,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'none',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x2f02d9ca,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r16uint',
+writeMask: 0,
+},
+undefined,
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 4061,
+stencilWriteMask: 2011,
+depthBias: 64,
+depthBiasSlopeScale: 41,
+depthBiasClamp: 100,
+},
+}
+);
+offscreenCanvas1.width = 785;
+let imageData2 = new ImageData(164, 148);
+let commandEncoder9 = device0.createCommandEncoder(
+{
+label: '\u0fdc\u0173\u9927\u0155',
+}
+);
+let renderPassEncoder3 = commandEncoder9.beginRenderPass(
+{
+label: '\u64d4\u031a\u702c\u0d54\u{1fd53}\u5863',
+colorAttachments: [
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView9,
+depthClearValue: 8.408766304582276,
+depthReadOnly: true,
+stencilReadOnly: true,
+},
+maxDrawCount: 15288,
+}
+);
+try {
+computePassEncoder2.setBindGroup(
+6,
+bindGroup0,
+new Uint32Array(1518),
+142,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -900.4, g: 784.8, b: -44.75, a: 359.1, });
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+122,
+1,
+138,
+0
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+6,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+4,
+bindGroup0,
+new Uint32Array(1375),
+183,
+0
+);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+gc();
+try {
+adapter1.label = '\u1163\u0e9d\u879d\u2763\u{1fcdd}\u07cb\u{1ff85}\u{1fd30}\u0cee';
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(
+8,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(310);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+141,
+0,
+58,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+3,
+buffer0,
+8420,
+2734
+);
+} catch {}
+try {
+renderBundleEncoder7.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture6,
+  mipLevel: 1,
+  origin: { x: 8, y: 60, z: 20 },
+  aspect: 'all',
+},
+new DataView(arrayBuffer0),
+/* required buffer size: 5068897 */{
+offset: 215,
+bytesPerRow: 378,
+rowsPerImage: 285,
+},
+{width: 20, height: 60, depthOrArrayLayers: 48}
+);
+} catch {}
+let gpuCanvasContext2 = canvas0.getContext('webgpu');
+let texture10 = device0.createTexture(
+{
+label: '\u0502\uba9b\u0efc\u07a3',
+size: [171, 135, 1],
+mipLevelCount: 7,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+71,
+1,
+170,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+5,
+buffer0,
+10040,
+899
+);
+} catch {}
+try {
+commandEncoder6.copyBufferToBuffer(
+buffer4,
+1476,
+buffer2,
+30296,
+100
+);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout(
+{
+label: '\u6678\u{1fe02}\u235d\ue680\u0780\u0b0e\u0eec\u{1f7b8}',
+entries: [
+{
+binding: 7623,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 2910,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let commandBuffer0 = commandEncoder6.finish();
+let texture11 = device0.createTexture(
+{
+label: '\uab5e\u898e\u0d15\ue4ee\u0632\u6b3b\u4e17',
+size: [80, 132, 1],
+mipLevelCount: 4,
+sampleCount: 1,
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+renderPassEncoder3.setScissorRect(
+208,
+1,
+84,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+21.02,
+0.6920,
+211.6,
+0.1108,
+0.4047,
+0.5797
+);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let pipeline11 = device0.createRenderPipeline(
+{
+label: '\u04bd\u{1fbf9}\u0f3f\u64bd',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 2684,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 11816,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 472,
+shaderLocation: 13,
+},
+{
+format: 'uint8x4',
+offset: 9480,
+shaderLocation: 6,
+},
+{
+format: 'sint32x2',
+offset: 1512,
+shaderLocation: 15,
+},
+{
+format: 'float32',
+offset: 4940,
+shaderLocation: 0,
+},
+{
+format: 'uint32x4',
+offset: 9924,
+shaderLocation: 14,
+},
+{
+format: 'uint32',
+offset: 972,
+shaderLocation: 12,
+},
+{
+format: 'float16x2',
+offset: 8076,
+shaderLocation: 5,
+},
+{
+format: 'snorm8x2',
+offset: 5624,
+shaderLocation: 17,
+},
+{
+format: 'float32x3',
+offset: 76,
+shaderLocation: 8,
+},
+{
+format: 'uint16x2',
+offset: 2020,
+shaderLocation: 16,
+},
+{
+format: 'uint16x4',
+offset: 10388,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x4',
+offset: 5444,
+shaderLocation: 1,
+},
+{
+format: 'uint32x3',
+offset: 508,
+shaderLocation: 7,
+},
+{
+format: 'sint32x2',
+offset: 808,
+shaderLocation: 10,
+},
+{
+format: 'uint16x4',
+offset: 3828,
+shaderLocation: 11,
+},
+{
+format: 'uint16x4',
+offset: 3464,
+shaderLocation: 18,
+},
+{
+format: 'sint16x2',
+offset: 10716,
+shaderLocation: 4,
+},
+{
+format: 'float16x2',
+offset: 2312,
+shaderLocation: 9,
+},
+{
+format: 'uint32x2',
+offset: 8956,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-constant',
+dstFactor: 'src'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'src-alpha-saturated',
+dstFactor: 'one-minus-constant'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.GREEN,
+},
+undefined,
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+let gpuCanvasContext3 = offscreenCanvas3.getContext('webgpu');
+try {
+offscreenCanvas4.getContext('bitmaprenderer');
+} catch {}
+let shaderModule3 = device0.createShaderModule(
+{
+label: '\u{1fd39}\ub2da',
+code: `@group(0) @binding(6973)
+var<storage, read_write> global8: array<u32>;
+@group(1) @binding(6973)
+var<storage, read_write> field8: array<u32>;
+@group(8) @binding(6973)
+var<storage, read_write> field9: array<u32>;
+@group(1) @binding(2242)
+var<storage, read_write> type9: array<u32>;
+@group(3) @binding(2242)
+var<storage, read_write> type10: array<u32>;
+@group(7) @binding(6973)
+var<storage, read_write> function8: array<u32>;
+@group(4) @binding(6973)
+var<storage, read_write> field10: array<u32>;
+@group(0) @binding(6956)
+var<storage, read_write> function9: array<u32>;
+@group(8) @binding(6956)
+var<storage, read_write> parameter6: array<u32>;
+@group(6) @binding(6973)
+var<storage, read_write> local7: array<u32>;
+@group(4) @binding(2242)
+var<storage, read_write> type11: array<u32>;
+@group(3) @binding(6973)
+var<storage, read_write> i8: array<u32>;
+@group(8) @binding(2242)
+var<storage, read_write> i9: array<u32>;
+@group(2) @binding(6973)
+var<storage, read_write> parameter7: array<u32>;
+@group(6) @binding(6956)
+var<storage, read_write> local8: array<u32>;
+
+@compute @workgroup_size(6, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(7) f0: vec3<i32>,
+@location(3) f1: vec4<u32>,
+@location(1) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @location(38) a1: vec4<u32>, @builtin(sample_mask) a2: u32, @location(35) a3: vec4<f16>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S2 {
+@location(17) f0: f32,
+@location(11) f1: vec2<i32>,
+@location(3) f2: vec3<i32>
+}
+struct VertexOutput0 {
+@location(35) f0: vec4<f16>,
+@location(41) f1: vec3<i32>,
+@location(44) f2: vec2<f32>,
+@location(24) f3: u32,
+@location(3) f4: f16,
+@location(48) f5: vec2<u32>,
+@builtin(position) f6: vec4<f32>,
+@location(38) f7: vec4<u32>,
+@location(0) f8: u32
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec3<f32>, a1: S2) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet11 = device0.createQuerySet({
+label: '\ua79f\u0b25\u8cbd\u{1f8e7}\u1763\u{1fa5e}\u{1fbc4}\uf76c\u05e8\u7916',
+type: 'occlusion',
+count: 798,
+});
+let textureView13 = texture5.createView(
+{
+label: '\u7e28\u1403\u0dd5\u7982\u0110\u6683\u0051\u0989\u015a\u026f',
+baseMipLevel: 2,
+mipLevelCount: 4,
+baseArrayLayer: 48,
+arrayLayerCount: 73,
+}
+);
+let renderBundle15 = renderBundleEncoder5.finish(
+{
+label: '\u8071\u08a9\u7515'
+}
+);
+try {
+renderPassEncoder3.setBindGroup(
+4,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+183,
+1,
+59,
+0
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+4,
+bindGroup0
+);
+} catch {}
+try {
+querySet1.destroy();
+} catch {}
+let pipeline12 = await device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 5472,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 4424,
+shaderLocation: 18,
+},
+{
+format: 'float16x4',
+offset: 4136,
+shaderLocation: 5,
+},
+{
+format: 'uint16x2',
+offset: 1772,
+shaderLocation: 14,
+},
+{
+format: 'snorm8x2',
+offset: 2176,
+shaderLocation: 9,
+},
+{
+format: 'uint32x2',
+offset: 4436,
+shaderLocation: 16,
+},
+{
+format: 'uint16x2',
+offset: 1308,
+shaderLocation: 11,
+},
+{
+format: 'uint32x2',
+offset: 5080,
+shaderLocation: 3,
+},
+{
+format: 'uint16x2',
+offset: 4192,
+shaderLocation: 13,
+},
+{
+format: 'float16x4',
+offset: 3360,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 15392,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 14816,
+shaderLocation: 12,
+},
+{
+format: 'uint16x2',
+offset: 2924,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 2700,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x2',
+offset: 2660,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 6372,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 1120,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 30272,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 4696,
+shaderLocation: 7,
+},
+{
+format: 'sint16x2',
+offset: 156,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x4',
+offset: 26532,
+shaderLocation: 1,
+},
+{
+format: 'sint8x4',
+offset: 3036,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 30280,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x4',
+offset: 6076,
+shaderLocation: 17,
+},
+{
+format: 'float32',
+offset: 3776,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xa85feab4,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r32float',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'r8uint',
+writeMask: 0,
+},
+undefined,
+{
+format: 'rgba32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+}
+],
+},
+}
+);
+let texture12 = device0.createTexture(
+{
+label: '\u{1fa71}\u993a',
+size: {width: 2086},
+dimension: '1d',
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundleEncoder10 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fd9c}\u{1f8ae}',
+colorFormats: [
+'rgba16uint',
+'r8sint',
+'rg32sint',
+'rg8unorm'
+],
+sampleCount: 580,
+depthReadOnly: true,
+}
+);
+let renderBundle16 = renderBundleEncoder1.finish(
+{
+label: '\u0169\u{1fdc8}\ua2af\uaf38\u{1f90f}\u3c17\u{1f648}\u{1f7b8}'
+}
+);
+let sampler21 = device0.createSampler(
+{
+label: '\ub1a1\u5c68\uc0e3\u{1ff12}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 85.191,
+maxAnisotropy: 16,
+}
+);
+try {
+renderPassEncoder2.beginOcclusionQuery(305);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+32,
+0,
+265,
+1
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+5,
+buffer0,
+5668,
+2204
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+computePassEncoder2.setBindGroup(
+0,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+1,
+bindGroup0,
+new Uint32Array(1388),
+218,
+0
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+11,
+buffer0,
+2308
+);
+} catch {}
+let promise5 = device0.createRenderPipelineAsync(
+{
+label: '\u0ff3\u{1f908}\u595a\u{1fda0}\ubb58\udd5a',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 16772,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 15676,
+shaderLocation: 3,
+},
+{
+format: 'unorm16x4',
+offset: 15264,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 31132,
+attributes: [
+{
+format: 'float32x2',
+offset: 10460,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 5664,
+attributes: [
+
+],
+},
+{
+arrayStride: 17648,
+attributes: [
+
+],
+},
+{
+arrayStride: 8128,
+attributes: [
+
+],
+},
+{
+arrayStride: 15328,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 34376,
+attributes: [
+
+],
+},
+{
+arrayStride: 4572,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 9036,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 5860,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'replace',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 3514,
+stencilWriteMask: 946,
+depthBias: 11,
+depthBiasSlopeScale: 67,
+depthBiasClamp: 83,
+},
+}
+);
+let texture13 = device0.createTexture(
+{
+label: '\u0688\u{1f947}\ud5d3\ua2c5\u07e1\u6a68\u0469\u2367\u0ca2',
+size: {width: 979, height: 1, depthOrArrayLayers: 1316},
+dimension: '3d',
+format: 'rg32float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32float',
+'rg32float'
+],
+}
+);
+try {
+renderPassEncoder2.setBindGroup(
+2,
+bindGroup0,
+new Uint32Array(8086),
+482,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+299,
+1,
+1,
+0
+);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(
+3796
+);
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+112.8,
+0.7447,
+32.93,
+0.1823,
+0.6402,
+0.8164
+);
+} catch {}
+let pipeline13 = await device0.createComputePipelineAsync(
+{
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let canvas1 = document.createElement('canvas');
+let buffer5 = device0.createBuffer(
+{
+label: '\u024c\u091c\u{1fcc1}\u3db8',
+size: 14063,
+usage: GPUBufferUsage.QUERY_RESOLVE,
+}
+);
+let texture14 = device0.createTexture(
+{
+label: '\u0b75\u0a03\u4de7\u027f\u69f6\u7e93\uf2a0\u0965',
+size: {width: 5701},
+dimension: '1d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+}
+);
+let renderBundleEncoder11 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+undefined,
+'rgba8uint',
+'rgb10a2uint',
+'rg16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 124,
+}
+);
+try {
+computePassEncoder2.setBindGroup(
+8,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 309.0, g: 721.6, b: 514.7, a: -696.8, });
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+185,
+1,
+20,
+0
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+20016,
+new Float32Array(23153),
+13371,
+244
+);
+} catch {}
+let pipeline14 = await device0.createComputePipelineAsync(
+{
+label: '\u00f0\u589b\u0166\u{1fbf8}\u{1f953}\u{1fbd5}\u{1f60b}\u{1f6ed}',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let querySet12 = device0.createQuerySet({
+type: 'occlusion',
+count: 2613,
+});
+let renderBundle17 = renderBundleEncoder10.finish(
+{
+label: '\uc355\u29b5\u{1f9b0}\u13a8\u{1fcb6}\ude3b\ud955\u0c59\u14e4'
+}
+);
+try {
+renderPassEncoder3.setStencilReference(
+1663
+);
+} catch {}
+try {
+texture3.destroy();
+} catch {}
+gc();
+let querySet13 = device0.createQuerySet({
+type: 'occlusion',
+count: 3493,
+});
+let renderBundle18 = renderBundleEncoder7.finish();
+try {
+renderPassEncoder2.setBindGroup(
+4,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+112,
+1,
+9,
+0
+);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(
+802
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+3,
+bindGroup0
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+7360,
+new BigUint64Array(21701),
+6796,
+1864
+);
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+let pipeline15 = device0.createRenderPipeline(
+{
+label: '\u06a0\u{1fdb6}\u{1fc14}\u0abd\u0929\uc025\u0ea6\u868a',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 34940,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 3982,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 29828,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 18580,
+shaderLocation: 3,
+},
+{
+format: 'sint32',
+offset: 14452,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 33844,
+attributes: [
+{
+format: 'float16x4',
+offset: 32184,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'rgba32uint',
+},
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+let sampler22 = device0.createSampler(
+{
+label: '\u087e\u03e2\u04e2\u05ad\u{1fa67}\u235c\u0621\u236e',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 17.939,
+lodMaxClamp: 48.479,
+maxAnisotropy: 9,
+}
+);
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+166,
+1,
+95,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+119.6,
+0.1844,
+91.07,
+0.8110,
+0.5391,
+0.5827
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 1575, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(arrayBuffer0),
+/* required buffer size: 564 */{
+offset: 564,
+},
+{width: 361, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let textureView14 = texture4.createView(
+{
+aspect: 'depth-only',
+baseMipLevel: 3,
+mipLevelCount: 1,
+baseArrayLayer: 3,
+arrayLayerCount: 7,
+}
+);
+let sampler23 = device0.createSampler(
+{
+label: '\u{1f7b4}\u0bb1\u6a1e\u1ba3\u{1fd46}\ube86\ue6a4\u034c',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 21.565,
+lodMaxClamp: 31.418,
+}
+);
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+41,
+0,
+157,
+0
+);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(
+1509
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+5,
+bindGroup0,
+[]
+);
+} catch {}
+try {
+buffer1.destroy();
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 206, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(0),
+/* required buffer size: 798 */{
+offset: 798,
+},
+{width: 1514, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let commandEncoder10 = device0.createCommandEncoder(
+{
+label: '\u{1f61b}\u053b\u4452',
+}
+);
+let renderBundle19 = renderBundleEncoder8.finish(
+{
+
+}
+);
+let sampler24 = device0.createSampler(
+{
+label: '\u{1f62f}\uf617\ue0dd\ued94\u{1ff3b}\u0681\u{1f7d6}\uec53\u766b\u{1fc2d}\u1635',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 14.796,
+lodMaxClamp: 80.440,
+maxAnisotropy: 11,
+}
+);
+try {
+renderPassEncoder3.setBindGroup(
+1,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(
+8,
+buffer0,
+1792,
+4934
+);
+} catch {}
+try {
+commandEncoder10.clearBuffer(
+buffer2,
+20960,
+8640
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let pipeline16 = await device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 7872,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 964,
+shaderLocation: 1,
+},
+{
+format: 'uint32x2',
+offset: 4560,
+shaderLocation: 5,
+},
+{
+format: 'sint32x4',
+offset: 3168,
+shaderLocation: 11,
+},
+{
+format: 'float16x4',
+offset: 3252,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x2',
+offset: 4644,
+shaderLocation: 6,
+},
+{
+format: 'unorm16x2',
+offset: 7560,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x2',
+offset: 2598,
+shaderLocation: 13,
+},
+{
+format: 'float16x2',
+offset: 844,
+shaderLocation: 14,
+},
+{
+format: 'float16x4',
+offset: 6780,
+shaderLocation: 2,
+},
+{
+format: 'uint16x4',
+offset: 1168,
+shaderLocation: 4,
+},
+{
+format: 'uint32x2',
+offset: 4800,
+shaderLocation: 12,
+},
+{
+format: 'sint16x4',
+offset: 1272,
+shaderLocation: 17,
+},
+{
+format: 'snorm16x2',
+offset: 3624,
+shaderLocation: 10,
+},
+{
+format: 'uint8x4',
+offset: 5896,
+shaderLocation: 0,
+},
+{
+format: 'uint32x4',
+offset: 3960,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x4',
+offset: 5332,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 9148,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 8912,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x4',
+offset: 748,
+shaderLocation: 8,
+},
+{
+format: 'snorm16x2',
+offset: 2732,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 10912,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 26040,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 9648,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 5660,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 2912,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 23532,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 19164,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32',
+offset: 4444,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0xb9c89e80,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r32sint',
+},
+{
+format: 'rg8uint',
+},
+{
+format: 'r8unorm',
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'src',
+dstFactor: 'zero'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'bgra8unorm',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater-equal',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 1738,
+stencilWriteMask: 1464,
+depthBias: 48,
+depthBiasSlopeScale: 48,
+depthBiasClamp: 70,
+},
+}
+);
+document.body.prepend(img1);
+let videoFrame4 = new VideoFrame(canvas1, {timestamp: 0});
+let querySet14 = device0.createQuerySet({
+label: '\u{1f721}\u01a1\uaf9a\u0ab2\ufb17\u0fb0',
+type: 'occlusion',
+count: 3947,
+});
+let textureView15 = texture12.createView(
+{
+mipLevelCount: 1,
+}
+);
+try {
+renderPassEncoder1.setScissorRect(
+240,
+0,
+59,
+1
+);
+} catch {}
+try {
+commandEncoder4.copyBufferToTexture(
+{
+/* bytesInLastRow: 136 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 57632 */
+offset: 57632,
+rowsPerImage: 260,
+buffer: buffer3,
+},
+{
+  texture: texture2,
+  mipLevel: 5,
+  origin: { x: 38, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 17, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+renderBundleEncoder3.insertDebugMarker(
+'\u0579'
+);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer0,
+]);
+} catch {}
+offscreenCanvas2.width = 675;
+let offscreenCanvas5 = new OffscreenCanvas(899, 988);
+let textureView16 = texture4.createView(
+{
+label: '\ub2e0\u06cb\u{1f91d}\u0398\u2b3e\u{1f64c}\ub027\u{1fb96}\u009c',
+dimension: '2d',
+aspect: 'depth-only',
+mipLevelCount: 2,
+baseArrayLayer: 19,
+}
+);
+let renderBundleEncoder12 = device0.createRenderBundleEncoder(
+{
+label: '\u09d7\u6655\u{1fbb3}\u458a\u7663',
+colorFormats: [
+'bgra8unorm-srgb',
+'rg16float'
+],
+sampleCount: 235,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(
+8,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(
+9,
+buffer0,
+5736,
+2136
+);
+} catch {}
+try {
+commandEncoder10.copyBufferToBuffer(
+buffer3,
+48244,
+buffer2,
+812,
+3092
+);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder10.clearBuffer(
+buffer2,
+35156,
+1584
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView17 = texture5.createView(
+{
+dimension: '2d',
+aspect: 'depth-only',
+baseMipLevel: 8,
+baseArrayLayer: 237,
+}
+);
+let renderPassEncoder4 = commandEncoder4.beginRenderPass(
+{
+label: '\u9382\u787b\u{1fe32}\u228f\u4aea',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView9,
+depthClearValue: 0.7472833518551169,
+depthLoadOp: 'clear',
+depthStoreOp: 'discard',
+stencilClearValue: 56633,
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet9,
+maxDrawCount: 411032,
+}
+);
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+commandEncoder10.clearBuffer(
+buffer2,
+18456,
+16280
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let pipeline17 = await device0.createComputePipelineAsync(
+{
+layout: 'auto',
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+},
+}
+);
+let pipeline18 = await device0.createRenderPipelineAsync(
+{
+label: '\u4b63\u0760\ud1fd\ubbd7\u014f',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 28940,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 21576,
+shaderLocation: 2,
+},
+{
+format: 'sint32x2',
+offset: 13484,
+shaderLocation: 10,
+},
+{
+format: 'snorm16x4',
+offset: 24884,
+shaderLocation: 17,
+},
+{
+format: 'uint32x3',
+offset: 4640,
+shaderLocation: 14,
+},
+{
+format: 'float32',
+offset: 16884,
+shaderLocation: 5,
+},
+{
+format: 'uint8x4',
+offset: 1408,
+shaderLocation: 7,
+},
+{
+format: 'float32',
+offset: 6536,
+shaderLocation: 9,
+},
+{
+format: 'uint32x4',
+offset: 25992,
+shaderLocation: 18,
+},
+{
+format: 'sint32',
+offset: 20648,
+shaderLocation: 4,
+},
+{
+format: 'uint16x2',
+offset: 1668,
+shaderLocation: 6,
+},
+{
+format: 'float32x3',
+offset: 13204,
+shaderLocation: 0,
+},
+{
+format: 'uint32x4',
+offset: 18240,
+shaderLocation: 13,
+},
+{
+format: 'float32x4',
+offset: 20060,
+shaderLocation: 8,
+},
+{
+format: 'uint16x2',
+offset: 22528,
+shaderLocation: 16,
+},
+{
+format: 'sint8x2',
+offset: 13530,
+shaderLocation: 15,
+},
+{
+format: 'uint8x4',
+offset: 25272,
+shaderLocation: 3,
+},
+{
+format: 'float16x2',
+offset: 21216,
+shaderLocation: 1,
+},
+{
+format: 'uint32',
+offset: 13100,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 9672,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 4732,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+passOp: 'keep',
+},
+stencilBack: {
+compare: 'greater-equal',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3990,
+stencilWriteMask: 3968,
+depthBias: 93,
+depthBiasSlopeScale: 29,
+},
+}
+);
+let bindGroupLayout5 = device0.createBindGroupLayout(
+{
+label: '\ufbe2\u{1f9e8}\u{1fdbd}\u0ab1\ucd5b\ubc76\u{1fe39}\u{1f9c2}\ub1af',
+entries: [
+{
+binding: 1972,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'storage', minBindingSize: 537287, hasDynamicOffset: false },
+}
+],
+}
+);
+let querySet15 = device0.createQuerySet({
+label: '\ufeca\u620c\u{1fd3a}\u4e17\uc540\ufd43\u0152',
+type: 'occlusion',
+count: 327,
+});
+let textureView18 = texture7.createView(
+{
+label: '\u{1fdcd}\u0d10',
+baseArrayLayer: 0,
+}
+);
+let renderPassEncoder5 = commandEncoder5.beginRenderPass(
+{
+label: '\ud0da\u0560\u617a\ube48\u{1f65a}\ufced\uf49d',
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView4,
+depthClearValue: 0.3100994274556048,
+depthLoadOp: 'clear',
+depthStoreOp: 'discard',
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet9,
+maxDrawCount: 320496,
+}
+);
+let renderBundle20 = renderBundleEncoder3.finish(
+{
+label: '\u{1fdac}\u{1f73b}\u138e\ua404\u{1f924}'
+}
+);
+let sampler25 = device0.createSampler(
+{
+label: '\uf702\u5ff2\u73db\u08f9\u6d8f\u3b1c\uab22\u0e96\uec21\u4688',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 47.124,
+lodMaxClamp: 76.591,
+}
+);
+try {
+renderPassEncoder2.beginOcclusionQuery(388);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(
+10,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(
+5,
+buffer0,
+5544,
+5401
+);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let pipeline19 = await device0.createComputePipelineAsync(
+{
+label: '\uc892\u1d43\u{1f787}\u9308\uf34a',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+renderPassEncoder3.setVertexBuffer(
+6,
+buffer0,
+10688,
+385
+);
+} catch {}
+try {
+commandEncoder10.clearBuffer(
+buffer2,
+33132,
+124
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 1741, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Float64Array(new ArrayBuffer(32)),
+/* required buffer size: 343 */{
+offset: 343,
+bytesPerRow: 1124,
+},
+{width: 251, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let textureView19 = texture12.createView(
+{
+label: '\u{1f746}\uca57\ub077\u0b68\u8486',
+}
+);
+let computePassEncoder4 = commandEncoder10.beginComputePass(
+{
+label: '\u3560\u0ed8\u0eb1'
+}
+);
+let renderBundle21 = renderBundleEncoder10.finish(
+{
+label: '\u0b77\u1f82\u75af\u46e1'
+}
+);
+try {
+computePassEncoder4.setBindGroup(
+5,
+bindGroup0,
+new Uint32Array(7697),
+7625,
+0
+);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(
+0,
+buffer0,
+7436,
+262
+);
+} catch {}
+let pipeline20 = device0.createRenderPipeline(
+{
+label: '\u5533\u099b\u0785\u2b22\u0887\u1120\u{1f795}\u5402\ue8d8\u01db\u339c',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 14200,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 8584,
+shaderLocation: 18,
+},
+{
+format: 'sint16x4',
+offset: 3932,
+shaderLocation: 11,
+},
+{
+format: 'uint32x4',
+offset: 4240,
+shaderLocation: 4,
+},
+{
+format: 'snorm16x2',
+offset: 5576,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x2',
+offset: 12374,
+shaderLocation: 14,
+},
+{
+format: 'uint32x3',
+offset: 2320,
+shaderLocation: 0,
+},
+{
+format: 'uint32x2',
+offset: 8960,
+shaderLocation: 5,
+},
+{
+format: 'sint32',
+offset: 5184,
+shaderLocation: 8,
+},
+{
+format: 'uint32x4',
+offset: 12408,
+shaderLocation: 3,
+},
+{
+format: 'float16x4',
+offset: 11868,
+shaderLocation: 2,
+},
+{
+format: 'sint16x4',
+offset: 320,
+shaderLocation: 17,
+},
+{
+format: 'float32x3',
+offset: 6248,
+shaderLocation: 1,
+},
+{
+format: 'unorm16x2',
+offset: 2428,
+shaderLocation: 10,
+},
+{
+format: 'sint32',
+offset: 11188,
+shaderLocation: 16,
+},
+{
+format: 'float32x3',
+offset: 13756,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x2',
+offset: 11056,
+shaderLocation: 6,
+},
+{
+format: 'float32x2',
+offset: 3888,
+shaderLocation: 13,
+},
+{
+format: 'float32x2',
+offset: 6696,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 11464,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 18536,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 2436,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 1748,
+shaderLocation: 12,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xc6f3a08d,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.ALL,
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'zero',
+dstFactor: 'one-minus-src'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'one',
+dstFactor: 'one-minus-src'
+},
+},
+format: 'rg16float',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilReadMask: 1485,
+stencilWriteMask: 467,
+depthBias: 97,
+depthBiasSlopeScale: 26,
+depthBiasClamp: 90,
+},
+}
+);
+let commandEncoder11 = device0.createCommandEncoder(
+{
+}
+);
+let renderBundle22 = renderBundleEncoder10.finish(
+{
+label: '\u02a9\u030c\uefef\ub353\u526e\u5ee9\ucb94\u5761\u{1fe38}\uea6a\u586a'
+}
+);
+let sampler26 = device0.createSampler(
+{
+label: '\uf263\u0cd1\uba69\u7ad4\u350b\u0e22\u019f\u{1f635}\u8286',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMaxClamp: 18.576,
+compare: 'less',
+}
+);
+try {
+renderPassEncoder4.setBindGroup(
+1,
+bindGroup0,
+new Uint32Array(412),
+166,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+commandEncoder11.copyBufferToBuffer(
+buffer4,
+1936,
+buffer2,
+3548,
+56
+);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder11.copyTextureToTexture(
+{
+  texture: texture5,
+  mipLevel: 1,
+  origin: { x: 609, y: 42, z: 22 },
+  aspect: 'depth-only',
+},
+{
+  texture: texture5,
+  mipLevel: 3,
+  origin: { x: 0, y: 13, z: 32 },
+  aspect: 'all',
+},
+{width: 282, height: 0, depthOrArrayLayers: 200}
+);
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(
+querySet13,
+2269,
+744,
+buffer5,
+5376
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture6,
+  mipLevel: 1,
+  origin: { x: 44, y: 28, z: 27 },
+  aspect: 'all',
+},
+new ArrayBuffer(56),
+/* required buffer size: 559248 */{
+offset: 476,
+bytesPerRow: 83,
+rowsPerImage: 204,
+},
+{width: 4, height: 4, depthOrArrayLayers: 34}
+);
+} catch {}
+document.body.prepend(canvas1);
+let texture15 = device0.createTexture(
+{
+label: '\u9d81\u06b6\u971d\u2996\u082e\u{1f738}\u7bef\ue386\u{1fd3b}',
+size: {width: 9832},
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rg32sint'
+],
+}
+);
+let textureView20 = texture13.createView(
+{
+label: '\u{1fc91}\u0591\u01fb',
+baseArrayLayer: 0,
+}
+);
+try {
+computePassEncoder4.setPipeline(
+pipeline19
+);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(316);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(
+3,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder11.pushDebugGroup(
+'\u527c'
+);
+} catch {}
+let pipeline21 = await promise5;
+let commandEncoder12 = device0.createCommandEncoder(
+{
+label: '\uc101\uc8af\uf09e\u{1fc0e}\ua853',
+}
+);
+let renderPassEncoder6 = commandEncoder11.beginRenderPass(
+{
+label: '\u4f62\u0f16\ucf8b\u6bd9\u0925\ue37d\u361a\u3ce9\u7f60',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView9,
+depthClearValue: 0.3194711620806985,
+depthLoadOp: 'clear',
+depthStoreOp: 'discard',
+stencilClearValue: 34101,
+},
+occlusionQuerySet: querySet8,
+maxDrawCount: 193288,
+}
+);
+let renderBundle23 = renderBundleEncoder12.finish();
+try {
+renderPassEncoder3.setBindGroup(
+0,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+7,
+bindGroup0,
+new Uint32Array(9721),
+1980,
+0
+);
+} catch {}
+try {
+renderPassEncoder6.setViewport(
+175.4,
+0.7126,
+94.14,
+0.1422,
+0.1728,
+0.9168
+);
+} catch {}
+try {
+renderBundleEncoder11.insertDebugMarker(
+'\u04cd'
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb',
+'rgba8unorm-srgb'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+20272,
+new Float32Array(64870),
+37525,
+3040
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture11,
+  mipLevel: 1,
+  origin: { x: 0, y: 24, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 822 */{
+offset: 822,
+bytesPerRow: 166,
+rowsPerImage: 30,
+},
+{width: 36, height: 28, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await promise6;
+} catch {}
+offscreenCanvas1.width = 458;
+gc();
+let canvas2 = document.createElement('canvas');
+let commandEncoder13 = device0.createCommandEncoder(
+{
+label: '\u00e6\ua63c\u{1f7ec}',
+}
+);
+let texture16 = device0.createTexture(
+{
+label: '\u49c4\u7f51\u0e7b\u{1f886}\u16a3',
+size: [10316, 2, 1],
+mipLevelCount: 2,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'depth24plus'
+],
+}
+);
+let renderBundle24 = renderBundleEncoder10.finish();
+try {
+computePassEncoder4.setPipeline(
+pipeline17
+);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(
+3,
+buffer0,
+5868,
+1550
+);
+} catch {}
+try {
+commandEncoder12.clearBuffer(
+buffer2,
+28992,
+6880
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder12.resolveQuerySet(
+querySet14,
+2648,
+1220,
+buffer5,
+256
+);
+} catch {}
+canvas1.height = 263;
+gc();
+let commandEncoder14 = device0.createCommandEncoder();
+let textureView21 = texture3.createView(
+{
+label: '\u{1fb77}\uf790\u5e73\u003a\ud904',
+dimension: '2d-array',
+format: 'depth32float',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+let renderBundleEncoder13 = device0.createRenderBundleEncoder(
+{
+label: '\u1bb4\u069b\u{1f941}\u955d\u{1fad4}\u0a38\u110e',
+colorFormats: [
+'rgba8unorm-srgb'
+],
+sampleCount: 411,
+stencilReadOnly: true,
+}
+);
+let renderBundle25 = renderBundleEncoder7.finish(
+{
+label: '\u{1ffa6}\u{1f9c9}\ude5b\u2e4a\u0b83\u9e03\u56aa\uc8c1\u0388'
+}
+);
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: -471.0, g: 48.69, b: -826.9, a: 969.1, });
+} catch {}
+let pipeline22 = await device0.createComputePipelineAsync(
+{
+label: '\u{1ff0d}\u9a9c\ub37b\u{1f605}\u2b61\u24aa\u9ca8\u7055\u7db6\u0650\u801e',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let video3 = await videoWithData();
+try {
+canvas1.getContext('webgl2');
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout(
+{
+label: '\u2394\u2892\u{1fc7c}\u{1fb8f}\u{1fbcf}\u6d40\u{1f755}\ue637\u9bf8\u01b9\u0c2e',
+entries: [
+{
+binding: 5112,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 4291,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 4361,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let texture17 = device0.createTexture(
+{
+size: [2992, 1, 133],
+mipLevelCount: 6,
+sampleCount: 1,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'stencil8',
+'stencil8'
+],
+}
+);
+let textureView22 = texture13.createView(
+{
+label: '\u629b\u4d5e\u007b\u97f5\u0fe2\u02bd\u6b17',
+dimension: '3d',
+}
+);
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 833.9, g: 364.5, b: 709.3, a: 842.1, });
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+7,
+buffer0,
+8880,
+1973
+);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(
+7,
+buffer0,
+1864,
+7686
+);
+} catch {}
+let pipeline23 = await device0.createComputePipelineAsync(
+{
+label: '\u0110\u2f1d\u8a7f\u8e78\u0d22\ub1b3\u{1fa26}\u{1fc9a}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+},
+}
+);
+let canvas3 = document.createElement('canvas');
+let shaderModule4 = device0.createShaderModule(
+{
+label: '\u0052\ufd97\ua60d\u{1fe46}\u7633\uab6d\u95cb',
+code: `@group(0) @binding(6956)
+var<storage, read_write> global9: array<u32>;
+@group(3) @binding(166)
+var<storage, read_write> parameter8: array<u32>;
+@group(3) @binding(1109)
+var<storage, read_write> function10: array<u32>;
+@group(0) @binding(2242)
+var<storage, read_write> function11: array<u32>;
+@group(3) @binding(5018)
+var<storage, read_write> parameter9: array<u32>;
+@group(2) @binding(6956)
+var<storage, read_write> type12: array<u32>;
+@group(2) @binding(6973)
+var<storage, read_write> function12: array<u32>;
+
+@compute @workgroup_size(1, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: vec2<f32>,
+@location(7) f1: vec4<f32>,
+@location(1) f2: vec4<u32>,
+@location(2) f3: vec3<i32>,
+@location(5) f4: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(45) a0: vec4<f32>, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S3 {
+@location(3) f0: vec2<f32>
+}
+struct VertexOutput0 {
+@location(45) f9: vec4<f32>,
+@builtin(position) f10: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec2<f16>, @location(12) a1: vec2<u32>, @location(11) a2: vec3<f32>, @location(15) a3: vec3<f16>, @location(6) a4: u32, @location(17) a5: f32, @location(10) a6: u32, @location(4) a7: vec3<i32>, @location(13) a8: vec3<i32>, @location(5) a9: i32, @builtin(vertex_index) a10: u32, @location(2) a11: vec3<f16>, @location(9) a12: u32, @location(0) a13: vec2<i32>, @location(8) a14: vec4<u32>, @location(1) a15: vec2<u32>, @location(7) a16: f16, @location(18) a17: vec2<f16>, @location(16) a18: vec2<i32>, a19: S3, @builtin(instance_index) a20: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let computePassEncoder5 = commandEncoder12.beginComputePass(
+{
+label: '\ua3e3\u{1f628}\ua934\u7dbc\u670e\u{1fe01}\u{1fd4f}'
+}
+);
+try {
+computePassEncoder5.setBindGroup(
+10,
+bindGroup0,
+new Uint32Array(4956),
+643,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+11,
+buffer0,
+9656,
+826
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+7,
+buffer0
+);
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(
+querySet0,
+43,
+69,
+buffer5,
+4352
+);
+} catch {}
+let gpuCanvasContext4 = canvas3.getContext('webgpu');
+let canvas4 = document.createElement('canvas');
+let videoFrame5 = new VideoFrame(offscreenCanvas5, {timestamp: 0});
+let shaderModule5 = device0.createShaderModule(
+{
+label: '\u64b7\u0ecf',
+code: `@group(3) @binding(5018)
+var<storage, read_write> field11: array<u32>;
+@group(3) @binding(166)
+var<storage, read_write> function13: array<u32>;
+@group(0) @binding(6973)
+var<storage, read_write> type13: array<u32>;
+@group(2) @binding(2242)
+var<storage, read_write> global10: array<u32>;
+@group(2) @binding(6973)
+var<storage, read_write> field12: array<u32>;
+@group(3) @binding(1109)
+var<storage, read_write> function14: array<u32>;
+@group(1) @binding(1894)
+var<storage, read_write> field13: array<u32>;
+@group(0) @binding(2242)
+var<storage, read_write> field14: array<u32>;
+
+@compute @workgroup_size(3, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: vec4<f32>,
+@location(7) f1: vec4<f32>,
+@location(2) f2: vec2<u32>,
+@location(0) f3: u32,
+@location(5) f4: f32,
+@location(3) f5: vec3<f32>,
+@builtin(frag_depth) f6: f32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(6) a0: f16, @location(4) a1: f32, @location(5) a2: vec3<f32>, @location(13) a3: f16, @location(9) a4: f16, @builtin(instance_index) a5: u32, @location(18) a6: vec2<i32>, @location(3) a7: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let pipelineLayout3 = device0.createPipelineLayout(
+{
+label: '\uc505\u5cba\u0af5\u8e57\u{1f711}\u062e',
+bindGroupLayouts: [
+bindGroupLayout0,
+bindGroupLayout2,
+bindGroupLayout3,
+bindGroupLayout4,
+bindGroupLayout6,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout2,
+bindGroupLayout4,
+bindGroupLayout5,
+bindGroupLayout3
+]
+}
+);
+let querySet16 = device0.createQuerySet({
+label: '\u{1f7bd}\ubb6e\u{1fb35}\ucf54\ud337\u02fe\uf2e8\u14b0\u4c19',
+type: 'occlusion',
+count: 3113,
+});
+let computePassEncoder6 = commandEncoder13.beginComputePass(
+{
+label: '\u4770\uf6ec\u{1f9bb}\uaac1\u05ed\u3cb5\ue7b4\u0db4\u{1fa5e}\u{1f862}'
+}
+);
+let renderPassEncoder7 = commandEncoder14.beginRenderPass(
+{
+label: '\u1419\u3c06\u0458\uad16',
+colorAttachments: [
+
+],
+depthStencilAttachment: {
+view: textureView21,
+depthClearValue: 2.255484187111861,
+depthReadOnly: true,
+stencilClearValue: 34377,
+stencilReadOnly: true,
+},
+maxDrawCount: 23904,
+}
+);
+try {
+computePassEncoder5.setBindGroup(
+6,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(
+400
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+8,
+buffer0,
+5180,
+250
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+8,
+buffer0,
+2132,
+5070
+);
+} catch {}
+try {
+commandEncoder10.copyBufferToBuffer(
+buffer3,
+24164,
+buffer2,
+14316,
+14356
+);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder10.clearBuffer(
+buffer2,
+18436,
+8384
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let imageData3 = new ImageData(36, 236);
+let commandEncoder15 = device0.createCommandEncoder(
+{
+label: '\u{1fb02}\ua63c\ueb75\ud82c\u03e4\u{1f7dd}\uea47\u0cff\u77b8\u{1fe79}',
+}
+);
+let querySet17 = device0.createQuerySet({
+label: '\u42e6\u091f\ub1a0\u8a51\u7a9e\u{1fdcf}\ue2b6\u{1fe84}',
+type: 'occlusion',
+count: 2,
+});
+let renderPassEncoder8 = commandEncoder15.beginRenderPass(
+{
+label: '\u4fc4\u{1ff20}\u0288\uc8dd\u{1fb49}\ue68d\u523d\u1ac2\u47f6\ud126',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView4,
+depthLoadOp: 'load',
+depthStoreOp: 'discard',
+stencilClearValue: 50054,
+},
+occlusionQuerySet: querySet16,
+}
+);
+try {
+renderPassEncoder5.setBindGroup(
+1,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(
+1,
+bindGroup0
+);
+} catch {}
+let pipeline24 = await device0.createRenderPipelineAsync(
+{
+label: '\u06fd\uaa34',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 18768,
+attributes: [
+{
+format: 'sint16x4',
+offset: 5476,
+shaderLocation: 8,
+},
+{
+format: 'float32x3',
+offset: 15572,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 28444,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x2',
+offset: 24608,
+shaderLocation: 16,
+},
+{
+format: 'uint32',
+offset: 6728,
+shaderLocation: 5,
+},
+{
+format: 'sint32x3',
+offset: 14228,
+shaderLocation: 11,
+},
+{
+format: 'float32x4',
+offset: 19264,
+shaderLocation: 14,
+},
+{
+format: 'sint32x3',
+offset: 2140,
+shaderLocation: 17,
+},
+{
+format: 'snorm8x2',
+offset: 26512,
+shaderLocation: 9,
+},
+{
+format: 'uint32x3',
+offset: 1764,
+shaderLocation: 3,
+},
+{
+format: 'uint8x2',
+offset: 20608,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x4',
+offset: 14428,
+shaderLocation: 18,
+},
+{
+format: 'snorm8x2',
+offset: 14620,
+shaderLocation: 1,
+},
+{
+format: 'uint8x4',
+offset: 20272,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 28520,
+attributes: [
+{
+format: 'snorm8x4',
+offset: 9912,
+shaderLocation: 2,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 3680,
+shaderLocation: 13,
+},
+{
+format: 'float32',
+offset: 18624,
+shaderLocation: 6,
+},
+{
+format: 'snorm8x2',
+offset: 13498,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 12960,
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 9304,
+shaderLocation: 7,
+},
+{
+format: 'uint32',
+offset: 5040,
+shaderLocation: 12,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one',
+dstFactor: 'zero'
+},
+},
+format: 'r16float',
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+failOp: 'invert',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'increment-clamp',
+},
+stencilWriteMask: 2150,
+depthBiasSlopeScale: 45,
+depthBiasClamp: 63,
+},
+}
+);
+let querySet18 = device0.createQuerySet({
+label: '\u8540\u0a25',
+type: 'occlusion',
+count: 1781,
+});
+let textureView23 = texture4.createView(
+{
+label: '\u00bc\uf995\u974c',
+dimension: '2d',
+aspect: 'depth-only',
+baseMipLevel: 0,
+mipLevelCount: 2,
+baseArrayLayer: 3,
+}
+);
+let computePassEncoder7 = commandEncoder10.beginComputePass(
+{
+label: '\u{1f812}\u{1f6f7}\u2630\ube6f\uf74a\u1f3b\u14e4\u03fa\u1ee0'
+}
+);
+let renderBundle26 = renderBundleEncoder9.finish(
+{
+label: '\ube62\u{1fc7c}\u0a47\u04f2\u2d67\ua040'
+}
+);
+let pipeline25 = device0.createComputePipeline(
+{
+label: '\u0812\u{1fd43}\u{1fbdb}\u99cd',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let videoFrame6 = new VideoFrame(canvas4, {timestamp: 0});
+let texture18 = gpuCanvasContext3.getCurrentTexture();
+let textureView24 = texture8.createView(
+{
+label: '\uda8a\u0630\u{1f828}\u080d\ufbc2',
+baseMipLevel: 4,
+mipLevelCount: 1,
+}
+);
+try {
+computePassEncoder5.setPipeline(
+pipeline2
+);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(
+4,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 713.8, g: 395.5, b: 912.6, a: 768.4, });
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+232.7,
+0.6214,
+15.95,
+0.1253,
+0.4048,
+0.4080
+);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(
+5,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder11.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb',
+'rgba8unorm-srgb',
+'rg8sint',
+'depth32float'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline26 = device0.createRenderPipeline(
+{
+label: '\u090f\u{1fb24}',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule4,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1460,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 1052,
+shaderLocation: 18,
+},
+{
+format: 'sint32x4',
+offset: 428,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 2536,
+attributes: [
+{
+format: 'float32x3',
+offset: 2440,
+shaderLocation: 11,
+},
+{
+format: 'float32x3',
+offset: 1232,
+shaderLocation: 17,
+},
+{
+format: 'uint8x2',
+offset: 674,
+shaderLocation: 12,
+},
+{
+format: 'uint8x2',
+offset: 882,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 35204,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 27296,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x2',
+offset: 27568,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 24396,
+attributes: [
+{
+format: 'sint16x4',
+offset: 17320,
+shaderLocation: 0,
+},
+{
+format: 'sint16x2',
+offset: 9912,
+shaderLocation: 5,
+},
+{
+format: 'sint8x2',
+offset: 17392,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 32520,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 31060,
+shaderLocation: 10,
+},
+{
+format: 'sint16x2',
+offset: 7396,
+shaderLocation: 16,
+},
+{
+format: 'uint16x2',
+offset: 9108,
+shaderLocation: 6,
+},
+{
+format: 'float32',
+offset: 13844,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x4',
+offset: 16628,
+shaderLocation: 14,
+},
+{
+format: 'uint32x2',
+offset: 3752,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 13848,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 4792,
+shaderLocation: 3,
+},
+{
+format: 'uint32x4',
+offset: 2192,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule4,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+},
+{
+format: 'rgba16uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+{
+format: 'rgba32uint',
+},
+undefined
+],
+},
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+canvas4.getContext('2d');
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder(
+{
+label: '\u530d\u{1f8b6}\u9d4e\u0520\u0d83',
+}
+);
+let texture19 = device0.createTexture(
+{
+label: '\u{1fcbf}\u9318\ucc68\u00fd\u8b24\u0a6e\u{1fff2}',
+size: [7279],
+dimension: '1d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16sint',
+'rgba16sint'
+],
+}
+);
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(
+buffer4,
+1976,
+buffer2,
+21292,
+248
+);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder16.clearBuffer(
+buffer2,
+33140,
+1668
+);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+renderBundleEncoder11.insertDebugMarker(
+'\u{1f7dc}'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+17080,
+new Float32Array(41627),
+21364,
+3896
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 24, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 739 */{
+offset: 739,
+},
+{width: 1957, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let texture20 = gpuCanvasContext0.getCurrentTexture();
+let renderPassEncoder9 = commandEncoder16.beginRenderPass(
+{
+label: '\u{1ffc9}\u0983\u09ab\u{1fc5c}\uf278',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView21,
+depthClearValue: 8.69555487439714,
+depthLoadOp: 'load',
+depthStoreOp: 'discard',
+stencilClearValue: 36185,
+},
+occlusionQuerySet: querySet8,
+}
+);
+try {
+computePassEncoder5.setPipeline(
+pipeline22
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+5,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+8,
+bindGroup0
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture17,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 20 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer0),
+/* required buffer size: 6940188 */{
+offset: 714,
+bytesPerRow: 431,
+rowsPerImage: 161,
+},
+{width: 374, height: 1, depthOrArrayLayers: 101}
+);
+} catch {}
+let shaderModule6 = device0.createShaderModule(
+{
+label: '\u{1f7ba}\u2a8a\u0c81\u33e3\u0cc2\u{1f74f}\ua8fe\u{1fb17}\u{1f627}',
+code: `@group(3) @binding(166)
+var<storage, read_write> local9: array<u32>;
+@group(2) @binding(6956)
+var<storage, read_write> field15: array<u32>;
+@group(3) @binding(1109)
+var<storage, read_write> function15: array<u32>;
+@group(1) @binding(1894)
+var<storage, read_write> local10: array<u32>;
+@group(2) @binding(2242)
+var<storage, read_write> function16: array<u32>;
+@group(0) @binding(6973)
+var<storage, read_write> i10: array<u32>;
+@group(3) @binding(5018)
+var<storage, read_write> local11: array<u32>;
+@group(0) @binding(6956)
+var<storage, read_write> global11: array<u32>;
+
+@compute @workgroup_size(4, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S4 {
+@location(21) f0: f16,
+@location(29) f1: vec2<f16>,
+@location(12) f2: vec2<i32>,
+@location(33) f3: vec2<f32>,
+@location(35) f4: vec3<f16>,
+@location(46) f5: u32,
+@location(45) f6: vec4<f16>,
+@location(44) f7: vec2<f32>,
+@location(10) f8: vec2<f32>,
+@location(16) f9: vec2<u32>,
+@location(5) f10: vec4<f32>,
+@builtin(sample_index) f11: u32,
+@location(36) f12: vec3<f16>,
+@location(0) f13: vec3<u32>,
+@location(7) f14: vec4<i32>,
+@location(24) f15: vec4<u32>,
+@location(15) f16: vec2<i32>,
+@location(17) f17: i32,
+@location(31) f18: vec3<i32>,
+@location(30) f19: vec4<u32>,
+@location(39) f20: f32,
+@location(34) f21: vec2<f16>
+}
+struct FragmentOutput0 {
+@location(4) f0: vec2<u32>,
+@location(2) f1: vec4<i32>,
+@location(6) f2: f32
+}
+
+@fragment
+fn fragment0(a0: S4, @location(43) a1: f16, @location(32) a2: vec2<u32>, @location(1) a3: f16, @location(23) a4: vec3<f32>, @location(6) a5: vec3<f32>, @location(22) a6: vec3<f16>, @location(18) a7: vec4<i32>, @location(37) a8: u32, @location(4) a9: vec3<f16>, @location(13) a10: vec4<u32>, @builtin(front_facing) a11: bool, @builtin(position) a12: vec4<f32>, @builtin(sample_mask) a13: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(21) f11: f16,
+@location(35) f12: vec3<f16>,
+@location(16) f13: vec2<u32>,
+@location(7) f14: vec4<i32>,
+@location(32) f15: vec2<u32>,
+@location(5) f16: vec4<f32>,
+@location(0) f17: vec3<u32>,
+@location(23) f18: vec3<f32>,
+@location(6) f19: vec3<f32>,
+@location(31) f20: vec3<i32>,
+@location(10) f21: vec2<f32>,
+@builtin(position) f22: vec4<f32>,
+@location(43) f23: f16,
+@location(39) f24: f32,
+@location(34) f25: vec2<f16>,
+@location(30) f26: vec4<u32>,
+@location(4) f27: vec3<f16>,
+@location(46) f28: u32,
+@location(37) f29: u32,
+@location(33) f30: vec2<f32>,
+@location(1) f31: f16,
+@location(13) f32: vec4<u32>,
+@location(12) f33: vec2<i32>,
+@location(36) f34: vec3<f16>,
+@location(18) f35: vec4<i32>,
+@location(15) f36: vec2<i32>,
+@location(29) f37: vec2<f16>,
+@location(24) f38: vec4<u32>,
+@location(17) f39: i32,
+@location(44) f40: vec2<f32>,
+@location(45) f41: vec4<f16>,
+@location(22) f42: vec3<f16>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @builtin(instance_index) a1: u32, @location(16) a2: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let renderBundle27 = renderBundleEncoder3.finish(
+{
+label: '\ua126\ub765\u{1f8ea}\u76f0\u92c6'
+}
+);
+try {
+computePassEncoder6.setBindGroup(
+0,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(483);
+} catch {}
+try {
+renderPassEncoder6.setViewport(
+272.9,
+0.1286,
+4.027,
+0.8518,
+0.2289,
+0.9659
+);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(
+9,
+bindGroup0
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 4, y: 162 },
+  flipY: true,
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.destroy();
+} catch {}
+try {
+computePassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder8.setViewport(
+86.30,
+0.5817,
+173.8,
+0.03585,
+0.1083,
+0.2749
+);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(
+2,
+bindGroup0,
+new Uint32Array(5566),
+1774,
+0
+);
+} catch {}
+try {
+commandEncoder12.resolveQuerySet(
+querySet8,
+356,
+156,
+buffer5,
+9728
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'r8uint',
+'bgra8unorm-srgb'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer2,
+6152,
+new BigUint64Array(324),
+85,
+164
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas3,
+  origin: { x: 68, y: 19 },
+  flipY: true,
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let adapter2 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let offscreenCanvas6 = new OffscreenCanvas(14, 304);
+let video4 = await videoWithData();
+let imageData4 = new ImageData(44, 72);
+try {
+offscreenCanvas5.getContext('webgl');
+} catch {}
+document.body.prepend(video1);
+let promise7 = adapter2.requestAdapterInfo();
+try {
+offscreenCanvas6.getContext('webgl2');
+} catch {}
+let computePassEncoder8 = commandEncoder12.beginComputePass(
+{
+
+}
+);
+let renderBundle28 = renderBundleEncoder10.finish(
+{
+
+}
+);
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(
+140,
+0,
+3,
+0
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+9,
+bindGroup0,
+new Uint32Array(6486),
+2404,
+0
+);
+} catch {}
+let canvas5 = document.createElement('canvas');
+let gpuCanvasContext5 = canvas5.getContext('webgpu');
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageBitmap3 = await createImageBitmap(videoFrame1);
+document.body.prepend(img1);
+let offscreenCanvas7 = new OffscreenCanvas(471, 952);
+let videoFrame7 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let bindGroupLayout7 = device0.createBindGroupLayout(
+{
+label: '\u{1f8cb}\uccff\uffa6\u0b37\u0196\u048d',
+entries: [
+{
+binding: 8113,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+},
+{
+binding: 4418,
+visibility: 0,
+externalTexture: {},
+}
+],
+}
+);
+try {
+renderPassEncoder6.setBlendConstant({ r: 750.5, g: -791.6, b: -0.08069, a: 510.2, });
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+243,
+1,
+33,
+0
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture1,
+  mipLevel: 3,
+  origin: { x: 0, y: 4, z: 26 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 3277525 */{
+offset: 419,
+bytesPerRow: 656,
+rowsPerImage: 185,
+},
+{width: 193, height: 1, depthOrArrayLayers: 28}
+);
+} catch {}
+let pipeline27 = await device0.createRenderPipelineAsync(
+{
+label: '\u013e\ud6f3\u{1f624}\u2872\u{1faf0}\u0959\u{1fbe7}\ue400',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule6,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 5432,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 34664,
+attributes: [
+
+],
+},
+{
+arrayStride: 26892,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 28904,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 20292,
+attributes: [
+
+],
+},
+{
+arrayStride: 24404,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 25944,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 32280,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 21324,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 15880,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+},
+multisample: {
+mask: 0xc3bb141d,
+},
+fragment: {
+module: shaderModule6,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilReadMask: 831,
+stencilWriteMask: 122,
+depthBias: 37,
+depthBiasSlopeScale: 85,
+depthBiasClamp: 49,
+},
+}
+);
+let img2 = await imageWithData(143, 104, '#e9170b07', '#a560d4e5');
+video1.height = 25;
+try {
+offscreenCanvas7.getContext('webgpu');
+} catch {}
+let querySet19 = device0.createQuerySet({
+label: '\u{1faf3}\u{1f6f3}\u157d\u{1f9b8}\u{1fa23}\u7029\u0903',
+type: 'occlusion',
+count: 3309,
+});
+let textureView25 = texture2.createView(
+{
+baseMipLevel: 3,
+mipLevelCount: 2,
+baseArrayLayer: 0,
+}
+);
+let renderBundleEncoder14 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba32float',
+'rg16sint',
+'r32float',
+'bgra8unorm-srgb',
+'r8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 963,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder8.setBindGroup(
+1,
+bindGroup0,
+new Uint32Array(2887),
+289,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+145,
+1,
+43,
+0
+);
+} catch {}
+try {
+renderPassEncoder4.setViewport(
+60.64,
+0.04998,
+183.1,
+0.7947,
+0.7015,
+0.7456
+);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(
+3,
+buffer0,
+5004,
+462
+);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+await promise7;
+} catch {}
+gc();
+let img3 = await imageWithData(168, 149, '#4a979f46', '#1f532b4f');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(760, 388);
+try {
+offscreenCanvas8.getContext('webgpu');
+} catch {}
+offscreenCanvas2.width = 144;
+document.body.prepend(img1);
+let offscreenCanvas9 = new OffscreenCanvas(462, 351);
+gc();
+let gpuCanvasContext6 = offscreenCanvas9.getContext('webgpu');
+let gpuCanvasContext7 = canvas2.getContext('webgpu');
+let imageData5 = new ImageData(88, 164);
+let imageData6 = new ImageData(20, 136);
+let videoFrame8 = new VideoFrame(videoFrame6, {timestamp: 0});
+try {
+adapter0.label = '\u0728\uf152\uc87c\u{1fe72}\ua72f\ucef3';
+} catch {}
+let imageData7 = new ImageData(160, 256);
+let canvas6 = document.createElement('canvas');
+let imageBitmap4 = await createImageBitmap(video3);
+gc();
+let canvas7 = document.createElement('canvas');
+try {
+canvas6.getContext('webgl');
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+canvas0.width = 635;
+let adapter3 = await navigator.gpu.requestAdapter(
+{
+}
+);
+try {
+canvas7.getContext('webgpu');
+} catch {}
+let imageData8 = new ImageData(208, 252);
+document.body.prepend(canvas1);
+let imageData9 = new ImageData(240, 120);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let device1 = await adapter2.requestDevice({
+label: '\u{1f691}\u06ea\u91ba\u12f2\ub476\u0bc6\uc73b\u2fba\ud8de\uf280\u0127',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 42,
+maxVertexAttributes: 28,
+maxVertexBufferArrayStride: 62924,
+maxStorageTexturesPerShaderStage: 31,
+maxStorageBuffersPerShaderStage: 35,
+maxDynamicStorageBuffersPerPipelineLayout: 14503,
+maxBindingsPerBindGroup: 6920,
+maxTextureDimension1D: 11698,
+maxTextureDimension2D: 10765,
+maxVertexBuffers: 10,
+maxUniformBufferBindingSize: 100063698,
+maxUniformBuffersPerShaderStage: 19,
+maxInterStageShaderVariables: 109,
+maxInterStageShaderComponents: 63,
+maxSamplersPerShaderStage: 16,
+},
+});
+let promise8 = adapter3.requestAdapterInfo();
+offscreenCanvas1.height = 56;
+let renderBundleEncoder15 = device1.createRenderBundleEncoder(
+{
+label: '\u0f55\u5dca\u7ab9\ud556\u{1ff3a}\u6b61\ubdb7\ud715\u28ad',
+colorFormats: [
+undefined,
+'rg16uint',
+'rg32uint',
+'rg11b10ufloat',
+'rg32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 376,
+stencilReadOnly: true,
+}
+);
+let sampler27 = device1.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 54.809,
+lodMaxClamp: 66.021,
+maxAnisotropy: 5,
+}
+);
+let imageBitmap5 = await createImageBitmap(video2);
+try {
+device1.queue.label = '\u5cf1\u4332\ub1a6';
+} catch {}
+try {
+gpuCanvasContext6.configure(
+{
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm',
+'rgba32float',
+'rgba16uint'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let promise9 = device1.queue.onSubmittedWorkDone();
+canvas3.width = 608;
+let offscreenCanvas10 = new OffscreenCanvas(26, 215);
+let videoFrame9 = new VideoFrame(img2, {timestamp: 0});
+let buffer6 = device1.createBuffer(
+{
+label: '\u1669\u01df\u{1f890}\u8835\u{1f8da}\u0ec2\u0a60\ubdca\u11b0',
+size: 10843,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+mappedAtCreation: false,
+}
+);
+let commandEncoder17 = device1.createCommandEncoder(
+{
+label: '\u06e1\u{1fb1d}\u{1f914}\uc2c4\ud8c8\u7082\ud27f\u{1fc91}\ueffb\u85a4\u2934',
+}
+);
+try {
+renderBundleEncoder15.setIndexBuffer(
+buffer6,
+'uint32'
+);
+} catch {}
+let gpuCanvasContext8 = offscreenCanvas10.getContext('webgpu');
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+try {
+await promise8;
+} catch {}
+let texture21 = device1.createTexture(
+{
+size: {width: 3830},
+dimension: '1d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let promise10 = device1.popErrorScope();
+try {
+buffer6.unmap();
+} catch {}
+let buffer7 = device1.createBuffer(
+{
+label: '\ub3c0\u8f07\u{1f773}\u67d6',
+size: 13394,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+}
+);
+let renderBundle29 = renderBundleEncoder15.finish(
+{
+label: '\uc787\u5b37'
+}
+);
+video3.width = 272;
+canvas4.height = 220;
+gc();
+let imageBitmap6 = await createImageBitmap(offscreenCanvas7);
+let commandEncoder18 = device1.createCommandEncoder(
+{
+}
+);
+let textureView26 = texture21.createView(
+{
+label: '\u{1fa7f}\u0b81\u0246\u{1f8d8}',
+}
+);
+try {
+commandEncoder17.clearBuffer(
+buffer7,
+10796,
+324
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder17.insertDebugMarker(
+'\ud812'
+);
+} catch {}
+let commandEncoder19 = device1.createCommandEncoder(
+{
+label: '\u0e3d\ucca6\u375f\u0580\u{1f9df}\u{1fb18}\u{1f7f3}\uff6b\ubefb\u0311',
+}
+);
+let textureView27 = texture21.createView(
+{
+aspect: 'all',
+}
+);
+let computePassEncoder9 = commandEncoder17.beginComputePass(
+{
+label: '\u{1fd92}\u0147\u0fb7\u9321\uc625\u0b12'
+}
+);
+let sampler28 = device1.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 47.535,
+lodMaxClamp: 59.039,
+compare: 'less',
+maxAnisotropy: 18,
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+await promise10;
+} catch {}
+let bindGroupLayout8 = device1.createBindGroupLayout(
+{
+entries: [
+{
+binding: 1617,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 1761,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '3d' },
+}
+],
+}
+);
+let pipelineLayout4 = device1.createPipelineLayout(
+{
+label: '\u{1fdf3}\u3236\u{1fefc}\u2d25\u{1fb8d}\udf13\u0cf2\u0f77\u1f7e\u4767\u{1fb87}',
+bindGroupLayouts: [
+bindGroupLayout8,
+bindGroupLayout8,
+bindGroupLayout8,
+bindGroupLayout8,
+bindGroupLayout8,
+bindGroupLayout8
+]
+}
+);
+let querySet20 = device1.createQuerySet({
+label: '\u5b7f\u{1f992}\ua029\uccb6\ubea0',
+type: 'occlusion',
+count: 2081,
+});
+let renderBundleEncoder16 = device1.createRenderBundleEncoder(
+{
+label: '\u3fc8\ub158\u6837\u08e9\u7c96\u0fa2\u{1fba7}\uf208',
+colorFormats: [
+'r8sint',
+'r32float',
+'bgra8unorm',
+'rg16sint',
+undefined,
+'rgba8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 387,
+stencilReadOnly: true,
+}
+);
+let renderBundle30 = renderBundleEncoder15.finish();
+try {
+commandEncoder18.clearBuffer(
+buffer7,
+228,
+10896
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder19.resolveQuerySet(
+querySet20,
+1253,
+449,
+buffer7,
+6400
+);
+} catch {}
+try {
+await promise9;
+} catch {}
+let querySet21 = device1.createQuerySet({
+type: 'occlusion',
+count: 2133,
+});
+let texture22 = device1.createTexture(
+{
+label: '\u937a\u069d',
+size: [101, 62, 241],
+mipLevelCount: 3,
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8uint'
+],
+}
+);
+let sampler29 = device1.createSampler(
+{
+label: '\u7bca\u024f',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 22.017,
+lodMaxClamp: 48.207,
+}
+);
+try {
+renderBundleEncoder16.setIndexBuffer(
+buffer6,
+'uint32',
+956,
+6361
+);
+} catch {}
+try {
+device1.pushErrorScope('internal');
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+12808,
+new Int16Array(53547),
+3630,
+184
+);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let promise11 = adapter0.requestAdapterInfo();
+let shaderModule7 = device1.createShaderModule(
+{
+label: '\u5a7f\u{1f96c}\u{1f656}\u7969\ua07e\u03d3\u3cb2\u7ece',
+code: `@group(5) @binding(1761)
+var<storage, read_write> type14: array<u32>;
+@group(0) @binding(1761)
+var<storage, read_write> local12: array<u32>;
+@group(1) @binding(1761)
+var<storage, read_write> global12: array<u32>;
+@group(0) @binding(1617)
+var<storage, read_write> field16: array<u32>;
+@group(3) @binding(1761)
+var<storage, read_write> field17: array<u32>;
+@group(4) @binding(1761)
+var<storage, read_write> global13: array<u32>;
+@group(2) @binding(1761)
+var<storage, read_write> i11: array<u32>;
+@group(4) @binding(1617)
+var<storage, read_write> type15: array<u32>;
+@group(1) @binding(1617)
+var<storage, read_write> function17: array<u32>;
+@group(2) @binding(1617)
+var<storage, read_write> i12: array<u32>;
+
+@compute @workgroup_size(1, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S6 {
+@location(42) f0: vec4<f16>,
+@location(90) f1: vec3<f16>,
+@location(45) f2: vec4<i32>,
+@location(65) f3: i32,
+@location(100) f4: vec3<u32>,
+@location(69) f5: vec3<u32>,
+@location(98) f6: vec4<f16>,
+@location(13) f7: vec2<f16>,
+@location(31) f8: i32
+}
+struct FragmentOutput0 {
+@location(2) f0: vec3<f32>,
+@location(7) f1: f32,
+@location(4) f2: i32,
+@location(5) f3: vec2<f32>,
+@location(3) f4: vec2<f32>,
+@location(1) f5: vec2<f32>,
+@location(6) f6: vec4<f32>,
+@location(0) f7: vec4<i32>,
+@builtin(frag_depth) f8: f32
+}
+
+@fragment
+fn fragment0(@location(4) a0: vec3<u32>, @builtin(position) a1: vec4<f32>, @location(68) a2: u32, @location(51) a3: i32, @location(58) a4: vec3<i32>, a5: S6, @location(108) a6: vec2<i32>, @location(26) a7: f32, @location(18) a8: vec4<u32>, @location(101) a9: vec3<f16>, @location(59) a10: vec4<f16>, @location(33) a11: vec4<i32>, @location(46) a12: i32, @location(22) a13: vec3<f16>, @location(84) a14: vec3<i32>, @location(32) a15: vec4<u32>, @builtin(sample_index) a16: u32, @builtin(sample_mask) a17: u32, @builtin(front_facing) a18: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S5 {
+@location(16) f0: vec3<i32>,
+@location(9) f1: vec2<f32>,
+@location(12) f2: vec3<f16>,
+@location(13) f3: vec3<f16>,
+@location(7) f4: vec2<f16>,
+@location(1) f5: vec2<f16>,
+@location(4) f6: vec4<f16>,
+@builtin(instance_index) f7: u32,
+@location(14) f8: vec4<f32>,
+@location(5) f9: vec4<u32>,
+@location(0) f10: vec2<u32>,
+@location(24) f11: vec3<f16>,
+@location(25) f12: vec3<i32>,
+@location(2) f13: vec2<i32>,
+@location(17) f14: vec3<u32>,
+@location(19) f15: vec4<u32>,
+@location(20) f16: vec3<i32>
+}
+struct VertexOutput0 {
+@location(101) f43: vec3<f16>,
+@location(65) f44: i32,
+@location(59) f45: vec4<f16>,
+@location(26) f46: f32,
+@location(68) f47: u32,
+@location(108) f48: vec2<i32>,
+@location(4) f49: vec3<u32>,
+@location(45) f50: vec4<i32>,
+@location(13) f51: vec2<f16>,
+@location(100) f52: vec3<u32>,
+@location(33) f53: vec4<i32>,
+@location(84) f54: vec3<i32>,
+@location(90) f55: vec3<f16>,
+@location(18) f56: vec4<u32>,
+@builtin(position) f57: vec4<f32>,
+@location(42) f58: vec4<f16>,
+@location(58) f59: vec3<i32>,
+@location(32) f60: vec4<u32>,
+@location(98) f61: vec4<f16>,
+@location(51) f62: i32,
+@location(31) f63: i32,
+@location(69) f64: vec3<u32>,
+@location(46) f65: i32,
+@location(22) f66: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec4<i32>, @location(18) a1: vec4<f32>, @location(15) a2: vec4<i32>, @builtin(vertex_index) a3: u32, @location(10) a4: vec3<u32>, a5: S5, @location(6) a6: vec4<f16>, @location(26) a7: vec3<f16>, @location(23) a8: vec2<u32>, @location(27) a9: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout9 = device1.createBindGroupLayout(
+{
+label: '\u4e1f\u8193\u02c9',
+entries: [
+{
+binding: 381,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+},
+{
+binding: 746,
+visibility: 0,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let querySet22 = device1.createQuerySet({
+label: '\u{1fb9e}\u05b7\u0224\u6849\u4e22\u684b\u01e8',
+type: 'occlusion',
+count: 1997,
+});
+let sampler30 = device1.createSampler(
+{
+label: '\u9669\u{1fd6e}\u4fd1\ufa73\u0bd1\u{1fa11}\u13a1\u{1f9e6}\u0ea9',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMaxClamp: 64.042,
+}
+);
+try {
+renderBundleEncoder16.setIndexBuffer(
+buffer6,
+'uint32',
+336
+);
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(
+buffer6,
+5192,
+buffer7,
+1900,
+2708
+);
+dissociateBuffer(device1, buffer6);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder18.clearBuffer(
+buffer7,
+12640,
+276
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 47, y: 29, z: 37 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 5608439 */{
+offset: 927,
+bytesPerRow: 295,
+rowsPerImage: 132,
+},
+{width: 38, height: 1, depthOrArrayLayers: 145}
+);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let texture23 = device1.createTexture(
+{
+label: '\u{1f7d3}\u463c',
+size: {width: 5100},
+dimension: '1d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView28 = texture23.createView(
+{
+label: '\u009a\u0c07',
+}
+);
+try {
+renderBundleEncoder16.setVertexBuffer(
+1,
+buffer6,
+7720
+);
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(
+buffer6,
+4200,
+buffer7,
+7180,
+5740
+);
+dissociateBuffer(device1, buffer6);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder19.clearBuffer(
+buffer7,
+9828,
+692
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 33, y: 52, z: 149 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 1057477 */{
+offset: 201,
+bytesPerRow: 84,
+rowsPerImage: 185,
+},
+{width: 13, height: 7, depthOrArrayLayers: 69}
+);
+} catch {}
+let pipeline28 = device1.createComputePipeline(
+{
+label: '\u0164\u{1f82c}\u45e7\u73ac\ud846\u0055\u1d30',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline29 = await device1.createRenderPipelineAsync(
+{
+label: '\uf1bf\u2b94\u4f22\u{1fc89}\u8888\udb79\u{1f665}\u{1fe8b}\u{1f995}\u8902',
+layout: 'auto',
+vertex: {
+module: shaderModule7,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 18752,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x2',
+offset: 2868,
+shaderLocation: 16,
+},
+{
+format: 'snorm16x4',
+offset: 4868,
+shaderLocation: 24,
+},
+{
+format: 'unorm16x4',
+offset: 15760,
+shaderLocation: 4,
+},
+{
+format: 'sint32x2',
+offset: 692,
+shaderLocation: 3,
+},
+{
+format: 'sint8x2',
+offset: 8634,
+shaderLocation: 27,
+},
+{
+format: 'sint16x4',
+offset: 10740,
+shaderLocation: 25,
+},
+{
+format: 'sint32x2',
+offset: 4896,
+shaderLocation: 20,
+},
+{
+format: 'float32x2',
+offset: 304,
+shaderLocation: 6,
+},
+{
+format: 'uint8x2',
+offset: 18036,
+shaderLocation: 23,
+},
+{
+format: 'unorm16x4',
+offset: 14644,
+shaderLocation: 1,
+},
+{
+format: 'uint32',
+offset: 1016,
+shaderLocation: 17,
+},
+{
+format: 'uint8x4',
+offset: 9216,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x2',
+offset: 1934,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x2',
+offset: 8548,
+shaderLocation: 14,
+},
+{
+format: 'unorm16x2',
+offset: 18184,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x4',
+offset: 6996,
+shaderLocation: 26,
+},
+{
+format: 'sint8x4',
+offset: 9656,
+shaderLocation: 2,
+},
+{
+format: 'float32x2',
+offset: 3452,
+shaderLocation: 12,
+},
+{
+format: 'uint16x4',
+offset: 15976,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 26920,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 1156,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x3',
+offset: 26120,
+shaderLocation: 0,
+},
+{
+format: 'sint32x2',
+offset: 49064,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x2',
+offset: 31750,
+shaderLocation: 13,
+},
+{
+format: 'float32x3',
+offset: 40220,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule7,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilWriteMask: 1158,
+depthBias: 81,
+depthBiasClamp: 99,
+},
+}
+);
+canvas7.width = 891;
+gc();
+let img4 = await imageWithData(65, 83, '#d843c4b1', '#dcbaa9a1');
+try {
+await promise11;
+} catch {}
+let imageData10 = new ImageData(20, 128);
+let bindGroup1 = device1.createBindGroup({
+label: '\u{1ff9f}\u5167\u{1f69e}\u09ad\u1ff1\u0637\u0e4b\u83c9\ua53c\u82c0\u{1f73a}',
+layout: bindGroupLayout9,
+entries: [
+{
+binding: 381,
+resource: sampler27
+},
+{
+binding: 746,
+resource: sampler27
+}
+],
+});
+let commandEncoder20 = device1.createCommandEncoder(
+{
+label: '\u06a6\ubfc2\u{1fa88}',
+}
+);
+let texture24 = device1.createTexture(
+{
+label: '\u{1fbbc}\u050d\u0966\u0c4f\u0a6a\u1455',
+size: {width: 92, height: 71, depthOrArrayLayers: 6},
+mipLevelCount: 4,
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let renderBundle31 = renderBundleEncoder15.finish();
+try {
+renderBundleEncoder16.setBindGroup(
+0,
+bindGroup1
+);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(
+0,
+buffer6,
+8812
+);
+} catch {}
+try {
+commandEncoder19.copyTextureToTexture(
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 33, y: 36, z: 137 },
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 1,
+  origin: { x: 30, y: 4, z: 0 },
+  aspect: 'all',
+},
+{width: 19, height: 25, depthOrArrayLayers: 76}
+);
+} catch {}
+let promise12 = adapter1.requestDevice({
+label: '\u{1fec8}\u734c\u{1fcfb}\u{1fbba}',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 35,
+maxVertexAttributes: 19,
+maxVertexBufferArrayStride: 9735,
+maxStorageTexturesPerShaderStage: 42,
+maxStorageBuffersPerShaderStage: 39,
+maxDynamicStorageBuffersPerPipelineLayout: 36997,
+maxBindingsPerBindGroup: 6479,
+maxTextureDimension1D: 11102,
+maxTextureDimension2D: 9485,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 65134441,
+maxUniformBuffersPerShaderStage: 18,
+maxInterStageShaderVariables: 88,
+maxInterStageShaderComponents: 61,
+maxSamplersPerShaderStage: 21,
+},
+});
+let textureView29 = texture23.createView(
+{
+label: '\u2e8a\ue483',
+}
+);
+let computePassEncoder10 = commandEncoder18.beginComputePass(
+{
+
+}
+);
+let sampler31 = device1.createSampler(
+{
+label: '\u598c\ua674\uac36\u{1f8a9}\u222f\u0907\u11a5\u08f7',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 18.021,
+maxAnisotropy: 14,
+}
+);
+try {
+computePassEncoder10.setBindGroup(
+9,
+bindGroup1
+);
+} catch {}
+try {
+commandEncoder19.resolveQuerySet(
+querySet21,
+1865,
+103,
+buffer7,
+8448
+);
+} catch {}
+let commandEncoder21 = device1.createCommandEncoder();
+let renderBundleEncoder17 = device1.createRenderBundleEncoder(
+{
+label: '\u99b1\u{1fa60}\u7fc2\u0db4\u{1f80a}\u0cba\u05f0\u0132\u{1ff16}\u{1ff96}',
+colorFormats: [
+'rgba32float',
+'rgba16float'
+],
+sampleCount: 297,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder16.setIndexBuffer(
+buffer6,
+'uint32'
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+5764,
+new BigUint64Array(61404),
+55099,
+12
+);
+} catch {}
+let promise13 = device1.queue.onSubmittedWorkDone();
+let pipeline30 = device1.createRenderPipeline(
+{
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule7,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'float32x3',
+offset: 40688,
+shaderLocation: 24,
+},
+{
+format: 'sint32x4',
+offset: 29316,
+shaderLocation: 20,
+},
+{
+format: 'sint8x2',
+offset: 62142,
+shaderLocation: 2,
+},
+{
+format: 'float32',
+offset: 26692,
+shaderLocation: 4,
+},
+{
+format: 'unorm16x4',
+offset: 59220,
+shaderLocation: 1,
+},
+{
+format: 'uint32x3',
+offset: 12220,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x2',
+offset: 17792,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x4',
+offset: 22068,
+shaderLocation: 26,
+},
+{
+format: 'sint8x2',
+offset: 22570,
+shaderLocation: 25,
+},
+{
+format: 'sint16x2',
+offset: 23240,
+shaderLocation: 15,
+},
+{
+format: 'uint32x3',
+offset: 43480,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 17388,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 12138,
+shaderLocation: 5,
+},
+{
+format: 'uint32x3',
+offset: 11168,
+shaderLocation: 17,
+},
+{
+format: 'sint8x2',
+offset: 5262,
+shaderLocation: 27,
+},
+{
+format: 'sint16x2',
+offset: 16596,
+shaderLocation: 3,
+},
+{
+format: 'float16x4',
+offset: 8716,
+shaderLocation: 18,
+},
+{
+format: 'float32x4',
+offset: 8884,
+shaderLocation: 6,
+},
+{
+format: 'uint16x4',
+offset: 10524,
+shaderLocation: 23,
+},
+{
+format: 'float32x3',
+offset: 7504,
+shaderLocation: 13,
+},
+{
+format: 'uint16x2',
+offset: 12524,
+shaderLocation: 19,
+},
+{
+format: 'unorm8x4',
+offset: 2476,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x2',
+offset: 15804,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 39268,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x2',
+offset: 16564,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 52592,
+attributes: [
+{
+format: 'sint32x3',
+offset: 52004,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule7,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgba8sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r8unorm',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'keep',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+},
+stencilReadMask: 1914,
+depthBias: 60,
+depthBiasSlopeScale: 78,
+},
+}
+);
+let pipelineLayout5 = device1.createPipelineLayout(
+{
+label: '\u9599\u0a21\u3918\u{1f600}\u6032\u6204\u035d\u0c8c\u9b56\u{1fdbb}',
+bindGroupLayouts: [
+bindGroupLayout8,
+bindGroupLayout9,
+bindGroupLayout8,
+bindGroupLayout9,
+bindGroupLayout8,
+bindGroupLayout8,
+bindGroupLayout9
+]
+}
+);
+let computePassEncoder11 = commandEncoder19.beginComputePass(
+{
+label: '\ub423\u5bcd\ub806\u015d\u0bec'
+}
+);
+let renderBundle32 = renderBundleEncoder15.finish(
+{
+label: '\u32ef\u24dc\u27b6\u0e19'
+}
+);
+try {
+computePassEncoder11.setBindGroup(
+4,
+bindGroup1,
+new Uint32Array(686),
+561,
+0
+);
+} catch {}
+try {
+commandEncoder21.clearBuffer(
+buffer7,
+10964,
+196
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture22,
+  mipLevel: 1,
+  origin: { x: 24, y: 0, z: 113 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 4709130 */{
+offset: 566,
+bytesPerRow: 224,
+rowsPerImage: 236,
+},
+{width: 21, height: 17, depthOrArrayLayers: 90}
+);
+} catch {}
+let querySet23 = device1.createQuerySet({
+label: '\u7a54\u7f47\udf0d\u3e5f\u0b83\u7ca8\u0fa1\uec1e\u06ea\u525a',
+type: 'occlusion',
+count: 2243,
+});
+let texture25 = device1.createTexture(
+{
+label: '\u6a3f\u990c\uafb7\u0487\u0aca\uae9a\u{1ffcd}\uc0a4\u0137\u973c\u5313',
+size: {width: 153, height: 1, depthOrArrayLayers: 1501},
+mipLevelCount: 8,
+dimension: '3d',
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32uint',
+'rgba32uint'
+],
+}
+);
+try {
+computePassEncoder10.setPipeline(
+pipeline28
+);
+} catch {}
+try {
+commandEncoder21.resolveQuerySet(
+querySet20,
+260,
+81,
+buffer7,
+1280
+);
+} catch {}
+let device2 = await adapter3.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'shader-f16',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 6,
+maxColorAttachmentBytesPerSample: 42,
+maxVertexAttributes: 17,
+maxVertexBufferArrayStride: 52955,
+maxStorageTexturesPerShaderStage: 26,
+maxStorageBuffersPerShaderStage: 30,
+maxDynamicStorageBuffersPerPipelineLayout: 1019,
+maxBindingsPerBindGroup: 2762,
+maxTextureDimension1D: 9587,
+maxTextureDimension2D: 13178,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 70292620,
+maxUniformBuffersPerShaderStage: 36,
+maxInterStageShaderVariables: 18,
+maxInterStageShaderComponents: 85,
+maxSamplersPerShaderStage: 20,
+},
+});
+let renderBundleEncoder18 = device2.createRenderBundleEncoder(
+{
+label: '\u768a\u0f68\u2eda\u6acd\u0edd',
+colorFormats: [
+'rg16uint',
+'rg32uint',
+undefined,
+'rg16float',
+'rg16uint',
+'rg8uint',
+'rg16float',
+undefined
+],
+sampleCount: 402,
+stencilReadOnly: true,
+}
+);
+try {
+device2.pushErrorScope('internal');
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+} catch {}
+let querySet24 = device1.createQuerySet({
+label: '\u{1fe86}\u08a7\u7097\u045b\u0942\u3692\u{1fe67}',
+type: 'occlusion',
+count: 1838,
+});
+let renderBundleEncoder19 = device1.createRenderBundleEncoder(
+{
+label: '\u6557\u{1fcc7}\u2a1c\u0cd6\u0e6e\u1676\u8976\u22a8\u0793\u0e7e\u789f',
+colorFormats: [
+'rg8unorm',
+'rg32float',
+'rgba8sint',
+'r32uint'
+],
+sampleCount: 692,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle33 = renderBundleEncoder15.finish(
+{
+
+}
+);
+try {
+renderBundleEncoder17.setIndexBuffer(
+buffer7,
+'uint16',
+8872,
+3268
+);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(
+5,
+buffer6,
+9172,
+1252
+);
+} catch {}
+try {
+commandEncoder20.clearBuffer(
+buffer7,
+2748,
+2792
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+let pipeline31 = await device1.createComputePipelineAsync(
+{
+label: '\u32b9\u0b0d\u4bb8\uaafe\u04c1\u19d6',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageBitmap7 = await createImageBitmap(img4);
+let renderBundle34 = renderBundleEncoder18.finish(
+{
+label: '\uc3e7\u0afb\ub281\u0fa0\ua611'
+}
+);
+let textureView30 = texture22.createView(
+{
+label: '\u1835\u{1fb63}\ua885\uc6d7\u{1fe5f}\uceed\ua18d\ue7bb\ud970\u591e',
+dimension: '2d',
+baseMipLevel: 1,
+mipLevelCount: 1,
+baseArrayLayer: 122,
+}
+);
+let computePassEncoder12 = commandEncoder21.beginComputePass(
+{
+label: '\u0d66\u{1f708}\u0429'
+}
+);
+try {
+renderBundleEncoder16.setVertexBuffer(
+9,
+buffer6
+);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture(
+{
+  texture: texture25,
+  mipLevel: 2,
+  origin: { x: 33, y: 1, z: 209 },
+  aspect: 'all',
+},
+{
+  texture: texture25,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 10}
+);
+} catch {}
+let texture26 = device2.createTexture(
+{
+label: '\u0616\u09f8\u9fb9\u{1fa0a}\u15c5\u04d6\u{1fd7e}\u{1f87f}',
+size: [9259],
+dimension: '1d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+
+],
+}
+);
+let sampler32 = device2.createSampler(
+{
+label: '\u{1f61d}\ubeae\ued4a\ubc1f\ufd72\u{1f89c}\u{1fd13}\u6f50\u3968',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 92.263,
+lodMaxClamp: 96.205,
+maxAnisotropy: 12,
+}
+);
+let img5 = await imageWithData(31, 172, '#576ffda3', '#ac8f183a');
+let commandEncoder22 = device2.createCommandEncoder();
+let querySet25 = device2.createQuerySet({
+label: '\ucdf6\uc28f\u4bec\u{1f637}\u0031\u3be7\u{1ff75}\u0e39\u6547\u7847',
+type: 'occlusion',
+count: 3000,
+});
+let commandBuffer1 = commandEncoder22.finish();
+let texture27 = gpuCanvasContext3.getCurrentTexture();
+let renderBundleEncoder20 = device2.createRenderBundleEncoder(
+{
+label: '\u5d53\u{1fb85}\u0f27\u{1fee4}\u287f\ufb30\u{1ff4a}\u75f7\u094d\u040d\u46e6',
+colorFormats: [
+'rgba16float',
+'r32uint',
+'rg8unorm',
+'rg32uint',
+undefined
+],
+sampleCount: 620,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler33 = device2.createSampler(
+{
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 47.786,
+lodMaxClamp: 55.601,
+}
+);
+try {
+await promise13;
+} catch {}
+let bindGroupLayout10 = pipeline28.getBindGroupLayout(3);
+let bindGroup2 = device1.createBindGroup({
+label: '\u03f2\u8ce9\u07ff\u02c1\u6f23\ua3cc\u{1f663}\u0374',
+layout: bindGroupLayout9,
+entries: [
+{
+binding: 381,
+resource: sampler31
+},
+{
+binding: 746,
+resource: sampler27
+}
+],
+});
+let buffer8 = device1.createBuffer(
+{
+label: '\u4d2e\u4205\ubfa4\u0dfb\u{1fb01}\uf049\u0a3b\u0f92\u0d9a\uf0f3',
+size: 34604,
+usage: GPUBufferUsage.UNIFORM,
+}
+);
+let computePassEncoder13 = commandEncoder20.beginComputePass(
+{
+label: '\u0d4d\u544a\u{1f71b}\u0842\uf2e8\ubfd7\u0e39\u0363\u4772\u2a84\u{1fe43}'
+}
+);
+try {
+renderBundleEncoder16.setBindGroup(
+6,
+bindGroup1,
+new Uint32Array(8002),
+1170,
+0
+);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(
+9,
+buffer6,
+6556,
+2901
+);
+} catch {}
+let pipeline32 = device1.createComputePipeline(
+{
+label: '\u2544\uc540\u{1fcd0}\ufdb0\u0b38\u0630\u06aa\u7c7d\u02d9\u{1fd23}',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+adapter0.label = '\ucb03\ubc11\uc46a\u8a70\u{1fed3}\u70cf\u15f7\u{1f614}\u36ad\u1105';
+} catch {}
+let bindGroup3 = device1.createBindGroup({
+label: '\u0ca8\u0509\u063f\u50fd\ud6f8\u0867\u9242\u{1feb6}\u0f3c\u0630\uffc5',
+layout: bindGroupLayout9,
+entries: [
+{
+binding: 746,
+resource: sampler27
+},
+{
+binding: 381,
+resource: sampler30
+}
+],
+});
+let renderBundleEncoder21 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg8sint',
+'rg16sint',
+'bgra8unorm',
+'r32uint',
+'r32uint',
+'rg16float',
+undefined,
+'r8uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 302,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder21.setBindGroup(
+5,
+bindGroup3
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture25,
+  mipLevel: 3,
+  origin: { x: 1, y: 0, z: 16 },
+  aspect: 'all',
+},
+new Int8Array(arrayBuffer0),
+/* required buffer size: 329863 */{
+offset: 733,
+bytesPerRow: 23,
+rowsPerImage: 90,
+},
+{width: 0, height: 0, depthOrArrayLayers: 160}
+);
+} catch {}
+document.body.prepend(img2);
+let imageData11 = new ImageData(208, 172);
+gc();
+try {
+adapter3.label = '\ud992\u7cdd\u{1fceb}\u10bc\u9dc5\ud071\u9adc\u0107\ufaa3\u3ef7\ufd7d';
+} catch {}
+let shaderModule8 = device1.createShaderModule(
+{
+label: '\u3e31\u0de1\u{1fc7e}\u1e46\uc0fe\u9fb2\uf6eb\u004e',
+code: `@group(5) @binding(1761)
+var<storage, read_write> local13: array<u32>;
+@group(6) @binding(746)
+var<storage, read_write> function18: array<u32>;
+@group(4) @binding(1617)
+var<storage, read_write> i13: array<u32>;
+@group(2) @binding(1617)
+var<storage, read_write> function19: array<u32>;
+@group(5) @binding(1617)
+var<storage, read_write> function20: array<u32>;
+@group(3) @binding(746)
+var<storage, read_write> global14: array<u32>;
+@group(6) @binding(381)
+var<storage, read_write> local14: array<u32>;
+@group(1) @binding(746)
+var<storage, read_write> type16: array<u32>;
+@group(0) @binding(1761)
+var<storage, read_write> global15: array<u32>;
+@group(2) @binding(1761)
+var<storage, read_write> field18: array<u32>;
+@group(0) @binding(1617)
+var<storage, read_write> type17: array<u32>;
+
+@compute @workgroup_size(5, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec2<i32>,
+@builtin(sample_mask) f1: u32,
+@location(4) f2: vec4<i32>,
+@location(7) f3: vec4<f32>,
+@location(2) f4: vec4<i32>,
+@location(1) f5: vec2<u32>,
+@location(0) f6: f32,
+@location(3) f7: f32,
+@location(5) f8: vec4<f32>,
+@builtin(frag_depth) f9: f32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S7 {
+@location(11) f0: vec3<i32>,
+@location(19) f1: vec4<f16>,
+@location(13) f2: vec2<f16>,
+@location(22) f3: vec4<f16>,
+@location(20) f4: vec4<i32>,
+@builtin(instance_index) f5: u32,
+@location(1) f6: vec3<f16>,
+@builtin(vertex_index) f7: u32,
+@location(23) f8: vec3<u32>,
+@location(9) f9: vec4<f16>,
+@location(7) f10: vec3<i32>,
+@location(15) f11: vec2<i32>,
+@location(17) f12: vec4<f32>,
+@location(16) f13: f32,
+@location(6) f14: vec4<i32>,
+@location(3) f15: vec3<u32>,
+@location(5) f16: vec3<u32>,
+@location(8) f17: vec3<i32>,
+@location(12) f18: vec4<i32>,
+@location(26) f19: vec3<f16>,
+@location(21) f20: i32,
+@location(27) f21: i32,
+@location(18) f22: f16,
+@location(14) f23: vec3<u32>,
+@location(4) f24: vec2<u32>,
+@location(24) f25: vec3<i32>,
+@location(25) f26: vec4<f32>,
+@location(2) f27: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: f16, a1: S7, @location(0) a2: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let renderBundle35 = renderBundleEncoder17.finish(
+{
+
+}
+);
+let sampler34 = device1.createSampler(
+{
+label: '\ub777\u0c6a\u4e81',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 31.466,
+maxAnisotropy: 12,
+}
+);
+try {
+renderBundleEncoder21.setBindGroup(
+0,
+bindGroup1
+);
+} catch {}
+try {
+querySet21.destroy();
+} catch {}
+try {
+texture23.destroy();
+} catch {}
+let pipeline33 = await device1.createComputePipelineAsync(
+{
+label: '\u9abb\u05fe\u054d\ub148\u{1fae4}\u0655',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+video4.width = 292;
+let offscreenCanvas11 = new OffscreenCanvas(927, 259);
+let shaderModule9 = device1.createShaderModule(
+{
+label: '\u{1fec9}\u98eb',
+code: `@group(6) @binding(746)
+var<storage, read_write> type18: array<u32>;
+@group(0) @binding(1617)
+var<storage, read_write> i14: array<u32>;
+@group(1) @binding(746)
+var<storage, read_write> field19: array<u32>;
+@group(5) @binding(1761)
+var<storage, read_write> local15: array<u32>;
+@group(4) @binding(1617)
+var<storage, read_write> function21: array<u32>;
+@group(3) @binding(746)
+var<storage, read_write> global16: array<u32>;
+@group(5) @binding(1617)
+var<storage, read_write> local16: array<u32>;
+@group(2) @binding(1761)
+var<storage, read_write> function22: array<u32>;
+@group(4) @binding(1761)
+var<storage, read_write> i15: array<u32>;
+@group(1) @binding(381)
+var<storage, read_write> parameter10: array<u32>;
+@group(3) @binding(381)
+var<storage, read_write> i16: array<u32>;
+@group(2) @binding(1617)
+var<storage, read_write> function23: array<u32>;
+@group(0) @binding(1761)
+var<storage, read_write> function24: array<u32>;
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S9 {
+@location(40) f0: vec3<f16>,
+@location(43) f1: vec2<u32>,
+@builtin(front_facing) f2: bool,
+@location(47) f3: f16,
+@location(53) f4: vec3<u32>,
+@location(34) f5: i32,
+@location(87) f6: vec4<f32>,
+@location(65) f7: vec2<i32>,
+@location(45) f8: u32,
+@location(32) f9: i32,
+@location(86) f10: u32,
+@location(17) f11: vec3<u32>,
+@builtin(sample_mask) f12: u32,
+@location(71) f13: vec4<u32>,
+@location(8) f14: vec3<f32>,
+@location(102) f15: vec4<u32>,
+@location(57) f16: vec4<f16>,
+@location(14) f17: vec2<f32>,
+@location(33) f18: vec3<f32>,
+@location(84) f19: vec3<f32>,
+@location(92) f20: f16,
+@builtin(sample_index) f21: u32
+}
+struct FragmentOutput0 {
+@location(0) f0: i32,
+@location(6) f1: vec2<f32>,
+@location(7) f2: f32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @location(108) a1: vec3<i32>, @location(46) a2: vec4<f32>, @location(98) a3: vec2<i32>, @location(58) a4: vec2<i32>, a5: S9, @location(101) a6: vec4<f16>, @location(7) a7: f32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S8 {
+@builtin(vertex_index) f0: u32,
+@location(18) f1: vec4<f32>,
+@location(22) f2: vec2<f16>,
+@location(9) f3: vec3<u32>,
+@location(10) f4: vec2<f32>,
+@location(27) f5: vec3<f32>,
+@location(12) f6: vec2<u32>,
+@location(20) f7: vec3<f16>,
+@location(1) f8: f16,
+@location(3) f9: vec4<f16>,
+@location(15) f10: vec4<i32>,
+@location(23) f11: vec2<u32>,
+@location(17) f12: vec2<u32>,
+@location(0) f13: vec4<f16>,
+@location(2) f14: vec4<f16>,
+@location(14) f15: vec3<i32>,
+@location(16) f16: vec3<f16>
+}
+struct VertexOutput0 {
+@location(87) f67: vec4<f32>,
+@builtin(position) f68: vec4<f32>,
+@location(8) f69: vec3<f32>,
+@location(53) f70: vec3<u32>,
+@location(65) f71: vec2<i32>,
+@location(84) f72: vec3<f32>,
+@location(43) f73: vec2<u32>,
+@location(17) f74: vec3<u32>,
+@location(102) f75: vec4<u32>,
+@location(46) f76: vec4<f32>,
+@location(7) f77: f32,
+@location(47) f78: f16,
+@location(58) f79: vec2<i32>,
+@location(57) f80: vec4<f16>,
+@location(86) f81: u32,
+@location(33) f82: vec3<f32>,
+@location(98) f83: vec2<i32>,
+@location(108) f84: vec3<i32>,
+@location(92) f85: f16,
+@location(40) f86: vec3<f16>,
+@location(34) f87: i32,
+@location(101) f88: vec4<f16>,
+@location(14) f89: vec2<f32>,
+@location(71) f90: vec4<u32>,
+@location(45) f91: u32,
+@location(32) f92: i32
+}
+
+@vertex
+fn vertex0(@location(24) a0: vec2<f16>, @location(21) a1: vec2<i32>, @location(26) a2: vec3<f16>, @builtin(instance_index) a3: u32, @location(11) a4: vec3<i32>, @location(6) a5: f32, a6: S8, @location(8) a7: f32, @location(19) a8: vec2<u32>, @location(5) a9: vec4<f32>, @location(13) a10: f32, @location(4) a11: vec4<f16>, @location(25) a12: vec2<f32>, @location(7) a13: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet26 = device1.createQuerySet({
+label: '\u0cf9\u6915\u{1fdaf}\ud069\u04e0\u{1f995}\u078f\u{1fc8e}\u{1fc7f}\u09da\u{1fd2d}',
+type: 'occlusion',
+count: 1740,
+});
+let textureView31 = texture22.createView(
+{
+baseArrayLayer: 68,
+arrayLayerCount: 73,
+}
+);
+try {
+computePassEncoder13.setBindGroup(
+3,
+bindGroup1
+);
+} catch {}
+try {
+computePassEncoder13.insertDebugMarker(
+'\u{1f653}'
+);
+} catch {}
+let pipeline34 = device1.createRenderPipeline(
+{
+label: '\u98a7\u{1f6bf}\u7dd7\ub1f4\u0e7a\u7205',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule8,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 14552,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 1592,
+shaderLocation: 22,
+},
+{
+format: 'uint16x2',
+offset: 8376,
+shaderLocation: 4,
+},
+{
+format: 'uint16x4',
+offset: 7512,
+shaderLocation: 23,
+},
+{
+format: 'float16x4',
+offset: 6004,
+shaderLocation: 25,
+},
+{
+format: 'snorm8x2',
+offset: 2826,
+shaderLocation: 26,
+},
+{
+format: 'sint8x4',
+offset: 4708,
+shaderLocation: 15,
+},
+{
+format: 'sint16x2',
+offset: 11592,
+shaderLocation: 6,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 5844,
+shaderLocation: 17,
+},
+{
+format: 'sint8x2',
+offset: 6204,
+shaderLocation: 8,
+},
+{
+format: 'sint16x2',
+offset: 14332,
+shaderLocation: 24,
+},
+{
+format: 'unorm8x2',
+offset: 6444,
+shaderLocation: 10,
+},
+{
+format: 'uint8x2',
+offset: 7452,
+shaderLocation: 5,
+},
+{
+format: 'sint16x2',
+offset: 13964,
+shaderLocation: 27,
+},
+{
+format: 'sint32x4',
+offset: 5360,
+shaderLocation: 21,
+},
+{
+format: 'snorm16x4',
+offset: 2356,
+shaderLocation: 13,
+},
+{
+format: 'unorm8x2',
+offset: 7154,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x2',
+offset: 7264,
+shaderLocation: 19,
+},
+{
+format: 'uint16x2',
+offset: 4800,
+shaderLocation: 14,
+},
+{
+format: 'sint32x4',
+offset: 9432,
+shaderLocation: 11,
+},
+{
+format: 'float16x4',
+offset: 156,
+shaderLocation: 1,
+},
+{
+format: 'sint16x2',
+offset: 3052,
+shaderLocation: 7,
+},
+{
+format: 'float32x2',
+offset: 7452,
+shaderLocation: 0,
+},
+{
+format: 'uint32x2',
+offset: 5664,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 17092,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 7928,
+shaderLocation: 20,
+},
+{
+format: 'sint32x4',
+offset: 3280,
+shaderLocation: 12,
+},
+{
+format: 'uint16x4',
+offset: 14920,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x4',
+offset: 8684,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 25980,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 33944,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 26336,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule8,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: 0,
+},
+{
+format: 'rg8uint',
+},
+{
+format: 'rgba16sint',
+writeMask: 0,
+},
+{
+format: 'r32float',
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'replace',
+passOp: 'replace',
+},
+stencilReadMask: 1130,
+stencilWriteMask: 3261,
+depthBias: 40,
+depthBiasSlopeScale: 18,
+depthBiasClamp: 11,
+},
+}
+);
+let offscreenCanvas12 = new OffscreenCanvas(897, 975);
+let promise14 = adapter1.requestAdapterInfo();
+let commandEncoder23 = device2.createCommandEncoder(
+{
+label: '\u{1fb38}\u2168\uaeb1\u92db\ufc70\u{1fb30}',
+}
+);
+let texture28 = device2.createTexture(
+{
+label: '\u{1fcec}\u{1fb2c}\u0e27\ua55b\u0f30\ua3f1\u0461\u5251\udf45\u{1ff92}\u5ee7',
+size: {width: 11409, height: 2, depthOrArrayLayers: 1},
+mipLevelCount: 10,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+try {
+renderBundleEncoder20.setVertexBuffer(
+3,
+undefined,
+3936400511,
+305646216
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture28,
+  mipLevel: 1,
+  origin: { x: 464, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 617 */{
+offset: 617,
+},
+{width: 4294, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let shaderModule10 = device1.createShaderModule(
+{
+label: '\u7b4e\u03cb',
+code: `@group(3) @binding(1761)
+var<storage, read_write> parameter11: array<u32>;
+@group(2) @binding(1761)
+var<storage, read_write> type19: array<u32>;
+@group(4) @binding(1761)
+var<storage, read_write> global17: array<u32>;
+@group(4) @binding(1617)
+var<storage, read_write> field20: array<u32>;
+@group(2) @binding(1617)
+var<storage, read_write> function25: array<u32>;
+@group(0) @binding(1617)
+var<storage, read_write> type20: array<u32>;
+@group(1) @binding(1617)
+var<storage, read_write> global18: array<u32>;
+@group(3) @binding(1617)
+var<storage, read_write> type21: array<u32>;
+@group(1) @binding(1761)
+var<storage, read_write> local17: array<u32>;
+
+@compute @workgroup_size(7, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(5) f0: vec2<u32>,
+@location(4) f1: vec4<f32>,
+@location(6) f2: vec3<f32>,
+@location(2) f3: vec4<u32>,
+@location(1) f4: vec2<f32>,
+@location(7) f5: u32,
+@builtin(sample_mask) f6: u32,
+@location(0) f7: vec4<f32>,
+@location(3) f8: vec3<f32>,
+@builtin(frag_depth) f9: f32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(front_facing) a2: bool, @builtin(sample_index) a3: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S10 {
+@location(7) f0: vec2<i32>,
+@location(10) f1: u32,
+@location(8) f2: vec2<i32>,
+@location(2) f3: f32,
+@location(4) f4: vec4<u32>,
+@location(17) f5: vec4<u32>,
+@location(6) f6: i32,
+@location(0) f7: vec3<i32>,
+@builtin(instance_index) f8: u32,
+@location(3) f9: vec4<u32>,
+@location(14) f10: vec3<f32>,
+@location(16) f11: vec2<u32>,
+@location(27) f12: vec3<u32>,
+@builtin(vertex_index) f13: u32,
+@location(13) f14: f32,
+@location(9) f15: vec2<f16>,
+@location(19) f16: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec4<f32>, @location(22) a1: vec4<i32>, @location(20) a2: vec3<i32>, @location(23) a3: vec4<i32>, @location(11) a4: vec4<f16>, @location(12) a5: vec2<f32>, a6: S10) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet27 = device1.createQuerySet({
+label: '\u{1fa3a}\uc1f4\uba30\u077e\u982f\ue71c\u3922\ua4f7\u434e',
+type: 'occlusion',
+count: 3988,
+});
+let renderBundleEncoder22 = device1.createRenderBundleEncoder(
+{
+label: '\u{1fa31}\ub888\u6ae0\u0159\u0e10\uc694',
+colorFormats: [
+undefined,
+'rg32float',
+'r32uint',
+'r8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 421,
+stencilReadOnly: true,
+}
+);
+let renderBundle36 = renderBundleEncoder22.finish(
+{
+label: '\u386a\ub79d\u0945\u0a63\u13b4\u0215\uefb4\u{1fc35}\u8f01\u0831'
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+4,
+bindGroup3
+);
+} catch {}
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(
+4,
+bindGroup1
+);
+} catch {}
+try {
+commandEncoder18.copyTextureToTexture(
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 1, y: 8, z: 123 },
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 2,
+  origin: { x: 12, y: 1, z: 117 },
+  aspect: 'all',
+},
+{width: 12, height: 10, depthOrArrayLayers: 115}
+);
+} catch {}
+try {
+renderBundleEncoder19.insertDebugMarker(
+'\u{1fdaa}'
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+2764,
+new BigUint64Array(22915),
+21818,
+880
+);
+} catch {}
+let promise15 = device1.queue.onSubmittedWorkDone();
+canvas3.width = 608;
+let canvas8 = document.createElement('canvas');
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+pseudoSubmit(device2, commandEncoder23);
+let renderBundleEncoder23 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16uint',
+'r8uint',
+'r16sint',
+'r32float',
+'rg32sint'
+],
+sampleCount: 816,
+stencilReadOnly: true,
+}
+);
+let sampler35 = device2.createSampler(
+{
+label: '\u063a\u{1f6d4}\u141f',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 1.701,
+lodMaxClamp: 66.452,
+}
+);
+try {
+device2.queue.submit([
+]);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 5704, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 43, y: 16 },
+  flipY: false,
+},
+{
+  texture: texture28,
+  mipLevel: 1,
+  origin: { x: 2595, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 7, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+offscreenCanvas11.getContext('webgpu');
+} catch {}
+let querySet28 = device2.createQuerySet({
+label: '\ua457\u6b44\u23a9\u{1f9a9}\u0c7a\u0acf\udfff',
+type: 'occlusion',
+count: 1991,
+});
+let texture29 = device2.createTexture(
+{
+label: '\u{1fd56}\u08c1\u5109\u0dbf\u9eeb\u042f\u0aea\u{1f703}\u091a',
+size: [130, 1, 929],
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView32 = texture27.createView(
+{
+label: '\u{1fe91}\u06c6\ud124\u63fe\u8214\u92de\u049f\udcec\u7ee0\u{1fa81}\u293d',
+baseMipLevel: 0,
+}
+);
+try {
+device2.pushErrorScope('validation');
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 1368, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer0),
+/* required buffer size: 697 */{
+offset: 697,
+},
+{width: 4316, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend(canvas0);
+try {
+canvas8.getContext('webgl2');
+} catch {}
+let commandEncoder24 = device1.createCommandEncoder(
+{
+label: '\u{1f6c0}\ud8df\u0eaa\u{1f9ab}\ud63a',
+}
+);
+let textureView33 = texture25.createView(
+{
+label: '\u{1f7ce}\u7cb0',
+baseMipLevel: 3,
+mipLevelCount: 4,
+}
+);
+let renderBundle37 = renderBundleEncoder21.finish(
+{
+label: '\u750c\u{1f6e1}\uef01\u0b81\u{1f75f}\u7dc7\u3f74\u0719\u{1fd97}\u03c5'
+}
+);
+let sampler36 = device1.createSampler(
+{
+label: '\udadc\uf6d8\u86d1\u0d2b\ufa50\u018d\uefba\ub7f5',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 2.657,
+lodMaxClamp: 70.097,
+maxAnisotropy: 16,
+}
+);
+try {
+computePassEncoder13.setPipeline(
+pipeline32
+);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(
+9,
+bindGroup2,
+new Uint32Array(7666),
+3775,
+0
+);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(
+buffer7,
+'uint16'
+);
+} catch {}
+try {
+commandEncoder18.copyTextureToTexture(
+{
+  texture: texture22,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 24 },
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 45, y: 16, z: 19 },
+  aspect: 'all',
+},
+{width: 5, height: 5, depthOrArrayLayers: 149}
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline35 = await device1.createRenderPipelineAsync(
+{
+label: '\uafe6\ua3bb\ue577\u22b7\u02ea',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule9,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 32968,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 10992,
+shaderLocation: 19,
+},
+{
+format: 'float16x2',
+offset: 26964,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x4',
+offset: 20912,
+shaderLocation: 22,
+},
+{
+format: 'unorm8x2',
+offset: 11504,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x2',
+offset: 5078,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x4',
+offset: 3600,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x2',
+offset: 21324,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x4',
+offset: 17160,
+shaderLocation: 16,
+},
+{
+format: 'sint8x4',
+offset: 5056,
+shaderLocation: 21,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 22252,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 19684,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 15388,
+shaderLocation: 6,
+},
+{
+format: 'uint8x2',
+offset: 19030,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x4',
+offset: 6428,
+shaderLocation: 18,
+},
+{
+format: 'sint8x4',
+offset: 17188,
+shaderLocation: 11,
+},
+{
+format: 'float32x2',
+offset: 10032,
+shaderLocation: 3,
+},
+{
+format: 'sint16x4',
+offset: 11708,
+shaderLocation: 15,
+},
+{
+format: 'snorm16x4',
+offset: 5928,
+shaderLocation: 26,
+},
+{
+format: 'sint16x4',
+offset: 7780,
+shaderLocation: 14,
+},
+{
+format: 'uint32x2',
+offset: 5652,
+shaderLocation: 23,
+},
+{
+format: 'unorm8x4',
+offset: 7384,
+shaderLocation: 13,
+},
+{
+format: 'float32x4',
+offset: 6656,
+shaderLocation: 24,
+},
+{
+format: 'float32x4',
+offset: 11692,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 15276,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 13192,
+shaderLocation: 5,
+},
+{
+format: 'float32',
+offset: 13464,
+shaderLocation: 27,
+},
+{
+format: 'uint8x2',
+offset: 15000,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 31196,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 2916,
+shaderLocation: 0,
+},
+{
+format: 'uint16x4',
+offset: 4104,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 30652,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 62192,
+attributes: [
+{
+format: 'float16x4',
+offset: 61132,
+shaderLocation: 25,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule9,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+offscreenCanvas12.getContext('webgl2');
+} catch {}
+let textureView34 = texture27.createView(
+{
+label: '\u9995\u9f8e\uc003\u{1fc5a}\u263d\u{1f8ed}\u3720\u{1f78a}\u007e\u8c19\u{1fddb}',
+}
+);
+let renderBundle38 = renderBundleEncoder18.finish();
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 5704, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas3,
+  origin: { x: 475, y: 74 },
+  flipY: true,
+},
+{
+  texture: texture28,
+  mipLevel: 1,
+  origin: { x: 2092, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 4, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let shaderModule11 = device1.createShaderModule(
+{
+label: '\ua28d\u0f41\u0472\ued07\u044a',
+code: `@group(5) @binding(1761)
+var<storage, read_write> parameter12: array<u32>;
+@group(0) @binding(1617)
+var<storage, read_write> parameter13: array<u32>;
+@group(3) @binding(1761)
+var<storage, read_write> type22: array<u32>;
+@group(4) @binding(1761)
+var<storage, read_write> i17: array<u32>;
+@group(3) @binding(1617)
+var<storage, read_write> local18: array<u32>;
+@group(1) @binding(1617)
+var<storage, read_write> parameter14: array<u32>;
+@group(2) @binding(1617)
+var<storage, read_write> parameter15: array<u32>;
+@group(1) @binding(1761)
+var<storage, read_write> parameter16: array<u32>;
+@group(0) @binding(1761)
+var<storage, read_write> global19: array<u32>;
+@group(4) @binding(1617)
+var<storage, read_write> function26: array<u32>;
+@group(2) @binding(1761)
+var<storage, read_write> parameter17: array<u32>;
+
+@compute @workgroup_size(7, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(5) f0: vec3<f32>,
+@location(3) f1: vec2<f32>,
+@location(0) f2: f32,
+@location(4) f3: vec4<u32>,
+@location(6) f4: vec4<i32>,
+@location(7) f5: vec3<f32>,
+@location(2) f6: u32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @location(97) a1: u32, @location(88) a2: f16, @builtin(sample_index) a3: u32, @location(79) a4: vec4<f16>, @location(105) a5: vec2<i32>, @location(71) a6: vec2<i32>, @location(14) a7: vec4<i32>, @builtin(front_facing) a8: bool, @location(6) a9: vec4<u32>, @location(83) a10: vec4<i32>, @location(10) a11: vec4<f32>, @location(62) a12: vec2<u32>, @location(46) a13: u32, @location(35) a14: f16, @location(31) a15: i32, @location(48) a16: f16, @location(9) a17: f16, @location(55) a18: vec2<u32>, @location(72) a19: u32, @location(81) a20: f16) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S11 {
+@location(24) f0: i32,
+@location(26) f1: u32,
+@location(12) f2: vec4<u32>
+}
+struct VertexOutput0 {
+@location(62) f93: vec2<u32>,
+@location(14) f94: vec4<i32>,
+@location(77) f95: u32,
+@location(40) f96: vec3<f32>,
+@location(79) f97: vec4<f16>,
+@location(9) f98: f16,
+@location(81) f99: f16,
+@location(88) f100: f16,
+@location(10) f101: vec4<f32>,
+@location(57) f102: vec2<i32>,
+@location(6) f103: vec4<u32>,
+@location(97) f104: u32,
+@location(35) f105: f16,
+@location(17) f106: vec4<f16>,
+@location(31) f107: i32,
+@location(49) f108: vec2<f16>,
+@location(87) f109: i32,
+@location(48) f110: f16,
+@location(24) f111: vec4<f16>,
+@builtin(position) f112: vec4<f32>,
+@location(55) f113: vec2<u32>,
+@location(46) f114: u32,
+@location(100) f115: vec3<i32>,
+@location(71) f116: vec2<i32>,
+@location(105) f117: vec2<i32>,
+@location(72) f118: u32,
+@location(34) f119: vec4<i32>,
+@location(70) f120: u32,
+@location(83) f121: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(23) a0: vec4<f16>, a1: S11, @location(4) a2: vec4<u32>, @location(20) a3: vec4<f32>, @location(18) a4: vec3<f32>, @location(22) a5: f32, @location(3) a6: vec4<f16>, @location(21) a7: vec3<u32>, @location(27) a8: u32, @location(6) a9: vec2<f32>, @location(14) a10: vec3<f16>, @location(15) a11: vec3<u32>, @location(25) a12: vec3<i32>, @location(0) a13: vec2<f32>, @location(2) a14: vec2<i32>, @location(13) a15: i32, @location(9) a16: f16, @location(1) a17: vec4<u32>, @location(17) a18: vec3<f16>, @location(7) a19: vec2<i32>, @location(11) a20: vec3<u32>, @location(10) a21: f32, @location(5) a22: vec4<f32>, @builtin(vertex_index) a23: u32, @location(19) a24: vec2<i32>, @builtin(instance_index) a25: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let querySet29 = device1.createQuerySet({
+type: 'occlusion',
+count: 3236,
+});
+let texture30 = device1.createTexture(
+{
+size: [2426],
+dimension: '1d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8snorm'
+],
+}
+);
+let textureView35 = texture30.createView(
+{
+label: '\u5553\u0de5\u4eda\uc761\ua731\ucaeb\u09ed\u0d8a\u33ee',
+}
+);
+let computePassEncoder14 = commandEncoder24.beginComputePass();
+let sampler37 = device1.createSampler(
+{
+label: '\ufb3a\u0b8b\u0b8c\u{1fa51}\u07bb\u078e\ub7b0\ubeae',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 8.350,
+lodMaxClamp: 89.871,
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+7,
+bindGroup2,
+new Uint32Array(3516),
+2862,
+0
+);
+} catch {}
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+await promise15;
+} catch {}
+let videoFrame10 = new VideoFrame(video0, {timestamp: 0});
+let commandEncoder25 = device2.createCommandEncoder(
+{
+}
+);
+let textureView36 = texture29.createView(
+{
+label: '\u7312\u{1fa22}\u{1f77c}',
+dimension: '3d',
+}
+);
+let renderPassEncoder10 = commandEncoder25.beginRenderPass(
+{
+label: '\udfb5\uab2f\ubcaf\u9ea1\u15a3\ud2c0',
+colorAttachments: [
+undefined,
+undefined,
+{
+view: textureView34,
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet25,
+maxDrawCount: 8264,
+}
+);
+let renderBundleEncoder24 = device2.createRenderBundleEncoder(
+{
+label: '\u4ba0\u567d\u{1fe06}\u{1fa91}\u0fd1\u05f5\u0022\u00e4\ue4ab',
+colorFormats: [
+'rgba8unorm',
+'r8sint',
+'rgba16sint',
+'rgba8uint',
+'rg8sint',
+'r32sint',
+'r16uint',
+'rg16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 172,
+stencilReadOnly: true,
+}
+);
+let renderBundle39 = renderBundleEncoder24.finish(
+{
+label: '\u7d8e\ua1a1\u3b6f\ud816\u075f\u0c91\ud5c0\u0c20'
+}
+);
+try {
+renderPassEncoder10.setBlendConstant({ r: 468.4, g: 901.0, b: 699.9, a: -498.9, });
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(
+0,
+1,
+1,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+3217
+);
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+0.5559,
+0.4850,
+0.2959,
+0.2387,
+0.1917,
+0.8760
+);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+26,
+undefined,
+983822418,
+1629296485
+);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(
+34,
+undefined,
+2462380781,
+19402705
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 4431, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer0),
+/* required buffer size: 5130 */{
+offset: 502,
+},
+{width: 2314, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let offscreenCanvas13 = new OffscreenCanvas(616, 82);
+let bindGroupLayout11 = device2.createBindGroupLayout(
+{
+entries: [
+{
+binding: 2146,
+visibility: 0,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 830,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+}
+],
+}
+);
+try {
+renderBundleEncoder20.setVertexBuffer(
+69,
+undefined,
+3428155624,
+341503554
+);
+} catch {}
+try {
+device2.pushErrorScope('validation');
+} catch {}
+try {
+device2.queue.submit([
+]);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 44, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap6,
+  origin: { x: 283, y: 448 },
+  flipY: false,
+},
+{
+  texture: texture28,
+  mipLevel: 8,
+  origin: { x: 11, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 22, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let imageBitmap8 = await createImageBitmap(offscreenCanvas4);
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+pseudoSubmit(device2, commandEncoder25);
+try {
+renderPassEncoder10.beginOcclusionQuery(254);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+0.9451,
+0.4690,
+0.04993,
+0.3297,
+0.08227,
+0.2860
+);
+} catch {}
+let commandEncoder26 = device2.createCommandEncoder();
+pseudoSubmit(device2, commandEncoder26);
+let textureView37 = texture27.createView(
+{
+label: '\u0ded\u8ed4\uceba',
+format: 'rgba8unorm',
+}
+);
+let sampler38 = device2.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 45.522,
+lodMaxClamp: 96.932,
+compare: 'always',
+}
+);
+let externalTexture1 = device2.importExternalTexture(
+{
+source: videoFrame2,
+colorSpace: 'srgb',
+}
+);
+try {
+renderPassEncoder10.setBlendConstant({ r: -579.5, g: 959.1, b: -99.73, a: -508.1, });
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 5004, y: 0, z: 0 },
+  aspect: 'all',
+},
+new BigInt64Array(new ArrayBuffer(0)),
+/* required buffer size: 71 */{
+offset: 71,
+rowsPerImage: 213,
+},
+{width: 3631, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let gpuCanvasContext9 = offscreenCanvas13.getContext('webgpu');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+offscreenCanvas8.height = 669;
+let querySet30 = device2.createQuerySet({
+label: '\uf04d\u0cd4\u{1fc92}',
+type: 'occlusion',
+count: 2235,
+});
+let renderBundleEncoder25 = device2.createRenderBundleEncoder(
+{
+label: '\u0eff\uf3d0\u081a\u0d7a\u0930\ue1f7\u18bb\u0480\u3a9d\u3560\u6293',
+colorFormats: [
+'r8uint',
+'rg11b10ufloat',
+'rgba8uint',
+'rgba32sint'
+],
+sampleCount: 112,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder10.setVertexBuffer(
+43,
+undefined,
+3363606373
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 22, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 66, y: 172 },
+  flipY: true,
+},
+{
+  texture: texture28,
+  mipLevel: 9,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 16, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let commandEncoder27 = device1.createCommandEncoder(
+{
+label: '\ued91\u0456\u969c\u0627\u22ac\u09e2\ua955\ud891\u1b05',
+}
+);
+let renderBundleEncoder26 = device1.createRenderBundleEncoder(
+{
+label: '\u{1fe67}\u0e10\u0a5b\u{1fc0a}',
+colorFormats: [
+'r16float',
+'rg32sint',
+'r32sint',
+'rgba8sint',
+'rgba32uint',
+'r16sint'
+],
+sampleCount: 458,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler39 = device1.createSampler(
+{
+label: '\u{1fc51}\uc9cc\u7c3b\u3f5d\u1d99\ud1bf\u0f7d\u1b2d',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 35.802,
+lodMaxClamp: 73.323,
+}
+);
+let renderBundle40 = renderBundleEncoder16.finish(
+{
+label: '\u9517\u{1f818}'
+}
+);
+let sampler40 = device1.createSampler(
+{
+label: '\u{1f70e}\u{1fa37}\uabe4\u588c\u0833\u0f9e',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMaxClamp: 79.929,
+compare: 'less',
+}
+);
+try {
+renderBundleEncoder19.setVertexBuffer(
+5,
+buffer6,
+5932,
+4355
+);
+} catch {}
+try {
+commandEncoder21.copyBufferToBuffer(
+buffer6,
+224,
+buffer7,
+9468,
+436
+);
+dissociateBuffer(device1, buffer6);
+dissociateBuffer(device1, buffer7);
+} catch {}
+let pipeline36 = device1.createComputePipeline(
+{
+label: '\u0741\u3386\ue624\u{1f637}\uaf2e\u49a8',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+},
+}
+);
+let texture31 = device1.createTexture(
+{
+label: '\u17f1\u9fea\ue2a8\u0072\u5b4e\u0e57',
+size: [2043, 1, 146],
+mipLevelCount: 2,
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8uint',
+'r8uint',
+'r8uint'
+],
+}
+);
+let textureView38 = texture23.createView(
+{
+label: '\ub2b1\u06a5\u0082',
+baseArrayLayer: 0,
+}
+);
+let renderBundleEncoder27 = device1.createRenderBundleEncoder(
+{
+label: '\u{1fd69}\u9528\u0df5\u14d2',
+colorFormats: [
+undefined,
+'r32float',
+'bgra8unorm',
+'r8unorm',
+'rg8unorm'
+],
+sampleCount: 208,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder27.copyBufferToBuffer(
+buffer6,
+4572,
+buffer7,
+13040,
+28
+);
+dissociateBuffer(device1, buffer6);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(
+querySet27,
+3139,
+168,
+buffer7,
+7424
+);
+} catch {}
+let pipeline37 = device1.createComputePipeline(
+{
+label: '\u43f7\u{1f97e}\u{1f8ac}\u1a56\u{1fa60}\u5bcd\u{1fee9}\u{1fb1d}\u0168',
+layout: 'auto',
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder28 = device2.createCommandEncoder(
+{
+label: '\uae3b\uc039\u0d75\u{1fcb1}\u8e90\ua069',
+}
+);
+let textureView39 = texture27.createView(
+{
+label: '\u9410\ud45e\u9b21\u{1fe24}\u792e\u03a4\u0ef1\u0552\u{1feaf}',
+dimension: '2d-array',
+arrayLayerCount: 1,
+}
+);
+let computePassEncoder15 = commandEncoder28.beginComputePass(
+{
+label: '\u5b15\u231d\u4051\u06de\ub634\u067c'
+}
+);
+let renderBundle41 = renderBundleEncoder24.finish(
+{
+label: '\ue2eb\u0316\u02c2\u2f76\u070b'
+}
+);
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+1850
+);
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+0.8973,
+0.5225,
+0.00559,
+0.1307,
+0.6805,
+0.7957
+);
+} catch {}
+let adapter4 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let textureView40 = texture26.createView(
+{
+label: '\u3739\u5a60\u3dc5\u0072\u2002',
+arrayLayerCount: 1,
+}
+);
+let renderBundleEncoder28 = device2.createRenderBundleEncoder(
+{
+label: '\u0a49\u0871\u9e6e\uee0d\u065e\u00fc\u0ae5',
+colorFormats: [
+'rgba8unorm',
+'bgra8unorm'
+],
+sampleCount: 153,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder10.setBlendConstant({ r: 543.0, g: 963.5, b: -922.7, a: -347.3, });
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(
+1,
+0,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+1708
+);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(
+52,
+undefined,
+896720730,
+2448174999
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1426, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img3,
+  origin: { x: 25, y: 16 },
+  flipY: false,
+},
+{
+  texture: texture28,
+  mipLevel: 3,
+  origin: { x: 826, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 91, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+2183
+);
+} catch {}
+let sampler41 = device2.createSampler(
+{
+label: '\u057c\u6bb6\u{1fa4c}\u68d7',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 58.166,
+lodMaxClamp: 81.974,
+}
+);
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: 236.0, g: 488.4, b: -275.6, a: -199.3, });
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+0.5317,
+0.03297,
+0.00965,
+0.4792,
+0.1454,
+0.1604
+);
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let offscreenCanvas14 = new OffscreenCanvas(426, 403);
+let pipelineLayout6 = device2.createPipelineLayout(
+{
+label: '\u{1f6e1}\u9d7f\u{1fc7e}\u0b4c\u07b7',
+bindGroupLayouts: [
+bindGroupLayout11,
+bindGroupLayout11,
+bindGroupLayout11,
+bindGroupLayout11
+]
+}
+);
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(
+1,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+0.3103,
+0.2405,
+0.6614,
+0.3595,
+0.3743,
+0.9063
+);
+} catch {}
+try {
+device2.queue.submit([
+commandBuffer1,
+]);
+} catch {}
+let bindGroupLayout12 = device1.createBindGroupLayout(
+{
+entries: [
+{
+binding: 6076,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+},
+{
+binding: 4733,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+}
+],
+}
+);
+let querySet31 = device1.createQuerySet({
+label: '\u02ff\u1995\u0e35\u573d\u4a30',
+type: 'occlusion',
+count: 3287,
+});
+let renderBundleEncoder29 = device1.createRenderBundleEncoder(
+{
+label: '\u1c95\u{1faaf}\u{1f6fc}\u0fcc',
+colorFormats: [
+'r32uint',
+undefined,
+'rgba32float',
+'rgba32sint',
+undefined,
+'r32uint'
+],
+sampleCount: 960,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler42 = device1.createSampler(
+{
+label: '\u5613\u9c01\u0ff7\u8aa4\u{1f7e9}\u046d\u300c\u7794',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 38.090,
+lodMaxClamp: 72.157,
+maxAnisotropy: 1,
+}
+);
+try {
+renderBundleEncoder26.setVertexBuffer(
+7,
+buffer6,
+9060,
+371
+);
+} catch {}
+try {
+commandEncoder21.copyTextureToTexture(
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 36, y: 13, z: 109 },
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 1,
+  origin: { x: 18, y: 12, z: 69 },
+  aspect: 'all',
+},
+{width: 31, height: 6, depthOrArrayLayers: 96}
+);
+} catch {}
+try {
+commandEncoder18.clearBuffer(
+buffer7,
+5868,
+6828
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+computePassEncoder11.insertDebugMarker(
+'\u7e68'
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+10856,
+new DataView(new ArrayBuffer(11651)),
+6898,
+1276
+);
+} catch {}
+let gpuCanvasContext10 = offscreenCanvas14.getContext('webgpu');
+let offscreenCanvas15 = new OffscreenCanvas(746, 1003);
+let shaderModule12 = device2.createShaderModule(
+{
+label: '\u5409\u9b60',
+code: `@group(1) @binding(2146)
+var<storage, read_write> type23: array<u32>;
+@group(0) @binding(2146)
+var<storage, read_write> global20: array<u32>;
+@group(2) @binding(2146)
+var<storage, read_write> type24: array<u32>;
+@group(2) @binding(830)
+var<storage, read_write> parameter18: array<u32>;
+@group(0) @binding(830)
+var<storage, read_write> local19: array<u32>;
+@group(3) @binding(830)
+var<storage, read_write> local20: array<u32>;
+@group(3) @binding(2146)
+var<storage, read_write> field21: array<u32>;
+
+@compute @workgroup_size(7, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(3) f0: vec4<u32>,
+@location(0) f1: u32,
+@location(2) f2: vec3<i32>,
+@location(1) f3: vec2<u32>,
+@location(4) f4: f32,
+@location(7) f5: i32,
+@location(6) f6: vec3<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(13) a0: f32, @location(0) a1: vec2<i32>, @location(9) a2: vec2<f16>, @location(3) a3: vec3<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture32 = gpuCanvasContext8.getCurrentTexture();
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+let querySet32 = device1.createQuerySet({
+label: '\u036b\u8a64\u0120\u{1fb1c}\u05d4\u0097\u07ae\u{1f8e2}\u1847',
+type: 'occlusion',
+count: 1148,
+});
+let texture33 = device1.createTexture(
+{
+label: '\ucffd\ue4fa\u7866\ud405\u{1f941}\u79ce',
+size: {width: 1646, height: 1, depthOrArrayLayers: 872},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16sint',
+'r16sint',
+'r16sint'
+],
+}
+);
+let textureView41 = texture31.createView(
+{
+label: '\u5b40\u0927\u0330\u54b7\ufdab\ue67a\u4d54\u60f9\u{1fef0}',
+dimension: '3d',
+mipLevelCount: 1,
+}
+);
+let renderBundleEncoder30 = device1.createRenderBundleEncoder(
+{
+label: '\u450f\u89fd\u370f\u20e7',
+colorFormats: [
+'rg32float',
+'bgra8unorm-srgb',
+'rg16float',
+'rg16float'
+],
+sampleCount: 665,
+stencilReadOnly: true,
+}
+);
+try {
+commandEncoder27.copyBufferToBuffer(
+buffer6,
+6308,
+buffer7,
+2396,
+1024
+);
+dissociateBuffer(device1, buffer6);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder21.clearBuffer(
+buffer7,
+11560,
+1484
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder21.resolveQuerySet(
+querySet31,
+792,
+825,
+buffer7,
+512
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture25,
+  mipLevel: 4,
+  origin: { x: 8, y: 0, z: 11 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 4775079 */{
+offset: 329,
+bytesPerRow: 250,
+rowsPerImage: 269,
+},
+{width: 0, height: 1, depthOrArrayLayers: 72}
+);
+} catch {}
+let buffer9 = device1.createBuffer(
+{
+label: '\u6340\u{1fe94}\u{1fcf7}\u06b3\u0c67\u0c02\ubc99\ua331\u{1fc60}\u741c',
+size: 44139,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX,
+}
+);
+let sampler43 = device1.createSampler(
+{
+label: '\uaabf\u778b\u{1ff02}\ud472\u0189\u9f10',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 84.029,
+lodMaxClamp: 89.316,
+compare: 'less-equal',
+maxAnisotropy: 4,
+}
+);
+try {
+computePassEncoder13.setPipeline(
+pipeline28
+);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(
+5,
+bindGroup1
+);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(
+8,
+buffer9,
+27616,
+6666
+);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture25,
+  mipLevel: 2,
+  origin: { x: 5, y: 0, z: 6 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 16572585 */{
+offset: 560,
+bytesPerRow: 535,
+rowsPerImage: 177,
+},
+{width: 25, height: 1, depthOrArrayLayers: 176}
+);
+} catch {}
+offscreenCanvas12.width = 764;
+try {
+offscreenCanvas15.getContext('bitmaprenderer');
+} catch {}
+let texture34 = device1.createTexture(
+{
+label: '\ub26a\u34c2\ua6af\u{1ffc6}\u95a3\u0f4c\ubbe2\uf5b0\uef35\uc714\u679f',
+size: {width: 44, height: 32, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'eac-r11unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-r11unorm',
+'eac-r11unorm'
+],
+}
+);
+let sampler44 = device1.createSampler(
+{
+label: '\u0d7d\uef83\u09e4\u0e49\u04cd\ub4c6\u5165\u53e7\u{1fba3}\ub34b\ud701',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 96.105,
+maxAnisotropy: 20,
+}
+);
+try {
+commandEncoder18.copyBufferToBuffer(
+buffer6,
+80,
+buffer7,
+9832,
+1472
+);
+dissociateBuffer(device1, buffer6);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder21.copyTextureToTexture(
+{
+  texture: texture25,
+  mipLevel: 6,
+  origin: { x: 1, y: 0, z: 22 },
+  aspect: 'all',
+},
+{
+  texture: texture25,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 10 },
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(
+querySet27,
+580,
+404,
+buffer7,
+9216
+);
+} catch {}
+let buffer10 = device2.createBuffer(
+{
+label: '\u{1ff20}\ub294\u0937\ub529\u04e0\u98b1\u0bb9\ubffc',
+size: 16200,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let renderBundle42 = renderBundleEncoder23.finish();
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setViewport(
+0.3809,
+0.1681,
+0.3215,
+0.8058,
+0.2301,
+0.6958
+);
+} catch {}
+canvas3.height = 978;
+let video5 = await videoWithData();
+let imageBitmap9 = await createImageBitmap(offscreenCanvas0);
+let imageData12 = new ImageData(72, 40);
+try {
+await adapter2.requestAdapterInfo();
+} catch {}
+let commandEncoder29 = device1.createCommandEncoder(
+{
+label: '\u78bb\u05a6\u0138\u0d98\u1fcf',
+}
+);
+let computePassEncoder16 = commandEncoder27.beginComputePass(
+{
+
+}
+);
+let renderPassEncoder11 = commandEncoder18.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView41,
+depthSlice: 30,
+clearValue: { r: 261.8, g: 617.7, b: 794.2, a: 362.0, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 65,
+clearValue: { r: -594.9, g: -586.3, b: -95.55, a: -437.0, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 84,
+clearValue: { r: -136.5, g: -549.9, b: 27.12, a: -147.1, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 74,
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet24,
+maxDrawCount: 16952,
+}
+);
+let renderBundleEncoder31 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba32uint',
+'rg32uint',
+'r16uint',
+'r8unorm'
+],
+sampleCount: 881,
+stencilReadOnly: true,
+}
+);
+let sampler45 = device1.createSampler(
+{
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 98.123,
+lodMaxClamp: 98.796,
+compare: 'never',
+maxAnisotropy: 5,
+}
+);
+try {
+computePassEncoder9.setPipeline(
+pipeline28
+);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(
+5,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(
+976
+);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(
+buffer7,
+'uint16',
+6092,
+3614
+);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(
+2,
+bindGroup2
+);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(
+2,
+bindGroup3,
+new Uint32Array(9842),
+8249,
+0
+);
+} catch {}
+try {
+commandEncoder21.copyBufferToBuffer(
+buffer6,
+7692,
+buffer7,
+1200,
+2424
+);
+dissociateBuffer(device1, buffer6);
+dissociateBuffer(device1, buffer7);
+} catch {}
+let imageBitmap10 = await createImageBitmap(imageData11);
+let textureView42 = texture26.createView(
+{
+}
+);
+let sampler46 = device2.createSampler(
+{
+label: '\u6f60\ub780\u0498\u0b7a\u00d1\ua78f\u05cf',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 28.553,
+lodMaxClamp: 70.077,
+}
+);
+try {
+renderPassEncoder10.setStencilReference(
+590
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+await promise14;
+} catch {}
+let img6 = await imageWithData(292, 258, '#2762e68c', '#7ce8573a');
+try {
+adapter0.label = '\u0809\u2bec\u941b';
+} catch {}
+let commandEncoder30 = device2.createCommandEncoder(
+{
+label: '\u418e\u0afc\u{1fa58}\u{1f95d}\u66e9\ueda1\u{1ff30}\u2dc7\uc0e5',
+}
+);
+let querySet33 = device2.createQuerySet({
+label: '\u0354\u{1fca8}\u9269\u{1fc5d}\u{1f79a}',
+type: 'occlusion',
+count: 1677,
+});
+let textureView43 = texture32.createView(
+{
+baseMipLevel: 0,
+}
+);
+try {
+commandEncoder30.clearBuffer(
+buffer10
+);
+dissociateBuffer(device2, buffer10);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16uint',
+'eac-rg11unorm',
+'rg8snorm',
+'rgba8unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 178, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas12,
+  origin: { x: 338, y: 789 },
+  flipY: false,
+},
+{
+  texture: texture28,
+  mipLevel: 6,
+  origin: { x: 4, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 164, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let offscreenCanvas16 = new OffscreenCanvas(939, 1007);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img7 = await imageWithData(110, 172, '#ed5fe9d0', '#2f7f43f3');
+let video6 = await videoWithData();
+let videoFrame11 = new VideoFrame(canvas0, {timestamp: 0});
+try {
+device1.label = '\u{1fa25}\u03c5\u8cbe\ubf7d\u04bc\u{1ff36}\uc7eb';
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(
+10,
+bindGroup1,
+new Uint32Array(4288),
+3260,
+0
+);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+9,
+buffer6,
+9240,
+1085
+);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+offscreenCanvas16.height = 120;
+let renderPassEncoder12 = commandEncoder30.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+{
+view: textureView32,
+clearValue: { r: -275.6, g: 579.6, b: -509.9, a: 713.9, },
+loadOp: 'load',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet25,
+maxDrawCount: 42808,
+}
+);
+try {
+renderPassEncoder12.beginOcclusionQuery(2297);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+54,
+undefined,
+2876384182,
+248938124
+);
+} catch {}
+let gpuCanvasContext11 = offscreenCanvas16.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageData13 = new ImageData(192, 8);
+let querySet34 = device1.createQuerySet({
+label: '\ud676\u0bd8\ud118',
+type: 'occlusion',
+count: 1973,
+});
+try {
+renderPassEncoder11.setBindGroup(
+10,
+bindGroup3
+);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(6);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: -68.97, g: -247.0, b: -995.7, a: -611.0, });
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(
+1869
+);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(
+2,
+bindGroup3
+);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(
+1,
+bindGroup1,
+new Uint32Array(7102),
+6544,
+0
+);
+} catch {}
+try {
+commandEncoder29.clearBuffer(
+buffer7,
+8520,
+2428
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+let pipeline38 = await device1.createComputePipelineAsync(
+{
+label: '\u275d\u{1f933}\ue74a\u2c4e\u{1fb63}\uc33a\u4de3\u5c6d\u6b10\u{1fcda}\u45b3',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline39 = device1.createRenderPipeline(
+{
+label: '\uee85\u{1fd85}\u0531',
+layout: pipelineLayout5,
+vertex: {
+module: shaderModule7,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 15380,
+attributes: [
+{
+format: 'sint16x2',
+offset: 14312,
+shaderLocation: 27,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 14028,
+shaderLocation: 6,
+},
+{
+format: 'unorm8x4',
+offset: 13388,
+shaderLocation: 1,
+},
+{
+format: 'uint32x3',
+offset: 11316,
+shaderLocation: 5,
+},
+{
+format: 'sint8x4',
+offset: 11168,
+shaderLocation: 2,
+},
+{
+format: 'sint16x2',
+offset: 13832,
+shaderLocation: 16,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 2776,
+shaderLocation: 12,
+},
+{
+format: 'sint32x3',
+offset: 8064,
+shaderLocation: 3,
+},
+{
+format: 'uint32',
+offset: 2972,
+shaderLocation: 0,
+},
+{
+format: 'uint32',
+offset: 4708,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 57744,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 7424,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 1664,
+shaderLocation: 17,
+},
+{
+format: 'unorm16x4',
+offset: 2744,
+shaderLocation: 14,
+},
+{
+format: 'float32x4',
+offset: 7200,
+shaderLocation: 24,
+},
+{
+format: 'float32x2',
+offset: 5844,
+shaderLocation: 18,
+},
+{
+format: 'sint16x2',
+offset: 2704,
+shaderLocation: 20,
+},
+{
+format: 'float32x2',
+offset: 2256,
+shaderLocation: 26,
+},
+{
+format: 'sint16x4',
+offset: 2292,
+shaderLocation: 25,
+},
+{
+format: 'sint32x3',
+offset: 3820,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x2',
+offset: 6182,
+shaderLocation: 13,
+},
+{
+format: 'float32x3',
+offset: 5804,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x2',
+offset: 1964,
+shaderLocation: 7,
+},
+{
+format: 'uint32x3',
+offset: 1728,
+shaderLocation: 10,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1100,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 390,
+shaderLocation: 19,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule7,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16sint',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'invert',
+},
+stencilWriteMask: 1423,
+depthBias: 66,
+depthBiasSlopeScale: 75,
+depthBiasClamp: 62,
+},
+}
+);
+let adapter5 = await navigator.gpu.requestAdapter();
+try {
+computePassEncoder9.setPipeline(
+pipeline31
+);
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+395.7,
+0.1356,
+99.70,
+0.3858,
+0.06661,
+0.9370
+);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+1,
+buffer6
+);
+} catch {}
+let texture35 = device1.createTexture(
+{
+label: '\u{1fa19}\ude0c\uff2d\u3b05\u5c66\u1d07',
+size: [18, 14, 57],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rg32sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(
+198,
+0,
+673,
+1
+);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(
+8,
+bindGroup2
+);
+} catch {}
+try {
+commandEncoder29.clearBuffer(
+buffer7,
+13388,
+0
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder21.resolveQuerySet(
+querySet24,
+1474,
+179,
+buffer7,
+3072
+);
+} catch {}
+let pipeline40 = device1.createRenderPipeline(
+{
+label: '\ud9b2\u1ff9\u3fe6\u0780\u7e6b\u{1fe25}',
+layout: pipelineLayout5,
+vertex: {
+module: shaderModule8,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 8152,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 3548,
+shaderLocation: 1,
+},
+{
+format: 'float32x3',
+offset: 4860,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x2',
+offset: 1060,
+shaderLocation: 19,
+},
+{
+format: 'sint32x4',
+offset: 3336,
+shaderLocation: 21,
+}
+],
+},
+{
+arrayStride: 28452,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x2',
+offset: 7934,
+shaderLocation: 7,
+},
+{
+format: 'float32x2',
+offset: 22872,
+shaderLocation: 16,
+},
+{
+format: 'float32x3',
+offset: 11452,
+shaderLocation: 22,
+},
+{
+format: 'float32',
+offset: 19900,
+shaderLocation: 18,
+},
+{
+format: 'sint32',
+offset: 14840,
+shaderLocation: 20,
+},
+{
+format: 'float32',
+offset: 6988,
+shaderLocation: 25,
+},
+{
+format: 'uint32',
+offset: 15340,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x4',
+offset: 10684,
+shaderLocation: 13,
+},
+{
+format: 'uint32x4',
+offset: 12288,
+shaderLocation: 4,
+},
+{
+format: 'sint32',
+offset: 10432,
+shaderLocation: 8,
+},
+{
+format: 'uint8x4',
+offset: 9160,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x2',
+offset: 558,
+shaderLocation: 26,
+},
+{
+format: 'sint32x3',
+offset: 3540,
+shaderLocation: 15,
+},
+{
+format: 'sint8x4',
+offset: 5216,
+shaderLocation: 27,
+},
+{
+format: 'unorm8x4',
+offset: 24876,
+shaderLocation: 17,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 13524,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x2',
+offset: 2004,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 50772,
+attributes: [
+{
+format: 'uint32x4',
+offset: 47048,
+shaderLocation: 14,
+},
+{
+format: 'uint16x2',
+offset: 33596,
+shaderLocation: 5,
+},
+{
+format: 'sint32x4',
+offset: 32616,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 21500,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 1636,
+shaderLocation: 24,
+},
+{
+format: 'sint32x4',
+offset: 14748,
+shaderLocation: 6,
+},
+{
+format: 'uint16x4',
+offset: 4088,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 53668,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 4336,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x84d02996,
+},
+fragment: {
+module: shaderModule8,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16float',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+},
+stencilReadMask: 1746,
+stencilWriteMask: 2497,
+depthBias: 60,
+depthBiasSlopeScale: 10,
+depthBiasClamp: 48,
+},
+}
+);
+let texture36 = device2.createTexture(
+{
+label: '\u81a0\u{1f6cb}',
+size: {width: 196, height: 216, depthOrArrayLayers: 5},
+mipLevelCount: 8,
+format: 'eac-rg11unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView44 = texture36.createView(
+{
+label: '\u0e5c\u{1fab6}\u6b3e\u41d6\u{1f91c}\u09b0\u{1f8f1}',
+baseMipLevel: 3,
+mipLevelCount: 2,
+baseArrayLayer: 2,
+arrayLayerCount: 3,
+}
+);
+try {
+renderPassEncoder10.setBlendConstant({ r: 158.2, g: -874.4, b: -272.2, a: 545.6, });
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+3204
+);
+} catch {}
+try {
+await device2.popErrorScope();
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer10,
+12328,
+new Int16Array(12952),
+801,
+540
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let textureView45 = texture26.createView(
+{
+label: '\uc2ce\ub8f1\uc88b\u{1f783}',
+}
+);
+let renderBundle43 = renderBundleEncoder24.finish(
+{
+label: '\u00f2\ub372\u54af\u9b0c\u08d5\u{1ff5d}\u1877'
+}
+);
+try {
+renderPassEncoder12.setBlendConstant({ r: -645.8, g: 405.0, b: -209.7, a: 63.18, });
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+3477
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+39,
+undefined,
+1833028295,
+2267051994
+);
+} catch {}
+let imageData14 = new ImageData(40, 20);
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(2123);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+let promise16 = buffer10.mapAsync(
+GPUMapMode.READ,
+13392,
+1368
+);
+try {
+commandEncoder28.copyTextureToTexture(
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder28.clearBuffer(
+buffer10
+);
+dissociateBuffer(device2, buffer10);
+} catch {}
+let buffer11 = device2.createBuffer(
+{
+label: '\u3286\u{1ffa4}\ud4e0\u0b55\u9814\u{1f6bb}\uf6e1\u{1fdd5}\u7809\u0ed5',
+size: 64173,
+usage: GPUBufferUsage.MAP_READ,
+}
+);
+try {
+renderPassEncoder10.setBlendConstant({ r: 977.7, g: 301.1, b: 625.4, a: 266.0, });
+} catch {}
+try {
+buffer11.destroy();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 356, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData9,
+  origin: { x: 2, y: 97 },
+  flipY: true,
+},
+{
+  texture: texture28,
+  mipLevel: 5,
+  origin: { x: 119, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 236, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let renderPassEncoder13 = commandEncoder21.beginRenderPass(
+{
+label: '\u8b22\u0d20',
+colorAttachments: [
+undefined,
+{
+view: textureView41,
+depthSlice: 56,
+clearValue: { r: 850.4, g: -671.9, b: 116.7, a: 573.9, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 135,
+clearValue: { r: 631.9, g: -560.6, b: -630.8, a: -641.9, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 58,
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 51,
+clearValue: { r: 16.83, g: 306.6, b: -789.4, a: 3.995, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 100,
+clearValue: { r: 576.7, g: 183.0, b: 380.9, a: 446.1, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 0,
+clearValue: { r: 476.8, g: 552.9, b: 599.5, a: -500.8, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 74,
+clearValue: { r: 445.6, g: 849.1, b: 379.8, a: -877.3, },
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet24,
+maxDrawCount: 19592,
+}
+);
+try {
+renderPassEncoder13.end();
+} catch {}
+try {
+commandEncoder29.copyBufferToBuffer(
+buffer9,
+7116,
+buffer7,
+11276,
+1144
+);
+dissociateBuffer(device1, buffer9);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+5956,
+new Float32Array(7065),
+1636,
+1752
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let shaderModule13 = device1.createShaderModule(
+{
+code: `@group(6) @binding(381)
+var<storage, read_write> local21: array<u32>;
+@group(0) @binding(1761)
+var<storage, read_write> parameter19: array<u32>;
+@group(2) @binding(1617)
+var<storage, read_write> field22: array<u32>;
+@group(3) @binding(381)
+var<storage, read_write> function27: array<u32>;
+@group(2) @binding(1761)
+var<storage, read_write> function28: array<u32>;
+@group(3) @binding(746)
+var<storage, read_write> i18: array<u32>;
+@group(4) @binding(1617)
+var<storage, read_write> function29: array<u32>;
+@group(1) @binding(746)
+var<storage, read_write> global21: array<u32>;
+@group(6) @binding(746)
+var<storage, read_write> parameter20: array<u32>;
+@group(5) @binding(1617)
+var<storage, read_write> global22: array<u32>;
+
+@compute @workgroup_size(6, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool) -> @location(4) i32 {
+return i32();
+}
+
+
+
+@vertex
+fn vertex0(@location(10) a0: vec3<i32>, @builtin(instance_index) a1: u32, @location(4) a2: vec2<u32>, @location(11) a3: vec2<i32>, @location(19) a4: u32, @location(25) a5: vec2<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+try {
+renderPassEncoder11.setBlendConstant({ r: 352.8, g: -238.7, b: -168.9, a: -855.0, });
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(
+551,
+1,
+1112,
+0
+);
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+388.5,
+0.2363,
+148.2,
+0.3814,
+0.7361,
+0.8262
+);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+7,
+buffer6,
+2204
+);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(
+buffer7,
+'uint32',
+9452,
+2138
+);
+} catch {}
+try {
+commandEncoder29.clearBuffer(
+buffer7,
+212,
+108
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+568,
+new DataView(new ArrayBuffer(13844)),
+11844,
+104
+);
+} catch {}
+let pipeline41 = device1.createRenderPipeline(
+{
+label: '\u7144\u7e91\u{1f8c8}\u{1fdfc}\uf7a7',
+layout: pipelineLayout5,
+vertex: {
+module: shaderModule10,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 14784,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 9158,
+shaderLocation: 4,
+},
+{
+format: 'uint16x2',
+offset: 4656,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x4',
+offset: 2324,
+shaderLocation: 13,
+},
+{
+format: 'uint32x3',
+offset: 3676,
+shaderLocation: 10,
+},
+{
+format: 'sint32x2',
+offset: 10172,
+shaderLocation: 20,
+},
+{
+format: 'sint16x2',
+offset: 9932,
+shaderLocation: 6,
+},
+{
+format: 'snorm8x4',
+offset: 5596,
+shaderLocation: 14,
+},
+{
+format: 'sint8x2',
+offset: 11782,
+shaderLocation: 0,
+},
+{
+format: 'sint32x3',
+offset: 12132,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x2',
+offset: 13680,
+shaderLocation: 5,
+},
+{
+format: 'uint32x2',
+offset: 2404,
+shaderLocation: 19,
+},
+{
+format: 'uint32x2',
+offset: 7536,
+shaderLocation: 16,
+},
+{
+format: 'sint16x4',
+offset: 6464,
+shaderLocation: 8,
+},
+{
+format: 'float32',
+offset: 6732,
+shaderLocation: 9,
+},
+{
+format: 'uint16x4',
+offset: 14024,
+shaderLocation: 27,
+},
+{
+format: 'sint8x4',
+offset: 10100,
+shaderLocation: 23,
+},
+{
+format: 'sint8x4',
+offset: 1136,
+shaderLocation: 22,
+},
+{
+format: 'snorm16x4',
+offset: 4012,
+shaderLocation: 12,
+},
+{
+format: 'float32x4',
+offset: 5776,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 40552,
+attributes: [
+{
+format: 'snorm16x2',
+offset: 33440,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 172,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 68,
+shaderLocation: 17,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule10,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rgba16float',
+writeMask: 0,
+},
+{
+format: 'rg32float',
+writeMask: 0,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg8unorm',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r8uint',
+},
+{
+format: 'rg11b10ufloat',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r8uint',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+failOp: 'decrement-wrap',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilWriteMask: 596,
+depthBias: 51,
+depthBiasSlopeScale: 34,
+depthBiasClamp: 30,
+},
+}
+);
+let bindGroupLayout13 = device2.createBindGroupLayout(
+{
+label: '\u{1fbf4}\u2f29\ufd0a\uc762\u5cd6\u12ec\u0677\u19a8\ud026\u3114',
+entries: [
+{
+binding: 1202,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+},
+{
+binding: 1665,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 699756, hasDynamicOffset: false },
+},
+{
+binding: 1466,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let computePassEncoder17 = commandEncoder28.beginComputePass(
+{
+label: '\u06b3\u3e6a\u7e66\u0eb0\u6001\u670e\u0e21'
+}
+);
+let renderBundleEncoder32 = device2.createRenderBundleEncoder(
+{
+label: '\u{1f81d}\u01ba\u01f6\ubf61\u733e\u0161\u9dc9',
+colorFormats: [
+undefined,
+'rg8unorm',
+'rg16uint',
+'rgba16sint',
+'r8uint',
+'r16float',
+'rg16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 706,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder10.beginOcclusionQuery(2415);
+} catch {}
+let canvas9 = document.createElement('canvas');
+let img8 = await imageWithData(219, 71, '#7800bc88', '#90d5d76f');
+let shaderModule14 = device2.createShaderModule(
+{
+label: '\u06fd\uee7e',
+code: `@group(0) @binding(830)
+var<storage, read_write> type25: array<u32>;
+@group(3) @binding(830)
+var<storage, read_write> function30: array<u32>;
+@group(1) @binding(2146)
+var<storage, read_write> type26: array<u32>;
+@group(3) @binding(2146)
+var<storage, read_write> field23: array<u32>;
+@group(2) @binding(830)
+var<storage, read_write> i19: array<u32>;
+@group(2) @binding(2146)
+var<storage, read_write> type27: array<u32>;
+
+@compute @workgroup_size(6, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S13 {
+@location(1) f0: vec2<f16>,
+@location(4) f1: vec2<f32>,
+@location(3) f2: vec2<f32>,
+@location(2) f3: vec2<f16>,
+@location(12) f4: vec4<u32>
+}
+struct FragmentOutput0 {
+@location(6) f0: vec3<f32>,
+@location(3) f1: vec4<f32>,
+@location(0) f2: f32,
+@location(5) f3: u32,
+@builtin(sample_mask) f4: u32
+}
+
+@fragment
+fn fragment0(@location(14) a0: vec4<i32>, @location(9) a1: vec4<f32>, a2: S13, @location(13) a3: i32, @location(17) a4: vec4<f16>, @location(7) a5: u32, @location(10) a6: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S12 {
+@location(2) f0: vec2<f32>,
+@location(4) f1: vec4<f16>,
+@location(9) f2: vec3<f16>,
+@location(11) f3: i32,
+@builtin(instance_index) f4: u32
+}
+struct VertexOutput0 {
+@location(11) f122: f32,
+@location(15) f123: vec4<i32>,
+@builtin(position) f124: vec4<f32>,
+@location(7) f125: u32,
+@location(4) f126: vec2<f32>,
+@location(10) f127: vec4<f32>,
+@location(9) f128: vec4<f32>,
+@location(17) f129: vec4<f16>,
+@location(3) f130: vec2<f32>,
+@location(2) f131: vec2<f16>,
+@location(12) f132: vec4<u32>,
+@location(1) f133: vec2<f16>,
+@location(13) f134: i32,
+@location(14) f135: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(13) a0: vec2<u32>, @location(8) a1: vec3<f16>, @location(0) a2: vec4<f16>, a3: S12, @builtin(vertex_index) a4: u32, @location(16) a5: vec2<f32>, @location(10) a6: vec3<f16>, @location(3) a7: i32, @location(12) a8: vec2<u32>, @location(5) a9: vec3<u32>, @location(6) a10: vec4<f16>, @location(7) a11: vec3<f32>, @location(1) a12: vec3<u32>, @location(14) a13: vec2<u32>, @location(15) a14: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let textureView46 = texture27.createView(
+{
+label: '\u01d5\u3d86',
+dimension: '2d-array',
+}
+);
+let renderBundle44 = renderBundleEncoder24.finish(
+{
+label: '\u8169\uc511\u{1f9e8}\u{1f67c}\u{1f736}\u2c27\u0a69\u13fa\u8b2e\u{1f808}'
+}
+);
+let sampler47 = device2.createSampler(
+{
+label: '\u0749\u0777\u37d1\u0d0b\ub21c\u1521\u0ddf\u8ff1\u{1f8dd}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 74.064,
+lodMaxClamp: 97.878,
+}
+);
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(
+28,
+undefined
+);
+} catch {}
+try {
+buffer11.destroy();
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture28,
+  mipLevel: 4,
+  origin: { x: 22, y: 1, z: 1 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(arrayBuffer0),
+/* required buffer size: 30 */{
+offset: 30,
+rowsPerImage: 299,
+},
+{width: 65, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let computePassEncoder18 = commandEncoder29.beginComputePass(
+{
+label: '\u{1fe2c}\u12c8\u0572\u8ba0\u7d26\u0e6a\ua7a7\u0a20\uc997\ufb54'
+}
+);
+try {
+renderPassEncoder11.setBindGroup(
+2,
+bindGroup3
+);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(
+8,
+buffer6,
+4204,
+5434
+);
+} catch {}
+let gpuCanvasContext12 = canvas9.getContext('webgpu');
+let commandEncoder31 = device1.createCommandEncoder(
+{
+label: '\u{1fa27}\u0da6\u3896\u7807\u0e0b\u0dbc\u2771\u{1f775}',
+}
+);
+let texture37 = device1.createTexture(
+{
+label: '\u0c0a\u3a83\u{1f704}\uc1ea\u7bc4\u01b9\uaa2e\ufcb9\ub336',
+size: {width: 6973},
+dimension: '1d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+let renderBundle45 = renderBundleEncoder16.finish(
+{
+
+}
+);
+try {
+computePassEncoder14.setPipeline(
+pipeline32
+);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(
+3695
+);
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+515.5,
+0.02387,
+698.0,
+0.07739,
+0.02197,
+0.9665
+);
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST,
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+await promise16;
+} catch {}
+let shaderModule15 = device2.createShaderModule(
+{
+code: `@group(2) @binding(2146)
+var<storage, read_write> field24: array<u32>;
+@group(1) @binding(2146)
+var<storage, read_write> function31: array<u32>;
+@group(1) @binding(830)
+var<storage, read_write> global23: array<u32>;
+@group(0) @binding(2146)
+var<storage, read_write> parameter21: array<u32>;
+@group(3) @binding(830)
+var<storage, read_write> global24: array<u32>;
+@group(0) @binding(830)
+var<storage, read_write> local22: array<u32>;
+
+@compute @workgroup_size(4, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(7) f0: vec2<f32>,
+@location(1) f1: vec2<i32>,
+@location(0) f2: vec2<i32>,
+@location(3) f3: i32,
+@location(4) f4: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(0) a0: f16, @location(4) a1: vec3<f32>, @location(5) a2: f32, @builtin(sample_mask) a3: u32, @builtin(sample_index) a4: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S14 {
+@location(12) f0: vec4<u32>,
+@builtin(vertex_index) f1: u32,
+@location(0) f2: f32,
+@location(10) f3: vec2<i32>,
+@location(16) f4: vec3<f16>,
+@location(3) f5: vec3<u32>,
+@builtin(instance_index) f6: u32,
+@location(15) f7: vec3<i32>,
+@location(1) f8: f32,
+@location(5) f9: vec2<f32>,
+@location(8) f10: vec3<f16>,
+@location(2) f11: f16
+}
+struct VertexOutput0 {
+@builtin(position) f136: vec4<f32>,
+@location(5) f137: f32,
+@location(4) f138: vec3<f32>,
+@location(0) f139: f16
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec3<i32>, a1: S14, @location(13) a2: f32, @location(14) a3: vec3<f16>, @location(6) a4: vec4<i32>, @location(4) a5: vec3<f16>, @location(11) a6: vec2<f16>, @location(9) a7: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder32 = device2.createCommandEncoder(
+{
+label: '\u3307\u0cde\u7b22\u5ad5\ud79f\u777c\u{1f79f}\u01c0\uf08f',
+}
+);
+let texture38 = device2.createTexture(
+{
+label: '\uc6ca\u6fad\u0e52\ubcf0\u47f5\u{1fc63}\u3853\u7e53',
+size: {width: 1067},
+dimension: '1d',
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32uint',
+'rgba32uint'
+],
+}
+);
+try {
+renderPassEncoder12.beginOcclusionQuery(1299);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(
+0,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+82,
+undefined,
+102062727
+);
+} catch {}
+let pipeline42 = await device2.createComputePipelineAsync(
+{
+label: '\u00f5\u79ec\u435b\ub046\u{1fc6c}\u0023\u0f4b\u07a3\ucc04\uddc1\u12d0',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let texture39 = device2.createTexture(
+{
+label: '\u03cc\u{1fe19}\u459d\u0f51',
+size: {width: 176, height: 199, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg16sint',
+'rg16sint'
+],
+}
+);
+let renderPassEncoder14 = commandEncoder32.beginRenderPass(
+{
+label: '\u{1f66d}\u1509',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+{
+view: textureView34,
+clearValue: { r: 834.5, g: -593.9, b: -125.3, a: -123.0, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+undefined,
+undefined
+],
+occlusionQuerySet: querySet33,
+maxDrawCount: 143648,
+}
+);
+let renderBundleEncoder33 = device2.createRenderBundleEncoder(
+{
+label: '\u0408\u000b\u04d7\u0e69',
+colorFormats: [
+'r16float',
+'rgba16sint',
+'rg32float',
+'rgba16float',
+'rgba8uint',
+'rgba16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 676,
+depthReadOnly: true,
+}
+);
+let renderBundle46 = renderBundleEncoder28.finish(
+{
+label: '\u94c3\u0faf\u124b'
+}
+);
+try {
+computePassEncoder17.setPipeline(
+pipeline42
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 3475, y: 1, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(666),
+/* required buffer size: 666 */{
+offset: 666,
+},
+{width: 1947, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise17 = device2.queue.onSubmittedWorkDone();
+let pipeline43 = await device2.createRenderPipelineAsync(
+{
+label: '\ud12b\ue883\ue814\u0bf2\ud3ad\u{1fbc2}\u61a6\u0b73',
+layout: pipelineLayout6,
+vertex: {
+module: shaderModule15,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 15772,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 43428,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 26432,
+shaderLocation: 10,
+},
+{
+format: 'float16x2',
+offset: 3296,
+shaderLocation: 13,
+},
+{
+format: 'sint8x2',
+offset: 4678,
+shaderLocation: 15,
+},
+{
+format: 'uint32x3',
+offset: 27224,
+shaderLocation: 3,
+},
+{
+format: 'sint16x4',
+offset: 11732,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x2',
+offset: 33756,
+shaderLocation: 8,
+},
+{
+format: 'sint16x4',
+offset: 6396,
+shaderLocation: 7,
+},
+{
+format: 'unorm16x4',
+offset: 9108,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x2',
+offset: 24218,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 40516,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 4904,
+shaderLocation: 11,
+},
+{
+format: 'unorm8x4',
+offset: 19124,
+shaderLocation: 5,
+},
+{
+format: 'float32',
+offset: 17324,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x4',
+offset: 14440,
+shaderLocation: 14,
+},
+{
+format: 'uint32x4',
+offset: 6240,
+shaderLocation: 12,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 30788,
+shaderLocation: 1,
+},
+{
+format: 'float32x3',
+offset: 31012,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 27368,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 24852,
+shaderLocation: 6,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule15,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg8sint',
+},
+{
+format: 'r8sint',
+},
+undefined,
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'src-alpha-saturated',
+dstFactor: 'dst'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'zero',
+depthFailOp: 'keep',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'always',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 2537,
+stencilWriteMask: 638,
+depthBias: 40,
+depthBiasClamp: 35,
+},
+}
+);
+let canvas10 = document.createElement('canvas');
+try {
+canvas10.getContext('2d');
+} catch {}
+try {
+await promise17;
+} catch {}
+let adapter6 = await navigator.gpu.requestAdapter();
+let querySet35 = device2.createQuerySet({
+label: '\u5a2a\u5de0\u9718\ua26a\u4721\u0f6c\u516e',
+type: 'occlusion',
+count: 3268,
+});
+let renderBundle47 = renderBundleEncoder32.finish(
+{
+label: '\u{1f76c}\u0c30\u91ba\u085d\uc492\u{1f971}\u43bc\u01fb\uc3a1\u2f28\ud904'
+}
+);
+let sampler48 = device2.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 91.608,
+lodMaxClamp: 97.518,
+maxAnisotropy: 18,
+}
+);
+try {
+renderPassEncoder14.setScissorRect(
+0,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder14.setViewport(
+0.6094,
+0.8887,
+0.1826,
+0.03438,
+0.5336,
+0.7591
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+21,
+undefined,
+1791999560,
+1000575790
+);
+} catch {}
+let commandEncoder33 = device1.createCommandEncoder(
+{
+label: '\u{1fa32}\ud283\u0ba5',
+}
+);
+pseudoSubmit(device1, commandEncoder18);
+try {
+renderPassEncoder11.beginOcclusionQuery(885);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+7,
+buffer9,
+40928,
+1489
+);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(
+3,
+bindGroup2
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+5312,
+new Float32Array(26474),
+21306,
+508
+);
+} catch {}
+let video7 = await videoWithData();
+let sampler49 = device2.createSampler(
+{
+label: '\u747e\uab65\u{1fd1a}\ua33d',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 22.922,
+lodMaxClamp: 83.711,
+maxAnisotropy: 6,
+}
+);
+try {
+renderPassEncoder14.setScissorRect(
+1,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder14.setViewport(
+0.8051,
+0.4979,
+0.1046,
+0.3271,
+0.6687,
+0.9493
+);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+let pipeline44 = await device2.createRenderPipelineAsync(
+{
+label: '\uaede\u{1f6ec}\ue691',
+layout: 'auto',
+vertex: {
+module: shaderModule15,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 51660,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 45312,
+shaderLocation: 3,
+},
+{
+format: 'float32x3',
+offset: 41696,
+shaderLocation: 8,
+},
+{
+format: 'float32x4',
+offset: 19832,
+shaderLocation: 2,
+},
+{
+format: 'sint16x4',
+offset: 18356,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x4',
+offset: 41136,
+shaderLocation: 0,
+},
+{
+format: 'sint16x4',
+offset: 40560,
+shaderLocation: 9,
+},
+{
+format: 'snorm8x2',
+offset: 6466,
+shaderLocation: 1,
+},
+{
+format: 'sint16x2',
+offset: 18688,
+shaderLocation: 15,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 11124,
+shaderLocation: 5,
+},
+{
+format: 'float16x2',
+offset: 36232,
+shaderLocation: 16,
+},
+{
+format: 'sint32x2',
+offset: 14924,
+shaderLocation: 6,
+},
+{
+format: 'float32',
+offset: 4848,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 36928,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x4',
+offset: 35616,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 21788,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 2304,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 11960,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 3512,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 5012,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 4046,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'back',
+},
+fragment: {
+module: shaderModule15,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16sint',
+},
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'rg32float',
+},
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+},
+stencilReadMask: 3551,
+depthBias: 67,
+depthBiasClamp: 49,
+},
+}
+);
+try {
+adapter4.label = '\u96db\u0b41\u{1f835}\u1fa1\u5e96\u59d7\u0251\u007a\u{1faec}\u9a83\uf6d6';
+} catch {}
+let shaderModule16 = device2.createShaderModule(
+{
+label: '\u0c95\u4062\u8a36\u3f33\u056d\u05f7\u7830\ue915',
+code: `@group(0) @binding(830)
+var<storage, read_write> function32: array<u32>;
+@group(1) @binding(830)
+var<storage, read_write> i20: array<u32>;
+@group(3) @binding(2146)
+var<storage, read_write> function33: array<u32>;
+@group(1) @binding(2146)
+var<storage, read_write> type28: array<u32>;
+@group(0) @binding(2146)
+var<storage, read_write> field25: array<u32>;
+@group(3) @binding(830)
+var<storage, read_write> function34: array<u32>;
+@group(2) @binding(2146)
+var<storage, read_write> function35: array<u32>;
+
+@compute @workgroup_size(1, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(2) f0: vec4<u32>,
+@location(7) f1: vec4<u32>,
+@location(1) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4<f32>, @builtin(sample_mask) a2: u32, @builtin(sample_index) a3: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S15 {
+@location(5) f0: vec3<u32>,
+@location(11) f1: vec2<f16>,
+@location(4) f2: vec3<u32>,
+@location(16) f3: i32,
+@location(13) f4: vec4<f32>,
+@location(7) f5: vec4<u32>,
+@location(1) f6: vec3<u32>,
+@builtin(vertex_index) f7: u32,
+@location(14) f8: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(12) a0: f32, @location(6) a1: vec4<u32>, @location(15) a2: vec3<u32>, @location(2) a3: vec3<f16>, @location(9) a4: vec3<u32>, @location(8) a5: vec3<i32>, @location(0) a6: i32, @location(10) a7: vec4<i32>, @location(3) a8: i32, a9: S15, @builtin(instance_index) a10: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet36 = device2.createQuerySet({
+label: '\u{1f787}\u0801\u{1f781}\u0b62\u0c3e\u{1fe75}',
+type: 'occlusion',
+count: 2318,
+});
+let renderBundleEncoder34 = device2.createRenderBundleEncoder(
+{
+label: '\uf76e\u7cd1\u3c71\ub3ad\u{1faab}\u03fd',
+colorFormats: [
+'rgba16uint',
+undefined,
+'bgra8unorm-srgb'
+],
+sampleCount: 672,
+}
+);
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(251);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(
+75,
+undefined,
+333460900,
+694232636
+);
+} catch {}
+try {
+commandEncoder28.clearBuffer(
+buffer10
+);
+dissociateBuffer(device2, buffer10);
+} catch {}
+let texture40 = device2.createTexture(
+{
+size: {width: 7224},
+dimension: '1d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderPassEncoder15 = commandEncoder28.beginRenderPass(
+{
+label: '\u0b60\u0ab7\uc3e2\u{1f613}\u{1f946}\u00bb\u0733\u5d7b\u0dce\ub671',
+colorAttachments: [
+{
+view: textureView46,
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+occlusionQuerySet: querySet28,
+maxDrawCount: 122088,
+}
+);
+let renderBundle48 = renderBundleEncoder34.finish(
+{
+label: '\u47ac\u027d'
+}
+);
+let sampler50 = device2.createSampler(
+{
+label: '\uebd7\u7eaa\u065b\ucd4d\u01e4\ue2e0',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+lodMinClamp: 21.983,
+lodMaxClamp: 37.593,
+}
+);
+try {
+renderPassEncoder15.beginOcclusionQuery(592);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -604.5, g: 679.0, b: -846.6, a: -738.0, });
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(
+4,
+undefined,
+906427180,
+2466850729
+);
+} catch {}
+let pipeline45 = await device2.createComputePipelineAsync(
+{
+layout: 'auto',
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+},
+}
+);
+let promise18 = device2.createRenderPipelineAsync(
+{
+label: '\ucc6a\u{1fff1}\u15e6\udc32\ud596\u2122\u0d92',
+layout: pipelineLayout6,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1176,
+attributes: [
+{
+format: 'snorm16x2',
+offset: 664,
+shaderLocation: 12,
+},
+{
+format: 'snorm16x4',
+offset: 984,
+shaderLocation: 11,
+},
+{
+format: 'sint32',
+offset: 52,
+shaderLocation: 16,
+},
+{
+format: 'sint8x4',
+offset: 156,
+shaderLocation: 10,
+},
+{
+format: 'uint8x2',
+offset: 960,
+shaderLocation: 15,
+},
+{
+format: 'sint16x2',
+offset: 672,
+shaderLocation: 14,
+},
+{
+format: 'uint8x4',
+offset: 468,
+shaderLocation: 4,
+},
+{
+format: 'sint32',
+offset: 384,
+shaderLocation: 0,
+},
+{
+format: 'sint16x2',
+offset: 1140,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 372,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x4',
+offset: 128,
+shaderLocation: 3,
+},
+{
+format: 'snorm16x4',
+offset: 216,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 51268,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 44644,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 37940,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32',
+offset: 22476,
+shaderLocation: 7,
+},
+{
+format: 'uint32x4',
+offset: 28152,
+shaderLocation: 5,
+},
+{
+format: 'uint32x4',
+offset: 728,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 21596,
+attributes: [
+{
+format: 'uint16x4',
+offset: 12004,
+shaderLocation: 1,
+},
+{
+format: 'uint16x2',
+offset: 12728,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'none',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule16,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'rgba16uint',
+},
+{
+format: 'rgb10a2uint',
+writeMask: 0,
+}
+],
+},
+}
+);
+let video8 = await videoWithData();
+let bindGroupLayout14 = device0.createBindGroupLayout(
+{
+label: '\u02fc\u{1fa74}\u0a9a\u{1fc6e}\u{1fcab}\u07a9',
+entries: [
+{
+binding: 4669,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 1374,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '2d-array' },
+},
+{
+binding: 4729,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+}
+],
+}
+);
+let buffer12 = device0.createBuffer(
+{
+label: '\u2441\u7f97\u4c07',
+size: 7265,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let texture41 = device0.createTexture(
+{
+label: '\u0fa2\uba06\uceac\u009a\udcb4\u0c31\u0ae1\u0832\ue277\u8fe7\ud915',
+size: [4278, 191, 1],
+mipLevelCount: 3,
+format: 'rgba16uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let sampler51 = device0.createSampler(
+{
+label: '\u0771\ud9ba\u2b92\u893d\u0c6d\u9748',
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+maxAnisotropy: 17,
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture2,
+  mipLevel: 4,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+},
+new DataView(arrayBuffer0),
+/* required buffer size: 360 */{
+offset: 360,
+},
+{width: 98, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img4,
+  origin: { x: 1, y: 35 },
+  flipY: true,
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let querySet37 = device1.createQuerySet({
+label: '\u07ce\ueee4\u{1fc5d}\u{1fc11}\uc9e5\u{1ff27}\u364c\u711d',
+type: 'occlusion',
+count: 2913,
+});
+let renderBundle49 = renderBundleEncoder19.finish();
+let sampler52 = device1.createSampler(
+{
+label: '\u1399\u492e\u23d3\u0cbc\u07f3\u9575\ua234\u082c\u{1feac}\u{1fefb}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 33.991,
+}
+);
+try {
+renderPassEncoder11.setStencilReference(
+3112
+);
+} catch {}
+try {
+querySet34.destroy();
+} catch {}
+try {
+commandEncoder31.resolveQuerySet(
+querySet23,
+91,
+256,
+buffer7,
+2304
+);
+} catch {}
+let video9 = await videoWithData();
+let querySet38 = device2.createQuerySet({
+label: '\u076f\u0daf\u9934\u01e4\u081b\u01f5\u0886\u51d6',
+type: 'occlusion',
+count: 3524,
+});
+let sampler53 = device2.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 37.159,
+lodMaxClamp: 50.766,
+}
+);
+let arrayBuffer1 = buffer10.getMappedRange(
+13520,
+1172
+);
+try {
+buffer10.unmap();
+} catch {}
+let pipeline46 = await device2.createRenderPipelineAsync(
+{
+label: '\ub532\uc13f\u899b\uf36b\u0e29\u035c\u6721',
+layout: pipelineLayout6,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 21848,
+attributes: [
+{
+format: 'uint32',
+offset: 17036,
+shaderLocation: 6,
+},
+{
+format: 'unorm16x4',
+offset: 4804,
+shaderLocation: 12,
+},
+{
+format: 'uint8x4',
+offset: 12612,
+shaderLocation: 7,
+},
+{
+format: 'uint16x2',
+offset: 8964,
+shaderLocation: 1,
+},
+{
+format: 'uint16x2',
+offset: 16268,
+shaderLocation: 5,
+},
+{
+format: 'sint16x2',
+offset: 2096,
+shaderLocation: 3,
+},
+{
+format: 'sint8x4',
+offset: 5752,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 28328,
+attributes: [
+{
+format: 'uint8x2',
+offset: 27674,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 5232,
+shaderLocation: 15,
+},
+{
+format: 'sint32x3',
+offset: 22308,
+shaderLocation: 14,
+},
+{
+format: 'sint8x4',
+offset: 20108,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 45128,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 44496,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x2',
+offset: 39754,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 22684,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 19360,
+shaderLocation: 0,
+},
+{
+format: 'uint32x4',
+offset: 12344,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x4',
+offset: 24948,
+shaderLocation: 11,
+},
+{
+format: 'sint32x3',
+offset: 43420,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule16,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+{
+format: 'rgb10a2uint',
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'zero',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 1922,
+stencilWriteMask: 2696,
+depthBias: 67,
+depthBiasSlopeScale: 94,
+},
+}
+);
+video6.height = 232;
+let querySet39 = device1.createQuerySet({
+label: '\u{1f658}\u0d2f\u{1f9b3}\u5ccb\u{1f9ad}\u{1ffa2}\u2afb\u1752\u{1fbc4}',
+type: 'occlusion',
+count: 3240,
+});
+let renderPassEncoder16 = commandEncoder33.beginRenderPass(
+{
+label: '\u71d6\u5dcc',
+colorAttachments: [
+{
+view: textureView41,
+depthSlice: 65,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 79,
+clearValue: { r: -161.4, g: 225.0, b: -796.6, a: 122.1, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 47,
+clearValue: { r: 996.5, g: -880.1, b: -160.1, a: -651.1, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 37,
+clearValue: { r: -830.6, g: 474.6, b: -373.6, a: -821.2, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 20,
+clearValue: { r: 749.2, g: 921.8, b: 613.0, a: 3.563, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 11,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 115,
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined
+],
+occlusionQuerySet: querySet39,
+maxDrawCount: 264624,
+}
+);
+try {
+computePassEncoder11.setPipeline(
+pipeline28
+);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(
+1622
+);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+5,
+buffer9
+);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder31.copyBufferToBuffer(
+buffer9,
+40556,
+buffer7,
+5084,
+1436
+);
+dissociateBuffer(device1, buffer9);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder31.resolveQuerySet(
+querySet29,
+554,
+1629,
+buffer7,
+0
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout15 = device2.createBindGroupLayout(
+{
+entries: [
+{
+binding: 2684,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '1d' },
+},
+{
+binding: 122,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '2d-array' },
+}
+],
+}
+);
+let pipelineLayout7 = device2.createPipelineLayout(
+{
+label: '\ub370\u06c2\u{1fcb1}\u913e\u6125\u4733',
+bindGroupLayouts: [
+bindGroupLayout15
+]
+}
+);
+let commandEncoder34 = device2.createCommandEncoder();
+let renderBundle50 = renderBundleEncoder24.finish(
+{
+
+}
+);
+let sampler54 = device2.createSampler(
+{
+label: '\u8e60\u{1f63c}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 93.977,
+lodMaxClamp: 96.610,
+maxAnisotropy: 18,
+}
+);
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant({ r: -93.42, g: -54.54, b: -51.60, a: -315.8, });
+} catch {}
+try {
+renderPassEncoder14.setStencilReference(
+1681
+);
+} catch {}
+try {
+renderPassEncoder14.setViewport(
+0.2487,
+0.3459,
+0.3202,
+0.08598,
+0.4112,
+0.4424
+);
+} catch {}
+try {
+renderBundleEncoder25.insertDebugMarker(
+'\ub0bf'
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer10,
+10688,
+new Int16Array(19336),
+1227,
+1856
+);
+} catch {}
+let pipeline47 = device2.createRenderPipeline(
+{
+layout: pipelineLayout6,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 25796,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 19536,
+shaderLocation: 10,
+},
+{
+format: 'uint8x4',
+offset: 5356,
+shaderLocation: 6,
+},
+{
+format: 'sint16x4',
+offset: 8164,
+shaderLocation: 8,
+},
+{
+format: 'uint32',
+offset: 13300,
+shaderLocation: 9,
+},
+{
+format: 'sint32x4',
+offset: 15308,
+shaderLocation: 0,
+},
+{
+format: 'uint32',
+offset: 14104,
+shaderLocation: 4,
+},
+{
+format: 'sint32x4',
+offset: 23760,
+shaderLocation: 16,
+},
+{
+format: 'uint16x2',
+offset: 14364,
+shaderLocation: 5,
+},
+{
+format: 'uint8x4',
+offset: 1888,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x4',
+offset: 10228,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 22960,
+shaderLocation: 2,
+},
+{
+format: 'sint8x4',
+offset: 40724,
+shaderLocation: 3,
+},
+{
+format: 'uint16x4',
+offset: 29960,
+shaderLocation: 1,
+},
+{
+format: 'uint32x4',
+offset: 15008,
+shaderLocation: 15,
+},
+{
+format: 'sint32x3',
+offset: 48388,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 18592,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x2',
+offset: 31940,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 35736,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 37544,
+attributes: [
+
+],
+},
+{
+arrayStride: 2948,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 196,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x8a53635d,
+},
+fragment: {
+module: shaderModule16,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'rgba8uint',
+writeMask: 0,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+stencilReadMask: 386,
+stencilWriteMask: 906,
+depthBias: 60,
+depthBiasSlopeScale: 12,
+depthBiasClamp: 33,
+},
+}
+);
+let shaderModule17 = device1.createShaderModule(
+{
+label: '\u{1f8f8}\u01ea\u{1f8df}\u0dfd\ube6b\u{1fc63}\u01d3\u0588\u{1fc2f}\u3da5',
+code: `@group(0) @binding(1761)
+var<storage, read_write> type29: array<u32>;
+@group(4) @binding(1617)
+var<storage, read_write> parameter22: array<u32>;
+@group(0) @binding(1617)
+var<storage, read_write> field26: array<u32>;
+@group(5) @binding(1761)
+var<storage, read_write> global25: array<u32>;
+@group(6) @binding(746)
+var<storage, read_write> function36: array<u32>;
+@group(1) @binding(381)
+var<storage, read_write> global26: array<u32>;
+@group(1) @binding(746)
+var<storage, read_write> local23: array<u32>;
+@group(5) @binding(1617)
+var<storage, read_write> i21: array<u32>;
+@group(3) @binding(746)
+var<storage, read_write> parameter23: array<u32>;
+@group(3) @binding(381)
+var<storage, read_write> local24: array<u32>;
+@group(6) @binding(381)
+var<storage, read_write> function37: array<u32>;
+@group(2) @binding(1761)
+var<storage, read_write> type30: array<u32>;
+@group(2) @binding(1617)
+var<storage, read_write> global27: array<u32>;
+
+@compute @workgroup_size(8, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: vec2<f32>,
+@location(7) f1: vec2<f32>,
+@location(5) f2: f32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S16 {
+@location(11) f0: vec4<u32>,
+@location(4) f1: f32,
+@location(3) f2: vec2<f32>,
+@location(22) f3: f16,
+@location(12) f4: vec4<i32>,
+@location(0) f5: vec3<i32>,
+@location(7) f6: vec2<u32>,
+@location(10) f7: vec2<u32>,
+@location(27) f8: f16
+}
+
+@vertex
+fn vertex0(@location(16) a0: vec2<i32>, @location(25) a1: vec2<u32>, @location(1) a2: vec4<f16>, @location(19) a3: vec4<u32>, @builtin(instance_index) a4: u32, @location(21) a5: f32, @location(6) a6: f32, @builtin(vertex_index) a7: u32, @location(14) a8: f32, @location(5) a9: u32, @location(20) a10: vec3<i32>, @location(8) a11: u32, @location(2) a12: vec2<f32>, @location(26) a13: vec4<u32>, @location(23) a14: i32, @location(17) a15: vec4<i32>, @location(15) a16: u32, a17: S16, @location(18) a18: vec3<f16>, @location(24) a19: vec3<u32>, @location(9) a20: vec2<f16>, @location(13) a21: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture42 = device1.createTexture(
+{
+size: {width: 34, height: 1, depthOrArrayLayers: 155},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundle51 = renderBundleEncoder29.finish(
+{
+label: '\udfc0\u{1fb10}\u1741'
+}
+);
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+computePassEncoder16.setPipeline(
+pipeline31
+);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(
+10,
+bindGroup1,
+new Uint32Array(2437),
+1819,
+0
+);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: 4.746, g: -639.4, b: 674.1, a: 276.1, });
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+1,
+buffer9,
+392
+);
+} catch {}
+try {
+commandEncoder31.copyTextureToTexture(
+{
+  texture: texture25,
+  mipLevel: 1,
+  origin: { x: 13, y: 0, z: 30 },
+  aspect: 'all',
+},
+{
+  texture: texture25,
+  mipLevel: 3,
+  origin: { x: 18, y: 0, z: 61 },
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 58}
+);
+} catch {}
+try {
+commandEncoder20.clearBuffer(
+buffer7,
+3312,
+6984
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder31.resolveQuerySet(
+querySet37,
+1142,
+1401,
+buffer7,
+768
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+6332,
+new DataView(new ArrayBuffer(2719)),
+2199,
+36
+);
+} catch {}
+let promise19 = device1.queue.onSubmittedWorkDone();
+let adapter7 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let bindGroupLayout16 = device2.createBindGroupLayout(
+{
+label: '\u01d3\ub6ed\uf0e4\u17bc\ubbef\ufe58\u{1f849}\ua415\u53ae',
+entries: [
+
+],
+}
+);
+let bindGroup4 = device2.createBindGroup({
+label: '\u{1f8c7}\u0479\uc9ae\u0078\u{1fccd}',
+layout: bindGroupLayout16,
+entries: [
+
+],
+});
+let textureView47 = texture26.createView(
+{
+label: '\u76a3\ud6fc',
+}
+);
+try {
+renderBundleEncoder25.setBindGroup(
+0,
+bindGroup4
+);
+} catch {}
+canvas2.width = 79;
+let imageBitmap11 = await createImageBitmap(offscreenCanvas12);
+let commandEncoder35 = device1.createCommandEncoder(
+{
+label: '\u02eb\u{1fa4d}\u{1fb41}',
+}
+);
+let texture43 = device1.createTexture(
+{
+label: '\u09d8\u0865\ueef7\ufea8\u{1f942}\u0a7e\u{1ff0c}\u0319\u727a\u136e\u6168',
+size: {width: 75, height: 7, depthOrArrayLayers: 42},
+mipLevelCount: 5,
+format: 'rgba32sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgba32sint',
+'rgba32sint'
+],
+}
+);
+try {
+renderPassEncoder16.setBlendConstant({ r: 493.5, g: -134.6, b: 401.1, a: -299.2, });
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+1359.4,
+0.8181,
+604.3,
+0.04709,
+0.5218,
+0.8831
+);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture(
+{
+  texture: texture25,
+  mipLevel: 6,
+  origin: { x: 2, y: 0, z: 23 },
+  aspect: 'all',
+},
+{
+  texture: texture25,
+  mipLevel: 3,
+  origin: { x: 5, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+632,
+new DataView(new ArrayBuffer(40257)),
+26978,
+4220
+);
+} catch {}
+let img9 = await imageWithData(218, 268, '#be24f0fe', '#0e7fb0d6');
+let bindGroup5 = device1.createBindGroup({
+label: '\u9cd0\u7659\u0107\u04b4\ub28c',
+layout: bindGroupLayout9,
+entries: [
+{
+binding: 381,
+resource: sampler31
+},
+{
+binding: 746,
+resource: sampler36
+}
+],
+});
+let commandEncoder36 = device1.createCommandEncoder(
+{
+}
+);
+let externalTexture2 = device1.importExternalTexture(
+{
+label: '\u0348\u0b6c\uada0',
+source: video8,
+colorSpace: 'display-p3',
+}
+);
+try {
+renderPassEncoder16.setScissorRect(
+924,
+0,
+490,
+1
+);
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+1819.7,
+0.3557,
+44.17,
+0.1595,
+0.1500,
+0.5077
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+0,
+buffer9,
+6568,
+18770
+);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(
+9,
+bindGroup5
+);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(
+2,
+buffer6,
+8908,
+1629
+);
+} catch {}
+try {
+commandEncoder36.copyTextureToTexture(
+{
+  texture: texture33,
+  mipLevel: 1,
+  origin: { x: 351, y: 0, z: 14 },
+  aspect: 'all',
+},
+{
+  texture: texture33,
+  mipLevel: 3,
+  origin: { x: 20, y: 0, z: 76 },
+  aspect: 'all',
+},
+{width: 176, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture25,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer1),
+/* required buffer size: 54638 */{
+offset: 454,
+bytesPerRow: 122,
+rowsPerImage: 222,
+},
+{width: 1, height: 1, depthOrArrayLayers: 3}
+);
+} catch {}
+let offscreenCanvas17 = new OffscreenCanvas(98, 53);
+let videoFrame12 = new VideoFrame(canvas7, {timestamp: 0});
+let computePassEncoder19 = commandEncoder35.beginComputePass(
+{
+label: '\u{1fc07}\u6ca4\u{1fd7f}\ude1f\u03fc\u4771\u{1f900}\u{1fa98}'
+}
+);
+let renderBundle52 = renderBundleEncoder30.finish();
+let sampler55 = device1.createSampler(
+{
+label: '\u08d4\u2c6b\ud5c5\u3422\u2411\ud35d\u50ca\u9577\uc27c',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 60.418,
+lodMaxClamp: 67.560,
+compare: 'less',
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder11.setStencilReference(
+1470
+);
+} catch {}
+try {
+renderPassEncoder16.setViewport(
+1859.0,
+0.9608,
+26.46,
+0.02207,
+0.1345,
+0.1363
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+66,
+undefined
+);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(
+9,
+buffer9,
+30380
+);
+} catch {}
+try {
+commandEncoder20.clearBuffer(
+buffer7,
+12852,
+4
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+let pipeline48 = await device1.createComputePipelineAsync(
+{
+label: '\u1d30\uc6cf\u3ef6\ufbfa\ub808\u{1fdd1}\u0327\u0e3b\u721d\ua1d8',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule10,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let promise20 = device1.createRenderPipelineAsync(
+{
+label: '\u{1fb2b}\u00d7\u0f68\ud439\uab6b\uca3a\u0c25\u4978\u18fa',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule13,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 59852,
+attributes: [
+{
+format: 'sint32x3',
+offset: 38840,
+shaderLocation: 11,
+},
+{
+format: 'uint16x2',
+offset: 45536,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 6912,
+attributes: [
+
+],
+},
+{
+arrayStride: 61348,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 29820,
+shaderLocation: 25,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32',
+offset: 12580,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 25800,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 41616,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32',
+offset: 26108,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'always',
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+},
+stencilWriteMask: 199,
+depthBiasSlopeScale: 96,
+depthBiasClamp: 56,
+},
+}
+);
+let imageBitmap12 = await createImageBitmap(imageData6);
+let videoFrame13 = new VideoFrame(videoFrame9, {timestamp: 0});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let video10 = await videoWithData();
+let imageBitmap13 = await createImageBitmap(imageData10);
+try {
+offscreenCanvas17.getContext('webgl');
+} catch {}
+let commandEncoder37 = device2.createCommandEncoder();
+let renderPassEncoder17 = commandEncoder37.beginRenderPass(
+{
+label: '\u7021\uec00',
+colorAttachments: [
+undefined,
+{
+view: textureView46,
+clearValue: { r: 502.4, g: -293.9, b: -404.1, a: 779.0, },
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet28,
+maxDrawCount: 89696,
+}
+);
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder34.clearBuffer(
+buffer10
+);
+dissociateBuffer(device2, buffer10);
+} catch {}
+let pipeline49 = await device2.createRenderPipelineAsync(
+{
+layout: 'auto',
+vertex: {
+module: shaderModule12,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 4824,
+attributes: [
+{
+format: 'float32x4',
+offset: 3900,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 25772,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 34900,
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 42556,
+attributes: [
+
+],
+},
+{
+arrayStride: 21040,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x4',
+offset: 20696,
+shaderLocation: 3,
+},
+{
+format: 'float16x4',
+offset: 20024,
+shaderLocation: 9,
+},
+{
+format: 'sint8x2',
+offset: 19968,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'back',
+},
+multisample: {
+count: 4,
+mask: 0x21a86e3e,
+},
+fragment: {
+module: shaderModule12,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16uint',
+writeMask: 0,
+},
+{
+format: 'rg16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+let video11 = await videoWithData();
+let querySet40 = device1.createQuerySet({
+label: '\u{1f9c6}\u0551\u00ea\u032e\u74d8\uc558\u7d6c\u{1fc2f}\u0ec3\ud7cf\u{1fcf2}',
+type: 'occlusion',
+count: 1226,
+});
+let renderBundleEncoder35 = device1.createRenderBundleEncoder(
+{
+label: '\u56ce\u{1fc44}\u1102\u{1fd3d}\u99d7\uaf04\u0501\u0047\u0009',
+colorFormats: [
+undefined,
+undefined,
+'r32float',
+'r8unorm',
+'rgb10a2unorm'
+],
+sampleCount: 861,
+depthReadOnly: true,
+}
+);
+let sampler56 = device1.createSampler(
+{
+label: '\ucd44\u{1ff4e}\u58d1\u0163\uf2b9',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 60.471,
+lodMaxClamp: 62.868,
+}
+);
+try {
+renderPassEncoder16.beginOcclusionQuery(2499);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+5,
+buffer9,
+37964,
+1056
+);
+} catch {}
+let pipeline50 = device1.createComputePipeline(
+{
+label: '\u077d\u{1fc99}',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+},
+}
+);
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let bindGroup6 = device2.createBindGroup({
+layout: bindGroupLayout16,
+entries: [
+
+],
+});
+let texture44 = device2.createTexture(
+{
+label: '\u099c\u67c7',
+size: {width: 172, height: 24, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'eac-rg11unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-rg11unorm'
+],
+}
+);
+let textureView48 = texture40.createView(
+{
+label: '\u0f68\u{1ff2e}\u0f7e\u6ead\u055f\u93c1\u0f79\u086e',
+baseMipLevel: 0,
+}
+);
+let renderBundleEncoder36 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg8sint',
+undefined,
+'r32sint',
+undefined,
+'rg32float',
+'rgba32float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 675,
+stencilReadOnly: true,
+}
+);
+let renderBundle53 = renderBundleEncoder20.finish(
+{
+label: '\ud05f\u0dcd\u{1ff27}\u{1fd57}\uea90\u0799\u{1fa8d}\ud29b'
+}
+);
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant({ r: 752.8, g: -264.9, b: 669.6, a: 444.5, });
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(
+2,
+bindGroup4
+);
+} catch {}
+let pipeline51 = await device2.createComputePipelineAsync(
+{
+label: '\uc334\u0915\u7437\u068d\u{1fef4}',
+layout: 'auto',
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+device2.destroy();
+} catch {}
+let bindGroupLayout17 = device1.createBindGroupLayout(
+{
+label: '\u0c38\uc1c5\u6783\u57e1',
+entries: [
+{
+binding: 2789,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+},
+{
+binding: 4311,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 2718,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+}
+],
+}
+);
+let textureView49 = texture21.createView(
+{
+label: '\u{1ff02}\u0bc6\u4222\u0ec0\u0759\u4427\u7f68',
+mipLevelCount: 1,
+}
+);
+let computePassEncoder20 = commandEncoder20.beginComputePass(
+{
+label: '\u90c7\u5c5b\ufcc2\u09e8\u0004\ucd71\u{1f801}\u5bd3\u2ddc\ubbfd\u{1fc8d}'
+}
+);
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: 351.6, g: 684.7, b: 252.9, a: 906.4, });
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(
+0,
+bindGroup2
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+928,
+new Float32Array(13669),
+1326,
+2252
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture31,
+  mipLevel: 0,
+  origin: { x: 499, y: 0, z: 41 },
+  aspect: 'all',
+},
+new ArrayBuffer(16),
+/* required buffer size: 23852054 */{
+offset: 254,
+bytesPerRow: 1262,
+rowsPerImage: 300,
+},
+{width: 1012, height: 0, depthOrArrayLayers: 64}
+);
+} catch {}
+let pipeline52 = device1.createComputePipeline(
+{
+label: '\u7bb5\u0a42\uf067\u1392\u7c17\u00d1\u{1fcd2}\ua479\u93dc',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+},
+}
+);
+let offscreenCanvas18 = new OffscreenCanvas(835, 58);
+try {
+device1.queue.label = '\u{1fb1f}\u0bb6\ufd2f\u0d58\ueaa6';
+} catch {}
+let pipelineLayout8 = device1.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout17,
+bindGroupLayout12,
+bindGroupLayout12
+]
+}
+);
+let computePassEncoder21 = commandEncoder31.beginComputePass();
+let renderBundle54 = renderBundleEncoder15.finish(
+{
+
+}
+);
+try {
+renderPassEncoder16.setBindGroup(
+10,
+bindGroup2,
+new Uint32Array(8209),
+4579,
+0
+);
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+825.8,
+0.5086,
+739.7,
+0.1868,
+0.3408,
+0.5201
+);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(
+buffer7,
+'uint16',
+888
+);
+} catch {}
+let pipeline53 = await device1.createComputePipelineAsync(
+{
+layout: pipelineLayout4,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+},
+}
+);
+let texture45 = device1.createTexture(
+{
+label: '\u30f5\u0aab\ud85a\u5fc6\u{1f713}\u8860\uce40',
+size: [1029, 1, 153],
+mipLevelCount: 11,
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba32float'
+],
+}
+);
+let renderBundle55 = renderBundleEncoder27.finish(
+{
+label: '\u1336\u{1f98a}\u{1f61b}\u0f99\u043f\ubdf8\u{1f62a}\u845d\ub0a4\uc837'
+}
+);
+try {
+renderPassEncoder11.setViewport(
+1213.3,
+0.6002,
+647.1,
+0.2517,
+0.8810,
+0.8847
+);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(
+buffer7,
+'uint16',
+10208,
+793
+);
+} catch {}
+try {
+commandEncoder36.copyBufferToBuffer(
+buffer9,
+1972,
+buffer7,
+2476,
+9032
+);
+dissociateBuffer(device1, buffer9);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder36.clearBuffer(
+buffer7,
+10100,
+2040
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture45,
+  mipLevel: 0,
+  origin: { x: 57, y: 0, z: 117 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 61695661 */{
+offset: 85,
+bytesPerRow: 14870,
+rowsPerImage: 122,
+},
+{width: 926, height: 1, depthOrArrayLayers: 35}
+);
+} catch {}
+let gpuCanvasContext13 = offscreenCanvas18.getContext('webgpu');
+let pipelineLayout9 = device1.createPipelineLayout(
+{
+label: '\u039b\u0d29\u3fd5',
+bindGroupLayouts: [
+bindGroupLayout9,
+bindGroupLayout8,
+bindGroupLayout17,
+bindGroupLayout10,
+bindGroupLayout9,
+bindGroupLayout17,
+bindGroupLayout17,
+bindGroupLayout12
+]
+}
+);
+let commandEncoder38 = device1.createCommandEncoder(
+{
+label: '\uc3fb\u35e5\ue784\u992d\u04f7\u4af7',
+}
+);
+let commandBuffer2 = commandEncoder38.finish();
+let texture46 = device1.createTexture(
+{
+label: '\u{1fc62}\u0f31\u{1f965}\u069f\u0a97\udf0d\u834b\u04ac\u{1fca8}\u{1fc28}',
+size: {width: 5024},
+sampleCount: 1,
+dimension: '1d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16float',
+'r16float',
+'r16float'
+],
+}
+);
+let textureView50 = texture43.createView(
+{
+label: '\u{1fb63}\u2e75\u1e0e\u0d48\uabbc\u016e',
+dimension: '2d',
+baseMipLevel: 4,
+baseArrayLayer: 7,
+}
+);
+try {
+computePassEncoder9.insertDebugMarker(
+'\u9991'
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 16, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: canvas8,
+  origin: { x: 108, y: 19 },
+  flipY: true,
+},
+{
+  texture: texture45,
+  mipLevel: 6,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 14, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline54 = device1.createComputePipeline(
+{
+label: '\u8d70\u3257\u021b\ud563\u{1f805}\u{1fa8f}\ub696',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend(canvas5);
+let adapter8 = await navigator.gpu.requestAdapter(
+{
+}
+);
+try {
+await adapter5.requestAdapterInfo();
+} catch {}
+canvas6.width = 285;
+let offscreenCanvas19 = new OffscreenCanvas(244, 948);
+let bindGroup7 = device1.createBindGroup({
+label: '\u0d94\ue255\u5be2\u0cd1\u0c97\uc670',
+layout: bindGroupLayout9,
+entries: [
+{
+binding: 746,
+resource: sampler31
+},
+{
+binding: 381,
+resource: sampler29
+}
+],
+});
+let texture47 = device1.createTexture(
+{
+label: '\u76e4\u{1fbaf}\u{1fd48}\u7da3\u3b71\u84ed\u0b90\u0381',
+size: {width: 80, height: 172, depthOrArrayLayers: 217},
+mipLevelCount: 2,
+format: 'eac-rg11unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-rg11unorm',
+'eac-rg11unorm',
+'eac-rg11unorm'
+],
+}
+);
+let computePassEncoder22 = commandEncoder36.beginComputePass(
+{
+
+}
+);
+try {
+computePassEncoder19.setPipeline(
+pipeline38
+);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(
+6,
+bindGroup7
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture33,
+  mipLevel: 5,
+  origin: { x: 3, y: 0, z: 15 },
+  aspect: 'all',
+},
+new ArrayBuffer(48),
+/* required buffer size: 348042 */{
+offset: 170,
+bytesPerRow: 209,
+rowsPerImage: 208,
+},
+{width: 48, height: 1, depthOrArrayLayers: 9}
+);
+} catch {}
+let imageBitmap14 = await createImageBitmap(videoFrame5);
+let textureView51 = texture35.createView(
+{
+label: '\ub483\uaad0\u{1ffb2}',
+format: 'rg32sint',
+baseMipLevel: 5,
+}
+);
+try {
+computePassEncoder19.setPipeline(
+pipeline53
+);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: -175.1, g: 432.5, b: -838.6, a: 947.6, });
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(
+1879,
+0,
+144,
+0
+);
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+1024.2,
+0.3713,
+733.1,
+0.5570,
+0.2476,
+0.5958
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+8,
+buffer9
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 514, height: 1, depthOrArrayLayers: 76}
+*/
+{
+  source: img6,
+  origin: { x: 114, y: 11 },
+  flipY: true,
+},
+{
+  texture: texture45,
+  mipLevel: 1,
+  origin: { x: 262, y: 1, z: 22 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 145, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline55 = device1.createComputePipeline(
+{
+label: '\uf24a\u373c\u{1ff35}\u0919\u7b25\u{1f98c}\ue24f\u3898\u0dab',
+layout: pipelineLayout8,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+await promise19;
+} catch {}
+let imageData15 = new ImageData(220, 136);
+try {
+offscreenCanvas19.getContext('2d');
+} catch {}
+let shaderModule18 = device1.createShaderModule(
+{
+label: '\u0c39\u{1f6ce}',
+code: `@group(0) @binding(2789)
+var<storage, read_write> field27: array<u32>;
+@group(2) @binding(4733)
+var<storage, read_write> parameter24: array<u32>;
+@group(1) @binding(6076)
+var<storage, read_write> global28: array<u32>;
+@group(0) @binding(4311)
+var<storage, read_write> function38: array<u32>;
+@group(0) @binding(2718)
+var<storage, read_write> field28: array<u32>;
+
+@compute @workgroup_size(2, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(3) f0: vec4<i32>,
+@location(5) f1: vec2<i32>,
+@location(1) f2: vec2<i32>,
+@location(0) f3: vec4<u32>,
+@location(6) f4: i32
+}
+
+@fragment
+fn fragment0(@location(11) a0: vec4<u32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S17 {
+@builtin(instance_index) f0: u32,
+@location(18) f1: u32,
+@location(17) f2: vec3<f16>,
+@location(6) f3: vec4<u32>,
+@location(11) f4: u32,
+@location(21) f5: vec2<i32>,
+@location(12) f6: vec2<f16>,
+@location(22) f7: vec4<i32>,
+@location(2) f8: f32,
+@location(5) f9: f32,
+@location(14) f10: u32,
+@location(8) f11: i32,
+@location(7) f12: vec2<f32>,
+@location(9) f13: u32,
+@location(13) f14: vec3<f16>,
+@location(23) f15: i32,
+@location(1) f16: f32,
+@location(0) f17: u32,
+@location(20) f18: vec2<u32>
+}
+struct VertexOutput0 {
+@location(7) f140: vec3<f16>,
+@location(11) f141: vec4<u32>,
+@location(57) f142: i32,
+@location(20) f143: f16,
+@location(34) f144: vec3<f16>,
+@location(81) f145: vec3<i32>,
+@builtin(position) f146: vec4<f32>,
+@location(68) f147: u32,
+@location(24) f148: vec3<f16>,
+@location(17) f149: vec2<u32>
+}
+
+@vertex
+fn vertex0(a0: S17, @location(15) a1: vec3<i32>, @location(3) a2: vec4<i32>, @location(25) a3: i32, @builtin(vertex_index) a4: u32, @location(4) a5: vec4<i32>, @location(27) a6: vec2<f16>, @location(26) a7: vec3<f32>, @location(16) a8: vec2<f32>, @location(10) a9: vec3<i32>, @location(24) a10: vec3<u32>, @location(19) a11: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder39 = device1.createCommandEncoder();
+try {
+renderPassEncoder16.setBindGroup(
+8,
+bindGroup3,
+new Uint32Array(2922),
+496,
+0
+);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(
+2620
+);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(
+4,
+buffer9,
+20444,
+14744
+);
+} catch {}
+try {
+commandEncoder39.copyBufferToBuffer(
+buffer6,
+432,
+buffer7,
+7288,
+4576
+);
+dissociateBuffer(device1, buffer6);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder39.clearBuffer(
+buffer7,
+5268,
+4508
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 32, height: 1, depthOrArrayLayers: 4}
+*/
+{
+  source: canvas9,
+  origin: { x: 119, y: 121 },
+  flipY: false,
+},
+{
+  texture: texture45,
+  mipLevel: 5,
+  origin: { x: 4, y: 1, z: 4 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 9, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline56 = await device1.createComputePipelineAsync(
+{
+label: '\u805a\ub2de',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageData16 = new ImageData(212, 4);
+try {
+window.someLabel = externalTexture2.label;
+} catch {}
+let bindGroup8 = device1.createBindGroup({
+layout: bindGroupLayout17,
+entries: [
+{
+binding: 2718,
+resource: externalTexture2
+},
+{
+binding: 4311,
+resource: {
+buffer: buffer8,
+offset: 6144,
+}
+},
+{
+binding: 2789,
+resource: textureView35
+}
+],
+});
+pseudoSubmit(device1, commandEncoder39);
+try {
+renderPassEncoder11.setBindGroup(
+9,
+bindGroup1
+);
+} catch {}
+let promise21 = adapter5.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 45,
+maxVertexAttributes: 28,
+maxVertexBufferArrayStride: 10450,
+maxStorageTexturesPerShaderStage: 41,
+maxStorageBuffersPerShaderStage: 27,
+maxDynamicStorageBuffersPerPipelineLayout: 57915,
+maxBindingsPerBindGroup: 6397,
+maxTextureDimension1D: 13488,
+maxTextureDimension2D: 8245,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 124530526,
+maxUniformBuffersPerShaderStage: 27,
+maxInterStageShaderVariables: 34,
+maxInterStageShaderComponents: 72,
+},
+});
+let computePassEncoder23 = commandEncoder34.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder37 = device2.createRenderBundleEncoder(
+{
+label: '\u9c35\uaa46\u10fd',
+colorFormats: [
+'rgba32uint',
+'rgb10a2unorm',
+'rg8unorm',
+'r8uint',
+undefined,
+'r16uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 157,
+stencilReadOnly: true,
+}
+);
+let sampler57 = device2.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 3.155,
+lodMaxClamp: 36.955,
+}
+);
+try {
+computePassEncoder23.setBindGroup(
+3,
+bindGroup6,
+new Uint32Array(6439),
+6230,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -196.9, g: 109.6, b: -423.7, a: 822.4, });
+} catch {}
+let commandEncoder40 = device1.createCommandEncoder();
+let querySet41 = device1.createQuerySet({
+type: 'occlusion',
+count: 3309,
+});
+let computePassEncoder24 = commandEncoder40.beginComputePass(
+{
+label: '\u{1f6f2}\u{1f7fc}\u{1fc19}\uc7b3\u48f8\u0bd1\u5c27'
+}
+);
+let renderBundleEncoder38 = device1.createRenderBundleEncoder(
+{
+label: '\u3a7d\u9ed6\uf3d9',
+colorFormats: [
+'rgba8sint',
+undefined,
+'rg8unorm',
+undefined,
+'rg8unorm',
+'rgba32uint',
+'r8unorm',
+'r8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 704,
+stencilReadOnly: true,
+}
+);
+let sampler58 = device1.createSampler(
+{
+label: '\u2455\u{1f940}\u1169',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 23.985,
+lodMaxClamp: 70.892,
+maxAnisotropy: 6,
+}
+);
+try {
+renderPassEncoder11.setViewport(
+210.7,
+0.3745,
+1226.6,
+0.3232,
+0.8570,
+0.9498
+);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(
+7,
+buffer6,
+8892,
+934
+);
+} catch {}
+let canvas11 = document.createElement('canvas');
+try {
+computePassEncoder18.setBindGroup(
+7,
+bindGroup2
+);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(
+6,
+bindGroup2,
+new Uint32Array(5516),
+210,
+0
+);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(
+8,
+bindGroup3
+);
+} catch {}
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(
+2,
+buffer6
+);
+} catch {}
+let pipeline57 = await device1.createComputePipelineAsync(
+{
+label: '\ubeee\u04fb\uc598\u3852\u95c5\u5e43',
+layout: pipelineLayout8,
+compute: {
+module: shaderModule18,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+gc();
+let video12 = await videoWithData();
+let bindGroupLayout18 = device2.createBindGroupLayout(
+{
+entries: [
+{
+binding: 2710,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '2d' },
+}
+],
+}
+);
+let sampler59 = device2.createSampler(
+{
+label: '\u34f4\u09c1',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 68.949,
+lodMaxClamp: 89.473,
+compare: 'not-equal',
+}
+);
+try {
+renderPassEncoder15.setBlendConstant({ r: 8.220, g: 962.4, b: -619.9, a: -116.3, });
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+81,
+undefined,
+3190033315,
+1002774383
+);
+} catch {}
+try {
+gpuCanvasContext13.configure(
+{
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let video13 = await videoWithData();
+let gpuCanvasContext14 = canvas11.getContext('webgpu');
+let video14 = await videoWithData();
+let videoFrame14 = new VideoFrame(imageBitmap6, {timestamp: 0});
+let buffer13 = device1.createBuffer(
+{
+label: '\u{1ff40}\uc1b4\u09da\uf4e1\u173b\u{1fb9a}\u8f96\u0e72',
+size: 1272,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+try {
+computePassEncoder14.setPipeline(
+pipeline50
+);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(
+2573
+);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(
+buffer6,
+'uint16',
+5140,
+957
+);
+} catch {}
+try {
+adapter5.label = '\u359e\u{1fa4e}\u01bd\u{1face}\u84d3';
+} catch {}
+let commandEncoder41 = device1.createCommandEncoder(
+{
+label: '\u953c\u0143',
+}
+);
+let renderPassEncoder18 = commandEncoder41.beginRenderPass(
+{
+label: '\u7495\u701d\u4166\u0b8e\ub300\u0596\uefaa\uce8f\u2bae\ucb2c\u465f',
+colorAttachments: [
+{
+view: textureView41,
+depthSlice: 10,
+clearValue: { r: 864.5, g: -323.7, b: 646.6, a: -261.2, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 37,
+clearValue: { r: 358.5, g: -333.2, b: -404.9, a: 953.3, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 40,
+clearValue: { r: 409.5, g: -846.7, b: 689.5, a: 640.5, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 16,
+clearValue: { r: -280.5, g: 739.1, b: -258.8, a: -879.3, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 132,
+clearValue: { r: -369.4, g: 445.2, b: 570.8, a: 612.0, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 74,
+clearValue: { r: 171.2, g: -849.0, b: 275.0, a: -955.4, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 7,
+clearValue: { r: -919.9, g: 439.0, b: 909.9, a: -898.7, },
+loadOp: 'load',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet31,
+maxDrawCount: 418384,
+}
+);
+try {
+renderPassEncoder16.beginOcclusionQuery(1725);
+} catch {}
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(
+buffer6,
+'uint32'
+);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(
+9,
+buffer9
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let promise22 = navigator.gpu.requestAdapter();
+let imageData17 = new ImageData(80, 144);
+let adapter9 = await navigator.gpu.requestAdapter();
+let offscreenCanvas20 = new OffscreenCanvas(129, 726);
+let renderBundleEncoder39 = device1.createRenderBundleEncoder(
+{
+label: '\u7f53\u{1ffa3}\u0d43\u280e\u61bc',
+colorFormats: [
+'r8unorm',
+'r32sint',
+'r32uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 64,
+}
+);
+try {
+computePassEncoder21.setPipeline(
+pipeline57
+);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(
+2432
+);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(
+buffer6,
+'uint16',
+5310,
+680
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+1,
+buffer6,
+4320,
+1704
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+544,
+new BigUint64Array(1000),
+323,
+4
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture45,
+  mipLevel: 3,
+  origin: { x: 105, y: 1, z: 12 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer1),
+/* required buffer size: 98226 */{
+offset: 176,
+bytesPerRow: 185,
+rowsPerImage: 265,
+},
+{width: 1, height: 0, depthOrArrayLayers: 3}
+);
+} catch {}
+let pipeline58 = await device1.createComputePipelineAsync(
+{
+label: '\uddb8\u{1f97c}\u{1fddd}\u840e',
+layout: 'auto',
+compute: {
+module: shaderModule18,
+entryPoint: 'compute0',
+},
+}
+);
+let gpuCanvasContext15 = offscreenCanvas20.getContext('webgpu');
+let imageData18 = new ImageData(68, 192);
+let bindGroupLayout19 = device1.createBindGroupLayout(
+{
+label: '\u{1f835}\u97ec\u967a\u10f2\u3dd1\u0a46\ucffc\u5596\u035c\u011c\u20fb',
+entries: [
+{
+binding: 3578,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+}
+],
+}
+);
+let querySet42 = device1.createQuerySet({
+label: '\u5abc\u03c2\uda2a\u535b\u{1f94a}\u0964\u0b2b\u90e9\ud566\u{1fa5f}',
+type: 'occlusion',
+count: 905,
+});
+let texture48 = device1.createTexture(
+{
+label: '\ud975\u3ec9\u0520',
+size: {width: 1498, height: 1, depthOrArrayLayers: 372},
+dimension: '3d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let textureView52 = texture23.createView(
+{
+baseArrayLayer: 0,
+}
+);
+let sampler60 = device1.createSampler(
+{
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 26.892,
+lodMaxClamp: 62.524,
+}
+);
+try {
+renderPassEncoder16.setBlendConstant({ r: 722.7, g: 927.7, b: 501.8, a: -238.7, });
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+8,
+buffer6,
+5656,
+5153
+);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(
+10,
+bindGroup7
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+5540,
+new Int16Array(9240),
+2681,
+960
+);
+} catch {}
+offscreenCanvas8.height = 367;
+let bindGroup9 = device1.createBindGroup({
+label: '\u9065\u6395\u{1ff57}\u06fc',
+layout: bindGroupLayout19,
+entries: [
+{
+binding: 3578,
+resource: textureView31
+}
+],
+});
+let commandEncoder42 = device1.createCommandEncoder(
+{
+label: '\u{1fa75}\u0150\u938e\u06dc\u0c08\u062c\u6140\u04c0\u0580\u{1f746}',
+}
+);
+let texture49 = device1.createTexture(
+{
+label: '\uea87\u17bf\u0179\u0c07\u24a2\u02fd\u3978\ubfa4\u134d\u17ec',
+size: {width: 10147},
+dimension: '1d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+let computePassEncoder25 = commandEncoder42.beginComputePass();
+try {
+renderPassEncoder18.setBindGroup(
+1,
+bindGroup3,
+new Uint32Array(9104),
+4972,
+0
+);
+} catch {}
+try {
+renderPassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(208);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(
+1494
+);
+} catch {}
+try {
+gpuCanvasContext11.configure(
+{
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+document.body.prepend(video5);
+let offscreenCanvas21 = new OffscreenCanvas(997, 404);
+let videoFrame15 = new VideoFrame(video4, {timestamp: 0});
+try {
+offscreenCanvas21.getContext('bitmaprenderer');
+} catch {}
+let bindGroup10 = device1.createBindGroup({
+label: '\uf2bf\u3dfb\u{1fe3d}\uf76d\u132e\u926c\u0f4b\u{1fa71}\u5fbc\u68b9\u0d06',
+layout: bindGroupLayout9,
+entries: [
+{
+binding: 746,
+resource: sampler39
+},
+{
+binding: 381,
+resource: sampler42
+}
+],
+});
+let commandEncoder43 = device1.createCommandEncoder(
+{
+}
+);
+let renderPassEncoder19 = commandEncoder43.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView41,
+depthSlice: 139,
+clearValue: { r: 301.6, g: 172.7, b: -203.1, a: -482.5, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 136,
+clearValue: { r: -448.2, g: -432.7, b: 596.1, a: 826.5, },
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet40,
+maxDrawCount: 145408,
+}
+);
+try {
+renderPassEncoder18.setStencilReference(
+3665
+);
+} catch {}
+try {
+renderPassEncoder19.setViewport(
+1468.0,
+0.5249,
+194.7,
+0.1366,
+0.1195,
+0.9728
+);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(
+6,
+buffer6,
+10372,
+274
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 1029, height: 1, depthOrArrayLayers: 153}
+*/
+{
+  source: imageBitmap13,
+  origin: { x: 5, y: 65 },
+  flipY: false,
+},
+{
+  texture: texture45,
+  mipLevel: 0,
+  origin: { x: 235, y: 1, z: 13 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let buffer14 = device1.createBuffer(
+{
+label: '\u5bfa\u6e97\u{1fd0e}',
+size: 65532,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandEncoder44 = device1.createCommandEncoder(
+{
+label: '\u0939\u4006\u76bf\u0b46\u00b9\ua2a8\uc08a\uc02e\u9ee5\u66f7',
+}
+);
+let textureView53 = texture37.createView(
+{
+label: '\uba6f\u{1f742}\u0dea\ubd77\ue9ff\u{1fc89}',
+}
+);
+let renderBundle56 = renderBundleEncoder17.finish(
+{
+
+}
+);
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(
+3901
+);
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+1482.2,
+0.2137,
+325.8,
+0.3340,
+0.1075,
+0.5049
+);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(
+16,
+undefined,
+3410285594,
+65274498
+);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(
+6,
+bindGroup7
+);
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8unorm',
+'etc2-rgba8unorm'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+3524,
+new BigUint64Array(31307),
+14551,
+492
+);
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let adapter10 = await promise22;
+try {
+window.someLabel = shaderModule14.label;
+} catch {}
+gc();
+let img10 = await imageWithData(119, 220, '#87d753be', '#02bbdb13');
+let querySet43 = device1.createQuerySet({
+label: '\ua63d\u1102\u9551\ubb27\u057d\u0a6c\u0339\u{1f972}',
+type: 'occlusion',
+count: 1344,
+});
+pseudoSubmit(device1, commandEncoder41);
+let texture50 = device1.createTexture(
+{
+label: '\u0ba9\u{1f805}',
+size: [2566, 162, 1],
+mipLevelCount: 3,
+dimension: '2d',
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth16unorm',
+'depth16unorm',
+'depth16unorm'
+],
+}
+);
+let computePassEncoder26 = commandEncoder44.beginComputePass(
+{
+
+}
+);
+let renderBundle57 = renderBundleEncoder21.finish();
+let sampler61 = device1.createSampler(
+{
+label: '\u7066\ufe4a\u9185\uc8ff',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 20.325,
+maxAnisotropy: 6,
+}
+);
+try {
+computePassEncoder26.setBindGroup(
+0,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(
+7,
+bindGroup3,
+new Uint32Array(7875),
+1638,
+0
+);
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(212);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: -327.6, g: 258.6, b: -737.7, a: 228.9, });
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(
+4,
+bindGroup2
+);
+} catch {}
+try {
+renderBundleEncoder39.setVertexBuffer(
+1,
+buffer6,
+3336,
+2185
+);
+} catch {}
+let renderBundleEncoder40 = device2.createRenderBundleEncoder(
+{
+label: '\u0fc3\u563a',
+colorFormats: [
+'rg16float'
+],
+sampleCount: 309,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder17.setBlendConstant({ r: -477.5, g: 836.3, b: 393.0, a: 880.0, });
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+let pipeline59 = device2.createComputePipeline(
+{
+layout: pipelineLayout7,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+let img11 = await imageWithData(85, 281, '#c6c9c36a', '#4287f9a4');
+let commandEncoder45 = device1.createCommandEncoder(
+{
+}
+);
+pseudoSubmit(device1, commandEncoder31);
+let sampler62 = device1.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 21.002,
+lodMaxClamp: 25.461,
+compare: 'less-equal',
+}
+);
+try {
+renderPassEncoder11.setBindGroup(
+0,
+bindGroup9
+);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(1313);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: 876.1, g: -998.1, b: -349.2, a: 777.7, });
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(
+117,
+0,
+405,
+0
+);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(
+1487
+);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(
+buffer6,
+'uint16',
+7450,
+3211
+);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(
+6,
+buffer6,
+10832,
+4
+);
+} catch {}
+try {
+commandEncoder45.clearBuffer(
+buffer13
+);
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+commandEncoder45.resolveQuerySet(
+querySet43,
+985,
+36,
+buffer7,
+9472
+);
+} catch {}
+try {
+gpuCanvasContext12.configure(
+{
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+3452,
+new DataView(new ArrayBuffer(19362)),
+12445,
+4852
+);
+} catch {}
+let pipeline60 = await device1.createComputePipelineAsync(
+{
+label: '\u{1fbef}\u6ead\u4349\u1eda',
+layout: pipelineLayout8,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let bindGroupLayout20 = device1.createBindGroupLayout(
+{
+label: '\u{1fc1e}\u9d5c\u{1fae9}\ud608\u0663\uf4b6\u842a\u{1fc72}\u{1fa1b}\u0288\u00e4',
+entries: [
+{
+binding: 4411,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '1d' },
+},
+{
+binding: 3068,
+visibility: 0,
+storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '2d' },
+}
+],
+}
+);
+let buffer15 = device1.createBuffer(
+{
+label: '\u8d8c\u{1fbf7}\u{1fcd1}\u{1fe41}\ub9ea\u2432\u99c7\ue218',
+size: 30660,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandEncoder46 = device1.createCommandEncoder(
+{
+label: '\ue637\u{1fa6a}\u0d2d',
+}
+);
+let sampler63 = device1.createSampler(
+{
+label: '\u{1fcd4}\ufbc8\u9c30\uc6d0\uafbe\u2cf6\u5741',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+lodMaxClamp: 93.174,
+}
+);
+try {
+renderPassEncoder19.beginOcclusionQuery(950);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.setStencilReference(
+2234
+);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(
+buffer6,
+'uint32',
+1744,
+4424
+);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+7,
+buffer6
+);
+} catch {}
+try {
+commandEncoder46.resolveQuerySet(
+querySet20,
+356,
+465,
+buffer7,
+3584
+);
+} catch {}
+let pipeline61 = device1.createRenderPipeline(
+{
+label: '\u9648\u616c\u039d\udc0d\ud9fc\u0a4c\u8cb4',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule7,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 42368,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x2',
+offset: 16412,
+shaderLocation: 16,
+},
+{
+format: 'sint8x2',
+offset: 2206,
+shaderLocation: 3,
+},
+{
+format: 'uint32x3',
+offset: 24848,
+shaderLocation: 23,
+},
+{
+format: 'float32',
+offset: 1680,
+shaderLocation: 6,
+},
+{
+format: 'float32x2',
+offset: 140,
+shaderLocation: 7,
+},
+{
+format: 'uint32x4',
+offset: 20164,
+shaderLocation: 17,
+},
+{
+format: 'sint32x2',
+offset: 39572,
+shaderLocation: 27,
+},
+{
+format: 'unorm8x4',
+offset: 38192,
+shaderLocation: 9,
+},
+{
+format: 'float32x4',
+offset: 3300,
+shaderLocation: 18,
+},
+{
+format: 'snorm8x2',
+offset: 41008,
+shaderLocation: 14,
+},
+{
+format: 'unorm8x4',
+offset: 25496,
+shaderLocation: 1,
+},
+{
+format: 'sint16x4',
+offset: 7824,
+shaderLocation: 20,
+},
+{
+format: 'float16x2',
+offset: 17432,
+shaderLocation: 24,
+},
+{
+format: 'snorm8x2',
+offset: 15872,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 57976,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 35220,
+shaderLocation: 10,
+},
+{
+format: 'sint16x4',
+offset: 17376,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x4',
+offset: 13660,
+shaderLocation: 12,
+},
+{
+format: 'sint32x3',
+offset: 18176,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x4',
+offset: 38092,
+shaderLocation: 26,
+}
+],
+},
+{
+arrayStride: 60068,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 1188,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 35964,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 5480,
+shaderLocation: 19,
+},
+{
+format: 'sint32x3',
+offset: 5692,
+shaderLocation: 25,
+},
+{
+format: 'uint32',
+offset: 29036,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x2',
+offset: 27564,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+primitive: {
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+},
+fragment: {
+module: shaderModule7,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'one-minus-constant',
+dstFactor: 'one-minus-constant'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'constant',
+dstFactor: 'src-alpha-saturated'
+},
+},
+format: 'rg16float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'one-minus-constant',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rg16float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one-minus-src-alpha',
+dstFactor: 'constant'
+},
+},
+format: 'r8unorm',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'keep',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 259,
+stencilWriteMask: 4016,
+depthBias: 10,
+depthBiasSlopeScale: 13,
+depthBiasClamp: 99,
+},
+}
+);
+let textureView54 = texture29.createView(
+{
+label: '\u{1fb9e}\u0744\u2f4c\u7046\u0e50\u9d7d\uee10\u{1fae7}',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+try {
+computePassEncoder23.end();
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -991.4, g: -237.7, b: -529.4, a: 394.7, });
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+58,
+undefined
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(48),
+/* required buffer size: 385 */{
+offset: 385,
+rowsPerImage: 181,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+gc();
+let videoFrame16 = new VideoFrame(imageBitmap14, {timestamp: 0});
+let textureView55 = texture28.createView(
+{
+baseMipLevel: 6,
+mipLevelCount: 3,
+}
+);
+try {
+renderPassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder15.setStencilReference(
+749
+);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(
+17,
+undefined,
+2707289027,
+609772494
+);
+} catch {}
+try {
+querySet25.destroy();
+} catch {}
+try {
+gpuCanvasContext7.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'r32sint',
+'rgb10a2unorm'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 44, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap8,
+  origin: { x: 250, y: 279 },
+  flipY: false,
+},
+{
+  texture: texture28,
+  mipLevel: 8,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 10, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise23 = device2.createRenderPipelineAsync(
+{
+label: '\u027a\ubc7b\u3b59\u028a',
+layout: pipelineLayout7,
+vertex: {
+module: shaderModule14,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 2560,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 1458,
+shaderLocation: 4,
+},
+{
+format: 'sint32x4',
+offset: 1964,
+shaderLocation: 3,
+},
+{
+format: 'uint32x2',
+offset: 180,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 1452,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32',
+offset: 1060,
+shaderLocation: 8,
+},
+{
+format: 'uint8x2',
+offset: 664,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x2',
+offset: 122,
+shaderLocation: 15,
+},
+{
+format: 'uint8x4',
+offset: 24,
+shaderLocation: 14,
+},
+{
+format: 'unorm16x4',
+offset: 488,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 48668,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 27236,
+shaderLocation: 1,
+},
+{
+format: 'uint8x2',
+offset: 28350,
+shaderLocation: 5,
+},
+{
+format: 'sint32x3',
+offset: 23036,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x4',
+offset: 24884,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x2',
+offset: 21684,
+shaderLocation: 9,
+},
+{
+format: 'float16x2',
+offset: 5408,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x2',
+offset: 27800,
+shaderLocation: 16,
+},
+{
+format: 'unorm8x4',
+offset: 15048,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 33844,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 42440,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 42256,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x3cdb97cb,
+},
+fragment: {
+module: shaderModule14,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'dst-alpha',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+undefined,
+undefined,
+{
+format: 'bgra8unorm',
+}
+],
+},
+}
+);
+let imageData19 = new ImageData(24, 120);
+let sampler64 = device1.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 81.589,
+lodMaxClamp: 96.431,
+compare: 'greater-equal',
+}
+);
+try {
+renderPassEncoder18.setBindGroup(
+2,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder11.end();
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(968);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(
+1033,
+1,
+804,
+0
+);
+} catch {}
+try {
+renderPassEncoder18.setViewport(
+478.6,
+0.9177,
+345.2,
+0.01226,
+0.1289,
+0.9064
+);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(
+5,
+buffer9,
+14320,
+25029
+);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(
+5,
+bindGroup1
+);
+} catch {}
+try {
+renderBundleEncoder39.setIndexBuffer(
+buffer7,
+'uint32',
+7544,
+809
+);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(
+9,
+buffer9,
+22520,
+6376
+);
+} catch {}
+try {
+commandEncoder46.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 53312 */
+offset: 53312,
+bytesPerRow: 0,
+buffer: buffer14,
+},
+{
+  texture: texture34,
+  mipLevel: 5,
+  origin: { x: 0, y: 4, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device1, buffer14);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture50,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 787 */{
+offset: 787,
+bytesPerRow: 5269,
+},
+{width: 2566, height: 162, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas9,
+  origin: { x: 241, y: 195 },
+  flipY: false,
+},
+{
+  texture: texture45,
+  mipLevel: 10,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline62 = await promise20;
+let adapter11 = await navigator.gpu.requestAdapter(
+{
+}
+);
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(
+8,
+bindGroup8,
+new Uint32Array(6085),
+5537,
+1
+);
+} catch {}
+try {
+renderPassEncoder18.setViewport(
+792.3,
+0.1806,
+656.0,
+0.3647,
+0.5598,
+0.6950
+);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(
+5,
+buffer9,
+28996,
+5502
+);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(
+7,
+bindGroup2
+);
+} catch {}
+try {
+commandEncoder45.resolveQuerySet(
+querySet22,
+1420,
+515,
+buffer7,
+8448
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+5764,
+new Float32Array(8053),
+7094,
+64
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 514, height: 1, depthOrArrayLayers: 76}
+*/
+{
+  source: imageBitmap7,
+  origin: { x: 14, y: 32 },
+  flipY: true,
+},
+{
+  texture: texture45,
+  mipLevel: 1,
+  origin: { x: 184, y: 0, z: 11 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 23, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let offscreenCanvas22 = new OffscreenCanvas(4, 32);
+let bindGroup11 = device1.createBindGroup({
+label: '\u0222\u{1fdd7}',
+layout: bindGroupLayout9,
+entries: [
+{
+binding: 746,
+resource: sampler29
+},
+{
+binding: 381,
+resource: sampler27
+}
+],
+});
+let texture51 = device1.createTexture(
+{
+label: '\u0161\uf7c1\ueeee\u{1fcb2}\u0d4f',
+size: [187, 1, 861],
+mipLevelCount: 7,
+dimension: '3d',
+format: 'r32float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32float',
+'r32float'
+],
+}
+);
+let sampler65 = device1.createSampler(
+{
+label: '\u{1f69c}\uea39\u48fa\u{1f705}\u{1fd40}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 70.924,
+lodMaxClamp: 82.143,
+}
+);
+try {
+computePassEncoder25.setPipeline(
+pipeline32
+);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(
+2040
+);
+} catch {}
+try {
+renderPassEncoder18.setViewport(
+1412.7,
+0.1243,
+275.3,
+0.6878,
+0.3850,
+0.9036
+);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(
+7,
+buffer6,
+2132,
+8544
+);
+} catch {}
+try {
+renderBundleEncoder39.setVertexBuffer(
+1,
+buffer9,
+10472,
+20524
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 8, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img8,
+  origin: { x: 126, y: 70 },
+  flipY: true,
+},
+{
+  texture: texture45,
+  mipLevel: 7,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 5, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline63 = await device1.createComputePipelineAsync(
+{
+label: '\uc60c\u32c7\u{1f8b4}\u0e9f\u{1f782}\u8455\u{1f786}\u497a\u0d87\u0a7f\ue1dc',
+layout: pipelineLayout8,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend(canvas6);
+let video15 = await videoWithData();
+let videoFrame17 = videoFrame3.clone();
+let device3 = await adapter10.requestDevice({
+label: '\u60ca\uea14',
+requiredFeatures: [
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 41,
+maxVertexAttributes: 26,
+maxVertexBufferArrayStride: 17403,
+maxStorageTexturesPerShaderStage: 10,
+maxStorageBuffersPerShaderStage: 29,
+maxDynamicStorageBuffersPerPipelineLayout: 20665,
+maxBindingsPerBindGroup: 5645,
+maxTextureDimension1D: 12182,
+maxTextureDimension2D: 10549,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 149078710,
+maxUniformBuffersPerShaderStage: 23,
+maxInterStageShaderVariables: 91,
+maxInterStageShaderComponents: 107,
+maxSamplersPerShaderStage: 18,
+},
+});
+let renderPassEncoder20 = commandEncoder45.beginRenderPass(
+{
+label: '\uc70d\u0dd6\u4494\u05c4\u73f8\u068f\u5822\u05ee\u054a\ud233',
+colorAttachments: [
+undefined,
+{
+view: textureView50,
+clearValue: { r: -701.2, g: -907.8, b: -715.0, a: 524.2, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined,
+undefined
+],
+occlusionQuerySet: querySet41,
+}
+);
+let renderBundle58 = renderBundleEncoder38.finish(
+{
+
+}
+);
+try {
+computePassEncoder9.setPipeline(
+pipeline53
+);
+} catch {}
+try {
+renderPassEncoder20.setStencilReference(
+2132
+);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(
+buffer6,
+'uint16',
+1870
+);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(
+4,
+bindGroup7,
+new Uint32Array(2084),
+999,
+0
+);
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(
+buffer14,
+58272,
+buffer7,
+3772,
+4144
+);
+dissociateBuffer(device1, buffer14);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+8932,
+new Int16Array(52259),
+3822,
+520
+);
+} catch {}
+let promise24 = device1.queue.onSubmittedWorkDone();
+let pipeline64 = device1.createComputePipeline(
+{
+label: '\u6115\uc342\u030a',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+gc();
+let computePassEncoder27 = commandEncoder46.beginComputePass(
+{
+label: '\u8bd2\u08ec\uad69\udb78'
+}
+);
+try {
+renderPassEncoder20.setBlendConstant({ r: 771.8, g: 576.5, b: -711.8, a: 715.7, });
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(
+2042,
+0,
+1,
+0
+);
+} catch {}
+try {
+computePassEncoder26.pushDebugGroup(
+'\u999c'
+);
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer2,
+]);
+} catch {}
+let promise25 = device1.queue.onSubmittedWorkDone();
+let gpuCanvasContext16 = offscreenCanvas22.getContext('webgpu');
+let video16 = await videoWithData();
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let img12 = await imageWithData(291, 73, '#1c573857', '#9658d428');
+let renderBundleEncoder41 = device3.createRenderBundleEncoder(
+{
+label: '\u{1f61a}\u0199',
+colorFormats: [
+undefined
+],
+sampleCount: 30,
+depthReadOnly: true,
+}
+);
+let bindGroup12 = device1.createBindGroup({
+label: '\u8d0f\u0f23',
+layout: bindGroupLayout19,
+entries: [
+{
+binding: 3578,
+resource: textureView31
+}
+],
+});
+let commandEncoder47 = device1.createCommandEncoder(
+{
+label: '\u{1fdbd}\u{1fba4}\ue82a\u9de2\u00b7\u0b9c\u{1f640}',
+}
+);
+let texture52 = device1.createTexture(
+{
+label: '\u8bc3\u8182\u0dad\u99c0\u{1fd78}\ucfe2\u5a25',
+size: [7004],
+dimension: '1d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8unorm',
+'rg8unorm',
+'rg8unorm'
+],
+}
+);
+let textureView56 = texture47.createView(
+{
+label: '\uba7a\u1767',
+dimension: '2d',
+baseMipLevel: 1,
+baseArrayLayer: 106,
+}
+);
+let renderBundleEncoder42 = device1.createRenderBundleEncoder(
+{
+label: '\u{1fe27}\u{1fdf3}\u0d74',
+colorFormats: [
+'rg8sint',
+'rgba16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 249,
+depthReadOnly: true,
+}
+);
+let renderBundle59 = renderBundleEncoder21.finish(
+{
+label: '\u41f3\u04d6\ub0fd\ue643\u{1ff43}\udc27\u0087\ud18a\u7e36\u03da'
+}
+);
+let sampler66 = device1.createSampler(
+{
+label: '\ub800\u52a2\u962f',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 18.760,
+lodMaxClamp: 43.197,
+}
+);
+try {
+renderPassEncoder18.setBindGroup(
+8,
+bindGroup10
+);
+} catch {}
+try {
+renderPassEncoder20.beginOcclusionQuery(2766);
+} catch {}
+try {
+renderPassEncoder18.setViewport(
+836.3,
+0.1199,
+411.1,
+0.7386,
+0.7273,
+0.7893
+);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(
+41,
+undefined,
+4086428899
+);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(
+0,
+bindGroup1
+);
+} catch {}
+try {
+commandEncoder47.resolveQuerySet(
+querySet42,
+244,
+342,
+buffer7,
+8192
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+9252,
+new BigUint64Array(14529),
+188,
+512
+);
+} catch {}
+let pipeline65 = device1.createRenderPipeline(
+{
+label: '\u0aa5\ud348\u13f0\u2d8d\ued26',
+layout: pipelineLayout8,
+vertex: {
+module: shaderModule9,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 4184,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 324,
+shaderLocation: 25,
+},
+{
+format: 'unorm16x4',
+offset: 2020,
+shaderLocation: 10,
+},
+{
+format: 'unorm8x4',
+offset: 3264,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x2',
+offset: 814,
+shaderLocation: 24,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 3568,
+shaderLocation: 7,
+},
+{
+format: 'float32x4',
+offset: 3564,
+shaderLocation: 13,
+},
+{
+format: 'uint32x3',
+offset: 1508,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x2',
+offset: 2028,
+shaderLocation: 8,
+},
+{
+format: 'float32x2',
+offset: 4096,
+shaderLocation: 4,
+},
+{
+format: 'sint32x4',
+offset: 2340,
+shaderLocation: 14,
+},
+{
+format: 'uint32x4',
+offset: 972,
+shaderLocation: 23,
+},
+{
+format: 'unorm8x4',
+offset: 3024,
+shaderLocation: 20,
+},
+{
+format: 'float32x4',
+offset: 1992,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x2',
+offset: 2500,
+shaderLocation: 18,
+},
+{
+format: 'uint32x2',
+offset: 3552,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 13852,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32',
+offset: 12508,
+shaderLocation: 16,
+},
+{
+format: 'uint8x2',
+offset: 4442,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 41536,
+attributes: [
+{
+format: 'unorm16x4',
+offset: 30188,
+shaderLocation: 26,
+},
+{
+format: 'float32x2',
+offset: 32488,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 2832,
+shaderLocation: 11,
+},
+{
+format: 'float32x3',
+offset: 31620,
+shaderLocation: 22,
+},
+{
+format: 'sint32x3',
+offset: 31556,
+shaderLocation: 21,
+},
+{
+format: 'snorm8x2',
+offset: 18744,
+shaderLocation: 27,
+},
+{
+format: 'sint32x3',
+offset: 17980,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x4',
+offset: 33476,
+shaderLocation: 1,
+},
+{
+format: 'uint8x4',
+offset: 32860,
+shaderLocation: 9,
+},
+{
+format: 'snorm8x2',
+offset: 52240,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 33400,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 264,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule9,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'zero',
+dstFactor: 'one-minus-dst'
+},
+},
+format: 'rg16float',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'dst',
+dstFactor: 'src'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'src-alpha',
+dstFactor: 'src'
+},
+},
+format: 'r8unorm',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'equal',
+depthFailOp: 'increment-clamp',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'never',
+depthFailOp: 'keep',
+passOp: 'zero',
+},
+depthBias: 64,
+depthBiasSlopeScale: 28,
+depthBiasClamp: 76,
+},
+}
+);
+let imageData20 = new ImageData(64, 240);
+let buffer16 = device3.createBuffer(
+{
+size: 5432,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE,
+mappedAtCreation: true,
+}
+);
+let texture53 = device3.createTexture(
+{
+size: {width: 483, height: 1, depthOrArrayLayers: 251},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+let textureView57 = texture53.createView(
+{
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+await promise25;
+} catch {}
+let arrayBuffer2 = buffer16.getMappedRange(
+0,
+3388
+);
+let bindGroupLayout21 = device1.createBindGroupLayout(
+{
+entries: [
+{
+binding: 6223,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '3d' },
+},
+{
+binding: 10,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+},
+{
+binding: 735,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let textureView58 = texture45.createView(
+{
+baseMipLevel: 4,
+mipLevelCount: 1,
+arrayLayerCount: 1,
+}
+);
+let renderBundle60 = renderBundleEncoder29.finish(
+{
+label: '\udc05\ua6d4\ud82a\u{1f710}\u{1f6db}\u0c8d\u4e2b\u{1fda0}\u0ff3\u02eb'
+}
+);
+try {
+renderPassEncoder18.setViewport(
+335.9,
+0.5404,
+1254.7,
+0.2201,
+0.5575,
+0.6096
+);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(
+5,
+buffer6
+);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(
+buffer6,
+'uint16',
+5756,
+4026
+);
+} catch {}
+try {
+buffer13.destroy();
+} catch {}
+try {
+commandEncoder47.clearBuffer(
+buffer7,
+10784,
+1584
+);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder47.resolveQuerySet(
+querySet21,
+1138,
+418,
+buffer7,
+7936
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+12272,
+new Int16Array(7894),
+5606,
+308
+);
+} catch {}
+let video17 = await videoWithData();
+let bindGroup13 = device1.createBindGroup({
+label: '\u5f2f\u05c4\u19bb\udfc1\u{1f639}',
+layout: bindGroupLayout17,
+entries: [
+{
+binding: 2789,
+resource: textureView52
+},
+{
+binding: 2718,
+resource: externalTexture2
+},
+{
+binding: 4311,
+resource: {
+buffer: buffer8,
+offset: 26112,
+size: 6884,
+}
+}
+],
+});
+let querySet44 = device1.createQuerySet({
+type: 'occlusion',
+count: 2119,
+});
+let sampler67 = device1.createSampler(
+{
+label: '\u0bbd\u900c\u{1fb9a}\u94af\ud042',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 49.766,
+maxAnisotropy: 12,
+}
+);
+try {
+renderPassEncoder20.setBindGroup(
+5,
+bindGroup13,
+[17920]
+);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(
+1671,
+0,
+348,
+0
+);
+} catch {}
+try {
+renderPassEncoder18.setViewport(
+289.4,
+0.1538,
+150.3,
+0.4702,
+0.03521,
+0.1537
+);
+} catch {}
+let videoFrame18 = new VideoFrame(video3, {timestamp: 0});
+gc();
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let canvas12 = document.createElement('canvas');
+let shaderModule19 = device1.createShaderModule(
+{
+label: '\u07ee\u4e5c\ubd14\u544a\u{1fbbb}\u0417\u3d9c\u{1fb8f}\u0467',
+code: `@group(4) @binding(1617)
+var<storage, read_write> parameter25: array<u32>;
+@group(2) @binding(1761)
+var<storage, read_write> parameter26: array<u32>;
+@group(3) @binding(1617)
+var<storage, read_write> local25: array<u32>;
+@group(3) @binding(1761)
+var<storage, read_write> parameter27: array<u32>;
+@group(1) @binding(1617)
+var<storage, read_write> global29: array<u32>;
+@group(0) @binding(1617)
+var<storage, read_write> function39: array<u32>;
+@group(5) @binding(1617)
+var<storage, read_write> parameter28: array<u32>;
+@group(5) @binding(1761)
+var<storage, read_write> parameter29: array<u32>;
+@group(2) @binding(1617)
+var<storage, read_write> function40: array<u32>;
+
+@compute @workgroup_size(6, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0() {
+
+}
+
+struct S18 {
+@builtin(vertex_index) f0: u32,
+@location(9) f1: vec4<f16>,
+@location(25) f2: vec3<f16>,
+@location(19) f3: vec4<i32>
+}
+
+@vertex
+fn vertex0(a0: S18, @location(13) a1: f32, @builtin(instance_index) a2: u32, @location(1) a3: vec3<f32>, @location(7) a4: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder48 = device1.createCommandEncoder(
+{
+label: '\u2e22\u{1fe60}\u{1f7ec}',
+}
+);
+let texture54 = device1.createTexture(
+{
+size: {width: 98, height: 98, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth32float-stencil8',
+'depth32float-stencil8'
+],
+}
+);
+let renderBundle61 = renderBundleEncoder15.finish(
+{
+
+}
+);
+try {
+renderPassEncoder20.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder47.copyBufferToBuffer(
+buffer14,
+46200,
+buffer13,
+64,
+1188
+);
+dissociateBuffer(device1, buffer14);
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+commandEncoder47.clearBuffer(
+buffer13
+);
+dissociateBuffer(device1, buffer13);
+} catch {}
+let querySet45 = device3.createQuerySet({
+label: '\u{1f741}\uaf54\u8fc0\u7101\u5b1e\u0887\u7033\u{1fc36}',
+type: 'occlusion',
+count: 2793,
+});
+let textureView59 = texture53.createView(
+{
+label: '\uc904\u0534\u3dad\u{1f9bb}\u05c9\u9290\u9aa0\u0cc0\ua5cc',
+baseMipLevel: 1,
+}
+);
+try {
+device3.queue.writeTexture(
+{
+  texture: texture53,
+  mipLevel: 1,
+  origin: { x: 44, y: 0, z: 26 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer2),
+/* required buffer size: 1655509 */{
+offset: 373,
+bytesPerRow: 634,
+rowsPerImage: 261,
+},
+{width: 99, height: 1, depthOrArrayLayers: 11}
+);
+} catch {}
+try {
+await promise24;
+} catch {}
+let querySet46 = device3.createQuerySet({
+label: '\u{1f6cf}\u9a1c',
+type: 'occlusion',
+count: 970,
+});
+let gpuCanvasContext17 = canvas12.getContext('webgpu');
+let imageData21 = new ImageData(124, 136);
+let videoFrame19 = new VideoFrame(offscreenCanvas22, {timestamp: 0});
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let buffer17 = device3.createBuffer(
+{
+size: 63918,
+usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+}
+);
+let commandEncoder49 = device3.createCommandEncoder();
+try {
+device3.queue.writeTexture(
+{
+  texture: texture53,
+  mipLevel: 3,
+  origin: { x: 12, y: 0, z: 3 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer1),
+/* required buffer size: 190339 */{
+offset: 772,
+bytesPerRow: 413,
+rowsPerImage: 27,
+},
+{width: 43, height: 0, depthOrArrayLayers: 18}
+);
+} catch {}
+video8.width = 93;
+gc();
+let pipelineLayout10 = device1.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout8,
+bindGroupLayout10,
+bindGroupLayout8,
+bindGroupLayout12,
+bindGroupLayout19,
+bindGroupLayout8
+]
+}
+);
+let commandEncoder50 = device1.createCommandEncoder(
+{
+label: '\uea88\u779b\u{1facd}\u{1fe52}\u{1fa66}\u2dc1\uf763\ud4ad',
+}
+);
+let querySet47 = device1.createQuerySet({
+label: '\u30d4\u0f19\ue955',
+type: 'occlusion',
+count: 2998,
+});
+let renderPassEncoder21 = commandEncoder48.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView41,
+depthSlice: 17,
+clearValue: { r: 704.9, g: 37.89, b: -389.0, a: -679.8, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 90,
+clearValue: { r: 802.2, g: 645.6, b: -858.0, a: -672.9, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 127,
+clearValue: { r: 237.5, g: -26.99, b: -874.4, a: -923.0, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 25,
+clearValue: { r: 827.2, g: -415.2, b: 243.7, a: 698.8, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 56,
+clearValue: { r: -276.0, g: -706.8, b: 773.6, a: -10.81, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 138,
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 144,
+clearValue: { r: 666.1, g: -894.8, b: -112.3, a: 48.13, },
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet21,
+maxDrawCount: 151416,
+}
+);
+let renderBundle62 = renderBundleEncoder27.finish(
+{
+label: '\u00ce\u0542\u3c15\u7ff8\u05be\u3869\uec22\u1035\u{1fd50}\u295b\u8ed9'
+}
+);
+try {
+renderPassEncoder18.setBindGroup(
+9,
+bindGroup3
+);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder35.insertDebugMarker(
+'\u{1ff2d}'
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let img13 = await imageWithData(128, 193, '#4f34645a', '#f28c8146');
+let video18 = await videoWithData();
+let imageBitmap15 = await createImageBitmap(imageBitmap4);
+let bindGroupLayout22 = device3.createBindGroupLayout(
+{
+label: '\u0937\ucaf0\u018d\u0c16\u03fa',
+entries: [
+{
+binding: 5591,
+visibility: 0,
+sampler: { type: 'non-filtering' },
+}
+],
+}
+);
+try {
+renderBundleEncoder41.setVertexBuffer(
+93,
+undefined,
+4230068691,
+32210845
+);
+} catch {}
+let buffer18 = device1.createBuffer(
+{
+label: '\u5ac7\u00a3\u86f9\u039c\u{1f86f}\u09e3\u0ed5',
+size: 2612,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let commandEncoder51 = device1.createCommandEncoder();
+let querySet48 = device1.createQuerySet({
+type: 'occlusion',
+count: 2761,
+});
+let textureView60 = texture31.createView(
+{
+label: '\ud787\u{1f6ab}\u{1f894}\ue57f\ua55b\u{1fa4d}\u0389\ud908',
+baseMipLevel: 1,
+}
+);
+try {
+computePassEncoder9.setPipeline(
+pipeline32
+);
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(
+624,
+0,
+1393,
+1
+);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(
+4,
+buffer9,
+22432,
+10118
+);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+commandEncoder51.copyTextureToTexture(
+{
+  texture: texture50,
+  mipLevel: 2,
+  origin: { x: 0, y: 11, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture50,
+  mipLevel: 1,
+  origin: { x: 438, y: 36, z: 1 },
+  aspect: 'depth-only',
+},
+{width: 641, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+computePassEncoder26.popDebugGroup();
+} catch {}
+let img14 = await imageWithData(91, 294, '#d8428a15', '#47fe9723');
+let video19 = await videoWithData();
+let renderBundle63 = renderBundleEncoder41.finish();
+try {
+buffer17.destroy();
+} catch {}
+try {
+commandEncoder49.clearBuffer(
+buffer16,
+2084
+);
+dissociateBuffer(device3, buffer16);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame20 = new VideoFrame(img5, {timestamp: 0});
+let pipelineLayout11 = device3.createPipelineLayout(
+{
+label: '\u0637\u{1fd0c}\uf2a1\u0f06',
+bindGroupLayouts: [
+bindGroupLayout22,
+bindGroupLayout22,
+bindGroupLayout22,
+bindGroupLayout22,
+bindGroupLayout22
+]
+}
+);
+let querySet49 = device3.createQuerySet({
+label: '\u0055\u13e7\u1e5e\u66ca\u{1f700}\u158c',
+type: 'occlusion',
+count: 3561,
+});
+let renderBundle64 = renderBundleEncoder41.finish(
+{
+label: '\ub9aa\u{1ff74}\u93d2\u0660\u{1f83d}\ue33f\uf7b3\ua486\uf9c5'
+}
+);
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(
+2,
+bindGroup8,
+[0]
+);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.setStencilReference(
+1507
+);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(
+4,
+buffer9
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+4684,
+new DataView(new ArrayBuffer(47000)),
+26736,
+5808
+);
+} catch {}
+let offscreenCanvas23 = new OffscreenCanvas(60, 539);
+try {
+commandEncoder49.label = '\u0914\ub501\u0203\u371e\u{1fc62}\u{1f787}\u7a65\ue5c2\u5a2e';
+} catch {}
+let commandEncoder52 = device3.createCommandEncoder();
+let renderPassEncoder22 = commandEncoder52.beginRenderPass(
+{
+label: '\u2b25\u0b0e\ua112\u{1fadb}\u02b8\ubc98\u2a97\u053f\u5d9f\u2147\u05a1',
+colorAttachments: [
+{
+view: textureView57,
+depthSlice: 18,
+clearValue: { r: 820.2, g: -507.6, b: -128.8, a: -722.3, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView57,
+depthSlice: 52,
+clearValue: { r: 263.7, g: -303.0, b: -883.2, a: 744.6, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView57,
+depthSlice: 19,
+clearValue: { r: -516.9, g: 439.9, b: -666.9, a: 628.6, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView57,
+depthSlice: 2,
+clearValue: { r: 533.5, g: 517.7, b: -72.66, a: -129.3, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView57,
+depthSlice: 85,
+clearValue: { r: 787.2, g: 806.6, b: -176.6, a: 23.05, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView57,
+depthSlice: 4,
+clearValue: { r: 886.0, g: 362.8, b: -886.3, a: -209.9, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView57,
+depthSlice: 106,
+clearValue: { r: -878.8, g: 962.7, b: -55.77, a: 83.20, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView57,
+depthSlice: 98,
+clearValue: { r: 301.2, g: 204.4, b: -385.2, a: -161.2, },
+loadOp: 'load',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet49,
+maxDrawCount: 63248,
+}
+);
+let renderBundleEncoder43 = device3.createRenderBundleEncoder(
+{
+label: '\u{1fb94}\u6d1d\u0e76\ue96a',
+colorFormats: [
+'rgba8sint',
+'r32sint'
+],
+sampleCount: 224,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+let commandEncoder53 = device1.createCommandEncoder(
+{
+}
+);
+let querySet50 = device1.createQuerySet({
+type: 'occlusion',
+count: 1058,
+});
+let texture55 = device1.createTexture(
+{
+label: '\u{1f7ac}\uf2f2\u80cc\ua4ca\u{1f9dd}\u{1fe84}',
+size: {width: 77, height: 162, depthOrArrayLayers: 217},
+mipLevelCount: 1,
+dimension: '2d',
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth32float-stencil8'
+],
+}
+);
+let renderPassEncoder23 = commandEncoder51.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView51,
+depthSlice: 0,
+clearValue: { r: -314.5, g: -135.9, b: 566.9, a: -482.9, },
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined,
+undefined,
+undefined
+],
+occlusionQuerySet: querySet31,
+maxDrawCount: 33864,
+}
+);
+let sampler68 = device1.createSampler(
+{
+label: '\u1f55\u0ad1\u26c5\u{1fa8d}\udfe8',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 12.474,
+lodMaxClamp: 20.253,
+compare: 'not-equal',
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+6,
+bindGroup13,
+new Uint32Array(3444),
+995,
+1
+);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(
+8,
+bindGroup9
+);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(
+7,
+bindGroup9
+);
+} catch {}
+let arrayBuffer3 = buffer18.getMappedRange(
+0,
+664
+);
+try {
+commandEncoder50.resolveQuerySet(
+querySet26,
+552,
+102,
+buffer7,
+256
+);
+} catch {}
+let pipeline66 = await device1.createRenderPipelineAsync(
+{
+label: '\u0ac7\u5af4\ub640',
+layout: pipelineLayout5,
+vertex: {
+module: shaderModule10,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 54264,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 8386,
+shaderLocation: 9,
+},
+{
+format: 'sint8x4',
+offset: 52968,
+shaderLocation: 0,
+},
+{
+format: 'sint32x2',
+offset: 8476,
+shaderLocation: 23,
+},
+{
+format: 'sint8x4',
+offset: 3740,
+shaderLocation: 20,
+},
+{
+format: 'uint32',
+offset: 50504,
+shaderLocation: 10,
+},
+{
+format: 'uint8x2',
+offset: 51426,
+shaderLocation: 19,
+},
+{
+format: 'float16x4',
+offset: 12188,
+shaderLocation: 12,
+},
+{
+format: 'sint32x4',
+offset: 7956,
+shaderLocation: 6,
+},
+{
+format: 'uint32x2',
+offset: 23372,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x2',
+offset: 38234,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x2',
+offset: 29664,
+shaderLocation: 13,
+},
+{
+format: 'uint32',
+offset: 47680,
+shaderLocation: 17,
+},
+{
+format: 'sint32',
+offset: 29996,
+shaderLocation: 8,
+},
+{
+format: 'uint8x2',
+offset: 16044,
+shaderLocation: 16,
+},
+{
+format: 'sint32',
+offset: 45196,
+shaderLocation: 22,
+},
+{
+format: 'sint8x4',
+offset: 24772,
+shaderLocation: 7,
+},
+{
+format: 'uint32x2',
+offset: 49908,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 15544,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 6116,
+shaderLocation: 27,
+},
+{
+format: 'unorm8x2',
+offset: 11356,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x2',
+offset: 2788,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x2',
+offset: 11228,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule10,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgba8unorm-srgb',
+writeMask: GPUColorWrite.ALL,
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+},
+{
+format: 'rg8unorm',
+writeMask: GPUColorWrite.BLUE,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'always',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilReadMask: 2817,
+stencilWriteMask: 2043,
+depthBias: 68,
+depthBiasSlopeScale: 30,
+depthBiasClamp: 99,
+},
+}
+);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas23.getContext('bitmaprenderer');
+} catch {}
+let texture56 = device1.createTexture(
+{
+label: '\u{1f843}\ua152\ueb83\u07d3\ue789\u2cfe\uc864',
+size: {width: 126, height: 1, depthOrArrayLayers: 461},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rg8sint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8sint',
+'rg8sint',
+'rg8sint'
+],
+}
+);
+let textureView61 = texture43.createView(
+{
+dimension: '2d',
+baseMipLevel: 2,
+mipLevelCount: 2,
+baseArrayLayer: 2,
+}
+);
+let renderPassEncoder24 = commandEncoder47.beginRenderPass(
+{
+label: '\u034f\u{1fac8}\u0f0e\u506d\u38c5\ub1d9\u{1f9ae}\u0795',
+colorAttachments: [
+{
+view: textureView41,
+depthSlice: 133,
+clearValue: { r: -938.0, g: 526.3, b: -436.3, a: 932.8, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 11,
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 92,
+clearValue: { r: 589.9, g: 223.8, b: -654.4, a: -389.9, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 74,
+clearValue: { r: 524.0, g: 555.3, b: 922.2, a: 927.1, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 72,
+clearValue: { r: 86.73, g: -132.0, b: -492.9, a: -163.8, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView41,
+depthSlice: 13,
+clearValue: { r: -660.6, g: 83.38, b: -288.9, a: -147.0, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 94,
+clearValue: { r: -360.1, g: 156.3, b: -638.5, a: -577.6, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView41,
+depthSlice: 54,
+clearValue: { r: 540.6, g: 854.2, b: -773.8, a: 455.1, },
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet31,
+maxDrawCount: 672,
+}
+);
+let sampler69 = device1.createSampler(
+{
+label: '\u729b\uf9a8\u0a15\u309a\u{1f86c}\u06af\uad5e\u6bf6\u0fdc\u3bfc\ud67c',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 63.798,
+lodMaxClamp: 66.303,
+}
+);
+try {
+computePassEncoder9.setBindGroup(
+0,
+bindGroup5
+);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(
+2,
+bindGroup9
+);
+} catch {}
+try {
+renderPassEncoder23.beginOcclusionQuery(1946);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder19.setViewport(
+1918.2,
+0.7485,
+49.29,
+0.2357,
+0.4932,
+0.9592
+);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(
+buffer7,
+'uint32'
+);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(
+3,
+buffer6,
+928,
+9796
+);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(
+buffer7,
+'uint32',
+10500,
+1830
+);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(
+3,
+buffer9,
+36040,
+7776
+);
+} catch {}
+try {
+await buffer15.mapAsync(
+GPUMapMode.WRITE,
+0,
+1136
+);
+} catch {}
+try {
+commandEncoder53.copyBufferToBuffer(
+buffer6,
+2072,
+buffer13,
+744,
+144
+);
+dissociateBuffer(device1, buffer6);
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let shaderModule20 = device3.createShaderModule(
+{
+label: '\u0dfa\u0161\ua2a2\u0739\u0a09\u{1fc1e}\u{1fd51}',
+code: `@group(2) @binding(5591)
+var<storage, read_write> type31: array<u32>;
+@group(1) @binding(5591)
+var<storage, read_write> local26: array<u32>;
+
+@compute @workgroup_size(8, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S20 {
+@location(89) f0: vec3<i32>,
+@location(51) f1: vec2<f16>,
+@location(39) f2: vec4<i32>,
+@location(74) f3: vec3<f16>,
+@location(6) f4: vec3<i32>,
+@location(56) f5: vec4<f16>,
+@location(90) f6: vec3<f16>,
+@location(52) f7: vec2<f16>,
+@location(3) f8: u32,
+@location(85) f9: f32,
+@location(46) f10: vec4<f16>,
+@location(1) f11: vec4<u32>,
+@location(5) f12: vec2<i32>,
+@location(80) f13: vec3<f32>,
+@builtin(position) f14: vec4<f32>,
+@location(14) f15: vec3<u32>,
+@location(11) f16: vec2<i32>,
+@location(33) f17: vec3<f16>,
+@location(61) f18: vec4<f32>,
+@location(64) f19: vec2<f32>,
+@location(65) f20: vec4<f16>
+}
+struct FragmentOutput0 {
+@location(2) f0: vec3<f32>,
+@location(0) f1: f32,
+@location(1) f2: vec3<f32>,
+@location(5) f3: u32,
+@location(7) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(4) a0: vec4<f16>, @location(68) a1: i32, @location(63) a2: vec3<f16>, a3: S20, @location(45) a4: u32, @location(34) a5: vec4<i32>, @builtin(sample_index) a6: u32, @builtin(front_facing) a7: bool, @builtin(sample_mask) a8: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S19 {
+@location(12) f0: vec3<i32>,
+@location(11) f1: vec3<u32>,
+@location(17) f2: vec4<i32>,
+@location(6) f3: vec4<f32>,
+@location(25) f4: vec4<f32>,
+@location(3) f5: f16,
+@location(13) f6: vec2<u32>,
+@location(4) f7: vec2<f16>,
+@location(15) f8: i32
+}
+struct VertexOutput0 {
+@location(89) f150: vec3<i32>,
+@location(90) f151: vec3<f16>,
+@location(74) f152: vec3<f16>,
+@location(85) f153: f32,
+@location(65) f154: vec4<f16>,
+@location(5) f155: vec2<i32>,
+@location(6) f156: vec3<i32>,
+@location(4) f157: vec4<f16>,
+@location(39) f158: vec4<i32>,
+@builtin(position) f159: vec4<f32>,
+@location(46) f160: vec4<f16>,
+@location(11) f161: vec2<i32>,
+@location(1) f162: vec4<u32>,
+@location(45) f163: u32,
+@location(61) f164: vec4<f32>,
+@location(80) f165: vec3<f32>,
+@location(14) f166: vec3<u32>,
+@location(68) f167: i32,
+@location(63) f168: vec3<f16>,
+@location(56) f169: vec4<f16>,
+@location(34) f170: vec4<i32>,
+@location(64) f171: vec2<f32>,
+@location(51) f172: vec2<f16>,
+@location(33) f173: vec3<f16>,
+@location(3) f174: u32,
+@location(52) f175: vec2<f16>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(5) a1: vec2<f32>, @location(10) a2: vec3<u32>, @location(24) a3: vec2<u32>, @location(8) a4: f16, a5: S19, @location(21) a6: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture57 = device3.createTexture(
+{
+label: '\u{1f7e1}\u462b\u092a\u6133\u09f0\ue9df\u8e75\u{1fd1e}',
+size: [8112, 6, 1],
+mipLevelCount: 7,
+dimension: '2d',
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-8x6-unorm-srgb'
+],
+}
+);
+let computePassEncoder28 = commandEncoder49.beginComputePass();
+let renderBundleEncoder44 = device3.createRenderBundleEncoder(
+{
+colorFormats: [
+'bgra8unorm-srgb',
+'rg11b10ufloat'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 36,
+depthReadOnly: true,
+}
+);
+let sampler70 = device3.createSampler(
+{
+label: '\u9679\u14f7\u9126\u0c9c\ubd35\u0f0f',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 86.824,
+maxAnisotropy: 19,
+}
+);
+try {
+renderPassEncoder22.beginOcclusionQuery(2864);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder22.insertDebugMarker(
+'\u02fa'
+);
+} catch {}
+try {
+gpuCanvasContext5.configure(
+{
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let promise26 = device3.queue.onSubmittedWorkDone();
+let pipeline67 = device3.createRenderPipeline(
+{
+label: '\u4089\u0ed7\u0638\u{1fca7}\u48d0\u065b\u0470\u7acf',
+layout: pipelineLayout11,
+vertex: {
+module: shaderModule20,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 17296,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x3',
+offset: 10316,
+shaderLocation: 21,
+},
+{
+format: 'sint32x3',
+offset: 9756,
+shaderLocation: 12,
+},
+{
+format: 'sint32',
+offset: 4212,
+shaderLocation: 15,
+},
+{
+format: 'uint16x4',
+offset: 10564,
+shaderLocation: 13,
+},
+{
+format: 'uint8x2',
+offset: 8082,
+shaderLocation: 24,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 16380,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 3728,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 1068,
+shaderLocation: 3,
+},
+{
+format: 'float16x2',
+offset: 1136,
+shaderLocation: 4,
+},
+{
+format: 'uint32x4',
+offset: 736,
+shaderLocation: 10,
+},
+{
+format: 'sint8x2',
+offset: 1236,
+shaderLocation: 17,
+},
+{
+format: 'uint32x3',
+offset: 492,
+shaderLocation: 11,
+},
+{
+format: 'float32',
+offset: 316,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 4896,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 4184,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 2788,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 928,
+shaderLocation: 25,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xdf549161,
+},
+fragment: {
+module: shaderModule20,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r16float',
+},
+{
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+undefined,
+undefined,
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+undefined
+],
+},
+}
+);
+gc();
+let commandEncoder54 = device2.createCommandEncoder(
+{
+label: '\u0598\u57b1\u336d',
+}
+);
+let querySet51 = device2.createQuerySet({
+label: '\u94f1\u2da6\u08bd\uaed7\u{1fee4}\u{1f9e9}\u0985\u{1fc50}\u{1fd6e}',
+type: 'occlusion',
+count: 623,
+});
+let textureView62 = texture29.createView(
+{
+label: '\u{1f794}\u{1ff9d}\u8edb\u0a35\u6925\u{1fcf7}',
+dimension: '3d',
+baseMipLevel: 2,
+}
+);
+let computePassEncoder29 = commandEncoder34.beginComputePass(
+{
+label: '\ucaf0\u0271\u{1f9a9}\u{1f899}\u07ff'
+}
+);
+let sampler71 = device2.createSampler(
+{
+label: '\u{1fd43}\u9898\uc1d6\u3f44\uc784',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 68.817,
+maxAnisotropy: 2,
+}
+);
+try {
+renderPassEncoder17.setScissorRect(
+0,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(
+1,
+bindGroup6
+);
+} catch {}
+document.body.prepend(video0);
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let offscreenCanvas24 = new OffscreenCanvas(680, 811);
+let imageBitmap16 = await createImageBitmap(offscreenCanvas1);
+let imageData22 = new ImageData(8, 84);
+let shaderModule21 = device3.createShaderModule(
+{
+label: '\u{1fbc4}\ua941\u7a9e\u4e66\u{1f9d4}\uf418\u5603\u0f83\u0950\u0776\u0440',
+code: `@group(4) @binding(5591)
+var<storage, read_write> field29: array<u32>;
+@group(0) @binding(5591)
+var<storage, read_write> type32: array<u32>;
+@group(3) @binding(5591)
+var<storage, read_write> field30: array<u32>;
+
+@compute @workgroup_size(5, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S22 {
+@location(64) f0: vec2<i32>
+}
+struct FragmentOutput0 {
+@location(1) f0: vec2<f32>,
+@builtin(frag_depth) f1: f32,
+@location(0) f2: vec2<i32>,
+@location(4) f3: i32,
+@location(7) f4: f32,
+@location(5) f5: vec4<u32>,
+@builtin(sample_mask) f6: u32,
+@location(2) f7: vec2<u32>,
+@location(6) f8: vec3<i32>,
+@location(3) f9: u32
+}
+
+@fragment
+fn fragment0(@location(19) a0: vec4<i32>, @location(43) a1: vec2<f32>, @location(25) a2: vec3<i32>, @location(1) a3: i32, @location(73) a4: f16, @location(33) a5: f16, @location(61) a6: f16, @location(53) a7: vec4<f16>, @location(39) a8: vec4<u32>, @location(62) a9: vec4<i32>, @builtin(sample_index) a10: u32, @location(3) a11: vec4<i32>, @location(40) a12: vec4<f16>, @builtin(position) a13: vec4<f32>, @location(74) a14: vec3<i32>, @location(65) a15: vec2<i32>, a16: S22, @location(88) a17: vec3<i32>, @location(51) a18: vec4<f16>, @location(13) a19: f32, @location(77) a20: vec3<i32>, @location(7) a21: vec2<f32>, @location(17) a22: f16, @builtin(sample_mask) a23: u32, @builtin(front_facing) a24: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S21 {
+@location(24) f0: vec3<f16>,
+@location(17) f1: vec3<f16>,
+@location(3) f2: i32,
+@location(16) f3: vec2<f16>,
+@location(4) f4: vec4<u32>,
+@location(15) f5: vec3<i32>,
+@location(7) f6: vec4<u32>,
+@location(23) f7: f32,
+@location(1) f8: f32,
+@builtin(vertex_index) f9: u32,
+@location(11) f10: f16,
+@location(25) f11: vec3<u32>,
+@location(2) f12: vec3<u32>,
+@location(13) f13: vec3<u32>,
+@location(5) f14: vec2<i32>,
+@builtin(instance_index) f15: u32,
+@location(10) f16: u32
+}
+struct VertexOutput0 {
+@location(65) f176: vec2<i32>,
+@location(73) f177: f16,
+@location(53) f178: vec4<f16>,
+@location(13) f179: f32,
+@location(1) f180: i32,
+@location(25) f181: vec3<i32>,
+@location(7) f182: vec2<f32>,
+@location(19) f183: vec4<i32>,
+@location(88) f184: vec3<i32>,
+@location(39) f185: vec4<u32>,
+@location(77) f186: vec3<i32>,
+@location(74) f187: vec3<i32>,
+@location(62) f188: vec4<i32>,
+@location(33) f189: f16,
+@location(40) f190: vec4<f16>,
+@location(51) f191: vec4<f16>,
+@builtin(position) f192: vec4<f32>,
+@location(64) f193: vec2<i32>,
+@location(61) f194: f16,
+@location(3) f195: vec4<i32>,
+@location(43) f196: vec2<f32>,
+@location(17) f197: f16
+}
+
+@vertex
+fn vertex0(a0: S21, @location(9) a1: f16, @location(19) a2: vec3<u32>, @location(12) a3: i32, @location(0) a4: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+}
+);
+let commandEncoder55 = device3.createCommandEncoder(
+{
+label: '\u2d0d\u{1fa4f}\u{1ff88}\u837d\u{1fba4}\u029c\u0b71\u6703\u{1fc8e}\ufbcb',
+}
+);
+let textureView63 = texture53.createView(
+{
+baseMipLevel: 3,
+mipLevelCount: 1,
+}
+);
+let sampler72 = device3.createSampler(
+{
+label: '\u36ae\u{1facd}\u0be9\u{1fb28}\u08ae',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+lodMaxClamp: 93.650,
+}
+);
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder22.setBlendConstant({ r: -341.2, g: -70.08, b: 933.3, a: 448.1, });
+} catch {}
+try {
+renderPassEncoder22.setScissorRect(
+32,
+0,
+104,
+1
+);
+} catch {}
+try {
+renderPassEncoder22.setStencilReference(
+2824
+);
+} catch {}
+try {
+commandEncoder55.clearBuffer(
+buffer16
+);
+dissociateBuffer(device3, buffer16);
+} catch {}
+try {
+gpuCanvasContext14.configure(
+{
+device: device3,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm',
+'astc-10x6-unorm',
+'rgba16float',
+'rgba16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+await promise26;
+} catch {}
+let textureView64 = texture47.createView(
+{
+dimension: '2d-array',
+mipLevelCount: 1,
+baseArrayLayer: 195,
+arrayLayerCount: 15,
+}
+);
+let renderBundle65 = renderBundleEncoder16.finish(
+{
+label: '\u88ac\u{1fd01}\u75db\u748e\ud1fa\u{1fe9c}\u0a07\u7ebd\u05ea\u{1fb09}'
+}
+);
+let sampler73 = device1.createSampler(
+{
+label: '\u0173\u0ce5\u671a\u08a5\uc175\u{1fca7}',
+addressModeV: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 17.651,
+}
+);
+try {
+renderPassEncoder18.beginOcclusionQuery(2794);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(
+10,
+bindGroup2
+);
+} catch {}
+try {
+commandEncoder50.copyBufferToBuffer(
+buffer6,
+7476,
+buffer7,
+13128,
+56
+);
+dissociateBuffer(device1, buffer6);
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder53.clearBuffer(
+buffer13
+);
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 16, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: imageBitmap9,
+  origin: { x: 486, y: 352 },
+  flipY: false,
+},
+{
+  texture: texture45,
+  mipLevel: 6,
+  origin: { x: 9, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+video14.height = 56;
+let video20 = await videoWithData();
+try {
+offscreenCanvas24.getContext('webgl2');
+} catch {}
+let bindGroupLayout23 = device0.createBindGroupLayout(
+{
+label: '\u60f9\u939d\uaeed\u{1f7eb}\uda1f\u1d37\u{1f8fc}\u{1fd88}\u{1f871}\ub340\u91d4',
+entries: [
+
+],
+}
+);
+let commandEncoder56 = device0.createCommandEncoder();
+try {
+computePassEncoder6.setBindGroup(
+8,
+bindGroup0,
+new Uint32Array(4765),
+4065,
+0
+);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(
+818
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+20.04,
+0.3505,
+93.00,
+0.5415,
+0.3825,
+0.7817
+);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+commandEncoder56.copyBufferToBuffer(
+buffer3,
+9420,
+buffer12,
+4716,
+2200
+);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder56.resolveQuerySet(
+querySet4,
+952,
+514,
+buffer5,
+1792
+);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16uint',
+'rgba8unorm-srgb',
+'rgba8unorm',
+'rgba8unorm'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+let pipeline68 = device0.createComputePipeline(
+{
+label: '\ufbf6\u07f9\ubcc2\u0ab1\ue077\u{1fcbc}',
+layout: 'auto',
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let img15 = await imageWithData(64, 228, '#1e8294b9', '#4589a6ec');
+let computePassEncoder30 = commandEncoder55.beginComputePass(
+{
+label: '\u1ffc\u0b64\u0c0a\u{1ff9b}\u{1fd32}\ub452'
+}
+);
+try {
+renderPassEncoder22.endOcclusionQuery();
+} catch {}
+let pipeline69 = device3.createRenderPipeline(
+{
+label: '\u8454\u{1fa64}\u0237\ue502\u{1f683}\u62b4',
+layout: pipelineLayout11,
+vertex: {
+module: shaderModule20,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 4664,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 2444,
+shaderLocation: 13,
+},
+{
+format: 'uint16x4',
+offset: 1272,
+shaderLocation: 21,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 32,
+shaderLocation: 25,
+},
+{
+format: 'float32',
+offset: 3884,
+shaderLocation: 4,
+},
+{
+format: 'uint16x2',
+offset: 4496,
+shaderLocation: 11,
+},
+{
+format: 'float32x4',
+offset: 3756,
+shaderLocation: 3,
+},
+{
+format: 'float32x2',
+offset: 2852,
+shaderLocation: 6,
+},
+{
+format: 'uint8x4',
+offset: 3436,
+shaderLocation: 10,
+},
+{
+format: 'sint16x2',
+offset: 2032,
+shaderLocation: 17,
+},
+{
+format: 'uint32x3',
+offset: 1484,
+shaderLocation: 24,
+},
+{
+format: 'sint32',
+offset: 3116,
+shaderLocation: 12,
+},
+{
+format: 'snorm16x4',
+offset: 3516,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 13388,
+attributes: [
+{
+format: 'sint16x4',
+offset: 11392,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 1492,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 872,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule20,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'dst-alpha',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: 0,
+},
+{
+format: 'rg11b10ufloat',
+},
+{
+format: 'rg16float',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+{
+format: 'r16uint',
+writeMask: 0,
+},
+undefined
+],
+},
+}
+);
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.prepend(img9);
+try {
+adapter6.label = '\u{1f836}\u{1fc55}\u{1fa19}\u7a5e\u0ce9\u5582\u5fc6\u0fef\u6ef1\u0478\u8303';
+} catch {}
+let renderBundleEncoder45 = device3.createRenderBundleEncoder(
+{
+label: '\u01dd\ufd2c\u{1fafd}',
+colorFormats: [
+undefined,
+'rgba16float',
+'rgba8unorm-srgb',
+'rg32float',
+'rg8uint',
+'rg16uint',
+'bgra8unorm'
+],
+sampleCount: 677,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+try {
+renderBundleEncoder44.setVertexBuffer(
+56,
+undefined,
+231929598,
+3885358721
+);
+} catch {}
+let canvas13 = document.createElement('canvas');
+let adapter12 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let querySet52 = device3.createQuerySet({
+label: '\u{1fcfc}\u08a7\ueef4\u0837\u0ef4\u0155\u0012\ue563\u0aea\u0fe8\u9a0c',
+type: 'occlusion',
+count: 3240,
+});
+let renderBundle66 = renderBundleEncoder41.finish(
+{
+label: '\u4fe3\u7c9b\u83d3\u{1f94f}\uc65d\u0bb0'
+}
+);
+let sampler74 = device3.createSampler(
+{
+label: '\u1f34\u{1fede}\u{1fae1}\u61b1',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 5.386,
+lodMaxClamp: 6.429,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder22.setStencilReference(
+3799
+);
+} catch {}
+try {
+gpuCanvasContext12.configure(
+{
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'stencil8'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let img16 = await imageWithData(83, 291, '#f6b1d65e', '#cb164285');
+let shaderModule22 = device1.createShaderModule(
+{
+label: '\u0970\ucde7\u10dd\uff16\uebb2\ue08f\u0ac2\ue0f1\u{1f6e3}\u9ddd',
+code: `@group(4) @binding(746)
+var<storage, read_write> type33: array<u32>;
+@group(5) @binding(2789)
+var<storage, read_write> global30: array<u32>;
+@group(0) @binding(746)
+var<storage, read_write> type34: array<u32>;
+@group(5) @binding(4311)
+var<storage, read_write> parameter30: array<u32>;
+@group(4) @binding(381)
+var<storage, read_write> field31: array<u32>;
+@group(7) @binding(6076)
+var<storage, read_write> local27: array<u32>;
+@group(6) @binding(4311)
+var<storage, read_write> type35: array<u32>;
+@group(6) @binding(2718)
+var<storage, read_write> field32: array<u32>;
+@group(6) @binding(2789)
+var<storage, read_write> type36: array<u32>;
+@group(2) @binding(2789)
+var<storage, read_write> field33: array<u32>;
+@group(0) @binding(381)
+var<storage, read_write> type37: array<u32>;
+@group(1) @binding(1617)
+var<storage, read_write> i22: array<u32>;
+@group(5) @binding(2718)
+var<storage, read_write> parameter31: array<u32>;
+@group(3) @binding(1761)
+var<storage, read_write> function41: array<u32>;
+@group(2) @binding(2718)
+var<storage, read_write> function42: array<u32>;
+@group(1) @binding(1761)
+var<storage, read_write> i23: array<u32>;
+@group(7) @binding(4733)
+var<storage, read_write> local28: array<u32>;
+
+@compute @workgroup_size(7, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S23 {
+@builtin(sample_index) f0: u32,
+@builtin(sample_mask) f1: u32,
+@builtin(front_facing) f2: bool,
+@builtin(position) f3: vec4<f32>
+}
+struct FragmentOutput0 {
+@location(5) f0: vec4<u32>,
+@location(3) f1: i32,
+@builtin(sample_mask) f2: u32,
+@location(7) f3: i32,
+@location(4) f4: vec3<f32>,
+@location(6) f5: vec3<u32>,
+@builtin(frag_depth) f6: f32,
+@location(1) f7: vec3<u32>
+}
+
+@fragment
+fn fragment0(a0: S23) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(18) a0: vec4<i32>, @location(16) a1: vec2<i32>, @location(12) a2: vec2<u32>, @location(2) a3: f32, @location(9) a4: vec2<f16>, @location(26) a5: vec3<u32>, @location(8) a6: vec4<f16>, @location(25) a7: f32, @location(11) a8: vec4<f32>, @location(22) a9: vec4<f32>, @location(13) a10: vec3<u32>, @location(0) a11: vec4<f32>, @location(3) a12: f16, @location(10) a13: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let textureView65 = texture33.createView(
+{
+label: '\u{1f6ea}\u8648\u2112\u95c2\uf3f2\u{1fcc4}\u019e\u{1f8c3}\u{1fcaa}',
+aspect: 'all',
+baseMipLevel: 2,
+mipLevelCount: 4,
+}
+);
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: -312.9, g: 311.6, b: 65.60, a: 183.5, });
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(
+1,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(
+269
+);
+} catch {}
+let bindGroup14 = device3.createBindGroup({
+layout: bindGroupLayout22,
+entries: [
+{
+binding: 5591,
+resource: sampler74
+}
+],
+});
+let texture58 = device3.createTexture(
+{
+label: '\uc432\u7dab',
+size: [80, 8, 157],
+mipLevelCount: 4,
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+renderBundleEncoder43.setBindGroup(
+0,
+bindGroup14,
+new Uint32Array(9575),
+3886,
+0
+);
+} catch {}
+let canvas14 = document.createElement('canvas');
+let shaderModule23 = device3.createShaderModule(
+{
+label: '\u2c58\u21ef',
+code: `@group(1) @binding(5591)
+var<storage, read_write> i24: array<u32>;
+@group(3) @binding(5591)
+var<storage, read_write> i25: array<u32>;
+@group(4) @binding(5591)
+var<storage, read_write> local29: array<u32>;
+@group(2) @binding(5591)
+var<storage, read_write> global31: array<u32>;
+
+@compute @workgroup_size(6, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: u32,
+@location(2) f1: u32,
+@location(1) f2: vec4<u32>,
+@location(0) f3: vec3<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(15) a0: vec3<f32>, @location(11) a1: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture59 = device3.createTexture(
+{
+label: '\u56a5\u6dbb\ufc71\ue5c1\u{1f761}\u036f\u8d05\u{1fa25}\u0c5f\u{1ff3e}\u0ffe',
+size: {width: 3127},
+dimension: '1d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rg11b10ufloat',
+'rg11b10ufloat',
+'rg11b10ufloat'
+],
+}
+);
+let renderBundle67 = renderBundleEncoder41.finish(
+{
+label: '\u{1f992}\uf5ac\u980a'
+}
+);
+try {
+renderPassEncoder22.setBlendConstant({ r: -459.4, g: -139.4, b: 211.4, a: -683.0, });
+} catch {}
+try {
+renderPassEncoder22.setStencilReference(
+1338
+);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(
+2,
+bindGroup14,
+new Uint32Array(1771),
+460,
+0
+);
+} catch {}
+try {
+renderPassEncoder22.pushDebugGroup(
+'\u{1f90c}'
+);
+} catch {}
+let gpuCanvasContext18 = canvas13.getContext('webgpu');
+let canvas15 = document.createElement('canvas');
+try {
+canvas15.getContext('webgpu');
+} catch {}
+let gpuCanvasContext19 = canvas14.getContext('webgpu');
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let imageBitmap17 = await createImageBitmap(offscreenCanvas17);
+let videoFrame21 = new VideoFrame(videoFrame12, {timestamp: 0});
+let buffer19 = device3.createBuffer(
+{
+size: 3516,
+usage: GPUBufferUsage.STORAGE,
+}
+);
+let renderBundle68 = renderBundleEncoder41.finish();
+try {
+computePassEncoder28.end();
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(
+50,
+undefined,
+827442284,
+2486172665
+);
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+let arrayBuffer4 = buffer16.getMappedRange(
+3392,
+812
+);
+try {
+commandEncoder49.copyTextureToTexture(
+{
+  texture: texture53,
+  mipLevel: 2,
+  origin: { x: 9, y: 0, z: 3 },
+  aspect: 'all',
+},
+{
+  texture: texture53,
+  mipLevel: 1,
+  origin: { x: 148, y: 1, z: 8 },
+  aspect: 'all',
+},
+{width: 45, height: 0, depthOrArrayLayers: 42}
+);
+} catch {}
+let computePassEncoder31 = commandEncoder53.beginComputePass(
+{
+label: '\u02bf\u0e14\u{1f7d8}\uf9fa'
+}
+);
+try {
+renderBundleEncoder42.setIndexBuffer(
+buffer6,
+'uint32',
+4472,
+4888
+);
+} catch {}
+try {
+commandEncoder50.copyBufferToBuffer(
+buffer9,
+24588,
+buffer13,
+992,
+0
+);
+dissociateBuffer(device1, buffer9);
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+8024,
+new BigUint64Array(26711),
+15633,
+224
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 257, height: 1, depthOrArrayLayers: 38}
+*/
+{
+  source: canvas15,
+  origin: { x: 158, y: 15 },
+  flipY: true,
+},
+{
+  texture: texture45,
+  mipLevel: 2,
+  origin: { x: 68, y: 1, z: 11 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 140, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline70 = await device1.createComputePipelineAsync(
+{
+layout: pipelineLayout4,
+compute: {
+module: shaderModule18,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let video21 = await videoWithData();
+let textureView66 = texture25.createView(
+{
+label: '\u6619\ub35a\u01e3',
+format: 'rgba32uint',
+baseMipLevel: 1,
+mipLevelCount: 4,
+baseArrayLayer: 0,
+}
+);
+let renderBundleEncoder46 = device1.createRenderBundleEncoder(
+{
+label: '\u0492\u{1fb9f}\u0f66\u0c32\u{1fc35}\udc12\uc419\u0fb9',
+colorFormats: [
+'r32sint',
+'rgba16uint',
+'rgba16uint',
+'rg11b10ufloat'
+],
+sampleCount: 762,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder21.beginOcclusionQuery(1053);
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(
+3752
+);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(
+buffer6,
+'uint32',
+3552
+);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(
+8,
+buffer9,
+41640,
+2127
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture33,
+  mipLevel: 1,
+  origin: { x: 570, y: 0, z: 8 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 3894391 */{
+offset: 39,
+bytesPerRow: 218,
+rowsPerImage: 154,
+},
+{width: 74, height: 0, depthOrArrayLayers: 117}
+);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(
+/*
+{width: 8, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas11,
+  origin: { x: 156, y: 114 },
+  flipY: true,
+},
+{
+  texture: texture45,
+  mipLevel: 7,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 4, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let video22 = await videoWithData();
+let bindGroup15 = device3.createBindGroup({
+layout: bindGroupLayout22,
+entries: [
+{
+binding: 5591,
+resource: sampler74
+}
+],
+});
+let commandBuffer3 = commandEncoder49.finish(
+{
+}
+);
+let renderBundle69 = renderBundleEncoder41.finish(
+{
+label: '\u0eff\u0caf\ud5be'
+}
+);
+try {
+renderBundleEncoder43.setBindGroup(
+4,
+bindGroup14,
+new Uint32Array(4959),
+289,
+0
+);
+} catch {}
+try {
+texture57.destroy();
+} catch {}
+let pipeline71 = device3.createRenderPipeline(
+{
+label: '\u0b2f\u0555\u87cf',
+layout: pipelineLayout11,
+vertex: {
+module: shaderModule20,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 4568,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 2012,
+shaderLocation: 24,
+},
+{
+format: 'float32x4',
+offset: 3304,
+shaderLocation: 6,
+},
+{
+format: 'snorm16x4',
+offset: 3132,
+shaderLocation: 8,
+},
+{
+format: 'uint32x4',
+offset: 336,
+shaderLocation: 11,
+},
+{
+format: 'unorm16x2',
+offset: 2588,
+shaderLocation: 3,
+},
+{
+format: 'sint32x4',
+offset: 2428,
+shaderLocation: 17,
+},
+{
+format: 'sint8x4',
+offset: 3060,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 14400,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 13360,
+shaderLocation: 25,
+},
+{
+format: 'sint16x2',
+offset: 8444,
+shaderLocation: 12,
+},
+{
+format: 'float32x2',
+offset: 424,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 96,
+shaderLocation: 21,
+},
+{
+format: 'uint32x3',
+offset: 16392,
+shaderLocation: 13,
+},
+{
+format: 'float32x3',
+offset: 852,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 9168,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 2960,
+attributes: [
+
+],
+},
+{
+arrayStride: 7828,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 492,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 44,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule20,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'constant',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.GREEN,
+},
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2524,
+depthBias: 46,
+depthBiasSlopeScale: 42,
+depthBiasClamp: 24,
+},
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let textureView67 = texture33.createView(
+{
+baseMipLevel: 4,
+}
+);
+let computePassEncoder32 = commandEncoder50.beginComputePass(
+{
+label: '\udb7e\u7ffd\u550d\u0f7d\u{1fdee}\ua4f6\u6a73\u06a8\uabac\ud5d2'
+}
+);
+let renderBundle70 = renderBundleEncoder26.finish(
+{
+label: '\u0390\u0ee4\u0bc4\u23bb\u{1f811}\u71db'
+}
+);
+try {
+renderPassEncoder20.setBindGroup(
+3,
+bindGroup9
+);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder20.setScissorRect(
+1,
+1,
+1,
+0
+);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(
+898
+);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(
+2,
+buffer9
+);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(
+8,
+buffer9,
+24972,
+14020
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline72 = device1.createComputePipeline(
+{
+label: '\u5fbe\u4284\u040a',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule19,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline73 = device1.createRenderPipeline(
+{
+label: '\u0579\u{1fe9e}\uaea7\u0c71\u0f10\u4eb2\uaf42\u02ca\u0f56\u8fb0',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule8,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 32368,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 15412,
+shaderLocation: 26,
+},
+{
+format: 'sint32x3',
+offset: 32144,
+shaderLocation: 24,
+},
+{
+format: 'snorm8x2',
+offset: 13566,
+shaderLocation: 16,
+},
+{
+format: 'unorm8x2',
+offset: 20264,
+shaderLocation: 25,
+},
+{
+format: 'float32x3',
+offset: 5396,
+shaderLocation: 17,
+},
+{
+format: 'float16x2',
+offset: 7636,
+shaderLocation: 1,
+},
+{
+format: 'snorm8x2',
+offset: 6434,
+shaderLocation: 18,
+},
+{
+format: 'sint32x3',
+offset: 29952,
+shaderLocation: 6,
+},
+{
+format: 'uint32',
+offset: 8584,
+shaderLocation: 14,
+},
+{
+format: 'sint8x2',
+offset: 27608,
+shaderLocation: 12,
+},
+{
+format: 'snorm16x4',
+offset: 14120,
+shaderLocation: 13,
+},
+{
+format: 'uint8x4',
+offset: 8632,
+shaderLocation: 5,
+},
+{
+format: 'uint8x2',
+offset: 2458,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 30760,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 23064,
+shaderLocation: 21,
+},
+{
+format: 'uint32x2',
+offset: 19080,
+shaderLocation: 2,
+},
+{
+format: 'sint32x2',
+offset: 3260,
+shaderLocation: 15,
+},
+{
+format: 'snorm16x4',
+offset: 29140,
+shaderLocation: 22,
+},
+{
+format: 'snorm16x4',
+offset: 18172,
+shaderLocation: 10,
+},
+{
+format: 'sint16x2',
+offset: 29708,
+shaderLocation: 27,
+}
+],
+},
+{
+arrayStride: 6704,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32',
+offset: 5148,
+shaderLocation: 20,
+},
+{
+format: 'uint32x4',
+offset: 3948,
+shaderLocation: 23,
+},
+{
+format: 'snorm16x4',
+offset: 1648,
+shaderLocation: 19,
+},
+{
+format: 'sint32x2',
+offset: 5124,
+shaderLocation: 8,
+},
+{
+format: 'sint8x4',
+offset: 4972,
+shaderLocation: 11,
+},
+{
+format: 'uint32x2',
+offset: 2568,
+shaderLocation: 3,
+},
+{
+format: 'sint32x4',
+offset: 5404,
+shaderLocation: 7,
+},
+{
+format: 'float16x2',
+offset: 2224,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 32668,
+attributes: [
+
+],
+},
+{
+arrayStride: 5344,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 37520,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32',
+offset: 4920,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+},
+fragment: {
+module: shaderModule8,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16float',
+writeMask: 0,
+},
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rgba16sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one-minus-constant',
+dstFactor: 'constant'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.BLUE,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'decrement-clamp',
+passOp: 'invert',
+},
+stencilReadMask: 3019,
+stencilWriteMask: 1592,
+depthBias: 96,
+depthBiasClamp: 48,
+},
+}
+);
+let canvas16 = document.createElement('canvas');
+let adapter13 = await navigator.gpu.requestAdapter();
+let renderBundle71 = renderBundleEncoder17.finish();
+try {
+renderPassEncoder23.setBindGroup(
+5,
+bindGroup12
+);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(
+2357
+);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(
+7,
+bindGroup9,
+new Uint32Array(2493),
+1648,
+0
+);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(
+8,
+buffer9,
+10140,
+28304
+);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let shaderModule24 = device3.createShaderModule(
+{
+label: '\u0d48\u9484\u{1fa1e}\u6636\u6220\ud626\ua320\u2b6e\u{1f92f}\u{1f693}',
+code: `@group(1) @binding(5591)
+var<storage, read_write> local30: array<u32>;
+@group(4) @binding(5591)
+var<storage, read_write> field34: array<u32>;
+@group(3) @binding(5591)
+var<storage, read_write> i26: array<u32>;
+
+@compute @workgroup_size(8, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(position) a2: vec4<f32>, @builtin(front_facing) a3: bool) {
+
+}
+
+struct S24 {
+@location(21) f0: vec4<f16>,
+@location(8) f1: vec3<f32>,
+@location(11) f2: f32,
+@location(12) f3: vec2<f32>,
+@location(15) f4: f16,
+@location(10) f5: f32,
+@location(18) f6: vec2<f16>,
+@builtin(vertex_index) f7: u32,
+@location(6) f8: vec4<u32>,
+@location(5) f9: vec3<u32>,
+@builtin(instance_index) f10: u32,
+@location(13) f11: vec3<u32>,
+@location(2) f12: vec4<f16>,
+@location(14) f13: vec2<i32>,
+@location(4) f14: i32,
+@location(7) f15: i32,
+@location(0) f16: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(20) a0: vec2<f32>, @location(16) a1: vec3<f32>, @location(24) a2: f16, @location(3) a3: f32, @location(19) a4: vec4<f16>, @location(9) a5: vec2<f32>, @location(17) a6: vec2<f32>, @location(23) a7: f32, @location(25) a8: i32, @location(22) a9: vec4<u32>, a10: S24, @location(1) a11: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+try {
+computePassEncoder30.setBindGroup(
+3,
+bindGroup15,
+new Uint32Array(1195),
+894,
+0
+);
+} catch {}
+try {
+renderPassEncoder22.setViewport(
+22.22,
+0.3629,
+195.4,
+0.1499,
+0.01639,
+0.8627
+);
+} catch {}
+let arrayBuffer5 = buffer16.getMappedRange(
+4208,
+1152
+);
+let img17 = await imageWithData(229, 118, '#4496d6b7', '#6a02bca8');
+let textureView68 = texture58.createView(
+{
+baseMipLevel: 3,
+baseArrayLayer: 51,
+arrayLayerCount: 65,
+}
+);
+let renderBundleEncoder47 = device3.createRenderBundleEncoder(
+{
+label: '\u8160\u0cb9\u48ed\u330f\u5c34',
+colorFormats: [
+'rg8sint',
+'rg32float',
+'rg16float'
+],
+sampleCount: 437,
+stencilReadOnly: false,
+}
+);
+try {
+renderPassEncoder22.setViewport(
+24.04,
+0.3482,
+203.8,
+0.1447,
+0.6197,
+0.8203
+);
+} catch {}
+try {
+renderPassEncoder22.insertDebugMarker(
+'\u{1f997}'
+);
+} catch {}
+let bindGroupLayout24 = device1.createBindGroupLayout(
+{
+label: '\uddf7\uf1f1\u1197\u0276\u7543\ubb68\u09fe\ucf97\u0d92',
+entries: [
+{
+binding: 3503,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+},
+{
+binding: 1455,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 2804,
+visibility: 0,
+storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '2d-array' },
+}
+],
+}
+);
+try {
+computePassEncoder26.setBindGroup(
+5,
+bindGroup8,
+new Uint32Array(2972),
+343,
+1
+);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(
+8,
+buffer9
+);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(
+7,
+bindGroup1
+);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(
+2,
+buffer6,
+8200,
+503
+);
+} catch {}
+try {
+await buffer14.mapAsync(
+GPUMapMode.WRITE
+);
+} catch {}
+let promise27 = device1.queue.onSubmittedWorkDone();
+let canvas17 = document.createElement('canvas');
+let videoFrame22 = new VideoFrame(canvas16, {timestamp: 0});
+let renderBundle72 = renderBundleEncoder43.finish(
+{
+
+}
+);
+try {
+renderPassEncoder22.setViewport(
+43.53,
+0.7616,
+150.6,
+0.2075,
+0.1055,
+0.4147
+);
+} catch {}
+try {
+renderBundleEncoder47.setBindGroup(
+0,
+bindGroup14
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture53,
+  mipLevel: 3,
+  origin: { x: 4, y: 0, z: 3 },
+  aspect: 'all',
+},
+new ArrayBuffer(385845),
+/* required buffer size: 385845 */{
+offset: 453,
+bytesPerRow: 222,
+rowsPerImage: 217,
+},
+{width: 54, height: 0, depthOrArrayLayers: 9}
+);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+await adapter7.requestAdapterInfo();
+} catch {}
+let device4 = await promise12;
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+let offscreenCanvas25 = new OffscreenCanvas(816, 607);
+let texture60 = device4.createTexture(
+{
+size: {width: 2322, height: 127, depthOrArrayLayers: 39},
+mipLevelCount: 10,
+dimension: '2d',
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2unorm'
+],
+}
+);
+gc();
+let img18 = await imageWithData(90, 192, '#75eafe33', '#343e993c');
+let video23 = await videoWithData();
+let texture61 = device3.createTexture(
+{
+label: '\u{1f629}\u47e1\u07e5\u0dd8\ud36e\u{1fe4b}\u{1f767}\uca7e\uf01b',
+size: [242, 1, 203],
+mipLevelCount: 4,
+sampleCount: 1,
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rg8unorm',
+'rg8unorm',
+'rg8unorm'
+],
+}
+);
+try {
+renderPassEncoder22.setBindGroup(
+4,
+bindGroup15,
+new Uint32Array(4228),
+732,
+0
+);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(
+1,
+bindGroup15,
+new Uint32Array(3543),
+1491,
+0
+);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+canvas14.width = 536;
+try {
+device2.label = '\u4c3f\u31d9';
+} catch {}
+let device5 = await promise21;
+try {
+canvas16.getContext('webgpu');
+} catch {}
+video20.height = 271;
+let renderBundleEncoder48 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16float',
+'rgb10a2unorm',
+'r32uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 254,
+stencilReadOnly: true,
+}
+);
+let renderBundle73 = renderBundleEncoder21.finish(
+{
+label: '\u0a29\u{1fe57}\u6f29\uaf33\u3edf\u0dc4\u06f2\u0ebd'
+}
+);
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder24.setScissorRect(
+762,
+1,
+759,
+0
+);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(
+1,
+buffer9,
+96,
+34806
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+6204,
+new Float32Array(7240),
+1518,
+1484
+);
+} catch {}
+let promise28 = device1.createComputePipelineAsync(
+{
+label: '\u5796\u3293\ue436\u0688\ub977\uef73\u{1ff40}\ude52',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+},
+}
+);
+let shaderModule25 = device3.createShaderModule(
+{
+label: '\u{1ffc0}\u0cad',
+code: `@group(2) @binding(5591)
+var<storage, read_write> function43: array<u32>;
+@group(4) @binding(5591)
+var<storage, read_write> global32: array<u32>;
+@group(1) @binding(5591)
+var<storage, read_write> local31: array<u32>;
+
+@compute @workgroup_size(4, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: i32,
+@location(6) f1: vec4<i32>,
+@location(5) f2: vec3<i32>,
+@location(4) f3: f32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S25 {
+@location(18) f0: vec3<i32>,
+@location(25) f1: i32,
+@builtin(vertex_index) f2: u32,
+@location(12) f3: f32
+}
+
+@vertex
+fn vertex0(@location(16) a0: vec4<i32>, @location(2) a1: vec3<f16>, @location(10) a2: vec3<f32>, @location(23) a3: vec3<f16>, @location(5) a4: vec4<f32>, @location(9) a5: vec4<f16>, @location(15) a6: vec2<i32>, @builtin(instance_index) a7: u32, a8: S25, @location(6) a9: vec3<f16>, @location(20) a10: vec4<f16>, @location(17) a11: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let pipelineLayout12 = device3.createPipelineLayout(
+{
+label: '\u4415\u0fb4\u173a\u5185\u{1f818}\ufebe',
+bindGroupLayouts: [
+bindGroupLayout22,
+bindGroupLayout22,
+bindGroupLayout22,
+bindGroupLayout22
+]
+}
+);
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder22.setViewport(
+235.0,
+0.4302,
+5.670,
+0.07851,
+0.5093,
+0.6020
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture61,
+  mipLevel: 0,
+  origin: { x: 24, y: 0, z: 87 },
+  aspect: 'all',
+},
+new ArrayBuffer(72),
+/* required buffer size: 874419 */{
+offset: 51,
+bytesPerRow: 396,
+rowsPerImage: 32,
+},
+{width: 109, height: 0, depthOrArrayLayers: 70}
+);
+} catch {}
+let pipeline74 = device3.createRenderPipeline(
+{
+label: '\u7ecf\ue6f9',
+layout: pipelineLayout11,
+vertex: {
+module: shaderModule25,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 13916,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32',
+offset: 1132,
+shaderLocation: 25,
+},
+{
+format: 'snorm8x4',
+offset: 9004,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x4',
+offset: 1236,
+shaderLocation: 20,
+},
+{
+format: 'float32x4',
+offset: 9236,
+shaderLocation: 12,
+},
+{
+format: 'sint8x2',
+offset: 7474,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x4',
+offset: 1092,
+shaderLocation: 6,
+},
+{
+format: 'snorm16x4',
+offset: 12352,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x2',
+offset: 8084,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 11972,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 11030,
+shaderLocation: 5,
+},
+{
+format: 'sint16x4',
+offset: 9464,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x4',
+offset: 5028,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 11360,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x2',
+offset: 7128,
+shaderLocation: 16,
+},
+{
+format: 'float16x4',
+offset: 700,
+shaderLocation: 17,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule25,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16sint',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'always',
+failOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+},
+stencilReadMask: 3399,
+stencilWriteMask: 3985,
+depthBias: 92,
+depthBiasSlopeScale: 73,
+depthBiasClamp: 35,
+},
+}
+);
+let commandEncoder57 = device5.createCommandEncoder();
+let computePassEncoder33 = commandEncoder57.beginComputePass(
+{
+label: '\u757c\u{1fd34}\u8505\u0c04'
+}
+);
+let promise29 = device5.queue.onSubmittedWorkDone();
+let gpuCanvasContext20 = offscreenCanvas25.getContext('webgpu');
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+try {
+canvas17.getContext('webgl');
+} catch {}
+let renderBundle74 = renderBundleEncoder15.finish(
+{
+label: '\u{1fbc3}\u0148\u9da9\ua1bf\u05b3'
+}
+);
+try {
+renderPassEncoder18.setBindGroup(
+8,
+bindGroup12,
+new Uint32Array(2474),
+2288,
+0
+);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(658);
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(
+411,
+0,
+859,
+1
+);
+} catch {}
+try {
+renderPassEncoder18.setViewport(
+501.9,
+0.9260,
+180.3,
+0.02571,
+0.7505,
+0.8855
+);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(
+5,
+buffer6,
+900,
+6054
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture34,
+  mipLevel: 2,
+  origin: { x: 0, y: 4, z: 1 },
+  aspect: 'all',
+},
+new Uint32Array(arrayBuffer1),
+/* required buffer size: 508 */{
+offset: 508,
+bytesPerRow: 224,
+},
+{width: 4, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let device6 = await adapter13.requestDevice({
+label: '\uec6e\ubbde\u46e6\u{1fefd}\u583c\u{1f94c}\u93af',
+requiredLimits: {
+maxBindGroups: 6,
+maxColorAttachmentBytesPerSample: 53,
+maxVertexAttributes: 23,
+maxVertexBufferArrayStride: 58239,
+maxStorageTexturesPerShaderStage: 39,
+maxStorageBuffersPerShaderStage: 37,
+maxDynamicStorageBuffersPerPipelineLayout: 26269,
+maxBindingsPerBindGroup: 3477,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 10034,
+maxTextureDimension2D: 10365,
+maxVertexBuffers: 11,
+maxUniformBufferBindingSize: 255911313,
+maxUniformBuffersPerShaderStage: 22,
+maxInterStageShaderVariables: 100,
+maxInterStageShaderComponents: 64,
+},
+});
+try {
+adapter10.label = '\uae33\u6868\u99a4\ueb04\u07c2\u09a8\ua421\u0639\ufa5d\ua97a';
+} catch {}
+let commandEncoder58 = device4.createCommandEncoder(
+{
+label: '\u50fd\u{1f848}\u5c38',
+}
+);
+let commandBuffer4 = commandEncoder58.finish(
+{
+label: '\ube0a\ub9cc\u3d6c',
+}
+);
+let sampler75 = device4.createSampler(
+{
+label: '\u{1fe6f}\u03ad\ue531\u{1f9b2}\u2cdc\u9ba8\u{1ff17}\uee20',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 65.409,
+lodMaxClamp: 98.204,
+maxAnisotropy: 19,
+}
+);
+try {
+gpuCanvasContext12.configure(
+{
+device: device4,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8unorm',
+'rgba16float',
+'rgba16float'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let buffer20 = device1.createBuffer(
+{
+label: '\ua57f\uf418',
+size: 6409,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: false,
+}
+);
+let querySet53 = device1.createQuerySet({
+label: '\u04ce\u{1f93e}\u3c0b\u082a\u1fcb\u{1f985}\u{1f7a5}\u0f6a\uc559',
+type: 'occlusion',
+count: 2185,
+});
+try {
+renderPassEncoder23.setViewport(
+0.04742,
+0.5855,
+0.8926,
+0.07658,
+0.3486,
+0.6165
+);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(
+0,
+buffer9,
+13620,
+13670
+);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(
+1,
+bindGroup1,
+[]
+);
+} catch {}
+let pipeline75 = await device1.createComputePipelineAsync(
+{
+label: '\uaedc\uc028\u4635\u98bb\uca3a\u4909\u{1f723}\u48df\u06f5\u331f',
+layout: pipelineLayout4,
+compute: {
+module: shaderModule19,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder59 = device4.createCommandEncoder(
+{
+label: '\u0f78\u081c\u38f3\u1dde\u0b20\u{1f65c}\uc350\u07e4\u79e8',
+}
+);
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let imageBitmap18 = await createImageBitmap(imageBitmap9);
+let shaderModule26 = device3.createShaderModule(
+{
+code: `@group(3) @binding(5591)
+var<storage, read_write> i27: array<u32>;
+@group(2) @binding(5591)
+var<storage, read_write> function44: array<u32>;
+@group(1) @binding(5591)
+var<storage, read_write> local32: array<u32>;
+@group(0) @binding(5591)
+var<storage, read_write> type38: array<u32>;
+
+@compute @workgroup_size(6, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S27 {
+@location(70) f0: vec4<i32>,
+@location(50) f1: u32,
+@location(37) f2: vec3<i32>,
+@location(83) f3: vec4<i32>,
+@location(23) f4: vec4<f32>,
+@location(1) f5: i32,
+@location(18) f6: vec3<f16>,
+@location(44) f7: vec2<i32>,
+@location(74) f8: vec3<i32>,
+@location(88) f9: vec3<i32>,
+@location(69) f10: u32,
+@location(30) f11: f16,
+@location(19) f12: vec3<i32>,
+@location(59) f13: vec2<u32>
+}
+struct FragmentOutput0 {
+@location(3) f0: vec2<f32>,
+@location(7) f1: vec4<f32>,
+@location(1) f2: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(56) a0: vec3<f16>, @location(79) a1: vec3<f32>, @location(32) a2: i32, @location(7) a3: i32, @location(55) a4: vec2<f16>, @builtin(sample_index) a5: u32, @location(62) a6: vec3<i32>, @location(85) a7: vec3<i32>, @location(4) a8: vec2<f32>, @location(63) a9: vec2<f16>, @location(78) a10: vec3<i32>, @location(68) a11: vec4<f32>, @location(10) a12: i32, @location(36) a13: f16, @location(84) a14: vec4<f16>, @location(31) a15: vec3<f16>, @location(71) a16: f32, @location(29) a17: vec4<f32>, @location(73) a18: vec4<i32>, @builtin(front_facing) a19: bool, @location(28) a20: vec3<f16>, a21: S27, @location(26) a22: vec2<u32>, @location(47) a23: vec4<i32>, @location(38) a24: f32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S26 {
+@location(7) f0: vec3<f16>,
+@location(6) f1: vec3<i32>,
+@location(1) f2: vec4<f32>,
+@location(5) f3: f32,
+@location(15) f4: vec2<u32>,
+@builtin(vertex_index) f5: u32,
+@location(17) f6: vec4<f32>,
+@location(24) f7: vec3<u32>,
+@location(8) f8: vec2<i32>,
+@location(9) f9: f32,
+@location(14) f10: vec4<u32>,
+@location(25) f11: f16,
+@location(13) f12: vec4<u32>,
+@location(10) f13: vec3<i32>,
+@location(2) f14: f16,
+@location(18) f15: vec3<f32>,
+@location(11) f16: i32,
+@location(4) f17: vec3<i32>,
+@location(23) f18: vec2<f16>,
+@location(16) f19: vec4<f32>,
+@location(19) f20: vec3<u32>
+}
+struct VertexOutput0 {
+@location(69) f198: u32,
+@location(37) f199: vec3<i32>,
+@location(68) f200: vec4<f32>,
+@location(56) f201: vec3<f16>,
+@location(73) f202: vec4<i32>,
+@location(36) f203: f16,
+@location(88) f204: vec3<i32>,
+@location(74) f205: vec3<i32>,
+@location(83) f206: vec4<i32>,
+@location(7) f207: i32,
+@location(55) f208: vec2<f16>,
+@location(28) f209: vec3<f16>,
+@location(62) f210: vec3<i32>,
+@location(4) f211: vec2<f32>,
+@location(59) f212: vec2<u32>,
+@location(70) f213: vec4<i32>,
+@location(79) f214: vec3<f32>,
+@location(84) f215: vec4<f16>,
+@location(1) f216: i32,
+@location(6) f217: f32,
+@location(58) f218: u32,
+@location(15) f219: f32,
+@location(50) f220: u32,
+@location(47) f221: vec4<i32>,
+@location(40) f222: u32,
+@location(66) f223: vec3<u32>,
+@location(32) f224: i32,
+@location(19) f225: vec3<i32>,
+@location(78) f226: vec3<i32>,
+@location(26) f227: vec2<u32>,
+@location(18) f228: vec3<f16>,
+@location(63) f229: vec2<f16>,
+@location(44) f230: vec2<i32>,
+@location(42) f231: vec4<f32>,
+@location(71) f232: f32,
+@location(23) f233: vec4<f32>,
+@location(29) f234: vec4<f32>,
+@location(61) f235: vec3<f16>,
+@location(31) f236: vec3<f16>,
+@location(10) f237: i32,
+@location(85) f238: vec3<i32>,
+@location(76) f239: vec2<i32>,
+@builtin(position) f240: vec4<f32>,
+@location(38) f241: f32,
+@location(30) f242: f16
+}
+
+@vertex
+fn vertex0(@location(21) a0: vec4<i32>, a1: S26, @location(0) a2: vec2<f16>, @location(22) a3: vec2<f32>, @location(12) a4: vec3<f32>, @location(20) a5: vec4<u32>, @location(3) a6: vec2<f16>, @builtin(instance_index) a7: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+}
+);
+let bindGroupLayout25 = device3.createBindGroupLayout(
+{
+label: '\uce42\u2157\ub7cc\u0856\ub6fb\u{1fc20}\u0329\u{1fba0}\u{1f7e8}\u{1fb3e}\u04c7',
+entries: [
+
+],
+}
+);
+let renderBundle75 = renderBundleEncoder47.finish(
+{
+label: '\u576f\u03d2\u0127\u3284\ub5e4\u{1ff47}\u1c60'
+}
+);
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder22.setStencilReference(
+3225
+);
+} catch {}
+try {
+device3.queue.submit([
+commandBuffer3,
+]);
+} catch {}
+let texture62 = device5.createTexture(
+{
+label: '\u8ef0\ua8ba\ud400\u{1ff81}\u{1f891}\u5971\uce71\u0ff4\u073d\u10e0\uf022',
+size: [6157, 46, 152],
+mipLevelCount: 7,
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'r16uint',
+'r16uint',
+'r16uint'
+],
+}
+);
+let textureView69 = texture62.createView(
+{
+label: '\u9b55\u{1f9bc}\ucb8a\u{1ff76}\u4951\u{1fcc2}\ud00e\u0314\ue204\u{1fda5}\u7d38',
+dimension: '2d',
+baseMipLevel: 3,
+mipLevelCount: 1,
+baseArrayLayer: 15,
+arrayLayerCount: 1,
+}
+);
+try {
+device5.addEventListener('uncapturederror', e => { log('device5.uncapturederror'); log(e); e.label = device5.label; });
+} catch {}
+let querySet54 = device3.createQuerySet({
+label: '\ufd7f\u{1fef0}\u{1fd50}\u1179\ucd71\u7ec1\ucbd5',
+type: 'occlusion',
+count: 940,
+});
+let renderBundleEncoder49 = device3.createRenderBundleEncoder(
+{
+label: '\u5044\u0bb9\u7842',
+colorFormats: [
+'r32float',
+'r32float',
+'rg16sint',
+'bgra8unorm-srgb',
+'r32sint',
+'rg32sint',
+'r8sint'
+],
+sampleCount: 15,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder22.setViewport(
+65.06,
+0.09930,
+32.00,
+0.6494,
+0.2682,
+0.8931
+);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(
+1,
+bindGroup15
+);
+} catch {}
+try {
+gpuCanvasContext13.configure(
+{
+device: device3,
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture62,
+  mipLevel: 4,
+  origin: { x: 31, y: 1, z: 9 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer2),
+/* required buffer size: 3266542 */{
+offset: 622,
+bytesPerRow: 648,
+rowsPerImage: 42,
+},
+{width: 256, height: 0, depthOrArrayLayers: 121}
+);
+} catch {}
+let querySet55 = device5.createQuerySet({
+label: '\u{1f895}\u{1fa34}\u2c9b\u{1ff09}\u5e26\ue1d8\u62af',
+type: 'occlusion',
+count: 2349,
+});
+try {
+querySet55.destroy();
+} catch {}
+let texture63 = device4.createTexture(
+{
+label: '\u0f3b\u{1fbed}\u{1f6e3}\u05b2\u5f67\ue56e',
+size: [196, 1, 1643],
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let texture64 = gpuCanvasContext13.getCurrentTexture();
+try {
+device4.queue.submit([
+commandBuffer4,
+]);
+} catch {}
+pseudoSubmit(device3, commandEncoder55);
+let renderBundle76 = renderBundleEncoder41.finish(
+{
+label: '\u06d0\ue156\u{1ff5d}\u{1f772}\u{1fc18}\u01b0\u0bc1\u{1fa2f}'
+}
+);
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline76 = await device3.createRenderPipelineAsync(
+{
+label: '\u{1f687}\u2329\ud238\uf37f',
+layout: pipelineLayout12,
+vertex: {
+module: shaderModule21,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 13324,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 1780,
+shaderLocation: 0,
+},
+{
+format: 'uint8x4',
+offset: 3652,
+shaderLocation: 25,
+},
+{
+format: 'sint8x4',
+offset: 8052,
+shaderLocation: 5,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 2648,
+shaderLocation: 1,
+},
+{
+format: 'sint16x2',
+offset: 3980,
+shaderLocation: 3,
+},
+{
+format: 'sint32x2',
+offset: 11220,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x4',
+offset: 12384,
+shaderLocation: 23,
+},
+{
+format: 'uint16x4',
+offset: 12644,
+shaderLocation: 10,
+},
+{
+format: 'sint16x2',
+offset: 3716,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x4',
+offset: 2964,
+shaderLocation: 17,
+},
+{
+format: 'uint32x2',
+offset: 9468,
+shaderLocation: 7,
+},
+{
+format: 'float16x2',
+offset: 5348,
+shaderLocation: 16,
+},
+{
+format: 'uint16x4',
+offset: 5844,
+shaderLocation: 4,
+},
+{
+format: 'unorm16x4',
+offset: 11244,
+shaderLocation: 9,
+},
+{
+format: 'uint16x4',
+offset: 7968,
+shaderLocation: 19,
+},
+{
+format: 'float32',
+offset: 7712,
+shaderLocation: 24,
+}
+],
+},
+{
+arrayStride: 9088,
+attributes: [
+{
+format: 'uint32x3',
+offset: 7224,
+shaderLocation: 13,
+},
+{
+format: 'uint16x4',
+offset: 216,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 6704,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32',
+offset: 6108,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule21,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'rg16sint',
+},
+{
+format: 'rg32float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r8uint',
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'less',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'always',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilWriteMask: 2475,
+depthBias: 93,
+depthBiasSlopeScale: 21,
+depthBiasClamp: 32,
+},
+}
+);
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let offscreenCanvas26 = new OffscreenCanvas(1023, 645);
+try {
+offscreenCanvas26.getContext('webgpu');
+} catch {}
+let querySet56 = device4.createQuerySet({
+type: 'occlusion',
+count: 1255,
+});
+let commandBuffer5 = commandEncoder59.finish(
+{
+}
+);
+let renderBundleEncoder50 = device4.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8sint',
+undefined,
+'rgba16uint',
+'bgra8unorm',
+'rg8sint',
+'r16uint',
+'rg16float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 136,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder50.setVertexBuffer(
+27,
+undefined,
+804053297,
+2730796036
+);
+} catch {}
+try {
+await promise29;
+} catch {}
+let video24 = await videoWithData();
+try {
+renderBundleEncoder50.setVertexBuffer(
+16,
+undefined,
+2369133106,
+1256595744
+);
+} catch {}
+try {
+device4.queue.submit([
+commandBuffer5,
+]);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture64,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(2),
+/* required buffer size: 2 */{
+offset: 2,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await promise27;
+} catch {}
+try {
+await adapter12.requestAdapterInfo();
+} catch {}
+let commandEncoder60 = device3.createCommandEncoder(
+{
+label: '\ud6b3\u{1f94f}\ub807\u3a16\u0b62',
+}
+);
+let textureView70 = texture57.createView(
+{
+label: '\u9438\ue91f',
+baseMipLevel: 5,
+mipLevelCount: 1,
+}
+);
+let computePassEncoder34 = commandEncoder60.beginComputePass();
+try {
+renderPassEncoder22.setViewport(
+3.305,
+0.8628,
+14.42,
+0.1065,
+0.6632,
+0.6829
+);
+} catch {}
+try {
+renderPassEncoder22.insertDebugMarker(
+'\uda1a'
+);
+} catch {}
+let pipeline77 = device3.createComputePipeline(
+{
+label: '\u0ed9\u{1f62f}',
+layout: pipelineLayout12,
+compute: {
+module: shaderModule23,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder61 = device6.createCommandEncoder(
+{
+}
+);
+let computePassEncoder35 = commandEncoder61.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder51 = device6.createRenderBundleEncoder(
+{
+label: '\u7ca8\u0bd0\ub5a1\u07d0\u{1fd57}\u0c5a',
+colorFormats: [
+'r8unorm',
+'rg16uint',
+'rg32float',
+'r16sint',
+'r32float',
+'bgra8unorm',
+undefined,
+'rg32sint'
+],
+sampleCount: 19,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder35.end();
+} catch {}
+try {
+device6.label = '\ud41d\u{1fbd8}\u0dcc\u0959\u0d4b\u{1f98f}\u023f\u{1faa7}\udf96';
+} catch {}
+let querySet57 = device6.createQuerySet({
+label: '\u0994\u0f58\u7298',
+type: 'occlusion',
+count: 1334,
+});
+let renderBundle77 = renderBundleEncoder51.finish(
+{
+label: '\u7b5a\uab4b\u07bf\u018e'
+}
+);
+let sampler76 = device6.createSampler(
+{
+label: '\ud2c8\ue8ea\u2ddc\u59c1\u5de1',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 61.914,
+lodMaxClamp: 76.169,
+maxAnisotropy: 4,
+}
+);
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let pipelineLayout13 = device1.createPipelineLayout(
+{
+label: '\ua7b3\u58a0\u{1f93f}\u0ff1\u{1f8ab}\u3efe\u0d3c',
+bindGroupLayouts: [
+bindGroupLayout12
+]
+}
+);
+let buffer21 = device1.createBuffer(
+{
+label: '\ue92c\u136c\u9256\u{1fa43}\u00f7',
+size: 47154,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandEncoder62 = device1.createCommandEncoder(
+{
+label: '\u{1feff}\u00ae\ub7e4\u4571\u31ea',
+}
+);
+let querySet58 = device1.createQuerySet({
+label: '\u0363\u0ae8\u{1fa65}\u79b4\u433c\u{1f72c}\u41b2\ue9ff',
+type: 'occlusion',
+count: 3446,
+});
+try {
+renderPassEncoder18.beginOcclusionQuery(2009);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(
+1,
+buffer6,
+6156,
+2207
+);
+} catch {}
+try {
+commandEncoder62.clearBuffer(
+buffer13
+);
+dissociateBuffer(device1, buffer13);
+} catch {}
+try {
+commandEncoder62.resolveQuerySet(
+querySet50,
+983,
+13,
+buffer7,
+7424
+);
+} catch {}
+try {
+device1.queue.writeBuffer(
+buffer7,
+488,
+new BigUint64Array(36464),
+26373,
+96
+);
+} catch {}
+let pipeline78 = await promise28;
+try {
+device1.destroy();
+} catch {}
+let canvas18 = document.createElement('canvas');
+let imageData23 = new ImageData(16, 32);
+try {
+device4.queue.writeTexture(
+{
+  texture: texture64,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(756),
+/* required buffer size: 756 */{
+offset: 756,
+bytesPerRow: 32,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+gc();
+let commandBuffer6 = commandEncoder61.finish(
+{
+label: '\u{1ff14}\u0431\u8a29\u{1f668}\u{1f85d}\ub432\ud6f1',
+}
+);
+let texture65 = device6.createTexture(
+{
+label: '\u{1fadf}\u1229\u{1f83c}',
+size: [192, 1, 113],
+mipLevelCount: 7,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'depth32float',
+'depth32float'
+],
+}
+);
+let renderBundle78 = renderBundleEncoder51.finish(
+{
+label: '\u{1fa9a}\ue070\u8a8f\u5bda\uf13a\u3193'
+}
+);
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let canvas19 = document.createElement('canvas');
+let imageData24 = new ImageData(176, 48);
+let promise30 = adapter11.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 52,
+maxVertexBufferArrayStride: 39820,
+maxStorageTexturesPerShaderStage: 43,
+maxStorageBuffersPerShaderStage: 21,
+maxDynamicStorageBuffersPerPipelineLayout: 37079,
+maxBindingsPerBindGroup: 5673,
+maxTextureDimension1D: 14014,
+maxTextureDimension2D: 14739,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 192112610,
+maxUniformBuffersPerShaderStage: 26,
+maxInterStageShaderComponents: 97,
+},
+});
+let renderBundle79 = renderBundleEncoder51.finish(
+{
+label: '\u069f\u6cdd\u{1febd}\u{1f943}\u25e5\u{1f9a4}\u{1f8f4}\u0609\u8d57\uc1ca'
+}
+);
+let sampler77 = device6.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+lodMinClamp: 22.921,
+}
+);
+let querySet59 = device5.createQuerySet({
+label: '\u2376\u11f0\u{1f782}\ubcce\u{1fd06}',
+type: 'occlusion',
+count: 965,
+});
+let renderBundleEncoder52 = device5.createRenderBundleEncoder(
+{
+label: '\u{1fca8}\ua77d\u0002\u2b4f\u7124\uc376\ud19a\u04da',
+colorFormats: [
+'rgba16uint',
+undefined,
+'rg16float',
+'rg32float'
+],
+sampleCount: 745,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+offscreenCanvas1.width = 198;
+let offscreenCanvas27 = new OffscreenCanvas(774, 65);
+let imageBitmap19 = await createImageBitmap(imageBitmap17);
+let textureView71 = texture62.createView(
+{
+label: '\u06cf\ufff4\u053d\ub26a\ud8ba\ubf50\u006e',
+dimension: '2d',
+aspect: 'all',
+baseMipLevel: 4,
+mipLevelCount: 2,
+baseArrayLayer: 49,
+}
+);
+let imageData25 = new ImageData(108, 184);
+try {
+canvas18.getContext('webgl2');
+} catch {}
+let buffer22 = device5.createBuffer(
+{
+label: '\u{1fc9c}\uf34c\u{1faff}\u32a9\ua45b\ua989',
+size: 59817,
+usage: GPUBufferUsage.VERTEX,
+mappedAtCreation: false,
+}
+);
+let textureView72 = texture62.createView(
+{
+label: '\u{1fc3e}\u0779\ua492',
+dimension: '2d-array',
+baseMipLevel: 5,
+baseArrayLayer: 93,
+arrayLayerCount: 52,
+}
+);
+let sampler78 = device5.createSampler(
+{
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 68.798,
+lodMaxClamp: 97.842,
+}
+);
+let promise31 = device5.queue.onSubmittedWorkDone();
+try {
+await promise31;
+} catch {}
+let commandEncoder63 = device3.createCommandEncoder(
+{
+label: '\u{1f992}\u29cf\ua5cb\u3561\u{1f989}\u0434\uf7d3\ud0a6\u{1f8ea}',
+}
+);
+let renderBundle80 = renderBundleEncoder49.finish();
+try {
+computePassEncoder34.setPipeline(
+pipeline77
+);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(
+4,
+bindGroup14
+);
+} catch {}
+try {
+device3.pushErrorScope('out-of-memory');
+} catch {}
+let arrayBuffer6 = buffer16.getMappedRange(
+5360,
+32
+);
+let gpuCanvasContext21 = canvas19.getContext('webgpu');
+let gpuCanvasContext22 = offscreenCanvas27.getContext('webgpu');
+document.body.prepend(video9);
+let bindGroup16 = device3.createBindGroup({
+label: '\u2eed\udf8d\u145b\u6645\u15ee\u9042\ud4f1\u45f7',
+layout: bindGroupLayout25,
+entries: [
+
+],
+});
+let texture66 = device3.createTexture(
+{
+label: '\ud69b\u0d4f\u{1f846}\u8beb\u0388\uf5f7',
+size: {width: 3590, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgb9e5ufloat',
+'rgb9e5ufloat'
+],
+}
+);
+try {
+renderBundleEncoder44.setBindGroup(
+1,
+bindGroup15,
+new Uint32Array(6359),
+4474,
+0
+);
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+commandEncoder63.clearBuffer(
+buffer16
+);
+dissociateBuffer(device3, buffer16);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture53,
+  mipLevel: 1,
+  origin: { x: 1, y: 1, z: 8 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer2),
+/* required buffer size: 10086714 */{
+offset: 714,
+bytesPerRow: 984,
+rowsPerImage: 125,
+},
+{width: 240, height: 0, depthOrArrayLayers: 83}
+);
+} catch {}
+let imageData26 = new ImageData(216, 256);
+try {
+adapter13.label = '\ua12c\u{1fd28}\u50b5\u01d9\u{1f80f}\u1df6\u4587\u4eae\ub9db\u044f';
+} catch {}
+let texture67 = device3.createTexture(
+{
+label: '\u61c0\u8b52\u0e84\u520f',
+size: [5807],
+dimension: '1d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let computePassEncoder36 = commandEncoder63.beginComputePass(
+{
+label: '\u0446\u6d5d\ufa30\u3bd5\u3a83\u{1fc91}\u{1fb92}'
+}
+);
+let renderBundleEncoder53 = device3.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg32float',
+'rg8sint',
+'r16sint',
+'rg32uint',
+'r32float',
+'rg16uint',
+'r16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 873,
+depthReadOnly: true,
+}
+);
+let sampler79 = device3.createSampler(
+{
+label: '\u{1fbc6}\ue872\u044e\ucbf8\u84ec\ub829\u{1f956}\u1ec9\u071b\u7238',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 80.305,
+lodMaxClamp: 90.756,
+}
+);
+try {
+renderBundleEncoder44.setBindGroup(
+4,
+bindGroup16
+);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(
+4,
+bindGroup16,
+new Uint32Array(9861),
+9548,
+0
+);
+} catch {}
+let pipeline79 = device3.createRenderPipeline(
+{
+label: '\u{1fa1e}\u9f07\u{1f786}\uf0f2\u02ae\u1152\ufa0e\u3e78',
+layout: pipelineLayout11,
+vertex: {
+module: shaderModule24,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 2328,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 1852,
+shaderLocation: 19,
+},
+{
+format: 'float16x4',
+offset: 1860,
+shaderLocation: 12,
+},
+{
+format: 'uint32',
+offset: 2140,
+shaderLocation: 13,
+},
+{
+format: 'sint8x2',
+offset: 2188,
+shaderLocation: 25,
+},
+{
+format: 'float32x4',
+offset: 1304,
+shaderLocation: 15,
+},
+{
+format: 'uint32',
+offset: 2036,
+shaderLocation: 22,
+}
+],
+},
+{
+arrayStride: 940,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 350,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x2',
+offset: 114,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x2',
+offset: 62,
+shaderLocation: 16,
+},
+{
+format: 'float32x2',
+offset: 56,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 5852,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x3',
+offset: 5704,
+shaderLocation: 6,
+},
+{
+format: 'unorm8x2',
+offset: 2550,
+shaderLocation: 9,
+},
+{
+format: 'sint32x4',
+offset: 4052,
+shaderLocation: 4,
+},
+{
+format: 'sint32x4',
+offset: 48,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x2',
+offset: 4600,
+shaderLocation: 24,
+},
+{
+format: 'float32x3',
+offset: 4988,
+shaderLocation: 20,
+},
+{
+format: 'unorm8x2',
+offset: 5400,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x2',
+offset: 5674,
+shaderLocation: 8,
+},
+{
+format: 'snorm16x2',
+offset: 3608,
+shaderLocation: 21,
+},
+{
+format: 'uint32',
+offset: 472,
+shaderLocation: 1,
+},
+{
+format: 'sint8x2',
+offset: 2170,
+shaderLocation: 14,
+},
+{
+format: 'float32x4',
+offset: 3640,
+shaderLocation: 11,
+},
+{
+format: 'float32x3',
+offset: 1756,
+shaderLocation: 23,
+}
+],
+},
+{
+arrayStride: 16608,
+attributes: [
+{
+format: 'unorm8x4',
+offset: 2972,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 15700,
+attributes: [
+{
+format: 'uint32x4',
+offset: 9384,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 8508,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 10004,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 10772,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 540,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 64,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+},
+}
+);
+let imageData27 = new ImageData(168, 200);
+try {
+adapter8.label = '\u05aa\u{1f60b}\uc2ce';
+} catch {}
+let promise32 = adapter7.requestDevice({
+label: '\u0b08\u{1f741}\u{1f8c4}\u881f\u{1ffcc}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 8,
+maxColorAttachmentBytesPerSample: 60,
+maxVertexAttributes: 25,
+maxVertexBufferArrayStride: 61581,
+maxStorageTexturesPerShaderStage: 9,
+maxStorageBuffersPerShaderStage: 16,
+maxDynamicStorageBuffersPerPipelineLayout: 54859,
+maxBindingsPerBindGroup: 1339,
+maxTextureDimension1D: 10039,
+maxTextureDimension2D: 13759,
+minStorageBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 59862826,
+maxUniformBuffersPerShaderStage: 36,
+maxInterStageShaderVariables: 41,
+maxInterStageShaderComponents: 82,
+maxSamplersPerShaderStage: 20,
+},
+});
+let commandEncoder64 = device4.createCommandEncoder(
+{
+label: '\uee97\ud4d3\u0544',
+}
+);
+let imageBitmap20 = await createImageBitmap(imageData4);
+let texture68 = device4.createTexture(
+{
+label: '\u0c6b\uaba6\u{1fba8}\u0436',
+size: [90, 1, 979],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'r16uint',
+'r16uint',
+'r16uint'
+],
+}
+);
+let textureView73 = texture60.createView(
+{
+label: '\u92c0\u684d\u01a7\ucc42\udbd3\u61bc\u3489\u05c0\u0cb3\u0c1b\ud7b6',
+dimension: '2d',
+baseMipLevel: 4,
+mipLevelCount: 5,
+baseArrayLayer: 34,
+}
+);
+try {
+renderBundleEncoder50.insertDebugMarker(
+'\u{1f80e}'
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture64,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer0),
+/* required buffer size: 853 */{
+offset: 853,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let renderBundleEncoder54 = device3.createRenderBundleEncoder(
+{
+colorFormats: [
+'bgra8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 595,
+depthReadOnly: true,
+}
+);
+let renderBundle81 = renderBundleEncoder47.finish(
+{
+label: '\u{1fde1}\uf188\u3659\uabba\udd37\uafdb\u0a17\u{1fbad}\u6bfe\udae6'
+}
+);
+let sampler80 = device3.createSampler(
+{
+label: '\u00a5\u69cd\u0ef9\u6688\u0af5',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'linear',
+lodMinClamp: 22.247,
+lodMaxClamp: 67.655,
+compare: 'equal',
+}
+);
+try {
+renderPassEncoder22.beginOcclusionQuery(3222);
+} catch {}
+try {
+renderPassEncoder22.setStencilReference(
+1430
+);
+} catch {}
+try {
+renderPassEncoder22.setViewport(
+57.12,
+0.2184,
+3.962,
+0.4658,
+0.5526,
+0.6117
+);
+} catch {}
+gc();
+try {
+renderBundleEncoder52.setVertexBuffer(
+2,
+buffer22,
+21108
+);
+} catch {}
+let commandBuffer7 = commandEncoder64.finish(
+{
+label: '\u{1f6fe}\u0b26\ub563\u1fb9\u{1ff3d}\u{1fd6d}\uf863\u0f08\u67e3',
+}
+);
+let sampler81 = device4.createSampler(
+{
+label: '\u21c9\u5230\u1f88\u080e',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 29.107,
+lodMaxClamp: 53.519,
+}
+);
+try {
+gpuCanvasContext9.configure(
+{
+device: device4,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-12x10-unorm-srgb',
+'astc-10x5-unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture64,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Float32Array(new ArrayBuffer(32)),
+/* required buffer size: 57 */{
+offset: 57,
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+texture6.label = '\u63f4\u0213\u{1f652}\u2d83\u{1f99c}';
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture69 = device4.createTexture(
+{
+label: '\u{1ffb1}\u549c\u0f87\ufff3\u0098\u0743\u9cef\u0c1c\ubdb1\u0c89',
+size: [876, 10, 1],
+mipLevelCount: 2,
+format: 'astc-12x10-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+gpuCanvasContext1.configure(
+{
+device: device4,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm',
+'bgra8unorm',
+'bgra8unorm-srgb',
+'astc-4x4-unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let renderBundleEncoder55 = device6.createRenderBundleEncoder(
+{
+label: '\u994b\u{1f714}\u0d97',
+colorFormats: [
+'rg16sint',
+'r32sint',
+'rgba8unorm-srgb',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 921,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+gpuCanvasContext22.unconfigure();
+} catch {}
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+document.body.prepend(canvas14);
+let imageBitmap21 = await createImageBitmap(img2);
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let img19 = await imageWithData(175, 114, '#a05b0d77', '#c2a1d588');
+let renderBundleEncoder56 = device5.createRenderBundleEncoder(
+{
+label: '\u0eda\ub49c\u4883\u69cb\ufcf5',
+colorFormats: [
+undefined,
+'rg16sint',
+'rg32float',
+'r16uint',
+'bgra8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 534,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+try {
+gpuCanvasContext12.configure(
+{
+device: device5,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device5.queue.writeTexture(
+{
+  texture: texture62,
+  mipLevel: 4,
+  origin: { x: 101, y: 1, z: 4 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer0),
+/* required buffer size: 4366119 */{
+offset: 827,
+bytesPerRow: 698,
+rowsPerImage: 53,
+},
+{width: 241, height: 0, depthOrArrayLayers: 119}
+);
+} catch {}
+try {
+await device5.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap22 = await createImageBitmap(imageBitmap0);
+let commandEncoder65 = device4.createCommandEncoder(
+{
+label: '\u099e\uf946\u3956\u{1f70e}',
+}
+);
+let texture70 = device4.createTexture(
+{
+label: '\u02e7\ubbf3\u{1f893}\u{1f73c}\u1e21\u5ac1\ud133\u0f6b',
+size: [2514, 170, 47],
+mipLevelCount: 12,
+format: 'astc-6x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-6x5-unorm',
+'astc-6x5-unorm-srgb',
+'astc-6x5-unorm'
+],
+}
+);
+try {
+commandEncoder65.copyTextureToTexture(
+{
+  texture: texture70,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 27 },
+  aspect: 'all',
+},
+{
+  texture: texture70,
+  mipLevel: 5,
+  origin: { x: 18, y: 0, z: 20 },
+  aspect: 'all',
+},
+{width: 48, height: 0, depthOrArrayLayers: 6}
+);
+} catch {}
+let imageBitmap23 = await createImageBitmap(video14);
+let imageData28 = new ImageData(20, 84);
+try {
+querySet57.destroy();
+} catch {}
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+let imageData29 = new ImageData(216, 100);
+let commandEncoder66 = device5.createCommandEncoder(
+{
+label: '\u07d6\u205c\uc3ce\u{1fe9c}\u{1fc4f}\u68a5',
+}
+);
+let texture71 = device5.createTexture(
+{
+size: {width: 208, height: 8, depthOrArrayLayers: 248},
+mipLevelCount: 7,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView74 = texture62.createView(
+{
+label: '\ub943\udcef\u9529\u095e\u{1f94e}\u08bf\uac75\u{1fa54}\u7d17',
+baseMipLevel: 2,
+mipLevelCount: 1,
+baseArrayLayer: 89,
+arrayLayerCount: 52,
+}
+);
+let renderBundleEncoder57 = device5.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgb10a2uint',
+'rgba32uint',
+'rg32sint',
+undefined,
+'rg16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 776,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let querySet60 = device6.createQuerySet({
+label: '\uc003\u3f41\u456d\ua307\u08e5\u99cf\u6dc9\ufec2',
+type: 'occlusion',
+count: 672,
+});
+let sampler82 = device6.createSampler(
+{
+mipmapFilter: 'nearest',
+lodMinClamp: 95.870,
+lodMaxClamp: 97.506,
+compare: 'less',
+}
+);
+try {
+renderBundleEncoder55.setVertexBuffer(
+26,
+undefined,
+1756171434,
+1322601241
+);
+} catch {}
+try {
+device6.pushErrorScope('internal');
+} catch {}
+let promise33 = device6.queue.onSubmittedWorkDone();
+let canvas20 = document.createElement('canvas');
+let querySet61 = device6.createQuerySet({
+label: '\u0aeb\uf548\u{1f676}\u01f0',
+type: 'occlusion',
+count: 2498,
+});
+let renderBundle82 = renderBundleEncoder55.finish(
+{
+label: '\u0d88\u8007\u0446\u0846\u4e01'
+}
+);
+try {
+canvas20.getContext('webgl');
+} catch {}
+let adapter14 = await navigator.gpu.requestAdapter(
+{
+}
+);
+try {
+window.someLabel = device4.label;
+} catch {}
+let texture72 = device4.createTexture(
+{
+label: '\u7ec5\u0513',
+size: [240, 12, 44],
+mipLevelCount: 3,
+dimension: '2d',
+format: 'astc-12x12-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-12x12-unorm-srgb',
+'astc-12x12-unorm'
+],
+}
+);
+let textureView75 = texture64.createView(
+{
+label: '\uc1ad\u01fd',
+}
+);
+try {
+commandEncoder65.copyTextureToTexture(
+{
+  texture: texture64,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture64,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+adapter6.label = '\u09b3\ud43a\ua62a\u9dbc\u0d9b';
+} catch {}
+try {
+window.someLabel = querySet57.label;
+} catch {}
+let texture73 = device6.createTexture(
+{
+label: '\u{1fd4a}\ua5ee',
+size: {width: 186, height: 1, depthOrArrayLayers: 1393},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder58 = device6.createRenderBundleEncoder(
+{
+colorFormats: [
+undefined
+],
+sampleCount: 963,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler83 = device6.createSampler(
+{
+label: '\u0d16\u0a2a\u3b09\u0c3b\u{1f95c}\uab46\u08bf',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 54.559,
+lodMaxClamp: 64.048,
+}
+);
+let imageData30 = new ImageData(200, 172);
+let commandBuffer8 = commandEncoder66.finish(
+{
+label: '\u1049\u{1ff9b}\u{1fa84}\u4e3f\u0f70\u2006',
+}
+);
+let renderBundleEncoder59 = device5.createRenderBundleEncoder(
+{
+label: '\u01ac\u30bf\u056f',
+colorFormats: [
+'rg32float',
+'rgba8uint',
+'bgra8unorm',
+'rg32sint',
+'r8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 638,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle83 = renderBundleEncoder57.finish(
+{
+label: '\u190a\ubc93\ub517\u50ab\u{1fc9e}\u6c0c\u0475'
+}
+);
+let canvas21 = document.createElement('canvas');
+let bindGroup17 = device3.createBindGroup({
+label: '\uc527\u08b1\u0ab7\uc742\u{1f6c0}',
+layout: bindGroupLayout22,
+entries: [
+{
+binding: 5591,
+resource: sampler74
+}
+],
+});
+let texture74 = device3.createTexture(
+{
+label: '\u8616\u813c\u0b6c\uad49\u51fd\u43aa',
+size: {width: 3194, height: 1, depthOrArrayLayers: 231},
+mipLevelCount: 7,
+dimension: '2d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8unorm',
+'rgba8unorm'
+],
+}
+);
+let textureView76 = texture58.createView(
+{
+label: '\uedae\u0f8e\u9fb6\ub53d\u0aec',
+dimension: '2d',
+aspect: 'all',
+baseMipLevel: 3,
+baseArrayLayer: 124,
+arrayLayerCount: 1,
+}
+);
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(
+/*
+{width: 199, height: 1, depthOrArrayLayers: 231}
+*/
+{
+  source: imageData27,
+  origin: { x: 56, y: 26 },
+  flipY: true,
+},
+{
+  texture: texture74,
+  mipLevel: 4,
+  origin: { x: 9, y: 0, z: 186 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 108, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline80 = device3.createComputePipeline(
+{
+layout: pipelineLayout12,
+compute: {
+module: shaderModule26,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+await promise33;
+} catch {}
+let commandEncoder67 = device4.createCommandEncoder();
+let textureView77 = texture63.createView(
+{
+label: '\u524d\u0633\u{1f6e1}\u03fe\uda76\u{1fe3c}\u87ec\u{1fa58}\u{1faee}\uece4\u0475',
+format: 'rg32sint',
+baseMipLevel: 3,
+}
+);
+let renderPassEncoder25 = commandEncoder67.beginRenderPass(
+{
+label: '\u06b9\ubb87\uf39a\u3fa9\u8603',
+colorAttachments: [
+{
+view: textureView75,
+clearValue: { r: -880.1, g: -395.9, b: -101.1, a: -409.8, },
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+maxDrawCount: 63176,
+}
+);
+try {
+renderPassEncoder25.setBlendConstant({ r: 886.3, g: -28.22, b: 569.3, a: -808.1, });
+} catch {}
+try {
+commandEncoder65.copyTextureToTexture(
+{
+  texture: texture64,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture64,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext17.configure(
+{
+device: device4,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let texture75 = device6.createTexture(
+{
+label: '\u0a16\u05ed\u0b56\u0f8d\u30c7',
+size: [6354],
+dimension: '1d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'r16sint',
+'r16sint',
+'r16sint'
+],
+}
+);
+let sampler84 = device6.createSampler(
+{
+label: '\u090f\ueb5e',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 51.481,
+lodMaxClamp: 65.105,
+maxAnisotropy: 19,
+}
+);
+try {
+gpuCanvasContext0.configure(
+{
+device: device6,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16float',
+'stencil8'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let adapter15 = await navigator.gpu.requestAdapter();
+let videoFrame23 = new VideoFrame(videoFrame10, {timestamp: 0});
+try {
+canvas21.getContext('2d');
+} catch {}
+let commandEncoder68 = device5.createCommandEncoder(
+{
+label: '\u06d5\u{1fe3b}\u6790\u0ded\uc82c\u2c5b',
+}
+);
+let texture76 = device5.createTexture(
+{
+label: '\uf7e0\u07a7',
+size: [1168, 6, 154],
+mipLevelCount: 11,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-8x6-unorm-srgb',
+'astc-8x6-unorm'
+],
+}
+);
+let sampler85 = device5.createSampler(
+{
+label: '\u0f20\u13cd\u{1faa1}\u{1fa2b}\u{1fe55}\u5785',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 88.654,
+maxAnisotropy: 9,
+}
+);
+let externalTexture3 = device5.importExternalTexture(
+{
+label: '\u{1f724}\u025b\u0bcc\u7ec6\u{1fdee}\ue3be',
+source: videoFrame6,
+colorSpace: 'display-p3',
+}
+);
+try {
+buffer22.destroy();
+} catch {}
+try {
+buffer22.unmap();
+} catch {}
+let querySet62 = device1.createQuerySet({
+label: '\ud9cd\ud5e7\uc308',
+type: 'occlusion',
+count: 1212,
+});
+let sampler86 = device1.createSampler(
+{
+label: '\u{1fa14}\u188f',
+addressModeU: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 37.457,
+lodMaxClamp: 86.485,
+}
+);
+try {
+computePassEncoder20.setBindGroup(
+8,
+bindGroup3,
+new Uint32Array(5605),
+1300,
+0
+);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(
+6,
+bindGroup2,
+new Uint32Array(970),
+795,
+0
+);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(
+1,
+0,
+0,
+1
+);
+} catch {}
+try {
+renderPassEncoder24.setViewport(
+345.0,
+0.1685,
+880.1,
+0.4451,
+0.5906,
+0.8346
+);
+} catch {}
+let pipeline81 = await device1.createRenderPipelineAsync(
+{
+label: '\u7764\u1474\u{1f89d}\u4bb5\u9742',
+layout: pipelineLayout9,
+vertex: {
+module: shaderModule13,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 23848,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 8624,
+shaderLocation: 11,
+},
+{
+format: 'uint8x2',
+offset: 536,
+shaderLocation: 25,
+}
+],
+},
+{
+arrayStride: 37440,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 52328,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x3',
+offset: 27408,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 6748,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 5144,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 34412,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 9216,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 3628,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule13,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16sint',
+},
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'keep',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilReadMask: 2822,
+stencilWriteMask: 3988,
+depthBias: 1,
+depthBiasSlopeScale: 36,
+depthBiasClamp: 35,
+},
+}
+);
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let renderPassEncoder26 = commandEncoder68.beginRenderPass(
+{
+label: '\u{1ff70}\u00e4\u5745\u{1feaa}',
+colorAttachments: [
+{
+view: textureView69,
+clearValue: { r: 464.3, g: 167.6, b: 907.4, a: -23.61, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined
+],
+occlusionQuerySet: querySet55,
+maxDrawCount: 14456,
+}
+);
+try {
+renderPassEncoder26.beginOcclusionQuery(2254);
+} catch {}
+try {
+renderPassEncoder26.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder26.setStencilReference(
+718
+);
+} catch {}
+try {
+renderPassEncoder26.setViewport(
+320.8,
+0.1238,
+24.38,
+2.411,
+0.9736,
+0.9983
+);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(
+6,
+buffer22,
+9564,
+7037
+);
+} catch {}
+let canvas22 = document.createElement('canvas');
+let canvas23 = document.createElement('canvas');
+try {
+canvas23.getContext('webgpu');
+} catch {}
+let bindGroupLayout26 = device5.createBindGroupLayout(
+{
+label: '\u8db6\u93aa\u5d29\u1804\u0ef4\ub3cc\u0356',
+entries: [
+{
+binding: 2341,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+},
+{
+binding: 651,
+visibility: 0,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let pipelineLayout14 = device5.createPipelineLayout(
+{
+label: '\u{1fda5}\u012d\uae9c\u{1f9f6}',
+bindGroupLayouts: [
+
+]
+}
+);
+let texture77 = device5.createTexture(
+{
+label: '\uf504\u92c4\u088b\u0a72\u9622\u0142\u{1f722}\u{1fbca}\u5326',
+size: {width: 2143, height: 205, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+sampleCount: 1,
+format: 'rg16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg16uint',
+'rg16uint',
+'rg16uint'
+],
+}
+);
+let textureView78 = texture62.createView(
+{
+label: '\ufff4\u{1fb0f}\u57c1\ua36c\u{1f66a}\u{1f7bf}\uea0f',
+baseMipLevel: 1,
+baseArrayLayer: 14,
+arrayLayerCount: 53,
+}
+);
+let renderBundleEncoder60 = device5.createRenderBundleEncoder(
+{
+label: '\u{1f71e}\u89a5\uf4e2\u0e73\u3edc\u0575\u{1fd53}\u669a\u0561',
+colorFormats: [
+'rgba8unorm-srgb',
+'r8uint',
+undefined
+],
+sampleCount: 668,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder26.beginOcclusionQuery(2281);
+} catch {}
+try {
+renderPassEncoder26.setBlendConstant({ r: 803.8, g: 715.0, b: -603.5, a: 194.3, });
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(
+7,
+buffer22,
+8828,
+9865
+);
+} catch {}
+let offscreenCanvas28 = new OffscreenCanvas(854, 814);
+let commandBuffer9 = commandEncoder65.finish(
+{
+}
+);
+let renderBundleEncoder61 = device4.createRenderBundleEncoder(
+{
+label: '\ub97c\u8ccc\uaf93\u0d4d\ud391',
+colorFormats: [
+'rgba32uint',
+undefined,
+'rgba8unorm',
+'r32sint',
+'r16sint',
+undefined,
+undefined
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 630,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle84 = renderBundleEncoder61.finish();
+let commandEncoder69 = device3.createCommandEncoder(
+{
+label: '\u8d52\ua030\ucf22\u{1fac2}\u5c2c',
+}
+);
+let querySet63 = device3.createQuerySet({
+label: '\u0d34\u077a\u249e\u{1ff5f}',
+type: 'occlusion',
+count: 2255,
+});
+let textureView79 = texture74.createView(
+{
+label: '\u0613\u09f3\u0749\ud3d7\u{1f969}\u951f\u{1f6bc}',
+dimension: '2d',
+baseMipLevel: 4,
+mipLevelCount: 2,
+baseArrayLayer: 57,
+}
+);
+let renderBundleEncoder62 = device3.createRenderBundleEncoder(
+{
+label: '\u{1fe1e}\u{1fc4c}\u8547\uec81\u0d04\u8bfb',
+colorFormats: [
+'rg16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 809,
+}
+);
+let renderBundle85 = renderBundleEncoder45.finish();
+try {
+computePassEncoder34.setBindGroup(
+1,
+bindGroup16,
+[]
+);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(
+1,
+bindGroup17
+);
+} catch {}
+try {
+renderPassEncoder22.setBlendConstant({ r: -495.8, g: -945.6, b: 763.9, a: 904.2, });
+} catch {}
+try {
+renderPassEncoder22.setStencilReference(
+1068
+);
+} catch {}
+try {
+renderPassEncoder22.setViewport(
+91.58,
+0.6262,
+64.86,
+0.1153,
+0.4366,
+0.9529
+);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+try {
+gpuCanvasContext11.configure(
+{
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2unorm',
+'rgba8unorm',
+'astc-5x5-unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let gpuCanvasContext23 = offscreenCanvas28.getContext('webgpu');
+let video25 = await videoWithData();
+let imageBitmap24 = await createImageBitmap(imageBitmap4);
+try {
+await adapter3.requestAdapterInfo();
+} catch {}
+let video26 = await videoWithData();
+let gpuCanvasContext24 = canvas22.getContext('webgpu');
+video8.height = 22;
+let offscreenCanvas29 = new OffscreenCanvas(201, 1024);
+let canvas24 = document.createElement('canvas');
+let querySet64 = device4.createQuerySet({
+type: 'occlusion',
+count: 2475,
+});
+let sampler87 = device4.createSampler(
+{
+label: '\u0b4b\u0172\uca00\u1f35\u6c5a',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 33.777,
+lodMaxClamp: 88.440,
+}
+);
+try {
+renderPassEncoder25.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder25.setScissorRect(
+0,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder25.setViewport(
+0.6640,
+0.3313,
+0.2317,
+0.03291,
+0.8249,
+0.8461
+);
+} catch {}
+let texture78 = device5.createTexture(
+{
+label: '\u01c7\u{1fcea}\u335e\u2011\u8531\u{1ff4f}\u0bb5\uc6d4\u{1fd1f}',
+size: [252, 132, 113],
+mipLevelCount: 3,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundle86 = renderBundleEncoder60.finish();
+try {
+renderPassEncoder26.setViewport(
+74.78,
+2.426,
+362.3,
+2.282,
+0.8784,
+0.9799
+);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(
+1,
+buffer22,
+41536,
+10032
+);
+} catch {}
+let commandEncoder70 = device6.createCommandEncoder(
+{
+label: '\u{1f8ab}\u{1fd73}\u{1fc07}\u074c\u{1fb14}\ubd55\u{1fe02}\uc14a\ucc5b\u22b8\u088b',
+}
+);
+let renderBundle87 = renderBundleEncoder58.finish(
+{
+label: '\u24c4\u7c96\u0f88\u{1f919}\ube64\u{1ff7f}\u{1f6d7}'
+}
+);
+try {
+canvas24.getContext('webgpu');
+} catch {}
+let querySet65 = device6.createQuerySet({
+label: '\u0bfd\u57a1\u2e77\u{1f8e2}\u51b8\u{1f601}\u{1f708}\ub004',
+type: 'occlusion',
+count: 1974,
+});
+let video27 = await videoWithData();
+let renderBundle88 = renderBundleEncoder58.finish(
+{
+label: '\uc360\u509c\u{1f65b}\u0978'
+}
+);
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+let canvas25 = document.createElement('canvas');
+let videoFrame24 = new VideoFrame(img6, {timestamp: 0});
+let buffer23 = device5.createBuffer(
+{
+label: '\u5120\u{1f7c2}\u2f84\u4825',
+size: 9431,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let renderBundle89 = renderBundleEncoder57.finish(
+{
+label: '\u0fd2\u74d9\uac77\u{1fe55}'
+}
+);
+let imageBitmap25 = await createImageBitmap(imageBitmap2);
+let bindGroup18 = device3.createBindGroup({
+label: '\u{1ff21}\uba2a\u08e9\u93c0\u0fcc\u{1fb3f}\u06d1\u{1f642}',
+layout: bindGroupLayout22,
+entries: [
+{
+binding: 5591,
+resource: sampler74
+}
+],
+});
+let buffer24 = device3.createBuffer(
+{
+label: '\u{1f8c0}\u0c5d\u{1fac1}\u{1fc5c}\u{1f7d6}\ube7c\u9343\u69fa\u{1fa53}',
+size: 56433,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let renderBundle90 = renderBundleEncoder49.finish();
+try {
+renderPassEncoder22.setViewport(
+34.28,
+0.9376,
+80.92,
+0.05387,
+0.3194,
+0.8757
+);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer16,
+4476,
+new Int16Array(39312),
+385,
+400
+);
+} catch {}
+offscreenCanvas18.width = 775;
+let textureView80 = texture75.createView(
+{
+label: '\u{1f630}\u5fd0\ufa08\u6c60\u9d9a\u{1fe61}\u5459',
+}
+);
+let computePassEncoder37 = commandEncoder70.beginComputePass(
+{
+label: '\ub4b7\u{1f72d}\u{1f686}\u03b8\u8706\u{1f863}\u4dd3'
+}
+);
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+  log('the end')
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -985,9 +985,10 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
                     if (bufferSizeArgumentBufferIndex)
                         *(uint32_t*)[argumentEncoder[stage] constantDataAtIndex:*bufferSizeArgumentBufferIndex] = std::min<uint32_t>(entrySize, buffer.length);
                 }
-                if (buffer)
+                if (buffer) {
                     stageResources[metalRenderStage(stage)][resourceUsage - 1].append(buffer);
-                stageResourceUsages[metalRenderStage(stage)][resourceUsage - 1].append(makeBindGroupEntryUsageData(usageForBuffer(layoutBinding->type), entry.binding, apiBuffer));
+                    stageResourceUsages[metalRenderStage(stage)][resourceUsage - 1].append(makeBindGroupEntryUsageData(usageForBuffer(layoutBinding->type), entry.binding, apiBuffer));
+                }
             } else if (samplerIsPresent) {
                 auto* layoutBinding = hasBinding<WGPUSamplerBindingLayout>(bindGroupLayoutEntries, bindingIndex);
                 if (!layoutBinding) {
@@ -1065,11 +1066,12 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
 
                 if (stage != ShaderStage::Undefined)
                     [argumentEncoder[stage] setTexture:texture atIndex:index];
-                if (texture)
+                if (texture) {
                     stageResources[metalRenderStage(stage)][resourceUsage - 1].append(texture);
-                ASSERT(texture.parentRelativeLevel == apiTextureView.baseMipLevel());
-                ASSERT(texture.parentRelativeSlice == apiTextureView.baseArrayLayer());
-                stageResourceUsages[metalRenderStage(stage)][resourceUsage - 1].append(makeBindGroupEntryUsageData(textureEntry ? usageForTexture(*textureEntry) : (storageTextureEntry ? usageForStorageTexture(*storageTextureEntry) : BindGroupEntryUsage::ConstantTexture), entry.binding, apiTextureView));
+                    ASSERT(texture.parentRelativeLevel == apiTextureView.baseMipLevel());
+                    ASSERT(texture.parentRelativeSlice == apiTextureView.baseArrayLayer());
+                    stageResourceUsages[metalRenderStage(stage)][resourceUsage - 1].append(makeBindGroupEntryUsageData(textureEntry ? usageForTexture(*textureEntry) : (storageTextureEntry ? usageForStorageTexture(*storageTextureEntry) : BindGroupEntryUsage::ConstantTexture), entry.binding, apiTextureView));
+                }
             } else if (externalTextureIsPresent) {
                 if (!hasBinding<WGPUExternalTextureBindingLayout>(bindGroupLayoutEntries, bindingIndex)) {
                     generateAValidationError("Expected external texture but it was not present in the bind group layout"_s);

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -633,8 +633,8 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
 
         if (zeroColorTargets) {
             mtlDescriptor.defaultRasterSampleCount = textureView.sampleCount();
-            mtlDescriptor.renderTargetWidth = textureView.width();
-            mtlDescriptor.renderTargetHeight = textureView.height();
+            mtlDescriptor.renderTargetWidth = metalDepthStencilTexture.width;
+            mtlDescriptor.renderTargetHeight = metalDepthStencilTexture.height;
         }
     }
 

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -443,7 +443,7 @@ void ComputePassEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& grou
 
     Vector<const BindableResources*> resourceList;
     for (const auto& resource : group.resources()) {
-        if (resource.renderStages == BindGroup::MTLRenderStageCompute)
+        if (resource.renderStages == BindGroup::MTLRenderStageCompute && resource.mtlResources.size())
             [m_computeCommandEncoder useResources:&resource.mtlResources[0] count:resource.mtlResources.size() usage:resource.usage];
 
         ASSERT(resource.mtlResources.size() == resource.resourceUsages.size());

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -132,7 +132,7 @@ public:
     static bool isStencilOnlyFormat(MTLPixelFormat);
     bool shouldStopCaptureAfterSubmit();
     id<MTLBuffer> placeholderBuffer() const;
-    id<MTLTexture> placeholderTexture() const;
+    id<MTLTexture> placeholderTexture(WGPUTextureFormat) const;
     bool isDestroyed() const;
     NSString *errorValidatingTextureCreation(const WGPUTextureDescriptor&, const Vector<WGPUTextureFormat>& viewFormats);
 
@@ -187,6 +187,7 @@ private:
 
     id<MTLBuffer> m_placeholderBuffer { nil };
     id<MTLTexture> m_placeholderTexture { nil };
+    id<MTLTexture> m_placeholderDepthStencilTexture { nil };
 
     const Ref<Adapter> m_adapter;
 #if HAVE(COREVIDEO_METAL_SUPPORT)

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -200,6 +200,8 @@ Device::Device(id<MTLDevice> device, id<MTLCommandQueue> defaultQueue, HardwareC
     desc.storageMode = MTLStorageModeShared;
     desc.usage = MTLTextureUsageShaderRead | MTLTextureUsageRenderTarget;
     m_placeholderTexture = [m_device newTextureWithDescriptor:desc];
+    desc.pixelFormat = MTLPixelFormatDepth32Float_Stencil8;
+    m_placeholderDepthStencilTexture = [m_device newTextureWithDescriptor:desc];
 }
 
 Device::Device(Adapter& adapter)
@@ -290,9 +292,9 @@ id<MTLBuffer> Device::placeholderBuffer() const
     return m_placeholderBuffer;
 }
 
-id<MTLTexture> Device::placeholderTexture() const
+id<MTLTexture> Device::placeholderTexture(WGPUTextureFormat format) const
 {
-    return m_placeholderTexture;
+    return Texture::isDepthOrStencilFormat(format) ? m_placeholderDepthStencilTexture : m_placeholderTexture;
 }
 
 Queue& Device::getQueue()

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -123,7 +123,7 @@ private:
     void addResource(RenderBundle::ResourcesContainer*, id<MTLResource>, MTLRenderStages, const BindGroupEntryUsageData::Resource&);
     void addResource(RenderBundle::ResourcesContainer*, id<MTLResource>, MTLRenderStages);
     bool icbNeedsToBeSplit(const RenderPipeline& a, const RenderPipeline& b);
-    void finalizeRenderCommand();
+    void finalizeRenderCommand(MTLIndirectCommandType);
     bool validToEncodeCommand() const;
     bool returnIfEncodingIsFinished(NSString* errorString);
     bool runIndexBufferValidation(uint32_t firstInstance, uint32_t instanceCount);

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -81,7 +81,7 @@ bool RenderBundleEncoder::returnIfEncodingIsFinished(NSString* errorString)
 }
 
 #define RETURN_IF_FINISHED() \
-if (returnIfEncodingIsFinished([NSString stringWithFormat:@"%s: failed as encoding has finished", __PRETTY_FUNCTION__])) \
+if (returnIfEncodingIsFinished([NSString stringWithFormat:@"%s: failed as encoding has finished", __PRETTY_FUNCTION__]) || !m_icbDescriptor) \
     return;
 
 static RenderBundleICBWithResources* makeRenderBundleICBWithResources(id<MTLIndirectCommandBuffer> icb, RenderBundle::ResourcesContainer* resources, id<MTLRenderPipelineState> renderPipelineState, id<MTLDepthStencilState> depthStencilState, MTLCullMode cullMode, MTLWinding frontFace, MTLDepthClipMode depthClipMode, float depthBias, float depthBiasSlopeScale, float depthBiasClamp, id<MTLBuffer> fragmentDynamicOffsetsBuffer, const RenderPipeline* pipeline)
@@ -97,6 +97,8 @@ static RenderBundleICBWithResources* makeRenderBundleICBWithResources(id<MTLIndi
             continue;
 
         ResourceUsageAndRenderStage *usageAndStage = [resources objectForKey:r];
+        if (!usageAndStage.renderStages || !usageAndStage.usage)
+            continue;
         stageResources[usageAndStage.renderStages - 1][usageAndStage.usage - 1].append(r);
         stageResourceUsages[usageAndStage.renderStages - 1][usageAndStage.usage - 1].append(BindGroupEntryUsageData { .usage = usageAndStage.entryUsage, .binding = usageAndStage.binding, .resource = usageAndStage.resource });
     }
@@ -364,15 +366,13 @@ void RenderBundleEncoder::draw(uint32_t vertexCount, uint32_t instanceCount, uin
 
         [icbCommand drawPrimitives:m_primitiveType vertexStart:firstVertex vertexCount:vertexCount instanceCount:instanceCount baseInstance:firstInstance];
     } else {
-        m_icbDescriptor.commandTypes |= MTLIndirectCommandTypeDraw;
-
         recordCommand([vertexCount, instanceCount, firstVertex, firstInstance, protectedThis = Ref { *this }] {
             protectedThis->draw(vertexCount, instanceCount, firstVertex, firstInstance);
             return true;
         });
     }
 
-    finalizeRenderCommand();
+    finalizeRenderCommand(MTLIndirectCommandTypeDraw);
 }
 
 uint32_t RenderBundleEncoder::maxVertexBufferIndex() const
@@ -421,10 +421,11 @@ NSString* RenderBundleEncoder::errorValidatingDrawIndexed() const
     return nil;
 }
 
-void RenderBundleEncoder::finalizeRenderCommand()
+void RenderBundleEncoder::finalizeRenderCommand(MTLIndirectCommandType commandTypes)
 {
     m_currentCommand = nil;
     ++m_currentCommandIndex;
+    m_icbDescriptor.commandTypes |= commandTypes;
 }
 
 
@@ -526,15 +527,13 @@ void RenderBundleEncoder::drawIndexed(uint32_t indexCount, uint32_t instanceCoun
 
         [icbCommand drawIndexedPrimitives:m_primitiveType indexCount:indexCount indexType:m_indexType indexBuffer:indexBuffer indexBufferOffset:(m_indexBufferOffset + firstIndexOffsetInBytes) instanceCount:instanceCount baseVertex:baseVertex baseInstance:firstInstance];
     } else {
-        m_icbDescriptor.commandTypes |= MTLIndirectCommandTypeDrawIndexed;
-
         recordCommand([indexCount, instanceCount, firstIndex, baseVertex, firstInstance, protectedThis = Ref { *this }] {
             protectedThis->drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
             return true;
         });
     }
 
-    finalizeRenderCommand();
+    finalizeRenderCommand(MTLIndirectCommandTypeDrawIndexed);
 }
 
 void RenderBundleEncoder::drawIndexedIndirect(const Buffer& indirectBuffer, uint64_t indirectOffset)
@@ -579,15 +578,13 @@ void RenderBundleEncoder::drawIndexedIndirect(const Buffer& indirectBuffer, uint
             return;
         }
 
-        m_icbDescriptor.commandTypes |= MTLIndirectCommandTypeDrawIndexed;
-
-        recordCommand([&indirectBuffer, indirectOffset, protectedThis = Ref { *this }] {
-            protectedThis->drawIndexedIndirect(indirectBuffer, indirectOffset);
+        recordCommand([indirectBuffer = Ref { indirectBuffer }, indirectOffset, protectedThis = Ref { *this }] {
+            protectedThis->drawIndexedIndirect(indirectBuffer.get(), indirectOffset);
             return true;
         });
     }
 
-    finalizeRenderCommand();
+    finalizeRenderCommand(MTLIndirectCommandTypeDrawIndexed);
 }
 
 void RenderBundleEncoder::drawIndirect(const Buffer& indirectBuffer, uint64_t indirectOffset)
@@ -611,8 +608,6 @@ void RenderBundleEncoder::drawIndirect(const Buffer& indirectBuffer, uint64_t in
             [icbCommand drawPrimitives:m_primitiveType vertexStart:contents->vertexStart vertexCount:contents->vertexCount instanceCount:contents->instanceCount baseInstance:contents->baseInstance];
         }
     } else {
-        m_icbDescriptor.commandTypes |= MTLIndirectCommandTypeDraw;
-
         if (!isValidToUseWith(indirectBuffer, *this)) {
             makeInvalid(@"drawIndirect: buffer was invalid");
             return;
@@ -628,13 +623,13 @@ void RenderBundleEncoder::drawIndirect(const Buffer& indirectBuffer, uint64_t in
             return;
         }
 
-        recordCommand([&indirectBuffer, indirectOffset, protectedThis = Ref { *this }] {
-            protectedThis->drawIndirect(indirectBuffer, indirectOffset);
+        recordCommand([indirectBuffer = Ref { indirectBuffer }, indirectOffset, protectedThis = Ref { *this }] {
+            protectedThis->drawIndirect(indirectBuffer.get(), indirectOffset);
             return true;
         });
     }
 
-    finalizeRenderCommand();
+    finalizeRenderCommand(MTLIndirectCommandTypeDraw);
 }
 
 void RenderBundleEncoder::endCurrentICB()
@@ -686,6 +681,7 @@ void RenderBundleEncoder::endCurrentICB()
     } else
         m_recordedCommands.remove(0, lastIndexOfRecordedCommand);
 
+    m_currentCommandIndex = commandCount - completedDraws;
     [m_icbArray addObject:makeRenderBundleICBWithResources(m_indirectCommandBuffer, m_resources, m_currentPipelineState, m_depthStencilState, m_cullMode, m_frontFace, m_depthClipMode, m_depthBias, m_depthBiasSlopeScale, m_depthBiasClamp, m_dynamicOffsetsFragmentBuffer, m_pipeline.get())];
     m_indirectCommandBuffer = nil;
     m_currentCommand = nil;
@@ -834,8 +830,8 @@ void RenderBundleEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& gro
         if (group.vertexArgumentBuffer())
             m_requiresMetalWorkaround = false;
 
-        recordCommand([groupIndex, &group, protectedThis = Ref { *this }, dynamicOffsets = WTFMove(dynamicOffsets)]() mutable {
-            protectedThis->setBindGroup(groupIndex, group, WTFMove(dynamicOffsets));
+        recordCommand([groupIndex, group = Ref { group }, protectedThis = Ref { *this }, dynamicOffsets = WTFMove(dynamicOffsets)]() mutable {
+            protectedThis->setBindGroup(groupIndex, group.get(), WTFMove(dynamicOffsets));
             return false;
         });
         return;
@@ -905,8 +901,8 @@ void RenderBundleEncoder::setIndexBuffer(const Buffer& buffer, WGPUIndexFormat f
             return;
         }
 
-        recordCommand([&buffer, format, offset, size, protectedThis = Ref { *this }] {
-            protectedThis->setIndexBuffer(buffer, format, offset, size);
+        recordCommand([buffer = Ref { buffer }, format, offset, size, protectedThis = Ref { *this }] {
+            protectedThis->setIndexBuffer(buffer.get(), format, offset, size);
             return false;
         });
         return;
@@ -1019,7 +1015,7 @@ void RenderBundleEncoder::setPipeline(const RenderPipeline& pipeline)
         if (m_pipeline && icbNeedsToBeSplit(*m_pipeline, pipeline) && !m_requiresMetalWorkaround)
             endCurrentICB();
 
-        recordCommand([&pipeline, protectedThis = Ref { *this }] {
+        recordCommand([pipeline = Ref { pipeline }, protectedThis = Ref { *this }] {
             protectedThis->setPipeline(pipeline);
             return false;
         });
@@ -1109,11 +1105,13 @@ void wgpuRenderBundleEncoderDrawIndexed(WGPURenderBundleEncoder renderBundleEnco
 
 void wgpuRenderBundleEncoderDrawIndexedIndirect(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset)
 {
+    RELEASE_ASSERT(indirectBuffer);
     WebGPU::fromAPI(renderBundleEncoder).drawIndexedIndirect(WebGPU::fromAPI(indirectBuffer), indirectOffset);
 }
 
 void wgpuRenderBundleEncoderDrawIndirect(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset)
 {
+    RELEASE_ASSERT(indirectBuffer);
     WebGPU::fromAPI(renderBundleEncoder).drawIndirect(WebGPU::fromAPI(indirectBuffer), indirectOffset);
 }
 

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -1012,7 +1012,7 @@ void RenderBundleEncoder::setPipeline(const RenderPipeline& pipeline)
         if (pipeline.sampleMask() != defaultSampleMask)
             m_requiresCommandReplay = true;
 
-        if (m_pipeline && icbNeedsToBeSplit(*m_pipeline, pipeline) && !m_requiresMetalWorkaround)
+        if (m_pipeline && m_currentCommandIndex && icbNeedsToBeSplit(*m_pipeline, pipeline) && !m_requiresMetalWorkaround)
             endCurrentICB();
 
         recordCommand([pipeline = Ref { pipeline }, protectedThis = Ref { *this }] {

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -725,7 +725,7 @@ void RenderPassEncoder::executeBundles(Vector<std::reference_wrapper<RenderBundl
             ASSERT(icb.resources);
 
             for (const auto& resource : *icb.resources) {
-                if (resource.renderStages & (MTLRenderStageVertex | MTLRenderStageFragment))
+                if ((resource.renderStages & (MTLRenderStageVertex | MTLRenderStageFragment)) && resource.mtlResources.size())
                     [m_renderCommandEncoder useResources:&resource.mtlResources[0] count:resource.mtlResources.size() usage:resource.usage stages:resource.renderStages];
 
                 ASSERT(resource.mtlResources.size() == resource.resourceUsages.size());
@@ -849,7 +849,7 @@ void RenderPassEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& group
         m_bindGroupDynamicOffsets.set(groupIndex, Vector<uint32_t>(std::span { dynamicOffsets, dynamicOffsetCount }));
 
     for (const auto& resource : group.resources()) {
-        if (resource.renderStages & (MTLRenderStageVertex | MTLRenderStageFragment))
+        if ((resource.renderStages & (MTLRenderStageVertex | MTLRenderStageFragment)) && resource.mtlResources.size())
             [m_renderCommandEncoder useResources:&resource.mtlResources[0] count:resource.mtlResources.size() usage:resource.usage stages:resource.renderStages];
 
         ASSERT(resource.mtlResources.size() == resource.resourceUsages.size());

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -96,8 +96,6 @@ RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEn
             continue;
 
         auto& texture = fromAPI(attachment.view);
-        m_renderTargetWidth = texture.width();
-        m_renderTargetHeight = texture.height();
         texture.setPreviouslyCleared();
         addResourceToActiveResources(texture, BindGroupEntryUsage::Attachment);
 
@@ -110,6 +108,8 @@ RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEn
 
         texture.setCommandEncoder(parentEncoder);
         id<MTLTexture> textureToClear = texture.texture();
+        m_renderTargetWidth = textureToClear.width;
+        m_renderTargetHeight = textureToClear.height;
         if (!textureToClear)
             continue;
         TextureAndClearColor *textureWithClearColor = [[TextureAndClearColor alloc] initWithTexture:textureToClear];
@@ -129,12 +129,12 @@ RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEn
         auto& textureView = fromAPI(attachment->view);
         textureView.setPreviouslyCleared();
         textureView.setCommandEncoder(parentEncoder);
+        id<MTLTexture> depthTexture = textureView.isDestroyed() ? nil : textureView.texture();
         if (textureView.width() && !m_renderTargetWidth) {
-            m_renderTargetWidth = textureView.width();
-            m_renderTargetHeight = textureView.height();
+            m_renderTargetWidth = depthTexture.width;
+            m_renderTargetHeight = depthTexture.height;
         }
 
-        id<MTLTexture> depthTexture = textureView.texture();
         m_depthClearValue = attachment->depthStoreOp == WGPUStoreOp_Discard ? 0 : quantizedDepthValue(attachment->depthClearValue, textureView.format());
         if (!Device::isStencilOnlyFormat(depthTexture.pixelFormat)) {
             m_clearDepthAttachment = depthTexture && attachment->depthStoreOp == WGPUStoreOp_Discard && attachment->depthLoadOp == WGPULoadOp_Load;
@@ -544,12 +544,12 @@ void RenderPassEncoder::drawIndexed(uint32_t indexCount, uint32_t instanceCount,
         return;
 
     auto firstIndexOffsetInBytes = firstIndex * indexSizeInBytes;
-    id<MTLBuffer> indexBuffer = m_indexBuffer->buffer();
     if (NSString* error = errorValidatingDrawIndexed()) {
         makeInvalid(error);
         return;
     }
 
+    id<MTLBuffer> indexBuffer = m_indexBuffer.get() ? m_indexBuffer->buffer() : nil;
     if (firstIndexOffsetInBytes + indexCount * indexSizeInBytes > m_indexBufferSize) {
         makeInvalid(@"Values to drawIndexed are invalid");
         return;

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -3212,7 +3212,7 @@ void Texture::destroy()
 {
     // https://gpuweb.github.io/gpuweb/#dom-gputexture-destroy
     if (!m_canvasBacking)
-        m_texture = m_device->placeholderTexture();
+        m_texture = m_device->placeholderTexture(format());
     m_destroyed = true;
     for (auto& view : m_textureViews) {
         if (view.get())

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -3680,6 +3680,9 @@ bool Texture::validateLinearTextureData(const WGPUTextureDataLayout& layout, uin
 
 bool Texture::previouslyCleared(uint32_t mipLevel, uint32_t slice) const
 {
+    if (isDestroyed())
+        return true;
+
     if (auto it = m_clearedToZero.find(mipLevel); it != m_clearedToZero.end())
         return it->value.contains(slice);
 

--- a/Source/WebGPU/WebGPU/TextureView.h
+++ b/Source/WebGPU/WebGPU/TextureView.h
@@ -58,7 +58,7 @@ public:
 
     bool isValid() const;
 
-    id<MTLTexture> texture() const { return m_texture; }
+    id<MTLTexture> texture() const;
     id<MTLTexture> parentTexture() const;
     const WGPUTextureViewDescriptor& descriptor() const { return m_descriptor; }
     const std::optional<WGPUExtent3D>& renderExtent() const { return m_renderExtent; }

--- a/Source/WebGPU/WebGPU/TextureView.mm
+++ b/Source/WebGPU/WebGPU/TextureView.mm
@@ -100,6 +100,11 @@ WGPUTextureUsageFlags TextureView::usage() const
     return m_parentTexture->usage();
 }
 
+id<MTLTexture> TextureView::texture() const
+{
+    return isDestroyed() ? parentTexture() : m_texture;
+}
+
 uint32_t TextureView::sampleCount() const
 {
     return m_parentTexture->sampleCount();
@@ -162,7 +167,7 @@ bool TextureView::isValid() const
 
 void TextureView::destroy()
 {
-    m_texture = m_device->placeholderTexture();
+    m_texture = m_device->placeholderTexture(format());
     if (m_commandEncoder && !m_parentTexture->isCanvasBacking())
         m_commandEncoder.get()->makeSubmitInvalid();
 


### PR DESCRIPTION
#### 902717c04ce241664f5854e191773e02eccbf885
<pre>
[WebGPU] Destroyed depth stencil textures should have a depth stencil format
<a href="https://bugs.webkit.org/show_bug.cgi?id=273573">https://bugs.webkit.org/show_bug.cgi?id=273573</a>
&lt;radar://127230159&gt;

Reviewed by NOBODY (OOPS!).

Destroyed textures are supposed to be usable in the command encoders,
so it simplifies validation if destroyed depth stencil textures maintain
a depth stencil format.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-273573-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-273573.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::beginRenderPass):
* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::Device):
(WebGPU::Device::placeholderTexture const):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::m_maxDrawCount):
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::destroy):
* Source/WebGPU/WebGPU/TextureView.mm:
(WebGPU::TextureView::destroy):
</pre>
----------------------------------------------------------------------
#### 2fb16da5461dfb5579813e2968b13e391e805ea8
<pre>
[WebGPU] no need to clear destroyed textures
<a href="https://bugs.webkit.org/show_bug.cgi?id=273570">https://bugs.webkit.org/show_bug.cgi?id=273570</a>
&lt;radar://127364747&gt;

Reviewed by NOBODY (OOPS!).

Destroyed textures act like valid objects but no operations
including clearing should occur on them.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-273570-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-273570.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::previouslyCleared const):
</pre>
----------------------------------------------------------------------
#### a668b99e58e176e55d3420a81abf5e31fe826e75
<pre>
[WebGPU] RenderBundleEncoder::endCurrentICB may fail validation when the bundle has zero draw calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=273566">https://bugs.webkit.org/show_bug.cgi?id=273566</a>
&lt;radar://127364748&gt;

Reviewed by NOBODY (OOPS!).

No need to split an ICB which has thus far encoded zero draw commands.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-273566-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-273566.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::setPipeline):
</pre>
----------------------------------------------------------------------
#### 16095796b9e961a8166c0f615a09c5132efab74b
<pre>
[WebGPU] useResources: should not be called on empty resource list
<a href="https://bugs.webkit.org/show_bug.cgi?id=273505">https://bugs.webkit.org/show_bug.cgi?id=273505</a>
&lt;radar://127230835&gt;

Reviewed by NOBODY (OOPS!).

Add additional validation to some render bundle commands
and writeTexture calls to ensure no metal validation errors occur
at runtime.

Confirmed no regressions to api CTS tests.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-273505-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-273505.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createBindGroup):
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::hasZeroDimension):
(WebGPU::CommandEncoder::copyTextureToBuffer):
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::setBindGroup):
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::writeTexture):
* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::makeRenderBundleICBWithResources):
(WebGPU::RenderBundleEncoder::draw):
(WebGPU::RenderBundleEncoder::finalizeRenderCommand):
(WebGPU::RenderBundleEncoder::drawIndexed):
(WebGPU::RenderBundleEncoder::drawIndexedIndirect):
(WebGPU::RenderBundleEncoder::drawIndirect):
(WebGPU::RenderBundleEncoder::endCurrentICB):
(WebGPU::RenderBundleEncoder::setBindGroup):
(WebGPU::RenderBundleEncoder::setIndexBuffer):
(WebGPU::RenderBundleEncoder::setPipeline):
(wgpuRenderBundleEncoderDrawIndexedIndirect):
(wgpuRenderBundleEncoderDrawIndirect):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::executeBundles):
(WebGPU::RenderPassEncoder::setBindGroup):
</pre>