### PR TITLE
[WebGPU] CommandEncoder::beginRenderPass can fail metal validation for destroyed textures

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2112,6 +2112,10 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-273573.html [ Pass Failure Timeout ]
 [ Debug ] fast/webgpu/fuzz-273570.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-273570.html [ Pass Failure Timeout ]
+[ Debug ] fast/webgpu/fuzz-273505.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-273505.html [ Pass Failure Timeout ]
+[ Debug ] fast/webgpu/fuzz-273503.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-273503.html [ Pass Failure Timeout ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-273503-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-273503-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-273503.html
+++ b/LayoutTests/fast/webgpu/fuzz-273503.html
@@ -1,0 +1,50339 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let device0 = await adapter0.requestDevice({
+label: '\uf529\u0f41\u4f55\u0c05\ua659\u{1fc8c}\u{1ff03}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 34,
+maxVertexAttributes: 22,
+maxVertexBufferArrayStride: 15499,
+maxStorageTexturesPerShaderStage: 18,
+maxStorageBuffersPerShaderStage: 27,
+maxDynamicStorageBuffersPerPipelineLayout: 36755,
+maxBindingsPerBindGroup: 6121,
+maxTextureDimension1D: 8337,
+maxTextureDimension2D: 13219,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 244595957,
+maxUniformBuffersPerShaderStage: 29,
+maxInterStageShaderVariables: 82,
+maxInterStageShaderComponents: 118,
+maxSamplersPerShaderStage: 22,
+},
+});
+let texture0 = device0.createTexture(
+{
+label: '\u11b1\u{1f85a}\u3da4\u1727\u5bb2',
+size: [6740],
+sampleCount: 1,
+dimension: '1d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8sint',
+'rg8sint'
+],
+}
+);
+let textureView0 = texture0.createView(
+{
+label: '\u3272\ufb7c\uae33\u0537\u{1f8b2}\u{1ff6f}\u9007\u{1f73e}\u{1fe09}\u1fd7',
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 646, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Int32Array(new ArrayBuffer(24)),
+/* required buffer size: 322 */{
+offset: 322,
+},
+{width: 3852, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let img0 = await imageWithData(131, 117, '#1c8562a8', '#2639b540');
+let commandEncoder0 = device0.createCommandEncoder(
+{
+label: '\u{1f8b6}\u{1ffd0}\u0b2a\u{1fb5d}\u{1fc9c}\uf083\u199c',
+}
+);
+let commandBuffer0 = commandEncoder0.finish(
+{
+label: '\u{1f810}\u08f6\uffd3\ua8fa\u0777\u2d2e',
+}
+);
+let texture1 = device0.createTexture(
+{
+label: '\u{1fc88}\u{1fa3a}\u12d4\u{1fe45}\u3620\ubde4\u0f31\uf3da\u31b3',
+size: [10, 88, 240],
+mipLevelCount: 7,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm'
+],
+}
+);
+let renderBundleEncoder0 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fad3}\ua770',
+colorFormats: [
+'r8sint',
+'rg8sint',
+'r32sint',
+'rg11b10ufloat',
+'r32float',
+undefined,
+'r8sint',
+'r32sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 891,
+}
+);
+let videoFrame0 = new VideoFrame(img0, {timestamp: 0});
+let bindGroupLayout0 = device0.createBindGroupLayout(
+{
+label: '\u0a8e\u6ffe\u{1fcc1}\uda26\ua275\uf422\uf3fe\u{1fdda}\u0f35\u00ee',
+entries: [
+{
+binding: 509,
+visibility: 0,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 2687,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+},
+{
+binding: 2200,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+try {
+renderBundleEncoder0.insertDebugMarker(
+'\u90d1'
+);
+} catch {}
+let canvas0 = document.createElement('canvas');
+try {
+canvas0.getContext('webgl2');
+} catch {}
+let pipelineLayout0 = device0.createPipelineLayout(
+{
+label: '\u02d2\u9a1b\u057f\ua6d9\u6689\u{1f64d}',
+bindGroupLayouts: [
+bindGroupLayout0
+]
+}
+);
+let texture2 = device0.createTexture(
+{
+size: {width: 564, height: 1, depthOrArrayLayers: 86},
+mipLevelCount: 8,
+dimension: '3d',
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView1 = texture1.createView(
+{
+label: '\u271a\u{1f9d2}\u4a02\u07ab\u0c9d\u8b93\u{1fb69}\u0d95\u6237\u2af0\u02f2',
+baseMipLevel: 5,
+baseArrayLayer: 59,
+arrayLayerCount: 149,
+}
+);
+let promise0 = device0.queue.onSubmittedWorkDone();
+let textureView2 = texture1.createView(
+{
+dimension: '2d',
+baseMipLevel: 3,
+mipLevelCount: 1,
+baseArrayLayer: 196,
+arrayLayerCount: 1,
+}
+);
+gc();
+let textureView3 = texture2.createView(
+{
+label: '\u2eba\ubf57\u0624\u{1f9c6}\u{1feb3}\u{1f720}\u0cb6\u089d\u2360\u212a',
+baseMipLevel: 7,
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture1,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 137 },
+  aspect: 'all',
+},
+new ArrayBuffer(16),
+/* required buffer size: 503691 */{
+offset: 803,
+bytesPerRow: 244,
+rowsPerImage: 228,
+},
+{width: 1, height: 10, depthOrArrayLayers: 10}
+);
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(457, 745);
+let texture3 = device0.createTexture(
+{
+size: [6205],
+dimension: '1d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 262, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(16),
+/* required buffer size: 598 */{
+offset: 598,
+rowsPerImage: 69,
+},
+{width: 6332, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+gc();
+let bindGroupLayout1 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 2409,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}
+],
+}
+);
+let commandEncoder1 = device0.createCommandEncoder(
+{
+}
+);
+let renderPassEncoder0 = commandEncoder1.beginRenderPass(
+{
+label: '\u34ec\u96cd\u2ba9\u0897',
+colorAttachments: [
+undefined,
+undefined,
+{
+view: textureView2,
+clearValue: { r: -35.07, g: 119.9, b: 805.2, a: -739.9, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+undefined,
+undefined
+],
+maxDrawCount: 95640,
+}
+);
+try {
+renderBundleEncoder0.setVertexBuffer(
+52,
+undefined,
+159880791,
+4000940022
+);
+} catch {}
+let bindGroupLayout2 = device0.createBindGroupLayout(
+{
+label: '\u2dd3\u5f97\u{1fd01}\u{1fdf8}',
+entries: [
+{
+binding: 1510,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 922524, hasDynamicOffset: false },
+},
+{
+binding: 4639,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}
+],
+}
+);
+let sampler0 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 57.974,
+lodMaxClamp: 70.036,
+compare: 'less-equal',
+}
+);
+try {
+renderPassEncoder0.setBlendConstant({ r: 730.6, g: -853.4, b: -312.4, a: 781.0, });
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+0.4498,
+5.475,
+0.2101,
+2.807,
+0.8318,
+0.9007
+);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let pipelineLayout1 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+
+]
+}
+);
+let imageData0 = new ImageData(176, 216);
+let videoFrame1 = new VideoFrame(img0, {timestamp: 0});
+let shaderModule0 = device0.createShaderModule(
+{
+label: '\u0d1d\u86b6\u08d4\u0fff',
+code: `@group(0) @binding(509)
+var<storage, read_write> function0: array<u32>;
+@group(0) @binding(2200)
+var<storage, read_write> type0: array<u32>;
+@group(0) @binding(2687)
+var<storage, read_write> global0: array<u32>;
+
+@compute @workgroup_size(6, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S0 {
+@location(28) f0: vec2<i32>,
+@location(34) f1: vec3<f32>,
+@location(3) f2: f32,
+@location(0) f3: vec4<f16>,
+@location(46) f4: vec4<f32>,
+@location(79) f5: u32,
+@location(37) f6: vec2<u32>,
+@location(5) f7: f32,
+@location(18) f8: vec4<u32>,
+@location(48) f9: vec2<u32>,
+@location(68) f10: f16,
+@location(41) f11: vec4<u32>,
+@location(69) f12: vec3<f32>,
+@location(49) f13: f16,
+@location(7) f14: u32,
+@location(8) f15: vec2<f16>,
+@location(4) f16: vec4<i32>,
+@location(24) f17: u32,
+@location(19) f18: vec3<f16>,
+@location(56) f19: vec4<i32>,
+@location(27) f20: vec4<u32>,
+@builtin(sample_index) f21: u32,
+@location(39) f22: vec4<f32>
+}
+struct FragmentOutput0 {
+@location(6) f0: u32,
+@location(1) f1: vec3<u32>,
+@location(5) f2: vec2<u32>,
+@location(7) f3: vec4<i32>,
+@location(0) f4: vec4<i32>,
+@location(3) f5: i32,
+@builtin(frag_depth) f6: f32,
+@location(4) f7: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(76) a0: i32, @location(58) a1: vec4<u32>, @builtin(front_facing) a2: bool, a3: S0, @location(14) a4: f16, @location(32) a5: vec2<i32>, @location(47) a6: u32, @location(44) a7: vec4<i32>, @location(73) a8: vec3<u32>, @location(71) a9: vec3<f32>, @location(30) a10: vec2<f16>, @location(61) a11: vec3<u32>, @location(38) a12: f16, @location(75) a13: vec2<i32>, @location(25) a14: vec4<f16>, @location(1) a15: f16, @location(53) a16: u32, @location(23) a17: f16, @builtin(sample_mask) a18: u32, @location(70) a19: vec4<f32>, @location(55) a20: i32, @location(65) a21: vec2<i32>, @location(31) a22: vec4<i32>, @location(26) a23: u32, @location(13) a24: u32, @location(81) a25: vec2<f16>, @location(29) a26: vec4<f16>, @location(33) a27: vec4<u32>, @location(78) a28: vec4<i32>, @builtin(position) a29: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(78) f0: vec4<i32>,
+@location(19) f1: vec3<f16>,
+@location(7) f2: u32,
+@location(38) f3: f16,
+@location(65) f4: vec2<i32>,
+@location(37) f5: vec2<u32>,
+@location(47) f6: u32,
+@location(69) f7: vec3<f32>,
+@location(34) f8: vec3<f32>,
+@location(46) f9: vec4<f32>,
+@location(24) f10: u32,
+@location(13) f11: u32,
+@location(58) f12: vec4<u32>,
+@location(53) f13: u32,
+@location(76) f14: i32,
+@location(49) f15: f16,
+@location(18) f16: vec4<u32>,
+@location(48) f17: vec2<u32>,
+@builtin(position) f18: vec4<f32>,
+@location(32) f19: vec2<i32>,
+@location(71) f20: vec3<f32>,
+@location(23) f21: f16,
+@location(39) f22: vec4<f32>,
+@location(33) f23: vec4<u32>,
+@location(61) f24: vec3<u32>,
+@location(27) f25: vec4<u32>,
+@location(79) f26: u32,
+@location(75) f27: vec2<i32>,
+@location(41) f28: vec4<u32>,
+@location(1) f29: f16,
+@location(81) f30: vec2<f16>,
+@location(8) f31: vec2<f16>,
+@location(3) f32: f32,
+@location(30) f33: vec2<f16>,
+@location(5) f34: f32,
+@location(73) f35: vec3<u32>,
+@location(56) f36: vec4<i32>,
+@location(68) f37: f16,
+@location(55) f38: i32,
+@location(4) f39: vec4<i32>,
+@location(26) f40: u32,
+@location(0) f41: vec4<f16>,
+@location(29) f42: vec4<f16>,
+@location(25) f43: vec4<f16>,
+@location(44) f44: vec4<i32>,
+@location(28) f45: vec2<i32>,
+@location(31) f46: vec4<i32>,
+@location(14) f47: f16,
+@location(70) f48: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(0) a0: i32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout3 = device0.createBindGroupLayout(
+{
+label: '\u{1fdb7}\u4a35\u0618\u00f6\u0cfe',
+entries: [
+{
+binding: 1642,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 59,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+},
+{
+binding: 4134,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let texture4 = device0.createTexture(
+{
+label: '\u7dac\u06eb\ubcff\u713f\uac6f\u01f7\u{1f668}\u03c9\u{1f77e}\u07bb',
+size: {width: 12, height: 16, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'etc2-rgb8a1unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+try {
+renderPassEncoder0.setBlendConstant({ r: 607.7, g: 760.3, b: 891.9, a: 149.1, });
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+0.1556,
+8.430,
+0.1890,
+1.563,
+0.9904,
+0.9953
+);
+} catch {}
+let shaderModule1 = device0.createShaderModule(
+{
+code: `@group(0) @binding(2687)
+var<storage, read_write> function1: array<u32>;
+@group(0) @binding(2200)
+var<storage, read_write> field0: array<u32>;
+@group(0) @binding(509)
+var<storage, read_write> field1: array<u32>;
+
+@compute @workgroup_size(7, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@location(55) a0: vec3<f16>, @location(74) a1: vec2<f32>, @location(12) a2: vec4<u32>, @location(67) a3: i32, @location(61) a4: vec3<i32>) -> @location(2) u32 {
+return u32();
+}
+
+struct S1 {
+@builtin(instance_index) f0: u32,
+@builtin(vertex_index) f1: u32,
+@location(4) f2: i32,
+@location(8) f3: f16,
+@location(11) f4: vec3<i32>,
+@location(7) f5: f16
+}
+struct VertexOutput0 {
+@location(57) f49: vec4<i32>,
+@location(74) f50: vec2<f32>,
+@location(55) f51: vec3<f16>,
+@location(31) f52: vec3<u32>,
+@builtin(position) f53: vec4<f32>,
+@location(19) f54: vec2<u32>,
+@location(12) f55: vec4<u32>,
+@location(67) f56: i32,
+@location(3) f57: i32,
+@location(48) f58: vec3<f32>,
+@location(80) f59: i32,
+@location(46) f60: vec4<f16>,
+@location(26) f61: vec4<u32>,
+@location(62) f62: vec3<f32>,
+@location(23) f63: vec4<f16>,
+@location(15) f64: vec2<u32>,
+@location(61) f65: vec3<i32>,
+@location(68) f66: vec3<i32>,
+@location(20) f67: vec4<u32>,
+@location(40) f68: vec3<i32>,
+@location(54) f69: vec4<u32>,
+@location(52) f70: i32,
+@location(63) f71: vec2<f32>
+}
+
+@vertex
+fn vertex0(a0: S1, @location(3) a1: u32, @location(19) a2: vec4<f16>, @location(17) a3: f32, @location(13) a4: i32, @location(10) a5: vec4<f32>, @location(18) a6: f16, @location(0) a7: f32, @location(2) a8: vec2<u32>, @location(9) a9: vec2<u32>, @location(1) a10: vec2<u32>, @location(21) a11: vec3<i32>, @location(5) a12: vec3<f32>, @location(12) a13: f32, @location(14) a14: vec4<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+}
+);
+let querySet0 = device0.createQuerySet({
+label: '\u{1fdbb}\u{1fa34}\u{1fbab}',
+type: 'occlusion',
+count: 174,
+});
+let textureView4 = texture3.createView(
+{
+label: '\u{1f636}\u0858\u07b4\u316c\u{1ff84}\udffd\u9cf8',
+}
+);
+try {
+renderPassEncoder0.setScissorRect(
+0,
+8,
+1,
+2
+);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(
+8,
+undefined,
+1343639106,
+2575761639
+);
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+let pipeline0 = await device0.createComputePipelineAsync(
+{
+layout: pipelineLayout1,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+let querySet1 = device0.createQuerySet({
+label: '\ud838\ued7f',
+type: 'occlusion',
+count: 2133,
+});
+pseudoSubmit(device0, commandEncoder1);
+let textureView5 = texture0.createView(
+{
+label: '\u6704\ud26a',
+format: 'rg8sint',
+}
+);
+try {
+renderPassEncoder0.setViewport(
+0.3750,
+3.689,
+0.2862,
+1.076,
+0.8317,
+0.8619
+);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let pipeline1 = device0.createRenderPipeline(
+{
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 13976,
+attributes: [
+
+],
+},
+{
+arrayStride: 3712,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x3',
+offset: 1508,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+cullMode: 'front',
+},
+multisample: {
+count: 4,
+mask: 0xdc128c03,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'always',
+failOp: 'zero',
+passOp: 'replace',
+},
+stencilBack: {
+failOp: 'zero',
+depthFailOp: 'invert',
+},
+stencilReadMask: 3761,
+stencilWriteMask: 3338,
+depthBias: 67,
+depthBiasClamp: 76,
+},
+}
+);
+let renderBundle0 = renderBundleEncoder0.finish(
+{
+label: '\uf358\u0212\u7585\u0be6\u01bf\u7a16\u0df9\uc206\u21ca\ud52a\u7c7a'
+}
+);
+try {
+renderPassEncoder0.setStencilReference(
+23
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: { x: 8, y: 8, z: 1 },
+  aspect: 'all',
+},
+new DataView(new ArrayBuffer(24)),
+/* required buffer size: 604 */{
+offset: 604,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline2 = await device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 2592,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x2',
+offset: 1014,
+shaderLocation: 4,
+},
+{
+format: 'sint32x4',
+offset: 2568,
+shaderLocation: 13,
+},
+{
+format: 'uint32x2',
+offset: 1692,
+shaderLocation: 1,
+},
+{
+format: 'sint32',
+offset: 972,
+shaderLocation: 21,
+},
+{
+format: 'sint32x2',
+offset: 1736,
+shaderLocation: 11,
+},
+{
+format: 'unorm8x4',
+offset: 1892,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x4',
+offset: 1592,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 2064,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 1644,
+shaderLocation: 14,
+},
+{
+format: 'unorm16x2',
+offset: 1268,
+shaderLocation: 12,
+},
+{
+format: 'uint16x2',
+offset: 1976,
+shaderLocation: 3,
+},
+{
+format: 'float16x4',
+offset: 1324,
+shaderLocation: 19,
+},
+{
+format: 'unorm8x2',
+offset: 1498,
+shaderLocation: 0,
+},
+{
+format: 'float32x4',
+offset: 852,
+shaderLocation: 10,
+},
+{
+format: 'uint16x4',
+offset: 1236,
+shaderLocation: 9,
+},
+{
+format: 'uint16x2',
+offset: 984,
+shaderLocation: 2,
+},
+{
+format: 'float32x2',
+offset: 688,
+shaderLocation: 17,
+},
+{
+format: 'float16x2',
+offset: 1344,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 8764,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 8428,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x5bc2d529,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+},
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let renderBundle1 = renderBundleEncoder0.finish(
+{
+label: '\u{1fdeb}\uad0c\u02e5\u{1f8e9}'
+}
+);
+let promise2 = device0.queue.onSubmittedWorkDone();
+let pipeline3 = await device0.createRenderPipelineAsync(
+{
+label: '\u669e\u5acd\u{1fad1}\ua510\u0aeb',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 14440,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 5692,
+shaderLocation: 9,
+},
+{
+format: 'uint32',
+offset: 3808,
+shaderLocation: 3,
+},
+{
+format: 'uint32x2',
+offset: 4420,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x2',
+offset: 10376,
+shaderLocation: 18,
+},
+{
+format: 'snorm16x4',
+offset: 4960,
+shaderLocation: 8,
+},
+{
+format: 'sint32x3',
+offset: 3068,
+shaderLocation: 4,
+},
+{
+format: 'float32x4',
+offset: 9896,
+shaderLocation: 0,
+},
+{
+format: 'float32',
+offset: 6524,
+shaderLocation: 17,
+},
+{
+format: 'snorm8x4',
+offset: 12748,
+shaderLocation: 5,
+},
+{
+format: 'unorm8x4',
+offset: 12392,
+shaderLocation: 7,
+},
+{
+format: 'float32',
+offset: 14068,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 13208,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 13112,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 11764,
+shaderLocation: 14,
+},
+{
+format: 'uint8x2',
+offset: 6298,
+shaderLocation: 1,
+},
+{
+format: 'sint8x4',
+offset: 2352,
+shaderLocation: 21,
+},
+{
+format: 'sint32x3',
+offset: 6692,
+shaderLocation: 11,
+},
+{
+format: 'sint16x4',
+offset: 10208,
+shaderLocation: 13,
+},
+{
+format: 'float32',
+offset: 8096,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+
+],
+},
+{
+arrayStride: 11016,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 5594,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+let buffer0 = device0.createBuffer(
+{
+size: 46756,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let sampler1 = device0.createSampler(
+{
+label: '\u{1fba1}\u9c94\u2ada\uf763\u7d80\u05ea\uc28e',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 31.418,
+lodMaxClamp: 66.028,
+compare: 'always',
+}
+);
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -243.1, g: -806.6, b: 0.1445, a: 838.1, });
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture4,
+  mipLevel: 3,
+  origin: { x: 0, y: 4, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(32),
+/* required buffer size: 662 */{
+offset: 662,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let videoFrame2 = new VideoFrame(videoFrame1, {timestamp: 0});
+let texture5 = device0.createTexture(
+{
+label: '\u08a9\ucd1c\u016d\u47c2\u{1f6f7}\u{1f823}',
+size: {width: 68, height: 1, depthOrArrayLayers: 1877},
+dimension: '3d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder1 = device0.createRenderBundleEncoder(
+{
+label: '\u1f95\u0b1b\u6661\u047e\u065e\u01c8\ub5a3\u65eb\u0e4e',
+colorFormats: [
+'rg16sint',
+undefined,
+'r8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 97,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle2 = renderBundleEncoder0.finish(
+{
+label: '\u2b82\u0233'
+}
+);
+let sampler2 = device0.createSampler(
+{
+label: '\u0327\u{1f704}\u{1ff07}\u7b11\u{1fbba}\u{1f827}\uf4b0\uea08',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 40.238,
+lodMaxClamp: 41.494,
+maxAnisotropy: 4,
+}
+);
+let externalTexture0 = device0.importExternalTexture(
+{
+label: '\u9ea5\u0879\u{1fea1}',
+source: videoFrame2,
+colorSpace: 'srgb',
+}
+);
+try {
+renderPassEncoder0.setBlendConstant({ r: 436.9, g: -181.4, b: 955.0, a: 261.2, });
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(
+0,
+10,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+1973
+);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(
+24,
+undefined,
+251174809,
+3624910488
+);
+} catch {}
+let pipeline4 = device0.createRenderPipeline(
+{
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 12976,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 3648,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 1740,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 1536,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x4',
+offset: 1200,
+shaderLocation: 7,
+},
+{
+format: 'uint16x4',
+offset: 1588,
+shaderLocation: 3,
+},
+{
+format: 'uint32x3',
+offset: 472,
+shaderLocation: 14,
+},
+{
+format: 'sint16x2',
+offset: 376,
+shaderLocation: 11,
+},
+{
+format: 'uint8x4',
+offset: 1424,
+shaderLocation: 1,
+},
+{
+format: 'sint32x3',
+offset: 820,
+shaderLocation: 13,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1192,
+shaderLocation: 17,
+},
+{
+format: 'unorm16x4',
+offset: 1272,
+shaderLocation: 0,
+},
+{
+format: 'uint16x4',
+offset: 584,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x2',
+offset: 1530,
+shaderLocation: 12,
+},
+{
+format: 'snorm16x4',
+offset: 228,
+shaderLocation: 8,
+},
+{
+format: 'snorm16x2',
+offset: 1396,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 14268,
+attributes: [
+{
+format: 'snorm8x2',
+offset: 13180,
+shaderLocation: 5,
+},
+{
+format: 'float32x2',
+offset: 3800,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 2872,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 5412,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x3',
+offset: 4188,
+shaderLocation: 4,
+},
+{
+format: 'sint32x4',
+offset: 3844,
+shaderLocation: 21,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r16uint',
+},
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+let offscreenCanvas1 = new OffscreenCanvas(757, 341);
+let img1 = await imageWithData(136, 230, '#1152f58f', '#d4a1bd42');
+try {
+window.someLabel = texture3.label;
+} catch {}
+let arrayBuffer0 = buffer0.getMappedRange(
+23288
+);
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 240}
+*/
+{
+  source: imageData0,
+  origin: { x: 135, y: 198 },
+  flipY: true,
+},
+{
+  texture: texture1,
+  mipLevel: 6,
+  origin: { x: 1, y: 0, z: 42 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let img2 = await imageWithData(205, 149, '#eed5d436', '#09e0d101');
+try {
+offscreenCanvas1.getContext('webgpu');
+} catch {}
+let querySet2 = device0.createQuerySet({
+label: '\ub6d8\ua47e\ufba2\u25a5\u09e4\u06da\u075e',
+type: 'occlusion',
+count: 2399,
+});
+let renderBundle3 = renderBundleEncoder1.finish(
+{
+label: '\u6695\uf24e\u096e\uef71\u099f\u10b1\u07f8\u6b25\uc350\u00f2'
+}
+);
+try {
+renderPassEncoder0.setVertexBuffer(
+90,
+undefined
+);
+} catch {}
+let pipeline5 = await device0.createRenderPipelineAsync(
+{
+label: '\u{1f8f9}\u{1f7c3}\u0243\u{1f743}\u00ef\u{1fea6}\u4c8e\ud31a\ud516\u508b',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 4340,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 3608,
+shaderLocation: 5,
+},
+{
+format: 'uint16x4',
+offset: 3976,
+shaderLocation: 2,
+},
+{
+format: 'float32x3',
+offset: 576,
+shaderLocation: 0,
+},
+{
+format: 'sint16x2',
+offset: 384,
+shaderLocation: 11,
+},
+{
+format: 'uint8x4',
+offset: 3864,
+shaderLocation: 1,
+},
+{
+format: 'sint32',
+offset: 2984,
+shaderLocation: 21,
+},
+{
+format: 'unorm8x4',
+offset: 84,
+shaderLocation: 8,
+},
+{
+format: 'sint16x2',
+offset: 4292,
+shaderLocation: 13,
+},
+{
+format: 'snorm16x2',
+offset: 4156,
+shaderLocation: 7,
+},
+{
+format: 'unorm16x2',
+offset: 3196,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 7748,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 3024,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x2',
+offset: 7718,
+shaderLocation: 17,
+},
+{
+format: 'float16x4',
+offset: 7012,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 12220,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x2',
+offset: 5140,
+shaderLocation: 9,
+},
+{
+format: 'sint8x4',
+offset: 2368,
+shaderLocation: 4,
+},
+{
+format: 'uint32x3',
+offset: 9560,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 11492,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 10336,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 11720,
+attributes: [
+{
+format: 'unorm8x4',
+offset: 3980,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilReadMask: 3587,
+stencilWriteMask: 2795,
+depthBias: 36,
+depthBiasSlopeScale: 74,
+depthBiasClamp: 56,
+},
+}
+);
+try {
+await promise0;
+} catch {}
+let texture6 = device0.createTexture(
+{
+label: '\ub2fe\u4e2e\u{1f65d}\u06e0\u3758\u0fde\u0613\u05d1\u60f5\u{1fa56}\u2739',
+size: [6026],
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 1101, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 23741 */{
+offset: 461,
+},
+{width: 2910, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline6 = await device0.createComputePipelineAsync(
+{
+label: '\u0730\u9728\u0233\u14ab\u{1fe7c}\ufe9b',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+}
+);
+let pipeline7 = device0.createRenderPipeline(
+{
+label: '\u0bf9\u0b80\u73cc',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3472,
+attributes: [
+{
+format: 'float32x4',
+offset: 0,
+shaderLocation: 18,
+},
+{
+format: 'sint8x4',
+offset: 76,
+shaderLocation: 21,
+},
+{
+format: 'snorm8x2',
+offset: 2996,
+shaderLocation: 7,
+},
+{
+format: 'float16x2',
+offset: 472,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x4',
+offset: 380,
+shaderLocation: 0,
+},
+{
+format: 'uint8x2',
+offset: 1282,
+shaderLocation: 2,
+},
+{
+format: 'uint16x4',
+offset: 3136,
+shaderLocation: 14,
+},
+{
+format: 'sint8x2',
+offset: 2768,
+shaderLocation: 4,
+},
+{
+format: 'uint32',
+offset: 2248,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x4',
+offset: 68,
+shaderLocation: 12,
+},
+{
+format: 'sint16x4',
+offset: 1196,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 2320,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 1432,
+shaderLocation: 10,
+},
+{
+format: 'sint8x4',
+offset: 1476,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 8692,
+attributes: [
+{
+format: 'uint16x4',
+offset: 4316,
+shaderLocation: 3,
+},
+{
+format: 'uint16x4',
+offset: 7408,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x2',
+offset: 426,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 14388,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 12632,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 7764,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 1430,
+shaderLocation: 19,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'back',
+},
+multisample: {
+mask: 0x25936b6d,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less',
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 566,
+stencilWriteMask: 4079,
+depthBias: 67,
+depthBiasSlopeScale: 21,
+depthBiasClamp: 34,
+},
+}
+);
+let canvas1 = document.createElement('canvas');
+let video0 = await videoWithData();
+let imageData1 = new ImageData(240, 100);
+let commandEncoder2 = device0.createCommandEncoder();
+let textureView6 = texture3.createView(
+{
+format: 'r16float',
+baseArrayLayer: 0,
+}
+);
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(
+80,
+undefined,
+1309793980,
+1270940127
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 240}
+*/
+{
+  source: img1,
+  origin: { x: 12, y: 191 },
+  flipY: true,
+},
+{
+  texture: texture1,
+  mipLevel: 6,
+  origin: { x: 1, y: 0, z: 232 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend(video0);
+let querySet3 = device0.createQuerySet({
+label: '\u0603\ubd16\u9e1e\u6645\u{1ff03}\u62d6\u084e\u5c19\ue49f',
+type: 'occlusion',
+count: 2082,
+});
+let texture7 = device0.createTexture(
+{
+label: '\u{1fdad}\u2df4\ua6a4\u96fd\u2a5d\u0dfd',
+size: {width: 62, height: 62, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+renderPassEncoder0.setVertexBuffer(
+31,
+undefined,
+3758979112,
+124903033
+);
+} catch {}
+let promise3 = device0.createComputePipelineAsync(
+{
+label: '\u781c\u23ed\u{1f872}\u{1f8cd}\ub7d8\u6ad1\udc00\u{1fb5d}\u00bf',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+}
+);
+let promise4 = navigator.gpu.requestAdapter(
+{
+}
+);
+let buffer1 = device0.createBuffer(
+{
+size: 58361,
+usage: GPUBufferUsage.MAP_WRITE,
+}
+);
+let renderPassEncoder1 = commandEncoder2.beginRenderPass(
+{
+label: '\uc567\u4781\u{1f8b0}\u2fd3\u9332\u{1f901}\u{1fafd}\u0b58',
+colorAttachments: [
+{
+view: textureView2,
+clearValue: { r: 577.6, g: 308.2, b: -669.4, a: 60.86, },
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+maxDrawCount: 3080,
+}
+);
+try {
+renderPassEncoder1.setStencilReference(
+3099
+);
+} catch {}
+let pipeline8 = device0.createRenderPipeline(
+{
+label: '\u0d9a\u0da8\u9b6c\u354a\ud45a\ua903\u{1f8bc}',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 8688,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgba16sint',
+writeMask: GPUColorWrite.ALPHA,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilWriteMask: 2444,
+depthBias: 85,
+depthBiasSlopeScale: 95,
+},
+}
+);
+document.body.prepend(canvas0);
+try {
+adapter0.label = '\u32f6\u876f\u036a';
+} catch {}
+try {
+canvas1.getContext('webgpu');
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout2,
+bindGroupLayout2,
+bindGroupLayout0,
+bindGroupLayout1,
+bindGroupLayout1,
+bindGroupLayout3
+]
+}
+);
+let buffer2 = device0.createBuffer(
+{
+size: 31844,
+usage: GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+pseudoSubmit(device0, commandEncoder2);
+let renderBundleEncoder2 = device0.createRenderBundleEncoder(
+{
+label: '\u{1f8d6}\u795a',
+colorFormats: [
+'r8uint',
+'r8unorm',
+'r8unorm'
+],
+sampleCount: 390,
+}
+);
+let renderBundle4 = renderBundleEncoder0.finish(
+{
+label: '\u{1f6c0}\u06cc\ub46b\u{1f817}\u{1f92b}'
+}
+);
+try {
+renderPassEncoder0.setBlendConstant({ r: -311.0, g: 3.680, b: 800.3, a: -360.2, });
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+0,
+7,
+0,
+1
+);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+972
+);
+} catch {}
+let pipeline9 = await promise3;
+try {
+adapter0.label = '\u8fb8\u5066\ud545\ufe69\ud1a5';
+} catch {}
+let renderBundle5 = renderBundleEncoder0.finish(
+{
+
+}
+);
+let sampler3 = device0.createSampler(
+{
+label: '\u{1f8ff}\uabad\u4f48\u{1fc2a}',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 62.978,
+lodMaxClamp: 77.425,
+maxAnisotropy: 19,
+}
+);
+try {
+renderPassEncoder1.setBlendConstant({ r: -454.7, g: 392.2, b: 946.3, a: -983.0, });
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+2024
+);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(
+14,
+undefined
+);
+} catch {}
+let arrayBuffer1 = buffer2.getMappedRange(
+16464,
+14524
+);
+try {
+device0.queue.submit([
+commandBuffer0,
+]);
+} catch {}
+let videoFrame3 = new VideoFrame(img0, {timestamp: 0});
+try {
+renderPassEncoder1.setBlendConstant({ r: -661.7, g: -512.2, b: -771.2, a: -694.6, });
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(
+0,
+1,
+0,
+3
+);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+2289
+);
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+0.5554,
+10.54,
+0.2450,
+0.3468,
+0.3857,
+0.4316
+);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(
+14,
+undefined,
+4178248808,
+44414101
+);
+} catch {}
+gc();
+let canvas2 = document.createElement('canvas');
+let commandEncoder3 = device0.createCommandEncoder(
+{
+label: '\u63b1\u0545\u0744\uf458\ua0c3\u{1fccd}',
+}
+);
+let texture8 = device0.createTexture(
+{
+label: '\u097e\u{1ff2f}\u9844\u08c3\u024a\u8aea\u2bb5',
+size: {width: 20, height: 4, depthOrArrayLayers: 89},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rg16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle6 = renderBundleEncoder1.finish(
+{
+
+}
+);
+try {
+renderBundleEncoder2.insertDebugMarker(
+'\u{1f84e}'
+);
+} catch {}
+let querySet4 = device0.createQuerySet({
+label: '\u{1ffa6}\u3d39\u1d5c\u{1f6b6}\u{1fa8f}\u6021\udd99\u0183\u00f8',
+type: 'occlusion',
+count: 2502,
+});
+let computePassEncoder0 = commandEncoder3.beginComputePass(
+{
+
+}
+);
+try {
+renderPassEncoder1.setBlendConstant({ r: -434.8, g: 838.4, b: -934.7, a: -562.0, });
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+2449
+);
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+0.2642,
+8.024,
+0.3578,
+2.348,
+0.6189,
+0.8923
+);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+0,
+11,
+1,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+1355
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture7,
+  mipLevel: 1,
+  origin: { x: 0, y: 12, z: 0 },
+  aspect: 'stencil-only',
+},
+new BigUint64Array(arrayBuffer0),
+/* required buffer size: 253 */{
+offset: 253,
+bytesPerRow: 158,
+},
+{width: 31, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(540, 774);
+let bindGroupLayout4 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 4313,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+try {
+renderPassEncoder1.setBlendConstant({ r: -73.44, g: 719.0, b: -314.0, a: -152.5, });
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+0.6374,
+4.800,
+0.2477,
+3.803,
+0.4064,
+0.7471
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+81,
+undefined,
+1856888997,
+210540836
+);
+} catch {}
+let pipeline10 = await device0.createComputePipelineAsync(
+{
+label: '\u0a2a\u61ee\u067e\u{1faed}',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let promise5 = adapter0.requestAdapterInfo();
+let bindGroupLayout5 = device0.createBindGroupLayout(
+{
+entries: [
+
+],
+}
+);
+let querySet5 = device0.createQuerySet({
+type: 'occlusion',
+count: 1083,
+});
+let texture9 = device0.createTexture(
+{
+label: '\u0b7f\u46ab\u0301\u{1fda9}',
+size: {width: 14, height: 69, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'r16sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+let externalTexture1 = device0.importExternalTexture(
+{
+label: '\u{1fc3a}\u00b1\ufd64\u049f\uff9c',
+source: video0,
+colorSpace: 'srgb',
+}
+);
+try {
+renderBundleEncoder2.setVertexBuffer(
+11,
+undefined,
+610769754,
+519818253
+);
+} catch {}
+let pipeline11 = await device0.createComputePipelineAsync(
+{
+label: '\u735f\u8961',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline12 = device0.createRenderPipeline(
+{
+label: '\u{1fd61}\u4188\u736a\u0e19\uc6b1\u{1f7ad}\u40c2\u0f82\u0d2e\u0e42\u{1f82a}',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 5568,
+attributes: [
+{
+format: 'sint32x4',
+offset: 4176,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+cullMode: 'back',
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'never',
+failOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'invert',
+depthFailOp: 'increment-wrap',
+passOp: 'keep',
+},
+stencilWriteMask: 1286,
+depthBias: 92,
+depthBiasSlopeScale: 94,
+depthBiasClamp: 26,
+},
+}
+);
+let imageBitmap0 = await createImageBitmap(offscreenCanvas2);
+let pipelineLayout3 = device0.createPipelineLayout(
+{
+label: '\u743f\u{1f97c}\uadf2\u{1f980}\u82be',
+bindGroupLayouts: [
+bindGroupLayout5,
+bindGroupLayout4,
+bindGroupLayout1,
+bindGroupLayout0,
+bindGroupLayout3,
+bindGroupLayout2,
+bindGroupLayout5,
+bindGroupLayout5,
+bindGroupLayout2
+]
+}
+);
+try {
+renderPassEncoder0.setBlendConstant({ r: 959.6, g: -239.8, b: 141.1, a: -182.8, });
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+0.5145,
+5.713,
+0.4702,
+2.086,
+0.7593,
+0.9371
+);
+} catch {}
+let video1 = await videoWithData();
+try {
+canvas2.getContext('bitmaprenderer');
+} catch {}
+let texture10 = device0.createTexture(
+{
+label: '\u0235\uecb2\u0ef1\u0aa3\u{1f637}',
+size: [253, 213, 1],
+mipLevelCount: 4,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'depth32float-stencil8',
+'depth32float-stencil8'
+],
+}
+);
+let textureView7 = texture4.createView(
+{
+baseMipLevel: 3,
+mipLevelCount: 1,
+}
+);
+try {
+renderBundleEncoder2.setVertexBuffer(
+24,
+undefined,
+581719715,
+221897593
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 3077, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer1),
+/* required buffer size: 10 */{
+offset: 10,
+bytesPerRow: 6527,
+},
+{width: 3202, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+externalTexture1.label = '\u41a2\u{1ff49}\u{1fed5}\u1383\u0674\ud803\u06d7\ue63d';
+} catch {}
+let querySet6 = device0.createQuerySet({
+label: '\u0b30\u{1fbf4}\u8926\u90b0\u22c7\ue1c1\u0a0e\u0787\uf427\u4ad1\u0c12',
+type: 'occlusion',
+count: 1621,
+});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder(
+{
+label: '\uab5c\u6f50\uaf25\udd3d\ub338',
+colorFormats: [
+undefined
+],
+depthReadOnly: true,
+}
+);
+let sampler4 = device0.createSampler(
+{
+label: '\u0148\ub71f\u6b4b',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 69.671,
+lodMaxClamp: 79.538,
+maxAnisotropy: 16,
+}
+);
+try {
+renderPassEncoder0.setScissorRect(
+0,
+8,
+0,
+1
+);
+} catch {}
+try {
+await buffer1.mapAsync(
+GPUMapMode.WRITE,
+0,
+9600
+);
+} catch {}
+try {
+computePassEncoder0.insertDebugMarker(
+'\u020f'
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture4,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer0),
+/* required buffer size: 340 */{
+offset: 340,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline13 = device0.createRenderPipeline(
+{
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 13188,
+attributes: [
+{
+format: 'sint32x4',
+offset: 348,
+shaderLocation: 4,
+},
+{
+format: 'float16x2',
+offset: 2264,
+shaderLocation: 18,
+},
+{
+format: 'float16x2',
+offset: 11252,
+shaderLocation: 17,
+},
+{
+format: 'snorm8x4',
+offset: 9384,
+shaderLocation: 8,
+},
+{
+format: 'sint16x4',
+offset: 5744,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 4608,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 856,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x2',
+offset: 1572,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x2',
+offset: 744,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x4',
+offset: 2592,
+shaderLocation: 19,
+},
+{
+format: 'sint32x3',
+offset: 4384,
+shaderLocation: 21,
+},
+{
+format: 'uint32',
+offset: 1372,
+shaderLocation: 3,
+},
+{
+format: 'uint32x3',
+offset: 2444,
+shaderLocation: 1,
+},
+{
+format: 'uint32x4',
+offset: 2560,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x2',
+offset: 724,
+shaderLocation: 7,
+},
+{
+format: 'uint32x2',
+offset: 1968,
+shaderLocation: 2,
+},
+{
+format: 'sint32',
+offset: 1456,
+shaderLocation: 13,
+},
+{
+format: 'unorm16x4',
+offset: 1416,
+shaderLocation: 0,
+},
+{
+format: 'uint32x3',
+offset: 3908,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'back',
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16uint',
+writeMask: 0,
+},
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+let bindGroupLayout6 = device0.createBindGroupLayout(
+{
+label: '\u2f89\u28c1\u7275\u1a18\u0356',
+entries: [
+{
+binding: 5523,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '2d-array' },
+}
+],
+}
+);
+pseudoSubmit(device0, commandEncoder3);
+try {
+renderBundleEncoder3.setVertexBuffer(
+4,
+undefined,
+1069572147,
+315536114
+);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+let pipeline14 = await device0.createComputePipelineAsync(
+{
+layout: pipelineLayout2,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let img3 = await imageWithData(213, 28, '#028c4d1b', '#0fd19c72');
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgba16float',
+'rg11b10ufloat',
+'rg16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 492, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 463 */{
+offset: 463,
+},
+{width: 4818, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline15 = device0.createComputePipeline(
+{
+label: '\uf4d5\u6380\u{1fd2a}\u{1fe55}\u5bd5',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline16 = await device0.createRenderPipelineAsync(
+{
+label: '\u6f77\u0262\uef1f\u07fc',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 4844,
+attributes: [
+{
+format: 'snorm16x4',
+offset: 3928,
+shaderLocation: 17,
+},
+{
+format: 'snorm8x4',
+offset: 1660,
+shaderLocation: 5,
+},
+{
+format: 'uint32',
+offset: 2816,
+shaderLocation: 14,
+},
+{
+format: 'sint32x3',
+offset: 1892,
+shaderLocation: 21,
+},
+{
+format: 'sint16x2',
+offset: 2328,
+shaderLocation: 13,
+},
+{
+format: 'sint8x4',
+offset: 4604,
+shaderLocation: 4,
+},
+{
+format: 'float32',
+offset: 2896,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 12436,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 10792,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x2',
+offset: 108,
+shaderLocation: 7,
+},
+{
+format: 'sint8x2',
+offset: 4752,
+shaderLocation: 11,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 6120,
+shaderLocation: 12,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 5596,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 1030,
+shaderLocation: 8,
+},
+{
+format: 'unorm8x2',
+offset: 11040,
+shaderLocation: 10,
+},
+{
+format: 'uint32x4',
+offset: 14396,
+shaderLocation: 3,
+},
+{
+format: 'uint8x2',
+offset: 10954,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 10504,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 1256,
+shaderLocation: 0,
+},
+{
+format: 'uint16x2',
+offset: 5820,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+unclippedDepth: false,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16uint',
+},
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer3 = device0.createBuffer(
+{
+label: '\u59bc\u61c2\ue0f6\u0297\uc9ac\uf1a2\u09e8\u0f46\u071b\u{1fa5c}\u0e9e',
+size: 13818,
+usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+}
+);
+let sampler5 = device0.createSampler(
+{
+label: '\uba9f\u{1fc90}\u10f0\u0d1b\u0d1a\u597a\u{1ff01}\u{1ff37}\u0649\u85fe',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 29.009,
+}
+);
+try {
+renderPassEncoder1.setScissorRect(
+0,
+11,
+0,
+0
+);
+} catch {}
+let arrayBuffer2 = buffer1.getMappedRange(
+8984,
+424
+);
+let pipeline17 = await device0.createComputePipelineAsync(
+{
+label: '\ubac0\u66b6\u0b58',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+}
+);
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroup0 = device0.createBindGroup({
+label: '\u{1fd4d}\u60c1',
+layout: bindGroupLayout5,
+entries: [
+
+],
+});
+let texture11 = device0.createTexture(
+{
+label: '\u{1f787}\u3d6b\u0632\u6d3b\u0fd1\u{1fec1}\u{1f615}\ub93a\u0957\u22ae\u2a21',
+size: [12208, 4, 1],
+mipLevelCount: 10,
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+let textureView8 = texture10.createView(
+{
+aspect: 'depth-only',
+baseMipLevel: 1,
+arrayLayerCount: 1,
+}
+);
+let renderBundleEncoder4 = device0.createRenderBundleEncoder(
+{
+label: '\u0ba3\ue9d1\u{1fd88}\u024d\ueeac',
+colorFormats: [
+'rgba8unorm'
+],
+sampleCount: 385,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder0.setBindGroup(
+1,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(
+2178
+);
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+0.3447,
+8.250,
+0.3615,
+0.3352,
+0.2784,
+0.9123
+);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(
+4,
+bindGroup0
+);
+} catch {}
+let arrayBuffer3 = buffer1.getMappedRange(
+0,
+3016
+);
+let promise6 = device0.createComputePipelineAsync(
+{
+label: '\u{1faad}\u0cf7\uda60\u{1f8e7}\u{1f9ef}\u{1f759}\u0c95',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend(video1);
+let buffer4 = device0.createBuffer(
+{
+label: '\u{1f7fe}\u0eae',
+size: 49554,
+usage: GPUBufferUsage.UNIFORM,
+}
+);
+let querySet7 = device0.createQuerySet({
+label: '\u0342\u0392\u0184\u16f2\u{1fe88}',
+type: 'occlusion',
+count: 1820,
+});
+let texture12 = device0.createTexture(
+{
+label: '\u{1fdcb}\u4084\u334f',
+size: {width: 1864},
+dimension: '1d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg8unorm',
+'rg8unorm'
+],
+}
+);
+let renderBundleEncoder5 = device0.createRenderBundleEncoder(
+{
+label: '\u117b\u2017\ud949',
+colorFormats: [
+'rgb10a2unorm',
+'r8unorm',
+'rg11b10ufloat',
+undefined,
+'rg11b10ufloat',
+'r8uint'
+],
+sampleCount: 333,
+stencilReadOnly: true,
+}
+);
+let renderBundle7 = renderBundleEncoder5.finish(
+{
+label: '\u19e6\u880b\u454d\u6a00\u82df\u0745\u6fac\ufcde\ub5e9\u0414\u5020'
+}
+);
+try {
+renderBundleEncoder2.setBindGroup(
+7,
+bindGroup0
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 240}
+*/
+{
+  source: img3,
+  origin: { x: 140, y: 20 },
+  flipY: false,
+},
+{
+  texture: texture1,
+  mipLevel: 6,
+  origin: { x: 0, y: 1, z: 39 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline18 = device0.createComputePipeline(
+{
+label: '\u462a\u{1fcb2}\u151a\u{1fd57}\u92ed',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let bindGroup1 = device0.createBindGroup({
+layout: bindGroupLayout1,
+entries: [
+{
+binding: 2409,
+resource: externalTexture1
+}
+],
+});
+let commandEncoder4 = device0.createCommandEncoder(
+{
+label: '\u080b\u0515\u3e03\u750f\ub042\u0809',
+}
+);
+let textureView9 = texture10.createView(
+{
+label: '\u04a7\uc9c6\u65c0\u0204',
+dimension: '2d-array',
+baseMipLevel: 3,
+}
+);
+try {
+renderPassEncoder1.setBindGroup(
+9,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -255.5, g: -966.6, b: 97.59, a: -213.3, });
+} catch {}
+try {
+await buffer2.mapAsync(
+GPUMapMode.WRITE
+);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext1 = offscreenCanvas2.getContext('webgpu');
+let video2 = await videoWithData();
+try {
+window.someLabel = externalTexture1.label;
+} catch {}
+try {
+window.someLabel = querySet1.label;
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+label: '\u0cb6\u0dab\u00c3\u9a4f\u{1fd7e}\u7a2c\uea2f',
+layout: bindGroupLayout5,
+entries: [
+
+],
+});
+let querySet8 = device0.createQuerySet({
+label: '\ub4ae\u65e8\u{1ff02}\u00e5\ue061\uacdd\ue994\u6dfd\u{1fb68}',
+type: 'occlusion',
+count: 187,
+});
+pseudoSubmit(device0, commandEncoder4);
+let renderBundle8 = renderBundleEncoder1.finish(
+{
+label: '\u8c6d\u0087\ua1cb\ub77e\uc720\u4562'
+}
+);
+try {
+renderPassEncoder0.setScissorRect(
+1,
+1,
+0,
+1
+);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline3);
+} catch {}
+let pipeline19 = device0.createRenderPipeline(
+{
+label: '\ue669\u{1fa7f}\u{1f814}\u021b\uc64c\u{1fd88}\u{1fde2}\u04eb\u0b7d',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3880,
+attributes: [
+{
+format: 'sint8x4',
+offset: 2656,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'invert',
+depthFailOp: 'replace',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'replace',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 3649,
+stencilWriteMask: 2276,
+depthBias: 36,
+depthBiasSlopeScale: 12,
+depthBiasClamp: 14,
+},
+}
+);
+let texture13 = device0.createTexture(
+{
+label: '\uc3b1\u8998\u4c60\u0166',
+size: [239, 28, 1],
+mipLevelCount: 6,
+format: 'r16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'r16float',
+'r16float'
+],
+}
+);
+let sampler6 = device0.createSampler(
+{
+label: '\uc991\u0642\u{1f65c}\u{1fafe}\u0220\u{1f828}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+lodMaxClamp: 51.597,
+}
+);
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 350.7, g: -415.4, b: 837.2, a: 376.9, });
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(
+81,
+undefined,
+3813101110,
+386487135
+);
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+let videoFrame4 = new VideoFrame(img0, {timestamp: 0});
+let querySet9 = device0.createQuerySet({
+label: '\u{1fe12}\u0b98\u0348\u43cf\u0a0b\ub1ee\uc7bd\udabd',
+type: 'occlusion',
+count: 3457,
+});
+let renderBundle9 = renderBundleEncoder4.finish();
+try {
+renderPassEncoder1.setViewport(
+0.2386,
+0.8589,
+0.1558,
+8.592,
+0.3194,
+0.6225
+);
+} catch {}
+try {
+await promise8;
+} catch {}
+let img4 = await imageWithData(26, 175, '#89cde53f', '#3ae5b816');
+let videoFrame5 = new VideoFrame(img0, {timestamp: 0});
+let commandEncoder5 = device0.createCommandEncoder(
+{
+}
+);
+try {
+renderPassEncoder1.setBindGroup(
+5,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -333.3, g: 598.9, b: -709.2, a: -868.6, });
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(
+61,
+undefined,
+118479245
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+}
+);
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+let commandEncoder6 = device0.createCommandEncoder(
+{
+label: '\u3c22\u076a\u{1f9fb}\u0033\u9411\u{1f8d9}',
+}
+);
+let renderBundle10 = renderBundleEncoder1.finish(
+{
+label: '\ufcef\u893c\ued73\u0d64\u1950\u963c\u{1fbdc}\u794f\u950f\ud10c'
+}
+);
+try {
+renderPassEncoder0.setBindGroup(
+7,
+bindGroup0,
+new Uint32Array(5780),
+3927,
+0
+);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(
+3,
+bindGroup1,
+new Uint32Array(1396),
+118,
+0
+);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(
+buffer3,
+'uint16'
+);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(
+57,
+undefined,
+3355299398,
+496903049
+);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+let textureView10 = texture7.createView(
+{
+aspect: 'stencil-only',
+baseMipLevel: 2,
+}
+);
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setViewport(
+0.8740,
+9.674,
+0.00953,
+0.3186,
+0.1763,
+0.1937
+);
+} catch {}
+try {
+querySet0.destroy();
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundle11 = renderBundleEncoder1.finish();
+try {
+renderPassEncoder1.setBindGroup(
+7,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+0.2209,
+2.910,
+0.2970,
+4.445,
+0.06716,
+0.4108
+);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(
+buffer3,
+'uint32'
+);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline16);
+} catch {}
+try {
+computePassEncoder0.insertDebugMarker(
+'\u2199'
+);
+} catch {}
+let texture14 = device0.createTexture(
+{
+label: '\ub35c\ua91a\u8976',
+size: [108, 1, 136],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba32float',
+'rgba32float',
+'rgba32float'
+],
+}
+);
+let computePassEncoder1 = commandEncoder5.beginComputePass(
+{
+label: '\u{1f712}\u4131\u{1f8d8}\u17ac\u3704\u{1fe49}\u1ae3\u0f59\u0c61\u023e\u047f'
+}
+);
+let renderBundle12 = renderBundleEncoder5.finish();
+try {
+renderPassEncoder0.setScissorRect(
+1,
+4,
+0,
+1
+);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(
+4,
+bindGroup1,
+new Uint32Array(8097),
+1189,
+0
+);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(
+buffer3,
+'uint16',
+7928,
+769
+);
+} catch {}
+let imageBitmap1 = await createImageBitmap(videoFrame1);
+try {
+pipeline3.label = '\ud876\u01db\ub4c6\u{1fc26}\u0130\ud471\u0f2d\uf449\ue7af';
+} catch {}
+let pipelineLayout4 = device0.createPipelineLayout(
+{
+label: '\u2c46\u0edd\u2010\u09d1\u{1f98d}\ua1e0\u4cd0\u{1f6c0}\u{1ffd5}\ub6ff\u3c6a',
+bindGroupLayouts: [
+bindGroupLayout2,
+bindGroupLayout0,
+bindGroupLayout6
+]
+}
+);
+let commandEncoder7 = device0.createCommandEncoder(
+{
+label: '\u09b1\u{1f69d}\u{1f725}\u9281\u0c01\u0919',
+}
+);
+let querySet10 = device0.createQuerySet({
+label: '\ubce6\u91ec',
+type: 'occlusion',
+count: 917,
+});
+let commandBuffer1 = commandEncoder6.finish(
+{
+label: '\u7301\ud402\u0f2b\u00e6',
+}
+);
+let texture15 = device0.createTexture(
+{
+label: '\u{1f9a4}\ub217\u872e\uf26a\u84d6',
+size: [1689, 1, 704],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+renderPassEncoder0.setViewport(
+0.2903,
+3.941,
+0.5469,
+0.02146,
+0.8500,
+0.8716
+);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(
+7,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder3.drawIndexed(
+56
+);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 1139, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int32Array(new ArrayBuffer(32)),
+/* required buffer size: 581 */{
+offset: 581,
+},
+{width: 980, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline20 = await device0.createRenderPipelineAsync(
+{
+label: '\u7e70\u48a7\u5304\u37fb\u01e6\u05c4\ub920\u2c78\u0fc2',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 10280,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x4',
+offset: 5592,
+shaderLocation: 21,
+},
+{
+format: 'float32',
+offset: 772,
+shaderLocation: 18,
+},
+{
+format: 'sint32x3',
+offset: 6412,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 2972,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 1608,
+shaderLocation: 19,
+},
+{
+format: 'uint8x2',
+offset: 2474,
+shaderLocation: 1,
+},
+{
+format: 'snorm16x4',
+offset: 1220,
+shaderLocation: 10,
+},
+{
+format: 'sint32x2',
+offset: 2928,
+shaderLocation: 4,
+},
+{
+format: 'uint8x2',
+offset: 920,
+shaderLocation: 3,
+},
+{
+format: 'sint8x2',
+offset: 2664,
+shaderLocation: 11,
+},
+{
+format: 'float16x4',
+offset: 504,
+shaderLocation: 5,
+},
+{
+format: 'float16x2',
+offset: 2040,
+shaderLocation: 12,
+},
+{
+format: 'uint16x2',
+offset: 1924,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x4',
+offset: 1580,
+shaderLocation: 8,
+},
+{
+format: 'float16x4',
+offset: 2264,
+shaderLocation: 7,
+},
+{
+format: 'float32',
+offset: 2928,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 3360,
+attributes: [
+{
+format: 'uint32x3',
+offset: 2844,
+shaderLocation: 14,
+},
+{
+format: 'float16x4',
+offset: 1324,
+shaderLocation: 0,
+},
+{
+format: 'uint16x2',
+offset: 1536,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 1,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'keep',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 1584,
+stencilWriteMask: 3959,
+depthBiasSlopeScale: 78,
+depthBiasClamp: 31,
+},
+}
+);
+let imageBitmap2 = await createImageBitmap(img1);
+let buffer5 = device0.createBuffer(
+{
+label: '\u0b7b\u55d9\u14eb\u1ead\u{1fd9f}\u05a7\u0617\u0126\u{1f6e6}\u72c7',
+size: 44622,
+usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+}
+);
+let querySet11 = device0.createQuerySet({
+label: '\u0f3b\u{1f83d}',
+type: 'occlusion',
+count: 99,
+});
+let textureView11 = texture6.createView(
+{
+label: '\uc59e\ufcf4\ufe59\u4272\u{1fee9}\uf512\u{1fc72}\u{1f71c}\u6930\u0969\ua024',
+dimension: '1d',
+}
+);
+try {
+renderBundleEncoder3.draw(
+40,
+32,
+16,
+48
+);
+} catch {}
+try {
+commandEncoder7.copyTextureToTexture(
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 62, height: 62, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+computePassEncoder1.insertDebugMarker(
+'\u152e'
+);
+} catch {}
+let img5 = await imageWithData(237, 95, '#7ef97ba4', '#0d7d03c4');
+try {
+renderPassEncoder0.setBlendConstant({ r: -488.8, g: 579.5, b: 93.25, a: 607.3, });
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(
+buffer3,
+'uint32',
+13356,
+432
+);
+} catch {}
+video2.height = 216;
+try {
+computePassEncoder1.setBindGroup(
+2,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(
+1,
+2,
+0,
+7
+);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(
+buffer5,
+'uint16',
+5860
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+2,
+bindGroup0
+);
+} catch {}
+let arrayBuffer4 = buffer2.getMappedRange(
+0,
+7524
+);
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 5, depthOrArrayLayers: 240}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 43, y: 81 },
+  flipY: false,
+},
+{
+  texture: texture1,
+  mipLevel: 4,
+  origin: { x: 1, y: 5, z: 75 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline21 = await device0.createRenderPipelineAsync(
+{
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 12476,
+attributes: [
+{
+format: 'sint32x4',
+offset: 6612,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 252,
+depthBias: 0,
+depthBiasSlopeScale: 20,
+depthBiasClamp: 33,
+},
+}
+);
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let shaderModule2 = device0.createShaderModule(
+{
+label: '\u0288\u{1fc9c}\u{1fd80}',
+code: `@group(3) @binding(2200)
+var<storage, read_write> global1: array<u32>;
+@group(5) @binding(1510)
+var<storage, read_write> field2: array<u32>;
+@group(1) @binding(4313)
+var<storage, read_write> function2: array<u32>;
+@group(3) @binding(509)
+var<storage, read_write> function3: array<u32>;
+@group(2) @binding(2409)
+var<storage, read_write> local0: array<u32>;
+@group(8) @binding(1510)
+var<storage, read_write> field3: array<u32>;
+@group(4) @binding(1642)
+var<storage, read_write> field4: array<u32>;
+@group(4) @binding(4134)
+var<storage, read_write> local1: array<u32>;
+@group(8) @binding(4639)
+var<storage, read_write> field5: array<u32>;
+
+@compute @workgroup_size(8, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(3) f0: i32,
+@location(6) f1: vec4<u32>,
+@location(0) f2: vec4<i32>,
+@location(2) f3: vec4<f32>,
+@location(1) f4: vec2<i32>,
+@location(4) f5: vec3<f32>,
+@location(5) f6: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_index) a1: u32, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(5) a0: vec2<f32>, @location(20) a1: vec2<f32>, @location(2) a2: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+}
+);
+let texture16 = device0.createTexture(
+{
+label: '\u{1fb25}\u8213\u947c\u23dc\u136a\u0cd5\ud4e6\ud682',
+size: {width: 175, height: 56, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+sampleCount: 1,
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView12 = texture2.createView(
+{
+baseMipLevel: 6,
+mipLevelCount: 1,
+}
+);
+let computePassEncoder2 = commandEncoder7.beginComputePass(
+{
+label: '\u{1f614}\uecc2\uef1a\u0564\u68c2\u00f3\u{1fc4c}'
+}
+);
+try {
+computePassEncoder2.setPipeline(
+pipeline14
+);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(
+buffer3,
+'uint32',
+8740,
+804
+);
+} catch {}
+let pipeline22 = device0.createRenderPipeline(
+{
+label: '\u3bb2\u6967\u0d16\u{1fb92}\uc429\u5e08\u1e5f\u5f69\u0134\u52ec',
+layout: pipelineLayout4,
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 11952,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 13404,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 4060,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x2',
+offset: 732,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgba32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'rg16uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+undefined,
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'invert',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3358,
+depthBias: 90,
+depthBiasSlopeScale: 34,
+depthBiasClamp: 92,
+},
+}
+);
+let querySet12 = device0.createQuerySet({
+label: '\u0e4c\ue083\u{1f7d1}\u{1fa83}\u0172\u{1f91b}\uf00d',
+type: 'occlusion',
+count: 3958,
+});
+let texture17 = device0.createTexture(
+{
+label: '\uf108\ufc44\u099f',
+size: [43, 43, 1],
+mipLevelCount: 5,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle13 = renderBundleEncoder2.finish(
+{
+
+}
+);
+try {
+renderPassEncoder0.setStencilReference(
+1601
+);
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+0.9145,
+0.4733,
+0.03417,
+4.927,
+0.1632,
+0.6831
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+7,
+bindGroup2,
+new Uint32Array(7255),
+3341,
+0
+);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 21, height: 7, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 465, y: 91 },
+  flipY: true,
+},
+{
+  texture: texture16,
+  mipLevel: 3,
+  origin: { x: 8, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 6, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await promise1;
+} catch {}
+document.body.prepend(canvas0);
+try {
+externalTexture1.label = '\ucb89\u954b\u61ed\uc427';
+} catch {}
+let buffer6 = device0.createBuffer(
+{
+label: '\u{1fd00}\ua045',
+size: 31615,
+usage: GPUBufferUsage.INDEX,
+}
+);
+let texture18 = device0.createTexture(
+{
+label: '\u9e70\u16c3\u{1f9fc}\u4be5\u{1fd4a}',
+size: [6264, 1, 180],
+mipLevelCount: 10,
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+try {
+computePassEncoder1.setPipeline(
+pipeline17
+);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(
+8,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 410.8, g: 859.5, b: 108.5, a: 729.8, });
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+3,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder3.drawIndexed(
+0,
+8
+);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 728, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(new ArrayBuffer(80)),
+/* required buffer size: 604 */{
+offset: 604,
+},
+{width: 4955, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline23 = await device0.createComputePipelineAsync(
+{
+layout: pipelineLayout1,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+await promise7;
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout3,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout1,
+bindGroupLayout4
+]
+}
+);
+let textureView13 = texture1.createView(
+{
+label: '\u4ac5\u{1fe60}\u48e1\u1f88\ucb24',
+baseMipLevel: 3,
+mipLevelCount: 3,
+baseArrayLayer: 23,
+arrayLayerCount: 18,
+}
+);
+let sampler7 = device0.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 42.478,
+lodMaxClamp: 78.212,
+maxAnisotropy: 3,
+}
+);
+try {
+renderPassEncoder0.setStencilReference(
+1051
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+8,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+8,
+bindGroup1,
+new Uint32Array(2500),
+2007,
+0
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 43, height: 14, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 94, y: 85 },
+  flipY: true,
+},
+{
+  texture: texture16,
+  mipLevel: 2,
+  origin: { x: 12, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 29, height: 14, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline24 = device0.createComputePipeline(
+{
+label: '\uaa29\u1f1e\udd1d\u1d17\u0ea2\ud22e\u{1f846}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let textureView14 = texture1.createView(
+{
+label: '\u7f4f\uf189\u{1f824}\u{1fa19}',
+aspect: 'all',
+baseMipLevel: 2,
+baseArrayLayer: 92,
+arrayLayerCount: 24,
+}
+);
+let sampler8 = device0.createSampler(
+{
+label: '\u0767\u98d4\u0c88\u6d73\u{1fa1b}\ue2b3\u9a0a\ucfd6\u08b3\ua824',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 97.915,
+}
+);
+try {
+computePassEncoder1.setBindGroup(
+9,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(
+1,
+bindGroup0,
+new Uint32Array(6799),
+1818,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+0,
+5,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(
+buffer3,
+'uint32',
+3744,
+2336
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+9,
+bindGroup1
+);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(
+60,
+undefined,
+4093975786,
+193928952
+);
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(752, 567);
+let texture19 = device0.createTexture(
+{
+label: '\u90ab\ue634',
+size: [146, 7, 1],
+mipLevelCount: 2,
+format: 'rgba16uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+let renderBundleEncoder6 = device0.createRenderBundleEncoder(
+{
+label: '\u59b5\u0d0c\u{1fa08}\u4889\u0c60\u33f4\u0e23',
+colorFormats: [
+'rg32sint',
+'rg16sint',
+'bgra8unorm',
+'rg32sint',
+'rg8sint'
+],
+sampleCount: 989,
+}
+);
+try {
+renderPassEncoder1.setBindGroup(
+2,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(
+0,
+4,
+1,
+6
+);
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+0.3042,
+0.4686,
+0.4364,
+5.739,
+0.00653,
+0.5990
+);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(
+95,
+undefined,
+1627178948,
+2203737564
+);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer1,
+]);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 5, depthOrArrayLayers: 240}
+*/
+{
+  source: video2,
+  origin: { x: 4, y: 3 },
+  flipY: true,
+},
+{
+  texture: texture1,
+  mipLevel: 4,
+  origin: { x: 0, y: 1, z: 232 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 3, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let bindGroupLayout7 = pipeline6.getBindGroupLayout(0);
+let texture20 = device0.createTexture(
+{
+label: '\u9983\u0dd4\u0ece',
+size: {width: 1408},
+dimension: '1d',
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rgba32uint',
+'rgba32uint',
+'rgba32uint'
+],
+}
+);
+let textureView15 = texture20.createView(
+{
+baseMipLevel: 0,
+}
+);
+let renderBundleEncoder7 = device0.createRenderBundleEncoder(
+{
+label: '\u{1fdce}\u1edc\ue9a7\u{1ff2e}\ua3e0\ubfa0\u{1f95b}\u{1fe29}',
+colorFormats: [
+'rgb10a2unorm',
+undefined,
+'r16float',
+'r32uint',
+'r32sint',
+undefined,
+'rgba16uint',
+undefined
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 692,
+}
+);
+let renderBundle14 = renderBundleEncoder0.finish(
+{
+label: '\u2afb\ub41a'
+}
+);
+try {
+renderPassEncoder1.setViewport(
+0.4135,
+1.748,
+0.02497,
+8.115,
+0.8734,
+0.9093
+);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(
+buffer5,
+'uint32'
+);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(
+8,
+bindGroup0
+);
+} catch {}
+let pipeline25 = device0.createComputePipeline(
+{
+label: '\ud8c1\u08a1\u1e19\u0209\u42b0\u01a6\u95ee\u0de4\u{1f8ad}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline26 = device0.createRenderPipeline(
+{
+label: '\u64b3\u23d5\u669c\ucbc5\ud4ff',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 940,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 724,
+shaderLocation: 5,
+},
+{
+format: 'snorm8x2',
+offset: 96,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 9304,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 3616,
+attributes: [
+
+],
+},
+{
+arrayStride: 6648,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 1120,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 836,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+primitive: {
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 1,
+mask: 0x972798d9,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgba32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+let pipelineLayout6 = device0.createPipelineLayout(
+{
+label: '\uf1af\u03e4\u07fe\u37d9\u828d\ua702\ub937\u7bcb\uea12\ub3d1',
+bindGroupLayouts: [
+bindGroupLayout4,
+bindGroupLayout0,
+bindGroupLayout3,
+bindGroupLayout7,
+bindGroupLayout7,
+bindGroupLayout5,
+bindGroupLayout2,
+bindGroupLayout3
+]
+}
+);
+try {
+renderBundleEncoder6.setIndexBuffer(
+buffer5,
+'uint32',
+15580,
+3941
+);
+} catch {}
+let imageData2 = new ImageData(116, 108);
+let bindGroup3 = device0.createBindGroup({
+label: '\u3b62\u157c\u0ffd\u05ed\u07af\u{1fad5}\u{1fbb2}\u{1fcc5}\uaa21',
+layout: bindGroupLayout5,
+entries: [
+
+],
+});
+let textureView16 = texture10.createView(
+{
+label: '\u3b26\u499f\ub0d5\u894e\u7f79',
+dimension: '2d-array',
+mipLevelCount: 2,
+}
+);
+try {
+computePassEncoder2.setPipeline(
+pipeline10
+);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+9,
+bindGroup2
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+43,
+undefined,
+243789408,
+221956842
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 2419, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer3),
+/* required buffer size: 994 */{
+offset: 994,
+bytesPerRow: 2523,
+},
+{width: 1165, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+try {
+offscreenCanvas3.getContext('bitmaprenderer');
+} catch {}
+let bindGroup4 = device0.createBindGroup({
+layout: bindGroupLayout5,
+entries: [
+
+],
+});
+let texture21 = device0.createTexture(
+{
+size: [12512, 4, 251],
+mipLevelCount: 11,
+format: 'etc2-rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'etc2-rgba8unorm'
+],
+}
+);
+try {
+computePassEncoder2.setBindGroup(
+4,
+bindGroup2,
+new Uint32Array(3217),
+3118,
+0
+);
+} catch {}
+try {
+computePassEncoder1.setPipeline(
+pipeline15
+);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(
+1,
+bindGroup0
+);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+let pipeline27 = await promise6;
+let commandEncoder8 = device0.createCommandEncoder(
+{
+label: '\u0f7a\u3a2d\u3cda\u{1fb3f}',
+}
+);
+let textureView17 = texture11.createView(
+{
+label: '\u3a85\u08b3\u06e2\u7e52',
+baseMipLevel: 9,
+baseArrayLayer: 0,
+}
+);
+let renderBundle15 = renderBundleEncoder3.finish();
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(
+1,
+0,
+0,
+7
+);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(
+buffer5,
+'uint16',
+40020,
+4518
+);
+} catch {}
+try {
+renderBundleEncoder7.insertDebugMarker(
+'\u0566'
+);
+} catch {}
+let bindGroup5 = device0.createBindGroup({
+label: '\u04ee\u30df\u0437\u{1feb5}\u97ef\u0fda',
+layout: bindGroupLayout7,
+entries: [
+{
+binding: 2200,
+resource: sampler2
+},
+{
+binding: 2687,
+resource: sampler3
+},
+{
+binding: 509,
+resource: sampler6
+}
+],
+});
+let querySet13 = device0.createQuerySet({
+label: '\u07b7\u{1f904}\uf179\u{1f7d2}\u{1fdae}\u3f8b\ua19d',
+type: 'occlusion',
+count: 1860,
+});
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+3181
+);
+} catch {}
+let querySet14 = device0.createQuerySet({
+label: '\u40e0\u0fab\u{1fdf9}\ude99\u0953\u0f81',
+type: 'occlusion',
+count: 1094,
+});
+let texture22 = device0.createTexture(
+{
+label: '\ue080\ua644\u0601\u0563\ue73f\ua04e\u4be2\ud010\u0ebd\u{1f92b}\ufdd9',
+size: {width: 10676, height: 108, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'eac-r11unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'eac-r11unorm',
+'eac-r11unorm',
+'eac-r11unorm'
+],
+}
+);
+let textureView18 = texture6.createView(
+{
+label: '\uf118\u5ceb\u2c87\ueb39\u8065\u08f0\u5c2c\u{1fc5c}\u{1fce7}',
+baseMipLevel: 0,
+}
+);
+let renderPassEncoder2 = commandEncoder8.beginRenderPass(
+{
+label: '\uc4fb\uf525\u0046\ucd82\u0bf9\ubc68\u504f\u2842',
+colorAttachments: [
+undefined
+],
+depthStencilAttachment: {
+view: textureView10,
+depthClearValue: -2.8611101635574006,
+stencilLoadOp: 'load',
+stencilStoreOp: 'discard',
+},
+occlusionQuerySet: querySet8,
+maxDrawCount: 49408,
+}
+);
+let renderBundleEncoder8 = device0.createRenderBundleEncoder(
+{
+label: '\ue87a\u087f\u03f2\u7b20\uc76e\u0ae0\u{1ff9f}\u{1f677}\u0e74\u053b\u7c7c',
+colorFormats: [
+'rg32sint',
+'rg32uint',
+'rgb10a2unorm',
+'rg32float'
+],
+sampleCount: 546,
+}
+);
+let sampler9 = device0.createSampler(
+{
+label: '\udddb\u9e7f\u{1fc46}\u0ad2\u57bf\u{1f95c}\u9062',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 84.282,
+lodMaxClamp: 87.990,
+compare: 'greater',
+maxAnisotropy: 13,
+}
+);
+try {
+renderPassEncoder1.setBlendConstant({ r: -190.4, g: -352.0, b: -59.73, a: -293.1, });
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+0.9919,
+5.005,
+0.00268,
+4.583,
+0.9318,
+0.9465
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+3,
+bindGroup5,
+new Uint32Array(3150),
+1719,
+0
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm',
+'bgra8unorm-srgb',
+'bgra8unorm-srgb'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let querySet15 = device0.createQuerySet({
+type: 'occlusion',
+count: 1508,
+});
+let renderBundle16 = renderBundleEncoder2.finish(
+{
+label: '\u0d9b\u{1f706}\uf009\u1ddb\u5373\u3680\u34ca\u484b\u{1f82d}\u5870'
+}
+);
+let sampler10 = device0.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 74.750,
+lodMaxClamp: 79.597,
+}
+);
+try {
+renderPassEncoder1.setBindGroup(
+7,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(
+7,
+bindGroup0,
+new Uint32Array(8331),
+5699,
+0
+);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(
+0,
+6,
+0,
+5
+);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(
+48,
+undefined,
+2419636696
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+32,
+undefined,
+481360057,
+3574218191
+);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let pipeline28 = await device0.createComputePipelineAsync(
+{
+label: '\u{1fd19}\u{1ff4f}\u{1f7a8}\u031c\uafeb',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageBitmap3 = await createImageBitmap(videoFrame3);
+let bindGroupLayout8 = device0.createBindGroupLayout(
+{
+label: '\uc00d\u003f\u{1f688}\u{1fb62}\u{1ff99}\u1030\uda52\ufd8b\u0337\u1ce0\uc927',
+entries: [
+{
+binding: 3546,
+visibility: 0,
+storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '1d' },
+}
+],
+}
+);
+let textureView19 = texture17.createView(
+{
+label: '\u7015\u3c2c\u3f92\ua0f8\u0e54\u011e',
+format: 'bgra8unorm',
+mipLevelCount: 5,
+baseArrayLayer: 0,
+}
+);
+try {
+computePassEncoder2.setPipeline(
+pipeline9
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+6,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(
+buffer6,
+'uint32',
+23316,
+4946
+);
+} catch {}
+let promise11 = buffer0.mapAsync(
+GPUMapMode.WRITE,
+38304
+);
+let pipeline29 = device0.createComputePipeline(
+{
+layout: pipelineLayout1,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let videoFrame6 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let buffer7 = device0.createBuffer(
+{
+label: '\u0b08\u8a29\u529a\u0656\ue2d6\u3725',
+size: 50100,
+usage: GPUBufferUsage.COPY_DST,
+}
+);
+let commandEncoder9 = device0.createCommandEncoder(
+{
+}
+);
+let texture23 = gpuCanvasContext1.getCurrentTexture();
+let textureView20 = texture12.createView(
+{
+label: '\u467f\u{1fde3}\ubea3\u{1fe9d}\u{1fb53}\uf215\u{1f949}\u0acd',
+}
+);
+let computePassEncoder3 = commandEncoder9.beginComputePass(
+{
+label: '\u2d81\u9ad0\u5353\u{1f9e0}\uea26\u{1fc9d}\u36b0'
+}
+);
+try {
+renderPassEncoder2.beginOcclusionQuery(111);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(
+3601
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+73,
+undefined
+);
+} catch {}
+try {
+computePassEncoder0.insertDebugMarker(
+'\u081e'
+);
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(136, 775);
+let bindGroupLayout9 = device0.createBindGroupLayout(
+{
+label: '\u{1fa22}\u06a5',
+entries: [
+
+],
+}
+);
+let buffer8 = device0.createBuffer(
+{
+label: '\u0a48\u81e0\ubb5c\u0b5e\u{1fc8b}',
+size: 1671,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let textureView21 = texture15.createView(
+{
+label: '\uae09\u0c49\u04b7',
+aspect: 'all',
+baseMipLevel: 2,
+}
+);
+try {
+renderPassEncoder0.setStencilReference(
+657
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+1,
+bindGroup5
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 45, y: 82 },
+  flipY: false,
+},
+{
+  texture: texture23,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline30 = device0.createComputePipeline(
+{
+layout: pipelineLayout2,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+}
+);
+let sampler11 = device0.createSampler(
+{
+label: '\uc91b\u2392\u18d7\u{1f78e}\u0800\u{1f932}\uea98\u878d\uc654\uea22\u{1fa06}',
+addressModeU: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 28.053,
+lodMaxClamp: 88.903,
+maxAnisotropy: 14,
+}
+);
+try {
+computePassEncoder1.setPipeline(
+pipeline9
+);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let pipeline31 = device0.createRenderPipeline(
+{
+label: '\u0104\uf8a9\ua5f1\u0064\u0d3e\u7179\u0c17',
+layout: pipelineLayout2,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x2',
+offset: 3472,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 7700,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 7544,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 3984,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 7536,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 14664,
+attributes: [
+{
+format: 'snorm16x4',
+offset: 12744,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilReadMask: 3422,
+stencilWriteMask: 2353,
+depthBias: 45,
+depthBiasSlopeScale: 31,
+depthBiasClamp: 71,
+},
+}
+);
+let adapter1 = await promise4;
+let video3 = await videoWithData();
+let renderBundle17 = renderBundleEncoder7.finish();
+try {
+computePassEncoder1.setBindGroup(
+9,
+bindGroup1
+);
+} catch {}
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(
+6,
+bindGroup5
+);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(
+buffer3,
+'uint32',
+8304,
+2519
+);
+} catch {}
+try {
+commandEncoder9.clearBuffer(
+buffer7
+);
+dissociateBuffer(device0, buffer7);
+} catch {}
+let querySet16 = device0.createQuerySet({
+label: '\u4ec8\u032a\ua700\u{1fbee}',
+type: 'occlusion',
+count: 2996,
+});
+try {
+computePassEncoder1.setPipeline(
+pipeline11
+);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+2,
+11,
+6,
+4
+);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(
+2295
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 4954, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer1),
+/* required buffer size: 322 */{
+offset: 322,
+},
+{width: 285, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let querySet17 = device0.createQuerySet({
+label: '\u8938\u3f8e',
+type: 'occlusion',
+count: 2764,
+});
+let textureView22 = texture2.createView(
+{
+label: '\u0917\u7584\u{1fa46}\udf7c\u0800\u3096\ue118\u4b61\ucb76',
+format: 'rgb9e5ufloat',
+mipLevelCount: 7,
+}
+);
+try {
+computePassEncoder2.setBindGroup(
+1,
+bindGroup5
+);
+} catch {}
+try {
+computePassEncoder1.setPipeline(
+pipeline28
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+9,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(84);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 374.1, g: -828.2, b: 612.2, a: -174.7, });
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+32356,
+new DataView(new ArrayBuffer(20074)),
+11895,
+5100
+);
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+let pipeline32 = await device0.createRenderPipelineAsync(
+{
+label: '\uab4c\u4a56\u028f\u{1f65b}\u0a79\u{1f7ea}\u7f66\ua314\u0e5d\u9e54',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 5348,
+shaderLocation: 2,
+},
+{
+format: 'uint16x4',
+offset: 11628,
+shaderLocation: 9,
+},
+{
+format: 'float16x2',
+offset: 11188,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x4',
+offset: 9296,
+shaderLocation: 0,
+},
+{
+format: 'float16x4',
+offset: 13160,
+shaderLocation: 19,
+},
+{
+format: 'snorm8x4',
+offset: 7016,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x4',
+offset: 5700,
+shaderLocation: 17,
+},
+{
+format: 'sint8x2',
+offset: 14892,
+shaderLocation: 13,
+},
+{
+format: 'sint32',
+offset: 8664,
+shaderLocation: 11,
+},
+{
+format: 'sint16x2',
+offset: 4588,
+shaderLocation: 4,
+},
+{
+format: 'float32x3',
+offset: 1660,
+shaderLocation: 7,
+},
+{
+format: 'uint8x2',
+offset: 4832,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x4',
+offset: 3840,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x4',
+offset: 128,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 6688,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 1196,
+shaderLocation: 14,
+},
+{
+format: 'sint8x4',
+offset: 4524,
+shaderLocation: 21,
+},
+{
+format: 'float32',
+offset: 1056,
+shaderLocation: 18,
+},
+{
+format: 'uint8x2',
+offset: 634,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+cullMode: 'back',
+},
+multisample: {
+count: 4,
+mask: 0xacb7e450,
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'not-equal',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2925,
+stencilWriteMask: 3467,
+depthBias: 0,
+depthBiasSlopeScale: 6,
+depthBiasClamp: 89,
+},
+}
+);
+video1.width = 128;
+let bindGroup6 = device0.createBindGroup({
+label: '\u7165\u3b06\ue477\ud0d2\uee8a\u0ed2\udc74\u{1fc77}',
+layout: bindGroupLayout0,
+entries: [
+{
+binding: 2200,
+resource: sampler6
+},
+{
+binding: 509,
+resource: sampler8
+},
+{
+binding: 2687,
+resource: sampler2
+}
+],
+});
+pseudoSubmit(device0, commandEncoder5);
+let texture24 = device0.createTexture(
+{
+label: '\u08b0\u1240',
+size: [8135],
+mipLevelCount: 1,
+dimension: '1d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32float',
+'rgba32float'
+],
+}
+);
+try {
+renderPassEncoder1.setViewport(
+0.5085,
+1.804,
+0.4786,
+3.599,
+0.1748,
+0.4068
+);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(
+buffer3,
+'uint32',
+8548
+);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(
+98,
+undefined
+);
+} catch {}
+try {
+querySet5.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+3324,
+new Float32Array(13057),
+7023,
+2048
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: { x: 4089, y: 0, z: 1 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer4),
+/* required buffer size: 66 */{
+offset: 66,
+},
+{width: 1741, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let textureView23 = texture17.createView(
+{
+baseMipLevel: 1,
+mipLevelCount: 2,
+}
+);
+let computePassEncoder4 = commandEncoder9.beginComputePass(
+{
+
+}
+);
+let renderBundle18 = renderBundleEncoder2.finish(
+{
+
+}
+);
+try {
+renderPassEncoder2.setStencilReference(
+1207
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer5,
+'uint32',
+2316,
+28849
+);
+} catch {}
+let shaderModule3 = device0.createShaderModule(
+{
+label: '\uf744\u{1f8d8}\u0f37\u{1f985}\u0ee7\u{1fe74}\ucd24\u05a4',
+code: `@group(3) @binding(509)
+var<storage, read_write> global2: array<u32>;
+@group(4) @binding(1642)
+var<storage, read_write> function4: array<u32>;
+@group(5) @binding(1510)
+var<storage, read_write> global3: array<u32>;
+@group(2) @binding(2409)
+var<storage, read_write> global4: array<u32>;
+@group(4) @binding(4134)
+var<storage, read_write> field6: array<u32>;
+@group(1) @binding(4313)
+var<storage, read_write> parameter0: array<u32>;
+@group(4) @binding(59)
+var<storage, read_write> field7: array<u32>;
+@group(3) @binding(2200)
+var<storage, read_write> global5: array<u32>;
+@group(8) @binding(4639)
+var<storage, read_write> parameter1: array<u32>;
+@group(5) @binding(4639)
+var<storage, read_write> local2: array<u32>;
+@group(3) @binding(2687)
+var<storage, read_write> local3: array<u32>;
+
+@compute @workgroup_size(7, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(1) f0: vec4<f32>,
+@location(3) f1: i32,
+@location(0) f2: vec2<u32>,
+@location(2) f3: vec3<i32>,
+@location(4) f4: u32,
+@location(7) f5: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(52) a0: u32, @location(58) a1: i32, @location(45) a2: vec4<i32>, @location(37) a3: vec4<f32>, @location(9) a4: vec4<i32>, @builtin(position) a5: vec4<f32>, @builtin(sample_index) a6: u32, @builtin(front_facing) a7: bool, @builtin(sample_mask) a8: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(58) f72: i32,
+@location(37) f73: vec4<f32>,
+@location(9) f74: vec4<i32>,
+@location(52) f75: u32,
+@builtin(position) f76: vec4<f32>,
+@location(45) f77: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(17) a0: vec4<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+}
+);
+let textureView24 = texture14.createView(
+{
+label: '\ufa63\u{1f8bb}\u4d57\u3609\u0d5e\u7229',
+baseMipLevel: 3,
+}
+);
+try {
+computePassEncoder2.setPipeline(
+pipeline17
+);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(
+5,
+bindGroup5
+);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(
+3771
+);
+} catch {}
+try {
+renderPassEncoder0.setViewport(
+0.9261,
+5.878,
+0.03310,
+1.456,
+0.2681,
+0.6468
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+64,
+undefined,
+621358467,
+1697774422
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture16,
+  mipLevel: 3,
+  origin: { x: 3, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Int8Array(new ArrayBuffer(0)),
+/* required buffer size: 737 */{
+offset: 518,
+bytesPerRow: 147,
+rowsPerImage: 268,
+},
+{width: 18, height: 2, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+canvas0.height = 1000;
+try {
+renderPassEncoder1.setBindGroup(
+1,
+bindGroup0,
+new Uint32Array(9552),
+6474,
+0
+);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 198.6, g: -506.0, b: 449.9, a: 426.0, });
+} catch {}
+let pipeline33 = await device0.createComputePipelineAsync(
+{
+label: '\u03ca\u{1fc1c}\ubff5\u{1fca3}\u0c95\u0400\u0280\u0da6\u{1f727}',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let querySet18 = device0.createQuerySet({
+label: '\u0bbe\udd95\ub73a\ueb2e\u5f71\u{1f818}',
+type: 'occlusion',
+count: 726,
+});
+let renderBundle19 = renderBundleEncoder3.finish(
+{
+label: '\u64f1\u2fc7\ub365\u{1f9d1}\u{1f8ed}\u8d61\u6556\u{1fbb3}\u{1f659}\u0472\u{1fef9}'
+}
+);
+let sampler12 = device0.createSampler(
+{
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 28.180,
+maxAnisotropy: 12,
+}
+);
+try {
+computePassEncoder2.setPipeline(
+pipeline6
+);
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(100);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+computePassEncoder4.setPipeline(
+pipeline11
+);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let pipeline34 = device0.createComputePipeline(
+{
+label: '\ucc15\u0f49\u1639\u{1fb9f}\u{1feac}\ud4a1\u3453\u{1f728}\ue89b\ucb6a\u3aa2',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline35 = await device0.createRenderPipelineAsync(
+{
+label: '\u853b\uf0c7\u9595\u400a\uefa0\u{1fee2}\u{1f8cb}\u760c\uddac\u486b\u4d9b',
+layout: pipelineLayout6,
+vertex: {
+module: shaderModule2,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 9172,
+shaderLocation: 2,
+},
+{
+format: 'float32',
+offset: 1820,
+shaderLocation: 20,
+},
+{
+format: 'float16x4',
+offset: 15420,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule2,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilReadMask: 2670,
+stencilWriteMask: 434,
+depthBias: 95,
+depthBiasSlopeScale: 19,
+depthBiasClamp: 50,
+},
+}
+);
+let bindGroupLayout10 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 3011,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 2496,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}
+],
+}
+);
+let textureView25 = texture8.createView(
+{
+label: '\u{1f7a9}\u8008\u051d\u27db\udf31\ub530\u{1f790}\ub35f\u0329',
+aspect: 'all',
+}
+);
+try {
+computePassEncoder2.setPipeline(
+pipeline33
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+0,
+bindGroup6
+);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(
+0,
+6,
+0,
+3
+);
+} catch {}
+let arrayBuffer5 = buffer1.getMappedRange(
+9424,
+16
+);
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32sint',
+'rgba16float'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+offscreenCanvas4.getContext('webgl');
+} catch {}
+let shaderModule4 = device0.createShaderModule(
+{
+label: '\u86ab\u7869',
+code: `@group(8) @binding(1510)
+var<storage, read_write> local4: array<u32>;
+@group(2) @binding(2409)
+var<storage, read_write> parameter2: array<u32>;
+@group(3) @binding(2687)
+var<storage, read_write> global6: array<u32>;
+@group(3) @binding(509)
+var<storage, read_write> global7: array<u32>;
+@group(4) @binding(1642)
+var<storage, read_write> i0: array<u32>;
+@group(4) @binding(4134)
+var<storage, read_write> local5: array<u32>;
+@group(4) @binding(59)
+var<storage, read_write> global8: array<u32>;
+@group(1) @binding(4313)
+var<storage, read_write> type1: array<u32>;
+@group(5) @binding(4639)
+var<storage, read_write> i1: array<u32>;
+@group(8) @binding(4639)
+var<storage, read_write> parameter3: array<u32>;
+@group(3) @binding(2200)
+var<storage, read_write> field8: array<u32>;
+
+@compute @workgroup_size(6, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S3 {
+@builtin(sample_mask) f0: u32,
+@builtin(sample_index) f1: u32
+}
+struct FragmentOutput0 {
+@location(3) f0: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, a1: S3) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S2 {
+@location(16) f0: vec3<f32>,
+@location(15) f1: vec3<u32>,
+@builtin(vertex_index) f2: u32
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec2<f32>, @location(20) a1: u32, @location(0) a2: f32, @location(4) a3: vec3<i32>, @location(21) a4: vec3<u32>, a5: S2, @location(12) a6: f32, @builtin(instance_index) a7: u32, @location(7) a8: vec2<f32>, @location(13) a9: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet19 = device0.createQuerySet({
+label: '\uaf1a\u{1fec1}',
+type: 'occlusion',
+count: 2171,
+});
+try {
+renderPassEncoder0.setBlendConstant({ r: 429.4, g: 976.7, b: 207.4, a: 600.0, });
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+4.439,
+11.41,
+4.893,
+0.9011,
+0.6796,
+0.8087
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+9,
+bindGroup4
+);
+} catch {}
+let pipeline36 = device0.createComputePipeline(
+{
+label: '\u{1f99d}\uda04\ue5c4\u41f4\u{1fda0}\u{1f884}\u0c2f\u0d79',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline37 = device0.createRenderPipeline(
+{
+label: '\u60c4\u{1fc4f}\u{1fd19}\u2f1c',
+layout: 'auto',
+vertex: {
+module: shaderModule4,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 13636,
+shaderLocation: 21,
+},
+{
+format: 'float32x4',
+offset: 5912,
+shaderLocation: 16,
+},
+{
+format: 'snorm16x4',
+offset: 13020,
+shaderLocation: 6,
+},
+{
+format: 'sint8x4',
+offset: 3328,
+shaderLocation: 4,
+},
+{
+format: 'float32x3',
+offset: 1692,
+shaderLocation: 7,
+},
+{
+format: 'unorm16x4',
+offset: 8632,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x2',
+offset: 2734,
+shaderLocation: 12,
+},
+{
+format: 'uint32',
+offset: 8668,
+shaderLocation: 15,
+},
+{
+format: 'uint32',
+offset: 9872,
+shaderLocation: 20,
+},
+{
+format: 'sint32x2',
+offset: 7268,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'none',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x54aae91a,
+},
+fragment: {
+module: shaderModule4,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+{
+format: 'rg32uint',
+},
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+let shaderModule5 = device0.createShaderModule(
+{
+label: '\u{1fb83}\uaa5b\u081c\u64e0\u03dc',
+code: `@group(0) @binding(2687)
+var<storage, read_write> field9: array<u32>;
+@group(0) @binding(509)
+var<storage, read_write> type2: array<u32>;
+
+@compute @workgroup_size(2, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: u32,
+@location(7) f1: vec4<i32>,
+@location(1) f2: f32,
+@location(4) f3: u32,
+@location(3) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S4 {
+@location(16) f0: vec3<u32>,
+@location(6) f1: vec3<f32>,
+@location(3) f2: vec4<i32>,
+@location(4) f3: vec3<i32>,
+@location(15) f4: vec3<u32>,
+@location(21) f5: u32,
+@location(9) f6: f32,
+@location(10) f7: vec2<i32>,
+@location(8) f8: f16,
+@location(17) f9: vec2<f16>,
+@builtin(vertex_index) f10: u32
+}
+
+@vertex
+fn vertex0(@location(13) a0: f16, @location(18) a1: vec2<i32>, @location(14) a2: vec4<u32>, @location(11) a3: i32, @location(1) a4: u32, a5: S4, @location(0) a6: i32, @location(7) a7: i32, @location(12) a8: vec4<i32>, @location(5) a9: vec3<f16>, @location(2) a10: f16, @location(20) a11: i32, @builtin(instance_index) a12: u32, @location(19) a13: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture25 = device0.createTexture(
+{
+label: '\u6140\u1c8a\u09d8\u2f43',
+size: {width: 1531},
+dimension: '1d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+let textureView26 = texture11.createView(
+{
+baseMipLevel: 3,
+mipLevelCount: 3,
+}
+);
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -924.4, g: -901.9, b: 490.9, a: 708.2, });
+} catch {}
+try {
+await buffer8.mapAsync(
+GPUMapMode.WRITE,
+0,
+180
+);
+} catch {}
+let pipeline38 = await device0.createComputePipelineAsync(
+{
+layout: pipelineLayout2,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+gc();
+let img6 = await imageWithData(242, 273, '#2fcbf8a4', '#61608cb5');
+let querySet20 = device0.createQuerySet({
+label: '\uff8b\u0120\u0382\u09f2\u105b\u{1f673}\u6b5c\u{1fde3}\u7530',
+type: 'occlusion',
+count: 1475,
+});
+let texture26 = device0.createTexture(
+{
+label: '\ufe17\u5872\u53ce\u0260\u070c',
+size: [13160, 1, 1],
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle20 = renderBundleEncoder4.finish(
+{
+label: '\u22c5\u{1fe15}\u{1f9f5}\u628a\u07d7\u53a3'
+}
+);
+let sampler13 = device0.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 53.716,
+maxAnisotropy: 12,
+}
+);
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 21, height: 7, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 85, y: 72 },
+  flipY: true,
+},
+{
+  texture: texture16,
+  mipLevel: 3,
+  origin: { x: 7, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 5, height: 5, depthOrArrayLayers: 1}
+);
+} catch {}
+let texture27 = device0.createTexture(
+{
+label: '\u{1fd37}\u{1f638}\u0c62\u0336\u04f6\u06c1',
+size: {width: 49, height: 126, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+renderBundleEncoder6.setIndexBuffer(
+buffer3,
+'uint16'
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+1,
+undefined,
+1208543950,
+2774004194
+);
+} catch {}
+try {
+window.someLabel = externalTexture1.label;
+} catch {}
+let bindGroup7 = device0.createBindGroup({
+label: '\u057b\u06ce\u0f59\uf36d\u0d92\u{1fff0}\u7fe0\ub71d\ud01d\u0e0f',
+layout: bindGroupLayout7,
+entries: [
+{
+binding: 2687,
+resource: sampler8
+},
+{
+binding: 2200,
+resource: sampler3
+},
+{
+binding: 509,
+resource: sampler5
+}
+],
+});
+let renderBundle21 = renderBundleEncoder0.finish(
+{
+label: '\u{1f8db}\u07dc\u11a1\u050f'
+}
+);
+let sampler14 = device0.createSampler(
+{
+label: '\u0292\uc4f1\u{1fdfc}\u0d01\u1451\u6ea3\u140e\u8f85\u07dc\ub30c',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 78.448,
+compare: 'always',
+maxAnisotropy: 15,
+}
+);
+try {
+computePassEncoder4.setPipeline(
+pipeline15
+);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(
+4,
+bindGroup7
+);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+5,
+13,
+4,
+1
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer6,
+'uint16',
+638,
+5553
+);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+4,
+bindGroup0
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+33,
+undefined,
+3766998618
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING,
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+17676,
+new BigUint64Array(10456),
+2544,
+1932
+);
+} catch {}
+let pipeline39 = await device0.createComputePipelineAsync(
+{
+label: '\u0a14\ud488\u19f0',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+adapter0.label = '\u0381\u{1f803}\u0fea\u{1f8a2}\ud590\udb12';
+} catch {}
+let bindGroupLayout11 = device0.createBindGroupLayout(
+{
+label: '\u{1fec7}\u02f1\u9a51\u{1f79b}\u1ddf\ue40f\ua5f7',
+entries: [
+
+],
+}
+);
+let bindGroup8 = device0.createBindGroup({
+label: '\ue65d\u09f1\u7a4d\u156f\u0441\u{1fe18}\u{1f7f5}\u{1f6a1}',
+layout: bindGroupLayout7,
+entries: [
+{
+binding: 2687,
+resource: sampler13
+},
+{
+binding: 2200,
+resource: sampler13
+},
+{
+binding: 509,
+resource: sampler8
+}
+],
+});
+let buffer9 = device0.createBuffer(
+{
+label: '\u5d31\u0845\ub481\ud7f9\ufa9b\u0f15\u{1fb90}\u7cdd\uae74\udc42\uf755',
+size: 53265,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let querySet21 = device0.createQuerySet({
+label: '\uaa57\u98e8\u{1f77c}\u15f4\uee11\u01d6',
+type: 'occlusion',
+count: 1221,
+});
+try {
+computePassEncoder4.setBindGroup(
+9,
+bindGroup8,
+new Uint32Array(6199),
+3993,
+0
+);
+} catch {}
+try {
+computePassEncoder4.setPipeline(
+pipeline27
+);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(102);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(
+8,
+bindGroup1
+);
+} catch {}
+try {
+computePassEncoder2.pushDebugGroup(
+'\u{1ff29}'
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let textureView27 = texture21.createView(
+{
+dimension: '2d',
+format: 'etc2-rgba8unorm',
+baseMipLevel: 4,
+mipLevelCount: 3,
+}
+);
+let sampler15 = device0.createSampler(
+{
+label: '\u{1fa65}\u0a17\u{1f66c}',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 14.135,
+compare: 'always',
+}
+);
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+3849
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer3,
+'uint32',
+8292
+);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(
+85,
+undefined,
+2853297190,
+885236888
+);
+} catch {}
+let pipeline40 = await device0.createComputePipelineAsync(
+{
+label: '\ud8b6\uf19b\u{1fb48}\u0fcd\uf8f8',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageBitmap4 = await createImageBitmap(video3);
+let pipelineLayout7 = device0.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout10,
+bindGroupLayout6,
+bindGroupLayout2,
+bindGroupLayout10,
+bindGroupLayout11,
+bindGroupLayout5,
+bindGroupLayout0,
+bindGroupLayout0,
+bindGroupLayout7
+]
+}
+);
+let querySet22 = device0.createQuerySet({
+type: 'occlusion',
+count: 2981,
+});
+let texture28 = device0.createTexture(
+{
+label: '\u0c1f\u{1fce1}\u0997',
+size: [7868],
+dimension: '1d',
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+
+],
+}
+);
+try {
+computePassEncoder2.setBindGroup(
+7,
+bindGroup1,
+new Uint32Array(9356),
+8384,
+0
+);
+} catch {}
+try {
+computePassEncoder4.setPipeline(
+pipeline33
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+6,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer3,
+'uint16',
+10598
+);
+} catch {}
+let video4 = await videoWithData();
+let bindGroup9 = device0.createBindGroup({
+label: '\u0293\uc3d8\ubf83\u09eb\u5669',
+layout: bindGroupLayout7,
+entries: [
+{
+binding: 2687,
+resource: sampler4
+},
+{
+binding: 509,
+resource: sampler8
+},
+{
+binding: 2200,
+resource: sampler6
+}
+],
+});
+try {
+computePassEncoder4.setBindGroup(
+9,
+bindGroup9,
+new Uint32Array(9765),
+9278,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(145);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer5,
+'uint16',
+44604
+);
+} catch {}
+let arrayBuffer6 = buffer2.getMappedRange(
+7528,
+5840
+);
+let querySet23 = device0.createQuerySet({
+label: '\u819f\u784a\u2079\uabc0\u{1f618}\ud423\uaf66\u{1fd0e}\u0930\u0023',
+type: 'occlusion',
+count: 3280,
+});
+let texture29 = device0.createTexture(
+{
+label: '\u02c6\uad85\u6148\u{1f943}\u98e2\u9fc4\u{1f695}\u0c81\u9289',
+size: {width: 208, height: 68, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+dimension: '2d',
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+3,
+2,
+4,
+4
+);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(
+buffer6,
+'uint32'
+);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(
+32,
+undefined,
+2160435256,
+304841498
+);
+} catch {}
+try {
+computePassEncoder2.popDebugGroup();
+} catch {}
+let querySet24 = device0.createQuerySet({
+label: '\u08d1\u0ab8\u{1f6e7}\u0b13\u032e\ub847\uf6d5\uef1f\ubb11\u{1f63b}\ucf66',
+type: 'occlusion',
+count: 183,
+});
+try {
+renderPassEncoder0.setBlendConstant({ r: -366.4, g: 92.37, b: -202.0, a: 122.4, });
+} catch {}
+let arrayBuffer7 = buffer8.getMappedRange(
+96,
+76
+);
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 98, y: 12 },
+  flipY: false,
+},
+{
+  texture: texture23,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(257, 390);
+let bindGroup10 = device0.createBindGroup({
+label: '\u6f4d\u{1fb8c}',
+layout: bindGroupLayout5,
+entries: [
+
+],
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder(
+{
+label: '\u0e67\u6dd9\u5597\u3ffe\u9914\u{1f796}\u60b5\ub3d4',
+colorFormats: [
+'rg11b10ufloat',
+'rgba8unorm-srgb'
+],
+sampleCount: 366,
+stencilReadOnly: false,
+}
+);
+let renderBundle22 = renderBundleEncoder6.finish();
+try {
+renderPassEncoder0.setBindGroup(
+4,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer3,
+'uint16'
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture10,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'stencil-only',
+},
+arrayBuffer6,
+/* required buffer size: 7679 */{
+offset: 173,
+bytesPerRow: 299,
+rowsPerImage: 138,
+},
+{width: 31, height: 26, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video1,
+  origin: { x: 4, y: 7 },
+  flipY: false,
+},
+{
+  texture: texture23,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise13 = device0.createRenderPipelineAsync(
+{
+label: '\u359c\u9a05\ub7c0\u0bb1\u0203\u00bf\u{1f663}\ua288\ub610\u{1f600}',
+layout: pipelineLayout7,
+vertex: {
+module: shaderModule4,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 7060,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 2456,
+shaderLocation: 7,
+},
+{
+format: 'float16x2',
+offset: 2680,
+shaderLocation: 6,
+},
+{
+format: 'sint32',
+offset: 4560,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 5752,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 3700,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 5568,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 4656,
+shaderLocation: 12,
+},
+{
+format: 'float32x3',
+offset: 3964,
+shaderLocation: 16,
+},
+{
+format: 'uint8x2',
+offset: 1118,
+shaderLocation: 20,
+},
+{
+format: 'sint8x2',
+offset: 3218,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 4380,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 4064,
+shaderLocation: 15,
+},
+{
+format: 'float32',
+offset: 2740,
+shaderLocation: 0,
+},
+{
+format: 'uint16x2',
+offset: 328,
+shaderLocation: 21,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x632cc6c4,
+},
+fragment: {
+module: shaderModule4,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'not-equal',
+passOp: 'replace',
+},
+stencilReadMask: 3789,
+stencilWriteMask: 1847,
+depthBias: 43,
+depthBiasSlopeScale: 31,
+},
+}
+);
+let commandEncoder10 = device0.createCommandEncoder(
+{
+}
+);
+let texture30 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder5 = commandEncoder10.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder10 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+undefined,
+'r8sint',
+undefined
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 669,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder2.setStencilReference(
+3630
+);
+} catch {}
+let promise14 = buffer9.mapAsync(
+GPUMapMode.READ,
+2600,
+20552
+);
+try {
+device0.queue.writeBuffer(
+buffer7,
+22552,
+new BigUint64Array(8994),
+2676,
+1964
+);
+} catch {}
+let pipeline41 = device0.createComputePipeline(
+{
+layout: pipelineLayout1,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let gpuCanvasContext2 = offscreenCanvas5.getContext('webgpu');
+let canvas3 = document.createElement('canvas');
+let commandEncoder11 = device0.createCommandEncoder(
+{
+label: '\u18de\u09ec\uce02\u65a0\ubff9\u65d9\ue5d9\u0690',
+}
+);
+try {
+renderPassEncoder0.setBindGroup(
+6,
+bindGroup8
+);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(
+0,
+8,
+0,
+2
+);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(
+263
+);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(
+buffer3,
+'uint32'
+);
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(
+querySet22,
+1375,
+21,
+buffer5,
+39168
+);
+} catch {}
+let bindGroupLayout12 = device0.createBindGroupLayout(
+{
+label: '\u0f11\u72ce\u{1fb95}\u1a0c\u0af8',
+entries: [
+{
+binding: 3457,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+let commandEncoder12 = device0.createCommandEncoder(
+{
+label: '\u0246\u{1fef1}\u{1fb59}\u6685\u08fc\u{1fe5d}\u{1fc9e}',
+}
+);
+let texture31 = device0.createTexture(
+{
+size: [10159, 2, 1],
+mipLevelCount: 3,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'depth24plus-stencil8',
+'depth24plus-stencil8'
+],
+}
+);
+let renderPassEncoder3 = commandEncoder11.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView10,
+depthClearValue: -5.612368627762168,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet20,
+maxDrawCount: 85312,
+}
+);
+let renderBundleEncoder11 = device0.createRenderBundleEncoder(
+{
+label: '\u22dc\u007e\u067d\u{1f8e8}',
+colorFormats: [
+undefined
+],
+sampleCount: 703,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle23 = renderBundleEncoder5.finish(
+{
+label: '\u{1fef4}\u049b\uee72\u8121\u02d6\u{1f7d1}'
+}
+);
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(
+86
+);
+} catch {}
+try {
+renderPassEncoder3.setViewport(
+1.825,
+12.25,
+1.970,
+1.144,
+0.06392,
+0.5820
+);
+} catch {}
+let pipeline42 = device0.createRenderPipeline(
+{
+label: '\u0955\u0028\u0f48\u72ab\u{1fecb}\u{1fff0}\u3523\u4d7e\u8a9c\u6f33\u{1f775}',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 8240,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x2',
+offset: 7502,
+shaderLocation: 17,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0xb075aba4,
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r16uint',
+writeMask: 0,
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'one-minus-constant',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'zero',
+dstFactor: 'dst-alpha'
+},
+},
+format: 'rg8unorm',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r32sint',
+},
+{
+format: 'r32sint',
+writeMask: 0,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'replace',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilReadMask: 2988,
+stencilWriteMask: 2983,
+depthBias: 55,
+depthBiasSlopeScale: 41,
+depthBiasClamp: 90,
+},
+}
+);
+let promise15 = navigator.gpu.requestAdapter(
+{
+}
+);
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+let bindGroup11 = device0.createBindGroup({
+label: '\uf67c\u014f\u012d\u0b63\ud7cf\u19a5',
+layout: bindGroupLayout5,
+entries: [
+
+],
+});
+let commandEncoder13 = device0.createCommandEncoder(
+{
+label: '\uc3b8\u19d5\u09ab\ud66a\u055e\u0fb4\udd92',
+}
+);
+let textureView28 = texture10.createView(
+{
+label: '\udecc\uf282\u{1feda}\u0fe2\u{1f76b}\u0d44\u5fbe\ue815',
+dimension: '2d-array',
+aspect: 'all',
+baseMipLevel: 3,
+}
+);
+try {
+renderPassEncoder2.setBindGroup(
+7,
+bindGroup4,
+new Uint32Array(8522),
+2435,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -821.8, g: 235.1, b: 193.2, a: -203.4, });
+} catch {}
+try {
+commandEncoder13.clearBuffer(
+buffer9,
+48068,
+4600
+);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+39444,
+new BigUint64Array(25266),
+16379,
+88
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture7,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'stencil-only',
+},
+arrayBuffer0,
+/* required buffer size: 338 */{
+offset: 338,
+bytesPerRow: 315,
+},
+{width: 15, height: 15, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 43, height: 14, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas2,
+  origin: { x: 20, y: 39 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 2,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 14, height: 13, depthOrArrayLayers: 1}
+);
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(763, 472);
+let shaderModule6 = device0.createShaderModule(
+{
+label: '\u03a4\u92fd\ua5c0',
+code: `@group(5) @binding(59)
+var<storage, read_write> parameter4: array<u32>;
+@group(1) @binding(1510)
+var<storage, read_write> field10: array<u32>;
+@group(2) @binding(2687)
+var<storage, read_write> local6: array<u32>;
+@group(3) @binding(2409)
+var<storage, read_write> type3: array<u32>;
+@group(0) @binding(4639)
+var<storage, read_write> i2: array<u32>;
+@group(5) @binding(4134)
+var<storage, read_write> type4: array<u32>;
+@group(2) @binding(2200)
+var<storage, read_write> local7: array<u32>;
+@group(5) @binding(1642)
+var<storage, read_write> function5: array<u32>;
+@group(4) @binding(2409)
+var<storage, read_write> function6: array<u32>;
+@group(1) @binding(4639)
+var<storage, read_write> function7: array<u32>;
+@group(2) @binding(509)
+var<storage, read_write> global9: array<u32>;
+
+@compute @workgroup_size(8, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: vec4<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(21) a0: vec3<i32>, @location(10) a1: vec4<f16>, @location(8) a2: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+}
+);
+let textureView29 = texture15.createView(
+{
+label: '\u0bfb\u0257\u8873\u{1f9ff}',
+mipLevelCount: 3,
+}
+);
+let computePassEncoder6 = commandEncoder12.beginComputePass(
+{
+label: '\u9916\u7d7b\uf0d3\u9dc0\ud594\u095a\u8d74'
+}
+);
+try {
+renderPassEncoder2.executeBundles([
+renderBundle15,
+renderBundle19,
+renderBundle15
+]);
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(
+querySet8,
+102,
+13,
+buffer5,
+768
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+17076,
+new DataView(new ArrayBuffer(37068)),
+34757,
+652
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture31,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'stencil-only',
+},
+new ArrayBuffer(5770),
+/* required buffer size: 5770 */{
+offset: 691,
+bytesPerRow: 5214,
+},
+{width: 5079, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline43 = await device0.createComputePipelineAsync(
+{
+label: '\u6cdf\uc37b\u0cd5\u5d79\u7a6f\u{1f624}\u92c3',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let querySet25 = device0.createQuerySet({
+label: '\ucd68\u8816\u{1fae5}\u7459',
+type: 'occlusion',
+count: 3729,
+});
+let renderPassEncoder4 = commandEncoder13.beginRenderPass(
+{
+label: '\u0ea2\ueb7c\u087c',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView10,
+stencilClearValue: 26585,
+stencilLoadOp: 'clear',
+stencilStoreOp: 'store',
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet18,
+maxDrawCount: 296248,
+}
+);
+let renderBundle24 = renderBundleEncoder1.finish(
+{
+label: '\u0a39\u3831\u{1fc98}\u0ab1\u090c\ucc9e'
+}
+);
+try {
+renderPassEncoder3.beginOcclusionQuery(1304);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let bindGroupLayout13 = device0.createBindGroupLayout(
+{
+label: '\u9ffd\u{1f9d1}\u042e',
+entries: [
+{
+binding: 5954,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 3052,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let buffer10 = device0.createBuffer(
+{
+label: '\u5ae4\u2f18\uff63',
+size: 2777,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let texture32 = device0.createTexture(
+{
+size: {width: 4045},
+dimension: '1d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+let textureView30 = texture14.createView(
+{
+format: 'rgba32float',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+try {
+renderPassEncoder2.setStencilReference(
+3896
+);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(
+buffer3,
+'uint16',
+13360,
+212
+);
+} catch {}
+let pipeline44 = await promise13;
+let bindGroupLayout14 = device0.createBindGroupLayout(
+{
+label: '\u{1f8c3}\u{1f86e}\u0c10\u{1fe67}\ufe8b\u051e\u6290\u078f',
+entries: [
+{
+binding: 5436,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '3d' },
+},
+{
+binding: 3425,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+}
+],
+}
+);
+let querySet26 = device0.createQuerySet({
+label: '\u7944\u8d68\u62ce\u4e93\u3b77',
+type: 'occlusion',
+count: 105,
+});
+try {
+computePassEncoder2.setPipeline(
+pipeline17
+);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer3,
+'uint16',
+5962,
+6557
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+2,
+bindGroup11
+);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(
+5,
+bindGroup6,
+new Uint32Array(1647),
+742,
+0
+);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(
+buffer5,
+'uint32',
+692,
+26002
+);
+} catch {}
+try {
+offscreenCanvas6.getContext('webgl2');
+} catch {}
+let shaderModule7 = device0.createShaderModule(
+{
+label: '\uf55d\uf385\u{1f85a}\u0128\u5e7a\u{1feeb}\u{1f706}\u9a7e\ub207\u7cff',
+code: `@group(8) @binding(4639)
+var<storage, read_write> i3: array<u32>;
+@group(4) @binding(59)
+var<storage, read_write> i4: array<u32>;
+@group(1) @binding(4313)
+var<storage, read_write> type5: array<u32>;
+@group(5) @binding(1510)
+var<storage, read_write> local8: array<u32>;
+@group(5) @binding(4639)
+var<storage, read_write> global10: array<u32>;
+@group(8) @binding(1510)
+var<storage, read_write> type6: array<u32>;
+@group(3) @binding(509)
+var<storage, read_write> field11: array<u32>;
+@group(4) @binding(4134)
+var<storage, read_write> field12: array<u32>;
+@group(2) @binding(2409)
+var<storage, read_write> i5: array<u32>;
+
+@compute @workgroup_size(1, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: vec2<u32>,
+@location(5) f1: i32,
+@location(3) f2: vec2<i32>,
+@location(1) f3: vec3<u32>,
+@location(0) f4: i32,
+@location(6) f5: f32,
+@builtin(frag_depth) f6: f32,
+@location(2) f7: f32,
+@location(7) f8: vec3<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let textureView31 = texture6.createView(
+{
+label: '\u11fe\u{1faad}\uc43a\u8fbb\u2676\ub4bb\u0641\u1cf3',
+}
+);
+let sampler16 = device0.createSampler(
+{
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 9.358,
+compare: 'less',
+}
+);
+try {
+renderPassEncoder4.setBindGroup(
+0,
+bindGroup0,
+new Uint32Array(6926),
+3202,
+0
+);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(235);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(
+63,
+undefined
+);
+} catch {}
+let promise16 = adapter1.requestAdapterInfo();
+try {
+window.someLabel = renderBundleEncoder5.label;
+} catch {}
+let querySet27 = device0.createQuerySet({
+label: '\u2613\u{1fecc}\u1234\u434e\u0ce2',
+type: 'occlusion',
+count: 3510,
+});
+let textureView32 = texture29.createView(
+{
+label: '\u78d7\u090f\uad57\u3b7a',
+aspect: 'stencil-only',
+format: 'stencil8',
+baseMipLevel: 5,
+mipLevelCount: 1,
+arrayLayerCount: 1,
+}
+);
+try {
+renderPassEncoder2.setBindGroup(
+1,
+bindGroup9,
+new Uint32Array(9921),
+1115,
+0
+);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 370.6, g: -910.2, b: 501.2, a: -21.78, });
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(
+3929
+);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(
+buffer5,
+'uint32',
+27484
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+13,
+undefined,
+66384407
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 5, height: 44, depthOrArrayLayers: 240}
+*/
+{
+  source: canvas0,
+  origin: { x: 66, y: 459 },
+  flipY: true,
+},
+{
+  texture: texture1,
+  mipLevel: 1,
+  origin: { x: 1, y: 10, z: 100 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 4, height: 16, depthOrArrayLayers: 0}
+);
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder(
+{
+}
+);
+let renderPassEncoder5 = commandEncoder14.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView32,
+depthClearValue: -7.181592114950246,
+depthReadOnly: false,
+stencilClearValue: 62768,
+stencilLoadOp: 'clear',
+stencilStoreOp: 'discard',
+},
+maxDrawCount: 98064,
+}
+);
+let renderBundleEncoder12 = device0.createRenderBundleEncoder(
+{
+label: '\u4688\u{1fb3f}\ue6c6',
+colorFormats: [
+'bgra8unorm',
+'r32float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 117,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder2.setPipeline(
+pipeline24
+);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -551.7, g: 968.0, b: -970.4, a: -509.5, });
+} catch {}
+try {
+renderPassEncoder3.setViewport(
+4.944,
+4.725,
+1.454,
+8.063,
+0.8668,
+0.9920
+);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer5,
+'uint16',
+36904,
+455
+);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(
+32,
+undefined,
+1220992860,
+657189511
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 10, height: 3, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 47, y: 49 },
+  flipY: true,
+},
+{
+  texture: texture16,
+  mipLevel: 4,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 5, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline45 = await device0.createComputePipelineAsync(
+{
+label: '\u0b69\uffe2\ueee3',
+layout: 'auto',
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageBitmap5 = await createImageBitmap(video4);
+try {
+computePassEncoder4.setPipeline(
+pipeline27
+);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(
+1,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder3.setViewport(
+11.59,
+11.83,
+0.7977,
+2.608,
+0.1313,
+0.3908
+);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(
+buffer5,
+'uint16',
+31600,
+10273
+);
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+let pipeline46 = await device0.createRenderPipelineAsync(
+{
+label: '\u3b11\ue157\u{1f6a9}\u{1fdda}\ufaad\ub827\u{1ff8a}\u{1f82d}\u0212\u{1fe37}\u{1f670}',
+layout: pipelineLayout3,
+vertex: {
+module: shaderModule5,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 904,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 388,
+shaderLocation: 0,
+},
+{
+format: 'sint8x4',
+offset: 476,
+shaderLocation: 3,
+},
+{
+format: 'float16x2',
+offset: 444,
+shaderLocation: 9,
+},
+{
+format: 'uint16x4',
+offset: 544,
+shaderLocation: 14,
+},
+{
+format: 'uint32x4',
+offset: 636,
+shaderLocation: 16,
+},
+{
+format: 'uint16x2',
+offset: 28,
+shaderLocation: 21,
+},
+{
+format: 'sint32x2',
+offset: 320,
+shaderLocation: 18,
+},
+{
+format: 'sint32x3',
+offset: 444,
+shaderLocation: 19,
+},
+{
+format: 'snorm8x4',
+offset: 804,
+shaderLocation: 2,
+},
+{
+format: 'sint32',
+offset: 492,
+shaderLocation: 10,
+},
+{
+format: 'uint32x4',
+offset: 200,
+shaderLocation: 1,
+},
+{
+format: 'uint16x2',
+offset: 548,
+shaderLocation: 15,
+},
+{
+format: 'sint32x4',
+offset: 460,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x4',
+offset: 12,
+shaderLocation: 8,
+},
+{
+format: 'sint32x2',
+offset: 16,
+shaderLocation: 12,
+},
+{
+format: 'unorm8x4',
+offset: 172,
+shaderLocation: 13,
+},
+{
+format: 'sint8x2',
+offset: 564,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x2',
+offset: 412,
+shaderLocation: 6,
+},
+{
+format: 'unorm8x4',
+offset: 524,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 1720,
+attributes: [
+
+],
+},
+{
+arrayStride: 9008,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 5120,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 5212,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x3',
+offset: 1164,
+shaderLocation: 20,
+},
+{
+format: 'float16x2',
+offset: 4268,
+shaderLocation: 5,
+}
+],
+}
+]
+},
+primitive: {
+cullMode: 'none',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x3982b5e8,
+},
+fragment: {
+module: shaderModule5,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'invert',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 2161,
+stencilWriteMask: 1526,
+depthBias: 16,
+depthBiasSlopeScale: 85,
+},
+}
+);
+let bindGroupLayout15 = device0.createBindGroupLayout(
+{
+label: '\u3d81\u09cd\u983b\u5617\u9a2b\u{1fef8}\ue219\uece3\ufe8c',
+entries: [
+
+],
+}
+);
+pseudoSubmit(device0, commandEncoder12);
+try {
+computePassEncoder5.setPipeline(
+pipeline23
+);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 390.6, g: -41.37, b: -25.38, a: -653.2, });
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+1.096,
+8.125,
+5.003,
+2.248,
+0.4592,
+0.8150
+);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer5,
+'uint16',
+43730,
+490
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture18,
+  mipLevel: 8,
+  origin: { x: 2, y: 0, z: 8 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer4),
+/* required buffer size: 8619282 */{
+offset: 882,
+bytesPerRow: 280,
+rowsPerImage: 180,
+},
+{width: 0, height: 0, depthOrArrayLayers: 172}
+);
+} catch {}
+let pipeline47 = await device0.createComputePipelineAsync(
+{
+label: '\ucd6a\u082d',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+},
+}
+);
+let gpuCanvasContext3 = canvas3.getContext('webgpu');
+let bindGroupLayout16 = device0.createBindGroupLayout(
+{
+entries: [
+
+],
+}
+);
+let commandEncoder15 = device0.createCommandEncoder(
+{
+}
+);
+let querySet28 = device0.createQuerySet({
+type: 'occlusion',
+count: 1493,
+});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder(
+{
+label: '\u4229\u0547\ufa88\ub407\u00c9\u7afa\ua008\u9dbb\u0f1a\u06ac\uc5e7',
+colorFormats: [
+'rgba32uint',
+'rg16sint',
+undefined
+],
+sampleCount: 460,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder0.setBindGroup(
+4,
+bindGroup4
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+4,
+bindGroup10,
+new Uint32Array(1306),
+1104,
+0
+);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(
+1,
+2,
+0,
+9
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg11b10ufloat'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let pipeline48 = device0.createComputePipeline(
+{
+label: '\ucca5\u8d64\u3a0c\ua4f7',
+layout: 'auto',
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+gc();
+let bindGroup12 = device0.createBindGroup({
+label: '\u0488\u022e\u155d\ud9c7\ua5f3\uceb7\u{1f909}\u{1f864}',
+layout: bindGroupLayout11,
+entries: [
+
+],
+});
+try {
+renderPassEncoder4.setBlendConstant({ r: -23.62, g: -183.3, b: 512.1, a: -512.3, });
+} catch {}
+try {
+commandEncoder15.resolveQuerySet(
+querySet28,
+233,
+965,
+buffer5,
+17152
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 1448, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Int8Array(arrayBuffer5),
+/* required buffer size: 500 */{
+offset: 500,
+},
+{width: 3689, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let textureView33 = texture27.createView(
+{
+label: '\u150e\u998a\u0151\u04bc\u91bc\u2ebd\u{1ffe7}\ucb3f\u37d4',
+dimension: '2d-array',
+baseMipLevel: 2,
+mipLevelCount: 1,
+arrayLayerCount: 1,
+}
+);
+let renderBundleEncoder14 = device0.createRenderBundleEncoder(
+{
+label: '\u03b7\u{1fe6d}\u{1fbe6}\ub4e1\u{1fef3}\ue7c6\u0bde\u{1f627}\u1d12\ubb59',
+colorFormats: [
+'rgba8unorm',
+'r32float',
+'r16uint',
+'rg16sint',
+'rgba8unorm',
+'r32uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 88,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder0.setBindGroup(
+6,
+bindGroup12
+);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(68);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: -108.0, g: 527.8, b: 52.49, a: 388.5, });
+} catch {}
+try {
+commandEncoder15.resolveQuerySet(
+querySet13,
+1695,
+129,
+buffer5,
+37888
+);
+} catch {}
+let device1 = await adapter1.requestDevice({
+label: '\ud95b\u8ef6\u{1fb45}\u{1ffa8}\u1761\u491c\u{1fecf}\uc1ff\ubc6b\u6d45\u09c6',
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 64,
+maxVertexBufferArrayStride: 23585,
+maxStorageTexturesPerShaderStage: 15,
+maxStorageBuffersPerShaderStage: 42,
+maxDynamicStorageBuffersPerPipelineLayout: 55450,
+maxBindingsPerBindGroup: 3242,
+maxTextureDimension1D: 16297,
+maxTextureDimension2D: 13899,
+maxVertexBuffers: 10,
+maxUniformBufferBindingSize: 16260065,
+maxUniformBuffersPerShaderStage: 16,
+maxInterStageShaderVariables: 20,
+maxInterStageShaderComponents: 63,
+maxSamplersPerShaderStage: 17,
+},
+});
+let sampler17 = device1.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 41.601,
+lodMaxClamp: 94.981,
+}
+);
+try {
+gpuCanvasContext1.configure(
+{
+device: device1,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float',
+'r8sint'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+gc();
+let imageData3 = new ImageData(68, 60);
+let texture33 = device1.createTexture(
+{
+size: {width: 2272},
+dimension: '1d',
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'r32sint',
+'r32sint',
+'r32sint'
+],
+}
+);
+let textureView34 = texture33.createView(
+{
+label: '\u{1f9e0}\u028e\ud1ce\u5d95\u{1f83c}\u06ef\uae65\u032f\u{1f827}',
+}
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 146, y: 0, z: 0 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer1),
+/* required buffer size: 3567 */{
+offset: 639,
+},
+{width: 732, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let querySet29 = device0.createQuerySet({
+label: '\u0293\u0686\uc528\u0348\ueaa0\u{1fc6f}',
+type: 'occlusion',
+count: 498,
+});
+let renderPassEncoder6 = commandEncoder15.beginRenderPass(
+{
+label: '\u{1f656}\uafab\u5b55\u3f52\u{1fb6d}\uddc3\ubc4c\u8200\ub5e8',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView32,
+depthReadOnly: false,
+stencilReadOnly: true,
+},
+occlusionQuerySet: querySet5,
+maxDrawCount: 130544,
+}
+);
+let externalTexture2 = device0.importExternalTexture(
+{
+source: videoFrame3,
+colorSpace: 'srgb',
+}
+);
+try {
+computePassEncoder5.setBindGroup(
+3,
+bindGroup12
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+2,
+bindGroup5
+);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: 450.9, g: 759.5, b: -425.4, a: -501.1, });
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+7,
+bindGroup12
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer10,
+2068,
+new DataView(new ArrayBuffer(39043)),
+26733,
+536
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture27,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer7,
+/* required buffer size: 871 */{
+offset: 871,
+bytesPerRow: 213,
+rowsPerImage: 83,
+},
+{width: 4, height: 14, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+let textureView35 = texture16.createView(
+{
+label: '\u0bab\udad2\u{1f683}\ua02c\ud74a\u{1fa83}\u0943\u90f2',
+baseMipLevel: 3,
+baseArrayLayer: 0,
+}
+);
+let renderBundle25 = renderBundleEncoder10.finish(
+{
+label: '\u07f8\u04a7\u0976\u8a79\u0c43'
+}
+);
+try {
+computePassEncoder2.setPipeline(
+pipeline40
+);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(
+1,
+bindGroup12
+);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+29,
+undefined,
+1846763746,
+1973017363
+);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(
+buffer6,
+'uint16',
+13790
+);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(
+89,
+undefined
+);
+} catch {}
+let pipeline49 = device0.createRenderPipeline(
+{
+label: '\u{1fbc5}\u004d\u{1f6cd}\u815d',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule1,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 13284,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 1784,
+shaderLocation: 19,
+},
+{
+format: 'uint16x2',
+offset: 9244,
+shaderLocation: 2,
+},
+{
+format: 'uint16x4',
+offset: 5508,
+shaderLocation: 9,
+},
+{
+format: 'float32x2',
+offset: 1648,
+shaderLocation: 18,
+},
+{
+format: 'unorm8x2',
+offset: 2434,
+shaderLocation: 7,
+},
+{
+format: 'sint32x4',
+offset: 892,
+shaderLocation: 21,
+},
+{
+format: 'uint8x4',
+offset: 11260,
+shaderLocation: 3,
+},
+{
+format: 'unorm16x4',
+offset: 6952,
+shaderLocation: 12,
+},
+{
+format: 'uint32x2',
+offset: 404,
+shaderLocation: 14,
+},
+{
+format: 'sint16x4',
+offset: 9340,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x2',
+offset: 10180,
+shaderLocation: 17,
+},
+{
+format: 'uint16x4',
+offset: 4460,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x2',
+offset: 2992,
+shaderLocation: 10,
+},
+{
+format: 'sint16x2',
+offset: 3180,
+shaderLocation: 13,
+},
+{
+format: 'snorm8x2',
+offset: 6074,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 2572,
+attributes: [
+{
+format: 'sint8x2',
+offset: 1486,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 6288,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x2',
+offset: 3816,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 2764,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 2860,
+attributes: [
+{
+format: 'float16x4',
+offset: 744,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule1,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 63,
+depthBias: 100,
+},
+}
+);
+let texture34 = device0.createTexture(
+{
+label: '\u{1f69e}\u{1ff05}',
+size: {width: 6503},
+dimension: '1d',
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let sampler18 = device0.createSampler(
+{
+label: '\ud7ef\u337d\ud47d\u7962\u2ba1\u11c0\u{1fbff}\uea16\u454b',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 15.160,
+lodMaxClamp: 57.318,
+}
+);
+try {
+renderPassEncoder6.beginOcclusionQuery(44);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(
+buffer5,
+'uint32',
+23616,
+3950
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 11, depthOrArrayLayers: 240}
+*/
+{
+  source: canvas3,
+  origin: { x: 203, y: 103 },
+  flipY: true,
+},
+{
+  texture: texture1,
+  mipLevel: 3,
+  origin: { x: 1, y: 1, z: 2 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 0, height: 8, depthOrArrayLayers: 1}
+);
+} catch {}
+let renderBundleEncoder15 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'r32uint',
+'bgra8unorm'
+],
+sampleCount: 948,
+depthReadOnly: true,
+}
+);
+let adapter2 = await navigator.gpu.requestAdapter(
+{
+powerPreference: 'high-performance',
+}
+);
+let renderBundleEncoder16 = device0.createRenderBundleEncoder(
+{
+label: '\u7fcf\u2091\uc827\u098c',
+colorFormats: [
+'rg32float',
+undefined,
+'rgb10a2uint',
+'rg32uint',
+'rgba8uint',
+'rgba8sint'
+],
+sampleCount: 660,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder5.setBindGroup(
+0,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(
+4002
+);
+} catch {}
+try {
+await buffer10.mapAsync(
+GPUMapMode.READ,
+0,
+2488
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 499, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(new ArrayBuffer(0)),
+/* required buffer size: 964 */{
+offset: 964,
+},
+{width: 443, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+adapter1.label = '\u0f09\u097a';
+} catch {}
+let querySet30 = device1.createQuerySet({
+label: '\u0366\ud415\uedfa\u{1f9a0}\u{1f946}',
+type: 'occlusion',
+count: 4009,
+});
+let texture35 = device1.createTexture(
+{
+size: [222, 1, 186],
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8snorm',
+'rg8snorm'
+],
+}
+);
+let textureView36 = texture33.createView(
+{
+label: '\ubab4\u05ea\ua459',
+aspect: 'all',
+mipLevelCount: 1,
+}
+);
+try {
+await promise16;
+} catch {}
+let texture36 = device0.createTexture(
+{
+label: '\u5bf4\u{1fc12}\u6437\u156a\uc171\u0e6c\u05d1\uf0e0\u4cfd',
+size: {width: 16, height: 37, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16sint',
+'rgba16sint'
+],
+}
+);
+let renderBundle26 = renderBundleEncoder9.finish(
+{
+label: '\u24ee\u8823'
+}
+);
+try {
+computePassEncoder4.dispatchWorkgroups(
+4,
+4,
+3
+);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(
+0,
+bindGroup4,
+new Uint32Array(6542),
+568,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([
+renderBundle15,
+renderBundle15,
+renderBundle15,
+renderBundle15,
+renderBundle15
+]);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: 74.24, g: -142.5, b: 505.9, a: -466.3, });
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+24760,
+new DataView(new ArrayBuffer(35934)),
+18095,
+16164
+);
+} catch {}
+let bindGroupLayout17 = device1.createBindGroupLayout(
+{
+label: '\uec21\ua208\u3763\u{1f943}\u0874',
+entries: [
+{
+binding: 1830,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+},
+{
+binding: 2941,
+visibility: 0,
+texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+}
+],
+}
+);
+let querySet31 = device1.createQuerySet({
+type: 'occlusion',
+count: 3032,
+});
+let textureView37 = texture33.createView(
+{
+label: '\u{1f79b}\u8f3c\u{1f796}\u{1f66c}\u9d9c\u2542\u50e4\u8ad2',
+}
+);
+let renderBundle27 = renderBundleEncoder15.finish();
+let sampler19 = device1.createSampler(
+{
+label: '\u0d12\u6d39\uf6ca\u7287\uedda\u769b\u03a8\u{1fd3d}\u00ca',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 73.514,
+lodMaxClamp: 99.690,
+maxAnisotropy: 1,
+}
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 373, y: 1, z: 1 },
+  aspect: 'all',
+},
+new Int8Array(new ArrayBuffer(72)),
+/* required buffer size: 268 */{
+offset: 268,
+},
+{width: 1856, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+gc();
+let bindGroup13 = device0.createBindGroup({
+label: '\u19e5\u21b9\u2cf4\u980f\u0d66',
+layout: bindGroupLayout1,
+entries: [
+{
+binding: 2409,
+resource: externalTexture1
+}
+],
+});
+try {
+computePassEncoder4.setPipeline(
+pipeline45
+);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -504.1, g: -912.7, b: 191.4, a: 727.8, });
+} catch {}
+try {
+renderPassEncoder6.setViewport(
+3.584,
+1.872,
+1.985,
+0.1014,
+0.02977,
+0.8241
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+43752,
+new Float32Array(65320),
+10327,
+332
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img3,
+  origin: { x: 14, y: 24 },
+  flipY: false,
+},
+{
+  texture: texture23,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+window.someLabel = externalTexture1.label;
+} catch {}
+try {
+computePassEncoder4.setPipeline(
+pipeline28
+);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: -519.3, g: 612.6, b: 175.0, a: 383.8, });
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(
+buffer3,
+'uint16'
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+16140,
+new BigUint64Array(34349),
+12023,
+1116
+);
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder(
+{
+}
+);
+let textureView38 = texture1.createView(
+{
+label: '\ufbcd\u{1f9d7}\uf69a\u08bc\u0f07\uf0ac\u0be7\u38a7',
+dimension: '2d',
+baseMipLevel: 2,
+mipLevelCount: 1,
+baseArrayLayer: 183,
+}
+);
+try {
+computePassEncoder2.setPipeline(
+pipeline6
+);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(
+5,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: 899.9, g: 267.7, b: -988.5, a: -462.2, });
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(
+35,
+undefined,
+4235909512,
+18524442
+);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(
+3,
+bindGroup3,
+new Uint32Array(3517),
+1825,
+0
+);
+} catch {}
+try {
+commandEncoder16.clearBuffer(
+buffer9,
+13368,
+28512
+);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder16.resolveQuerySet(
+querySet0,
+69,
+83,
+buffer5,
+16384
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture16,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer0),
+/* required buffer size: 275 */{
+offset: 275,
+bytesPerRow: 150,
+},
+{width: 6, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 10, height: 3, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 4, y: 37 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 4,
+  origin: { x: 3, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 3, height: 3, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline50 = await device0.createComputePipelineAsync(
+{
+label: '\u0aad\uba92\u940e\u0deb\uafe9\uda78\u{1f95e}\u{1f6e0}\u1241\u6fca',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder17 = device1.createCommandEncoder(
+{
+label: '\u0937\u0ec7\u0364',
+}
+);
+let renderBundleEncoder17 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'r16float',
+'rgba16uint',
+'rgba8sint',
+undefined,
+'r16uint',
+'r32float',
+'r16uint'
+],
+sampleCount: 31,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder17.setVertexBuffer(
+64,
+undefined,
+456483200,
+1893097823
+);
+} catch {}
+gc();
+let commandEncoder18 = device1.createCommandEncoder(
+{
+}
+);
+let textureView39 = texture35.createView(
+{
+label: '\u{1fd59}\u{1fb25}',
+baseMipLevel: 1,
+arrayLayerCount: 1,
+}
+);
+try {
+commandEncoder18.copyTextureToTexture(
+{
+  texture: texture35,
+  mipLevel: 2,
+  origin: { x: 4, y: 0, z: 9 },
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 81, y: 0, z: 72 },
+  aspect: 'all',
+},
+{width: 34, height: 1, depthOrArrayLayers: 30}
+);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb',
+'rg16uint'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let promise19 = adapter2.requestAdapterInfo();
+let shaderModule8 = device0.createShaderModule(
+{
+label: '\u1614\u5394\u{1f700}\ued6f\u69c1\u02e3\ud688\u0d15',
+code: `@group(2) @binding(2687)
+var<storage, read_write> type7: array<u32>;
+@group(1) @binding(2200)
+var<storage, read_write> type8: array<u32>;
+@group(2) @binding(2200)
+var<storage, read_write> i6: array<u32>;
+@group(0) @binding(59)
+var<storage, read_write> field13: array<u32>;
+@group(1) @binding(2687)
+var<storage, read_write> type9: array<u32>;
+@group(0) @binding(4134)
+var<storage, read_write> global11: array<u32>;
+@group(3) @binding(2409)
+var<storage, read_write> i7: array<u32>;
+@group(2) @binding(509)
+var<storage, read_write> parameter5: array<u32>;
+
+@compute @workgroup_size(5, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S6 {
+@location(81) f0: vec2<u32>,
+@location(71) f1: f16,
+@location(30) f2: vec3<f32>,
+@location(35) f3: vec4<i32>,
+@builtin(sample_mask) f4: u32,
+@builtin(position) f5: vec4<f32>,
+@builtin(front_facing) f6: bool,
+@location(80) f7: vec4<f16>,
+@location(11) f8: vec2<f16>,
+@location(78) f9: vec4<f32>,
+@location(56) f10: vec3<u32>,
+@location(48) f11: u32,
+@location(50) f12: vec4<u32>,
+@location(33) f13: vec4<f16>,
+@location(3) f14: f16,
+@location(6) f15: vec4<i32>,
+@location(44) f16: i32,
+@location(40) f17: vec4<f32>,
+@location(20) f18: vec2<f16>,
+@location(37) f19: u32,
+@location(16) f20: vec2<f16>,
+@location(39) f21: f16,
+@location(79) f22: vec4<f32>,
+@location(32) f23: f32,
+@location(18) f24: vec3<u32>,
+@location(77) f25: vec3<f32>,
+@location(38) f26: f16,
+@location(47) f27: vec3<u32>,
+@location(29) f28: f32,
+@location(26) f29: vec3<f32>,
+@location(54) f30: u32,
+@location(66) f31: vec2<f16>,
+@location(25) f32: f16,
+@location(28) f33: vec4<i32>,
+@location(55) f34: f32,
+@location(23) f35: vec2<i32>,
+@location(7) f36: vec4<u32>,
+@location(0) f37: vec4<f32>,
+@location(13) f38: f32,
+@location(9) f39: i32,
+@location(59) f40: vec2<f32>,
+@location(21) f41: vec3<f32>,
+@location(69) f42: vec4<i32>,
+@location(19) f43: vec2<f32>,
+@location(36) f44: f16,
+@location(43) f45: vec4<f16>,
+@location(68) f46: vec4<i32>,
+@location(46) f47: vec3<f16>
+}
+struct FragmentOutput0 {
+@location(6) f0: vec3<u32>,
+@location(3) f1: u32,
+@location(7) f2: f32,
+@location(0) f3: vec2<i32>,
+@location(2) f4: u32
+}
+
+@fragment
+fn fragment0(@location(60) a0: i32, @location(15) a1: vec4<f16>, @location(58) a2: f16, a3: S6, @builtin(sample_index) a4: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S5 {
+@builtin(vertex_index) f0: u32
+}
+struct VertexOutput0 {
+@location(28) f78: vec4<i32>,
+@location(48) f79: u32,
+@location(16) f80: vec2<f16>,
+@location(58) f81: f16,
+@location(81) f82: vec2<u32>,
+@location(20) f83: vec2<f16>,
+@location(66) f84: vec2<f16>,
+@location(59) f85: vec2<f32>,
+@location(3) f86: f16,
+@location(37) f87: u32,
+@location(25) f88: f16,
+@location(56) f89: vec3<u32>,
+@location(36) f90: f16,
+@location(40) f91: vec4<f32>,
+@location(68) f92: vec4<i32>,
+@location(6) f93: vec4<i32>,
+@builtin(position) f94: vec4<f32>,
+@location(35) f95: vec4<i32>,
+@location(0) f96: vec4<f32>,
+@location(19) f97: vec2<f32>,
+@location(55) f98: f32,
+@location(69) f99: vec4<i32>,
+@location(29) f100: f32,
+@location(26) f101: vec3<f32>,
+@location(23) f102: vec2<i32>,
+@location(32) f103: f32,
+@location(18) f104: vec3<u32>,
+@location(71) f105: f16,
+@location(77) f106: vec3<f32>,
+@location(30) f107: vec3<f32>,
+@location(60) f108: i32,
+@location(43) f109: vec4<f16>,
+@location(38) f110: f16,
+@location(46) f111: vec3<f16>,
+@location(54) f112: u32,
+@location(9) f113: i32,
+@location(21) f114: vec3<f32>,
+@location(33) f115: vec4<f16>,
+@location(47) f116: vec3<u32>,
+@location(7) f117: vec4<u32>,
+@location(11) f118: vec2<f16>,
+@location(15) f119: vec4<f16>,
+@location(78) f120: vec4<f32>,
+@location(44) f121: i32,
+@location(13) f122: f32,
+@location(80) f123: vec4<f16>,
+@location(39) f124: f16,
+@location(79) f125: vec4<f32>,
+@location(50) f126: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec2<f32>, @location(13) a1: vec4<f16>, @location(5) a2: vec4<i32>, @location(15) a3: vec4<i32>, @location(9) a4: vec4<f32>, @location(17) a5: vec4<f32>, @location(12) a6: vec4<u32>, @location(18) a7: vec2<f16>, @location(20) a8: i32, @location(8) a9: f16, @location(0) a10: f32, @location(19) a11: vec2<u32>, @location(6) a12: i32, @location(2) a13: vec2<f16>, @location(7) a14: vec2<f16>, @location(11) a15: vec2<f16>, @builtin(instance_index) a16: u32, @location(1) a17: vec4<i32>, @location(4) a18: i32, @location(3) a19: vec4<u32>, @location(14) a20: vec3<f32>, @location(21) a21: u32, a22: S5, @location(16) a23: i32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandBuffer2 = commandEncoder16.finish(
+{
+label: '\u0fcb\u{1fe6e}',
+}
+);
+let texture37 = device0.createTexture(
+{
+label: '\u0cc7\u8c5f\u5b62\u2e53\u20d3\u0691\u0f6f\u0d40',
+size: [187, 1, 534],
+mipLevelCount: 9,
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgba32float',
+'rgba32float'
+],
+}
+);
+try {
+computePassEncoder5.setBindGroup(
+4,
+bindGroup10,
+new Uint32Array(2945),
+2083,
+0
+);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(
+7,
+bindGroup9,
+new Uint32Array(7672),
+6883,
+0
+);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(
+1,
+1,
+2,
+1
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video2,
+  origin: { x: 14, y: 6 },
+  flipY: true,
+},
+{
+  texture: texture23,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise20 = device0.createComputePipelineAsync(
+{
+label: '\u{1fdd7}\u{1fd1f}\u0f50',
+layout: 'auto',
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let texture38 = device1.createTexture(
+{
+label: '\u{1fbb0}\u{1fd2b}\u09be\u0d23\uce8e\ua3c0\uc715\u08c2\u{1fb51}',
+size: {width: 6277, height: 238, depthOrArrayLayers: 1},
+mipLevelCount: 11,
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let textureView40 = texture35.createView(
+{
+label: '\u025e\u{1f911}\u{1f987}',
+baseMipLevel: 2,
+}
+);
+let renderBundle28 = renderBundleEncoder15.finish(
+{
+
+}
+);
+offscreenCanvas2.height = 339;
+let pipelineLayout8 = device1.createPipelineLayout(
+{
+label: '\u6b91\u4d77\u{1f80e}\u0741\u85c5\u5504',
+bindGroupLayouts: [
+bindGroupLayout17,
+bindGroupLayout17,
+bindGroupLayout17
+]
+}
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 647, y: 0, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(31),
+/* required buffer size: 31 */{
+offset: 31,
+},
+{width: 465, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend(video2);
+let commandEncoder19 = device0.createCommandEncoder(
+{
+label: '\u8f27\uca1d\u29b5\u0507\u0142\u9b71\u7e00\ud14f',
+}
+);
+pseudoSubmit(device0, commandEncoder14);
+let textureView41 = texture28.createView(
+{
+label: '\u2e25\u9bfd\u{1f8b8}\u6517\ufa95\uf532\u{1f693}\uc137\u0904\u{1fb31}',
+}
+);
+try {
+renderPassEncoder4.setBlendConstant({ r: 333.9, g: -420.5, b: 785.7, a: -484.7, });
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(
+0,
+0,
+1,
+1
+);
+} catch {}
+try {
+commandEncoder19.copyBufferToBuffer(
+buffer0,
+24488,
+buffer7,
+15600,
+8036
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+gpuCanvasContext0.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder(
+{
+label: '\u{1fa34}\u44a9\u939b\u06ea\ud9e2\u079c\u{1f9fb}\u0e09\u0e4f\u5e52',
+}
+);
+let textureView42 = texture2.createView(
+{
+label: '\ucedc\uafbb\u0dad\u{1fd4e}',
+aspect: 'all',
+baseMipLevel: 7,
+}
+);
+try {
+renderPassEncoder6.setScissorRect(
+5,
+2,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+26,
+undefined,
+439200366
+);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(
+2,
+bindGroup10
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture28,
+  mipLevel: 0,
+  origin: { x: 3258, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(48),
+/* required buffer size: 4242 */{
+offset: 491,
+},
+{width: 3751, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline51 = await device0.createRenderPipelineAsync(
+{
+label: '\u7920\u0294\u01bf\uc1d4\ue3e1\u{1f871}\u{1f7a7}\ue0af\u2ef7\u457a',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 10244,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 8464,
+shaderLocation: 17,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16uint',
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'dst-alpha',
+dstFactor: 'one-minus-src'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rg16float',
+},
+{
+format: 'r8sint',
+writeMask: 0,
+},
+{
+format: 'r32sint',
+writeMask: 0,
+},
+{
+format: 'r32uint',
+writeMask: 0,
+},
+undefined
+],
+},
+}
+);
+document.body.prepend(canvas0);
+let bindGroupLayout18 = device0.createBindGroupLayout(
+{
+label: '\u0ce9\u8d96\u810a\u15b9\u0421\u{1fb65}\u7f33\u{1fba3}\u0e31\uc483',
+entries: [
+{
+binding: 1297,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 1707,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 5903,
+visibility: 0,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+let computePassEncoder7 = commandEncoder20.beginComputePass(
+{
+
+}
+);
+let renderBundle29 = renderBundleEncoder5.finish(
+{
+label: '\u0c30\ud728\ue835\ude0f\u0f98\u07a5\u{1fdef}\uff15\u2293\u09a8'
+}
+);
+try {
+renderBundleEncoder8.setIndexBuffer(
+buffer5,
+'uint32',
+36048,
+306
+);
+} catch {}
+try {
+querySet11.destroy();
+} catch {}
+try {
+commandEncoder19.copyTextureToBuffer(
+{
+  texture: texture2,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 84 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 22548 */
+offset: 22548,
+buffer: buffer7,
+},
+{width: 21, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: { x: 2033, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Float64Array(new ArrayBuffer(64)),
+/* required buffer size: 824 */{
+offset: 824,
+},
+{width: 4560, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 87, height: 28, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 62, y: 68 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 1,
+  origin: { x: 66, y: 3, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 21, height: 24, depthOrArrayLayers: 1}
+);
+} catch {}
+let querySet32 = device1.createQuerySet({
+type: 'occlusion',
+count: 1653,
+});
+try {
+renderBundleEncoder17.setVertexBuffer(
+18,
+undefined,
+2282891238
+);
+} catch {}
+try {
+await device1.popErrorScope();
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(
+6,
+bindGroup8,
+new Uint32Array(5945),
+3754,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+14,
+12,
+1,
+3
+);
+} catch {}
+try {
+renderPassEncoder3.setViewport(
+11.24,
+11.27,
+1.710,
+3.470,
+0.7759,
+0.9205
+);
+} catch {}
+try {
+commandEncoder19.copyTextureToTexture(
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: { x: 3267, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 4,
+  origin: { x: 0, y: 3, z: 0 },
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder19.clearBuffer(
+buffer7
+);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder19.insertDebugMarker(
+'\u01dc'
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 87, height: 28, depthOrArrayLayers: 1}
+*/
+{
+  source: img4,
+  origin: { x: 3, y: 121 },
+  flipY: true,
+},
+{
+  texture: texture16,
+  mipLevel: 1,
+  origin: { x: 14, y: 12, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 8, height: 4, depthOrArrayLayers: 0}
+);
+} catch {}
+let renderBundleEncoder18 = device1.createRenderBundleEncoder(
+{
+label: '\u49a6\ucbb3\ud3eb\ued2e\u316f\uedb7',
+colorFormats: [
+'rgba32float',
+'rgba16uint',
+'rgba32float',
+'rgba16uint',
+undefined,
+'r32uint',
+undefined,
+'bgra8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 311,
+}
+);
+let renderBundle30 = renderBundleEncoder18.finish(
+{
+label: '\u{1fc7a}\u0ddd\u395e\u{1ffc6}\u84aa\uc93b\ub28e'
+}
+);
+try {
+renderBundleEncoder17.pushDebugGroup(
+'\u7ab8'
+);
+} catch {}
+let renderBundleEncoder19 = device1.createRenderBundleEncoder(
+{
+label: '\u0031\u9176\u9c2e\u577a',
+colorFormats: [
+'rg8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 400,
+}
+);
+try {
+renderBundleEncoder19.setVertexBuffer(
+30,
+undefined,
+501829049,
+732468361
+);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let shaderModule9 = device0.createShaderModule(
+{
+code: `@group(3) @binding(2496)
+var<storage, read_write> function8: array<u32>;
+@group(8) @binding(2200)
+var<storage, read_write> function9: array<u32>;
+@group(2) @binding(1510)
+var<storage, read_write> global12: array<u32>;
+@group(0) @binding(3011)
+var<storage, read_write> function10: array<u32>;
+@group(3) @binding(3011)
+var<storage, read_write> parameter6: array<u32>;
+@group(6) @binding(2687)
+var<storage, read_write> field14: array<u32>;
+@group(6) @binding(509)
+var<storage, read_write> i8: array<u32>;
+@group(7) @binding(509)
+var<storage, read_write> function11: array<u32>;
+@group(0) @binding(2496)
+var<storage, read_write> global13: array<u32>;
+@group(2) @binding(4639)
+var<storage, read_write> type10: array<u32>;
+@group(8) @binding(2687)
+var<storage, read_write> global14: array<u32>;
+@group(7) @binding(2200)
+var<storage, read_write> global15: array<u32>;
+@group(6) @binding(2200)
+var<storage, read_write> field15: array<u32>;
+@group(8) @binding(509)
+var<storage, read_write> parameter7: array<u32>;
+@group(7) @binding(2687)
+var<storage, read_write> function12: array<u32>;
+
+@compute @workgroup_size(7, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(5) f0: vec3<u32>,
+@location(1) f1: vec3<i32>,
+@location(3) f2: vec3<u32>,
+@location(2) f3: vec4<f32>,
+@location(6) f4: vec4<u32>,
+@location(0) f5: vec4<i32>,
+@location(7) f6: vec4<f32>,
+@location(4) f7: vec2<i32>,
+@builtin(frag_depth) f8: f32
+}
+
+@fragment
+fn fragment0(@location(22) a0: vec4<f32>, @location(23) a1: vec4<f16>, @location(60) a2: vec3<u32>, @location(20) a3: f16, @location(42) a4: u32, @location(8) a5: vec4<f16>, @location(56) a6: vec2<f32>, @location(13) a7: vec3<f16>, @location(35) a8: vec3<f32>, @location(54) a9: vec4<i32>, @builtin(front_facing) a10: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S7 {
+@location(12) f0: vec2<f32>,
+@location(3) f1: vec3<f16>,
+@location(20) f2: vec4<u32>,
+@location(0) f3: vec3<f32>,
+@location(11) f4: vec4<i32>,
+@location(16) f5: vec3<f32>,
+@location(10) f6: f32,
+@location(14) f7: vec2<f32>,
+@location(6) f8: vec4<f16>,
+@location(18) f9: vec3<i32>,
+@location(8) f10: vec2<f32>,
+@location(19) f11: vec3<i32>
+}
+struct VertexOutput0 {
+@location(54) f127: vec4<i32>,
+@location(56) f128: vec2<f32>,
+@location(20) f129: f16,
+@location(74) f130: vec2<f16>,
+@location(80) f131: vec2<i32>,
+@location(15) f132: vec3<f16>,
+@location(7) f133: vec2<i32>,
+@location(3) f134: vec4<f32>,
+@location(22) f135: vec4<f32>,
+@location(76) f136: vec4<f16>,
+@location(32) f137: vec4<i32>,
+@location(31) f138: f32,
+@location(81) f139: vec4<u32>,
+@location(33) f140: vec2<f32>,
+@location(13) f141: vec3<f16>,
+@location(51) f142: vec2<f32>,
+@location(42) f143: u32,
+@location(67) f144: f16,
+@location(24) f145: vec3<i32>,
+@location(46) f146: vec3<f16>,
+@location(77) f147: vec3<u32>,
+@location(69) f148: vec2<f16>,
+@location(0) f149: f16,
+@location(47) f150: vec3<f16>,
+@location(43) f151: f32,
+@location(35) f152: vec3<f32>,
+@location(34) f153: vec4<u32>,
+@location(62) f154: f16,
+@location(8) f155: vec4<f16>,
+@location(23) f156: vec4<f16>,
+@location(52) f157: vec2<f32>,
+@location(60) f158: vec3<u32>,
+@builtin(position) f159: vec4<f32>,
+@location(57) f160: vec3<i32>,
+@location(1) f161: vec4<i32>
+}
+
+@vertex
+fn vertex0(a0: S7, @location(5) a1: i32, @location(21) a2: vec4<f16>, @builtin(instance_index) a3: u32, @builtin(vertex_index) a4: u32, @location(15) a5: u32, @location(7) a6: vec3<i32>, @location(1) a7: vec4<f32>, @location(2) a8: f32, @location(9) a9: vec4<i32>, @location(13) a10: u32, @location(17) a11: f32, @location(4) a12: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture39 = device0.createTexture(
+{
+label: '\u{1fa18}\u5273\u090e\u1997\u4a49\uc4ca\u8280\u{1fc67}\u30d9\u0429',
+size: {width: 7424, height: 252, depthOrArrayLayers: 67},
+mipLevelCount: 6,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'stencil8'
+],
+}
+);
+let renderPassEncoder7 = commandEncoder19.beginRenderPass(
+{
+label: '\uea6e\u0556\u0559\u{1fdfd}\u6b33\u{1f9e8}\u8cf0',
+colorAttachments: [
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView32,
+depthClearValue: 5.387481157135131,
+stencilClearValue: 31963,
+stencilLoadOp: 'load',
+stencilStoreOp: 'discard',
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet14,
+maxDrawCount: 9392,
+}
+);
+try {
+computePassEncoder7.setBindGroup(
+1,
+bindGroup0
+);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(
+buffer6,
+'uint32',
+12508,
+10999
+);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(
+42,
+undefined,
+2909978115,
+526137528
+);
+} catch {}
+let canvas4 = document.createElement('canvas');
+let shaderModule10 = device1.createShaderModule(
+{
+label: '\u059c\u4bdd\u{1fba6}\ue7f0\u0e29\u{1fc2d}\uf161\ub460',
+code: `@group(2) @binding(2941)
+var<storage, read_write> type11: array<u32>;
+@group(2) @binding(1830)
+var<storage, read_write> parameter8: array<u32>;
+@group(0) @binding(2941)
+var<storage, read_write> i9: array<u32>;
+@group(1) @binding(1830)
+var<storage, read_write> type12: array<u32>;
+@group(0) @binding(1830)
+var<storage, read_write> global16: array<u32>;
+@group(1) @binding(2941)
+var<storage, read_write> i10: array<u32>;
+
+@compute @workgroup_size(3, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(7) f0: vec3<f32>,
+@location(1) f1: vec2<u32>,
+@location(5) f2: vec2<u32>,
+@builtin(frag_depth) f3: f32,
+@location(0) f4: vec2<i32>,
+@location(2) f5: i32,
+@location(3) f6: u32,
+@location(4) f7: vec3<i32>,
+@location(6) f8: vec2<i32>,
+@builtin(sample_mask) f9: u32
+}
+
+@fragment
+fn fragment0(@location(6) a0: f16) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S8 {
+@location(5) f0: f32
+}
+struct VertexOutput0 {
+@location(15) f162: vec2<u32>,
+@builtin(position) f163: vec4<f32>,
+@location(6) f164: f16,
+@location(16) f165: f32,
+@location(0) f166: vec4<i32>,
+@location(10) f167: vec2<i32>,
+@location(13) f168: vec4<u32>,
+@location(4) f169: i32,
+@location(12) f170: vec4<u32>,
+@location(9) f171: vec2<f32>,
+@location(19) f172: vec3<u32>,
+@location(14) f173: f32,
+@location(1) f174: vec2<f16>,
+@location(18) f175: vec3<u32>,
+@location(11) f176: vec2<f32>,
+@location(2) f177: vec4<f16>,
+@location(7) f178: vec2<i32>,
+@location(8) f179: u32
+}
+
+@vertex
+fn vertex0(@location(6) a0: u32, @location(8) a1: i32, @location(1) a2: i32, @location(15) a3: f32, @location(9) a4: vec4<f32>, @builtin(instance_index) a5: u32, @location(11) a6: vec4<f32>, @location(10) a7: vec3<i32>, @location(2) a8: u32, @location(14) a9: vec3<f32>, a10: S8, @location(3) a11: vec3<f32>, @location(12) a12: i32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder21 = device1.createCommandEncoder(
+{
+label: '\u0fea\uf66a\u4c31\ubee7\u6307\uac81\u97a7\u3143\u0dc9',
+}
+);
+let texture40 = device1.createTexture(
+{
+label: '\u0ef2\u046b\u7f55\u0e09\u0fcd\u7da2\u{1fe5b}\u{1f74d}\u0c2a',
+size: {width: 128, height: 1, depthOrArrayLayers: 224},
+mipLevelCount: 2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let offscreenCanvas7 = new OffscreenCanvas(397, 334);
+let commandEncoder22 = device0.createCommandEncoder(
+{
+label: '\u499b\u5e82\u154b\u0afe\u0fb5\ua229\u662a\u3b74\u{1fa71}\u6448',
+}
+);
+let querySet33 = device0.createQuerySet({
+label: '\u4a45\ua3eb\ueaab\u{1f9c7}\uc7e5\u0855\u12c5',
+type: 'occlusion',
+count: 302,
+});
+let texture41 = device0.createTexture(
+{
+label: '\u4861\u9fbb',
+size: [2017, 1, 110],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16uint',
+'r16uint',
+'r16uint'
+],
+}
+);
+let computePassEncoder8 = commandEncoder22.beginComputePass(
+{
+label: '\u818e\u0e86\u0588\u04c1\u{1f7f2}\u{1fa98}'
+}
+);
+try {
+computePassEncoder7.setBindGroup(
+8,
+bindGroup8,
+new Uint32Array(2906),
+1855,
+0
+);
+} catch {}
+try {
+computePassEncoder5.setPipeline(
+pipeline47
+);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -501.9, g: 986.2, b: -575.7, a: -34.45, });
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(
+0,
+0,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(
+80,
+undefined,
+1956634175,
+845582834
+);
+} catch {}
+offscreenCanvas2.height = 659;
+let querySet34 = device1.createQuerySet({
+label: '\u14f2\u2685\u9c2d',
+type: 'occlusion',
+count: 2512,
+});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let querySet35 = device1.createQuerySet({
+label: '\uef59\ua819\u532a\ue461\ua052\u079d',
+type: 'occlusion',
+count: 455,
+});
+let renderBundle31 = renderBundleEncoder15.finish(
+{
+label: '\u079d\uf66a\u0764\ucd2b\u{1fc20}'
+}
+);
+try {
+commandEncoder21.copyTextureToTexture(
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 6, y: 0, z: 62 },
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 2,
+  origin: { x: 40, y: 0, z: 17 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 16}
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture35,
+  mipLevel: 1,
+  origin: { x: 11, y: 1, z: 6 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 128373 */{
+offset: 393,
+bytesPerRow: 324,
+rowsPerImage: 79,
+},
+{width: 76, height: 0, depthOrArrayLayers: 6}
+);
+} catch {}
+let promise21 = device1.queue.onSubmittedWorkDone();
+let pipeline52 = device1.createRenderPipeline(
+{
+label: '\udb42\ub1ff\u105b\u0016\u7457\u2699\u9921',
+layout: pipelineLayout8,
+vertex: {
+module: shaderModule10,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 13604,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 10328,
+shaderLocation: 3,
+},
+{
+format: 'float16x4',
+offset: 11012,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 2782,
+shaderLocation: 6,
+},
+{
+format: 'snorm16x2',
+offset: 8536,
+shaderLocation: 11,
+},
+{
+format: 'sint32x2',
+offset: 8608,
+shaderLocation: 8,
+},
+{
+format: 'sint8x2',
+offset: 986,
+shaderLocation: 10,
+},
+{
+format: 'float32',
+offset: 6428,
+shaderLocation: 14,
+},
+{
+format: 'uint32x3',
+offset: 6476,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 7352,
+attributes: [
+{
+format: 'sint8x4',
+offset: 3520,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x2',
+offset: 530,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 428,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 280,
+shaderLocation: 1,
+},
+{
+format: 'snorm8x2',
+offset: 204,
+shaderLocation: 15,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+},
+multisample: {
+mask: 0xf6f4a6cc,
+},
+fragment: {
+module: shaderModule10,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32sint',
+},
+{
+format: 'rg32uint',
+writeMask: 0,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'one-minus-dst-alpha',
+dstFactor: 'one-minus-dst'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'dst',
+dstFactor: 'one'
+},
+},
+format: 'rg16float',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+failOp: 'decrement-wrap',
+depthFailOp: 'invert',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'decrement-clamp',
+},
+stencilReadMask: 2600,
+stencilWriteMask: 1942,
+depthBias: 65,
+depthBiasClamp: 11,
+},
+}
+);
+gc();
+try {
+window.someLabel = querySet35.label;
+} catch {}
+let renderBundleEncoder20 = device1.createRenderBundleEncoder(
+{
+label: '\u3073\u0fd8\ucfc7\u74b0\ub3cd\u2763\u0800\u9a07\ub08a',
+colorFormats: [
+'rgb10a2uint',
+'r8sint',
+'rgb10a2unorm',
+'rgb10a2unorm',
+'rgba8unorm-srgb',
+'rgba32sint',
+'bgra8unorm',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 461,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder20.setVertexBuffer(
+14,
+undefined,
+1611614016,
+707735574
+);
+} catch {}
+try {
+commandEncoder21.copyTextureToTexture(
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 110, y: 0, z: 83 },
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 1,
+  origin: { x: 25, y: 0, z: 8 },
+  aspect: 'all',
+},
+{width: 69, height: 1, depthOrArrayLayers: 85}
+);
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(950, 157);
+let sampler20 = device1.createSampler(
+{
+label: '\u{1ff69}\u5ef3\u083b\u07d4\u{1f918}\u4d43\u2e5d\u5b6c',
+addressModeU: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 12.487,
+lodMaxClamp: 24.125,
+compare: 'never',
+maxAnisotropy: 4,
+}
+);
+try {
+renderBundleEncoder17.popDebugGroup();
+} catch {}
+let texture42 = device1.createTexture(
+{
+label: '\u00f7\u{1f641}\u08d8\ua6de\u0fa4',
+size: {width: 238, height: 199, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture40,
+  mipLevel: 1,
+  origin: { x: 21, y: 0, z: 7 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 2489605 */{
+offset: 374,
+bytesPerRow: 343,
+rowsPerImage: 123,
+},
+{width: 20, height: 1, depthOrArrayLayers: 60}
+);
+} catch {}
+let pipeline53 = device1.createRenderPipeline(
+{
+label: '\u0a33\u7466\ua0ce\u03a0\udd0e\u{1fbf4}\u0eee\u98ba',
+layout: pipelineLayout8,
+vertex: {
+module: shaderModule10,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 4400,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 236,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x4',
+offset: 864,
+shaderLocation: 15,
+},
+{
+format: 'uint32x3',
+offset: 1784,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x4',
+offset: 304,
+shaderLocation: 5,
+},
+{
+format: 'sint16x2',
+offset: 4228,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 10280,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x2',
+offset: 7930,
+shaderLocation: 1,
+},
+{
+format: 'float32',
+offset: 7628,
+shaderLocation: 14,
+},
+{
+format: 'sint32x3',
+offset: 7556,
+shaderLocation: 12,
+},
+{
+format: 'uint32',
+offset: 1356,
+shaderLocation: 6,
+},
+{
+format: 'float32x3',
+offset: 8960,
+shaderLocation: 11,
+},
+{
+format: 'float32x3',
+offset: 9436,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 7456,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 13036,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 988,
+attributes: [
+
+],
+},
+{
+arrayStride: 16468,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x2',
+offset: 16260,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'none',
+},
+multisample: {
+count: 4,
+mask: 0x136eb096,
+},
+fragment: {
+module: shaderModule10,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'rg16sint',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'decrement-clamp',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'zero',
+},
+stencilReadMask: 923,
+depthBias: 48,
+depthBiasSlopeScale: 75,
+},
+}
+);
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let shaderModule11 = device0.createShaderModule(
+{
+label: '\u6d33\u3864\u{1f66d}\u6c59\u{1ff9a}\u069d\u5dd8',
+code: `@group(1) @binding(509)
+var<storage, read_write> parameter9: array<u32>;
+@group(0) @binding(4639)
+var<storage, read_write> type13: array<u32>;
+@group(1) @binding(2687)
+var<storage, read_write> field16: array<u32>;
+@group(2) @binding(5523)
+var<storage, read_write> field17: array<u32>;
+@group(0) @binding(1510)
+var<storage, read_write> parameter10: array<u32>;
+@group(1) @binding(2200)
+var<storage, read_write> i11: array<u32>;
+
+@compute @workgroup_size(8, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S10 {
+@location(53) f0: vec4<i32>,
+@location(58) f1: vec4<f16>,
+@location(41) f2: f16,
+@location(16) f3: vec2<i32>,
+@builtin(position) f4: vec4<f32>,
+@location(62) f5: vec3<f16>,
+@location(30) f6: vec3<f32>
+}
+struct FragmentOutput0 {
+@location(1) f0: vec4<u32>,
+@builtin(frag_depth) f1: f32
+}
+
+@fragment
+fn fragment0(a0: S10, @location(72) a1: vec2<f16>, @builtin(sample_mask) a2: u32, @location(15) a3: vec2<i32>, @location(54) a4: f32, @location(75) a5: vec2<u32>, @builtin(sample_index) a6: u32, @location(19) a7: vec4<u32>, @location(80) a8: vec3<f16>, @location(67) a9: vec4<u32>, @location(50) a10: vec3<f32>, @builtin(front_facing) a11: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S9 {
+@location(4) f0: vec3<f16>,
+@location(12) f1: vec2<i32>,
+@location(9) f2: vec4<i32>,
+@location(7) f3: i32,
+@location(2) f4: vec4<u32>,
+@location(8) f5: vec2<f32>,
+@location(5) f6: vec4<f32>,
+@location(15) f7: vec3<i32>,
+@location(21) f8: vec3<f32>,
+@location(11) f9: u32,
+@location(20) f10: vec2<f32>,
+@location(6) f11: vec2<f32>,
+@builtin(vertex_index) f12: u32
+}
+struct VertexOutput0 {
+@location(15) f180: vec2<i32>,
+@location(67) f181: vec4<u32>,
+@location(52) f182: f16,
+@location(54) f183: f32,
+@location(72) f184: vec2<f16>,
+@location(75) f185: vec2<u32>,
+@location(50) f186: vec3<f32>,
+@location(8) f187: f16,
+@location(16) f188: vec2<i32>,
+@location(19) f189: vec4<u32>,
+@location(53) f190: vec4<i32>,
+@location(62) f191: vec3<f16>,
+@location(80) f192: vec3<f16>,
+@location(30) f193: vec3<f32>,
+@builtin(position) f194: vec4<f32>,
+@location(49) f195: vec3<f16>,
+@location(41) f196: f16,
+@location(58) f197: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(17) a0: vec2<u32>, @location(10) a1: vec2<f32>, @location(3) a2: vec4<u32>, @builtin(instance_index) a3: u32, @location(19) a4: vec2<u32>, @location(18) a5: f16, @location(1) a6: vec2<f32>, @location(14) a7: f16, a8: S9, @location(13) a9: vec4<i32>, @location(0) a10: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture43 = device0.createTexture(
+{
+label: '\u6f9c\u10d2\udbfb',
+size: [11548, 4, 253],
+mipLevelCount: 8,
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView43 = texture25.createView(
+{
+label: '\u{1ff6e}\ue490\u{1ff1d}\u{1ffbe}\u898d\u0405\u9abd\u8835\u0152',
+baseArrayLayer: 0,
+}
+);
+let renderBundle32 = renderBundleEncoder16.finish();
+let sampler21 = device0.createSampler(
+{
+label: '\u8198\u{1fa62}\u07f4\ue891\u{1ff49}\u70d8\u9fe8\u06f6',
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMaxClamp: 57.247,
+}
+);
+try {
+computePassEncoder4.setBindGroup(
+1,
+bindGroup6,
+new Uint32Array(1512),
+896,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setViewport(
+0.7254,
+0.3581,
+4.389,
+0.7645,
+0.7641,
+0.8335
+);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(
+buffer6,
+'uint16',
+15686,
+14703
+);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16float',
+'stencil8',
+'bgra8unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+34592,
+new DataView(new ArrayBuffer(15239)),
+14465,
+344
+);
+} catch {}
+let pipeline54 = await device0.createComputePipelineAsync(
+{
+label: '\u{1faec}\uc8f6\u06ff\u07ce\u228f',
+layout: 'auto',
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline55 = device0.createRenderPipeline(
+{
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule5,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 12932,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 3940,
+shaderLocation: 16,
+},
+{
+format: 'sint16x2',
+offset: 8132,
+shaderLocation: 20,
+},
+{
+format: 'unorm16x2',
+offset: 4268,
+shaderLocation: 13,
+},
+{
+format: 'sint8x4',
+offset: 7740,
+shaderLocation: 7,
+},
+{
+format: 'sint16x4',
+offset: 8620,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 10788,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 2812,
+shaderLocation: 10,
+},
+{
+format: 'float32',
+offset: 1600,
+shaderLocation: 17,
+},
+{
+format: 'uint8x2',
+offset: 6914,
+shaderLocation: 21,
+},
+{
+format: 'uint32',
+offset: 316,
+shaderLocation: 15,
+},
+{
+format: 'sint32x4',
+offset: 7360,
+shaderLocation: 3,
+},
+{
+format: 'sint32x4',
+offset: 8436,
+shaderLocation: 11,
+},
+{
+format: 'sint8x4',
+offset: 92,
+shaderLocation: 18,
+}
+],
+},
+{
+arrayStride: 1396,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 5568,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 3080,
+shaderLocation: 6,
+},
+{
+format: 'uint16x2',
+offset: 4188,
+shaderLocation: 1,
+},
+{
+format: 'float32x3',
+offset: 1980,
+shaderLocation: 8,
+},
+{
+format: 'float16x4',
+offset: 392,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x2',
+offset: 3914,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 15128,
+attributes: [
+{
+format: 'snorm16x2',
+offset: 412,
+shaderLocation: 9,
+},
+{
+format: 'sint32',
+offset: 5148,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 1924,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 9696,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 296,
+shaderLocation: 12,
+},
+{
+format: 'sint32x4',
+offset: 7608,
+shaderLocation: 0,
+},
+{
+format: 'uint32x4',
+offset: 7424,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+multisample: {
+mask: 0xc0d5739,
+},
+fragment: {
+module: shaderModule5,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'r16float',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r16uint',
+},
+undefined,
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilWriteMask: 128,
+depthBias: 34,
+depthBiasSlopeScale: 98,
+},
+}
+);
+let querySet36 = device1.createQuerySet({
+label: '\ud2b9\u0780\u0ab5\u{1fbc5}\uf9bd\u0ee5\u0881',
+type: 'occlusion',
+count: 622,
+});
+let textureView44 = texture42.createView(
+{
+label: '\ufb47\u{1fea2}\u29bb\u00bf\u{1fa51}\u{1f9a7}\u80b1\u{1ff42}',
+baseMipLevel: 1,
+}
+);
+let sampler22 = device1.createSampler(
+{
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 95.834,
+maxAnisotropy: 10,
+}
+);
+try {
+commandEncoder17.copyTextureToTexture(
+{
+  texture: texture40,
+  mipLevel: 0,
+  origin: { x: 39, y: 0, z: 92 },
+  aspect: 'all',
+},
+{
+  texture: texture40,
+  mipLevel: 1,
+  origin: { x: 22, y: 0, z: 77 },
+  aspect: 'all',
+},
+{width: 42, height: 1, depthOrArrayLayers: 129}
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture35,
+  mipLevel: 1,
+  origin: { x: 23, y: 0, z: 36 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 212421 */{
+offset: 117,
+bytesPerRow: 299,
+rowsPerImage: 142,
+},
+{width: 7, height: 1, depthOrArrayLayers: 6}
+);
+} catch {}
+try {
+await promise11;
+} catch {}
+video2.width = 54;
+let renderBundle33 = renderBundleEncoder3.finish();
+try {
+renderPassEncoder6.beginOcclusionQuery(928);
+} catch {}
+try {
+renderPassEncoder5.setViewport(
+1.002,
+1.374,
+0.4944,
+0.3730,
+0.6245,
+0.7485
+);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(
+25,
+undefined,
+1273231003,
+1519893782
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 5, height: 44, depthOrArrayLayers: 240}
+*/
+{
+  source: img1,
+  origin: { x: 100, y: 59 },
+  flipY: true,
+},
+{
+  texture: texture1,
+  mipLevel: 1,
+  origin: { x: 4, y: 3, z: 94 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 31, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise22 = device0.createComputePipelineAsync(
+{
+layout: pipelineLayout6,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+},
+}
+);
+let shaderModule12 = device1.createShaderModule(
+{
+label: '\u{1ffa2}\u16ba\u{1fee9}\u693c\u{1f900}\u0de1\u3ca8\u{1f86c}\u{1fedf}\u9f42\u05e3',
+code: `@group(2) @binding(2941)
+var<storage, read_write> field18: array<u32>;
+@group(0) @binding(1830)
+var<storage, read_write> parameter11: array<u32>;
+@group(0) @binding(2941)
+var<storage, read_write> field19: array<u32>;
+@group(2) @binding(1830)
+var<storage, read_write> type14: array<u32>;
+@group(1) @binding(1830)
+var<storage, read_write> global17: array<u32>;
+
+@compute @workgroup_size(3, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S12 {
+@location(8) f0: u32,
+@builtin(sample_index) f1: u32
+}
+struct FragmentOutput0 {
+@location(5) f0: f32,
+@location(0) f1: vec4<i32>,
+@builtin(sample_mask) f2: u32,
+@location(4) f3: vec4<f32>,
+@location(1) f4: vec2<i32>
+}
+
+@fragment
+fn fragment0(@location(0) a0: f16, @location(11) a1: vec3<f16>, @location(4) a2: vec3<i32>, @location(16) a3: vec4<u32>, @builtin(front_facing) a4: bool, @location(15) a5: vec4<i32>, @builtin(position) a6: vec4<f32>, @builtin(sample_mask) a7: u32, @location(2) a8: vec2<f16>, @location(6) a9: vec3<f32>, @location(13) a10: vec2<i32>, @location(18) a11: vec4<u32>, @location(14) a12: vec3<u32>, a13: S12, @location(17) a14: vec2<f32>, @location(3) a15: vec2<u32>, @location(1) a16: vec3<i32>, @location(12) a17: i32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S11 {
+@location(10) f0: vec2<f32>,
+@location(6) f1: i32,
+@location(2) f2: vec4<i32>,
+@location(5) f3: vec3<f32>,
+@location(8) f4: u32,
+@location(7) f5: i32,
+@location(3) f6: f16,
+@location(9) f7: vec4<i32>,
+@location(13) f8: vec4<i32>,
+@location(12) f9: vec4<f16>
+}
+struct VertexOutput0 {
+@location(17) f198: vec2<f32>,
+@location(2) f199: vec2<f16>,
+@location(3) f200: vec2<u32>,
+@location(0) f201: f16,
+@location(11) f202: vec3<f16>,
+@location(16) f203: vec4<u32>,
+@location(14) f204: vec3<u32>,
+@location(4) f205: vec3<i32>,
+@location(1) f206: vec3<i32>,
+@location(12) f207: i32,
+@location(13) f208: vec2<i32>,
+@location(6) f209: vec3<f32>,
+@builtin(position) f210: vec4<f32>,
+@location(8) f211: u32,
+@location(18) f212: vec4<u32>,
+@location(15) f213: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(0) a0: vec4<i32>, @location(4) a1: vec2<f32>, @builtin(instance_index) a2: u32, a3: S11, @location(15) a4: vec3<i32>, @location(14) a5: vec4<i32>, @location(1) a6: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let computePassEncoder9 = commandEncoder21.beginComputePass(
+{
+
+}
+);
+try {
+commandEncoder18.copyTextureToTexture(
+{
+  texture: texture42,
+  mipLevel: 6,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 2,
+  origin: { x: 12, y: 30, z: 0 },
+  aspect: 'all',
+},
+{width: 2, height: 3, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder17.insertDebugMarker(
+'\ucc1f'
+);
+} catch {}
+let pipeline56 = device1.createComputePipeline(
+{
+label: '\u03f4\u47c8',
+layout: pipelineLayout8,
+compute: {
+module: shaderModule10,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let device2 = await adapter2.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxBindGroups: 9,
+maxColorAttachmentBytesPerSample: 55,
+maxVertexAttributes: 22,
+maxVertexBufferArrayStride: 15864,
+maxStorageTexturesPerShaderStage: 40,
+maxStorageBuffersPerShaderStage: 30,
+maxDynamicStorageBuffersPerPipelineLayout: 1310,
+maxBindingsPerBindGroup: 9268,
+maxTextureDimension1D: 14652,
+maxTextureDimension2D: 16210,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 213946968,
+maxInterStageShaderVariables: 92,
+maxInterStageShaderComponents: 115,
+maxSamplersPerShaderStage: 17,
+},
+});
+let querySet37 = device1.createQuerySet({
+label: '\u07df\uc420\u70ec\u8988\u9778\u4870\u20c8\ua969\ue77d\uae45',
+type: 'occlusion',
+count: 3672,
+});
+let renderBundleEncoder21 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+undefined
+],
+sampleCount: 707,
+depthReadOnly: true,
+}
+);
+try {
+gpuCanvasContext1.configure(
+{
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8unorm',
+'rgba8unorm',
+'rg32sint',
+'r8unorm'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let imageBitmap6 = await createImageBitmap(canvas3);
+let bindGroup14 = device0.createBindGroup({
+label: '\u06cf\u{1fbca}',
+layout: bindGroupLayout0,
+entries: [
+{
+binding: 2200,
+resource: sampler7
+},
+{
+binding: 2687,
+resource: sampler12
+},
+{
+binding: 509,
+resource: sampler6
+}
+],
+});
+let renderBundle34 = renderBundleEncoder6.finish(
+{
+label: '\u670d\uf04d\u12c5\u6b69\u{1f6c3}\u0308\u002a\ud890\u{1fd5e}\u907e'
+}
+);
+try {
+renderPassEncoder4.setBindGroup(
+2,
+bindGroup4,
+new Uint32Array(9633),
+3969,
+0
+);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(
+2781
+);
+} catch {}
+try {
+renderPassEncoder7.setViewport(
+2.971,
+1.735,
+2.764,
+0.2026,
+0.04719,
+0.4463
+);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(
+95,
+undefined,
+2770800845,
+990071200
+);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 10, height: 3, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 125, y: 97 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 4,
+  origin: { x: 4, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 3, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline57 = await device0.createComputePipelineAsync(
+{
+label: '\u01e7\u1e03\u0dfa',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let texture44 = device1.createTexture(
+{
+label: '\u5b70\u250f\u9f1a\u0570\u07eb\u0820\ub8ed',
+size: {width: 196, height: 164, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth32float',
+'depth32float'
+],
+}
+);
+let renderBundleEncoder22 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 372,
+depthReadOnly: true,
+}
+);
+let sampler23 = device1.createSampler(
+{
+label: '\u51dd\u090e\u1c06\u5325\u109e\u2d04\u0459\u0249\u{1f834}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 95.987,
+lodMaxClamp: 99.195,
+maxAnisotropy: 12,
+}
+);
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let textureView45 = texture43.createView(
+{
+baseMipLevel: 2,
+mipLevelCount: 1,
+baseArrayLayer: 37,
+arrayLayerCount: 211,
+}
+);
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: 347.0, g: -225.7, b: 726.5, a: -719.5, });
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(
+1,
+0,
+4,
+2
+);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(
+58,
+undefined,
+347195488,
+281155998
+);
+} catch {}
+try {
+buffer2.destroy();
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let canvas5 = document.createElement('canvas');
+try {
+bindGroupLayout13.label = '\u6a4c\ud8d2\u{1fcfe}\u58d8\u2457\u3461';
+} catch {}
+let buffer11 = device0.createBuffer(
+{
+label: '\u0667\u91a9\u{1fc16}\u8fc6',
+size: 65529,
+usage: GPUBufferUsage.COPY_SRC,
+}
+);
+let commandEncoder23 = device0.createCommandEncoder();
+let renderPassEncoder8 = commandEncoder23.beginRenderPass(
+{
+label: '\u3cf4\u{1fd3f}\ue570\uacd8\u0320',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+depthStencilAttachment: {
+view: textureView32,
+depthClearValue: -3.3167924525546617,
+depthReadOnly: false,
+stencilLoadOp: 'load',
+stencilStoreOp: 'discard',
+},
+occlusionQuerySet: querySet33,
+maxDrawCount: 8904,
+}
+);
+let renderBundleEncoder23 = device0.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16uint',
+'r32float',
+'rgba8uint',
+undefined,
+'r8uint',
+'rgba8unorm-srgb'
+],
+sampleCount: 26,
+depthReadOnly: true,
+}
+);
+let renderBundle35 = renderBundleEncoder14.finish(
+{
+label: '\ufedc\u91e5\u6b03\u{1fd68}\u0d95\u47ea'
+}
+);
+try {
+renderPassEncoder4.setBlendConstant({ r: -236.2, g: 838.2, b: 883.1, a: 234.5, });
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(
+1389
+);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(
+buffer3,
+'uint32',
+2800,
+7670
+);
+} catch {}
+try {
+canvas4.getContext('2d');
+} catch {}
+let sampler24 = device2.createSampler(
+{
+label: '\u0335\u0dc2\u988a\u{1f676}\u07ed\u{1fd4a}',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 14.950,
+lodMaxClamp: 58.494,
+}
+);
+let img7 = await imageWithData(47, 100, '#20b75cf6', '#c5a9843b');
+let shaderModule13 = device0.createShaderModule(
+{
+label: '\u{1fdd1}\u{1fcce}\u0e13\u{1ff2c}\u0d73\u6104\u0781\u{1f718}\u{1ffd5}\u038f',
+code: `@group(2) @binding(2687)
+var<storage, read_write> local9: array<u32>;
+@group(1) @binding(1510)
+var<storage, read_write> global18: array<u32>;
+@group(2) @binding(2200)
+var<storage, read_write> type15: array<u32>;
+@group(5) @binding(1642)
+var<storage, read_write> parameter12: array<u32>;
+@group(2) @binding(509)
+var<storage, read_write> type16: array<u32>;
+@group(5) @binding(59)
+var<storage, read_write> global19: array<u32>;
+@group(0) @binding(1510)
+var<storage, read_write> function13: array<u32>;
+@group(3) @binding(2409)
+var<storage, read_write> global20: array<u32>;
+@group(1) @binding(4639)
+var<storage, read_write> i12: array<u32>;
+
+@compute @workgroup_size(4, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S13 {
+@location(13) f0: vec4<i32>,
+@location(60) f1: vec3<f32>
+}
+struct FragmentOutput0 {
+@location(5) f0: vec3<u32>,
+@location(6) f1: i32,
+@location(3) f2: vec4<f32>,
+@location(4) f3: u32,
+@location(1) f4: vec4<u32>,
+@location(7) f5: vec2<u32>,
+@location(2) f6: vec4<f32>,
+@location(0) f7: i32
+}
+
+@fragment
+fn fragment0(@location(4) a0: vec4<i32>, @location(2) a1: vec4<f32>, @location(33) a2: i32, @location(41) a3: vec3<u32>, @location(8) a4: vec3<u32>, @location(36) a5: vec4<i32>, @location(29) a6: vec4<i32>, @location(66) a7: vec2<f16>, @location(12) a8: u32, @location(54) a9: f16, @builtin(front_facing) a10: bool, @location(3) a11: vec2<f16>, @location(80) a12: vec3<f16>, @location(22) a13: vec2<u32>, @location(18) a14: vec4<f16>, @location(37) a15: vec3<u32>, @location(44) a16: f16, @location(23) a17: vec3<f16>, @location(5) a18: f32, @location(46) a19: f16, @location(63) a20: f32, a21: S13, @location(35) a22: vec3<i32>, @location(72) a23: vec3<f16>, @location(45) a24: f32, @builtin(sample_mask) a25: u32, @builtin(position) a26: vec4<f32>, @builtin(sample_index) a27: u32, @location(55) a28: vec2<f32>, @location(78) a29: f16, @location(47) a30: vec3<f16>, @location(81) a31: vec2<f32>, @location(64) a32: vec2<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(47) f214: vec3<f16>,
+@location(67) f215: vec4<i32>,
+@location(13) f216: vec4<i32>,
+@location(74) f217: vec4<f16>,
+@builtin(position) f218: vec4<f32>,
+@location(64) f219: vec2<f32>,
+@location(38) f220: vec4<u32>,
+@location(45) f221: f32,
+@location(37) f222: vec3<u32>,
+@location(77) f223: vec4<u32>,
+@location(1) f224: vec3<i32>,
+@location(60) f225: vec3<f32>,
+@location(4) f226: vec4<i32>,
+@location(81) f227: vec2<f32>,
+@location(59) f228: vec4<f32>,
+@location(54) f229: f16,
+@location(63) f230: f32,
+@location(16) f231: vec3<u32>,
+@location(72) f232: vec3<f16>,
+@location(12) f233: u32,
+@location(80) f234: vec3<f16>,
+@location(66) f235: vec2<f16>,
+@location(44) f236: f16,
+@location(28) f237: vec3<f16>,
+@location(3) f238: vec2<f16>,
+@location(22) f239: vec2<u32>,
+@location(27) f240: vec2<u32>,
+@location(78) f241: f16,
+@location(46) f242: f16,
+@location(25) f243: vec4<u32>,
+@location(8) f244: vec3<u32>,
+@location(29) f245: vec4<i32>,
+@location(55) f246: vec2<f32>,
+@location(41) f247: vec3<u32>,
+@location(36) f248: vec4<i32>,
+@location(18) f249: vec4<f16>,
+@location(5) f250: f32,
+@location(42) f251: vec2<i32>,
+@location(32) f252: vec3<u32>,
+@location(23) f253: vec3<f16>,
+@location(26) f254: vec2<i32>,
+@location(33) f255: i32,
+@location(2) f256: vec4<f32>,
+@location(35) f257: vec3<i32>,
+@location(34) f258: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(20) a0: vec2<u32>, @location(12) a1: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let textureView46 = texture25.createView(
+{
+label: '\u571e\u{1fa4b}\ufc2c\u2de3\u28e3\ua4cc',
+aspect: 'all',
+}
+);
+let renderBundle36 = renderBundleEncoder13.finish(
+{
+label: '\ue77e\u4f92\u09ac\u8819\u{1fcf0}\u4ece\u0cb0\u{1faf1}\u1d63'
+}
+);
+try {
+renderPassEncoder6.setBindGroup(
+9,
+bindGroup1
+);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(
+2,
+bindGroup1,
+new Uint32Array(431),
+23,
+0
+);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.pushDebugGroup(
+'\uc82c'
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 21, height: 7, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 46, y: 276 },
+  flipY: true,
+},
+{
+  texture: texture16,
+  mipLevel: 3,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 6, height: 5, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline58 = device0.createRenderPipeline(
+{
+label: '\u006b\u8ac7\u03f9\u30c4\u0782\u01aa\u8eff\u0fdc',
+layout: 'auto',
+vertex: {
+module: shaderModule13,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3776,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 5284,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 3332,
+shaderLocation: 20,
+},
+{
+format: 'float16x4',
+offset: 1520,
+shaderLocation: 12,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule13,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+},
+{
+format: 'rgba32uint',
+writeMask: 0,
+}
+],
+},
+}
+);
+offscreenCanvas3.width = 742;
+let shaderModule14 = device1.createShaderModule(
+{
+code: `@group(0) @binding(1830)
+var<storage, read_write> global21: array<u32>;
+@group(1) @binding(1830)
+var<storage, read_write> local10: array<u32>;
+@group(0) @binding(2941)
+var<storage, read_write> function14: array<u32>;
+@group(1) @binding(2941)
+var<storage, read_write> function15: array<u32>;
+@group(2) @binding(1830)
+var<storage, read_write> parameter13: array<u32>;
+
+@compute @workgroup_size(6, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(4) f0: f32,
+@location(3) f1: i32,
+@location(0) f2: vec3<u32>,
+@location(1) f3: vec2<u32>,
+@builtin(sample_mask) f4: u32,
+@location(2) f5: vec2<f32>,
+@location(6) f6: vec3<i32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S14 {
+@location(1) f0: vec2<u32>,
+@location(5) f1: vec3<i32>,
+@location(0) f2: vec2<f16>,
+@location(6) f3: f32,
+@builtin(instance_index) f4: u32,
+@location(10) f5: vec2<i32>,
+@location(14) f6: vec4<u32>,
+@location(7) f7: vec2<f16>,
+@location(4) f8: vec4<i32>
+}
+struct VertexOutput0 {
+@builtin(position) f259: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec2<f16>, @location(11) a1: f32, @location(9) a2: vec2<f16>, @builtin(vertex_index) a3: u32, @location(13) a4: vec3<u32>, @location(3) a5: vec3<f32>, @location(12) a6: vec3<i32>, a7: S14, @location(15) a8: vec3<i32>, @location(8) a9: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let querySet38 = device1.createQuerySet({
+label: '\u4d38\u{1f8f2}\u1569\u{1f98b}\u05d2\ud5b4\u9038\u1849\u0684',
+type: 'occlusion',
+count: 1175,
+});
+let commandBuffer3 = commandEncoder17.finish(
+{
+label: '\ub761\uaf2f\ue586\u{1ffd8}\udbb8\ufc3d\u6520\u2a93\u{1f747}\uaf0c\uea1e',
+}
+);
+let renderBundleEncoder24 = device1.createRenderBundleEncoder(
+{
+label: '\u78eb\u{1f8dd}\u{1f622}\u0a47',
+colorFormats: [
+undefined,
+'rgb10a2unorm',
+'rgba16uint',
+'r8sint',
+undefined,
+'rg8unorm',
+'r32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 458,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let gpuCanvasContext4 = offscreenCanvas8.getContext('webgpu');
+try {
+await promise18;
+} catch {}
+let textureView47 = texture41.createView(
+{
+baseMipLevel: 2,
+}
+);
+let sampler25 = device0.createSampler(
+{
+label: '\u438c\udd57',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 91.522,
+maxAnisotropy: 8,
+}
+);
+try {
+renderPassEncoder8.setBlendConstant({ r: 404.1, g: -389.0, b: 441.7, a: -438.8, });
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(
+3048
+);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(
+9,
+undefined,
+3224858542,
+29041165
+);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: { x: 0, y: 120, z: 0 },
+  aspect: 'stencil-only',
+},
+new ArrayBuffer(292),
+/* required buffer size: 292 */{
+offset: 39,
+},
+{width: 253, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let bindGroupLayout19 = device2.createBindGroupLayout(
+{
+label: '\u2305\u041c\ubbc1\u{1f9e0}\uc64e',
+entries: [
+
+],
+}
+);
+let pipelineLayout9 = device2.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout19,
+bindGroupLayout19,
+bindGroupLayout19,
+bindGroupLayout19,
+bindGroupLayout19
+]
+}
+);
+let texture45 = device2.createTexture(
+{
+label: '\u{1fbf4}\u0edf\u{1fda4}\u{1fab4}\u4beb\u0eef\u8aa7\u{1fe0f}\uc8f9\u5991',
+size: {width: 215, height: 80, depthOrArrayLayers: 5},
+mipLevelCount: 7,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let buffer12 = device1.createBuffer(
+{
+label: '\u{1f7d8}\u0185\ua75d\u023e\u0109',
+size: 27458,
+usage: GPUBufferUsage.UNIFORM,
+mappedAtCreation: false,
+}
+);
+let commandEncoder24 = device1.createCommandEncoder(
+{
+}
+);
+pseudoSubmit(device1, commandEncoder24);
+let imageData4 = new ImageData(100, 68);
+let bindGroup15 = device0.createBindGroup({
+label: '\u0a74\u1131\u{1fa62}\u0f87\u{1fa94}\u0b1c\u00b3\ue5b0\u0458\u706c\u01bb',
+layout: bindGroupLayout9,
+entries: [
+
+],
+});
+let texture46 = device0.createTexture(
+{
+label: '\u{1f862}\u0d1a\u08b9',
+size: {width: 7532},
+dimension: '1d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+renderPassEncoder8.setStencilReference(
+1738
+);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(
+5,
+bindGroup12
+);
+} catch {}
+try {
+renderPassEncoder2.popDebugGroup();
+} catch {}
+pseudoSubmit(device0, commandEncoder10);
+let renderBundle37 = renderBundleEncoder23.finish(
+{
+label: '\u67d5\u{1ff6a}\u{1f7e7}\u06f3\u0bf9'
+}
+);
+try {
+computePassEncoder4.setBindGroup(
+5,
+bindGroup10,
+[]
+);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(
+7,
+bindGroup2
+);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(
+3,
+6,
+11,
+2
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16sint',
+'rg8sint',
+'bgra8unorm'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+let pipeline59 = device0.createComputePipeline(
+{
+label: '\u{1fb61}\u0ed7\u{1feb2}\u1457\udfe1\ude9b\u46af\u{1fb74}\u02d1',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let video5 = await videoWithData();
+let querySet39 = device1.createQuerySet({
+label: '\ua01d\ufbb1\uec7d\uf111',
+type: 'occlusion',
+count: 3304,
+});
+let texture47 = device1.createTexture(
+{
+label: '\uaddc\u9021\udd78\uf047\u0e07\uf281\u73d6\u392f',
+size: {width: 233, height: 59, depthOrArrayLayers: 1},
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2unorm'
+],
+}
+);
+try {
+renderBundleEncoder20.insertDebugMarker(
+'\u0d6d'
+);
+} catch {}
+let video6 = await videoWithData();
+let commandEncoder25 = device2.createCommandEncoder();
+let textureView48 = texture45.createView(
+{
+dimension: '2d',
+baseMipLevel: 1,
+mipLevelCount: 5,
+baseArrayLayer: 4,
+}
+);
+let gpuCanvasContext5 = canvas5.getContext('webgpu');
+let adapter3 = await promise15;
+let buffer13 = device2.createBuffer(
+{
+size: 23807,
+usage: GPUBufferUsage.STORAGE,
+}
+);
+let texture48 = device2.createTexture(
+{
+label: '\u898a\ud1f0\u056a',
+size: {width: 1392, height: 116, depthOrArrayLayers: 18},
+mipLevelCount: 5,
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32uint',
+'r32uint'
+],
+}
+);
+let computePassEncoder10 = commandEncoder25.beginComputePass(
+{
+
+}
+);
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let commandEncoder26 = device1.createCommandEncoder(
+{
+label: '\uaff1\u0191\u{1ffb3}\u414e',
+}
+);
+let querySet40 = device1.createQuerySet({
+label: '\u{1fd77}\u76db\u2ee7\uc785',
+type: 'occlusion',
+count: 601,
+});
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(
+55,
+undefined,
+719022331
+);
+} catch {}
+try {
+commandEncoder26.copyTextureToTexture(
+{
+  texture: texture40,
+  mipLevel: 0,
+  origin: { x: 13, y: 0, z: 122 },
+  aspect: 'all',
+},
+{
+  texture: texture40,
+  mipLevel: 0,
+  origin: { x: 20, y: 1, z: 24 },
+  aspect: 'all',
+},
+{width: 105, height: 0, depthOrArrayLayers: 98}
+);
+} catch {}
+let gpuCanvasContext6 = offscreenCanvas7.getContext('webgpu');
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+gc();
+let videoFrame7 = new VideoFrame(img4, {timestamp: 0});
+let shaderModule15 = device1.createShaderModule(
+{
+label: '\ub57f\u7aee\u2de1\u61ff\u056d\ubad6\u2904\u29fb',
+code: `@group(1) @binding(1830)
+var<storage, read_write> type17: array<u32>;
+@group(1) @binding(2941)
+var<storage, read_write> local11: array<u32>;
+@group(2) @binding(2941)
+var<storage, read_write> field20: array<u32>;
+@group(0) @binding(2941)
+var<storage, read_write> function16: array<u32>;
+
+@compute @workgroup_size(7, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) {
+
+}
+
+struct S15 {
+@location(3) f0: vec3<i32>,
+@location(11) f1: vec2<f32>,
+@location(10) f2: f32,
+@location(7) f3: vec3<f16>,
+@location(6) f4: vec4<f32>,
+@location(12) f5: i32,
+@location(5) f6: vec4<f32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(8) a1: vec3<i32>, @location(4) a2: vec2<f16>, a3: S15) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let textureView49 = texture42.createView(
+{
+label: '\u{1fa9f}\u{1f78c}\u7263\u0a4d',
+dimension: '2d-array',
+baseMipLevel: 3,
+mipLevelCount: 1,
+baseArrayLayer: 0,
+}
+);
+try {
+await promise9;
+} catch {}
+let canvas6 = document.createElement('canvas');
+let textureView50 = texture40.createView(
+{
+label: '\u0417\u{1feed}\u0ef4\u0cd0\u3ff2\u{1fc36}',
+dimension: '2d',
+baseArrayLayer: 4,
+}
+);
+let renderPassEncoder9 = commandEncoder18.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+{
+view: textureView49,
+clearValue: { r: -987.1, g: 194.4, b: 658.0, a: -194.5, },
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined
+],
+occlusionQuerySet: querySet31,
+}
+);
+try {
+device1.queue.writeTexture(
+{
+  texture: texture40,
+  mipLevel: 1,
+  origin: { x: 12, y: 0, z: 21 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 3841582 */{
+offset: 822,
+bytesPerRow: 215,
+rowsPerImage: 116,
+},
+{width: 43, height: 0, depthOrArrayLayers: 155}
+);
+} catch {}
+let gpuCanvasContext7 = canvas6.getContext('webgpu');
+pseudoSubmit(device2, commandEncoder25);
+let textureView51 = texture45.createView(
+{
+label: '\u81d8\udd43\u{1f63e}\ud3a6\ud6a7\u8231\u0f23\ud31d\u7cc2\u{1f942}',
+baseMipLevel: 4,
+mipLevelCount: 1,
+baseArrayLayer: 4,
+arrayLayerCount: 1,
+}
+);
+let promise24 = adapter3.requestDevice({
+label: '\u27af\u567a\u0b3c\u6cca\u20ce\ub82d',
+});
+let querySet41 = device0.createQuerySet({
+label: '\u04ff\u95e4\u7cdd\uc242\u2f1b\ud989',
+type: 'occlusion',
+count: 3663,
+});
+try {
+renderPassEncoder7.setBindGroup(
+9,
+bindGroup4,
+new Uint32Array(2770),
+160,
+0
+);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -311.1, g: -846.7, b: -352.3, a: 860.7, });
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer5,
+'uint16',
+14584,
+5664
+);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+45,
+undefined,
+2661166464,
+1008066970
+);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgba8unorm-srgb',
+'rgb9e5ufloat',
+'rgba8unorm'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let pipeline60 = await promise20;
+let pipeline61 = await device0.createRenderPipelineAsync(
+{
+label: '\u{1faa0}\u62ef\u{1f8fa}\u{1f718}\u{1f98f}\u5234\u{1ff6f}\u{1fcbd}\u2221\u09f5\u0a8b',
+layout: 'auto',
+vertex: {
+module: shaderModule0,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1000,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x2',
+offset: 320,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xfede7499,
+},
+fragment: {
+module: shaderModule0,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgba8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilReadMask: 2891,
+stencilWriteMask: 3906,
+depthBias: 2,
+depthBiasSlopeScale: 85,
+},
+}
+);
+let pipelineLayout10 = device1.createPipelineLayout(
+{
+label: '\u3fcb\u{1fc5d}\ue8b2\u{1f821}',
+bindGroupLayouts: [
+bindGroupLayout17,
+bindGroupLayout17
+]
+}
+);
+let renderPassEncoder10 = commandEncoder21.beginRenderPass(
+{
+label: '\u02c8\u{1f75d}\u492d\u6ce5\u{1fd11}',
+colorAttachments: [
+{
+view: textureView49,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined
+],
+occlusionQuerySet: querySet32,
+maxDrawCount: 51592,
+}
+);
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(
+4,
+13,
+14,
+11
+);
+} catch {}
+let pipeline62 = device1.createRenderPipeline(
+{
+label: '\u{1fd2c}\u{1fd52}\u0f7a\uaa89\ufeff\u02d9',
+layout: pipelineLayout8,
+vertex: {
+module: shaderModule14,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 6240,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 3728,
+shaderLocation: 0,
+},
+{
+format: 'sint32',
+offset: 3172,
+shaderLocation: 5,
+},
+{
+format: 'sint8x2',
+offset: 1226,
+shaderLocation: 15,
+},
+{
+format: 'float16x4',
+offset: 5020,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x4',
+offset: 1740,
+shaderLocation: 2,
+},
+{
+format: 'uint32x3',
+offset: 212,
+shaderLocation: 14,
+},
+{
+format: 'sint16x2',
+offset: 2876,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x4',
+offset: 16,
+shaderLocation: 9,
+},
+{
+format: 'float32x4',
+offset: 2532,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 18112,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 12544,
+shaderLocation: 11,
+},
+{
+format: 'sint32x3',
+offset: 14492,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x2',
+offset: 11326,
+shaderLocation: 6,
+},
+{
+format: 'uint32x3',
+offset: 16860,
+shaderLocation: 13,
+},
+{
+format: 'uint16x4',
+offset: 5944,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 17368,
+attributes: [
+{
+format: 'float32x4',
+offset: 8036,
+shaderLocation: 8,
+},
+{
+format: 'sint16x4',
+offset: 14856,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+unclippedDepth: false,
+},
+multisample: {
+},
+fragment: {
+module: shaderModule14,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r32uint',
+writeMask: 0,
+},
+{
+format: 'r32uint',
+},
+{
+format: 'rg8unorm',
+},
+{
+format: 'r8sint',
+writeMask: 0,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'zero',
+dstFactor: 'constant'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one-minus-src-alpha',
+dstFactor: 'src'
+},
+},
+format: 'r16float',
+writeMask: 0,
+},
+undefined
+],
+},
+}
+);
+gc();
+let canvas7 = document.createElement('canvas');
+let bindGroupLayout20 = device1.createBindGroupLayout(
+{
+label: '\u0a40\u79c4\ua149\u03fe\ud01e\u0b32\u0734\u6c08',
+entries: [
+
+],
+}
+);
+let querySet42 = device1.createQuerySet({
+label: '\u32d6\u0a7a\u11e4\u04bd',
+type: 'occlusion',
+count: 2874,
+});
+let computePassEncoder11 = commandEncoder26.beginComputePass(
+{
+label: '\u0e75\u0bcb\u{1f8b5}\u0883\u84c0\u06d3\u0e29\u35e0\u{1fa27}\u0cd5'
+}
+);
+let renderBundleEncoder25 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'r32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 769,
+}
+);
+try {
+renderBundleEncoder25.setVertexBuffer(
+12,
+undefined
+);
+} catch {}
+let bindGroupLayout21 = device1.createBindGroupLayout(
+{
+label: '\u0d74\u{1ff48}\u30f5\u{1faea}\ub70f\u0a4c\u021f',
+entries: [
+
+],
+}
+);
+let pipelineLayout11 = device1.createPipelineLayout(
+{
+label: '\u021e\u26d1\u0d18\u0d1b\u{1fbf4}',
+bindGroupLayouts: [
+bindGroupLayout21,
+bindGroupLayout20,
+bindGroupLayout17,
+bindGroupLayout17,
+bindGroupLayout20
+]
+}
+);
+let buffer14 = device1.createBuffer(
+{
+size: 63976,
+usage: GPUBufferUsage.UNIFORM,
+}
+);
+let externalTexture3 = device1.importExternalTexture(
+{
+label: '\u{1f888}\u6c25\u05c5\u0ea6\uafea\u0652\ubb15\u2e8b',
+source: video4,
+colorSpace: 'srgb',
+}
+);
+try {
+renderPassEncoder9.setBlendConstant({ r: -779.3, g: -247.0, b: -21.79, a: -61.60, });
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+688
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture42,
+  mipLevel: 0,
+  origin: { x: 19, y: 36, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(32),
+/* required buffer size: 112942 */{
+offset: 768,
+bytesPerRow: 738,
+},
+{width: 184, height: 152, depthOrArrayLayers: 1}
+);
+} catch {}
+let gpuCanvasContext8 = canvas7.getContext('webgpu');
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let pipelineLayout12 = device2.createPipelineLayout(
+{
+label: '\u085c\u9c6b',
+bindGroupLayouts: [
+bindGroupLayout19,
+bindGroupLayout19
+]
+}
+);
+let texture49 = device2.createTexture(
+{
+label: '\u019b\u{1ff64}\u{1f600}\ub322\u{1fce0}\uc3ee',
+size: [56, 4, 202],
+mipLevelCount: 3,
+dimension: '2d',
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-rg11snorm',
+'eac-rg11snorm',
+'eac-rg11snorm'
+],
+}
+);
+let renderBundleEncoder26 = device2.createRenderBundleEncoder(
+{
+label: '\u3f35\u03de\u{1fe74}',
+colorFormats: [
+'rgb10a2unorm',
+'rgb10a2uint',
+'rg16float',
+'rgba8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 411,
+stencilReadOnly: false,
+}
+);
+try {
+renderBundleEncoder26.pushDebugGroup(
+'\u05b8'
+);
+} catch {}
+let promise25 = adapter0.requestAdapterInfo();
+let texture50 = device1.createTexture(
+{
+label: '\u{1ff3f}\u0838\u{1fa36}\u{1f894}\u{1fcfd}',
+size: [13859],
+mipLevelCount: 1,
+dimension: '1d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'bgra8unorm-srgb'
+],
+}
+);
+let texture51 = gpuCanvasContext2.getCurrentTexture();
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture35,
+  mipLevel: 1,
+  origin: { x: 23, y: 0, z: 55 },
+  aspect: 'all',
+},
+new ArrayBuffer(1278041),
+/* required buffer size: 1278041 */{
+offset: 511,
+bytesPerRow: 249,
+rowsPerImage: 171,
+},
+{width: 80, height: 1, depthOrArrayLayers: 31}
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder27 = device1.createCommandEncoder(
+{
+label: '\u{1f6ed}\u041b\u09c3\ue045\u55b9\u7b44\u2e85',
+}
+);
+pseudoSubmit(device1, commandEncoder21);
+let renderBundle38 = renderBundleEncoder17.finish(
+{
+label: '\u{1f64f}\ua94e\ue23a\u0b5e\u0ef1\u{1f758}\ue248'
+}
+);
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let offscreenCanvas9 = new OffscreenCanvas(991, 288);
+let bindGroupLayout22 = device2.createBindGroupLayout(
+{
+label: '\u60ff\uf821\ua746',
+entries: [
+{
+binding: 2398,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 6969,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+},
+{
+binding: 4032,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+}
+],
+}
+);
+let textureView52 = texture45.createView(
+{
+label: '\u956e\uf785\u{1f710}\u786c\u{1fe13}\u19b3\u03b5\u02fb\u2189\u{1ff42}',
+dimension: '2d',
+format: 'astc-5x5-unorm',
+mipLevelCount: 2,
+baseArrayLayer: 2,
+}
+);
+let renderBundleEncoder27 = device2.createRenderBundleEncoder(
+{
+label: '\ua7bf\uf32b\u93b6\u00d6\uc036\u{1fa4e}\u58f7\u08d7\u0f5c\uad7e',
+colorFormats: [
+'rg16uint',
+'rgba8sint',
+'r8unorm',
+'r16sint',
+'rg32float',
+'rgb10a2uint',
+'rgba32uint'
+],
+sampleCount: 806,
+depthReadOnly: true,
+}
+);
+let renderBundleEncoder28 = device1.createRenderBundleEncoder(
+{
+label: '\uf9a9\u2fb1\u{1fe3b}\u{1fd81}\ud145\u6cc7\u4044\u07cb',
+colorFormats: [
+'rg32sint'
+],
+sampleCount: 188,
+}
+);
+let renderBundle39 = renderBundleEncoder24.finish(
+{
+label: '\u0991\u2804\u8c43\u9f9d\u0896\u7060\u7039\u{1fa9c}\u{1fcb1}\u{1fb01}\u645c'
+}
+);
+try {
+renderPassEncoder10.setBlendConstant({ r: -207.7, g: -152.3, b: 969.1, a: 419.1, });
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+1904
+);
+} catch {}
+let pipeline63 = await device1.createRenderPipelineAsync(
+{
+label: '\u{1f66b}\u{1ffc5}\u2398\u32a9\u6f11\u4a7c\u5ee2\u0439',
+layout: pipelineLayout8,
+vertex: {
+module: shaderModule14,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 12968,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x3',
+offset: 10504,
+shaderLocation: 14,
+},
+{
+format: 'sint16x2',
+offset: 9868,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x4',
+offset: 8652,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x2',
+offset: 2670,
+shaderLocation: 12,
+},
+{
+format: 'sint8x4',
+offset: 92,
+shaderLocation: 15,
+},
+{
+format: 'sint32x4',
+offset: 20724,
+shaderLocation: 5,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 13116,
+shaderLocation: 11,
+},
+{
+format: 'snorm8x2',
+offset: 11928,
+shaderLocation: 2,
+},
+{
+format: 'float32x4',
+offset: 23400,
+shaderLocation: 8,
+},
+{
+format: 'float16x2',
+offset: 5788,
+shaderLocation: 0,
+},
+{
+format: 'snorm16x4',
+offset: 21468,
+shaderLocation: 6,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1512,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 2754,
+shaderLocation: 1,
+},
+{
+format: 'sint8x2',
+offset: 7412,
+shaderLocation: 4,
+},
+{
+format: 'float32',
+offset: 15532,
+shaderLocation: 3,
+},
+{
+format: 'uint16x2',
+offset: 12592,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0xff2cce86,
+},
+fragment: {
+module: shaderModule14,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg8uint',
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r16float',
+writeMask: 0,
+},
+{
+format: 'r16sint',
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: 0,
+},
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'zero',
+depthFailOp: 'invert',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 1889,
+stencilWriteMask: 1536,
+depthBias: 68,
+depthBiasSlopeScale: 44,
+depthBiasClamp: 31,
+},
+}
+);
+canvas1.width = 674;
+let pipelineLayout13 = device0.createPipelineLayout(
+{
+label: '\u071a\ucb00\u068e\u0c9c\u77d5\u0efe\ue8b8',
+bindGroupLayouts: [
+bindGroupLayout12,
+bindGroupLayout13
+]
+}
+);
+let textureView53 = texture27.createView(
+{
+dimension: '2d-array',
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+try {
+renderBundleEncoder12.setVertexBuffer(
+24,
+undefined
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture4,
+  mipLevel: 3,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int8Array(new ArrayBuffer(0)),
+/* required buffer size: 470 */{
+offset: 470,
+rowsPerImage: 44,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline64 = device0.createRenderPipeline(
+{
+label: '\u833d\u078c',
+layout: pipelineLayout1,
+vertex: {
+module: shaderModule7,
+entryPoint: 'vertex0',
+buffers: [
+
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+},
+fragment: {
+module: shaderModule7,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32sint',
+writeMask: 0,
+},
+{
+format: 'r16uint',
+writeMask: 0,
+},
+{
+format: 'r8unorm',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilWriteMask: 3632,
+depthBiasSlopeScale: 33,
+depthBiasClamp: 67,
+},
+}
+);
+let renderBundle40 = renderBundleEncoder27.finish(
+{
+label: '\u{1f841}\u{1fdb3}\u{1fb99}\u1e53\u5d6a'
+}
+);
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup16 = device1.createBindGroup({
+label: '\u028e\uce01\ua834\u0090',
+layout: bindGroupLayout21,
+entries: [
+
+],
+});
+let renderPassEncoder11 = commandEncoder27.beginRenderPass(
+{
+label: '\u0d36\ub774\u{1f9fb}\uafb7\u562b\u154e\u{1fffc}\ube93\u40b5',
+colorAttachments: [
+{
+view: textureView49,
+clearValue: { r: 90.05, g: 533.7, b: 110.7, a: 269.1, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined
+],
+occlusionQuerySet: querySet35,
+maxDrawCount: 17600,
+}
+);
+let renderBundleEncoder29 = device1.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg8uint',
+'rgb10a2uint',
+'rgba32float',
+'rg32sint',
+'rgba8unorm-srgb',
+'rg16float',
+'rgba8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 50,
+}
+);
+try {
+computePassEncoder11.setPipeline(
+pipeline56
+);
+} catch {}
+try {
+offscreenCanvas9.getContext('webgpu');
+} catch {}
+try {
+window.someLabel = externalTexture2.label;
+} catch {}
+let textureView54 = texture24.createView(
+{
+label: '\u0101\u183a\ud335\u134a\udade\u08f3\u0618\u8c3a\ud64c',
+dimension: '1d',
+arrayLayerCount: 1,
+}
+);
+let sampler26 = device0.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 20.688,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder6.setBlendConstant({ r: -620.5, g: -158.9, b: -554.6, a: 514.8, });
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(
+buffer3,
+'uint32',
+1636,
+6301
+);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let canvas8 = document.createElement('canvas');
+let commandEncoder28 = device2.createCommandEncoder();
+pseudoSubmit(device2, commandEncoder28);
+let renderBundleEncoder30 = device2.createRenderBundleEncoder(
+{
+label: '\u{1fb02}\u0b40\u068c\udce5\u86bf\u02ae\u0845\u005f',
+colorFormats: [
+'r8uint',
+'rgba32sint',
+undefined,
+'rgba8unorm',
+'rgba32sint'
+],
+sampleCount: 787,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder26.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let buffer15 = device1.createBuffer(
+{
+label: '\u9652\u08cd\ub2f4\ubbcb\u31f6\u525a\u06fa\uba69\ub7b5\u0505',
+size: 7118,
+usage: GPUBufferUsage.VERTEX,
+mappedAtCreation: false,
+}
+);
+try {
+renderPassEncoder11.beginOcclusionQuery(69);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+24.21,
+21.02,
+3.847,
+0.4388,
+0.8750,
+0.8936
+);
+} catch {}
+try {
+computePassEncoder11.pushDebugGroup(
+'\u{1fd3b}'
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline65 = await device1.createRenderPipelineAsync(
+{
+layout: pipelineLayout8,
+vertex: {
+module: shaderModule15,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 1768,
+shaderLocation: 7,
+},
+{
+format: 'unorm16x4',
+offset: 11788,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 9732,
+attributes: [
+{
+format: 'unorm16x2',
+offset: 328,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x2',
+offset: 3246,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 8196,
+attributes: [
+{
+format: 'sint32x4',
+offset: 7196,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x2',
+offset: 2730,
+shaderLocation: 11,
+},
+{
+format: 'sint8x2',
+offset: 2800,
+shaderLocation: 12,
+},
+{
+format: 'sint8x2',
+offset: 4596,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 11224,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 6172,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 3740,
+shaderLocation: 6,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule15,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilWriteMask: 2602,
+depthBias: 10,
+depthBiasClamp: 62,
+},
+}
+);
+let texture52 = device2.createTexture(
+{
+label: '\u{1f9d8}\u08a7\u{1fe81}\u04a3\u0269',
+size: [152, 72, 1],
+mipLevelCount: 8,
+format: 'etc2-rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+computePassEncoder10.pushDebugGroup(
+'\u{1ff3f}'
+);
+} catch {}
+let gpuCanvasContext9 = canvas8.getContext('webgpu');
+try {
+await promise17;
+} catch {}
+let commandEncoder29 = device2.createCommandEncoder();
+let textureView55 = texture45.createView(
+{
+label: '\ubd3e\u{1fea3}',
+dimension: '2d-array',
+mipLevelCount: 5,
+baseArrayLayer: 2,
+arrayLayerCount: 1,
+}
+);
+let renderBundle41 = renderBundleEncoder26.finish(
+{
+
+}
+);
+try {
+computePassEncoder10.popDebugGroup();
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture52,
+  mipLevel: 5,
+  origin: { x: 4, y: 4, z: 1 },
+  aspect: 'all',
+},
+new Float32Array(new ArrayBuffer(0)),
+/* required buffer size: 31 */{
+offset: 31,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let offscreenCanvas10 = new OffscreenCanvas(85, 949);
+let shaderModule16 = device0.createShaderModule(
+{
+label: '\u{1f627}\u045c\u0681\u6a48\u{1fea8}\u{1fd0b}\u{1fdc0}\u{1f955}\u0073\u786f\u69a8',
+code: `@group(1) @binding(2200)
+var<storage, read_write> parameter14: array<u32>;
+@group(0) @binding(4313)
+var<storage, read_write> i13: array<u32>;
+@group(1) @binding(2687)
+var<storage, read_write> local12: array<u32>;
+@group(7) @binding(1642)
+var<storage, read_write> parameter15: array<u32>;
+@group(7) @binding(59)
+var<storage, read_write> global22: array<u32>;
+@group(3) @binding(2687)
+var<storage, read_write> local13: array<u32>;
+@group(6) @binding(1510)
+var<storage, read_write> parameter16: array<u32>;
+@group(1) @binding(509)
+var<storage, read_write> type18: array<u32>;
+@group(3) @binding(509)
+var<storage, read_write> function17: array<u32>;
+@group(6) @binding(4639)
+var<storage, read_write> field21: array<u32>;
+@group(7) @binding(4134)
+var<storage, read_write> local14: array<u32>;
+@group(2) @binding(4134)
+var<storage, read_write> local15: array<u32>;
+@group(2) @binding(1642)
+var<storage, read_write> parameter17: array<u32>;
+@group(4) @binding(2200)
+var<storage, read_write> type19: array<u32>;
+@group(3) @binding(2200)
+var<storage, read_write> field22: array<u32>;
+@group(4) @binding(509)
+var<storage, read_write> type20: array<u32>;
+
+@compute @workgroup_size(8, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(1) f0: vec4<u32>,
+@location(3) f1: i32,
+@location(2) f2: vec4<f32>,
+@location(5) f3: i32,
+@builtin(sample_mask) f4: u32,
+@location(0) f5: vec4<u32>,
+@location(4) f6: vec3<f32>,
+@location(6) f7: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(58) a0: vec3<i32>, @location(50) a1: vec3<f32>, @location(43) a2: vec2<f16>, @location(47) a3: vec3<i32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S16 {
+@builtin(vertex_index) f0: u32,
+@location(17) f1: vec4<i32>,
+@location(5) f2: vec3<u32>,
+@location(8) f3: vec3<f16>,
+@location(11) f4: vec3<f32>,
+@location(3) f5: vec4<f16>,
+@location(20) f6: vec4<f16>,
+@location(18) f7: i32,
+@location(21) f8: f32
+}
+struct VertexOutput0 {
+@location(12) f260: vec3<f16>,
+@location(8) f261: vec4<f16>,
+@location(1) f262: vec2<u32>,
+@location(32) f263: vec3<i32>,
+@location(43) f264: vec2<f16>,
+@location(64) f265: vec2<f32>,
+@location(31) f266: vec3<i32>,
+@location(11) f267: vec3<f32>,
+@location(59) f268: vec4<i32>,
+@location(14) f269: vec2<i32>,
+@location(7) f270: vec4<f32>,
+@location(49) f271: u32,
+@location(30) f272: vec4<f16>,
+@location(66) f273: vec2<f32>,
+@location(25) f274: i32,
+@location(74) f275: vec4<f16>,
+@location(51) f276: vec4<f32>,
+@location(67) f277: vec3<u32>,
+@location(73) f278: i32,
+@location(5) f279: vec4<f16>,
+@location(40) f280: vec2<f32>,
+@location(53) f281: vec2<i32>,
+@location(80) f282: vec2<i32>,
+@builtin(position) f283: vec4<f32>,
+@location(68) f284: vec3<u32>,
+@location(62) f285: u32,
+@location(38) f286: f32,
+@location(52) f287: vec4<f32>,
+@location(47) f288: vec3<i32>,
+@location(2) f289: vec2<i32>,
+@location(50) f290: vec3<f32>,
+@location(13) f291: vec4<u32>,
+@location(58) f292: vec3<i32>,
+@location(75) f293: vec2<i32>,
+@location(39) f294: vec3<u32>,
+@location(48) f295: vec2<i32>,
+@location(69) f296: f16,
+@location(3) f297: f16,
+@location(77) f298: f16,
+@location(10) f299: f16,
+@location(29) f300: vec2<u32>,
+@location(15) f301: vec3<i32>,
+@location(61) f302: f16,
+@location(72) f303: f16,
+@location(56) f304: vec3<i32>,
+@location(42) f305: f16,
+@location(4) f306: vec3<i32>,
+@location(79) f307: vec3<i32>,
+@location(17) f308: i32,
+@location(6) f309: vec2<u32>
+}
+
+@vertex
+fn vertex0(a0: S16, @location(9) a1: vec2<f16>, @location(14) a2: vec3<u32>, @builtin(instance_index) a3: u32, @location(10) a4: i32, @location(7) a5: f16, @location(0) a6: vec4<i32>, @location(4) a7: f32, @location(12) a8: f16, @location(13) a9: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let renderBundle42 = renderBundleEncoder8.finish(
+{
+label: '\u03c0\u036c\u{1f764}\u0506\u04f8\u0f89\u0715\ube8c\u9ae9'
+}
+);
+try {
+renderPassEncoder7.setScissorRect(
+5,
+1,
+1,
+0
+);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(
+3766
+);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(
+0,
+bindGroup1
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture1,
+  mipLevel: 4,
+  origin: { x: 0, y: 1, z: 182 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 20850 */{
+offset: 219,
+bytesPerRow: 13,
+rowsPerImage: 198,
+},
+{width: 0, height: 4, depthOrArrayLayers: 9}
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas6,
+  origin: { x: 190, y: 395 },
+  flipY: false,
+},
+{
+  texture: texture23,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline66 = device0.createRenderPipeline(
+{
+layout: 'auto',
+vertex: {
+module: shaderModule8,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 4344,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 564,
+shaderLocation: 13,
+},
+{
+format: 'snorm16x2',
+offset: 464,
+shaderLocation: 17,
+},
+{
+format: 'sint8x4',
+offset: 2984,
+shaderLocation: 20,
+},
+{
+format: 'float32x4',
+offset: 1516,
+shaderLocation: 9,
+},
+{
+format: 'uint16x4',
+offset: 468,
+shaderLocation: 3,
+},
+{
+format: 'snorm16x2',
+offset: 940,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x2',
+offset: 1010,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 4120,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 684,
+shaderLocation: 0,
+},
+{
+format: 'uint16x2',
+offset: 2844,
+shaderLocation: 21,
+}
+],
+},
+{
+arrayStride: 11072,
+attributes: [
+{
+format: 'unorm16x4',
+offset: 380,
+shaderLocation: 14,
+},
+{
+format: 'sint32x4',
+offset: 10112,
+shaderLocation: 16,
+},
+{
+format: 'sint32x3',
+offset: 11000,
+shaderLocation: 6,
+},
+{
+format: 'float32x4',
+offset: 6016,
+shaderLocation: 10,
+},
+{
+format: 'uint16x2',
+offset: 8944,
+shaderLocation: 12,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 2212,
+shaderLocation: 11,
+},
+{
+format: 'sint32',
+offset: 1612,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 9112,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 3308,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 13840,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 12264,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 12332,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 4524,
+shaderLocation: 18,
+},
+{
+format: 'sint8x4',
+offset: 9460,
+shaderLocation: 5,
+},
+{
+format: 'sint8x4',
+offset: 11408,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 11324,
+attributes: [
+{
+format: 'sint16x4',
+offset: 8836,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 13636,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 9940,
+shaderLocation: 19,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule8,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16sint',
+writeMask: 0,
+},
+undefined,
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+let imageData5 = new ImageData(152, 196);
+let shaderModule17 = device1.createShaderModule(
+{
+label: '\u949c\u358e\u315b\uf4c3\ue820\u10a9\ua4bf\u05b2',
+code: `@group(0) @binding(1830)
+var<storage, read_write> i14: array<u32>;
+@group(2) @binding(1830)
+var<storage, read_write> global23: array<u32>;
+@group(1) @binding(1830)
+var<storage, read_write> function18: array<u32>;
+@group(0) @binding(2941)
+var<storage, read_write> type21: array<u32>;
+
+@compute @workgroup_size(3, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(2) f0: vec4<u32>,
+@location(5) f1: vec4<f32>,
+@location(6) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(6) a0: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout23 = pipeline63.getBindGroupLayout(2);
+let commandEncoder30 = device1.createCommandEncoder();
+try {
+renderPassEncoder9.setBindGroup(
+1,
+bindGroup16
+);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(
+2,
+bindGroup16,
+new Uint32Array(5674),
+3859,
+0
+);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -812.0, g: 61.10, b: -402.8, a: -31.19, });
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(
+10,
+2,
+12,
+22
+);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(
+2,
+bindGroup16
+);
+} catch {}
+try {
+commandEncoder30.copyTextureToTexture(
+{
+  texture: texture50,
+  mipLevel: 0,
+  origin: { x: 7032, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture40,
+  mipLevel: 0,
+  origin: { x: 15, y: 0, z: 114 },
+  aspect: 'all',
+},
+{width: 18, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device1.queue.submit([
+]);
+} catch {}
+let pipeline67 = device1.createRenderPipeline(
+{
+label: '\u34cc\ufbbc\u804c\u0d28',
+layout: 'auto',
+vertex: {
+module: shaderModule10,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 18728,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 19344,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x4',
+offset: 13368,
+shaderLocation: 12,
+},
+{
+format: 'sint16x4',
+offset: 4088,
+shaderLocation: 10,
+},
+{
+format: 'uint16x2',
+offset: 4272,
+shaderLocation: 2,
+},
+{
+format: 'float32',
+offset: 17776,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x4',
+offset: 12200,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x4',
+offset: 4572,
+shaderLocation: 3,
+},
+{
+format: 'sint8x4',
+offset: 10720,
+shaderLocation: 8,
+},
+{
+format: 'snorm16x2',
+offset: 18104,
+shaderLocation: 5,
+},
+{
+format: 'sint32x4',
+offset: 16892,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'uint16x4',
+offset: 11172,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 14020,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 13168,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'unorm8x2',
+offset: 12266,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule10,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.RED,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg16uint',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2236,
+stencilWriteMask: 1069,
+depthBias: 4,
+depthBiasClamp: 50,
+},
+}
+);
+let commandBuffer4 = commandEncoder29.finish(
+{
+label: '\u0a61\u0e5d',
+}
+);
+let textureView56 = texture48.createView(
+{
+label: '\u{1fd5a}\u01a1\u7736',
+dimension: '2d',
+format: 'r32uint',
+baseMipLevel: 3,
+mipLevelCount: 1,
+baseArrayLayer: 8,
+}
+);
+try {
+buffer13.unmap();
+} catch {}
+let videoFrame8 = new VideoFrame(img0, {timestamp: 0});
+let shaderModule18 = device0.createShaderModule(
+{
+code: `@group(1) @binding(509)
+var<storage, read_write> function19: array<u32>;
+@group(0) @binding(1510)
+var<storage, read_write> field23: array<u32>;
+@group(1) @binding(2200)
+var<storage, read_write> function20: array<u32>;
+@group(2) @binding(5523)
+var<storage, read_write> function21: array<u32>;
+@group(1) @binding(2687)
+var<storage, read_write> field24: array<u32>;
+
+@compute @workgroup_size(5, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(2) f0: vec3<u32>,
+@location(6) f1: vec4<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S17 {
+@location(0) f0: vec2<f32>,
+@location(7) f1: f32,
+@location(3) f2: f32,
+@location(12) f3: vec4<i32>,
+@location(1) f4: vec3<f32>,
+@location(13) f5: i32
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(19) a1: u32, @location(4) a2: vec4<i32>, @location(20) a3: f16, @location(2) a4: vec3<f16>, @location(14) a5: u32, @location(9) a6: vec2<f16>, @location(11) a7: vec4<f16>, @location(8) a8: i32, @location(5) a9: vec3<f32>, @location(10) a10: vec4<i32>, @location(17) a11: vec4<f16>, @location(18) a12: vec2<f32>, @location(16) a13: f32, @location(15) a14: f32, @location(6) a15: f16, @location(21) a16: vec4<f16>, a17: S17, @builtin(vertex_index) a18: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+pseudoSubmit(device0, commandEncoder11);
+let renderBundleEncoder31 = device0.createRenderBundleEncoder(
+{
+label: '\ua530\u079e\ude10\u2925\u{1fbde}\u1b50\u3e7a',
+colorFormats: [
+'rg8sint',
+'rgba32float',
+'rgba16uint',
+'r32uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 215,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder8.setBindGroup(
+0,
+bindGroup9
+);
+} catch {}
+try {
+renderPassEncoder2.setViewport(
+0.6851,
+8.135,
+8.006,
+6.278,
+0.6534,
+0.6809
+);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(
+43,
+undefined,
+3356140757,
+725878852
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+27944,
+new Float32Array(45768),
+39956,
+3452
+);
+} catch {}
+try {
+await promise10;
+} catch {}
+let bindGroupLayout24 = device2.createBindGroupLayout(
+{
+label: '\u{1fd0c}\u8dde\u0ee4\u981a\u{1fcdc}\u00b5\u40b3\u{1f789}\u{1ff5d}',
+entries: [
+{
+binding: 6245,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '2d' },
+},
+{
+binding: 4164,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let commandEncoder31 = device2.createCommandEncoder(
+{
+label: '\u6483\u8a04\u{1f624}\u057a\u{1f9f6}\u{1fb73}',
+}
+);
+let texture53 = device2.createTexture(
+{
+size: {width: 10952},
+dimension: '1d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView57 = texture48.createView(
+{
+aspect: 'all',
+baseMipLevel: 2,
+mipLevelCount: 2,
+baseArrayLayer: 10,
+}
+);
+let videoFrame9 = new VideoFrame(video5, {timestamp: 0});
+let querySet43 = device0.createQuerySet({
+label: '\u00f4\u{1ffc4}\u{1ff8d}\u4804\u{1fb8b}\uf583\u0a50',
+type: 'occlusion',
+count: 171,
+});
+try {
+computePassEncoder7.setPipeline(
+pipeline23
+);
+} catch {}
+try {
+renderPassEncoder6.setViewport(
+0.09450,
+0.7234,
+3.056,
+1.232,
+0.1894,
+0.7315
+);
+} catch {}
+let pipeline68 = await promise22;
+let pipeline69 = await device0.createRenderPipelineAsync(
+{
+label: '\ue017\u33b9\u{1f96f}\u0388\u0bde\u8bea',
+layout: pipelineLayout0,
+vertex: {
+module: shaderModule13,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 5740,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 4956,
+shaderLocation: 20,
+},
+{
+format: 'float16x2',
+offset: 2836,
+shaderLocation: 12,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xdf5d5a4c,
+},
+fragment: {
+module: shaderModule13,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+let shaderModule19 = device0.createShaderModule(
+{
+label: '\u5a1a\u{1fe9b}\uffeb\u003f\u{1f632}\uf4a6\u2de7',
+code: `@group(0) @binding(509)
+var<storage, read_write> type22: array<u32>;
+@group(0) @binding(2687)
+var<storage, read_write> parameter18: array<u32>;
+
+@compute @workgroup_size(6, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(7) f0: vec2<u32>,
+@location(6) f1: vec3<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(15) a0: i32, @location(3) a1: f16, @location(11) a2: vec2<u32>, @location(9) a3: vec2<i32>, @location(0) a4: vec4<i32>, @location(1) a5: vec4<f16>, @location(14) a6: vec2<i32>, @builtin(vertex_index) a7: u32, @location(12) a8: vec2<i32>, @location(17) a9: i32, @location(13) a10: vec2<f32>, @location(6) a11: vec3<f32>, @location(19) a12: i32, @location(7) a13: vec4<u32>, @builtin(instance_index) a14: u32, @location(18) a15: vec2<f32>, @location(4) a16: vec2<f32>, @location(2) a17: vec3<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder32 = device0.createCommandEncoder(
+{
+label: '\ubc0b\u{1fa78}',
+}
+);
+let sampler27 = device0.createSampler(
+{
+label: '\u61a7\u04ff\u{1fbf0}\uf0cd\u7ac0',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 10.908,
+maxAnisotropy: 11,
+}
+);
+try {
+computePassEncoder7.setBindGroup(
+9,
+bindGroup14,
+new Uint32Array(5868),
+782,
+0
+);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -186.2, g: -768.6, b: -239.3, a: -368.8, });
+} catch {}
+try {
+renderPassEncoder5.setViewport(
+3.945,
+0.4567,
+1.897,
+0.4375,
+0.1833,
+0.8490
+);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(
+22,
+undefined,
+1049622822,
+1644793081
+);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(
+9,
+bindGroup13
+);
+} catch {}
+try {
+commandEncoder32.resolveQuerySet(
+querySet7,
+223,
+462,
+buffer5,
+3072
+);
+} catch {}
+let pipeline70 = await device0.createComputePipelineAsync(
+{
+label: '\u0dc6\u0394\u5f7a\uf910\u0d49\u0bb8\ubbd1\u37a8\uf472\u0a30\u0f89',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let canvas9 = document.createElement('canvas');
+let renderBundle43 = renderBundleEncoder21.finish(
+{
+label: '\u09d7\ud572\ua2e3\u13e8\ude52\u{1fe70}\u0b48\udd23\ubcd3\u11fb\u0d52'
+}
+);
+try {
+computePassEncoder11.setBindGroup(
+1,
+bindGroup16,
+new Uint32Array(8699),
+1470,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+7,
+buffer15,
+5160,
+1114
+);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(
+2,
+bindGroup16,
+new Uint32Array(8155),
+6699,
+0
+);
+} catch {}
+try {
+commandEncoder30.copyTextureToTexture(
+{
+  texture: texture35,
+  mipLevel: 2,
+  origin: { x: 34, y: 0, z: 20 },
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 1,
+  origin: { x: 95, y: 0, z: 44 },
+  aspect: 'all',
+},
+{width: 9, height: 1, depthOrArrayLayers: 16}
+);
+} catch {}
+let pipeline71 = device1.createComputePipeline(
+{
+label: '\ud746\uc0ed\u2e30\uf3c1\u{1fec3}\u95e5\uc741',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+},
+}
+);
+let img8 = await imageWithData(288, 104, '#6705e89a', '#46dc84a7');
+let buffer16 = device2.createBuffer(
+{
+label: '\u99bc\u7b05\u{1f63f}',
+size: 28567,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let commandEncoder33 = device2.createCommandEncoder(
+{
+}
+);
+let querySet44 = device2.createQuerySet({
+label: '\u85c3\u0b8e\uef08\u265e\ub811\u48b0\ud07c\u04db',
+type: 'occlusion',
+count: 4078,
+});
+try {
+await promise21;
+} catch {}
+offscreenCanvas8.height = 701;
+try {
+window.someLabel = device2.label;
+} catch {}
+let texture54 = device2.createTexture(
+{
+size: {width: 220, height: 20, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'etc2-rgb8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'etc2-rgb8unorm-srgb'
+],
+}
+);
+try {
+device2.queue.writeBuffer(
+buffer16,
+27264,
+new Float32Array(43701),
+5155,
+24
+);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let adapter4 = await navigator.gpu.requestAdapter();
+let img9 = await imageWithData(72, 283, '#4a2f79b5', '#f1d2e8aa');
+let commandEncoder34 = device0.createCommandEncoder(
+{
+label: '\ub24a\uc157\u0a01\ub146',
+}
+);
+let querySet45 = device0.createQuerySet({
+type: 'occlusion',
+count: 342,
+});
+let texture55 = device0.createTexture(
+{
+size: [8366, 2, 1],
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgba32sint',
+'rgba32sint'
+],
+}
+);
+let sampler28 = device0.createSampler(
+{
+label: '\uba66\ua9a2\u1b9e\ud820\u074e',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 14.136,
+lodMaxClamp: 91.869,
+compare: 'less',
+}
+);
+try {
+renderPassEncoder8.setBindGroup(
+9,
+bindGroup7,
+new Uint32Array(8284),
+5715,
+0
+);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(
+3,
+1,
+2,
+1
+);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(
+2,
+bindGroup6
+);
+} catch {}
+try {
+commandEncoder32.copyTextureToTexture(
+{
+  texture: texture21,
+  mipLevel: 4,
+  origin: { x: 548, y: 0, z: 6 },
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 5,
+  origin: { x: 140, y: 0, z: 19 },
+  aspect: 'all',
+},
+{width: 16, height: 4, depthOrArrayLayers: 187}
+);
+} catch {}
+try {
+commandEncoder32.resolveQuerySet(
+querySet2,
+768,
+628,
+buffer5,
+6400
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+43228,
+new Float32Array(52218),
+31145,
+1524
+);
+} catch {}
+let pipeline72 = await device0.createRenderPipelineAsync(
+{
+label: '\u09bb\ua74f\u790f\u{1f935}\u1946',
+layout: pipelineLayout13,
+vertex: {
+module: shaderModule19,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3124,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 3118,
+shaderLocation: 18,
+},
+{
+format: 'sint32x3',
+offset: 140,
+shaderLocation: 14,
+},
+{
+format: 'float16x4',
+offset: 2492,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x4',
+offset: 2232,
+shaderLocation: 6,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 2028,
+shaderLocation: 1,
+},
+{
+format: 'float32x2',
+offset: 64,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 13352,
+attributes: [
+{
+format: 'sint8x4',
+offset: 7876,
+shaderLocation: 9,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 7900,
+shaderLocation: 13,
+},
+{
+format: 'sint32x2',
+offset: 4416,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 4164,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 3404,
+shaderLocation: 11,
+},
+{
+format: 'sint32x2',
+offset: 656,
+shaderLocation: 19,
+}
+],
+},
+{
+arrayStride: 2744,
+attributes: [
+{
+format: 'float32x4',
+offset: 1272,
+shaderLocation: 4,
+},
+{
+format: 'sint8x4',
+offset: 2012,
+shaderLocation: 12,
+},
+{
+format: 'sint32',
+offset: 1664,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 1372,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32',
+offset: 408,
+shaderLocation: 15,
+},
+{
+format: 'uint32x2',
+offset: 604,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x5abfc55f,
+},
+fragment: {
+module: shaderModule19,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+stencilBack: {
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+passOp: 'decrement-clamp',
+},
+depthBias: 30,
+depthBiasSlopeScale: 81,
+depthBiasClamp: 41,
+},
+}
+);
+try {
+adapter2.label = '\uf01e\u0b8e\uac73\u{1f820}\u992f';
+} catch {}
+let commandEncoder35 = device1.createCommandEncoder(
+{
+label: '\u5e75\u0445\u98a6\ufa55',
+}
+);
+let querySet46 = device1.createQuerySet({
+type: 'occlusion',
+count: 2713,
+});
+let textureView58 = texture51.createView(
+{
+label: '\u0bef\ufed8\u{1ffe8}',
+dimension: '2d-array',
+format: 'rg16float',
+arrayLayerCount: 1,
+}
+);
+let renderBundleEncoder32 = device1.createRenderBundleEncoder(
+{
+label: '\uf2ab\u0c27\u852a\u0736\u2ec6\u3ee1\u590e\u0c7d\u3fe8',
+colorFormats: [
+'bgra8unorm',
+'rg8sint',
+'rgba16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 773,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler29 = device1.createSampler(
+{
+label: '\u{1fa8c}\uecf2\u0b05\u6aa5\u57cb\u007a',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+}
+);
+try {
+computePassEncoder11.setPipeline(
+pipeline56
+);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: 392.2, g: -213.5, b: -795.3, a: 526.9, });
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(
+29,
+6,
+0,
+5
+);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+3253
+);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(
+4,
+bindGroup16,
+new Uint32Array(8491),
+3962,
+0
+);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(
+3,
+buffer15,
+2788,
+2029
+);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+gc();
+let bindGroupLayout25 = device1.createBindGroupLayout(
+{
+entries: [
+{
+binding: 917,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+},
+{
+binding: 621,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '2d' },
+},
+{
+binding: 1129,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}
+],
+}
+);
+let commandEncoder36 = device1.createCommandEncoder(
+{
+}
+);
+let querySet47 = device1.createQuerySet({
+label: '\u5ab4\u5f31\u{1fb94}\u0aad\ua293\uaed8\u{1fa98}\u0783\u310f',
+type: 'occlusion',
+count: 3146,
+});
+let renderBundle44 = renderBundleEncoder21.finish(
+{
+label: '\ua031\u0d9b\u0a4c\u1c2e\u933a\udce8\u{1fd3a}\u870a\ua853\u5c63'
+}
+);
+try {
+computePassEncoder11.setBindGroup(
+1,
+bindGroup16,
+new Uint32Array(758),
+539,
+0
+);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(
+4,
+bindGroup16,
+[]
+);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(
+5,
+buffer15,
+7012,
+101
+);
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer3,
+]);
+} catch {}
+let computePassEncoder12 = commandEncoder33.beginComputePass(
+{
+label: '\u0b00\u0d47'
+}
+);
+try {
+device2.queue.writeBuffer(
+buffer16,
+14384,
+new BigUint64Array(64388),
+51966,
+1604
+);
+} catch {}
+let texture56 = device1.createTexture(
+{
+label: '\u0bcc\ucd57\u527d',
+size: [1358, 1, 188],
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundle45 = renderBundleEncoder15.finish(
+{
+label: '\u0257\u8b8c\u61d5\u6799\u4283\u21bb\u91e1'
+}
+);
+try {
+renderPassEncoder11.setBlendConstant({ r: -726.0, g: 927.4, b: -805.5, a: 879.5, });
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(
+3223
+);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(
+1,
+bindGroup16
+);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(
+2834
+);
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+21.21,
+11.74,
+0.9034,
+7.531,
+0.6198,
+0.8012
+);
+} catch {}
+offscreenCanvas1.width = 947;
+let device3 = await adapter4.requestDevice({
+requiredLimits: {
+maxBindGroups: 9,
+maxColorAttachmentBytesPerSample: 56,
+maxVertexAttributes: 29,
+maxVertexBufferArrayStride: 42456,
+maxStorageTexturesPerShaderStage: 34,
+maxStorageBuffersPerShaderStage: 19,
+maxDynamicStorageBuffersPerPipelineLayout: 9847,
+maxBindingsPerBindGroup: 2504,
+maxTextureDimension1D: 15508,
+maxTextureDimension2D: 15096,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 41315111,
+maxUniformBuffersPerShaderStage: 32,
+maxInterStageShaderVariables: 58,
+maxInterStageShaderComponents: 86,
+maxSamplersPerShaderStage: 17,
+},
+});
+let renderBundle46 = renderBundleEncoder30.finish();
+let sampler30 = device2.createSampler(
+{
+label: '\u6718\u1dd3\uadaa\u{1fdff}\u498a\u7435',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 43.211,
+lodMaxClamp: 84.112,
+maxAnisotropy: 4,
+}
+);
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let bindGroup17 = device2.createBindGroup({
+label: '\u6215\ufdf2\ua194\u4cb6\u070d\u48d1\u2309',
+layout: bindGroupLayout19,
+entries: [
+
+],
+});
+try {
+computePassEncoder12.setBindGroup(
+3,
+bindGroup17,
+[]
+);
+} catch {}
+let gpuCanvasContext10 = canvas9.getContext('webgpu');
+canvas8.width = 280;
+let pipelineLayout14 = device1.createPipelineLayout(
+{
+label: '\u08ef\u4026\u018a\u4823\ua1a2\u7233\u{1f7f7}\u3f3b\u0b8c\u{1fc3f}',
+bindGroupLayouts: [
+bindGroupLayout20
+]
+}
+);
+let renderPassEncoder12 = commandEncoder30.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+{
+view: textureView49,
+clearValue: { r: -110.7, g: -802.2, b: -629.1, a: 219.9, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+undefined
+],
+occlusionQuerySet: querySet40,
+maxDrawCount: 36928,
+}
+);
+let sampler31 = device1.createSampler(
+{
+label: '\udfb6\u0e38\u754f\u0b53\u08ef\ud6ef\u0e48\u5fb6\u1c23\u{1fa6b}',
+addressModeU: 'mirror-repeat',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 16.038,
+lodMaxClamp: 68.065,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder9.setBindGroup(
+3,
+bindGroup16,
+new Uint32Array(388),
+254,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(
+737
+);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(
+3,
+bindGroup16,
+[]
+);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device1,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rg8unorm',
+'rgba8unorm-srgb',
+'rgba8unorm-srgb',
+'rg32float'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let adapter5 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let buffer17 = device3.createBuffer(
+{
+label: '\u{1fe3d}\u6f84\u052b\u9842\u2ed9\u053e\u0c8b\u551e\u{1fa0f}',
+size: 48112,
+usage: GPUBufferUsage.UNIFORM,
+}
+);
+document.body.prepend(canvas1);
+let offscreenCanvas11 = new OffscreenCanvas(975, 790);
+let texture57 = device2.createTexture(
+{
+label: '\ub013\u9f3e\u{1ff18}\ub4c5\u0799\u637b\u1b1b',
+size: {width: 15181, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 14,
+sampleCount: 1,
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView59 = texture53.createView(
+{
+label: '\u1c03\u09b7\uf334\u61ac\u927a\ud647\u5fff',
+format: 'rgba16sint',
+arrayLayerCount: 1,
+}
+);
+try {
+computePassEncoder12.setBindGroup(
+2,
+bindGroup17,
+new Uint32Array(6263),
+2252,
+0
+);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer16,
+16712,
+new BigUint64Array(46942),
+20752,
+1048
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture52,
+  mipLevel: 4,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer2),
+/* required buffer size: 894 */{
+offset: 894,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+canvas6.height = 964;
+let imageBitmap7 = await createImageBitmap(img7);
+try {
+offscreenCanvas11.getContext('webgl2');
+} catch {}
+let commandEncoder37 = device1.createCommandEncoder();
+let querySet48 = device1.createQuerySet({
+type: 'occlusion',
+count: 3031,
+});
+let renderBundleEncoder33 = device1.createRenderBundleEncoder(
+{
+label: '\u0ba7\u0f01\u4e6f\u5bf4\u{1f646}',
+colorFormats: [
+'rg16float',
+'r16float',
+'rgba16float',
+'rgba8sint',
+'bgra8unorm-srgb',
+undefined,
+'rgb10a2unorm'
+],
+sampleCount: 476,
+depthReadOnly: true,
+}
+);
+let renderBundle47 = renderBundleEncoder33.finish();
+let sampler32 = device1.createSampler(
+{
+label: '\u{1f713}\ue894\u0727\uc6cb\u42f8\u0c92\ua60e\u038c\u{1fcfe}\u4e51\ubde9',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 42.523,
+lodMaxClamp: 49.391,
+maxAnisotropy: 12,
+}
+);
+let externalTexture4 = device1.importExternalTexture(
+{
+label: '\u02e0\u01cb\ua2ad\u{1fb21}\u5947\u0fe9',
+source: video3,
+colorSpace: 'srgb',
+}
+);
+try {
+renderPassEncoder11.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+8.370,
+9.057,
+3.216,
+13.01,
+0.2481,
+0.8148
+);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(
+2,
+bindGroup16
+);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(
+9,
+buffer15,
+252
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture42,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer7,
+/* required buffer size: 738 */{
+offset: 738,
+},
+{width: 2, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline73 = device1.createRenderPipeline(
+{
+label: '\u0177\u0363\u3e7d\u1e61\u9028',
+layout: pipelineLayout14,
+vertex: {
+module: shaderModule15,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x2',
+offset: 6532,
+shaderLocation: 4,
+},
+{
+format: 'sint8x2',
+offset: 5496,
+shaderLocation: 8,
+},
+{
+format: 'sint32x2',
+offset: 15144,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x2',
+offset: 6652,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 14408,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x2',
+offset: 2678,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 14760,
+attributes: [
+
+],
+},
+{
+arrayStride: 18692,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 8224,
+shaderLocation: 10,
+},
+{
+format: 'float32x4',
+offset: 16476,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 10068,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 5328,
+shaderLocation: 5,
+},
+{
+format: 'float32x2',
+offset: 7164,
+shaderLocation: 6,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+},
+}
+);
+let promise26 = adapter1.requestAdapterInfo();
+let shaderModule20 = device0.createShaderModule(
+{
+label: '\u{1fba1}\u{1faf8}\u3518\u1966\ue14d\u{1f874}\u0d4f\uffd1\u0240',
+code: `@group(7) @binding(4134)
+var<storage, read_write> global24: array<u32>;
+@group(2) @binding(59)
+var<storage, read_write> parameter19: array<u32>;
+@group(6) @binding(4639)
+var<storage, read_write> parameter20: array<u32>;
+@group(3) @binding(509)
+var<storage, read_write> function22: array<u32>;
+@group(4) @binding(2200)
+var<storage, read_write> global25: array<u32>;
+@group(4) @binding(509)
+var<storage, read_write> field25: array<u32>;
+@group(0) @binding(4313)
+var<storage, read_write> field26: array<u32>;
+@group(2) @binding(4134)
+var<storage, read_write> local16: array<u32>;
+@group(1) @binding(2687)
+var<storage, read_write> global26: array<u32>;
+@group(3) @binding(2687)
+var<storage, read_write> type23: array<u32>;
+@group(2) @binding(1642)
+var<storage, read_write> field27: array<u32>;
+@group(7) @binding(59)
+var<storage, read_write> field28: array<u32>;
+@group(7) @binding(1642)
+var<storage, read_write> local17: array<u32>;
+@group(4) @binding(2687)
+var<storage, read_write> parameter21: array<u32>;
+@group(1) @binding(509)
+var<storage, read_write> field29: array<u32>;
+@group(6) @binding(1510)
+var<storage, read_write> field30: array<u32>;
+@group(1) @binding(2200)
+var<storage, read_write> i15: array<u32>;
+
+@compute @workgroup_size(6, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(5) f0: vec4<u32>,
+@location(2) f1: vec4<i32>,
+@location(4) f2: vec4<u32>,
+@location(3) f3: vec4<f32>,
+@location(6) f4: vec2<u32>,
+@location(0) f5: u32,
+@location(7) f6: vec3<i32>,
+@location(1) f7: f32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S18 {
+@location(15) f0: u32,
+@location(12) f1: vec4<u32>,
+@location(3) f2: f32,
+@location(13) f3: f16,
+@location(8) f4: f32,
+@location(9) f5: vec2<f32>,
+@location(18) f6: vec2<f32>,
+@location(16) f7: vec3<u32>,
+@location(6) f8: f16,
+@location(5) f9: f32,
+@location(14) f10: u32,
+@location(21) f11: f32,
+@location(2) f12: vec3<i32>,
+@location(17) f13: vec3<f16>,
+@location(20) f14: vec2<u32>,
+@builtin(vertex_index) f15: u32,
+@location(4) f16: vec2<f16>,
+@location(0) f17: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec4<f32>, @location(1) a1: vec2<f16>, a2: S18, @location(11) a3: i32, @location(19) a4: vec2<f32>, @location(10) a5: vec3<f32>, @builtin(instance_index) a6: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let buffer18 = device0.createBuffer(
+{
+label: '\u{1fee6}\u{1f9b9}\u72b8\ub458\uc3f2\u{1fa72}',
+size: 64059,
+usage: GPUBufferUsage.MAP_READ,
+}
+);
+let sampler33 = device0.createSampler(
+{
+label: '\u0978\u9e55\u{1fa39}\u10d6\u5cae\u08ad\ufea6',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 69.115,
+compare: 'greater-equal',
+}
+);
+try {
+renderPassEncoder8.setBindGroup(
+8,
+bindGroup14
+);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(
+1,
+bindGroup5
+);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(
+2,
+bindGroup11,
+new Uint32Array(2682),
+760,
+0
+);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(
+buffer6,
+'uint32',
+15368
+);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(
+45,
+undefined,
+6904714
+);
+} catch {}
+try {
+commandEncoder32.resolveQuerySet(
+querySet9,
+420,
+2887,
+buffer5,
+12032
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 87, height: 28, depthOrArrayLayers: 1}
+*/
+{
+  source: video6,
+  origin: { x: 0, y: 15 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 1,
+  origin: { x: 55, y: 24, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 5, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+video0.width = 266;
+gc();
+try {
+offscreenCanvas10.getContext('bitmaprenderer');
+} catch {}
+let shaderModule21 = device1.createShaderModule(
+{
+label: '\u43e4\u4fb9\uae7a\u{1f85f}\u2d2f\u4213\u043f\u0d6a',
+code: `@group(1) @binding(1830)
+var<storage, read_write> type24: array<u32>;
+@group(0) @binding(1830)
+var<storage, read_write> parameter22: array<u32>;
+@group(0) @binding(2941)
+var<storage, read_write> function23: array<u32>;
+@group(2) @binding(1830)
+var<storage, read_write> i16: array<u32>;
+@group(1) @binding(2941)
+var<storage, read_write> parameter23: array<u32>;
+
+@compute @workgroup_size(8, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(2) f0: vec2<i32>,
+@location(6) f1: vec2<i32>,
+@location(3) f2: u32,
+@location(7) f3: vec2<i32>,
+@location(4) f4: vec4<i32>,
+@location(5) f5: vec4<i32>,
+@location(1) f6: vec3<f32>,
+@location(0) f7: vec4<u32>,
+@builtin(sample_mask) f8: u32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S19 {
+@location(14) f0: vec2<i32>,
+@location(1) f1: vec2<u32>,
+@location(6) f2: vec4<u32>,
+@builtin(vertex_index) f3: u32,
+@location(4) f4: vec4<f16>,
+@location(12) f5: f16,
+@location(5) f6: vec3<i32>,
+@location(11) f7: f16
+}
+
+@vertex
+fn vertex0(a0: S19, @location(10) a1: u32, @location(8) a2: vec4<u32>, @location(0) a3: f16, @location(9) a4: vec4<i32>, @location(3) a5: vec3<f16>, @location(7) a6: vec3<f32>, @location(2) a7: vec4<u32>, @location(15) a8: vec4<i32>, @location(13) a9: vec2<i32>, @builtin(instance_index) a10: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder38 = device1.createCommandEncoder(
+{
+label: '\u8477\u{1fc7c}',
+}
+);
+try {
+renderPassEncoder12.setBindGroup(
+0,
+bindGroup16
+);
+} catch {}
+try {
+commandEncoder36.copyTextureToTexture(
+{
+  texture: texture42,
+  mipLevel: 6,
+  origin: { x: 2, y: 3, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 3,
+  origin: { x: 20, y: 12, z: 1 },
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer2),
+/* required buffer size: 526 */{
+offset: 526,
+rowsPerImage: 56,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise27 = device1.queue.onSubmittedWorkDone();
+let pipeline74 = device1.createRenderPipeline(
+{
+label: '\u073b\udecf\u{1fd38}\u6049\u{1fa92}',
+layout: 'auto',
+vertex: {
+module: shaderModule10,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 11568,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 6796,
+shaderLocation: 15,
+},
+{
+format: 'snorm8x4',
+offset: 4148,
+shaderLocation: 3,
+},
+{
+format: 'snorm8x4',
+offset: 9064,
+shaderLocation: 14,
+},
+{
+format: 'sint16x2',
+offset: 10012,
+shaderLocation: 8,
+},
+{
+format: 'uint16x4',
+offset: 7380,
+shaderLocation: 6,
+},
+{
+format: 'snorm8x2',
+offset: 6122,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 23352,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 856,
+shaderLocation: 11,
+},
+{
+format: 'sint32x2',
+offset: 8516,
+shaderLocation: 1,
+},
+{
+format: 'sint8x4',
+offset: 22092,
+shaderLocation: 10,
+},
+{
+format: 'uint8x4',
+offset: 20548,
+shaderLocation: 2,
+},
+{
+format: 'float32x4',
+offset: 4268,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 11680,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 8848,
+attributes: [
+
+],
+},
+{
+arrayStride: 4940,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 428,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 136,
+shaderLocation: 12,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+},
+fragment: {
+module: shaderModule10,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+writeMask: 0,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL,
+},
+{
+format: 'r32sint',
+},
+{
+format: 'r16uint',
+writeMask: 0,
+},
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilReadMask: 2481,
+stencilWriteMask: 1084,
+depthBiasSlopeScale: 92,
+depthBiasClamp: 33,
+},
+}
+);
+let computePassEncoder13 = commandEncoder35.beginComputePass(
+{
+label: '\u0044\u{1f9bc}\u3b82'
+}
+);
+let renderBundle48 = renderBundleEncoder32.finish(
+{
+label: '\u9863\u8ff6\u2eb6\u6d4f\u{1fdf5}\u6f50\u447f\u08fc\ue54d'
+}
+);
+try {
+computePassEncoder11.setPipeline(
+pipeline71
+);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(
+2,
+bindGroup16,
+new Uint32Array(851),
+709,
+0
+);
+} catch {}
+try {
+commandEncoder38.copyTextureToTexture(
+{
+  texture: texture40,
+  mipLevel: 0,
+  origin: { x: 28, y: 1, z: 51 },
+  aspect: 'all',
+},
+{
+  texture: texture40,
+  mipLevel: 0,
+  origin: { x: 116, y: 1, z: 133 },
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 64}
+);
+} catch {}
+try {
+renderPassEncoder10.insertDebugMarker(
+'\u14c7'
+);
+} catch {}
+gc();
+try {
+buffer17.destroy();
+} catch {}
+let textureView60 = texture55.createView(
+{
+label: '\u017c\u{1f89f}\u242c\u064c\u002d',
+dimension: '2d-array',
+}
+);
+try {
+renderPassEncoder8.setStencilReference(
+3169
+);
+} catch {}
+try {
+commandEncoder34.copyBufferToBuffer(
+buffer0,
+22124,
+buffer9,
+46672,
+2676
+);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+124,
+new DataView(new ArrayBuffer(38871)),
+26780,
+5100
+);
+} catch {}
+let img10 = await imageWithData(36, 34, '#ca1f6b0a', '#526194ef');
+let imageBitmap8 = await createImageBitmap(img10);
+let texture58 = device2.createTexture(
+{
+label: '\u0b29\u{1fad5}\u966d\u0b9d\u9be2\u{1f978}\u{1fc68}\u{1fb64}\u{1fa76}\u045b\u05d0',
+size: {width: 1560, height: 10, depthOrArrayLayers: 222},
+mipLevelCount: 4,
+format: 'astc-10x10-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let bindGroup18 = device0.createBindGroup({
+layout: bindGroupLayout9,
+entries: [
+
+],
+});
+let texture59 = device0.createTexture(
+{
+size: [82, 1, 241],
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16sint',
+'rgba16sint'
+],
+}
+);
+let computePassEncoder14 = commandEncoder34.beginComputePass(
+{
+label: '\ub423\uee0e\udb7a\u0a77\u034c\u0c07\u3add\u0c8d'
+}
+);
+let renderBundleEncoder34 = device0.createRenderBundleEncoder(
+{
+label: '\u{1ff3b}\u0896\u21fb\u28cb\ud54f\u998c\ucd89\u06ea',
+colorFormats: [
+'rgba8sint',
+'rg8uint',
+'r8sint',
+'rgba32float'
+],
+sampleCount: 915,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle49 = renderBundleEncoder14.finish();
+try {
+renderPassEncoder5.setBindGroup(
+7,
+bindGroup10
+);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(
+1,
+bindGroup13,
+new Uint32Array(7005),
+1214,
+0
+);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(
+15,
+12,
+0,
+1
+);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(
+buffer5,
+'uint32',
+22476,
+11184
+);
+} catch {}
+try {
+commandEncoder32.copyBufferToBuffer(
+buffer8,
+368,
+buffer10,
+2488,
+252
+);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder32.clearBuffer(
+buffer9,
+21308,
+24724
+);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let pipeline75 = device0.createComputePipeline(
+{
+label: '\uf098\u778b\u4ad4\ude69\u{1f8b0}\u7614\ubf5b\u0144\u0e91',
+layout: pipelineLayout13,
+compute: {
+module: shaderModule19,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let computePassEncoder15 = commandEncoder32.beginComputePass(
+{
+label: '\u{1fb77}\u{1fd54}\u9fd0\u0672\uf3a3\u05d2\u591e\u9cd6'
+}
+);
+try {
+renderPassEncoder4.setStencilReference(
+3399
+);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(
+9,
+bindGroup12
+);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(
+buffer3,
+'uint32'
+);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+29580,
+new Int16Array(10398),
+5026
+);
+} catch {}
+let pipeline76 = device0.createRenderPipeline(
+{
+layout: pipelineLayout6,
+vertex: {
+module: shaderModule3,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 3860,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x4',
+offset: 3044,
+shaderLocation: 17,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule3,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'greater-equal',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 1002,
+depthBias: 52,
+depthBiasSlopeScale: 59,
+depthBiasClamp: 11,
+},
+}
+);
+let videoFrame10 = new VideoFrame(offscreenCanvas1, {timestamp: 0});
+let bindGroup19 = device2.createBindGroup({
+label: '\u0ca9\uc4d5\u1602\u3507\u03d8\u73f5\u21fc\u{1fa47}\u{1fdb3}',
+layout: bindGroupLayout19,
+entries: [
+
+],
+});
+let commandEncoder39 = device2.createCommandEncoder(
+{
+label: '\ue265\u0b33\u02a2\u0265\u40a1\ue9eb\u52b2\ub06f',
+}
+);
+video0.height = 275;
+try {
+adapter2.label = '\u{1f826}\u2641\u0844\u8ee8\u1d1d\u0987\u02fa\ufccd\u{1fd38}\u37c2\u846d';
+} catch {}
+let buffer19 = device3.createBuffer(
+{
+label: '\u{1fee9}\u0bd6\ue559\u547e\u1468\ufa20\u{1f9f6}\ue0f8\u046e\u05fc',
+size: 34703,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let commandEncoder40 = device3.createCommandEncoder(
+{
+label: '\u112c\uc0e7\u02af\u{1ff26}\ud910\ud1aa\u{1fbaa}\u1164',
+}
+);
+let texture60 = device3.createTexture(
+{
+label: '\u10f5\u44e1\ue9fb\u00c5\u2c28\u0771\u{1fd41}',
+size: [58, 58, 1],
+mipLevelCount: 5,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView61 = texture60.createView(
+{
+dimension: '2d-array',
+aspect: 'all',
+baseMipLevel: 1,
+mipLevelCount: 2,
+}
+);
+let computePassEncoder16 = commandEncoder40.beginComputePass(
+{
+label: '\u{1fc77}\u1c15\u741b\u{1fee3}\u{1f893}'
+}
+);
+let textureView62 = texture38.createView(
+{
+label: '\u{1fa98}\u5056\u2d09\u0a8f\u40fb\u{1fdb2}\u0d21\ub597',
+dimension: '2d-array',
+baseMipLevel: 8,
+}
+);
+let sampler34 = device1.createSampler(
+{
+label: '\u{1ff52}\u0445\u0cb2\u1209\u2b48\u196a',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 33.935,
+lodMaxClamp: 93.008,
+}
+);
+try {
+renderPassEncoder11.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant({ r: 809.5, g: 670.9, b: 776.6, a: -936.9, });
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(
+3440
+);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(
+8,
+buffer15
+);
+} catch {}
+try {
+commandEncoder37.copyTextureToTexture(
+{
+  texture: texture40,
+  mipLevel: 1,
+  origin: { x: 40, y: 0, z: 29 },
+  aspect: 'all',
+},
+{
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+bindGroup3.label = '\u6b0f\u7440\u5af9\u22a1\u6a0a\u089b\u{1fddb}\uec6b';
+} catch {}
+let buffer20 = device0.createBuffer(
+{
+label: '\u0bbf\u0cc1\u12a0\u7f7d',
+size: 18030,
+usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+}
+);
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(
+1916
+);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(
+8,
+buffer20
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+39612,
+new Int16Array(10045),
+3115,
+1012
+);
+} catch {}
+pseudoSubmit(device3, commandEncoder40);
+let sampler35 = device3.createSampler(
+{
+label: '\ubf6e\u7e1f\u0868\u{1fe2f}\uf7d6\uac87\u80b3',
+addressModeU: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 31.402,
+lodMaxClamp: 91.467,
+compare: 'always',
+maxAnisotropy: 6,
+}
+);
+let adapter6 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let pipelineLayout15 = device1.createPipelineLayout(
+{
+label: '\u403d\u{1fd6c}\u{1f9eb}\uf7e9\u0884\u40c0\u82d7',
+bindGroupLayouts: [
+bindGroupLayout17,
+bindGroupLayout21,
+bindGroupLayout20
+]
+}
+);
+let commandEncoder41 = device1.createCommandEncoder(
+{
+label: '\u24cf\udae9\u{1f80f}\u01a3\u{1fad9}\u0f8a\u34c3\uc036\u{1f715}',
+}
+);
+let renderPassEncoder13 = commandEncoder37.beginRenderPass(
+{
+label: '\uc8c3\u3d90\u7ac1\u0b6f\u745f\u0dfe',
+colorAttachments: [
+{
+view: textureView49,
+clearValue: { r: 3.445, g: -113.7, b: -653.7, a: 818.7, },
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet37,
+maxDrawCount: 181792,
+}
+);
+try {
+renderPassEncoder12.setVertexBuffer(
+7,
+buffer15
+);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(
+0,
+buffer15,
+7116,
+1
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas12 = new OffscreenCanvas(361, 617);
+let commandEncoder42 = device1.createCommandEncoder(
+{
+}
+);
+let sampler36 = device1.createSampler(
+{
+label: '\u07f9\u6c47\uc3cc\ua657\u0290\u0e4e\u0001\u5274\ue5f7\u{1f7c4}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 72.444,
+lodMaxClamp: 97.187,
+}
+);
+try {
+renderPassEncoder12.setBindGroup(
+2,
+bindGroup16
+);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(
+13,
+18,
+6,
+1
+);
+} catch {}
+try {
+await promise19;
+} catch {}
+let img11 = await imageWithData(139, 88, '#0cd17566', '#944191a6');
+let bindGroupLayout26 = device2.createBindGroupLayout(
+{
+label: '\u{1f76d}\ud9db\u72dc\uf94f\u{1f7f0}\u923c\u22fa\u0675\u2011\u0bf3\uce1e',
+entries: [
+{
+binding: 763,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+},
+{
+binding: 6440,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '2d' },
+}
+],
+}
+);
+let texture61 = device2.createTexture(
+{
+label: '\u39c4\u2f38\ubbde\u7af4\u451b\u{1fb71}',
+size: [4502],
+mipLevelCount: 1,
+dimension: '1d',
+format: 'rgba8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8sint',
+'rgba8sint'
+],
+}
+);
+let renderBundleEncoder35 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+'r8uint',
+'r8unorm'
+],
+sampleCount: 792,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+commandEncoder39.copyTextureToTexture(
+{
+  texture: texture52,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture52,
+  mipLevel: 7,
+  origin: { x: 0, y: 4, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder39.clearBuffer(
+buffer16,
+6940,
+15376
+);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture61,
+  mipLevel: 0,
+  origin: { x: 3561, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(arrayBuffer7),
+/* required buffer size: 410 */{
+offset: 410,
+},
+{width: 786, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let shaderModule22 = device0.createShaderModule(
+{
+label: '\u0a34\u{1fbe4}',
+code: `@group(4) @binding(2409)
+var<storage, read_write> type25: array<u32>;
+@group(5) @binding(4134)
+var<storage, read_write> field31: array<u32>;
+@group(2) @binding(509)
+var<storage, read_write> field32: array<u32>;
+@group(1) @binding(1510)
+var<storage, read_write> local18: array<u32>;
+@group(1) @binding(4639)
+var<storage, read_write> global27: array<u32>;
+@group(3) @binding(2409)
+var<storage, read_write> function24: array<u32>;
+@group(2) @binding(2687)
+var<storage, read_write> field33: array<u32>;
+@group(0) @binding(4639)
+var<storage, read_write> local19: array<u32>;
+@group(2) @binding(2200)
+var<storage, read_write> type26: array<u32>;
+
+@compute @workgroup_size(8, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(2) f0: u32,
+@location(5) f1: vec3<f32>,
+@location(6) f2: vec4<u32>,
+@location(4) f3: vec2<f32>,
+@builtin(sample_mask) f4: u32
+}
+
+@fragment
+fn fragment0(@location(70) a0: vec4<f16>, @location(50) a1: vec3<f32>, @location(78) a2: vec3<u32>, @location(54) a3: vec2<f32>, @location(18) a4: vec4<f16>, @location(27) a5: vec3<f32>, @location(12) a6: vec4<f32>, @builtin(front_facing) a7: bool, @location(32) a8: vec3<f16>, @location(26) a9: vec3<f32>, @builtin(sample_index) a10: u32, @builtin(sample_mask) a11: u32, @builtin(position) a12: vec4<f32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S20 {
+@builtin(vertex_index) f0: u32
+}
+struct VertexOutput0 {
+@location(27) f310: vec3<f32>,
+@location(54) f311: vec2<f32>,
+@location(70) f312: vec4<f16>,
+@location(32) f313: vec3<f16>,
+@location(50) f314: vec3<f32>,
+@location(78) f315: vec3<u32>,
+@location(26) f316: vec3<f32>,
+@location(18) f317: vec4<f16>,
+@location(12) f318: vec4<f32>,
+@builtin(position) f319: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec4<f32>, @location(21) a1: i32, @location(5) a2: u32, @location(1) a3: vec2<u32>, @location(9) a4: vec3<i32>, @location(6) a5: vec3<i32>, @location(17) a6: vec2<f16>, @location(10) a7: vec2<f32>, @location(4) a8: vec3<u32>, @location(16) a9: vec2<i32>, @builtin(instance_index) a10: u32, @location(20) a11: vec2<i32>, @location(2) a12: vec3<u32>, @location(15) a13: vec4<f16>, @location(18) a14: i32, @location(0) a15: u32, @location(3) a16: vec2<f32>, @location(19) a17: vec2<u32>, @location(8) a18: vec2<u32>, @location(7) a19: vec2<f16>, @location(12) a20: vec3<i32>, @location(11) a21: i32, a22: S20, @location(13) a23: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let querySet49 = device0.createQuerySet({
+label: '\ucefa\u6b97\u09a7\ue31c\u{1fcdb}\ua91e\u0143',
+type: 'occlusion',
+count: 2177,
+});
+let renderBundle50 = renderBundleEncoder16.finish(
+{
+label: '\u0739\u0cef'
+}
+);
+let sampler37 = device0.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+lodMinClamp: 89.903,
+lodMaxClamp: 97.869,
+}
+);
+try {
+renderPassEncoder6.setBindGroup(
+3,
+bindGroup13
+);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(
+3,
+bindGroup7,
+new Uint32Array(9245),
+5589,
+0
+);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(
+buffer3,
+'uint32',
+10436,
+2345
+);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(
+buffer5,
+'uint32',
+980,
+25524
+);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+9640,
+new Int16Array(16751),
+3442,
+3236
+);
+} catch {}
+try {
+device0.queue.writeTexture(
+{
+  texture: texture10,
+  mipLevel: 2,
+  origin: { x: 0, y: 49, z: 1 },
+  aspect: 'stencil-only',
+},
+new Int16Array(new ArrayBuffer(40)),
+/* required buffer size: 529 */{
+offset: 529,
+},
+{width: 63, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise28 = device0.createRenderPipelineAsync(
+{
+label: '\u245b\u{1f891}\u6c67\u0a16\u09cb\uffe3\u0f70',
+layout: pipelineLayout5,
+vertex: {
+module: shaderModule16,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 7476,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 6380,
+shaderLocation: 12,
+},
+{
+format: 'sint8x2',
+offset: 6574,
+shaderLocation: 18,
+},
+{
+format: 'float32x4',
+offset: 2040,
+shaderLocation: 20,
+},
+{
+format: 'snorm16x4',
+offset: 3980,
+shaderLocation: 13,
+},
+{
+format: 'snorm16x4',
+offset: 5404,
+shaderLocation: 21,
+}
+],
+},
+{
+arrayStride: 536,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x3',
+offset: 132,
+shaderLocation: 8,
+},
+{
+format: 'sint8x4',
+offset: 148,
+shaderLocation: 10,
+},
+{
+format: 'float32x3',
+offset: 368,
+shaderLocation: 9,
+},
+{
+format: 'uint16x4',
+offset: 376,
+shaderLocation: 14,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 388,
+shaderLocation: 7,
+},
+{
+format: 'sint32x3',
+offset: 188,
+shaderLocation: 0,
+},
+{
+format: 'sint16x2',
+offset: 476,
+shaderLocation: 17,
+},
+{
+format: 'unorm16x2',
+offset: 360,
+shaderLocation: 11,
+},
+{
+format: 'uint32x4',
+offset: 160,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 2804,
+attributes: [
+{
+format: 'snorm8x2',
+offset: 1838,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 8680,
+attributes: [
+{
+format: 'snorm8x2',
+offset: 494,
+shaderLocation: 4,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0xd5524ca6,
+},
+fragment: {
+module: shaderModule16,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'rg8uint',
+writeMask: 0,
+},
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rg11b10ufloat',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALL,
+}
+],
+},
+}
+);
+try {
+device0.destroy();
+} catch {}
+let videoFrame11 = new VideoFrame(img3, {timestamp: 0});
+let commandEncoder43 = device3.createCommandEncoder(
+{
+label: '\ud62a\u0fc4\u0c2a\u4792\u0682\u1be8\u3bfa\u0e87\ua723\u2f1c\u{1fcb4}',
+}
+);
+let querySet50 = device3.createQuerySet({
+label: '\u33b2\u080e\u563f\u08aa\u8bcc\u6bdc\u{1fc02}\u0a8d\ue3ad',
+type: 'occlusion',
+count: 2815,
+});
+let renderBundleEncoder36 = device1.createRenderBundleEncoder(
+{
+label: '\u{1f702}\u9d8a\uee50\ua4f3\u0ed8\u0be3',
+colorFormats: [
+undefined,
+'rg32float',
+'r16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 761,
+}
+);
+try {
+computePassEncoder11.setPipeline(
+pipeline71
+);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(
+0,
+bindGroup16
+);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(473);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -165.7, g: -680.6, b: 227.8, a: 869.7, });
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(
+5,
+buffer15,
+2836,
+2134
+);
+} catch {}
+let pipeline77 = await device1.createComputePipelineAsync(
+{
+label: '\uffbc\u{1f8b4}\u39b8\uaae1\u4773\u0279',
+layout: 'auto',
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let querySet51 = device2.createQuerySet({
+label: '\uce72\u5543\u{1fe20}\u0f87\u0c41\u064d\u9540',
+type: 'occlusion',
+count: 2151,
+});
+pseudoSubmit(device2, commandEncoder39);
+try {
+renderBundleEncoder35.setBindGroup(
+1,
+bindGroup17
+);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(
+53,
+undefined,
+3064711962,
+353989623
+);
+} catch {}
+try {
+buffer16.destroy();
+} catch {}
+let gpuCanvasContext11 = offscreenCanvas12.getContext('webgpu');
+canvas5.height = 515;
+try {
+device2.label = '\u841f\uac17\u{1f8b5}\u7245';
+} catch {}
+let bindGroup20 = device2.createBindGroup({
+label: '\u50c8\u210d\u1c06',
+layout: bindGroupLayout19,
+entries: [
+
+],
+});
+pseudoSubmit(device2, commandEncoder31);
+let textureView63 = texture57.createView(
+{
+label: '\ud03e\u3631\u{1fa2b}',
+baseMipLevel: 3,
+mipLevelCount: 10,
+}
+);
+let sampler38 = device2.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+lodMaxClamp: 84.740,
+}
+);
+try {
+renderBundleEncoder35.setVertexBuffer(
+72,
+undefined,
+2077054415,
+1038062310
+);
+} catch {}
+try {
+texture53.destroy();
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture52,
+  mipLevel: 1,
+  origin: { x: 4, y: 12, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer5,
+/* required buffer size: 1468 */{
+offset: 399,
+bytesPerRow: 303,
+rowsPerImage: 295,
+},
+{width: 40, height: 16, depthOrArrayLayers: 1}
+);
+} catch {}
+let commandEncoder44 = device3.createCommandEncoder(
+{
+label: '\u{1f6a2}\u074d\u64f7\u6c64\uc164',
+}
+);
+let renderBundleEncoder37 = device3.createRenderBundleEncoder(
+{
+label: '\u0be8\u0008',
+colorFormats: [
+undefined,
+'rgba8uint',
+'rg32float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 768,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler39 = device3.createSampler(
+{
+label: '\u53bc\u{1fb13}\u534f',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+lodMaxClamp: 83.930,
+}
+);
+try {
+commandEncoder44.clearBuffer(
+buffer19,
+34368,
+8
+);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+gpuCanvasContext2.configure(
+{
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let bindGroup21 = device1.createBindGroup({
+label: '\u0c88\ua1b6\u5f8f\ub66f\u{1f6a3}\u1190\ufe05',
+layout: bindGroupLayout21,
+entries: [
+
+],
+});
+let querySet52 = device1.createQuerySet({
+type: 'occlusion',
+count: 1940,
+});
+let renderPassEncoder14 = commandEncoder36.beginRenderPass(
+{
+label: '\u{1ff29}\ua181\u{1fb2d}\u3a9b\uf1a6',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+{
+view: textureView49,
+clearValue: { r: -789.2, g: -543.7, b: -982.9, a: 303.3, },
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+}
+);
+let renderBundle51 = renderBundleEncoder29.finish(
+{
+
+}
+);
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setViewport(
+19.98,
+12.78,
+1.511,
+0.02665,
+0.4191,
+0.7464
+);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(
+6,
+buffer15,
+1528,
+1256
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture42,
+  mipLevel: 4,
+  origin: { x: 0, y: 12, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer7,
+/* required buffer size: 623 */{
+offset: 623,
+},
+{width: 14, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+video2.width = 65;
+let offscreenCanvas13 = new OffscreenCanvas(411, 950);
+let imageBitmap9 = await createImageBitmap(videoFrame5);
+let img12 = await imageWithData(124, 175, '#424e9845', '#0f75468e');
+let bindGroup22 = device2.createBindGroup({
+label: '\u{1f841}\uc8de\u23af\u33ae\u0096\ub46e\u1e38\u0756\u4e84',
+layout: bindGroupLayout19,
+entries: [
+
+],
+});
+let buffer21 = device2.createBuffer(
+{
+label: '\u38b0\u{1fe8d}\u{1f8c3}\u0a1b\u0346\u016d\ufcb8',
+size: 23677,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandEncoder45 = device2.createCommandEncoder();
+let texture62 = device2.createTexture(
+{
+label: '\u0f85\u062e\u0ec1\ueb43\u6885\u9bff\u0830\u2937\u619e',
+size: [1810, 1, 229],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8snorm',
+'rgba8snorm',
+'rgba8snorm'
+],
+}
+);
+let computePassEncoder17 = commandEncoder45.beginComputePass(
+{
+
+}
+);
+try {
+renderBundleEncoder35.setVertexBuffer(
+93,
+undefined
+);
+} catch {}
+try {
+buffer13.destroy();
+} catch {}
+let texture63 = gpuCanvasContext3.getCurrentTexture();
+try {
+buffer19.destroy();
+} catch {}
+try {
+gpuCanvasContext8.configure(
+{
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+} catch {}
+let pipelineLayout16 = device1.createPipelineLayout(
+{
+label: '\u{1f75f}\u1099\u0f14\u{1fbaa}\u{1fe5c}\u0aed\u3900\ucb7a',
+bindGroupLayouts: [
+bindGroupLayout17,
+bindGroupLayout20,
+bindGroupLayout23,
+bindGroupLayout17,
+bindGroupLayout23
+]
+}
+);
+let texture64 = device1.createTexture(
+{
+label: '\u{1ff3c}\u{1fde2}\u63a1',
+size: {width: 184, height: 34, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+sampleCount: 1,
+format: 'rg32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let sampler40 = device1.createSampler(
+{
+label: '\u12f3\u09a3\u5df8\u666f\u0740',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 0.773,
+}
+);
+let externalTexture5 = device1.importExternalTexture(
+{
+label: '\u0553\u0015\u8567\u{1fe2d}\u460e\ub76f\u278d\u0267\u8fcf\u062f',
+source: videoFrame8,
+colorSpace: 'srgb',
+}
+);
+try {
+computePassEncoder13.setBindGroup(
+4,
+bindGroup16
+);
+} catch {}
+try {
+computePassEncoder13.setPipeline(
+pipeline77
+);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(653);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: -476.9, g: 731.7, b: 580.0, a: 989.1, });
+} catch {}
+let pipeline78 = await device1.createRenderPipelineAsync(
+{
+label: '\u{1fcc7}\u286a\u{1fe64}\u{1f82f}\ub9a9\u5c9c\u0847\u{1f945}',
+layout: pipelineLayout10,
+vertex: {
+module: shaderModule14,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 12148,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x4',
+offset: 4076,
+shaderLocation: 5,
+},
+{
+format: 'float16x2',
+offset: 10696,
+shaderLocation: 2,
+},
+{
+format: 'float16x2',
+offset: 2796,
+shaderLocation: 3,
+},
+{
+format: 'sint16x2',
+offset: 9352,
+shaderLocation: 4,
+},
+{
+format: 'sint32x3',
+offset: 8636,
+shaderLocation: 12,
+},
+{
+format: 'float32',
+offset: 10124,
+shaderLocation: 0,
+},
+{
+format: 'uint32x3',
+offset: 3504,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 4984,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 2184,
+shaderLocation: 1,
+},
+{
+format: 'uint16x4',
+offset: 576,
+shaderLocation: 14,
+},
+{
+format: 'unorm16x2',
+offset: 4804,
+shaderLocation: 6,
+},
+{
+format: 'unorm16x2',
+offset: 204,
+shaderLocation: 7,
+},
+{
+format: 'float16x4',
+offset: 2668,
+shaderLocation: 11,
+},
+{
+format: 'sint16x4',
+offset: 356,
+shaderLocation: 10,
+},
+{
+format: 'sint32x2',
+offset: 1160,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 20828,
+attributes: [
+
+],
+},
+{
+arrayStride: 6820,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 14064,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 2226,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 12868,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 8822,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule14,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16uint',
+},
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'one',
+dstFactor: 'one-minus-dst'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one-minus-constant',
+dstFactor: 'zero'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2823,
+stencilWriteMask: 607,
+depthBias: 26,
+depthBiasSlopeScale: 15,
+depthBiasClamp: 16,
+},
+}
+);
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas13.getContext('webgpu');
+} catch {}
+try {
+await promise26;
+} catch {}
+let video7 = await videoWithData();
+try {
+device3.queue.label = '\u18ff\u{1f7b9}\ue810\u6515\u0d03\u0ea9\u{1ff27}\u{1f8a7}\u0740\u2dae';
+} catch {}
+let bindGroupLayout27 = device3.createBindGroupLayout(
+{
+label: '\u0938\u0a8e\u1ec3\u02e3\u70e4\u{1faa5}\ue310\u0571',
+entries: [
+
+],
+}
+);
+let bindGroup23 = device3.createBindGroup({
+label: '\u40eb\u{1f742}\u4165\u0889\uc728\ue2a9\u34e3\uf0ae',
+layout: bindGroupLayout27,
+entries: [
+
+],
+});
+let pipelineLayout17 = device3.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout27,
+bindGroupLayout27,
+bindGroupLayout27,
+bindGroupLayout27,
+bindGroupLayout27,
+bindGroupLayout27,
+bindGroupLayout27,
+bindGroupLayout27
+]
+}
+);
+let texture65 = gpuCanvasContext2.getCurrentTexture();
+let adapter7 = await navigator.gpu.requestAdapter(
+{
+}
+);
+canvas0.width = 748;
+let device4 = await adapter6.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 51,
+maxVertexAttributes: 18,
+maxVertexBufferArrayStride: 30091,
+maxStorageTexturesPerShaderStage: 19,
+maxStorageBuffersPerShaderStage: 16,
+maxDynamicStorageBuffersPerPipelineLayout: 16610,
+maxBindingsPerBindGroup: 4058,
+maxTextureDimension1D: 10597,
+maxTextureDimension2D: 8983,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 30341357,
+maxUniformBuffersPerShaderStage: 23,
+maxInterStageShaderVariables: 69,
+maxInterStageShaderComponents: 65,
+maxSamplersPerShaderStage: 17,
+},
+});
+let imageBitmap10 = await createImageBitmap(img0);
+let bindGroupLayout28 = device0.createBindGroupLayout(
+{
+entries: [
+{
+binding: 2076,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}
+],
+}
+);
+let querySet53 = device0.createQuerySet({
+label: '\u{1f8b6}\u{1fbd6}\uc39f\u01ed\u0a73\ud9bb\u8238',
+type: 'occlusion',
+count: 3965,
+});
+let texture66 = device0.createTexture(
+{
+label: '\u626f\uea9b\ue881\u9186\u{1f834}\ud80c\u0bce\uf730',
+size: {width: 152, height: 1, depthOrArrayLayers: 302},
+mipLevelCount: 8,
+dimension: '3d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm',
+'bgra8unorm-srgb',
+'bgra8unorm-srgb'
+],
+}
+);
+let texture67 = gpuCanvasContext1.getCurrentTexture();
+let renderBundleEncoder38 = device0.createRenderBundleEncoder(
+{
+label: '\u4538\u28f5\u2c72\u63f2\uc926\u0fdf\u80d2\ua37c\u0750\ub3e0\u008a',
+colorFormats: [
+'rg32float',
+'rg8sint',
+'rgba32float',
+'rg16uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 582,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder11.setBindGroup(
+3,
+bindGroup9,
+new Uint32Array(2909),
+1496,
+0
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+36200,
+new DataView(new ArrayBuffer(54956)),
+2639,
+12532
+);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(
+/*
+{width: 175, height: 56, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 33, y: 25 },
+  flipY: false,
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 2, y: 18, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 57, height: 21, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline79 = device0.createComputePipeline(
+{
+label: '\ud798\u00eb\u0db8\u0f3a\u35a6\uf10c\u7691\u0ac6\u0ac8\u6a59',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+},
+}
+);
+let promise29 = navigator.gpu.requestAdapter(
+{
+powerPreference: 'high-performance',
+}
+);
+let texture68 = device2.createTexture(
+{
+label: '\ue520\u0f4c',
+size: [206, 109, 1],
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'stencil8'
+],
+}
+);
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(
+3,
+bindGroup17,
+new Uint32Array(3569),
+3282,
+0
+);
+} catch {}
+try {
+commandEncoder33.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 18720 */
+offset: 18720,
+bytesPerRow: 0,
+buffer: buffer21,
+},
+{
+  texture: texture52,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 4, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device2, buffer21);
+} catch {}
+try {
+commandEncoder33.clearBuffer(
+buffer16,
+11256,
+11320
+);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture57,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer2),
+/* required buffer size: 1190 */{
+offset: 246,
+bytesPerRow: 1225,
+rowsPerImage: 46,
+},
+{width: 59, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+offscreenCanvas1.width = 276;
+let renderBundleEncoder39 = device2.createRenderBundleEncoder(
+{
+label: '\uad62\udc9e\u5b08\u0637\ud567\u{1f75a}\u39c9\u8b21\u1fbe\u365e\u0338',
+colorFormats: [
+'r32sint',
+undefined,
+'rgba8unorm-srgb'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 169,
+}
+);
+try {
+commandEncoder33.copyTextureToTexture(
+{
+  texture: texture48,
+  mipLevel: 3,
+  origin: { x: 33, y: 11, z: 6 },
+  aspect: 'all',
+},
+{
+  texture: texture48,
+  mipLevel: 0,
+  origin: { x: 153, y: 102, z: 1 },
+  aspect: 'all',
+},
+{width: 110, height: 1, depthOrArrayLayers: 12}
+);
+} catch {}
+try {
+commandEncoder33.clearBuffer(
+buffer16,
+3052,
+11256
+);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let bindGroupLayout29 = device4.createBindGroupLayout(
+{
+label: '\u1698\u9ff1\u01ba\u09f4\u0069',
+entries: [
+{
+binding: 2325,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+},
+{
+binding: 3375,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '2d-array' },
+},
+{
+binding: 221,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+}
+],
+}
+);
+let texture69 = device4.createTexture(
+{
+label: '\u0101\uafa8\uf0a5\u{1fbce}',
+size: {width: 164, height: 1, depthOrArrayLayers: 131},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 41, height: 1, depthOrArrayLayers: 32}
+*/
+{
+  source: canvas4,
+  origin: { x: 173, y: 68 },
+  flipY: false,
+},
+{
+  texture: texture69,
+  mipLevel: 2,
+  origin: { x: 9, y: 0, z: 16 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 32, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipelineLayout18 = device4.createPipelineLayout(
+{
+label: '\u4503\u9ed9\u6f60\udb9f',
+bindGroupLayouts: [
+bindGroupLayout29,
+bindGroupLayout29,
+bindGroupLayout29,
+bindGroupLayout29
+]
+}
+);
+let buffer22 = device4.createBuffer(
+{
+label: '\u{1fef7}\u8723\u0ad9',
+size: 55986,
+usage: GPUBufferUsage.STORAGE,
+}
+);
+let sampler41 = device4.createSampler(
+{
+label: '\u0998\u1686\u0a9b\u{1fb81}\u461d\ufc76\u{1f726}',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 81.821,
+lodMaxClamp: 88.680,
+}
+);
+document.body.prepend(img1);
+let img13 = await imageWithData(195, 38, '#b764dd6d', '#31cfda00');
+let bindGroupLayout30 = device2.createBindGroupLayout(
+{
+label: '\udc1a\ub5c9\u0386\ua3f6\u0a6e\u{1f9ae}\u65c3\u0f7f\ud113\u0e6c\u92ac',
+entries: [
+{
+binding: 9120,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+},
+{
+binding: 7884,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '3d' },
+},
+{
+binding: 5223,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+let texture70 = device2.createTexture(
+{
+size: {width: 240, height: 8, depthOrArrayLayers: 19},
+mipLevelCount: 3,
+format: 'astc-10x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-10x8-unorm-srgb',
+'astc-10x8-unorm-srgb'
+],
+}
+);
+let computePassEncoder18 = commandEncoder33.beginComputePass(
+{
+
+}
+);
+let renderBundleEncoder40 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba16sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 11,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder17.setBindGroup(
+2,
+bindGroup19
+);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(
+4,
+bindGroup17
+);
+} catch {}
+try {
+await buffer21.mapAsync(
+GPUMapMode.WRITE,
+0,
+12556
+);
+} catch {}
+try {
+gpuCanvasContext6.configure(
+{
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-4x4-unorm',
+'rgba8unorm-srgb',
+'rgba8unorm',
+'rgba8unorm-srgb'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let commandBuffer5 = commandEncoder38.finish(
+{
+label: '\u0e32\u0e7c\u0ff1\ud934\u{1f7c3}\u937a\u82bf\u01f0\u{1f6fd}\u0f81\u{1fb2c}',
+}
+);
+let renderBundleEncoder41 = device1.createRenderBundleEncoder(
+{
+label: '\udb8a\u0915\u{1f8c0}\u8875',
+colorFormats: [
+'r16float'
+],
+sampleCount: 8,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder11.setBindGroup(
+4,
+bindGroup21,
+new Uint32Array(1660),
+686,
+0
+);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setViewport(
+13.70,
+17.06,
+9.372,
+2.848,
+0.3745,
+0.9559
+);
+} catch {}
+try {
+renderBundleEncoder20.pushDebugGroup(
+'\u0a99'
+);
+} catch {}
+let pipeline80 = await device1.createComputePipelineAsync(
+{
+label: '\u083b\u0795\u2b3e\u0c32',
+layout: 'auto',
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+gc();
+let bindGroup24 = device2.createBindGroup({
+label: '\u9fde\u2e2f\u{1fac2}\u016a',
+layout: bindGroupLayout19,
+entries: [
+
+],
+});
+let texture71 = device2.createTexture(
+{
+label: '\u083a\u{1fbb0}\u{1fadd}\u705f\ub19c\u4843\u985c\ucd31',
+size: {width: 1539, height: 4, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+computePassEncoder17.setBindGroup(
+2,
+bindGroup24,
+new Uint32Array(4773),
+560,
+0
+);
+} catch {}
+try {
+await promise27;
+} catch {}
+try {
+adapter5.label = '\u0401\uc805\u{1fbac}';
+} catch {}
+let shaderModule23 = device4.createShaderModule(
+{
+label: '\u405a\u8043\u{1fd88}\u0b77\u5472\u{1fa4e}\u3aed\u5942',
+code: `@group(2) @binding(221)
+var<storage, read_write> parameter24: array<u32>;
+@group(3) @binding(221)
+var<storage, read_write> parameter25: array<u32>;
+@group(1) @binding(3375)
+var<storage, read_write> parameter26: array<u32>;
+@group(2) @binding(3375)
+var<storage, read_write> function25: array<u32>;
+@group(0) @binding(3375)
+var<storage, read_write> field34: array<u32>;
+@group(0) @binding(221)
+var<storage, read_write> global28: array<u32>;
+@group(0) @binding(2325)
+var<storage, read_write> global29: array<u32>;
+@group(1) @binding(2325)
+var<storage, read_write> local20: array<u32>;
+
+@compute @workgroup_size(3, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: vec3<f32>,
+@location(7) f1: vec4<u32>,
+@builtin(frag_depth) f2: f32,
+@location(0) f3: vec4<u32>,
+@location(2) f4: vec3<i32>,
+@location(4) f5: vec3<u32>,
+@location(5) f6: vec3<i32>,
+@location(1) f7: vec4<i32>,
+@builtin(sample_mask) f8: u32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S21 {
+@location(15) f0: f32,
+@location(2) f1: vec4<u32>,
+@location(6) f2: vec4<u32>,
+@location(8) f3: vec2<i32>,
+@location(14) f4: vec2<f32>,
+@location(16) f5: i32
+}
+
+@vertex
+fn vertex0(@location(13) a0: vec3<f32>, @location(9) a1: vec3<f16>, @location(5) a2: vec4<u32>, @location(4) a3: u32, @location(11) a4: vec4<u32>, @location(1) a5: f32, a6: S21, @location(17) a7: i32, @location(12) a8: f16, @builtin(vertex_index) a9: u32, @location(3) a10: f16, @location(0) a11: vec2<f32>, @location(10) a12: vec4<f16>, @location(7) a13: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+try {
+adapter0.label = '\u0eb5\u{1f87b}\ub48a\ufa57\u008c';
+} catch {}
+let commandEncoder46 = device2.createCommandEncoder(
+{
+}
+);
+let textureView64 = texture70.createView(
+{
+label: '\u{1f867}\u0c2c\u002b\u05dc\u00e4\u96ca',
+dimension: '2d',
+aspect: 'all',
+baseMipLevel: 1,
+baseArrayLayer: 1,
+}
+);
+try {
+commandEncoder46.copyBufferToBuffer(
+buffer21,
+21744,
+buffer16,
+17944,
+420
+);
+dissociateBuffer(device2, buffer21);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+try {
+await promise14;
+} catch {}
+video5.width = 66;
+let querySet54 = device4.createQuerySet({
+type: 'occlusion',
+count: 1948,
+});
+let pipeline81 = device4.createRenderPipeline(
+{
+layout: pipelineLayout18,
+vertex: {
+module: shaderModule23,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 23500,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 11112,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x4',
+offset: 2832,
+shaderLocation: 0,
+},
+{
+format: 'float16x4',
+offset: 4396,
+shaderLocation: 14,
+},
+{
+format: 'uint8x2',
+offset: 19842,
+shaderLocation: 7,
+},
+{
+format: 'uint32',
+offset: 1780,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x4',
+offset: 15208,
+shaderLocation: 10,
+},
+{
+format: 'sint32x2',
+offset: 9284,
+shaderLocation: 8,
+},
+{
+format: 'snorm16x4',
+offset: 16208,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 6280,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x2',
+offset: 3948,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x4',
+offset: 5636,
+shaderLocation: 12,
+},
+{
+format: 'float32x4',
+offset: 784,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 13960,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 4744,
+shaderLocation: 4,
+},
+{
+format: 'uint32x2',
+offset: 9672,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 7644,
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 3008,
+shaderLocation: 9,
+},
+{
+format: 'uint32',
+offset: 6812,
+shaderLocation: 6,
+},
+{
+format: 'sint32x4',
+offset: 212,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 9828,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 3872,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x2',
+offset: 1680,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x4',
+offset: 3412,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x1188602d,
+},
+fragment: {
+module: shaderModule23,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgba32uint',
+writeMask: GPUColorWrite.ALL,
+},
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+{
+format: 'r32sint',
+writeMask: 0,
+},
+undefined,
+{
+format: 'rg16uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 871,
+depthBias: 67,
+depthBiasSlopeScale: 29,
+depthBiasClamp: 54,
+},
+}
+);
+try {
+window.someLabel = device3.queue.label;
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+renderBundleEncoder37.insertDebugMarker(
+'\u424d'
+);
+} catch {}
+try {
+commandEncoder24.label = '\u0a22\u5991\u5e26\u{1f856}\u8b27\uf5ea\u085c\ue478\u5f2e\u4abc';
+} catch {}
+let bindGroup25 = device1.createBindGroup({
+layout: bindGroupLayout20,
+entries: [
+
+],
+});
+let textureView65 = texture44.createView(
+{
+label: '\u00eb\u8151',
+aspect: 'depth-only',
+baseMipLevel: 5,
+mipLevelCount: 1,
+}
+);
+try {
+computePassEncoder13.setBindGroup(
+0,
+bindGroup25,
+new Uint32Array(4982),
+4294,
+0
+);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(
+2,
+bindGroup21
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture33,
+  mipLevel: 0,
+  origin: { x: 437, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(64),
+/* required buffer size: 4285 */{
+offset: 761,
+},
+{width: 881, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let querySet55 = device1.createQuerySet({
+label: '\u087e\ue3b7\u{1faf8}\u3e84\u7aef\ud0f2\ud99c\u0003\u0adc\u01f3',
+type: 'occlusion',
+count: 1804,
+});
+let renderPassEncoder15 = commandEncoder41.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+{
+view: textureView49,
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet32,
+maxDrawCount: 87824,
+}
+);
+try {
+computePassEncoder13.setBindGroup(
+4,
+bindGroup21,
+[]
+);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(
+4,
+buffer15
+);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(
+0,
+bindGroup25,
+new Uint32Array(9647),
+1336,
+0
+);
+} catch {}
+let querySet56 = device4.createQuerySet({
+label: '\u3355\u0e34\u{1f734}\u{1f745}\u{1f9b8}\u078d\ucbc2\ude2d\u04ce\u43fc\u0e55',
+type: 'occlusion',
+count: 1915,
+});
+let texture72 = device4.createTexture(
+{
+size: [164, 62, 1],
+mipLevelCount: 7,
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+
+],
+}
+);
+let arrayBuffer8 = buffer21.getMappedRange(
+0,
+5364
+);
+try {
+window.someLabel = device2.label;
+} catch {}
+let bindGroupLayout31 = device2.createBindGroupLayout(
+{
+label: '\ue0c4\u{1fa5a}\u092b\u{1f636}\u0505\u06c9\u{1f714}\u02cc\ubb09\u5b49\u0815',
+entries: [
+{
+binding: 8983,
+visibility: 0,
+texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+},
+{
+binding: 8951,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'non-filtering' },
+}
+],
+}
+);
+let commandEncoder47 = device2.createCommandEncoder(
+{
+label: '\u494d\u0b39\u06e2',
+}
+);
+let textureView66 = texture49.createView(
+{
+label: '\u0a7d\u{1fa30}\u023f\u7280\u32b4\uab9a\u40e2\u{1f946}\ud939\u7467\u091e',
+dimension: '2d',
+mipLevelCount: 1,
+baseArrayLayer: 111,
+}
+);
+let renderBundleEncoder42 = device2.createRenderBundleEncoder(
+{
+label: '\u0d9e\u3ff4\u0025\u05db\u1b58\u06ac',
+colorFormats: [
+'r16uint',
+'rg16uint',
+'rgba16sint',
+undefined,
+'rgba32sint',
+'r16uint',
+'r16uint',
+'rg32float'
+],
+sampleCount: 750,
+depthReadOnly: true,
+}
+);
+let sampler42 = device2.createSampler(
+{
+label: '\u{1fed7}\u0c20\u7ee1\u9846\u2f32\u08c0',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 20.654,
+lodMaxClamp: 72.429,
+}
+);
+try {
+renderBundleEncoder42.setBindGroup(
+8,
+bindGroup22
+);
+} catch {}
+try {
+commandEncoder46.copyTextureToTexture(
+{
+  texture: texture48,
+  mipLevel: 4,
+  origin: { x: 30, y: 3, z: 6 },
+  aspect: 'all',
+},
+{
+  texture: texture48,
+  mipLevel: 0,
+  origin: { x: 1039, y: 101, z: 12 },
+  aspect: 'all',
+},
+{width: 35, height: 1, depthOrArrayLayers: 5}
+);
+} catch {}
+try {
+commandEncoder47.clearBuffer(
+buffer16,
+16756,
+3868
+);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture48,
+  mipLevel: 4,
+  origin: { x: 10, y: 1, z: 6 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer6),
+/* required buffer size: 207007 */{
+offset: 581,
+bytesPerRow: 594,
+rowsPerImage: 115,
+},
+{width: 77, height: 3, depthOrArrayLayers: 4}
+);
+} catch {}
+let videoFrame12 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let querySet57 = device2.createQuerySet({
+label: '\uf940\u{1f9d1}\u0eb5\u0556\u09a2\u283e',
+type: 'occlusion',
+count: 542,
+});
+let textureView67 = texture53.createView(
+{
+}
+);
+let externalTexture6 = device2.importExternalTexture(
+{
+label: '\u2e9c\u1c6a\u2357\u{1faa7}\u7b8d\ue231\u{1fdd0}\u02f8\u{1f760}\ubba7',
+source: videoFrame7,
+colorSpace: 'srgb',
+}
+);
+try {
+await device2.popErrorScope();
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(
+buffer21,
+5392,
+buffer16,
+28484,
+20
+);
+dissociateBuffer(device2, buffer21);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+commandEncoder47.clearBuffer(
+buffer16,
+4316,
+348
+);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+adapter2.label = '\ue4da\u0279\u055d\u1f94\u7473\u0e27\u0aa9\uf364\uc9d6\ueec8';
+} catch {}
+let renderBundleEncoder43 = device2.createRenderBundleEncoder(
+{
+label: '\u8db4\u05e0\ub4c3',
+colorFormats: [
+'rgba16uint',
+'r16sint'
+],
+sampleCount: 551,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle52 = renderBundleEncoder40.finish(
+{
+label: '\u{1f602}\u058f\u0813\u09ac\u2778'
+}
+);
+try {
+commandEncoder46.copyBufferToBuffer(
+buffer21,
+720,
+buffer16,
+5676,
+6444
+);
+dissociateBuffer(device2, buffer21);
+dissociateBuffer(device2, buffer16);
+} catch {}
+let video8 = await videoWithData();
+let commandEncoder48 = device4.createCommandEncoder(
+{
+}
+);
+document.body.prepend(video8);
+try {
+await promise23;
+} catch {}
+let bindGroup26 = device3.createBindGroup({
+label: '\u{1f6d3}\ub47c\u040b\u41ae\u05a6\u084f\u498b\u0e5e\u{1fbb0}\u0103',
+layout: bindGroupLayout27,
+entries: [
+
+],
+});
+let querySet58 = device3.createQuerySet({
+label: '\u{1fb59}\u9fa2\u9635\ud3ab\u0b71\ub148',
+type: 'occlusion',
+count: 196,
+});
+let textureView68 = texture63.createView(
+{
+dimension: '2d-array',
+}
+);
+let computePassEncoder19 = commandEncoder43.beginComputePass(
+{
+
+}
+);
+try {
+commandEncoder44.clearBuffer(
+buffer19,
+28572,
+5492
+);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture65,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(398),
+/* required buffer size: 398 */{
+offset: 398,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+offscreenCanvas6.width = 948;
+let bindGroupLayout32 = device2.createBindGroupLayout(
+{
+label: '\u{1f936}\ue6b4\u5189\ub0b2\u2b59\uaffb',
+entries: [
+
+],
+}
+);
+let computePassEncoder20 = commandEncoder46.beginComputePass();
+try {
+device2.queue.submit([
+]);
+} catch {}
+let computePassEncoder21 = commandEncoder47.beginComputePass(
+{
+label: '\u18d7\uc4f9\u259c\ue3a7\u246d\u8cfe\u02fa\ua5b6\u{1f90b}\u{1f8c8}\u007f'
+}
+);
+try {
+device2.queue.submit([
+]);
+} catch {}
+document.body.prepend(video3);
+let textureView69 = texture48.createView(
+{
+label: '\u6392\u048d\ubab2\u039c',
+baseMipLevel: 3,
+mipLevelCount: 1,
+baseArrayLayer: 16,
+arrayLayerCount: 1,
+}
+);
+try {
+computePassEncoder18.setBindGroup(
+5,
+bindGroup17,
+new Uint32Array(9846),
+1630,
+0
+);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(
+8,
+bindGroup19
+);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(
+8,
+undefined,
+705954778,
+503178334
+);
+} catch {}
+try {
+await promise2;
+} catch {}
+let querySet59 = device3.createQuerySet({
+label: '\u078c\ua251\u87c7\u2e36\u0fe6\ub49e\ubb0a\u1f0c\u035d\u086d',
+type: 'occlusion',
+count: 164,
+});
+try {
+commandEncoder44.copyTextureToTexture(
+{
+  texture: texture63,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture65,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder44.clearBuffer(
+buffer19,
+34544,
+124
+);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+gpuCanvasContext9.configure(
+{
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+texture65.label = '\u09ce\u951b\u04a8\u0eb6\ud2f8\u{1f8d5}\uf7c4\u27cc\u{1ff35}';
+} catch {}
+let texture73 = device3.createTexture(
+{
+label: '\u4031\u01a2',
+size: {width: 48, height: 1, depthOrArrayLayers: 182},
+mipLevelCount: 3,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+try {
+renderBundleEncoder37.setVertexBuffer(
+21,
+undefined,
+1979675325,
+927132482
+);
+} catch {}
+let bindGroupLayout33 = device2.createBindGroupLayout(
+{
+label: '\uc653\u{1fde4}\u033d',
+entries: [
+{
+binding: 1144,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+try {
+renderBundleEncoder43.setBindGroup(
+1,
+bindGroup24,
+new Uint32Array(6854),
+3881,
+0
+);
+} catch {}
+try {
+gpuCanvasContext6.configure(
+{
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+computePassEncoder13.setBindGroup(
+3,
+bindGroup21,
+new Uint32Array(1724),
+261,
+0
+);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: -167.2, g: -516.6, b: -857.2, a: -463.7, });
+} catch {}
+try {
+renderPassEncoder14.setViewport(
+27.49,
+2.717,
+0.3897,
+20.78,
+0.6756,
+0.7072
+);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(
+6,
+buffer15
+);
+} catch {}
+let canvas10 = document.createElement('canvas');
+let textureView70 = texture65.createView(
+{
+dimension: '2d-array',
+baseArrayLayer: 0,
+}
+);
+let computePassEncoder22 = commandEncoder44.beginComputePass(
+{
+label: '\u021c\u{1f653}'
+}
+);
+try {
+texture65.destroy();
+} catch {}
+let commandEncoder49 = device1.createCommandEncoder(
+{
+label: '\uf179\u{1fe4c}\u680e',
+}
+);
+let renderBundleEncoder44 = device1.createRenderBundleEncoder(
+{
+label: '\u9285\u{1f788}\uba17\u5171\u0fcc\u8bc2\u0a36\u{1fa2c}\u08d2\u4f57',
+colorFormats: [
+'rg16float',
+'rgba16float',
+'r32float',
+'rgba8uint',
+'rgba8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 605,
+depthReadOnly: true,
+}
+);
+let renderBundle53 = renderBundleEncoder22.finish(
+{
+label: '\u04ad\u9e40'
+}
+);
+try {
+renderPassEncoder15.setVertexBuffer(
+6,
+buffer15,
+928
+);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture56,
+  mipLevel: 2,
+  origin: { x: 96, y: 0, z: 10 },
+  aspect: 'all',
+},
+new ArrayBuffer(0),
+/* required buffer size: 6273376 */{
+offset: 799,
+bytesPerRow: 1169,
+rowsPerImage: 185,
+},
+{width: 223, height: 1, depthOrArrayLayers: 30}
+);
+} catch {}
+let pipeline82 = await device1.createComputePipelineAsync(
+{
+layout: pipelineLayout8,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+canvas10.getContext('webgl');
+} catch {}
+try {
+pipeline30.label = '\u0efd\u453d\u{1f9e3}\u0a95\u2a1f\u{1fa14}';
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(
+2,
+bindGroup12
+);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(
+0,
+buffer20
+);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise30 = device0.createComputePipelineAsync(
+{
+layout: pipelineLayout6,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline83 = await device0.createRenderPipelineAsync(
+{
+label: '\u{1fa43}\u067c\u7bdd\u264c\u6ec6\u0887\u{1fc6b}\u4cce',
+layout: pipelineLayout7,
+vertex: {
+module: shaderModule22,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 8188,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x2',
+offset: 4784,
+shaderLocation: 9,
+},
+{
+format: 'sint32',
+offset: 4748,
+shaderLocation: 18,
+},
+{
+format: 'uint32x2',
+offset: 6312,
+shaderLocation: 13,
+},
+{
+format: 'uint32x3',
+offset: 28,
+shaderLocation: 2,
+},
+{
+format: 'float32x4',
+offset: 5388,
+shaderLocation: 10,
+},
+{
+format: 'uint32x4',
+offset: 8156,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x2',
+offset: 4252,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x4',
+offset: 2476,
+shaderLocation: 3,
+},
+{
+format: 'sint8x2',
+offset: 6480,
+shaderLocation: 6,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 3520,
+shaderLocation: 17,
+},
+{
+format: 'sint8x2',
+offset: 7276,
+shaderLocation: 16,
+},
+{
+format: 'uint8x4',
+offset: 2508,
+shaderLocation: 19,
+},
+{
+format: 'uint8x2',
+offset: 7590,
+shaderLocation: 8,
+},
+{
+format: 'sint8x2',
+offset: 3680,
+shaderLocation: 12,
+},
+{
+format: 'sint32',
+offset: 3480,
+shaderLocation: 11,
+},
+{
+format: 'uint32',
+offset: 1776,
+shaderLocation: 5,
+},
+{
+format: 'float16x4',
+offset: 904,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 12028,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 1208,
+shaderLocation: 21,
+}
+],
+},
+{
+arrayStride: 7236,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 3192,
+shaderLocation: 0,
+},
+{
+format: 'sint32x4',
+offset: 4804,
+shaderLocation: 20,
+},
+{
+format: 'uint16x4',
+offset: 6844,
+shaderLocation: 1,
+},
+{
+format: 'float32x4',
+offset: 2796,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 1,
+mask: 0x12c2e1b1,
+},
+fragment: {
+module: shaderModule22,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+{
+format: 'r16uint',
+},
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'greater-equal',
+depthFailOp: 'zero',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'invert',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-clamp',
+},
+stencilWriteMask: 3343,
+depthBias: 74,
+depthBiasSlopeScale: 19,
+depthBiasClamp: 9,
+},
+}
+);
+gc();
+try {
+externalTexture0.label = '\ue176\u666c';
+} catch {}
+let textureView71 = texture49.createView(
+{
+label: '\uedfc\uda71\u0093\u0bbb\udd6e\u{1fa9c}',
+baseMipLevel: 2,
+baseArrayLayer: 175,
+arrayLayerCount: 2,
+}
+);
+try {
+renderBundleEncoder35.setVertexBuffer(
+70,
+undefined,
+2548741158
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture62,
+  mipLevel: 1,
+  origin: { x: 309, y: 0, z: 15 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer7),
+/* required buffer size: 53603811 */{
+offset: 611,
+bytesPerRow: 2406,
+rowsPerImage: 282,
+},
+{width: 583, height: 1, depthOrArrayLayers: 80}
+);
+} catch {}
+let promise31 = device2.queue.onSubmittedWorkDone();
+try {
+await promise25;
+} catch {}
+let buffer23 = device2.createBuffer(
+{
+label: '\u{1fb97}\u9bfe\u041c\u03ce\u31a7\u1a25\u7cc1\u4f23\u{1fbfb}\u07a8',
+size: 50044,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let arrayBuffer9 = buffer21.getMappedRange(
+10816,
+1596
+);
+let canvas11 = document.createElement('canvas');
+gc();
+let bindGroup27 = device3.createBindGroup({
+label: '\u658a\u0784\u1c05\u7814\u9d96\u08be',
+layout: bindGroupLayout27,
+entries: [
+
+],
+});
+let commandEncoder50 = device3.createCommandEncoder(
+{
+label: '\u0606\u{1f660}\u0162\u0b35\ub3fb\u2e8d\ua0c1',
+}
+);
+let textureView72 = texture73.createView(
+{
+dimension: '2d',
+baseMipLevel: 2,
+baseArrayLayer: 154,
+}
+);
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule24 = device4.createShaderModule(
+{
+label: '\u00d6\u0e2e\u880e\u0c1b\u308a\uac14\ubd69\u68b8\u363d',
+code: `@group(3) @binding(221)
+var<storage, read_write> field35: array<u32>;
+@group(3) @binding(2325)
+var<storage, read_write> local21: array<u32>;
+@group(3) @binding(3375)
+var<storage, read_write> type27: array<u32>;
+@group(2) @binding(3375)
+var<storage, read_write> local22: array<u32>;
+@group(0) @binding(2325)
+var<storage, read_write> global30: array<u32>;
+@group(1) @binding(2325)
+var<storage, read_write> function26: array<u32>;
+@group(0) @binding(221)
+var<storage, read_write> type28: array<u32>;
+
+@compute @workgroup_size(3, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S22 {
+@location(8) f0: vec3<f32>,
+@location(52) f1: vec4<u32>,
+@builtin(front_facing) f2: bool,
+@location(53) f3: vec4<i32>
+}
+struct FragmentOutput0 {
+@location(3) f0: vec2<u32>,
+@location(5) f1: vec2<f32>,
+@location(1) f2: vec4<i32>,
+@builtin(sample_mask) f3: u32
+}
+
+@fragment
+fn fragment0(@location(0) a0: u32, @location(29) a1: f16, a2: S22) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(38) f320: vec2<f16>,
+@location(2) f321: vec3<u32>,
+@location(52) f322: vec4<u32>,
+@location(9) f323: vec3<f32>,
+@location(46) f324: u32,
+@location(39) f325: vec3<f32>,
+@builtin(position) f326: vec4<f32>,
+@location(53) f327: vec4<i32>,
+@location(12) f328: vec2<u32>,
+@location(49) f329: vec3<u32>,
+@location(67) f330: i32,
+@location(8) f331: vec3<f32>,
+@location(61) f332: vec3<u32>,
+@location(65) f333: i32,
+@location(26) f334: u32,
+@location(48) f335: vec3<f16>,
+@location(24) f336: vec4<u32>,
+@location(58) f337: u32,
+@location(0) f338: u32,
+@location(14) f339: vec2<f32>,
+@location(29) f340: f16,
+@location(28) f341: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec3<u32>, @location(7) a1: u32, @location(17) a2: vec4<u32>, @location(8) a3: vec3<f32>, @location(2) a4: vec3<f16>, @location(4) a5: f16, @location(16) a6: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let texture74 = device4.createTexture(
+{
+label: '\u89e7\u0d4e\u{1fa8f}\uc423\u0296',
+size: [6527],
+dimension: '1d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+gpuCanvasContext6.configure(
+{
+device: device4,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgba16float',
+'rgba32uint',
+'astc-8x8-unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture69,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 5 },
+  aspect: 'all',
+},
+new Float32Array(arrayBuffer8),
+/* required buffer size: 677 */{
+offset: 677,
+},
+{width: 10, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline84 = await device4.createRenderPipelineAsync(
+{
+label: '\ubd9e\u{1f74b}\u0e82\u{1fba5}\u0bc8\u{1fa7e}',
+layout: pipelineLayout18,
+vertex: {
+module: shaderModule24,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 4212,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 1296,
+shaderLocation: 4,
+},
+{
+format: 'uint32x2',
+offset: 1652,
+shaderLocation: 17,
+},
+{
+format: 'uint16x2',
+offset: 1544,
+shaderLocation: 7,
+},
+{
+format: 'uint16x4',
+offset: 2240,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x2',
+offset: 3456,
+shaderLocation: 8,
+},
+{
+format: 'unorm16x2',
+offset: 2796,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 21780,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 28160,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 11092,
+attributes: [
+
+],
+},
+{
+arrayStride: 3884,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 2868,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule24,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'rgba8sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+undefined
+],
+},
+}
+);
+let commandEncoder51 = device3.createCommandEncoder(
+{
+label: '\u{1ffdb}\u{1f7db}\u{1f7b2}\u{1f9cd}\u03a1',
+}
+);
+let textureView73 = texture73.createView(
+{
+label: '\u019b\u{1f8b7}\ub209',
+dimension: '2d-array',
+aspect: 'depth-only',
+baseMipLevel: 2,
+baseArrayLayer: 114,
+arrayLayerCount: 3,
+}
+);
+let renderBundleEncoder45 = device3.createRenderBundleEncoder(
+{
+label: '\u337e\u6eb9\u098a\ua4e7\u08ab\u59b9\u{1fd91}\u{1f823}\u0409\u084d',
+colorFormats: [
+'rg16float',
+'rg8uint',
+'r8sint',
+'rgba16sint',
+undefined,
+'rg8unorm',
+'rgba32sint'
+],
+sampleCount: 18,
+stencilReadOnly: true,
+}
+);
+let renderBundle54 = renderBundleEncoder37.finish(
+{
+label: '\u{1fbaa}\u9799\ubc7c\u043c'
+}
+);
+try {
+commandEncoder50.copyTextureToTexture(
+{
+  texture: texture63,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture65,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageData6 = new ImageData(136, 52);
+try {
+renderBundleEncoder45.setBindGroup(
+4,
+bindGroup27,
+new Uint32Array(1336),
+311,
+0
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture60,
+  mipLevel: 1,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 518 */{
+offset: 489,
+},
+{width: 29, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let offscreenCanvas14 = new OffscreenCanvas(991, 202);
+let shaderModule25 = device4.createShaderModule(
+{
+label: '\ud389\u2495\udcb7\u080d\u36ae\u0af4\u7972\u2ff2\u{1fcb1}',
+code: `@group(3) @binding(2325)
+var<storage, read_write> type29: array<u32>;
+@group(2) @binding(221)
+var<storage, read_write> type30: array<u32>;
+@group(2) @binding(2325)
+var<storage, read_write> function27: array<u32>;
+@group(1) @binding(2325)
+var<storage, read_write> i17: array<u32>;
+@group(3) @binding(3375)
+var<storage, read_write> function28: array<u32>;
+@group(0) @binding(2325)
+var<storage, read_write> global31: array<u32>;
+@group(1) @binding(221)
+var<storage, read_write> function29: array<u32>;
+@group(3) @binding(221)
+var<storage, read_write> local23: array<u32>;
+@group(0) @binding(221)
+var<storage, read_write> local24: array<u32>;
+
+@compute @workgroup_size(6, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_index) a1: u32, @builtin(sample_mask) a2: u32, @builtin(position) a3: vec4<f32>) -> @builtin(frag_depth) f32 {
+return f32();
+}
+
+
+
+@vertex
+fn vertex0(@location(14) a0: vec2<f16>, @location(11) a1: vec3<f16>, @location(16) a2: vec2<f16>, @location(13) a3: u32, @location(10) a4: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let pipelineLayout19 = device4.createPipelineLayout(
+{
+label: '\u{1fd9f}\u0869',
+bindGroupLayouts: [
+bindGroupLayout29,
+bindGroupLayout29,
+bindGroupLayout29
+]
+}
+);
+let textureView74 = texture69.createView(
+{
+label: '\ufedb\u2558\ua8c0\u094d\u{1fae1}\u7dec\u8142',
+format: 'rgba16float',
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+try {
+device4.queue.writeTexture(
+{
+  texture: texture69,
+  mipLevel: 3,
+  origin: { x: 11, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int8Array(arrayBuffer6),
+/* required buffer size: 156191 */{
+offset: 701,
+bytesPerRow: 142,
+rowsPerImage: 73,
+},
+{width: 2, height: 0, depthOrArrayLayers: 16}
+);
+} catch {}
+let pipeline85 = device4.createComputePipeline(
+{
+label: '\u{1f67e}\ud3e7\u{1fd9f}\u3d2c',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule23,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let gpuCanvasContext12 = canvas11.getContext('webgpu');
+let texture75 = device3.createTexture(
+{
+label: '\u{1fda6}\u{1fe1e}\uc751\uf88b\uea01\u93d0\u{1fa32}\u0fe6\u{1f758}\ua78e',
+size: {width: 2110},
+dimension: '1d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm',
+'rgba8unorm',
+'rgba8unorm'
+],
+}
+);
+let sampler43 = device3.createSampler(
+{
+label: '\u3727\u3428',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 46.361,
+lodMaxClamp: 47.481,
+maxAnisotropy: 18,
+}
+);
+let pipelineLayout20 = device2.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout33,
+bindGroupLayout22,
+bindGroupLayout19
+]
+}
+);
+let querySet60 = device2.createQuerySet({
+label: '\u0780\u373e\u7085\u2a05\u0be5\u0a9d\u01a3\u0f98\u540b\ua23a\u0d35',
+type: 'occlusion',
+count: 722,
+});
+let texture76 = device2.createTexture(
+{
+label: '\u244a\uc01b\u{1fed0}\u{1fdd2}\u7c51\u2535\u{1ff3d}\u{1f655}\u0af7',
+size: [124, 16, 246],
+mipLevelCount: 6,
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+}
+);
+let renderBundleEncoder46 = device2.createRenderBundleEncoder(
+{
+label: '\u05f1\u{1fc8e}\u814a\u{1f732}\u5415\u0d55\u7815',
+colorFormats: [
+'r16uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 617,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder17.pushDebugGroup(
+'\u39bf'
+);
+} catch {}
+let renderBundleEncoder47 = device2.createRenderBundleEncoder(
+{
+label: '\uba2f\u0e76\u0c46\u01c4\u154a\u496d\u{1feb6}\u0323',
+colorFormats: [
+'rgba32float',
+undefined,
+undefined,
+'rg8unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 44,
+}
+);
+document.body.prepend(video1);
+pseudoSubmit(device4, commandEncoder48);
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+let pipelineLayout21 = device3.createPipelineLayout(
+{
+label: '\u{1fad6}\u7743\u479d',
+bindGroupLayouts: [
+bindGroupLayout27,
+bindGroupLayout27,
+bindGroupLayout27
+]
+}
+);
+let commandEncoder52 = device3.createCommandEncoder(
+{
+}
+);
+let querySet61 = device3.createQuerySet({
+label: '\u87e9\u0277\u8737',
+type: 'occlusion',
+count: 3863,
+});
+let renderBundleEncoder48 = device3.createRenderBundleEncoder(
+{
+label: '\u181b\u59f9\ua3a1\u{1fc33}\u85ca\uf033\u04b6\u7ca2\u{1f64e}\u0a20\u0540',
+colorFormats: [
+'rg8sint',
+'rgba16uint',
+'rgba32float',
+'rg32float',
+'rg32sint',
+undefined,
+'rg16float',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 80,
+}
+);
+try {
+computePassEncoder22.setBindGroup(
+0,
+bindGroup27,
+[]
+);
+} catch {}
+try {
+commandEncoder52.clearBuffer(
+buffer19,
+172,
+8344
+);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let video9 = await videoWithData();
+let bindGroup28 = device3.createBindGroup({
+label: '\u{1f75b}\ud3a4\u1413\ua10f\u{1fabd}',
+layout: bindGroupLayout27,
+entries: [
+
+],
+});
+let commandEncoder53 = device3.createCommandEncoder(
+{
+label: '\u140e\u09bf\ud39c\u3bd8',
+}
+);
+let textureView75 = texture75.createView(
+{
+label: '\u0694\u2eb9\udc23\ub047\u{1fdcd}\uc9f6\u5a78\ufddc',
+baseMipLevel: 0,
+}
+);
+try {
+computePassEncoder22.setBindGroup(
+8,
+bindGroup26
+);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(
+21,
+undefined,
+3403160581
+);
+} catch {}
+gc();
+let img14 = await imageWithData(74, 152, '#cbe2d79f', '#2f90beaf');
+let commandEncoder54 = device4.createCommandEncoder(
+{
+}
+);
+try {
+commandEncoder54.pushDebugGroup(
+'\u5f9c'
+);
+} catch {}
+let pipeline86 = device4.createRenderPipeline(
+{
+label: '\ue386\u{1f8b0}\u{1f6ea}',
+layout: pipelineLayout19,
+vertex: {
+module: shaderModule23,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 612,
+attributes: [
+{
+format: 'snorm16x4',
+offset: 392,
+shaderLocation: 10,
+},
+{
+format: 'uint32x3',
+offset: 20,
+shaderLocation: 11,
+},
+{
+format: 'uint8x2',
+offset: 58,
+shaderLocation: 4,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 384,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x2',
+offset: 492,
+shaderLocation: 3,
+},
+{
+format: 'sint32',
+offset: 36,
+shaderLocation: 8,
+},
+{
+format: 'uint32x2',
+offset: 172,
+shaderLocation: 7,
+},
+{
+format: 'float16x4',
+offset: 400,
+shaderLocation: 14,
+},
+{
+format: 'unorm8x4',
+offset: 148,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 16004,
+attributes: [
+{
+format: 'float16x4',
+offset: 6972,
+shaderLocation: 1,
+},
+{
+format: 'snorm16x4',
+offset: 3388,
+shaderLocation: 13,
+},
+{
+format: 'uint16x2',
+offset: 4952,
+shaderLocation: 5,
+},
+{
+format: 'uint32x3',
+offset: 7572,
+shaderLocation: 6,
+},
+{
+format: 'sint32',
+offset: 6308,
+shaderLocation: 17,
+},
+{
+format: 'uint32',
+offset: 1640,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x4',
+offset: 172,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 20728,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x4',
+offset: 19560,
+shaderLocation: 12,
+},
+{
+format: 'sint32',
+offset: 3436,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+cullMode: 'back',
+},
+multisample: {
+count: 4,
+},
+fragment: {
+module: shaderModule23,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilReadMask: 363,
+stencilWriteMask: 780,
+depthBias: 84,
+depthBiasClamp: 82,
+},
+}
+);
+gc();
+let textureView76 = texture42.createView(
+{
+label: '\u0e47\u{1fe30}\u9d57\u8373\u0832\ub9e5\u02f2\u1725\u2a65\u03a4',
+dimension: '2d',
+baseMipLevel: 4,
+mipLevelCount: 1,
+}
+);
+try {
+renderPassEncoder11.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(
+0,
+bindGroup16,
+[]
+);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture56,
+  mipLevel: 3,
+  origin: { x: 45, y: 0, z: 13 },
+  aspect: 'all',
+},
+arrayBuffer9,
+/* required buffer size: 57422 */{
+offset: 236,
+bytesPerRow: 167,
+rowsPerImage: 38,
+},
+{width: 18, height: 1, depthOrArrayLayers: 10}
+);
+} catch {}
+let pipeline87 = await device1.createRenderPipelineAsync(
+{
+label: '\u27f0\u20c6\u9a2c',
+layout: pipelineLayout10,
+vertex: {
+module: shaderModule10,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 5004,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 1404,
+shaderLocation: 8,
+},
+{
+format: 'sint32x4',
+offset: 2156,
+shaderLocation: 10,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 2308,
+shaderLocation: 5,
+},
+{
+format: 'float32',
+offset: 2080,
+shaderLocation: 14,
+},
+{
+format: 'uint32x4',
+offset: 3276,
+shaderLocation: 6,
+},
+{
+format: 'snorm16x2',
+offset: 560,
+shaderLocation: 3,
+},
+{
+format: 'uint8x2',
+offset: 1926,
+shaderLocation: 2,
+},
+{
+format: 'sint8x4',
+offset: 3380,
+shaderLocation: 12,
+},
+{
+format: 'sint8x2',
+offset: 470,
+shaderLocation: 1,
+},
+{
+format: 'unorm16x4',
+offset: 1616,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 19392,
+attributes: [
+{
+format: 'float32x2',
+offset: 5192,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x4',
+offset: 6700,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+},
+fragment: {
+module: shaderModule10,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALPHA,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'always',
+failOp: 'invert',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'zero',
+depthFailOp: 'invert',
+},
+stencilReadMask: 3695,
+stencilWriteMask: 2048,
+depthBias: 73,
+depthBiasSlopeScale: 34,
+depthBiasClamp: 51,
+},
+}
+);
+let gpuCanvasContext13 = offscreenCanvas14.getContext('webgpu');
+try {
+await promise31;
+} catch {}
+let bindGroup29 = device3.createBindGroup({
+label: '\u{1fb2c}\u095c\u5a01\u5d10\u4a26',
+layout: bindGroupLayout27,
+entries: [
+
+],
+});
+let texture77 = device3.createTexture(
+{
+label: '\u{1fe2d}\uca9f\u4753\ud331\u0a76',
+size: {width: 2867},
+dimension: '1d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+device3.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder50.clearBuffer(
+buffer19,
+25108,
+176
+);
+dissociateBuffer(device3, buffer19);
+} catch {}
+let canvas12 = document.createElement('canvas');
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+document.body.prepend(video0);
+gc();
+let offscreenCanvas15 = new OffscreenCanvas(331, 888);
+try {
+offscreenCanvas15.getContext('webgpu');
+} catch {}
+let computePassEncoder23 = commandEncoder49.beginComputePass(
+{
+label: '\u2108\u8da7\u513b\u067f\u{1fa39}\u07be\u{1f71c}\u0770'
+}
+);
+let renderBundleEncoder49 = device1.createRenderBundleEncoder(
+{
+label: '\ua3b4\ud33e\u{1fd20}',
+colorFormats: [
+'rgba8unorm',
+undefined,
+'rgba16sint',
+'rgba16sint',
+'rgba32float',
+'bgra8unorm',
+'r8uint'
+],
+sampleCount: 610,
+stencilReadOnly: true,
+}
+);
+let renderBundle55 = renderBundleEncoder28.finish(
+{
+label: '\u1ca1\u908e\u0ed0\u269f\u10e9\ub625\u3ab5\u{1ff7c}\u{1f9ac}\u018a\u9ad0'
+}
+);
+try {
+renderPassEncoder15.setViewport(
+11.53,
+21.66,
+8.956,
+2.259,
+0.1275,
+0.1454
+);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(
+2,
+bindGroup16
+);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(
+0,
+bindGroup21,
+new Uint32Array(6307),
+760,
+0
+);
+} catch {}
+let gpuCanvasContext14 = canvas12.getContext('webgpu');
+let offscreenCanvas16 = new OffscreenCanvas(872, 418);
+let imageBitmap11 = await createImageBitmap(videoFrame2);
+let imageData7 = new ImageData(156, 116);
+let shaderModule26 = device4.createShaderModule(
+{
+code: `@group(0) @binding(221)
+var<storage, read_write> global32: array<u32>;
+@group(0) @binding(2325)
+var<storage, read_write> local25: array<u32>;
+@group(2) @binding(2325)
+var<storage, read_write> function30: array<u32>;
+@group(2) @binding(3375)
+var<storage, read_write> type31: array<u32>;
+@group(1) @binding(2325)
+var<storage, read_write> local26: array<u32>;
+@group(0) @binding(3375)
+var<storage, read_write> global33: array<u32>;
+
+@compute @workgroup_size(5, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S23 {
+@location(13) f0: vec3<f16>,
+@location(26) f1: i32,
+@builtin(front_facing) f2: bool,
+@location(65) f3: vec2<u32>,
+@location(32) f4: f32,
+@location(39) f5: vec3<f32>,
+@location(24) f6: vec4<f32>,
+@location(57) f7: vec4<u32>,
+@builtin(position) f8: vec4<f32>,
+@builtin(sample_mask) f9: u32,
+@location(10) f10: i32,
+@location(35) f11: vec3<f32>,
+@location(6) f12: vec3<f16>,
+@builtin(sample_index) f13: u32,
+@location(53) f14: f16,
+@location(68) f15: vec2<f32>,
+@location(48) f16: vec2<i32>,
+@location(49) f17: vec2<f32>,
+@location(7) f18: vec4<f16>,
+@location(37) f19: vec3<f32>,
+@location(67) f20: vec3<u32>,
+@location(23) f21: vec2<f32>
+}
+struct FragmentOutput0 {
+@location(2) f0: vec2<f32>,
+@location(3) f1: vec2<u32>,
+@location(6) f2: vec3<i32>,
+@location(1) f3: f32,
+@location(7) f4: vec2<u32>,
+@location(5) f5: vec3<i32>,
+@location(0) f6: u32,
+@location(4) f7: vec4<f32>,
+@builtin(frag_depth) f8: f32
+}
+
+@fragment
+fn fragment0(@location(46) a0: vec4<f32>, @location(55) a1: i32, a2: S23, @location(59) a3: vec3<i32>, @location(33) a4: vec3<f16>, @location(19) a5: vec4<u32>, @location(20) a6: vec2<f16>, @location(47) a7: vec3<u32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(6) f342: vec3<f16>,
+@location(46) f343: vec4<f32>,
+@location(13) f344: vec3<f16>,
+@location(57) f345: vec4<u32>,
+@location(24) f346: vec4<f32>,
+@location(32) f347: f32,
+@location(68) f348: vec2<f32>,
+@location(59) f349: vec3<i32>,
+@location(19) f350: vec4<u32>,
+@location(37) f351: vec3<f32>,
+@location(39) f352: vec3<f32>,
+@location(53) f353: f16,
+@location(48) f354: vec2<i32>,
+@location(67) f355: vec3<u32>,
+@location(33) f356: vec3<f16>,
+@location(10) f357: i32,
+@location(47) f358: vec3<u32>,
+@location(35) f359: vec3<f32>,
+@location(55) f360: i32,
+@location(7) f361: vec4<f16>,
+@builtin(position) f362: vec4<f32>,
+@location(23) f363: vec2<f32>,
+@location(20) f364: vec2<f16>,
+@location(65) f365: vec2<u32>,
+@location(49) f366: vec2<f32>,
+@location(26) f367: i32
+}
+
+@vertex
+fn vertex0(@location(0) a0: vec4<i32>, @location(11) a1: vec3<f32>, @location(14) a2: vec4<i32>, @location(10) a3: vec4<i32>, @location(15) a4: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let buffer24 = device4.createBuffer(
+{
+size: 47698,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let textureView77 = texture74.createView(
+{
+label: '\u039a\u9311\ufef9\u{1f63a}\u0a37\u4cdd\u0a4b',
+}
+);
+let sampler44 = device4.createSampler(
+{
+label: '\u5297\u0aca\u010e\u040a\ud6b6\u7323\u{1fff2}\uae90\u0ccc\u99b0',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 5.460,
+lodMaxClamp: 49.317,
+maxAnisotropy: 10,
+}
+);
+try {
+device4.queue.writeBuffer(
+buffer24,
+22352,
+new Int16Array(51474),
+29330,
+1264
+);
+} catch {}
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline88 = await device4.createComputePipelineAsync(
+{
+label: '\u{1f6c1}\ud1cf\u0208\u{1feac}\u0da5\u4ca2\u{1fee2}\u6a43\ube22\u0261\u7545',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule25,
+entryPoint: 'compute0',
+},
+}
+);
+let commandEncoder55 = device2.createCommandEncoder(
+{
+}
+);
+let textureView78 = texture62.createView(
+{
+label: '\u0acd\u0355\u{1ff74}\u0db7\u6e27\uf44e\u{1fef3}\u0e89\u{1f771}\u081b\u750d',
+baseMipLevel: 3,
+}
+);
+let renderBundleEncoder50 = device2.createRenderBundleEncoder(
+{
+label: '\u70b0\u0c93\ubceb\u20d6',
+colorFormats: [
+'r32sint',
+'rg32uint',
+'r32uint',
+'rgba8unorm',
+'rg16uint',
+'rgba8unorm-srgb',
+'bgra8unorm-srgb',
+'rgba16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 286,
+}
+);
+let gpuCanvasContext15 = offscreenCanvas16.getContext('webgpu');
+document.body.prepend(img4);
+let bindGroup30 = device2.createBindGroup({
+label: '\u824b\u064d\u{1fd9a}\ue25e\ub85e',
+layout: bindGroupLayout31,
+entries: [
+{
+binding: 8951,
+resource: sampler38
+},
+{
+binding: 8983,
+resource: textureView71
+}
+],
+});
+let commandEncoder56 = device2.createCommandEncoder(
+{
+label: '\u92a0\u0364\u00ae\u0773',
+}
+);
+let querySet62 = device2.createQuerySet({
+label: '\u0248\uc6fb\u{1fbf5}',
+type: 'occlusion',
+count: 1076,
+});
+let renderBundleEncoder51 = device2.createRenderBundleEncoder(
+{
+label: '\u{1fbb0}\u03d1\u91d8\u2bb3\u18e0',
+colorFormats: [
+'rgba16sint',
+'rgba16float'
+],
+sampleCount: 555,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder17.setBindGroup(
+2,
+bindGroup24,
+new Uint32Array(6335),
+2860,
+0
+);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(
+3,
+bindGroup20
+);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(
+92,
+undefined,
+2302115534
+);
+} catch {}
+try {
+commandEncoder55.copyBufferToBuffer(
+buffer21,
+8332,
+buffer16,
+12500,
+12788
+);
+dissociateBuffer(device2, buffer21);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+commandEncoder56.copyTextureToBuffer(
+{
+  texture: texture52,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 27376 */
+offset: 27376,
+bytesPerRow: 0,
+buffer: buffer16,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+await promise12;
+} catch {}
+document.body.prepend(video9);
+let canvas13 = document.createElement('canvas');
+let bindGroup31 = device2.createBindGroup({
+label: '\ue4e3\u{1fb18}\u0e2e',
+layout: bindGroupLayout19,
+entries: [
+
+],
+});
+let commandEncoder57 = device2.createCommandEncoder(
+{
+label: '\u12dc\u{1fc2e}\u3759\u0aa6\u086b\u1776',
+}
+);
+let renderBundle56 = renderBundleEncoder39.finish(
+{
+label: '\u4c52\u0b1f\u03f6\u0316\u{1fc0e}\u0568'
+}
+);
+let sampler45 = device2.createSampler(
+{
+label: '\u161a\ue712\u094a\ubfe4\u53c2\u{1fed3}\u040d\u5026\u0927\u{1f859}\u{1ffd5}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 36.779,
+lodMaxClamp: 85.774,
+maxAnisotropy: 12,
+}
+);
+try {
+renderBundleEncoder35.setVertexBuffer(
+2,
+undefined,
+2411943895
+);
+} catch {}
+try {
+commandEncoder56.clearBuffer(
+buffer16,
+4724,
+13224
+);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+await promise5;
+} catch {}
+let texture78 = device4.createTexture(
+{
+label: '\u3640\ua4b8\uf310\u0caa\u9b2b\u{1f6cb}\u{1fa04}\u{1f971}\ua130',
+size: {width: 96, height: 6, depthOrArrayLayers: 184},
+mipLevelCount: 7,
+format: 'astc-6x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-6x6-unorm',
+'astc-6x6-unorm'
+],
+}
+);
+let textureView79 = texture74.createView(
+{
+label: '\uda95\ufc02\uae9a\u2a0b\u8b74\uf54a',
+}
+);
+let renderPassEncoder16 = commandEncoder54.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView74,
+depthSlice: 28,
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView74,
+depthSlice: 49,
+clearValue: { r: 558.1, g: 831.6, b: 219.3, a: -266.6, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView74,
+depthSlice: 43,
+clearValue: { r: 750.4, g: 382.2, b: -488.3, a: -494.1, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView74,
+depthSlice: 13,
+clearValue: { r: 265.4, g: 95.62, b: -211.2, a: -259.9, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView74,
+depthSlice: 58,
+clearValue: { r: 62.50, g: 542.8, b: -824.7, a: 223.5, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView74,
+depthSlice: 14,
+clearValue: { r: -990.1, g: -892.9, b: 347.6, a: 374.3, },
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet54,
+maxDrawCount: 412800,
+}
+);
+try {
+await buffer24.mapAsync(
+GPUMapMode.READ,
+0,
+6688
+);
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device4,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgba8unorm-srgb',
+'rgba8unorm',
+'depth32float'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture69,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer3,
+/* required buffer size: 78820 */{
+offset: 520,
+bytesPerRow: 348,
+rowsPerImage: 75,
+},
+{width: 10, height: 0, depthOrArrayLayers: 4}
+);
+} catch {}
+let querySet63 = device4.createQuerySet({
+type: 'occlusion',
+count: 2665,
+});
+try {
+renderPassEncoder16.beginOcclusionQuery(1652);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer24,
+30148,
+new DataView(new ArrayBuffer(13525)),
+3042,
+1824
+);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 10, height: 1, depthOrArrayLayers: 8}
+*/
+{
+  source: video3,
+  origin: { x: 6, y: 10 },
+  flipY: true,
+},
+{
+  texture: texture69,
+  mipLevel: 4,
+  origin: { x: 8, y: 0, z: 3 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 2, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let imageData8 = new ImageData(196, 236);
+let pipelineLayout22 = device4.createPipelineLayout(
+{
+label: '\u{1f926}\u780b\u957b\ube0e\u04d7\u1a07\u{1f82f}\u9b6d\u0971',
+bindGroupLayouts: [
+bindGroupLayout29,
+bindGroupLayout29,
+bindGroupLayout29,
+bindGroupLayout29,
+bindGroupLayout29
+]
+}
+);
+pseudoSubmit(device4, commandEncoder54);
+let renderBundleEncoder52 = device4.createRenderBundleEncoder(
+{
+label: '\u0ec5\u0626\udebe\u0cf9\u546b\u9d9a\uf222\uec10\u51d3',
+colorFormats: [
+'bgra8unorm-srgb',
+'rgb10a2uint',
+'rgba8uint',
+'r8sint',
+undefined,
+'rgba16float',
+'rgba8uint',
+'rgba8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 153,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.setViewport(
+8.871,
+0.9863,
+34.94,
+0.00021,
+0.4986,
+0.5219
+);
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer24,
+20936,
+new BigUint64Array(37967),
+33281,
+2704
+);
+} catch {}
+let pipeline89 = await device4.createComputePipelineAsync(
+{
+label: '\uf1a5\u16d8\ue922\u6531\u{1ffde}\u2a08\u{1f84d}\u075d\u2a8a\u7d25',
+layout: pipelineLayout18,
+compute: {
+module: shaderModule25,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+canvas13.getContext('webgl');
+} catch {}
+let commandEncoder58 = device4.createCommandEncoder(
+{
+label: '\u3008\u89a1',
+}
+);
+let texture79 = device4.createTexture(
+{
+label: '\u0e18\u{1f6a7}',
+size: [3376, 4, 102],
+mipLevelCount: 9,
+dimension: '2d',
+format: 'astc-4x4-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-4x4-unorm-srgb'
+],
+}
+);
+let renderPassEncoder17 = commandEncoder58.beginRenderPass(
+{
+label: '\u{1f683}\u9140',
+colorAttachments: [
+undefined,
+{
+view: textureView74,
+depthSlice: 49,
+clearValue: { r: -703.2, g: 245.5, b: -20.97, a: 74.99, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView74,
+depthSlice: 17,
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView74,
+depthSlice: 40,
+clearValue: { r: 139.7, g: -467.5, b: 39.44, a: 228.1, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView74,
+depthSlice: 18,
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet54,
+maxDrawCount: 53200,
+}
+);
+try {
+renderPassEncoder17.setVertexBuffer(
+74,
+undefined
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture79,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 23 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer5),
+/* required buffer size: 1489326 */{
+offset: 582,
+bytesPerRow: 138,
+rowsPerImage: 174,
+},
+{width: 12, height: 0, depthOrArrayLayers: 63}
+);
+} catch {}
+let video10 = await videoWithData();
+let bindGroupLayout34 = device3.createBindGroupLayout(
+{
+label: '\u932d\uce13\ub465\ub889\u17a0\u251d',
+entries: [
+{
+binding: 1498,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '1d' },
+},
+{
+binding: 2038,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '3d' },
+}
+],
+}
+);
+let commandEncoder59 = device3.createCommandEncoder(
+{
+label: '\u05b1\u0fce',
+}
+);
+try {
+commandEncoder52.clearBuffer(
+buffer19,
+3972,
+2068
+);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+try {
+computePassEncoder22.setBindGroup(
+8,
+bindGroup28
+);
+} catch {}
+try {
+computePassEncoder19.end();
+} catch {}
+let videoFrame13 = new VideoFrame(offscreenCanvas8, {timestamp: 0});
+let bindGroupLayout35 = device3.createBindGroupLayout(
+{
+entries: [
+{
+binding: 129,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+},
+{
+binding: 2164,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+},
+{
+binding: 1031,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let commandEncoder60 = device3.createCommandEncoder(
+{
+label: '\u{1f821}\ud623\ua49b\u3b8a\u{1f866}\u9fe8\ub158\ue17c\u{1fc68}\u67be\u79e5',
+}
+);
+try {
+device3.queue.writeTexture(
+{
+  texture: texture60,
+  mipLevel: 0,
+  origin: { x: 0, y: 3, z: 0 },
+  aspect: 'stencil-only',
+},
+new Int16Array(new ArrayBuffer(64)),
+/* required buffer size: 974 */{
+offset: 974,
+bytesPerRow: 207,
+rowsPerImage: 261,
+},
+{width: 58, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+gc();
+let renderBundle57 = renderBundleEncoder52.finish(
+{
+label: '\u3575\u{1ff60}\u3316\u{1fee4}\u03f6'
+}
+);
+try {
+device4.queue.writeBuffer(
+buffer24,
+39432,
+new Int16Array(45296),
+33486,
+2812
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture79,
+  mipLevel: 6,
+  origin: { x: 8, y: 0, z: 44 },
+  aspect: 'all',
+},
+arrayBuffer4,
+/* required buffer size: 316 */{
+offset: 316,
+},
+{width: 0, height: 4, depthOrArrayLayers: 0}
+);
+} catch {}
+gc();
+let imageData9 = new ImageData(164, 92);
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+let bindGroup32 = device3.createBindGroup({
+layout: bindGroupLayout27,
+entries: [
+
+],
+});
+let commandEncoder61 = device3.createCommandEncoder(
+{
+}
+);
+let texture80 = device3.createTexture(
+{
+label: '\u49b3\u4e62\u0d1d\u04c6',
+size: [2978, 42, 192],
+sampleCount: 1,
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let sampler46 = device3.createSampler(
+{
+label: '\u6c0a\u04d1\u{1fc06}\u46e3\u000d\u0581\uf94f\ua74a\u{1ffd1}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 6.152,
+lodMaxClamp: 99.489,
+maxAnisotropy: 13,
+}
+);
+try {
+renderBundleEncoder48.setBindGroup(
+3,
+bindGroup28
+);
+} catch {}
+try {
+commandEncoder61.clearBuffer(
+buffer19,
+23168,
+2700
+);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: { x: 47, y: 1, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer5,
+/* required buffer size: 164 */{
+offset: 164,
+},
+{width: 1104, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+document.body.prepend(img10);
+try {
+commandEncoder51.clearBuffer(
+buffer19,
+23156,
+5036
+);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let querySet64 = device4.createQuerySet({
+label: '\u0277\u7abb\u19be',
+type: 'occlusion',
+count: 2242,
+});
+let texture81 = device4.createTexture(
+{
+label: '\u{1fd9b}\u484b\u2aa8\u0efc\u2238',
+size: [7360, 8, 212],
+mipLevelCount: 2,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-8x8-unorm-srgb',
+'astc-8x8-unorm'
+],
+}
+);
+let sampler47 = device4.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 16.993,
+lodMaxClamp: 54.198,
+}
+);
+try {
+renderPassEncoder16.setStencilReference(
+2985
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture72,
+  mipLevel: 3,
+  origin: { x: 1, y: 2, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer7,
+/* required buffer size: 589 */{
+offset: 589,
+bytesPerRow: 354,
+},
+{width: 16, height: 5, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise32 = device4.createComputePipelineAsync(
+{
+label: '\u6486\uaef5\uc74c\u{1ffc6}\u8ff3\u0926\u{1fc76}\u075e\u769e',
+layout: pipelineLayout22,
+compute: {
+module: shaderModule26,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+gc();
+let videoFrame14 = new VideoFrame(img13, {timestamp: 0});
+let texture82 = device1.createTexture(
+{
+label: '\u09a3\u2449\ua175\u047c',
+size: [4442, 3, 1],
+mipLevelCount: 9,
+format: 'r8sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder53 = device1.createRenderBundleEncoder(
+{
+label: '\u063e\u0556',
+colorFormats: [
+'rgba16float',
+'r16uint',
+'rgb10a2uint',
+'rgba16uint',
+'rg8uint',
+'rg16uint',
+undefined,
+'r32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 221,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder11.setBindGroup(
+3,
+bindGroup21
+);
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant({ r: -48.27, g: -44.08, b: -306.2, a: -741.3, });
+} catch {}
+try {
+commandEncoder42.copyTextureToTexture(
+{
+  texture: texture56,
+  mipLevel: 3,
+  origin: { x: 106, y: 0, z: 6 },
+  aspect: 'all',
+},
+{
+  texture: texture56,
+  mipLevel: 4,
+  origin: { x: 46, y: 0, z: 2 },
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 7}
+);
+} catch {}
+try {
+computePassEncoder11.insertDebugMarker(
+'\u0e34'
+);
+} catch {}
+try {
+renderPassEncoder14.insertDebugMarker(
+'\ufec5'
+);
+} catch {}
+let promise33 = device1.queue.onSubmittedWorkDone();
+let bindGroupLayout36 = device3.createBindGroupLayout(
+{
+label: '\u8315\u37d7\uad0e\u68e0\ud353',
+entries: [
+{
+binding: 620,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+},
+{
+binding: 984,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 2219,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+}
+],
+}
+);
+let buffer25 = device3.createBuffer(
+{
+label: '\u3ee5\u051d\u04dc\u1bd3\u{1f89d}\u0f5d\u{1fac9}\u0dc5\u0369',
+size: 62365,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let texture83 = device3.createTexture(
+{
+label: '\udc95\u04ad\u82d6\u6963\ubda9',
+size: [9012],
+dimension: '1d',
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb9e5ufloat'
+],
+}
+);
+let renderBundle58 = renderBundleEncoder37.finish(
+{
+
+}
+);
+try {
+renderBundleEncoder48.setBindGroup(
+4,
+bindGroup23,
+new Uint32Array(6562),
+1262,
+0
+);
+} catch {}
+let img15 = await imageWithData(256, 8, '#17c75a43', '#0ce1e478');
+let imageData10 = new ImageData(176, 184);
+let shaderModule27 = device4.createShaderModule(
+{
+code: `@group(2) @binding(221)
+var<storage, read_write> parameter27: array<u32>;
+@group(2) @binding(2325)
+var<storage, read_write> i18: array<u32>;
+@group(3) @binding(221)
+var<storage, read_write> parameter28: array<u32>;
+@group(4) @binding(2325)
+var<storage, read_write> local27: array<u32>;
+@group(1) @binding(3375)
+var<storage, read_write> global34: array<u32>;
+@group(1) @binding(2325)
+var<storage, read_write> global35: array<u32>;
+@group(3) @binding(2325)
+var<storage, read_write> type32: array<u32>;
+@group(3) @binding(3375)
+var<storage, read_write> global36: array<u32>;
+@group(0) @binding(2325)
+var<storage, read_write> global37: array<u32>;
+@group(1) @binding(221)
+var<storage, read_write> global38: array<u32>;
+@group(0) @binding(3375)
+var<storage, read_write> local28: array<u32>;
+@group(4) @binding(221)
+var<storage, read_write> type33: array<u32>;
+@group(4) @binding(3375)
+var<storage, read_write> field36: array<u32>;
+
+@compute @workgroup_size(3, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S24 {
+@location(43) f0: vec4<u32>,
+@location(35) f1: vec2<u32>,
+@location(66) f2: vec2<f16>,
+@builtin(sample_index) f3: u32,
+@builtin(position) f4: vec4<f32>,
+@location(22) f5: vec2<i32>,
+@location(1) f6: f16,
+@location(18) f7: vec2<f32>,
+@builtin(front_facing) f8: bool,
+@location(16) f9: f32,
+@location(51) f10: vec3<f16>,
+@location(19) f11: vec4<f32>,
+@location(59) f12: u32,
+@location(5) f13: vec3<i32>,
+@location(55) f14: vec3<f32>,
+@location(32) f15: vec3<f32>,
+@location(23) f16: vec3<i32>,
+@location(34) f17: vec4<i32>,
+@location(4) f18: vec3<u32>,
+@location(26) f19: u32,
+@location(10) f20: u32,
+@location(13) f21: vec4<f32>,
+@location(50) f22: f16,
+@location(14) f23: vec4<i32>
+}
+struct FragmentOutput0 {
+@location(2) f0: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(21) a0: f16, @location(56) a1: u32, a2: S24, @location(2) a3: vec3<f16>, @location(39) a4: vec3<u32>, @location(58) a5: vec2<i32>, @builtin(sample_mask) a6: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(5) f368: vec3<i32>,
+@location(14) f369: vec4<i32>,
+@location(16) f370: f32,
+@location(50) f371: f16,
+@location(1) f372: f16,
+@location(58) f373: vec2<i32>,
+@location(26) f374: u32,
+@location(13) f375: vec4<f32>,
+@location(4) f376: vec3<u32>,
+@location(55) f377: vec3<f32>,
+@builtin(position) f378: vec4<f32>,
+@location(23) f379: vec3<i32>,
+@location(56) f380: u32,
+@location(2) f381: vec3<f16>,
+@location(21) f382: f16,
+@location(32) f383: vec3<f32>,
+@location(19) f384: vec4<f32>,
+@location(18) f385: vec2<f32>,
+@location(66) f386: vec2<f16>,
+@location(22) f387: vec2<i32>,
+@location(34) f388: vec4<i32>,
+@location(35) f389: vec2<u32>,
+@location(59) f390: u32,
+@location(43) f391: vec4<u32>,
+@location(39) f392: vec3<u32>,
+@location(51) f393: vec3<f16>,
+@location(10) f394: u32
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec2<f16>, @location(17) a1: vec2<f16>, @location(6) a2: vec2<i32>, @location(7) a3: vec4<u32>, @builtin(vertex_index) a4: u32, @location(14) a5: f16, @location(0) a6: u32, @location(5) a7: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder62 = device4.createCommandEncoder(
+{
+}
+);
+let texture84 = device4.createTexture(
+{
+label: '\u3e7b\u1c08\u{1f6b4}\u0d9f\u0774\u00d3',
+size: [7164, 59, 114],
+mipLevelCount: 8,
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgb10a2unorm',
+'rgb10a2unorm',
+'rgb10a2unorm'
+],
+}
+);
+let textureView80 = texture69.createView(
+{
+label: '\u9051\u4085\u54b5\u455e\u{1f9ba}\u8796\u2ec2',
+aspect: 'all',
+baseMipLevel: 2,
+mipLevelCount: 1,
+arrayLayerCount: 1,
+}
+);
+let computePassEncoder24 = commandEncoder62.beginComputePass(
+{
+label: '\ud8fe\u6a05\ua25e\u01ee\u{1fc03}\u2923\u0cf1\u{1f8b9}'
+}
+);
+let renderBundle59 = renderBundleEncoder52.finish(
+{
+label: '\u27f1\u{1fba9}\uef42\u291d\u209b\u5891\u{1f9f6}\u{1feaf}\u7c84\u{1ff94}\u{1fd5a}'
+}
+);
+try {
+renderPassEncoder16.beginOcclusionQuery(472);
+} catch {}
+try {
+renderPassEncoder17.setStencilReference(
+3470
+);
+} catch {}
+let pipeline90 = device4.createComputePipeline(
+{
+layout: pipelineLayout18,
+compute: {
+module: shaderModule23,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+video9.height = 206;
+let querySet65 = device3.createQuerySet({
+type: 'occlusion',
+count: 3703,
+});
+let textureView81 = texture77.createView(
+{
+label: '\u07b9\u0680\u{1f908}',
+baseArrayLayer: 0,
+}
+);
+let imageBitmap12 = await createImageBitmap(offscreenCanvas12);
+let shaderModule28 = device4.createShaderModule(
+{
+code: `@group(2) @binding(221)
+var<storage, read_write> global39: array<u32>;
+@group(2) @binding(3375)
+var<storage, read_write> type34: array<u32>;
+@group(1) @binding(3375)
+var<storage, read_write> field37: array<u32>;
+@group(1) @binding(2325)
+var<storage, read_write> type35: array<u32>;
+@group(2) @binding(2325)
+var<storage, read_write> type36: array<u32>;
+@group(0) @binding(221)
+var<storage, read_write> global40: array<u32>;
+@group(0) @binding(3375)
+var<storage, read_write> i19: array<u32>;
+@group(1) @binding(221)
+var<storage, read_write> type37: array<u32>;
+
+@compute @workgroup_size(5, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(2) f0: u32,
+@location(7) f1: vec4<u32>,
+@builtin(frag_depth) f2: f32,
+@location(0) f3: f32,
+@location(3) f4: i32
+}
+
+@fragment
+fn fragment0(@location(46) a0: vec4<u32>, @location(11) a1: vec2<f16>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(27) f395: vec3<u32>,
+@location(39) f396: f16,
+@location(18) f397: f16,
+@location(9) f398: vec2<u32>,
+@location(41) f399: vec3<f16>,
+@location(2) f400: vec3<u32>,
+@location(35) f401: vec3<i32>,
+@location(5) f402: vec2<f32>,
+@location(48) f403: vec4<i32>,
+@location(55) f404: vec3<f16>,
+@location(61) f405: i32,
+@location(0) f406: u32,
+@location(24) f407: vec3<f32>,
+@location(58) f408: i32,
+@location(23) f409: vec4<f32>,
+@location(20) f410: vec3<u32>,
+@location(46) f411: vec4<u32>,
+@builtin(position) f412: vec4<f32>,
+@location(37) f413: vec3<i32>,
+@location(21) f414: vec3<f32>,
+@location(59) f415: vec4<i32>,
+@location(57) f416: vec3<i32>,
+@location(11) f417: vec2<f16>,
+@location(29) f418: vec4<i32>,
+@location(64) f419: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(6) a0: f32, @location(16) a1: vec4<f16>, @location(9) a2: vec2<f16>, @location(3) a3: vec4<f16>, @location(1) a4: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+}
+);
+let querySet66 = device4.createQuerySet({
+label: '\u{1f6a6}\u3304\u567f\u01d4',
+type: 'occlusion',
+count: 3102,
+});
+let renderBundle60 = renderBundleEncoder52.finish();
+let sampler48 = device4.createSampler(
+{
+label: '\u{1f6ab}\u00e1\ue950\u3c03\u0b83\u0671\u95b7',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 27.089,
+lodMaxClamp: 85.674,
+maxAnisotropy: 10,
+}
+);
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(
+2616
+);
+} catch {}
+try {
+renderPassEncoder16.setViewport(
+70.63,
+0.4477,
+7.064,
+0.4300,
+0.9037,
+0.9275
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+25,
+undefined,
+3243549367,
+499180144
+);
+} catch {}
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+let pipeline91 = await device4.createComputePipelineAsync(
+{
+label: '\ud4d5\u0601\uc7cd\u2608\u0bf4\uf2aa',
+layout: pipelineLayout18,
+compute: {
+module: shaderModule25,
+entryPoint: 'compute0',
+},
+}
+);
+let computePassEncoder25 = commandEncoder50.beginComputePass();
+try {
+await device3.popErrorScope();
+} catch {}
+try {
+commandEncoder59.copyTextureToBuffer(
+{
+  texture: texture77,
+  mipLevel: 0,
+  origin: { x: 22, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 8492 widthInBlocks: 2123 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 57396 */
+offset: 48904,
+rowsPerImage: 53,
+buffer: buffer25,
+},
+{width: 2123, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device3, buffer25);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let computePassEncoder26 = commandEncoder43.beginComputePass(
+{
+label: '\u08bf\u0600\u8a09\u1518\u{1f9de}\u{1f9e9}'
+}
+);
+try {
+renderBundleEncoder48.setVertexBuffer(
+6,
+undefined
+);
+} catch {}
+try {
+commandEncoder60.clearBuffer(
+buffer25,
+31016,
+3632
+);
+dissociateBuffer(device3, buffer25);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: { x: 1334, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer5,
+/* required buffer size: 909 */{
+offset: 909,
+},
+{width: 327, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let imageBitmap13 = await createImageBitmap(offscreenCanvas2);
+let querySet67 = device2.createQuerySet({
+label: '\u20fd\ue1e5\u764d\u{1fd7d}',
+type: 'occlusion',
+count: 5,
+});
+try {
+buffer23.unmap();
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(
+buffer21,
+21508,
+buffer16,
+22008,
+536
+);
+dissociateBuffer(device2, buffer21);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+device2.queue.submit([
+commandBuffer4,
+]);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture76,
+  mipLevel: 0,
+  origin: { x: 8, y: 0, z: 193 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(arrayBuffer5),
+/* required buffer size: 5826956 */{
+offset: 346,
+bytesPerRow: 389,
+rowsPerImage: 288,
+},
+{width: 84, height: 12, depthOrArrayLayers: 53}
+);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let promise34 = adapter5.requestDevice({
+label: '\u2f6f\ud7f2\u{1f7c5}\ua928',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 6,
+maxColorAttachmentBytesPerSample: 48,
+maxVertexAttributes: 27,
+maxVertexBufferArrayStride: 39681,
+maxStorageTexturesPerShaderStage: 9,
+maxStorageBuffersPerShaderStage: 19,
+maxDynamicStorageBuffersPerPipelineLayout: 846,
+maxBindingsPerBindGroup: 3240,
+maxTextureDimension1D: 15850,
+maxTextureDimension2D: 9273,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 140183934,
+maxUniformBuffersPerShaderStage: 35,
+maxInterStageShaderVariables: 110,
+maxInterStageShaderComponents: 101,
+maxSamplersPerShaderStage: 18,
+},
+});
+let videoFrame15 = new VideoFrame(img1, {timestamp: 0});
+let imageData11 = new ImageData(84, 236);
+let bindGroupLayout37 = device3.createBindGroupLayout(
+{
+label: '\u2f46\ub5fa\ue3ea\u3827\u0e9f\u7e32\u0ed1\ua5c8\u989d\ue790\u8d45',
+entries: [
+
+],
+}
+);
+let computePassEncoder27 = commandEncoder60.beginComputePass(
+{
+label: '\u570a\u464e\u1f79\u696f\u0bba\u{1ffc8}\ub8da'
+}
+);
+let sampler49 = device3.createSampler(
+{
+label: '\uc37b\u5cb8',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 25.351,
+lodMaxClamp: 97.319,
+}
+);
+try {
+commandEncoder61.clearBuffer(
+buffer25,
+24252,
+33200
+);
+dissociateBuffer(device3, buffer25);
+} catch {}
+let bindGroup33 = device2.createBindGroup({
+label: '\uc3a9\u{1fb12}',
+layout: bindGroupLayout32,
+entries: [
+
+],
+});
+let pipelineLayout23 = device2.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout33,
+bindGroupLayout30,
+bindGroupLayout32,
+bindGroupLayout22,
+bindGroupLayout22,
+bindGroupLayout26,
+bindGroupLayout19
+]
+}
+);
+let buffer26 = device2.createBuffer(
+{
+label: '\u{1f8c7}\u05b0\u5951\u72da',
+size: 62069,
+usage: GPUBufferUsage.STORAGE,
+mappedAtCreation: false,
+}
+);
+let texture85 = gpuCanvasContext1.getCurrentTexture();
+try {
+renderBundleEncoder51.setBindGroup(
+8,
+bindGroup17
+);
+} catch {}
+let video11 = await videoWithData();
+let imageBitmap14 = await createImageBitmap(offscreenCanvas3);
+gc();
+let device5 = await promise34;
+let imageData12 = new ImageData(164, 72);
+let commandEncoder63 = device1.createCommandEncoder();
+let texture86 = device1.createTexture(
+{
+label: '\u046f\u0e90\u05ce\uaf6d',
+size: {width: 5191},
+dimension: '1d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'bgra8unorm',
+'bgra8unorm-srgb'
+],
+}
+);
+let textureView82 = texture35.createView(
+{
+label: '\u{1feb0}\u33f9\u7aab\uab70\u{1fe93}\u{1f7fc}',
+format: 'rg8snorm',
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+try {
+computePassEncoder23.setPipeline(
+pipeline77
+);
+} catch {}
+try {
+renderPassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(
+8,
+buffer15
+);
+} catch {}
+let commandBuffer6 = commandEncoder63.finish();
+try {
+commandEncoder42.copyTextureToTexture(
+{
+  texture: texture56,
+  mipLevel: 3,
+  origin: { x: 44, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture56,
+  mipLevel: 1,
+  origin: { x: 458, y: 1, z: 51 },
+  aspect: 'all',
+},
+{width: 36, height: 0, depthOrArrayLayers: 20}
+);
+} catch {}
+let promise35 = adapter1.requestAdapterInfo();
+let commandEncoder64 = device1.createCommandEncoder(
+{
+label: '\uacfb\u92e7\ub7d1\u2897\u0a8c\u24a3',
+}
+);
+let texture87 = device1.createTexture(
+{
+label: '\u01d2\u2c3c\u{1fa00}\uac78\u3ae8\u{1fde5}\u688f\u24ec',
+size: [61, 1, 240],
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let renderPassEncoder18 = commandEncoder42.beginRenderPass(
+{
+label: '\u0c71\u{1fe3f}\u0a05\u90a7\u019e\u{1fcf2}\uac3d\ufe96',
+colorAttachments: [
+undefined,
+undefined,
+{
+view: textureView76,
+clearValue: { r: 299.1, g: -854.6, b: -616.2, a: -805.9, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined,
+undefined
+],
+occlusionQuerySet: querySet55,
+maxDrawCount: 25088,
+}
+);
+let renderBundleEncoder54 = device1.createRenderBundleEncoder(
+{
+label: '\u56cb\u0739',
+colorFormats: [
+'r16sint',
+'r8unorm',
+'rgba16float',
+'rg32uint',
+'rgba32uint',
+'r8sint',
+'rgb10a2unorm',
+'rg8sint'
+],
+sampleCount: 88,
+depthReadOnly: true,
+}
+);
+let renderBundle61 = renderBundleEncoder33.finish(
+{
+label: '\uc511\u8929\ufe0d\ueeb2'
+}
+);
+try {
+renderPassEncoder11.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -416.7, g: -289.5, b: 588.1, a: -537.8, });
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(
+2,
+buffer15,
+6416,
+174
+);
+} catch {}
+let video12 = await videoWithData();
+let sampler50 = device3.createSampler(
+{
+label: '\u0cb8\u{1fc6c}\u3808',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 30.253,
+lodMaxClamp: 62.662,
+compare: 'less',
+}
+);
+try {
+computePassEncoder26.end();
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(
+4,
+bindGroup27,
+new Uint32Array(6992),
+5674,
+0
+);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(
+19,
+undefined,
+1613973267,
+1784878352
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture60,
+  mipLevel: 1,
+  origin: { x: 0, y: 12, z: 1 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer1),
+/* required buffer size: 588 */{
+offset: 588,
+bytesPerRow: 142,
+},
+{width: 29, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let videoFrame16 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let renderBundle62 = renderBundleEncoder52.finish(
+{
+label: '\u{1f64d}\u{1fd88}\u{1fc7f}'
+}
+);
+try {
+computePassEncoder24.setPipeline(
+pipeline88
+);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: 787.6, g: 470.4, b: 894.8, a: -165.1, });
+} catch {}
+try {
+window.someLabel = buffer25.label;
+} catch {}
+let bindGroup34 = device3.createBindGroup({
+label: '\u3913\u01cc\u4e37\u0b4f\uc916\u22a7\u011c\u{1fa33}\ub449',
+layout: bindGroupLayout37,
+entries: [
+
+],
+});
+let renderBundle63 = renderBundleEncoder48.finish(
+{
+label: '\u0de1\u0798\u{1fadd}\u{1fe2b}\u03ed\u5564\u0700\u02bd'
+}
+);
+try {
+renderBundleEncoder45.setBindGroup(
+6,
+bindGroup26,
+new Uint32Array(9114),
+44,
+0
+);
+} catch {}
+try {
+renderBundleEncoder45.insertDebugMarker(
+'\uac67'
+);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer25,
+60004,
+new BigUint64Array(15031),
+3624,
+68
+);
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let commandEncoder65 = device2.createCommandEncoder(
+{
+label: '\ud353\u2009\u4b8e\u87c7\u990c\u01f8\u{1f7d3}\ua9b8',
+}
+);
+let texture88 = device2.createTexture(
+{
+size: {width: 8292, height: 1, depthOrArrayLayers: 9},
+mipLevelCount: 13,
+sampleCount: 1,
+format: 'depth16unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+commandEncoder55.copyBufferToBuffer(
+buffer23,
+1028,
+buffer16,
+3208,
+1568
+);
+dissociateBuffer(device2, buffer23);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+commandEncoder57.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 9056 */
+offset: 9056,
+buffer: buffer23,
+},
+{
+  texture: texture52,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 4, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device2, buffer23);
+} catch {}
+try {
+commandEncoder65.copyTextureToTexture(
+{
+  texture: texture48,
+  mipLevel: 3,
+  origin: { x: 94, y: 0, z: 7 },
+  aspect: 'all',
+},
+{
+  texture: texture48,
+  mipLevel: 4,
+  origin: { x: 1, y: 0, z: 6 },
+  aspect: 'all',
+},
+{width: 57, height: 7, depthOrArrayLayers: 11}
+);
+} catch {}
+try {
+commandEncoder56.clearBuffer(
+buffer16,
+3760,
+22952
+);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+computePassEncoder20.insertDebugMarker(
+'\u7870'
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 43, y: 102 },
+  flipY: true,
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+gc();
+let bindGroupLayout38 = device5.createBindGroupLayout(
+{
+label: '\u0afb\u0b77\u{1feaa}\u022e\u{1feee}\udb0e\u{1fce8}\u86ac\u{1ff27}',
+entries: [
+
+],
+}
+);
+let pipelineLayout24 = device5.createPipelineLayout(
+{
+label: '\uea8e\u0b39\u{1fd18}\u5245',
+bindGroupLayouts: [
+bindGroupLayout38,
+bindGroupLayout38,
+bindGroupLayout38,
+bindGroupLayout38,
+bindGroupLayout38
+]
+}
+);
+let buffer27 = device5.createBuffer(
+{
+label: '\u{1f789}\u6709\u0664\ubea1',
+size: 61838,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let renderBundleEncoder55 = device5.createRenderBundleEncoder(
+{
+colorFormats: [
+undefined,
+'rg8sint',
+'rgba8unorm',
+'r32uint',
+'rgba16uint',
+'r16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 142,
+}
+);
+let renderBundle64 = renderBundleEncoder55.finish(
+{
+label: '\ucf94\ub2ad\u3b41\u32ee\u{1fb19}\u3f69\uaf58'
+}
+);
+let offscreenCanvas17 = new OffscreenCanvas(937, 773);
+let video13 = await videoWithData();
+let buffer28 = device3.createBuffer(
+{
+size: 41361,
+usage: GPUBufferUsage.UNIFORM,
+}
+);
+let renderBundleEncoder56 = device3.createRenderBundleEncoder(
+{
+label: '\u7b49\u01a7\ubc7d\u6236\u96ac\ud3e4',
+colorFormats: [
+'r32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 426,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder27.setBindGroup(
+2,
+bindGroup26,
+[]
+);
+} catch {}
+let promise36 = device3.popErrorScope();
+let gpuCanvasContext16 = offscreenCanvas17.getContext('webgpu');
+document.body.prepend(canvas1);
+let canvas14 = document.createElement('canvas');
+let offscreenCanvas18 = new OffscreenCanvas(241, 752);
+let bindGroupLayout39 = device4.createBindGroupLayout(
+{
+entries: [
+{
+binding: 1390,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let textureView83 = texture79.createView(
+{
+label: '\u9b0a\u16d0',
+dimension: '2d',
+aspect: 'all',
+format: 'astc-4x4-unorm-srgb',
+baseMipLevel: 4,
+mipLevelCount: 2,
+baseArrayLayer: 61,
+arrayLayerCount: 1,
+}
+);
+try {
+renderPassEncoder17.beginOcclusionQuery(440);
+} catch {}
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+let commandBuffer7 = commandEncoder53.finish(
+{
+label: '\u0716\u{1f7d3}\u{1f864}\u184f\ub2f5\ue4df',
+}
+);
+let renderBundleEncoder57 = device3.createRenderBundleEncoder(
+{
+colorFormats: [
+'r32uint',
+'r16uint',
+'r8unorm',
+'rgba8uint',
+'rgba16sint',
+'rgba32uint'
+],
+sampleCount: 857,
+stencilReadOnly: true,
+}
+);
+try {
+await device3.popErrorScope();
+} catch {}
+try {
+await promise33;
+} catch {}
+let texture89 = device3.createTexture(
+{
+label: '\uf91f\u854d\u7594\u0727\u{1fe05}\uab99\u{1fc57}\ubd8f\u0497\u3790\ud6e0',
+size: [12258, 2, 1],
+mipLevelCount: 7,
+format: 'r32float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let promise37 = buffer25.mapAsync(
+GPUMapMode.READ,
+4512,
+29856
+);
+let video14 = await videoWithData();
+try {
+window.someLabel = pipeline71.label;
+} catch {}
+let textureView84 = texture86.createView(
+{
+format: 'bgra8unorm',
+}
+);
+try {
+renderPassEncoder9.setBindGroup(
+0,
+bindGroup25
+);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(
+1,
+buffer15,
+2704,
+349
+);
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer5,
+]);
+} catch {}
+try {
+device1.queue.writeTexture(
+{
+  texture: texture42,
+  mipLevel: 4,
+  origin: { x: 4, y: 1, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer8,
+/* required buffer size: 310 */{
+offset: 310,
+bytesPerRow: 81,
+},
+{width: 4, height: 10, depthOrArrayLayers: 0}
+);
+} catch {}
+let gpuCanvasContext17 = offscreenCanvas18.getContext('webgpu');
+let shaderModule29 = device1.createShaderModule(
+{
+label: '\uf141\uba44\u{1fb4e}\u8848\ua1a8\ufd79\u014a',
+code: `@group(2) @binding(2941)
+var<storage, read_write> parameter29: array<u32>;
+@group(0) @binding(2941)
+var<storage, read_write> type38: array<u32>;
+@group(0) @binding(1830)
+var<storage, read_write> function31: array<u32>;
+@group(1) @binding(1830)
+var<storage, read_write> type39: array<u32>;
+@group(2) @binding(1830)
+var<storage, read_write> global41: array<u32>;
+@group(1) @binding(2941)
+var<storage, read_write> field38: array<u32>;
+
+@compute @workgroup_size(6, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(5) f0: f32,
+@location(6) f1: i32,
+@location(4) f2: f32,
+@location(3) f3: vec2<f32>,
+@location(7) f4: vec3<i32>,
+@location(1) f5: i32,
+@location(0) f6: vec3<i32>,
+@location(2) f7: vec2<u32>,
+@builtin(sample_mask) f8: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @location(7) a1: vec3<u32>, @location(18) a2: vec2<f16>, @location(4) a3: vec4<i32>, @location(6) a4: vec4<u32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(6) f420: vec4<u32>,
+@location(7) f421: vec3<u32>,
+@location(4) f422: vec4<i32>,
+@builtin(position) f423: vec4<f32>,
+@location(18) f424: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(12) a0: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let computePassEncoder28 = commandEncoder64.beginComputePass(
+{
+
+}
+);
+let renderBundle65 = renderBundleEncoder25.finish(
+{
+label: '\u7693\uf13c\u5ad6\u6b01\u{1f847}'
+}
+);
+try {
+renderPassEncoder18.setStencilReference(
+1257
+);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+1,
+buffer15,
+5272
+);
+} catch {}
+let img16 = await imageWithData(195, 295, '#7338c9ba', '#a4d5f8cc');
+try {
+await adapter6.requestAdapterInfo();
+} catch {}
+let texture90 = device2.createTexture(
+{
+size: {width: 3, height: 73, depthOrArrayLayers: 14},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'r32float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView85 = texture45.createView(
+{
+label: '\u624c\uc112',
+dimension: '2d',
+baseMipLevel: 4,
+mipLevelCount: 2,
+baseArrayLayer: 2,
+}
+);
+try {
+commandEncoder55.copyBufferToBuffer(
+buffer23,
+9984,
+buffer16,
+22364,
+4668
+);
+dissociateBuffer(device2, buffer23);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video9,
+  origin: { x: 15, y: 12 },
+  flipY: true,
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let gpuCanvasContext18 = canvas14.getContext('webgpu');
+let imageBitmap15 = await createImageBitmap(video10);
+video9.height = 63;
+let shaderModule30 = device2.createShaderModule(
+{
+label: '\u{1f86a}\u2ac6\u{1f991}\u75db\uf76d\u0f87\u{1ffe8}\u{1f94f}\ud8d5',
+code: `@group(1) @binding(6969)
+var<storage, read_write> i20: array<u32>;
+@group(1) @binding(4032)
+var<storage, read_write> local29: array<u32>;
+@group(0) @binding(1144)
+var<storage, read_write> local30: array<u32>;
+@group(1) @binding(2398)
+var<storage, read_write> field39: array<u32>;
+
+@compute @workgroup_size(8, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S25 {
+@location(17) f0: vec4<f16>,
+@location(82) f1: vec4<f32>
+}
+struct FragmentOutput0 {
+@location(7) f0: vec2<u32>,
+@location(0) f1: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, a1: S25, @location(60) a2: vec3<u32>, @location(15) a3: f32, @location(22) a4: vec4<f16>, @builtin(front_facing) a5: bool, @builtin(position) a6: vec4<f32>, @location(40) a7: vec2<f16>, @location(31) a8: vec2<u32>, @location(33) a9: vec3<i32>, @location(57) a10: vec2<f16>, @location(58) a11: f16, @location(54) a12: vec3<u32>, @location(27) a13: f32, @location(52) a14: vec3<i32>, @builtin(sample_index) a15: u32, @location(78) a16: vec3<f32>, @location(38) a17: vec3<u32>, @location(75) a18: vec3<u32>, @location(39) a19: vec4<f16>, @location(91) a20: vec2<i32>, @location(1) a21: vec3<i32>, @location(36) a22: vec4<i32>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+@location(22) f425: vec4<f16>,
+@location(39) f426: vec4<f16>,
+@location(38) f427: vec3<u32>,
+@location(68) f428: vec4<f16>,
+@location(34) f429: vec3<f16>,
+@location(1) f430: vec3<i32>,
+@location(19) f431: vec4<f16>,
+@location(15) f432: f32,
+@location(26) f433: f16,
+@location(76) f434: vec3<u32>,
+@location(48) f435: vec4<f16>,
+@location(60) f436: vec3<u32>,
+@location(91) f437: vec2<i32>,
+@location(37) f438: vec3<i32>,
+@location(58) f439: f16,
+@location(33) f440: vec3<i32>,
+@location(89) f441: vec2<i32>,
+@location(17) f442: vec4<f16>,
+@location(27) f443: f32,
+@location(75) f444: vec3<u32>,
+@location(54) f445: vec3<u32>,
+@builtin(position) f446: vec4<f32>,
+@location(36) f447: vec4<i32>,
+@location(35) f448: vec3<f32>,
+@location(83) f449: vec2<u32>,
+@location(3) f450: vec3<i32>,
+@location(31) f451: vec2<u32>,
+@location(43) f452: vec3<i32>,
+@location(52) f453: vec3<i32>,
+@location(40) f454: vec2<f16>,
+@location(82) f455: vec4<f32>,
+@location(78) f456: vec3<f32>,
+@location(57) f457: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let textureView86 = texture76.createView(
+{
+label: '\ucb04\uda6f\u{1fba0}\u{1fae7}\ub074\u{1fa0c}\uc680\ub89b\u00b6\u{1f692}',
+dimension: '2d-array',
+baseArrayLayer: 165,
+arrayLayerCount: 69,
+}
+);
+let renderBundle66 = renderBundleEncoder30.finish();
+try {
+querySet62.destroy();
+} catch {}
+try {
+commandEncoder55.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 45296 */
+offset: 45296,
+bytesPerRow: 0,
+rowsPerImage: 171,
+buffer: buffer23,
+},
+{
+  texture: texture70,
+  mipLevel: 2,
+  origin: { x: 20, y: 0, z: 2 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 15}
+);
+dissociateBuffer(device2, buffer23);
+} catch {}
+try {
+commandEncoder57.clearBuffer(
+buffer16,
+11616,
+7756
+);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+computePassEncoder17.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext18.configure(
+{
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float',
+'rgba16float',
+'depth32float'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 17, y: 16 },
+  flipY: true,
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline92 = device2.createComputePipeline(
+{
+label: '\u830f\u{1fcba}\u{1f8ba}\u09ee\u8c57\u0957\u08d8\uab2a\u{1fbf9}\u0528\u{1f9ae}',
+layout: pipelineLayout12,
+compute: {
+module: shaderModule30,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+adapter3.label = '\u{1fd3f}\u{1fb3a}\ud0b5\u66e5';
+} catch {}
+try {
+computePassEncoder27.setBindGroup(
+4,
+bindGroup28
+);
+} catch {}
+try {
+commandEncoder51.clearBuffer(
+buffer25,
+36392,
+23236
+);
+dissociateBuffer(device3, buffer25);
+} catch {}
+try {
+device3.queue.submit([
+]);
+} catch {}
+let renderBundleEncoder58 = device2.createRenderBundleEncoder(
+{
+label: '\u0896\u4d96\ud322\ub2a5\u0f46\u5412\ucbb4\u735a',
+colorFormats: [
+'rgba32sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 902,
+}
+);
+try {
+commandEncoder55.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 36984 */
+offset: 36984,
+buffer: buffer23,
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device2, buffer23);
+} catch {}
+try {
+commandEncoder65.clearBuffer(
+buffer16,
+26108,
+1492
+);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+renderBundleEncoder35.insertDebugMarker(
+'\u6334'
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture76,
+  mipLevel: 0,
+  origin: { x: 12, y: 8, z: 154 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 308581 */{
+offset: 514,
+bytesPerRow: 267,
+rowsPerImage: 64,
+},
+{width: 108, height: 8, depthOrArrayLayers: 19}
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img16,
+  origin: { x: 93, y: 179 },
+  flipY: false,
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let shaderModule31 = device2.createShaderModule(
+{
+label: '\u0008\u1dde\ued68',
+code: `@group(0) @binding(1144)
+var<storage, read_write> field40: array<u32>;
+@group(1) @binding(4032)
+var<storage, read_write> global42: array<u32>;
+@group(1) @binding(2398)
+var<storage, read_write> type40: array<u32>;
+@group(1) @binding(6969)
+var<storage, read_write> field41: array<u32>;
+
+@compute @workgroup_size(7, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(1) f0: vec3<i32>,
+@builtin(sample_mask) f1: u32,
+@location(4) f2: vec3<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(2) a0: vec4<u32>, @location(1) a1: f32, @location(15) a2: f16, @location(14) a3: f32, @location(16) a4: vec3<u32>, @location(17) a5: vec3<f32>, @location(12) a6: vec4<u32>, @location(13) a7: vec4<u32>, @location(5) a8: vec2<f16>, @location(8) a9: vec4<f32>, @location(4) a10: vec2<i32>, @location(20) a11: vec2<f32>, @location(21) a12: vec4<u32>, @builtin(instance_index) a13: u32, @location(19) a14: f16, @location(10) a15: vec3<i32>, @location(11) a16: vec3<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+}
+);
+let renderBundleEncoder59 = device2.createRenderBundleEncoder(
+{
+label: '\ucc71\u0976\ub1db\u{1f960}\u2493\u0883\u00d0',
+colorFormats: [
+'rg16uint',
+'r16uint',
+'r8unorm',
+undefined,
+'rg8unorm',
+'rg32float',
+'rgba8unorm-srgb'
+],
+sampleCount: 670,
+depthReadOnly: true,
+}
+);
+try {
+commandEncoder65.copyBufferToTexture(
+{
+/* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 28480 */
+offset: 28480,
+buffer: buffer23,
+},
+{
+  texture: texture49,
+  mipLevel: 0,
+  origin: { x: 44, y: 0, z: 118 },
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device2, buffer23);
+} catch {}
+try {
+commandEncoder55.clearBuffer(
+buffer16,
+7668,
+11332
+);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+new DataView(new ArrayBuffer(48)),
+/* required buffer size: 897 */{
+offset: 897,
+rowsPerImage: 126,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let querySet68 = device4.createQuerySet({
+label: '\uaa45\udd45\ud6ee',
+type: 'occlusion',
+count: 2671,
+});
+try {
+computePassEncoder24.setPipeline(
+pipeline91
+);
+} catch {}
+try {
+gpuCanvasContext14.configure(
+{
+device: device4,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-12x10-unorm',
+'rgba16float'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer24,
+47600,
+new Int16Array(21795),
+4685,
+28
+);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 82, height: 1, depthOrArrayLayers: 65}
+*/
+{
+  source: offscreenCanvas8,
+  origin: { x: 189, y: 489 },
+  flipY: true,
+},
+{
+  texture: texture69,
+  mipLevel: 1,
+  origin: { x: 12, y: 0, z: 16 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 70, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline93 = device4.createRenderPipeline(
+{
+label: '\u{1f68c}\ueb5e\ua6fa\u1cb1\u0fff\u{1fdde}\u{1fd0c}\u{1fcce}\u{1fc1d}\u2116',
+layout: pipelineLayout19,
+vertex: {
+module: shaderModule24,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 23656,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 18588,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 22888,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 6372,
+shaderLocation: 16,
+},
+{
+format: 'uint32x4',
+offset: 10588,
+shaderLocation: 17,
+},
+{
+format: 'uint16x4',
+offset: 14116,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 17232,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x2',
+offset: 4040,
+shaderLocation: 8,
+},
+{
+format: 'unorm16x4',
+offset: 12156,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 13472,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x2',
+offset: 8400,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+},
+}
+);
+let textureView87 = texture85.createView(
+{
+label: '\u0ae4\u9f27\ue072',
+dimension: '2d-array',
+format: 'rgba8unorm-srgb',
+}
+);
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+commandEncoder56.copyBufferToBuffer(
+buffer23,
+1228,
+buffer16,
+12252,
+11740
+);
+dissociateBuffer(device2, buffer23);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+commandEncoder55.copyTextureToTexture(
+{
+  texture: texture62,
+  mipLevel: 3,
+  origin: { x: 19, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture62,
+  mipLevel: 1,
+  origin: { x: 553, y: 0, z: 87 },
+  aspect: 'all',
+},
+{width: 156, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder57.clearBuffer(
+buffer16,
+17968,
+2576
+);
+dissociateBuffer(device2, buffer16);
+} catch {}
+let adapter8 = await promise29;
+let bindGroupLayout40 = device4.createBindGroupLayout(
+{
+label: '\uddc1\uc929\udf2a\u2210\u0a2b\u01d2',
+entries: [
+{
+binding: 1675,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+}
+],
+}
+);
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer24,
+4896,
+new Int16Array(12767),
+4970,
+5148
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture72,
+  mipLevel: 5,
+  origin: { x: 3, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer2),
+/* required buffer size: 537 */{
+offset: 537,
+rowsPerImage: 221,
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+let promise38 = device4.createRenderPipelineAsync(
+{
+layout: pipelineLayout19,
+vertex: {
+module: shaderModule26,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 21932,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 10856,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 18152,
+shaderLocation: 10,
+},
+{
+format: 'float16x4',
+offset: 1076,
+shaderLocation: 11,
+},
+{
+format: 'sint32x4',
+offset: 7260,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 15396,
+attributes: [
+
+],
+},
+{
+arrayStride: 11004,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 9916,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x4',
+offset: 5268,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+multisample: {
+mask: 0x44cd16b5,
+},
+fragment: {
+module: shaderModule26,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r16float',
+writeMask: 0,
+},
+{
+format: 'r16float',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r8unorm',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+},
+stencilReadMask: 3732,
+stencilWriteMask: 673,
+depthBias: 87,
+depthBiasSlopeScale: 48,
+depthBiasClamp: 42,
+},
+}
+);
+let querySet69 = device3.createQuerySet({
+type: 'occlusion',
+count: 1953,
+});
+let computePassEncoder29 = commandEncoder61.beginComputePass();
+let sampler51 = device3.createSampler(
+{
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 7.385,
+maxAnisotropy: 8,
+}
+);
+try {
+commandEncoder43.clearBuffer(
+buffer19,
+33632,
+808
+);
+dissociateBuffer(device3, buffer19);
+} catch {}
+document.body.prepend(video8);
+let imageData13 = new ImageData(224, 144);
+let promise39 = buffer23.mapAsync(
+GPUMapMode.WRITE
+);
+let texture91 = device3.createTexture(
+{
+label: '\u{1f663}\u{1fd86}\u{1fcd7}\u{1ff0b}\u9965\u4689',
+size: [208, 1, 130],
+mipLevelCount: 2,
+dimension: '2d',
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let textureView88 = texture77.createView(
+{
+label: '\u7223\uba99\u955e\u{1f8da}\ud7e4\u{1f65e}\u{1fa5a}',
+aspect: 'all',
+}
+);
+try {
+renderBundleEncoder57.setVertexBuffer(
+0,
+undefined
+);
+} catch {}
+try {
+commandEncoder51.clearBuffer(
+buffer25,
+40296,
+11136
+);
+dissociateBuffer(device3, buffer25);
+} catch {}
+try {
+renderBundleEncoder57.setBindGroup(
+5,
+bindGroup23
+);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(
+48,
+undefined,
+2865799999,
+657615700
+);
+} catch {}
+let renderBundleEncoder60 = device3.createRenderBundleEncoder(
+{
+label: '\u8bdf\u73f8\u{1f9aa}\u{1fa89}\u1d02\u068e\udbb1\u{1fa2d}\u0fde\u{1fb57}\u5dde',
+colorFormats: [
+'r8uint',
+undefined,
+'r32sint',
+'rg16sint'
+],
+sampleCount: 128,
+depthReadOnly: true,
+}
+);
+try {
+renderBundleEncoder45.setBindGroup(
+3,
+bindGroup32
+);
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+commandEncoder51.clearBuffer(
+buffer25,
+4988,
+25760
+);
+dissociateBuffer(device3, buffer25);
+} catch {}
+try {
+gpuCanvasContext10.configure(
+{
+device: device3,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32sint',
+'rgba16float',
+'rgba16float',
+'rgba16float'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let renderPassEncoder19 = commandEncoder65.beginRenderPass(
+{
+label: '\u{1f80e}\u3172\u06ef\u728f\u0f6a\u{1fb19}',
+colorAttachments: [
+undefined,
+undefined,
+{
+view: textureView87,
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+occlusionQuerySet: querySet44,
+maxDrawCount: 284952,
+}
+);
+try {
+computePassEncoder21.setPipeline(
+pipeline92
+);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: -419.5, g: 549.1, b: 493.5, a: 305.8, });
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(
+0,
+1,
+1,
+0
+);
+} catch {}
+try {
+renderPassEncoder19.setStencilReference(
+3317
+);
+} catch {}
+try {
+commandEncoder55.clearBuffer(
+buffer16,
+11288,
+4168
+);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture48,
+  mipLevel: 1,
+  origin: { x: 4, y: 0, z: 10 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer4),
+/* required buffer size: 159776 */{
+offset: 660,
+bytesPerRow: 2795,
+rowsPerImage: 86,
+},
+{width: 649, height: 57, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video6,
+  origin: { x: 9, y: 0 },
+  flipY: true,
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline94 = await device2.createRenderPipelineAsync(
+{
+layout: pipelineLayout9,
+vertex: {
+module: shaderModule31,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 7972,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 1886,
+shaderLocation: 12,
+},
+{
+format: 'uint8x2',
+offset: 3452,
+shaderLocation: 13,
+},
+{
+format: 'snorm16x2',
+offset: 3064,
+shaderLocation: 20,
+},
+{
+format: 'sint32x4',
+offset: 5128,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x2',
+offset: 230,
+shaderLocation: 19,
+},
+{
+format: 'snorm8x2',
+offset: 3846,
+shaderLocation: 5,
+},
+{
+format: 'uint16x4',
+offset: 6656,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x2',
+offset: 5648,
+shaderLocation: 11,
+},
+{
+format: 'uint16x2',
+offset: 4096,
+shaderLocation: 21,
+}
+],
+},
+{
+arrayStride: 12100,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x4',
+offset: 3216,
+shaderLocation: 15,
+},
+{
+format: 'sint32x2',
+offset: 9016,
+shaderLocation: 4,
+},
+{
+format: 'unorm16x4',
+offset: 1452,
+shaderLocation: 14,
+},
+{
+format: 'uint8x2',
+offset: 7554,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 9592,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 3120,
+shaderLocation: 1,
+},
+{
+format: 'snorm16x2',
+offset: 3424,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x2',
+offset: 9064,
+shaderLocation: 8,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule31,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+undefined
+],
+},
+}
+);
+let texture92 = device1.createTexture(
+{
+label: '\u6914\u{1f99c}\u{1feb5}\ua7a4\uab49\ue9f0\u{1fe59}\u6811\u2e58\u{1fbfc}',
+size: [5932],
+dimension: '1d',
+format: 'rg16uint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rg16uint'
+],
+}
+);
+let textureView89 = texture33.createView(
+{
+}
+);
+let sampler52 = device1.createSampler(
+{
+label: '\u03f0\ub92c\u0759\u{1ffd7}\ud72d',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+lodMinClamp: 86.687,
+lodMaxClamp: 93.507,
+}
+);
+try {
+renderPassEncoder13.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(
+6,
+buffer15,
+1688
+);
+} catch {}
+try {
+computePassEncoder28.insertDebugMarker(
+'\u7f0b'
+);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline95 = device1.createComputePipeline(
+{
+label: '\ue901\u57ff\u{1ff34}\u{1fda7}\u{1fe46}\u073b\ubff9\ue31a',
+layout: pipelineLayout14,
+compute: {
+module: shaderModule29,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let bindGroupLayout41 = device4.createBindGroupLayout(
+{
+label: '\u0c1b\u08c3\u02bb\u{1fbb2}\u0125\u806f\u1372\uadaa\ue3e0',
+entries: [
+{
+binding: 2440,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let querySet70 = device4.createQuerySet({
+label: '\u5e04\u{1fb8a}',
+type: 'occlusion',
+count: 4055,
+});
+pseudoSubmit(device4, commandEncoder58);
+let renderBundleEncoder61 = device4.createRenderBundleEncoder(
+{
+label: '\ua417\udf50\u{1f955}\uf49c\u04a8\ub504',
+colorFormats: [
+'rg16uint',
+'rgba8uint',
+undefined,
+'r8sint',
+'r8unorm',
+'rgba8unorm-srgb',
+undefined,
+'rg8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 838,
+depthReadOnly: true,
+}
+);
+let sampler53 = device4.createSampler(
+{
+label: '\u4149\u0bdd',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 78.112,
+lodMaxClamp: 89.557,
+maxAnisotropy: 10,
+}
+);
+try {
+renderPassEncoder17.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(
+52,
+undefined
+);
+} catch {}
+let imageBitmap16 = await createImageBitmap(imageBitmap2);
+try {
+window.someLabel = externalTexture6.label;
+} catch {}
+let pipelineLayout25 = device2.createPipelineLayout(
+{
+label: '\u67af\u16a2\uc556',
+bindGroupLayouts: [
+bindGroupLayout24,
+bindGroupLayout32,
+bindGroupLayout22,
+bindGroupLayout32,
+bindGroupLayout31,
+bindGroupLayout24
+]
+}
+);
+let querySet71 = device2.createQuerySet({
+label: '\uc6d7\ue063\u06f8\u33a2\u{1f70c}\u06da\u738e\u0e2e\u011a\u98f8',
+type: 'occlusion',
+count: 3630,
+});
+let textureView90 = texture61.createView(
+{
+label: '\u588b\u13d3',
+arrayLayerCount: 1,
+}
+);
+let computePassEncoder30 = commandEncoder57.beginComputePass(
+{
+label: '\u0479\u0fb0\uebc8\u0800\ueeb0\u9c18\u0dec\u5cfd\u6a0a\ud27e'
+}
+);
+try {
+renderPassEncoder19.setBindGroup(
+0,
+bindGroup31
+);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(3141);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: -799.6, g: -500.9, b: 966.2, a: 614.9, });
+} catch {}
+let pipeline96 = await device2.createComputePipelineAsync(
+{
+label: '\uc9e7\uba2c\u0d1c\u9d72\uf52a\u06ca\ufca1',
+layout: pipelineLayout20,
+compute: {
+module: shaderModule31,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let offscreenCanvas19 = new OffscreenCanvas(572, 823);
+let bindGroupLayout42 = pipeline94.getBindGroupLayout(4);
+let buffer29 = device2.createBuffer(
+{
+size: 60006,
+usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+}
+);
+let commandEncoder66 = device2.createCommandEncoder(
+{
+label: '\u6854\ucbcf\uf382\u3193\u{1fe14}\u6ae9\u571f',
+}
+);
+try {
+computePassEncoder30.setBindGroup(
+3,
+bindGroup20
+);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(2152);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(
+1,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(
+54,
+undefined,
+1482146938,
+561612284
+);
+} catch {}
+try {
+commandEncoder56.resolveQuerySet(
+querySet44,
+1953,
+595,
+buffer29,
+23552
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture62,
+  mipLevel: 0,
+  origin: { x: 236, y: 1, z: 103 },
+  aspect: 'all',
+},
+new Int32Array(arrayBuffer6),
+/* required buffer size: 78793492 */{
+offset: 172,
+bytesPerRow: 4308,
+rowsPerImage: 295,
+},
+{width: 1067, height: 0, depthOrArrayLayers: 63}
+);
+} catch {}
+let gpuCanvasContext19 = offscreenCanvas19.getContext('webgpu');
+let texture93 = gpuCanvasContext9.getCurrentTexture();
+let sampler54 = device1.createSampler(
+{
+label: '\u0692\ufb0c\u4557\u{1f652}',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+}
+);
+let externalTexture7 = device1.importExternalTexture(
+{
+source: video10,
+}
+);
+try {
+computePassEncoder28.setPipeline(
+pipeline56
+);
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(
+14,
+9,
+0,
+1
+);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(
+6,
+buffer15,
+3708,
+243
+);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(
+3,
+bindGroup16
+);
+} catch {}
+let pipeline97 = await device1.createRenderPipelineAsync(
+{
+label: '\u{1f6c3}\u0121\u18f6\u06b1',
+layout: pipelineLayout15,
+vertex: {
+module: shaderModule15,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 6368,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm10-10-10-2',
+offset: 3876,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 23204,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x2',
+offset: 4324,
+shaderLocation: 3,
+},
+{
+format: 'float32',
+offset: 6820,
+shaderLocation: 5,
+},
+{
+format: 'float32x3',
+offset: 20016,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x4',
+offset: 56,
+shaderLocation: 7,
+},
+{
+format: 'sint32',
+offset: 19564,
+shaderLocation: 12,
+},
+{
+format: 'sint32x2',
+offset: 5896,
+shaderLocation: 8,
+},
+{
+format: 'float32x3',
+offset: 2988,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 21732,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 12496,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 14420,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 1552,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 1988,
+attributes: [
+{
+format: 'snorm16x2',
+offset: 1096,
+shaderLocation: 6,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'back',
+},
+multisample: {
+mask: 0x4cf6690e,
+},
+fragment: {
+module: shaderModule15,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'never',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'replace',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3638,
+stencilWriteMask: 562,
+depthBiasSlopeScale: 38,
+depthBiasClamp: 63,
+},
+}
+);
+try {
+await promise36;
+} catch {}
+let querySet72 = device5.createQuerySet({
+label: '\u3a4b\u0175\u336f\u20c5',
+type: 'occlusion',
+count: 974,
+});
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let bindGroupLayout43 = device5.createBindGroupLayout(
+{
+label: '\ua223\u8b08\u89ef\u{1f86e}\u436c\u17de\u944e\u{1ff5b}',
+entries: [
+{
+binding: 2241,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}
+],
+}
+);
+let pipelineLayout26 = device5.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout43,
+bindGroupLayout43,
+bindGroupLayout38,
+bindGroupLayout43
+]
+}
+);
+let texture94 = device5.createTexture(
+{
+label: '\u159d\u1b31\u0425\u{1fb3f}\u{1f9e5}\u965b',
+size: {width: 32, height: 60, depthOrArrayLayers: 236},
+mipLevelCount: 2,
+format: 'eac-rg11unorm',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+let renderBundle67 = renderBundleEncoder55.finish();
+let sampler55 = device5.createSampler(
+{
+label: '\uf00e\u2bb9\u15f3\u0082\u0ab6\u{1f6d0}\uff95',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 7.247,
+lodMaxClamp: 22.894,
+maxAnisotropy: 1,
+}
+);
+try {
+device5.destroy();
+} catch {}
+let querySet73 = device3.createQuerySet({
+type: 'occlusion',
+count: 3304,
+});
+try {
+commandEncoder59.copyTextureToTexture(
+{
+  texture: texture77,
+  mipLevel: 0,
+  origin: { x: 1882, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: { x: 784, y: 1, z: 0 },
+  aspect: 'all',
+},
+{width: 890, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder43.clearBuffer(
+buffer25,
+39864,
+22236
+);
+dissociateBuffer(device3, buffer25);
+} catch {}
+let canvas15 = document.createElement('canvas');
+let pipelineLayout27 = device0.createPipelineLayout(
+{
+label: '\u0cc6\u04ee\u{1f9c4}\u26e9',
+bindGroupLayouts: [
+bindGroupLayout18
+]
+}
+);
+let commandEncoder67 = device0.createCommandEncoder(
+{
+label: '\u{1fabf}\u08f9\u05ee\u0c30\u9e54\u4910\u{1fbf7}\u{1fcc3}\u{1f953}',
+}
+);
+let computePassEncoder31 = commandEncoder67.beginComputePass(
+{
+label: '\u04c4\u{1f997}'
+}
+);
+let renderBundle68 = renderBundleEncoder1.finish(
+{
+
+}
+);
+try {
+computePassEncoder7.setBindGroup(
+9,
+bindGroup6,
+new Uint32Array(2),
+1,
+0
+);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+let video15 = await videoWithData();
+let textureView91 = texture88.createView(
+{
+label: '\u3e98\u0108\u0b1b\u{1f9b2}\u0a98\u{1fcc3}\u5660\u0788\ua0cc\u4993',
+mipLevelCount: 12,
+baseArrayLayer: 3,
+arrayLayerCount: 2,
+}
+);
+let renderBundleEncoder62 = device2.createRenderBundleEncoder(
+{
+label: '\uab2c\ue4b3\u8e5d\u{1f7b2}\u0b3d\u01ce\u3c2b\u5c83',
+colorFormats: [
+'rgba8unorm-srgb',
+'rg8unorm',
+'r16float',
+'rg8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 741,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+computePassEncoder18.setPipeline(
+pipeline92
+);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+try {
+commandEncoder55.resolveQuerySet(
+querySet44,
+3680,
+87,
+buffer29,
+44800
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData11,
+  origin: { x: 18, y: 86 },
+  flipY: false,
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let gpuCanvasContext20 = canvas15.getContext('webgpu');
+let img17 = await imageWithData(35, 59, '#960f05c8', '#2bff2bf6');
+let bindGroup35 = device2.createBindGroup({
+label: '\u0c53\ub546\uf5f2\u5e34\u{1f964}',
+layout: bindGroupLayout19,
+entries: [
+
+],
+});
+let textureView92 = texture49.createView(
+{
+label: '\ue607\u0736\ubb02\u{1faa0}\ub85f\u0bfc\ue562\u{1fe01}\ubbb3\u{1ff06}\u{1fa78}',
+mipLevelCount: 2,
+baseArrayLayer: 155,
+arrayLayerCount: 5,
+}
+);
+let renderPassEncoder20 = commandEncoder55.beginRenderPass(
+{
+label: '\ud1ac\u03a2\u{1faee}\u{1f8ef}\u067a\u90ee\u0a18\u0b23\u1db1',
+colorAttachments: [
+undefined,
+{
+view: textureView87,
+clearValue: { r: -645.8, g: -32.47, b: 353.3, a: -241.5, },
+loadOp: 'load',
+storeOp: 'store'
+}
+],
+maxDrawCount: 116896,
+}
+);
+try {
+computePassEncoder18.end();
+} catch {}
+try {
+renderBundleEncoder62.setBindGroup(
+7,
+bindGroup17
+);
+} catch {}
+let promise40 = device2.queue.onSubmittedWorkDone();
+let img18 = await imageWithData(104, 214, '#9e9ad8cd', '#7ec47399');
+let sampler56 = device2.createSampler(
+{
+label: '\u4a13\ue6f4\u08d5\u2bf7\u3f4e\ub8c6\ua524\udd9b\u0902\ua87c',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMaxClamp: 86.028,
+}
+);
+try {
+computePassEncoder21.setBindGroup(
+7,
+bindGroup19,
+new Uint32Array(2231),
+338,
+0
+);
+} catch {}
+try {
+computePassEncoder30.end();
+} catch {}
+try {
+computePassEncoder21.setPipeline(
+pipeline92
+);
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: 122.1, g: 160.7, b: -408.4, a: -414.9, });
+} catch {}
+try {
+renderPassEncoder20.setScissorRect(
+0,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderBundleEncoder59.setBindGroup(
+0,
+bindGroup20,
+new Uint32Array(882),
+173,
+0
+);
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(
+buffer23,
+46780,
+buffer16,
+24412,
+3028
+);
+dissociateBuffer(device2, buffer23);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+commandEncoder56.resolveQuerySet(
+querySet60,
+168,
+383,
+buffer29,
+10240
+);
+} catch {}
+let offscreenCanvas20 = new OffscreenCanvas(464, 321);
+let bindGroupLayout44 = device2.createBindGroupLayout(
+{
+label: '\u0d8a\u026a\u1c29',
+entries: [
+{
+binding: 1110,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+},
+{
+binding: 8151,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 6348,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+}
+],
+}
+);
+let texture95 = device2.createTexture(
+{
+label: '\u3639\uaded\u{1fe31}\u{1ff52}\u0101\u{1f949}\u0c51\u0d4b',
+size: [170, 243, 223],
+mipLevelCount: 5,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16float',
+'rgba16float',
+'rgba16float'
+],
+}
+);
+let textureView93 = texture58.createView(
+{
+label: '\u0a27\u007d\u36b9\u47b7\u0f3d\u{1fae1}',
+format: 'astc-10x10-unorm-srgb',
+baseMipLevel: 3,
+baseArrayLayer: 52,
+arrayLayerCount: 157,
+}
+);
+let computePassEncoder32 = commandEncoder66.beginComputePass(
+{
+label: '\u246e\u009e\ufd43\u0119\uf761\u8e9b\u0bf7\u9417\u0aa7\u0710'
+}
+);
+let renderBundleEncoder63 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgb10a2unorm',
+'bgra8unorm',
+'rg11b10ufloat'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 345,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder21.setBindGroup(
+3,
+bindGroup30
+);
+} catch {}
+try {
+renderPassEncoder19.setViewport(
+0.5342,
+0.2060,
+0.3700,
+0.1306,
+0.4525,
+0.4699
+);
+} catch {}
+try {
+renderBundleEncoder59.setBindGroup(
+2,
+bindGroup24
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video4,
+  origin: { x: 2, y: 0 },
+  flipY: true,
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline98 = await device2.createComputePipelineAsync(
+{
+label: '\u{1ff02}\u8ea3',
+layout: 'auto',
+compute: {
+module: shaderModule30,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+gc();
+let texture96 = device3.createTexture(
+{
+label: '\u{1f7e9}\u0fe9\u026d\u6a58\u77f5\u0429\u2aaf',
+size: [79, 2, 82],
+mipLevelCount: 5,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'stencil8'
+],
+}
+);
+let sampler57 = device3.createSampler(
+{
+label: '\ud610\u5516\u{1fbc0}\u{1fbe5}\ue54b',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 95.840,
+maxAnisotropy: 11,
+}
+);
+try {
+computePassEncoder29.setBindGroup(
+2,
+bindGroup23,
+new Uint32Array(3255),
+455,
+0
+);
+} catch {}
+try {
+renderBundleEncoder56.setBindGroup(
+8,
+bindGroup27,
+new Uint32Array(2091),
+802,
+0
+);
+} catch {}
+try {
+commandEncoder52.clearBuffer(
+buffer25,
+41124,
+2180
+);
+dissociateBuffer(device3, buffer25);
+} catch {}
+let adapter9 = await navigator.gpu.requestAdapter();
+let bindGroupLayout45 = device2.createBindGroupLayout(
+{
+label: '\u{1fe0d}\u42a4\u{1feca}\u0415\ub294\udc25',
+entries: [
+{
+binding: 7605,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+},
+{
+binding: 9064,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '2d' },
+},
+{
+binding: 3697,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '2d-array' },
+}
+],
+}
+);
+let commandEncoder68 = device2.createCommandEncoder(
+{
+label: '\u9958\u7124\u084d\u{1ffd4}\u3f97\u01fc\u014e\u00c3\u240b',
+}
+);
+let renderPassEncoder21 = commandEncoder68.beginRenderPass(
+{
+label: '\u{1f7f5}\u{1fa37}\u06f3\u93c0\u72e9\u{1fc8d}\u{1fe7f}\u0072',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+{
+view: textureView87,
+clearValue: { r: 721.5, g: -339.8, b: 531.9, a: 352.2, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined
+],
+occlusionQuerySet: querySet57,
+maxDrawCount: 55472,
+}
+);
+try {
+computePassEncoder32.setBindGroup(
+2,
+bindGroup17,
+[]
+);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(
+0,
+bindGroup22
+);
+} catch {}
+try {
+renderBundleEncoder47.setBindGroup(
+5,
+bindGroup20,
+new Uint32Array(1521),
+634,
+0
+);
+} catch {}
+try {
+querySet57.destroy();
+} catch {}
+try {
+buffer23.destroy();
+} catch {}
+try {
+commandEncoder46.resolveQuerySet(
+querySet51,
+490,
+250,
+buffer29,
+24320
+);
+} catch {}
+let offscreenCanvas21 = new OffscreenCanvas(402, 467);
+try {
+await promise37;
+} catch {}
+let imageData14 = new ImageData(224, 220);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+offscreenCanvas11.width = 486;
+canvas14.width = 398;
+let bindGroup36 = device4.createBindGroup({
+layout: bindGroupLayout39,
+entries: [
+{
+binding: 1390,
+resource: sampler44
+}
+],
+});
+let commandEncoder69 = device4.createCommandEncoder(
+{
+}
+);
+let commandBuffer8 = commandEncoder69.finish(
+{
+}
+);
+let texture97 = device4.createTexture(
+{
+size: {width: 8060, height: 20, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x10-unorm',
+'astc-10x10-unorm-srgb',
+'astc-10x10-unorm-srgb'
+],
+}
+);
+let renderBundle69 = renderBundleEncoder61.finish(
+{
+label: '\ub252\u13e4'
+}
+);
+try {
+renderPassEncoder17.setBindGroup(
+2,
+bindGroup36,
+new Uint32Array(9368),
+422,
+0
+);
+} catch {}
+try {
+renderPassEncoder16.beginOcclusionQuery(1328);
+} catch {}
+try {
+computePassEncoder24.pushDebugGroup(
+'\u03bc'
+);
+} catch {}
+let pipeline99 = device4.createComputePipeline(
+{
+label: '\u60b9\u3da3\u1f89\uc3b9\u2411\u{1fbff}\u{1ff1b}\u0921\ue0fa',
+layout: pipelineLayout18,
+compute: {
+module: shaderModule25,
+entryPoint: 'compute0',
+},
+}
+);
+let img19 = await imageWithData(63, 176, '#b03ae85b', '#89b0efde');
+pseudoSubmit(device1, commandEncoder30);
+let sampler58 = device1.createSampler(
+{
+label: '\u0625\u0289\u81ca\u{1ff16}\u93c0\u0d2e\ufc78\u{1fd90}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 57.826,
+maxAnisotropy: 20,
+}
+);
+try {
+renderPassEncoder11.setBindGroup(
+4,
+bindGroup16
+);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline100 = await device1.createRenderPipelineAsync(
+{
+layout: pipelineLayout8,
+vertex: {
+module: shaderModule17,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 18256,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 4376,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 1572,
+shaderLocation: 6,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: false,
+},
+multisample: {
+mask: 0x9b983333,
+},
+fragment: {
+module: shaderModule17,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+{
+format: 'rgba32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'dst',
+dstFactor: 'one'
+},
+},
+format: 'r8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'rgb10a2uint',
+writeMask: GPUColorWrite.GREEN,
+}
+],
+},
+}
+);
+let video16 = await videoWithData();
+document.body.prepend(video4);
+let texture98 = device3.createTexture(
+{
+label: '\u{1fbee}\u1118\ubaeb\u4274',
+size: [29, 4, 65],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let computePassEncoder33 = commandEncoder51.beginComputePass(
+{
+
+}
+);
+let renderBundle70 = renderBundleEncoder60.finish();
+let sampler59 = device3.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMaxClamp: 98.189,
+}
+);
+try {
+computePassEncoder33.setBindGroup(
+3,
+bindGroup28
+);
+} catch {}
+try {
+computePassEncoder27.setBindGroup(
+2,
+bindGroup29,
+new Uint32Array(5449),
+3211,
+0
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: { x: 25, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer5),
+/* required buffer size: 287 */{
+offset: 287,
+bytesPerRow: 2393,
+rowsPerImage: 28,
+},
+{width: 570, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend(canvas3);
+let imageBitmap17 = await createImageBitmap(videoFrame16);
+let querySet74 = device4.createQuerySet({
+label: '\ud2b6\u9de7',
+type: 'occlusion',
+count: 797,
+});
+let texture99 = device4.createTexture(
+{
+label: '\u2f68\u0003\u0229\u29ed\ua995',
+size: {width: 78, height: 162, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-6x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView94 = texture79.createView(
+{
+dimension: '2d',
+aspect: 'all',
+format: 'astc-4x4-unorm-srgb',
+baseMipLevel: 6,
+mipLevelCount: 2,
+baseArrayLayer: 86,
+}
+);
+let renderBundleEncoder64 = device4.createRenderBundleEncoder(
+{
+label: '\u021a\uaaa1',
+colorFormats: [
+undefined,
+'rgb10a2unorm',
+'rg32uint',
+'rg11b10ufloat',
+'r8sint',
+'r8sint',
+'rg16sint',
+'rg8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 93,
+depthReadOnly: true,
+}
+);
+let sampler60 = device4.createSampler(
+{
+label: '\u0dc1\u08bc\ub10a\u{1fef8}\u8ada\u02da\u{1f685}\u0074\uffed',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 87.737,
+}
+);
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder64.setVertexBuffer(
+32,
+undefined
+);
+} catch {}
+try {
+gpuCanvasContext5.configure(
+{
+device: device4,
+format: 'rgba16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float',
+'astc-5x4-unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 164, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: img11,
+  origin: { x: 51, y: 50 },
+  flipY: true,
+},
+{
+  texture: texture69,
+  mipLevel: 0,
+  origin: { x: 134, y: 0, z: 73 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 11, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline101 = device4.createRenderPipeline(
+{
+layout: pipelineLayout18,
+vertex: {
+module: shaderModule27,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 9468,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x2',
+offset: 18466,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 19320,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x2',
+offset: 19310,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 17948,
+attributes: [
+{
+format: 'snorm8x2',
+offset: 15302,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x2',
+offset: 3184,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 20656,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 26512,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 2080,
+shaderLocation: 17,
+},
+{
+format: 'uint32',
+offset: 12896,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule27,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+undefined,
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+try {
+offscreenCanvas20.getContext('webgl');
+} catch {}
+let commandEncoder70 = device2.createCommandEncoder(
+{
+label: '\ubb8e\u7320',
+}
+);
+let querySet75 = device2.createQuerySet({
+label: '\ue407\u0e56\u6df6\u09f0\u{1fc66}\uf3de\u0dec',
+type: 'occlusion',
+count: 2539,
+});
+let textureView95 = texture54.createView(
+{
+label: '\u2399\u{1fc52}\u90df\uc16b\u8069\u08ad',
+dimension: '2d-array',
+format: 'etc2-rgb8unorm-srgb',
+baseMipLevel: 2,
+}
+);
+let renderBundleEncoder65 = device2.createRenderBundleEncoder(
+{
+label: '\ue967\ued4f\ued51\u6f4e',
+colorFormats: [
+'bgra8unorm',
+'bgra8unorm-srgb',
+'rg11b10ufloat',
+'r8sint',
+'rgba8unorm',
+'r8sint'
+],
+sampleCount: 636,
+stencilReadOnly: true,
+}
+);
+let renderBundle71 = renderBundleEncoder26.finish(
+{
+label: '\u{1f974}\u{1fb4e}\u22d5'
+}
+);
+try {
+computePassEncoder32.setPipeline(
+pipeline92
+);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(
+5,
+bindGroup19
+);
+} catch {}
+try {
+renderPassEncoder19.setStencilReference(
+1887
+);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(
+23,
+undefined,
+1182071664,
+2855925125
+);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(
+8,
+bindGroup20
+);
+} catch {}
+try {
+commandEncoder33.resolveQuerySet(
+querySet51,
+80,
+1499,
+buffer29,
+7680
+);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageData15 = new ImageData(156, 240);
+let commandEncoder71 = device1.createCommandEncoder(
+{
+label: '\u4096\u18bb\u0658\u0975\u{1fe1b}\u{1f6dc}\u2883',
+}
+);
+let renderBundle72 = renderBundleEncoder17.finish();
+try {
+computePassEncoder23.setPipeline(
+pipeline56
+);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(1057);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(
+2668
+);
+} catch {}
+let pipeline102 = device1.createComputePipeline(
+{
+label: '\u0866\u04f4\ue73b\u091e\u{1fa13}\u5db7\u073d\ucd57\u2dd9\u{1f7c3}',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule21,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend(canvas1);
+try {
+offscreenCanvas21.getContext('webgl2');
+} catch {}
+let commandBuffer9 = commandEncoder57.finish(
+{
+label: '\uefeb\u{1fc42}\u0679',
+}
+);
+let computePassEncoder34 = commandEncoder70.beginComputePass();
+let renderBundle73 = renderBundleEncoder59.finish(
+{
+label: '\u08cd\u06fa\u0521\uccc0\u2528\ue8e0\u08dc\u{1ffdf}'
+}
+);
+try {
+renderPassEncoder21.beginOcclusionQuery(142);
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(
+buffer23,
+22584,
+buffer16,
+17788,
+9036
+);
+dissociateBuffer(device2, buffer23);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+device2.queue.submit([
+]);
+} catch {}
+gc();
+let img20 = await imageWithData(37, 168, '#7b551759', '#48793020');
+try {
+computePassEncoder21.setPipeline(
+pipeline96
+);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+let arrayBuffer10 = buffer21.getMappedRange(
+5368,
+4
+);
+try {
+buffer16.unmap();
+} catch {}
+try {
+commandEncoder56.copyBufferToBuffer(
+buffer21,
+13152,
+buffer16,
+1800,
+2460
+);
+dissociateBuffer(device2, buffer21);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+commandEncoder33.resolveQuerySet(
+querySet60,
+80,
+634,
+buffer29,
+36352
+);
+} catch {}
+gc();
+let buffer30 = device3.createBuffer(
+{
+size: 60652,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let renderBundle74 = renderBundleEncoder48.finish(
+{
+label: '\u5a05\u{1fc00}\u5e99'
+}
+);
+try {
+renderBundleEncoder56.setVertexBuffer(
+69,
+undefined,
+3650791492,
+402364223
+);
+} catch {}
+try {
+computePassEncoder24.setBindGroup(
+6,
+bindGroup36
+);
+} catch {}
+try {
+computePassEncoder24.setPipeline(
+pipeline88
+);
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant({ r: -420.3, g: 334.5, b: 780.1, a: 790.9, });
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(
+53,
+0,
+22,
+0
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture99,
+  mipLevel: 2,
+  origin: { x: 0, y: 6, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(91),
+/* required buffer size: 91 */{
+offset: 91,
+bytesPerRow: 158,
+rowsPerImage: 213,
+},
+{width: 18, height: 6, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 164, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: img11,
+  origin: { x: 19, y: 64 },
+  flipY: false,
+},
+{
+  texture: texture69,
+  mipLevel: 0,
+  origin: { x: 44, y: 0, z: 25 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 19, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline103 = device4.createComputePipeline(
+{
+label: '\uf25e\u3520\u6531\uedbc\u0e7d\u{1fc98}\u{1f998}\ua20b\ua895',
+layout: pipelineLayout18,
+compute: {
+module: shaderModule23,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+await promise39;
+} catch {}
+let adapter10 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let texture100 = device3.createTexture(
+{
+label: '\uaf4d\u7f4c\u3ce8\u016a\u{1fe65}\u{1fa5d}',
+size: {width: 44, height: 9, depthOrArrayLayers: 19},
+mipLevelCount: 3,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+computePassEncoder25.setBindGroup(
+1,
+bindGroup26,
+new Uint32Array(9059),
+7097,
+0
+);
+} catch {}
+try {
+commandEncoder43.copyTextureToTexture(
+{
+  texture: texture96,
+  mipLevel: 2,
+  origin: { x: 4, y: 0, z: 23 },
+  aspect: 'stencil-only',
+},
+{
+  texture: texture60,
+  mipLevel: 3,
+  origin: { x: 0, y: 3, z: 0 },
+  aspect: 'all',
+},
+{width: 7, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext13.configure(
+{
+device: device3,
+format: 'rg32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'depth32float'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let canvas16 = document.createElement('canvas');
+let bindGroupLayout46 = device1.createBindGroupLayout(
+{
+label: '\u21ee\u26dd\u03d5\ud9ac',
+entries: [
+
+],
+}
+);
+let commandEncoder72 = device1.createCommandEncoder(
+{
+}
+);
+let querySet76 = device1.createQuerySet({
+type: 'occlusion',
+count: 3296,
+});
+let computePassEncoder35 = commandEncoder72.beginComputePass(
+{
+label: '\u0774\u0cd8\u090a\u4529\u80ce\u0cc8\u0cb9\u{1ffa1}'
+}
+);
+let sampler61 = device1.createSampler(
+{
+label: '\u0722\u9f0c\u0665\u0b29\u0265\u1f1e',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 99.622,
+lodMaxClamp: 99.930,
+maxAnisotropy: 5,
+}
+);
+try {
+renderPassEncoder12.beginOcclusionQuery(195);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(
+5,
+buffer15,
+1072,
+4136
+);
+} catch {}
+try {
+computePassEncoder11.popDebugGroup();
+} catch {}
+try {
+device1.destroy();
+} catch {}
+let gpuCanvasContext21 = canvas16.getContext('webgpu');
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+try {
+computePassEncoder32.setPipeline(
+pipeline96
+);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(
+7,
+bindGroup19
+);
+} catch {}
+try {
+renderPassEncoder19.end();
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(
+4,
+bindGroup19,
+[]
+);
+} catch {}
+let pipeline104 = device2.createComputePipeline(
+{
+label: '\uce3a\u{1f827}',
+layout: pipelineLayout23,
+compute: {
+module: shaderModule30,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let promise41 = device2.createRenderPipelineAsync(
+{
+label: '\u0d54\uf3e7\uc884\u06f8\u04ed\u{1fcef}\ue796',
+layout: pipelineLayout12,
+vertex: {
+module: shaderModule30,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 8076,
+attributes: [
+{
+format: 'uint8x2',
+offset: 7564,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+multisample: {
+mask: 0xc24b85a1,
+},
+fragment: {
+module: shaderModule30,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthCompare: 'always',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'replace',
+},
+stencilWriteMask: 451,
+depthBiasSlopeScale: 19,
+depthBiasClamp: 50,
+},
+}
+);
+let videoFrame17 = new VideoFrame(img7, {timestamp: 0});
+let commandEncoder73 = device3.createCommandEncoder(
+{
+}
+);
+let textureView96 = texture98.createView(
+{
+label: '\uebaa\u324b\u35aa\u{1f894}\uf1c3\u0f16\ud49e\u5438\u0181\u0de4\u{1feb8}',
+baseMipLevel: 3,
+}
+);
+try {
+renderBundleEncoder56.setVertexBuffer(
+26,
+undefined,
+2886459790,
+134279828
+);
+} catch {}
+try {
+commandEncoder52.copyTextureToTexture(
+{
+  texture: texture91,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 20 },
+  aspect: 'depth-only',
+},
+{
+  texture: texture91,
+  mipLevel: 0,
+  origin: { x: 9, y: 0, z: 51 },
+  aspect: 'depth-only',
+},
+{width: 104, height: 1, depthOrArrayLayers: 8}
+);
+} catch {}
+try {
+device3.queue.submit([
+commandBuffer7,
+]);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(
+/*
+{width: 29, height: 4, depthOrArrayLayers: 65}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 69, y: 27 },
+  flipY: false,
+},
+{
+  texture: texture98,
+  mipLevel: 0,
+  origin: { x: 27, y: 2, z: 6 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 2, depthOrArrayLayers: 1}
+);
+} catch {}
+let buffer31 = device3.createBuffer(
+{
+label: '\u421a\u0118\u0ab2\u5693\u87a2\u0ce5\uf033\u4e59\u{1f944}\u179e\ud9b4',
+size: 35837,
+usage: GPUBufferUsage.MAP_READ,
+}
+);
+let computePassEncoder36 = commandEncoder59.beginComputePass(
+{
+label: '\u0204\u6602\u94d3\uaeb8\u0804\u0d90\u{1fd4d}\u0677'
+}
+);
+let renderPassEncoder22 = commandEncoder43.beginRenderPass(
+{
+label: '\u442a\u432c\u0e11\u4931\u{1f90d}\u93c9\u7eda\u02a4\u07a9',
+colorAttachments: [
+{
+view: textureView96,
+depthSlice: 2,
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+{
+view: textureView96,
+depthSlice: 3,
+clearValue: { r: 928.7, g: 863.0, b: -107.4, a: 536.8, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView96,
+depthSlice: 4,
+clearValue: { r: -20.82, g: 528.0, b: -249.2, a: -944.6, },
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet59,
+maxDrawCount: 1272,
+}
+);
+let sampler62 = device3.createSampler(
+{
+label: '\u9fe1\u{1f7a4}\u{1fcc2}\u{1fe68}',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 90.151,
+lodMaxClamp: 97.924,
+}
+);
+try {
+renderPassEncoder22.beginOcclusionQuery(40);
+} catch {}
+try {
+renderPassEncoder22.setScissorRect(
+0,
+0,
+0,
+0
+);
+} catch {}
+try {
+commandEncoder73.copyTextureToTexture(
+{
+  texture: texture63,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture65,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext12.configure(
+{
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb',
+'rgba8unorm',
+'rgba8unorm',
+'rgba16sint'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+canvas13.width = 411;
+let canvas17 = document.createElement('canvas');
+let videoFrame18 = new VideoFrame(img9, {timestamp: 0});
+let bindGroupLayout47 = device4.createBindGroupLayout(
+{
+label: '\u9a7e\u502b\u{1f7f9}\ufb9f\u{1f710}\u08ae\u0c5f\u9edb\u95a0\ued1d',
+entries: [
+{
+binding: 731,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let commandEncoder74 = device4.createCommandEncoder();
+let textureView97 = texture79.createView(
+{
+label: '\u7311\u1604\u{1f91b}\u{1f6a9}\ucff2\ue830',
+baseMipLevel: 1,
+mipLevelCount: 1,
+baseArrayLayer: 55,
+arrayLayerCount: 40,
+}
+);
+let computePassEncoder37 = commandEncoder74.beginComputePass(
+{
+label: '\ub276\u0492\u{1f7bf}\u0097\u7cc5\uaac7\u00dd'
+}
+);
+let renderBundle75 = renderBundleEncoder64.finish(
+{
+label: '\u4330\u01ad'
+}
+);
+let sampler63 = device4.createSampler(
+{
+label: '\u53b3\u0664\u0636\uae22\u01f5',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 69.082,
+lodMaxClamp: 92.350,
+maxAnisotropy: 4,
+}
+);
+try {
+computePassEncoder37.setBindGroup(
+8,
+bindGroup36
+);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(
+42,
+0,
+5,
+0
+);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 82, height: 1, depthOrArrayLayers: 65}
+*/
+{
+  source: img8,
+  origin: { x: 176, y: 5 },
+  flipY: false,
+},
+{
+  texture: texture69,
+  mipLevel: 1,
+  origin: { x: 1, y: 0, z: 35 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 63, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+video0.height = 161;
+let bindGroup37 = device4.createBindGroup({
+label: '\u0074\u{1ff4e}\udfef\u75b6\u61a6\u0ba9\ueb0c\u{1fc15}',
+layout: bindGroupLayout40,
+entries: [
+{
+binding: 1675,
+resource: sampler41
+}
+],
+});
+try {
+renderPassEncoder16.setBindGroup(
+5,
+bindGroup36
+);
+} catch {}
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: -883.3, g: -906.3, b: -403.8, a: 13.11, });
+} catch {}
+let gpuCanvasContext22 = canvas17.getContext('webgpu');
+try {
+await promise40;
+} catch {}
+let imageBitmap18 = await createImageBitmap(imageBitmap9);
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+document.body.prepend(video1);
+offscreenCanvas16.width = 260;
+let textureView98 = texture78.createView(
+{
+label: '\uea99\u0ed9\u{1f782}\u847c\uc8ee\uc209\uf69a\ub8e2\u8fa4',
+dimension: '2d',
+aspect: 'all',
+baseMipLevel: 3,
+mipLevelCount: 3,
+baseArrayLayer: 32,
+}
+);
+let sampler64 = device4.createSampler(
+{
+label: '\u845c\u{1ffd8}\u0851\u0211\ue12c\u{1fa9f}\ub9a0',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 29.070,
+compare: 'never',
+maxAnisotropy: 6,
+}
+);
+try {
+renderPassEncoder16.setVertexBuffer(
+41,
+undefined
+);
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device4,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'bgra8unorm',
+'bgra8unorm',
+'bgra8unorm'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+let offscreenCanvas22 = new OffscreenCanvas(484, 338);
+let img21 = await imageWithData(240, 72, '#d5dedd1a', '#cee928a1');
+try {
+await adapter6.requestAdapterInfo();
+} catch {}
+try {
+offscreenCanvas22.getContext('webgl');
+} catch {}
+pseudoSubmit(device4, commandEncoder62);
+let renderBundle76 = renderBundleEncoder64.finish(
+{
+label: '\u0a66\u6ee3\u{1fd00}\uf56b\u518c\u09c1\u027a\u350f\u0217'
+}
+);
+try {
+computePassEncoder37.end();
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(
+1,
+bindGroup36,
+new Uint32Array(3897),
+767,
+0
+);
+} catch {}
+try {
+renderPassEncoder17.setStencilReference(
+3573
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+88,
+undefined,
+1139624800,
+1006853230
+);
+} catch {}
+try {
+commandEncoder74.copyTextureToTexture(
+{
+  texture: texture69,
+  mipLevel: 3,
+  origin: { x: 3, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture69,
+  mipLevel: 0,
+  origin: { x: 80, y: 0, z: 47 },
+  aspect: 'all',
+},
+{width: 17, height: 1, depthOrArrayLayers: 13}
+);
+} catch {}
+try {
+commandEncoder74.clearBuffer(
+buffer24,
+15844,
+27052
+);
+dissociateBuffer(device4, buffer24);
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer24,
+18856,
+new Int16Array(28745),
+18641,
+5872
+);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 10, height: 1, depthOrArrayLayers: 8}
+*/
+{
+  source: videoFrame16,
+  origin: { x: 93, y: 525 },
+  flipY: true,
+},
+{
+  texture: texture69,
+  mipLevel: 4,
+  origin: { x: 4, y: 0, z: 6 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 5, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let bindGroup38 = device3.createBindGroup({
+label: '\uc05a\u2bd3\u{1f9d5}\u050f\ud231\u{1ffde}\u0f82',
+layout: bindGroupLayout37,
+entries: [
+
+],
+});
+let commandEncoder75 = device3.createCommandEncoder(
+{
+label: '\u0509\uc8d0\u1d21\u{1f791}\u6480',
+}
+);
+let texture101 = device3.createTexture(
+{
+label: '\u163f\ue3b8',
+size: [6533, 134, 251],
+mipLevelCount: 7,
+format: 'r8sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8sint',
+'r8sint'
+],
+}
+);
+let renderPassEncoder23 = commandEncoder75.beginRenderPass(
+{
+label: '\uc626\u237b\u{1f8e4}\u{1fa96}\u{1fe3c}\u{1f8c1}\uccd4',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+{
+view: textureView96,
+depthSlice: 3,
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView96,
+depthSlice: 5,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView96,
+depthSlice: 6,
+clearValue: { r: -706.0, g: -333.8, b: 946.8, a: -802.4, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView96,
+depthSlice: 4,
+clearValue: { r: 859.2, g: -421.6, b: 718.6, a: -466.7, },
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet69,
+maxDrawCount: 290048,
+}
+);
+let renderBundle77 = renderBundleEncoder48.finish(
+{
+
+}
+);
+try {
+renderPassEncoder22.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder22.setViewport(
+1.863,
+0.8101,
+0.3257,
+0.02687,
+0.5173,
+0.6269
+);
+} catch {}
+try {
+buffer25.unmap();
+} catch {}
+let device6 = await adapter8.requestDevice({
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 9,
+maxColorAttachmentBytesPerSample: 58,
+maxVertexAttributes: 17,
+maxVertexBufferArrayStride: 61612,
+maxStorageTexturesPerShaderStage: 34,
+maxStorageBuffersPerShaderStage: 23,
+maxDynamicStorageBuffersPerPipelineLayout: 3096,
+maxBindingsPerBindGroup: 4442,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 10330,
+maxTextureDimension2D: 13384,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 200808680,
+maxUniformBuffersPerShaderStage: 36,
+maxInterStageShaderVariables: 81,
+maxInterStageShaderComponents: 110,
+maxSamplersPerShaderStage: 22,
+},
+});
+let commandEncoder76 = device3.createCommandEncoder(
+{
+}
+);
+let renderPassEncoder24 = commandEncoder52.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+{
+view: textureView96,
+depthSlice: 7,
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+{
+view: textureView96,
+depthSlice: 3,
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+occlusionQuerySet: querySet69,
+maxDrawCount: 91848,
+}
+);
+let sampler65 = device3.createSampler(
+{
+label: '\u0cb1\uc114\u{1f84d}\u0639\u04cc\u2ecb',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 61.899,
+lodMaxClamp: 92.340,
+}
+);
+try {
+renderPassEncoder24.setBindGroup(
+5,
+bindGroup34
+);
+} catch {}
+try {
+renderPassEncoder23.beginOcclusionQuery(57);
+} catch {}
+try {
+renderBundleEncoder56.setBindGroup(
+4,
+bindGroup34
+);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(
+63,
+undefined
+);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(
+/*
+{width: 3, height: 1, depthOrArrayLayers: 8}
+*/
+{
+  source: img18,
+  origin: { x: 0, y: 5 },
+  flipY: true,
+},
+{
+  texture: texture98,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 5 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 3, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let video17 = await videoWithData();
+document.body.prepend(video5);
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let texture102 = device2.createTexture(
+{
+label: '\u9ffc\u{1faeb}\u{1ff87}\u0f8b\uf628',
+size: {width: 8786},
+dimension: '1d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32float',
+'rgba32float'
+],
+}
+);
+let computePassEncoder38 = commandEncoder46.beginComputePass(
+{
+label: '\u007c\u{1f746}\u0fc8\u{1fc31}\u0c28\ub0e0\u85f4\u02e4'
+}
+);
+let renderBundle78 = renderBundleEncoder50.finish(
+{
+label: '\u1f3c\u0a2e\u{1f70f}\ucac7\u17d6'
+}
+);
+try {
+computePassEncoder32.setPipeline(
+pipeline98
+);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(
+32,
+undefined,
+260989061,
+2246999680
+);
+} catch {}
+try {
+commandEncoder33.copyBufferToBuffer(
+buffer23,
+48276,
+buffer16,
+26148,
+1756
+);
+dissociateBuffer(device2, buffer23);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture57,
+  mipLevel: 7,
+  origin: { x: 3, y: 1, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(32),
+/* required buffer size: 192 */{
+offset: 192,
+},
+{width: 70, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let offscreenCanvas23 = new OffscreenCanvas(84, 884);
+let renderBundleEncoder66 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba32sint',
+undefined,
+'rg32uint',
+'rgba16uint',
+'rgba8sint',
+'rg8unorm'
+],
+sampleCount: 222,
+}
+);
+let sampler66 = device2.createSampler(
+{
+label: '\u8ce3\u0e2a\u1879\u813e\u482d\u63e7\u48f5\uedf8\u353d\u5444\uf44a',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 31.710,
+lodMaxClamp: 66.177,
+maxAnisotropy: 10,
+}
+);
+try {
+computePassEncoder34.setPipeline(
+pipeline96
+);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(
+buffer23,
+46444,
+buffer16,
+19484,
+1648
+);
+dissociateBuffer(device2, buffer23);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+await promise35;
+} catch {}
+gc();
+let bindGroup39 = device4.createBindGroup({
+layout: bindGroupLayout40,
+entries: [
+{
+binding: 1675,
+resource: sampler41
+}
+],
+});
+let buffer32 = device4.createBuffer(
+{
+size: 21496,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let querySet77 = device4.createQuerySet({
+label: '\u56c9\u6253',
+type: 'occlusion',
+count: 84,
+});
+try {
+renderPassEncoder16.setVertexBuffer(
+91,
+undefined,
+2406370800
+);
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(
+buffer32,
+18804,
+buffer24,
+15708,
+1616
+);
+dissociateBuffer(device4, buffer32);
+dissociateBuffer(device4, buffer24);
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer24,
+39268,
+new Int16Array(62430),
+31734,
+3176
+);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 20, height: 1, depthOrArrayLayers: 16}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 7, y: 8 },
+  flipY: false,
+},
+{
+  texture: texture69,
+  mipLevel: 3,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 19, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let commandEncoder77 = device4.createCommandEncoder(
+{
+label: '\u9550\u0152\u0135\uf6e8\u4b61\u06e2',
+}
+);
+let querySet78 = device4.createQuerySet({
+label: '\u0329\ud0cc\u{1faa4}\u2525\u0136\u9ac5\u09ef\ud644\u010f\u0eeb',
+type: 'occlusion',
+count: 1219,
+});
+let texture103 = device4.createTexture(
+{
+label: '\ub3b3\ua1ff\ud763\u{1fd8f}\u0e55\uc1a3',
+size: {width: 168, height: 210, depthOrArrayLayers: 190},
+mipLevelCount: 5,
+format: 'astc-6x6-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder67 = device4.createRenderBundleEncoder(
+{
+label: '\ub9e8\u7dcb\u0802\u520e\u39ba\u7f6e\uddd9',
+colorFormats: [
+'rgba16float',
+undefined,
+'bgra8unorm',
+'rgba8uint',
+'rgb10a2unorm',
+'rg11b10ufloat',
+'rgba8unorm'
+],
+sampleCount: 55,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder16.setViewport(
+48.09,
+0.8236,
+24.00,
+0.1343,
+0.4213,
+0.4614
+);
+} catch {}
+try {
+renderBundleEncoder67.setBindGroup(
+1,
+bindGroup39,
+[]
+);
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(
+buffer32,
+18048,
+buffer24,
+35868,
+2984
+);
+dissociateBuffer(device4, buffer32);
+dissociateBuffer(device4, buffer24);
+} catch {}
+try {
+device4.queue.submit([
+]);
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer24,
+46716,
+new DataView(new ArrayBuffer(61210)),
+13485,
+56
+);
+} catch {}
+try {
+offscreenCanvas23.getContext('2d');
+} catch {}
+let renderPassEncoder25 = commandEncoder71.beginRenderPass(
+{
+label: '\uc664\u2575\u{1f83e}\ua297\u9ebf\uc087\u0e09\u{1f641}\u5423',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+{
+view: textureView49,
+clearValue: { r: 441.4, g: 44.05, b: -4.172, a: 775.3, },
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet42,
+}
+);
+try {
+renderPassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(
+3,
+bindGroup25
+);
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(
+2,
+bindGroup25,
+new Uint32Array(9325),
+6810,
+0
+);
+} catch {}
+offscreenCanvas17.height = 216;
+let querySet79 = device3.createQuerySet({
+type: 'occlusion',
+count: 3124,
+});
+try {
+renderBundleEncoder45.setBindGroup(
+8,
+bindGroup29
+);
+} catch {}
+try {
+await device3.popErrorScope();
+} catch {}
+let promise42 = navigator.gpu.requestAdapter(
+{
+}
+);
+let commandEncoder78 = device4.createCommandEncoder();
+try {
+renderPassEncoder17.setBindGroup(
+1,
+bindGroup36,
+new Uint32Array(996),
+927,
+0
+);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: 255.0, g: 41.98, b: -458.0, a: 861.5, });
+} catch {}
+try {
+device4.queue.submit([
+commandBuffer8,
+]);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 20, height: 1, depthOrArrayLayers: 16}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 70, y: 119 },
+  flipY: true,
+},
+{
+  texture: texture69,
+  mipLevel: 3,
+  origin: { x: 5, y: 1, z: 5 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 9, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline105 = await promise38;
+let textureView99 = texture77.createView(
+{
+label: '\u{1f7d5}\u0ea8\u317d\ue570\ue268\u{1fb20}',
+}
+);
+let computePassEncoder39 = commandEncoder76.beginComputePass();
+try {
+renderPassEncoder22.end();
+} catch {}
+try {
+renderPassEncoder24.setViewport(
+1.970,
+0.7182,
+1.009,
+0.1185,
+0.9797,
+0.9798
+);
+} catch {}
+try {
+renderBundleEncoder56.setBindGroup(
+0,
+bindGroup38,
+new Uint32Array(7836),
+5458,
+0
+);
+} catch {}
+try {
+commandEncoder73.clearBuffer(
+buffer25,
+42212,
+19808
+);
+dissociateBuffer(device3, buffer25);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(
+/*
+{width: 14, height: 2, depthOrArrayLayers: 32}
+*/
+{
+  source: imageData4,
+  origin: { x: 55, y: 61 },
+  flipY: true,
+},
+{
+  texture: texture98,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 7 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 11, height: 2, depthOrArrayLayers: 0}
+);
+} catch {}
+let imageBitmap19 = await createImageBitmap(imageData8);
+let bindGroup40 = device4.createBindGroup({
+label: '\u8605\u8d49\ua488',
+layout: bindGroupLayout39,
+entries: [
+{
+binding: 1390,
+resource: sampler63
+}
+],
+});
+let renderPassEncoder26 = commandEncoder77.beginRenderPass(
+{
+label: '\u7d7e\u{1f724}\u9f16\u0ca8\u05d8\u05a3',
+colorAttachments: [
+undefined,
+{
+view: textureView74,
+depthSlice: 7,
+clearValue: { r: -851.9, g: -550.5, b: 945.6, a: -919.8, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView74,
+depthSlice: 54,
+clearValue: { r: 936.8, g: 655.4, b: -708.1, a: 169.3, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined,
+{
+view: textureView74,
+depthSlice: 34,
+clearValue: { r: -355.2, g: -275.7, b: 150.6, a: -276.6, },
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet68,
+maxDrawCount: 106864,
+}
+);
+try {
+renderBundleEncoder67.setBindGroup(
+0,
+bindGroup39,
+new Uint32Array(1351),
+829,
+0
+);
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer24,
+33192,
+new BigUint64Array(29928),
+9823,
+756
+);
+} catch {}
+let videoFrame19 = new VideoFrame(offscreenCanvas19, {timestamp: 0});
+let commandEncoder79 = device3.createCommandEncoder(
+{
+}
+);
+try {
+renderPassEncoder23.setBlendConstant({ r: 470.3, g: 758.3, b: -65.06, a: 634.6, });
+} catch {}
+try {
+renderPassEncoder24.setViewport(
+1.187,
+0.3992,
+0.1857,
+0.1207,
+0.9555,
+0.9691
+);
+} catch {}
+try {
+computePassEncoder25.insertDebugMarker(
+'\u7d67'
+);
+} catch {}
+let imageData16 = new ImageData(96, 168);
+let commandEncoder80 = device4.createCommandEncoder(
+{
+}
+);
+let querySet80 = device4.createQuerySet({
+type: 'occlusion',
+count: 3632,
+});
+try {
+renderBundleEncoder67.setBindGroup(
+1,
+bindGroup40
+);
+} catch {}
+try {
+commandEncoder80.clearBuffer(
+buffer24,
+42880,
+1812
+);
+dissociateBuffer(device4, buffer24);
+} catch {}
+gc();
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let adapter11 = await navigator.gpu.requestAdapter();
+try {
+adapter1.label = '\uf586\u3595\u{1fd78}\u310b\u{1ffbf}';
+} catch {}
+let texture104 = device3.createTexture(
+{
+label: '\u8ec1\u5e83\u6d72\u0f10\uf031\u00e1',
+size: [243, 133, 62],
+mipLevelCount: 2,
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView100 = texture100.createView(
+{
+dimension: '2d',
+aspect: 'depth-only',
+mipLevelCount: 1,
+baseArrayLayer: 18,
+}
+);
+let renderBundle79 = renderBundleEncoder57.finish();
+let externalTexture8 = device3.importExternalTexture(
+{
+label: '\u5d90\u{1fb54}\u{1f9ee}\u35fc',
+source: videoFrame14,
+}
+);
+try {
+renderPassEncoder24.beginOcclusionQuery(382);
+} catch {}
+try {
+renderPassEncoder23.setStencilReference(
+3219
+);
+} catch {}
+try {
+renderPassEncoder24.setViewport(
+2.991,
+0.2857,
+0.00344,
+0.3279,
+0.3800,
+0.5567
+);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(
+5,
+bindGroup34
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture104,
+  mipLevel: 0,
+  origin: { x: 18, y: 29, z: 34 },
+  aspect: 'all',
+},
+new Uint32Array(new ArrayBuffer(8)),
+/* required buffer size: 436595 */{
+offset: 970,
+bytesPerRow: 819,
+rowsPerImage: 226,
+},
+{width: 184, height: 80, depthOrArrayLayers: 3}
+);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+document.body.prepend(img19);
+let buffer33 = device2.createBuffer(
+{
+size: 36322,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE,
+}
+);
+let textureView101 = texture102.createView(
+{
+label: '\uf38c\u42fa\u{1fa7a}\ua337\u04e1\u{1f954}\ud9a7\u5cd0\u1c45',
+format: 'rgba32float',
+}
+);
+let computePassEncoder40 = commandEncoder33.beginComputePass(
+{
+label: '\ub580\u0187\u0ea5'
+}
+);
+let renderBundle80 = renderBundleEncoder62.finish();
+try {
+computePassEncoder40.setPipeline(
+pipeline92
+);
+} catch {}
+try {
+commandEncoder45.clearBuffer(
+buffer33,
+716,
+11572
+);
+dissociateBuffer(device2, buffer33);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let canvas18 = document.createElement('canvas');
+let texture105 = device0.createTexture(
+{
+label: '\u{1f917}\u025c\u{1fc46}\ua30c\u{1f622}\uc3e7\u8153\u088f',
+size: {width: 7, height: 64, depthOrArrayLayers: 194},
+mipLevelCount: 5,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'depth24plus'
+],
+}
+);
+let textureView102 = texture17.createView(
+{
+baseMipLevel: 1,
+mipLevelCount: 3,
+baseArrayLayer: 0,
+}
+);
+let renderBundle81 = renderBundleEncoder1.finish();
+try {
+computePassEncoder14.setBindGroup(
+8,
+bindGroup12,
+new Uint32Array(9452),
+8588,
+0
+);
+} catch {}
+try {
+computePassEncoder14.setPipeline(
+pipeline47
+);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(116);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: 90.02, g: 899.1, b: 995.8, a: -651.3, });
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(
+2,
+buffer20,
+12332,
+378
+);
+} catch {}
+try {
+gpuCanvasContext20.configure(
+{
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+} catch {}
+try {
+device0.queue.writeBuffer(
+buffer7,
+35280,
+new BigUint64Array(22486),
+20605,
+424
+);
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let bindGroup41 = device3.createBindGroup({
+layout: bindGroupLayout27,
+entries: [
+
+],
+});
+let computePassEncoder41 = commandEncoder79.beginComputePass(
+{
+
+}
+);
+try {
+renderPassEncoder23.setStencilReference(
+2679
+);
+} catch {}
+try {
+commandEncoder73.clearBuffer(
+buffer19,
+5460,
+12320
+);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+gpuCanvasContext16.configure(
+{
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb',
+'rgba8unorm',
+'rgba8unorm-srgb',
+'rg32float'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let promise43 = adapter10.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 39,
+maxVertexAttributes: 22,
+maxVertexBufferArrayStride: 15132,
+maxStorageTexturesPerShaderStage: 6,
+maxStorageBuffersPerShaderStage: 29,
+maxDynamicStorageBuffersPerPipelineLayout: 60841,
+maxBindingsPerBindGroup: 4015,
+maxTextureDimension1D: 8741,
+maxTextureDimension2D: 9452,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 108754200,
+maxUniformBuffersPerShaderStage: 17,
+maxInterStageShaderVariables: 83,
+maxInterStageShaderComponents: 90,
+maxSamplersPerShaderStage: 18,
+},
+});
+try {
+canvas18.getContext('webgpu');
+} catch {}
+let texture106 = device6.createTexture(
+{
+label: '\u{1fb1a}\u8854\u{1f799}\u14e3\u044b\u0ce1\u{1fdd6}\u0a74\u085d',
+size: {width: 3785},
+dimension: '1d',
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+
+],
+}
+);
+try {
+device6.queue.writeTexture(
+{
+  texture: texture106,
+  mipLevel: 0,
+  origin: { x: 77, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 549 */{
+offset: 549,
+bytesPerRow: 6167,
+},
+{width: 2962, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+canvas5.height = 509;
+let texture107 = device6.createTexture(
+{
+label: '\u61f5\u8963\u3db5\u{1f91f}\u0e88\u0b61\udaeb\u9a2f',
+size: {width: 232, height: 56, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'etc2-rgb8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let sampler67 = device6.createSampler(
+{
+label: '\u0f85\u0e40\u311a\u7f83\u{1ff3d}\u1216\u{1ff02}\u012c\ud67b',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 93.054,
+maxAnisotropy: 14,
+}
+);
+try {
+device6.queue.writeTexture(
+{
+  texture: texture106,
+  mipLevel: 0,
+  origin: { x: 1704, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer7),
+/* required buffer size: 714 */{
+offset: 714,
+},
+{width: 936, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise44 = device6.queue.onSubmittedWorkDone();
+document.body.prepend(canvas3);
+let buffer34 = device3.createBuffer(
+{
+label: '\u0e4b\u0615\ufe1a\u58fe\u{1f701}\u{1fa16}\u03e4\u{1f833}\u0214\u6a63',
+size: 54196,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let texture108 = device3.createTexture(
+{
+size: [210, 1, 267],
+mipLevelCount: 5,
+dimension: '3d',
+format: 'r16sint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16sint',
+'r16sint',
+'r16sint'
+],
+}
+);
+let textureView103 = texture98.createView(
+{
+label: '\u0ff1\u{1fdbf}\u1d52\u0a0f\u05a9\u{1fd5e}',
+baseMipLevel: 1,
+}
+);
+let computePassEncoder42 = commandEncoder73.beginComputePass(
+{
+label: '\ubbf8\u9fc6'
+}
+);
+try {
+renderPassEncoder23.setBindGroup(
+8,
+bindGroup26
+);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(
+11,
+undefined,
+1590240140,
+1667851118
+);
+} catch {}
+try {
+await buffer25.mapAsync(
+GPUMapMode.READ,
+0,
+60956
+);
+} catch {}
+let buffer35 = device4.createBuffer(
+{
+label: '\udd20\u9e28',
+size: 37076,
+usage: GPUBufferUsage.MAP_READ,
+mappedAtCreation: true,
+}
+);
+let commandEncoder81 = device4.createCommandEncoder(
+{
+label: '\u{1f977}\u5df6\u05c5\udc96\u05d8\uf3a5\u{1ff64}\u7048',
+}
+);
+let textureView104 = texture78.createView(
+{
+label: '\ubf78\u7deb\u0e29\ufd4b\u5fac\u0890\ufebc\u020f\uf52f\u0481\u0999',
+dimension: '2d',
+format: 'astc-6x6-unorm',
+baseMipLevel: 5,
+mipLevelCount: 1,
+baseArrayLayer: 92,
+arrayLayerCount: 1,
+}
+);
+let renderPassEncoder27 = commandEncoder78.beginRenderPass(
+{
+label: '\u06b8\u73da\u6a60\u5903\u3b54\ube9e\ua024\u1b18\u8612',
+colorAttachments: [
+undefined,
+{
+view: textureView80,
+depthSlice: 19,
+clearValue: { r: -644.7, g: -737.9, b: 252.6, a: 944.1, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView80,
+depthSlice: 21,
+clearValue: { r: 113.0, g: -292.2, b: -724.3, a: 853.7, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView80,
+depthSlice: 20,
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView80,
+depthSlice: 5,
+clearValue: { r: -319.0, g: -42.60, b: 981.9, a: -866.5, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView80,
+depthSlice: 22,
+clearValue: { r: -35.42, g: -763.0, b: 642.9, a: -557.6, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView80,
+depthSlice: 4,
+clearValue: { r: 809.6, g: -205.0, b: -621.1, a: 800.1, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined
+],
+occlusionQuerySet: querySet78,
+maxDrawCount: 34016,
+}
+);
+let renderBundle82 = renderBundleEncoder52.finish(
+{
+label: '\u{1fe0a}\u0e12'
+}
+);
+try {
+renderPassEncoder27.executeBundles([]);
+} catch {}
+try {
+commandEncoder74.clearBuffer(
+buffer24,
+7564,
+32156
+);
+dissociateBuffer(device4, buffer24);
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer24,
+29872,
+new BigUint64Array(12705),
+9927,
+932
+);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 10, height: 1, depthOrArrayLayers: 8}
+*/
+{
+  source: video15,
+  origin: { x: 6, y: 13 },
+  flipY: false,
+},
+{
+  texture: texture69,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 9, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+try {
+await promise44;
+} catch {}
+document.body.prepend(img0);
+try {
+window.someLabel = device6.label;
+} catch {}
+let commandEncoder82 = device6.createCommandEncoder(
+{
+label: '\uf9ff\u0756\ue6fe\ub4f9\u01fa\udc7c\u{1fa2a}\u1477\ued3e',
+}
+);
+pseudoSubmit(device6, commandEncoder82);
+let textureView105 = texture107.createView(
+{
+dimension: '2d-array',
+baseMipLevel: 1,
+mipLevelCount: 3,
+}
+);
+let renderBundleEncoder68 = device6.createRenderBundleEncoder(
+{
+label: '\u{1fbee}\u1b96\ua477\u207f\u{1fd5c}\ua008',
+colorFormats: [
+undefined
+],
+sampleCount: 855,
+stencilReadOnly: true,
+}
+);
+let renderBundle83 = renderBundleEncoder68.finish(
+{
+label: '\u0813\u077f\ue7d6'
+}
+);
+canvas15.width = 96;
+try {
+textureView77.label = '\u2d64\u{1fa26}\u360c\u{1f7ec}\u02b0\u0a72';
+} catch {}
+let querySet81 = device4.createQuerySet({
+label: '\u08f0\u6402\u0ade',
+type: 'occlusion',
+count: 3594,
+});
+let texture109 = device4.createTexture(
+{
+label: '\u61fc\uc435\u004c',
+size: [80, 95, 126],
+mipLevelCount: 7,
+sampleCount: 1,
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-8x5-unorm',
+'astc-8x5-unorm',
+'astc-8x5-unorm-srgb'
+],
+}
+);
+try {
+renderPassEncoder26.setBindGroup(
+9,
+bindGroup39,
+[]
+);
+} catch {}
+try {
+computePassEncoder24.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext14.configure(
+{
+device: device4,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'etc2-rgb8unorm-srgb',
+'rgba32float',
+'astc-12x10-unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let pipeline106 = device4.createRenderPipeline(
+{
+label: '\u{1fa97}\u2dac\uaf47\ua2d6\u06e4\u6884\u{1fcb1}\u{1fe4d}\u{1f8cd}\u0893',
+layout: 'auto',
+vertex: {
+module: shaderModule23,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 20980,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32',
+offset: 19368,
+shaderLocation: 2,
+},
+{
+format: 'snorm8x4',
+offset: 2292,
+shaderLocation: 13,
+},
+{
+format: 'snorm16x2',
+offset: 10580,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 20536,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 14124,
+shaderLocation: 11,
+},
+{
+format: 'uint8x2',
+offset: 15476,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x2',
+offset: 19232,
+shaderLocation: 0,
+},
+{
+format: 'uint16x2',
+offset: 14004,
+shaderLocation: 7,
+},
+{
+format: 'unorm8x4',
+offset: 14080,
+shaderLocation: 14,
+},
+{
+format: 'sint32x3',
+offset: 820,
+shaderLocation: 17,
+},
+{
+format: 'unorm8x2',
+offset: 6334,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 16824,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x2',
+offset: 12568,
+shaderLocation: 9,
+},
+{
+format: 'sint16x4',
+offset: 10248,
+shaderLocation: 8,
+},
+{
+format: 'uint32x4',
+offset: 10312,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 4196,
+attributes: [
+{
+format: 'float32x2',
+offset: 3720,
+shaderLocation: 3,
+},
+{
+format: 'snorm16x2',
+offset: 0,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 504,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 404,
+shaderLocation: 6,
+},
+{
+format: 'sint32x3',
+offset: 244,
+shaderLocation: 16,
+},
+{
+format: 'float16x2',
+offset: 452,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+primitive: {
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule23,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rgba16uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.GREEN,
+},
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+},
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'decrement-clamp',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'zero',
+depthFailOp: 'decrement-clamp',
+passOp: 'replace',
+},
+stencilWriteMask: 2881,
+depthBias: 26,
+depthBiasSlopeScale: 48,
+},
+}
+);
+document.body.prepend(img11);
+let video18 = await videoWithData();
+try {
+adapter8.label = '\u02c4\u6357\ued6b\u00c3';
+} catch {}
+let texture110 = device2.createTexture(
+{
+size: [74, 1, 1701],
+mipLevelCount: 9,
+dimension: '3d',
+format: 'rg16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+computePassEncoder34.setPipeline(
+pipeline98
+);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(
+7,
+bindGroup19,
+new Uint32Array(7343),
+4107,
+0
+);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(
+51,
+undefined,
+4122040565,
+31688371
+);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(
+buffer23,
+28184,
+buffer33,
+4260,
+17284
+);
+dissociateBuffer(device2, buffer23);
+dissociateBuffer(device2, buffer33);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer33,
+34588,
+new BigUint64Array(42737),
+3233,
+96
+);
+} catch {}
+let canvas19 = document.createElement('canvas');
+let videoFrame20 = new VideoFrame(img14, {timestamp: 0});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+video13.width = 12;
+offscreenCanvas3.width = 380;
+try {
+textureView105.label = '\ua018\u42dd';
+} catch {}
+let texture111 = device6.createTexture(
+{
+label: '\u0983\u049e\u44d1\u{1fcc1}\u089c\u0f02\ueef8\u{1f7ee}\u02c7',
+size: [6582, 5, 64],
+mipLevelCount: 3,
+format: 'astc-6x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-6x5-unorm-srgb',
+'astc-6x5-unorm'
+],
+}
+);
+let renderBundleEncoder69 = device6.createRenderBundleEncoder(
+{
+label: '\u447f\uc41a\u2e1b\u174d\u01eb',
+colorFormats: [
+undefined,
+'rgba16sint',
+'rg8uint',
+'rgb10a2uint',
+'rgba16uint',
+'rgb10a2unorm',
+'rg16float',
+'rg16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 409,
+depthReadOnly: true,
+}
+);
+try {
+device6.queue.writeTexture(
+{
+  texture: texture106,
+  mipLevel: 0,
+  origin: { x: 332, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer7,
+/* required buffer size: 3471 */{
+offset: 753,
+},
+{width: 1359, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let gpuCanvasContext23 = canvas19.getContext('webgpu');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let canvas20 = document.createElement('canvas');
+let texture112 = device2.createTexture(
+{
+label: '\u22c5\u{1fd0e}\u{1fa63}\uc8fa',
+size: [220, 192, 1],
+mipLevelCount: 4,
+format: 'astc-10x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x6-unorm',
+'astc-10x6-unorm-srgb',
+'astc-10x6-unorm'
+],
+}
+);
+let textureView106 = texture70.createView(
+{
+dimension: '2d',
+baseArrayLayer: 13,
+}
+);
+try {
+renderPassEncoder21.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: 363.0, g: -571.0, b: 717.8, a: 691.8, });
+} catch {}
+try {
+commandEncoder56.resolveQuerySet(
+querySet57,
+4,
+430,
+buffer33,
+13824
+);
+} catch {}
+let textureView107 = texture106.createView(
+{
+label: '\ubec2\uffa6\u82fc\uc70f\u0c54\u0486\u34c7\u0ad5',
+}
+);
+gc();
+let renderBundleEncoder70 = device6.createRenderBundleEncoder(
+{
+colorFormats: [
+'bgra8unorm-srgb',
+'rgba16uint',
+'rg16float',
+'r32uint',
+undefined,
+undefined
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 675,
+}
+);
+let sampler68 = device3.createSampler(
+{
+label: '\u{1fe46}\uf408\u0f05\u{1fb27}\u4fde\u2a49',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 80.706,
+lodMaxClamp: 81.825,
+compare: 'less-equal',
+}
+);
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder24.setViewport(
+0.4832,
+0.00283,
+0.9206,
+0.9855,
+0.5095,
+0.9651
+);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(
+88,
+undefined,
+67102939,
+3647767587
+);
+} catch {}
+try {
+renderBundleEncoder56.setBindGroup(
+0,
+bindGroup28,
+new Uint32Array(2649),
+603,
+0
+);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer30,
+9956,
+new Float32Array(44648),
+40823
+);
+} catch {}
+let renderBundle84 = renderBundleEncoder70.finish(
+{
+
+}
+);
+let offscreenCanvas24 = new OffscreenCanvas(703, 715);
+try {
+offscreenCanvas24.getContext('webgl2');
+} catch {}
+let querySet82 = device4.createQuerySet({
+label: '\u99de\u282c\u27ed\udf55\u02fa\u953a\u6505\ud588\uce2e\u868a',
+type: 'occlusion',
+count: 3842,
+});
+let texture113 = device4.createTexture(
+{
+label: '\uad2e\u0257\u5fb2\ud187\uc0f4',
+size: {width: 5392, height: 4, depthOrArrayLayers: 148},
+mipLevelCount: 8,
+format: 'eac-r11unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'eac-r11unorm',
+'eac-r11unorm',
+'eac-r11unorm'
+],
+}
+);
+let sampler69 = device4.createSampler(
+{
+label: '\u4a27\ubd6d\u{1fced}\u{1fc83}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 60.912,
+lodMaxClamp: 78.788,
+compare: 'equal',
+}
+);
+try {
+renderPassEncoder27.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder26.setScissorRect(
+52,
+1,
+15,
+0
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture81,
+  mipLevel: 1,
+  origin: { x: 592, y: 0, z: 75 },
+  aspect: 'all',
+},
+arrayBuffer9,
+/* required buffer size: 15559221 */{
+offset: 997,
+bytesPerRow: 3244,
+rowsPerImage: 218,
+},
+{width: 1528, height: 0, depthOrArrayLayers: 23}
+);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 82, height: 1, depthOrArrayLayers: 65}
+*/
+{
+  source: imageBitmap8,
+  origin: { x: 2, y: 22 },
+  flipY: true,
+},
+{
+  texture: texture69,
+  mipLevel: 1,
+  origin: { x: 51, y: 0, z: 15 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 31, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline107 = await device4.createRenderPipelineAsync(
+{
+label: '\u{1f687}\u592c\u{1f6cd}\u3777\u5c27\u{1fef9}\uc0df\ue925\u{1fff8}',
+layout: pipelineLayout19,
+vertex: {
+module: shaderModule25,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 10648,
+attributes: [
+{
+format: 'unorm16x2',
+offset: 9744,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 7364,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 2784,
+shaderLocation: 16,
+},
+{
+format: 'uint32x2',
+offset: 4968,
+shaderLocation: 13,
+},
+{
+format: 'unorm8x4',
+offset: 1748,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 7040,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 24868,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 6556,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule25,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+failOp: 'keep',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 4047,
+stencilWriteMask: 1251,
+depthBias: 64,
+depthBiasSlopeScale: 44,
+depthBiasClamp: 17,
+},
+}
+);
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+let imageData17 = new ImageData(140, 216);
+let adapter12 = await promise42;
+let canvas21 = document.createElement('canvas');
+let img22 = await imageWithData(299, 245, '#6c03d8de', '#fa3bb8d2');
+let adapter13 = await navigator.gpu.requestAdapter();
+let canvas22 = document.createElement('canvas');
+let offscreenCanvas25 = new OffscreenCanvas(544, 665);
+try {
+await adapter11.requestAdapterInfo();
+} catch {}
+let buffer36 = device4.createBuffer(
+{
+label: '\u0d70\u3889\u{1ff0e}\u285d\u7eff\u49ce\u{1f91a}\u{1f75c}\u0b00',
+size: 45419,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let renderPassEncoder28 = commandEncoder81.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView80,
+depthSlice: 28,
+clearValue: { r: -514.7, g: 526.2, b: 295.9, a: -7.916, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView80,
+depthSlice: 24,
+clearValue: { r: 580.5, g: -547.0, b: -967.4, a: -103.7, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined,
+undefined,
+{
+view: textureView80,
+depthSlice: 20,
+clearValue: { r: 542.5, g: -332.0, b: 453.2, a: -454.7, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+undefined
+],
+maxDrawCount: 22816,
+}
+);
+try {
+renderPassEncoder27.setViewport(
+13.48,
+0.5417,
+17.55,
+0.2972,
+0.7875,
+0.9002
+);
+} catch {}
+try {
+device4.pushErrorScope('validation');
+} catch {}
+try {
+buffer24.destroy();
+} catch {}
+let pipeline108 = await device4.createComputePipelineAsync(
+{
+label: '\u0324\u5062\u0b08\u{1f9e3}\u0624\u8d37\u8e47\u06bf\u4de9',
+layout: pipelineLayout22,
+compute: {
+module: shaderModule28,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let gpuCanvasContext24 = offscreenCanvas25.getContext('webgpu');
+try {
+canvas22.getContext('webgl2');
+} catch {}
+let querySet83 = device4.createQuerySet({
+label: '\u11c6\u012c\u{1f6d7}\u896f\u{1ffa7}\ud038\ufff7',
+type: 'occlusion',
+count: 2052,
+});
+let textureView108 = texture74.createView(
+{
+format: 'rg8sint',
+}
+);
+let computePassEncoder43 = commandEncoder74.beginComputePass(
+{
+label: '\u8375\u{1fcd8}\u0655'
+}
+);
+let renderBundle85 = renderBundleEncoder67.finish();
+try {
+renderPassEncoder26.setBindGroup(
+0,
+bindGroup39,
+[]
+);
+} catch {}
+try {
+renderPassEncoder27.setBlendConstant({ r: -721.5, g: -231.3, b: 92.89, a: -557.7, });
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 82, height: 1, depthOrArrayLayers: 65}
+*/
+{
+  source: imageData5,
+  origin: { x: 64, y: 117 },
+  flipY: true,
+},
+{
+  texture: texture69,
+  mipLevel: 1,
+  origin: { x: 1, y: 0, z: 59 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 66, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let querySet84 = device6.createQuerySet({
+label: '\u{1fc7c}\u0bdf\u{1fd91}\u71b0\u7699\u{1fcfe}\ufd38\ucc56\u06ec\ubb67\u07fa',
+type: 'occlusion',
+count: 1189,
+});
+let renderBundle86 = renderBundleEncoder70.finish();
+let sampler70 = device6.createSampler(
+{
+label: '\u1ac0\u5c18\ub136\u1b5a\u{1f7e7}\uf43a\u6187\u5595\uc14e\u0db5',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 82.465,
+lodMaxClamp: 99.567,
+compare: 'greater',
+maxAnisotropy: 18,
+}
+);
+try {
+renderBundleEncoder69.setVertexBuffer(
+35,
+undefined,
+1137781476,
+2184679623
+);
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture106,
+  mipLevel: 0,
+  origin: { x: 57, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer2),
+/* required buffer size: 763 */{
+offset: 763,
+rowsPerImage: 86,
+},
+{width: 3226, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let offscreenCanvas26 = new OffscreenCanvas(607, 15);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+gc();
+let img23 = await imageWithData(164, 92, '#43a4a841', '#33473021');
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let imageBitmap20 = await createImageBitmap(imageBitmap8);
+let textureView109 = texture112.createView(
+{
+label: '\ucd72\u{1f9c8}\u{1fce5}\ufedd\u0088\u0997\uf93e\ufd9e\u{1fe26}\u{1f79e}',
+dimension: '2d-array',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+let computePassEncoder44 = commandEncoder45.beginComputePass();
+let renderPassEncoder29 = commandEncoder56.beginRenderPass(
+{
+label: '\u{1fce5}\u0773\u00e5\u3612',
+colorAttachments: [
+undefined,
+{
+view: textureView87,
+clearValue: { r: 757.6, g: 55.27, b: 499.1, a: 512.6, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+undefined
+],
+occlusionQuerySet: querySet60,
+maxDrawCount: 181360,
+}
+);
+let sampler71 = device2.createSampler(
+{
+label: '\u080f\uf6b4',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 3.684,
+}
+);
+try {
+renderPassEncoder21.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(
+81,
+undefined,
+3001045506
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer33,
+30580,
+new DataView(new ArrayBuffer(177)),
+60,
+88
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData12,
+  origin: { x: 104, y: 49 },
+  flipY: true,
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let gpuCanvasContext25 = offscreenCanvas26.getContext('webgpu');
+let videoFrame21 = new VideoFrame(offscreenCanvas19, {timestamp: 0});
+try {
+canvas21.getContext('webgpu');
+} catch {}
+let bindGroupLayout48 = device6.createBindGroupLayout(
+{
+label: '\u{1f692}\u9e8f\u{1fbaf}\u43db\u{1ffdd}',
+entries: [
+
+],
+}
+);
+let pipelineLayout28 = device6.createPipelineLayout(
+{
+label: '\u04b5\u580c\u{1fc73}\u8f85\u10e4\u093c',
+bindGroupLayouts: [
+bindGroupLayout48,
+bindGroupLayout48,
+bindGroupLayout48,
+bindGroupLayout48,
+bindGroupLayout48,
+bindGroupLayout48,
+bindGroupLayout48,
+bindGroupLayout48,
+bindGroupLayout48
+]
+}
+);
+let renderBundle87 = renderBundleEncoder70.finish(
+{
+
+}
+);
+try {
+renderBundleEncoder69.setVertexBuffer(
+17,
+undefined,
+81666545,
+3945991692
+);
+} catch {}
+video18.height = 115;
+canvas0.height = 489;
+let bindGroup42 = device4.createBindGroup({
+label: '\u01e0\ubbca\ud2b1\ud9ec\ud167\u0991\uea2e\ua4b2\u{1ff38}',
+layout: bindGroupLayout40,
+entries: [
+{
+binding: 1675,
+resource: sampler41
+}
+],
+});
+let commandBuffer10 = commandEncoder80.finish();
+let textureView110 = texture79.createView(
+{
+label: '\u2900\u027b\u418b\u6fea',
+dimension: '2d-array',
+format: 'astc-4x4-unorm-srgb',
+baseMipLevel: 7,
+mipLevelCount: 1,
+baseArrayLayer: 31,
+arrayLayerCount: 55,
+}
+);
+try {
+computePassEncoder43.setPipeline(
+pipeline85
+);
+} catch {}
+try {
+buffer35.destroy();
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer36,
+9220,
+new DataView(new ArrayBuffer(31608)),
+16327,
+10508
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture113,
+  mipLevel: 2,
+  origin: { x: 28, y: 0, z: 8 },
+  aspect: 'all',
+},
+new Uint8Array(arrayBuffer7),
+/* required buffer size: 2455843 */{
+offset: 427,
+bytesPerRow: 184,
+rowsPerImage: 139,
+},
+{width: 60, height: 4, depthOrArrayLayers: 97}
+);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 164, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 37, y: 139 },
+  flipY: true,
+},
+{
+  texture: texture69,
+  mipLevel: 0,
+  origin: { x: 21, y: 1, z: 122 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 87, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext22.unconfigure();
+} catch {}
+let offscreenCanvas27 = new OffscreenCanvas(45, 54);
+let querySet85 = device2.createQuerySet({
+label: '\uf5d6\u142b\u0f2e\u172e\u6144\uc6e8\u4056\u6679\u0e9b\u{1fc28}\u6f70',
+type: 'occlusion',
+count: 3096,
+});
+try {
+renderPassEncoder21.setVertexBuffer(
+5,
+undefined,
+3937944085,
+68976719
+);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame22 = new VideoFrame(offscreenCanvas3, {timestamp: 0});
+try {
+offscreenCanvas27.getContext('webgl');
+} catch {}
+let commandEncoder83 = device3.createCommandEncoder(
+{
+label: '\u{1fc3b}\ub3c6\u{1f935}\ub6fa\u8feb\u3b3c\u0708',
+}
+);
+try {
+renderPassEncoder23.setBlendConstant({ r: -286.7, g: -811.8, b: -646.6, a: -633.9, });
+} catch {}
+try {
+renderPassEncoder24.setViewport(
+2.005,
+0.4482,
+0.08992,
+0.4387,
+0.1862,
+0.3804
+);
+} catch {}
+try {
+commandEncoder83.copyTextureToBuffer(
+{
+  texture: texture83,
+  mipLevel: 0,
+  origin: { x: 3307, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 8328 widthInBlocks: 2082 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 39292 */
+offset: 30964,
+rowsPerImage: 92,
+buffer: buffer30,
+},
+{width: 2082, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device3, buffer30);
+} catch {}
+try {
+canvas20.getContext('webgpu');
+} catch {}
+let bindGroup43 = device6.createBindGroup({
+label: '\u0488\u{1fcc1}\ua4e0\u0575\u0afa\ue36c',
+layout: bindGroupLayout48,
+entries: [
+
+],
+});
+let querySet86 = device6.createQuerySet({
+label: '\u4590\u6e94\u{1fb93}\u2d2b\u{1f681}\u0a24\ud7ed',
+type: 'occlusion',
+count: 3609,
+});
+let renderBundleEncoder71 = device6.createRenderBundleEncoder(
+{
+label: '\u5173\u0d10',
+colorFormats: [
+'r16sint',
+'rg11b10ufloat',
+'r32uint',
+'r32float',
+'r8uint',
+'rgba8sint',
+'rgba16float'
+],
+sampleCount: 982,
+stencilReadOnly: true,
+}
+);
+let renderBundle88 = renderBundleEncoder69.finish();
+try {
+device6.queue.writeTexture(
+{
+  texture: texture111,
+  mipLevel: 0,
+  origin: { x: 2418, y: 0, z: 46 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer4),
+/* required buffer size: 26898801 */{
+offset: 501,
+bytesPerRow: 10890,
+rowsPerImage: 247,
+},
+{width: 4044, height: 0, depthOrArrayLayers: 11}
+);
+} catch {}
+let imageBitmap21 = await createImageBitmap(imageBitmap16);
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let canvas23 = document.createElement('canvas');
+let commandEncoder84 = device5.createCommandEncoder(
+{
+label: '\uef6e\u06da\u{1fcf2}',
+}
+);
+let textureView111 = texture94.createView(
+{
+label: '\u0cd1\u7035\u753a\u6c08\uc386\u{1fd1f}',
+dimension: '2d',
+mipLevelCount: 1,
+baseArrayLayer: 145,
+}
+);
+let promise45 = buffer27.mapAsync(
+GPUMapMode.WRITE,
+0,
+52632
+);
+canvas13.height = 39;
+gc();
+let texture114 = device4.createTexture(
+{
+size: {width: 874, height: 1, depthOrArrayLayers: 1092},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8snorm'
+],
+}
+);
+let sampler72 = device4.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMaxClamp: 86.153,
+}
+);
+try {
+computePassEncoder43.setBindGroup(
+7,
+bindGroup40,
+new Uint32Array(3758),
+3225,
+0
+);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(
+5,
+bindGroup37
+);
+} catch {}
+try {
+buffer22.unmap();
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture69,
+  mipLevel: 0,
+  origin: { x: 27, y: 1, z: 2 },
+  aspect: 'all',
+},
+new ArrayBuffer(6749125),
+/* required buffer size: 6749125 */{
+offset: 207,
+bytesPerRow: 671,
+rowsPerImage: 107,
+},
+{width: 79, height: 0, depthOrArrayLayers: 95}
+);
+} catch {}
+try {
+canvas23.getContext('webgl');
+} catch {}
+let bindGroupLayout49 = pipeline86.getBindGroupLayout(2);
+let texture115 = device4.createTexture(
+{
+label: '\u40a2\u0e77\ucdcf\u190b\u03ca\u0471\u04ff\uc1ed\u2aa8',
+size: {width: 3420, height: 8, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-4x4-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+try {
+renderPassEncoder28.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder26.setStencilReference(
+1231
+);
+} catch {}
+try {
+renderPassEncoder26.setViewport(
+12.95,
+0.7731,
+25.71,
+0.2123,
+0.8105,
+0.9196
+);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(
+26,
+undefined,
+546933321,
+1639432852
+);
+} catch {}
+try {
+device4.queue.submit([
+]);
+} catch {}
+let pipeline109 = await promise32;
+let renderBundleEncoder72 = device2.createRenderBundleEncoder(
+{
+label: '\ufbc5\u3229\u{1fdbc}\u81d9\u{1fb0f}\u9c8d\ua51b\u{1fcce}\u6651\ue9db\u7ef1',
+colorFormats: [
+'rg16sint',
+'rgba8uint',
+'rgba8unorm',
+'r16sint',
+'r32uint',
+'r32uint',
+'rgba8unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 34,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder21.setBindGroup(
+4,
+bindGroup31
+);
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(
+0,
+0,
+0,
+0
+);
+} catch {}
+try {
+texture110.destroy();
+} catch {}
+let device7 = await adapter13.requestDevice({
+label: '\u0a13\uc60a\u02aa\u6e89\uaa65',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 62,
+maxVertexAttributes: 17,
+maxVertexBufferArrayStride: 56446,
+maxStorageTexturesPerShaderStage: 40,
+maxStorageBuffersPerShaderStage: 27,
+maxDynamicStorageBuffersPerPipelineLayout: 53671,
+maxBindingsPerBindGroup: 3748,
+maxTextureDimension1D: 11373,
+maxTextureDimension2D: 10758,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 74047544,
+maxUniformBuffersPerShaderStage: 29,
+maxInterStageShaderVariables: 63,
+maxInterStageShaderComponents: 62,
+maxSamplersPerShaderStage: 18,
+},
+});
+let offscreenCanvas28 = new OffscreenCanvas(15, 675);
+let buffer37 = device6.createBuffer(
+{
+size: 17756,
+usage: GPUBufferUsage.MAP_READ,
+}
+);
+let texture116 = device6.createTexture(
+{
+label: '\u751f\u09bd\u{1fd36}\u{1f7dd}',
+size: {width: 61, height: 203, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8uint',
+'rgba8uint',
+'rgba8uint'
+],
+}
+);
+let renderBundleEncoder73 = device6.createRenderBundleEncoder(
+{
+label: '\u6e06\u{1ff19}\ueede\u{1fb89}\ud5ee',
+colorFormats: [
+'rg8uint',
+'r32uint',
+'rgb10a2uint',
+'rg32float',
+'bgra8unorm',
+'bgra8unorm-srgb',
+'r16float'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 571,
+}
+);
+try {
+gpuCanvasContext23.configure(
+{
+device: device6,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture116,
+  mipLevel: 1,
+  origin: { x: 8, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(arrayBuffer2),
+/* required buffer size: 12440 */{
+offset: 952,
+bytesPerRow: 190,
+},
+{width: 22, height: 61, depthOrArrayLayers: 1}
+);
+} catch {}
+let querySet87 = device4.createQuerySet({
+label: '\u8498\u{1fc35}\u6458\u0c97\u05a0\u0773\u0edf\u909d',
+type: 'occlusion',
+count: 3124,
+});
+let texture117 = device4.createTexture(
+{
+label: '\ub783\uee5a\u{1ffd8}\u7aaa\u8629\ue26b\ua71a\u0a32\u4de0\u0912\u3a6a',
+size: {width: 148, height: 1, depthOrArrayLayers: 200},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView112 = texture72.createView(
+{
+label: '\ufe5b\u64fd\u{1fe7d}\ueafd\u{1f8a4}\u{1f810}\u033f\u7550\u003e\ufee9\u0b5c',
+dimension: '2d-array',
+aspect: 'all',
+baseMipLevel: 1,
+mipLevelCount: 3,
+baseArrayLayer: 0,
+}
+);
+try {
+renderPassEncoder16.beginOcclusionQuery(520);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant({ r: -539.8, g: 861.6, b: 732.1, a: 79.80, });
+} catch {}
+try {
+renderPassEncoder27.setStencilReference(
+3707
+);
+} catch {}
+try {
+renderPassEncoder26.setViewport(
+65.22,
+0.9948,
+9.626,
+0.00442,
+0.7648,
+0.8161
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture81,
+  mipLevel: 1,
+  origin: { x: 960, y: 0, z: 16 },
+  aspect: 'all',
+},
+new ArrayBuffer(64),
+/* required buffer size: 8378435 */{
+offset: 494,
+bytesPerRow: 4303,
+rowsPerImage: 59,
+},
+{width: 2064, height: 0, depthOrArrayLayers: 34}
+);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let querySet88 = device3.createQuerySet({
+type: 'occlusion',
+count: 1454,
+});
+try {
+renderPassEncoder24.setBindGroup(
+0,
+bindGroup29
+);
+} catch {}
+try {
+renderPassEncoder23.beginOcclusionQuery(518);
+} catch {}
+try {
+commandEncoder83.copyBufferToBuffer(
+buffer34,
+43252,
+buffer30,
+55416,
+420
+);
+dissociateBuffer(device3, buffer34);
+dissociateBuffer(device3, buffer30);
+} catch {}
+try {
+renderBundleEncoder45.insertDebugMarker(
+'\u0e39'
+);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+gc();
+try {
+offscreenCanvas28.getContext('webgl');
+} catch {}
+let bindGroup44 = device2.createBindGroup({
+label: '\u{1fd3c}\u08ee\u70b8\ubf6d\ua518\u{1fd28}',
+layout: bindGroupLayout33,
+entries: [
+{
+binding: 1144,
+resource: sampler38
+}
+],
+});
+let buffer38 = device2.createBuffer(
+{
+label: '\u0797\ue4c2\u3340\u889c\u9e49',
+size: 49471,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let texture118 = device2.createTexture(
+{
+size: [212, 200, 1],
+mipLevelCount: 2,
+format: 'astc-4x4-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-4x4-unorm-srgb',
+'astc-4x4-unorm',
+'astc-4x4-unorm-srgb'
+],
+}
+);
+let renderBundle89 = renderBundleEncoder51.finish();
+try {
+renderPassEncoder21.setBindGroup(
+8,
+bindGroup44
+);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(
+7,
+bindGroup20,
+new Uint32Array(8166),
+1607,
+0
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer33,
+26352,
+new BigUint64Array(14884),
+10386,
+1032
+);
+} catch {}
+let promise46 = device2.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+offscreenCanvas2.width = 271;
+offscreenCanvas17.height = 693;
+try {
+window.someLabel = textureView111.label;
+} catch {}
+try {
+gpuCanvasContext19.unconfigure();
+} catch {}
+let sampler73 = device4.createSampler(
+{
+label: '\u0cc1\u{1ff30}\u{1f75b}\u7dc4\u80ed\u{1f969}\u5ec7',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+lodMaxClamp: 30.137,
+}
+);
+try {
+renderPassEncoder16.setScissorRect(
+29,
+0,
+50,
+1
+);
+} catch {}
+try {
+renderPassEncoder27.setStencilReference(
+965
+);
+} catch {}
+try {
+buffer35.unmap();
+} catch {}
+let pipeline110 = await device4.createRenderPipelineAsync(
+{
+label: '\u0c10\u7d4a\u44ee\u036c\u0a09\u0d94\u55a3\u8947\ue571',
+layout: 'auto',
+vertex: {
+module: shaderModule24,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 5252,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x2',
+offset: 3054,
+shaderLocation: 17,
+},
+{
+format: 'float32x4',
+offset: 3532,
+shaderLocation: 8,
+},
+{
+format: 'float32x4',
+offset: 4864,
+shaderLocation: 2,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1588,
+shaderLocation: 4,
+},
+{
+format: 'float16x2',
+offset: 1828,
+shaderLocation: 16,
+},
+{
+format: 'uint16x4',
+offset: 5216,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+
+],
+},
+{
+arrayStride: 24280,
+attributes: [
+
+],
+},
+{
+arrayStride: 5044,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 25756,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 23444,
+attributes: [
+{
+format: 'uint8x4',
+offset: 14192,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule24,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'decrement-clamp',
+passOp: 'zero',
+},
+stencilReadMask: 667,
+stencilWriteMask: 1530,
+depthBiasSlopeScale: 89,
+depthBiasClamp: 41,
+},
+}
+);
+let textureView113 = texture111.createView(
+{
+label: '\u{1f66e}\u0b27\ueb13',
+dimension: '2d',
+baseMipLevel: 2,
+baseArrayLayer: 57,
+arrayLayerCount: 1,
+}
+);
+try {
+renderBundleEncoder71.setBindGroup(
+1,
+bindGroup43,
+new Uint32Array(6701),
+1731,
+0
+);
+} catch {}
+let offscreenCanvas29 = new OffscreenCanvas(724, 122);
+let renderBundleEncoder74 = device4.createRenderBundleEncoder(
+{
+label: '\u00ec\u281a\u0af3\u0093\u9bc6\ue5d2',
+colorFormats: [
+undefined
+],
+sampleCount: 15,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder43.setPipeline(
+pipeline99
+);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(
+0,
+bindGroup39
+);
+} catch {}
+try {
+renderPassEncoder26.beginOcclusionQuery(463);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant({ r: -849.1, g: -898.7, b: -41.96, a: -505.4, });
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(
+418
+);
+} catch {}
+try {
+renderBundleEncoder74.setBindGroup(
+4,
+bindGroup40
+);
+} catch {}
+try {
+renderBundleEncoder74.setVertexBuffer(
+62,
+undefined,
+2132973453,
+947509401
+);
+} catch {}
+try {
+gpuCanvasContext4.configure(
+{
+device: device4,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'astc-8x8-unorm',
+'rgba8uint'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device4.queue.submit([
+]);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 41, height: 1, depthOrArrayLayers: 32}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 403, y: 343 },
+  flipY: false,
+},
+{
+  texture: texture69,
+  mipLevel: 2,
+  origin: { x: 6, y: 0, z: 3 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 31, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await promise45;
+} catch {}
+gc();
+let imageData18 = new ImageData(240, 108);
+try {
+offscreenCanvas29.getContext('2d');
+} catch {}
+let texture119 = device5.createTexture(
+{
+label: '\u6436\u0fc6',
+size: {width: 1736, height: 4, depthOrArrayLayers: 14},
+mipLevelCount: 5,
+format: 'eac-rg11unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-rg11unorm',
+'eac-rg11unorm'
+],
+}
+);
+let textureView114 = texture94.createView(
+{
+label: '\ud35f\u{1ffe3}\u5a3b\u06bc\u073c\u9b62\u{1ff49}',
+mipLevelCount: 1,
+baseArrayLayer: 94,
+arrayLayerCount: 130,
+}
+);
+try {
+buffer27.unmap();
+} catch {}
+let bindGroup45 = device2.createBindGroup({
+label: '\u0d89\u591d\u1cd3\u0756\u2230',
+layout: bindGroupLayout19,
+entries: [
+
+],
+});
+let querySet89 = device2.createQuerySet({
+type: 'occlusion',
+count: 1728,
+});
+try {
+renderPassEncoder21.setBindGroup(
+7,
+bindGroup19
+);
+} catch {}
+try {
+renderPassEncoder29.setBlendConstant({ r: -43.52, g: 98.51, b: -552.8, a: -977.5, });
+} catch {}
+try {
+await buffer38.mapAsync(
+GPUMapMode.WRITE,
+0,
+48928
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture61,
+  mipLevel: 0,
+  origin: { x: 1955, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(80),
+/* required buffer size: 424 */{
+offset: 424,
+},
+{width: 2137, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext23.unconfigure();
+} catch {}
+video3.width = 183;
+try {
+device5.queue.label = '\u0222\uecb1\u047a\u63ce\u{1ff8f}';
+} catch {}
+gc();
+let imageBitmap22 = await createImageBitmap(video3);
+let adapter14 = await navigator.gpu.requestAdapter();
+let textureView115 = texture102.createView(
+{
+label: '\uc4c4\u04b7\u00b5\u{1fdbf}\u7faf\u0eba\u{1fe00}\u017b',
+mipLevelCount: 1,
+}
+);
+try {
+computePassEncoder40.setBindGroup(
+7,
+bindGroup22,
+new Uint32Array(452),
+333,
+0
+);
+} catch {}
+try {
+computePassEncoder34.setPipeline(
+pipeline104
+);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas3,
+  origin: { x: 181, y: 75 },
+  flipY: false,
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let promise47 = device2.createRenderPipelineAsync(
+{
+label: '\u3354\u7ff9\u64fd\u0edd\u9bd4\u00fe\u8f18\u4627',
+layout: pipelineLayout9,
+vertex: {
+module: shaderModule30,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 10424,
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 5000,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 9024,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 9856,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 7248,
+attributes: [
+{
+format: 'uint32x3',
+offset: 5676,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+multisample: {
+},
+fragment: {
+module: shaderModule30,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r8uint',
+writeMask: 0,
+},
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+}
+);
+let buffer39 = device4.createBuffer(
+{
+label: '\u0479\u4b18\u215b',
+size: 58975,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let renderBundleEncoder75 = device4.createRenderBundleEncoder(
+{
+colorFormats: [
+'r32uint',
+'rg16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 977,
+depthReadOnly: true,
+}
+);
+let renderBundle90 = renderBundleEncoder74.finish(
+{
+label: '\u7939\u2f2d\u50ce\ubea6\u0f94\u9118\u0419\u81e9\u371c\u9aa2'
+}
+);
+try {
+renderPassEncoder17.setBindGroup(
+3,
+bindGroup42
+);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(
+81,
+undefined,
+1806625064,
+466819655
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture97,
+  mipLevel: 2,
+  origin: { x: 610, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(930),
+/* required buffer size: 930 */{
+offset: 930,
+},
+{width: 70, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline111 = await device4.createComputePipelineAsync(
+{
+label: '\u7227\uc8d1\u7768\uc1f3',
+layout: pipelineLayout22,
+compute: {
+module: shaderModule24,
+entryPoint: 'compute0',
+},
+}
+);
+let commandEncoder85 = device7.createCommandEncoder(
+{
+label: '\u0588\u{1f964}\ua5b0\u025f\u0b2e\u0fe6\u{1feb1}\u275b\u{1f7f4}',
+}
+);
+let querySet90 = device7.createQuerySet({
+label: '\u0843\u{1ffe8}',
+type: 'occlusion',
+count: 2132,
+});
+let computePassEncoder45 = commandEncoder85.beginComputePass(
+{
+
+}
+);
+try {
+device7.addEventListener('uncapturederror', e => { log('device7.uncapturederror'); log(e); e.label = device7.label; });
+} catch {}
+let offscreenCanvas30 = new OffscreenCanvas(663, 559);
+let imageBitmap23 = await createImageBitmap(canvas8);
+let offscreenCanvas31 = new OffscreenCanvas(426, 982);
+let commandEncoder86 = device3.createCommandEncoder(
+{
+}
+);
+let renderBundleEncoder76 = device3.createRenderBundleEncoder(
+{
+label: '\u0e92\u7542\u0ea9\u0677\u{1fabe}\u55a2\u3735\u54b7\ucb37\u0b74',
+colorFormats: [
+'rg8uint',
+'rg8uint',
+'rg16uint',
+'r32float',
+'rg32sint',
+'r32uint'
+],
+sampleCount: 442,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let externalTexture9 = device3.importExternalTexture(
+{
+label: '\u45e0\u0d47\u{1fb33}\u0575\u0f8f',
+source: videoFrame0,
+colorSpace: 'display-p3',
+}
+);
+try {
+computePassEncoder27.end();
+} catch {}
+try {
+renderPassEncoder24.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(
+3,
+bindGroup38,
+new Uint32Array(8905),
+6861,
+0
+);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer30,
+58820,
+new Float32Array(62210),
+44444,
+64
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture60,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+new Uint32Array(new ArrayBuffer(8)),
+/* required buffer size: 65 */{
+offset: 65,
+bytesPerRow: 78,
+},
+{width: 7, height: 7, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+await promise46;
+} catch {}
+document.body.prepend(img1);
+let offscreenCanvas32 = new OffscreenCanvas(693, 987);
+let imageData19 = new ImageData(176, 140);
+let texture120 = device2.createTexture(
+{
+label: '\u7586\u00a6\u0127\ue0c1\u0433\u{1f6a0}',
+size: {width: 36, height: 4, depthOrArrayLayers: 141},
+dimension: '3d',
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+renderPassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(
+0,
+1,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder29.setViewport(
+0.2853,
+0.7781,
+0.05766,
+0.1977,
+0.2340,
+0.5416
+);
+} catch {}
+try {
+renderPassEncoder29.pushDebugGroup(
+'\u{1f956}'
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer33,
+13560,
+new DataView(new ArrayBuffer(28135)),
+4979,
+10608
+);
+} catch {}
+try {
+gpuCanvasContext19.unconfigure();
+} catch {}
+let device8 = await adapter14.requestDevice({
+label: '\u{1f931}\u8886\uc917\u{1f8f1}\u20fa\u{1ff5d}\u1eec\u{1f7ad}\u05be\u8dd1\u{1fbec}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-astc',
+'indirect-first-instance',
+'bgra8unorm-storage'
+],
+});
+try {
+offscreenCanvas32.getContext('webgpu');
+} catch {}
+let bindGroup46 = device2.createBindGroup({
+layout: bindGroupLayout31,
+entries: [
+{
+binding: 8983,
+resource: textureView95
+},
+{
+binding: 8951,
+resource: sampler24
+}
+],
+});
+let pipelineLayout29 = device2.createPipelineLayout(
+{
+label: '\u3871\udfec\u{1fa73}\u{1f851}\u{1fb9e}\u08e2\u5ee5\u0ab2',
+bindGroupLayouts: [
+bindGroupLayout32,
+bindGroupLayout24,
+bindGroupLayout24,
+bindGroupLayout44,
+bindGroupLayout45
+]
+}
+);
+try {
+renderPassEncoder29.setVertexBuffer(
+40,
+undefined,
+1918205299
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer33,
+25700,
+new BigUint64Array(26536),
+18585,
+764
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img2,
+  origin: { x: 88, y: 142 },
+  flipY: true,
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline112 = device2.createComputePipeline(
+{
+label: '\u3803\uad78\u{1f6c5}\u0e95\u{1f633}\u{1f65d}',
+layout: pipelineLayout25,
+compute: {
+module: shaderModule30,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline113 = device2.createRenderPipeline(
+{
+label: '\uf144\u{1fa44}',
+layout: pipelineLayout23,
+vertex: {
+module: shaderModule31,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 2568,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x2',
+offset: 1332,
+shaderLocation: 1,
+},
+{
+format: 'uint8x4',
+offset: 896,
+shaderLocation: 2,
+},
+{
+format: 'snorm16x2',
+offset: 904,
+shaderLocation: 15,
+},
+{
+format: 'float16x4',
+offset: 1852,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x2',
+offset: 1680,
+shaderLocation: 19,
+},
+{
+format: 'snorm16x4',
+offset: 208,
+shaderLocation: 17,
+},
+{
+format: 'uint32x2',
+offset: 1188,
+shaderLocation: 13,
+},
+{
+format: 'uint8x2',
+offset: 1080,
+shaderLocation: 12,
+},
+{
+format: 'uint16x2',
+offset: 448,
+shaderLocation: 16,
+},
+{
+format: 'float32x4',
+offset: 1776,
+shaderLocation: 5,
+},
+{
+format: 'sint32x2',
+offset: 1484,
+shaderLocation: 10,
+},
+{
+format: 'float32x4',
+offset: 1044,
+shaderLocation: 8,
+},
+{
+format: 'snorm16x4',
+offset: 808,
+shaderLocation: 14,
+},
+{
+format: 'sint16x2',
+offset: 648,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x2',
+offset: 446,
+shaderLocation: 20,
+}
+],
+},
+{
+arrayStride: 1492,
+attributes: [
+{
+format: 'uint32x3',
+offset: 464,
+shaderLocation: 21,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+},
+fragment: {
+module: shaderModule31,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+{
+format: 'rg8sint',
+},
+undefined,
+undefined,
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'greater',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 2952,
+stencilWriteMask: 62,
+depthBias: 90,
+depthBiasClamp: 84,
+},
+}
+);
+try {
+device8.addEventListener('uncapturederror', e => { log('device8.uncapturederror'); log(e); e.label = device8.label; });
+} catch {}
+let pipelineLayout30 = device4.createPipelineLayout(
+{
+label: '\ue196\u0261\u0e63\u2a56\u3234\u972e\u0205\u04fb\u2069\u0e88\u3cf4',
+bindGroupLayouts: [
+bindGroupLayout47
+]
+}
+);
+let querySet91 = device4.createQuerySet({
+label: '\u060c\u6c91\u4284',
+type: 'occlusion',
+count: 2728,
+});
+pseudoSubmit(device4, commandEncoder78);
+try {
+renderPassEncoder17.setBindGroup(
+1,
+bindGroup40,
+new Uint32Array(8731),
+6515,
+0
+);
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant({ r: 167.1, g: -690.0, b: 503.4, a: -92.88, });
+} catch {}
+let gpuCanvasContext26 = offscreenCanvas30.getContext('webgpu');
+let videoFrame23 = new VideoFrame(video3, {timestamp: 0});
+try {
+adapter0.label = '\ud2e2\udd52\ud30a\u8bcf\u0ffc';
+} catch {}
+let bindGroup47 = device6.createBindGroup({
+label: '\u08f3\u6dbe\udfc5\uc9e0\uc576\u07f6\udaf5',
+layout: bindGroupLayout48,
+entries: [
+
+],
+});
+try {
+device6.queue.writeTexture(
+{
+  texture: texture106,
+  mipLevel: 0,
+  origin: { x: 2004, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer9,
+/* required buffer size: 3910 */{
+offset: 580,
+},
+{width: 1665, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let offscreenCanvas33 = new OffscreenCanvas(506, 72);
+let sampler74 = device7.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 97.056,
+lodMaxClamp: 97.560,
+maxAnisotropy: 12,
+}
+);
+try {
+computePassEncoder45.pushDebugGroup(
+'\u6d22'
+);
+} catch {}
+let gpuCanvasContext27 = offscreenCanvas33.getContext('webgpu');
+let device9 = await adapter11.requestDevice({
+label: '\u8294\uf195\ufa66\u{1fddd}\u{1ff5d}\u0089\u9d09\ua61b\u6a31\u{1fb49}\uc527',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-astc',
+'indirect-first-instance',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 40,
+maxVertexAttributes: 19,
+maxVertexBufferArrayStride: 43008,
+maxStorageTexturesPerShaderStage: 23,
+maxStorageBuffersPerShaderStage: 17,
+maxDynamicStorageBuffersPerPipelineLayout: 36653,
+maxBindingsPerBindGroup: 7558,
+maxTextureDimension1D: 14542,
+maxTextureDimension2D: 15595,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 47772194,
+maxUniformBuffersPerShaderStage: 44,
+maxInterStageShaderVariables: 54,
+maxInterStageShaderComponents: 89,
+maxSamplersPerShaderStage: 17,
+},
+});
+gc();
+try {
+offscreenCanvas31.getContext('webgl');
+} catch {}
+let videoFrame24 = new VideoFrame(offscreenCanvas8, {timestamp: 0});
+let commandEncoder87 = device8.createCommandEncoder(
+{
+label: '\uc488\ud8ed\ub34a\u5cdf\u0770\u9516\ub298\u{1fc32}\u004f\u0b6c',
+}
+);
+let texture121 = device8.createTexture(
+{
+label: '\u03c1\u739a\u7ea7\u03d9\u53f4',
+size: [712],
+mipLevelCount: 1,
+dimension: '1d',
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+device8.queue.writeTexture(
+{
+  texture: texture121,
+  mipLevel: 0,
+  origin: { x: 60, y: 0, z: 1 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer3),
+/* required buffer size: 952 */{
+offset: 952,
+},
+{width: 619, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let promise48 = adapter9.requestDevice({
+label: '\u6231\u1142\u05b4\u093b\u7dff\uc7b1\u6fc3\u2457\u570e\u{1f746}',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 60,
+maxVertexAttributes: 27,
+maxVertexBufferArrayStride: 16729,
+maxStorageTexturesPerShaderStage: 34,
+maxStorageBuffersPerShaderStage: 15,
+maxDynamicStorageBuffersPerPipelineLayout: 33528,
+maxBindingsPerBindGroup: 7866,
+maxTextureDimension1D: 9266,
+maxTextureDimension2D: 11173,
+maxVertexBuffers: 10,
+maxUniformBufferBindingSize: 191674357,
+maxUniformBuffersPerShaderStage: 35,
+maxInterStageShaderVariables: 66,
+maxInterStageShaderComponents: 102,
+maxSamplersPerShaderStage: 21,
+},
+});
+let externalTexture10 = device9.importExternalTexture(
+{
+label: '\u9197\u4fa6\u50a2\u3e6f\u45d5\u2c73\u{1f9ef}\u7612',
+source: videoFrame24,
+colorSpace: 'display-p3',
+}
+);
+let promise49 = device9.queue.onSubmittedWorkDone();
+let commandEncoder88 = device2.createCommandEncoder(
+{
+label: '\u{1fce8}\u0641\ua171\u10a0\u0008\ucb3c',
+}
+);
+let renderBundleEncoder77 = device2.createRenderBundleEncoder(
+{
+label: '\u{1fdea}\uad96\u4788',
+colorFormats: [
+'r16uint',
+'r16uint',
+'rg16uint',
+'rgba32sint',
+'rgb10a2unorm',
+undefined,
+'rgba32float'
+],
+sampleCount: 322,
+}
+);
+try {
+computePassEncoder21.setBindGroup(
+1,
+bindGroup17
+);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(
+61,
+undefined,
+1227740837,
+2919097407
+);
+} catch {}
+try {
+commandEncoder88.copyBufferToBuffer(
+buffer23,
+14156,
+buffer16,
+5408,
+16292
+);
+dissociateBuffer(device2, buffer23);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+commandEncoder88.copyTextureToBuffer(
+{
+  texture: texture71,
+  mipLevel: 0,
+  origin: { x: 897, y: 1, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 918 widthInBlocks: 459 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 10806 */
+offset: 10806,
+bytesPerRow: 1024,
+buffer: buffer16,
+},
+{width: 459, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+commandEncoder88.copyTextureToTexture(
+{
+  texture: texture76,
+  mipLevel: 2,
+  origin: { x: 28, y: 0, z: 95 },
+  aspect: 'all',
+},
+{
+  texture: texture76,
+  mipLevel: 4,
+  origin: { x: 4, y: 0, z: 154 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 85}
+);
+} catch {}
+try {
+renderPassEncoder29.insertDebugMarker(
+'\u{1f8dd}'
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer33,
+1076,
+new DataView(new ArrayBuffer(57808)),
+53239,
+452
+);
+} catch {}
+let texture122 = gpuCanvasContext16.getCurrentTexture();
+let textureView116 = texture122.createView(
+{
+aspect: 'all',
+format: 'rgba8unorm-srgb',
+}
+);
+let texture123 = device4.createTexture(
+{
+label: '\u{1fd2f}\u0484\u6f3f\u{1fdbd}\u25b5\uabc7\u71a8\u874e\u9738\u8851',
+size: [539, 1, 100],
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgba8uint'
+],
+}
+);
+let renderBundle91 = renderBundleEncoder75.finish(
+{
+
+}
+);
+try {
+renderPassEncoder26.endOcclusionQuery();
+} catch {}
+let pipeline114 = await device4.createRenderPipelineAsync(
+{
+layout: pipelineLayout19,
+vertex: {
+module: shaderModule27,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 184,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 108,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x2',
+offset: 152,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 22184,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 15436,
+shaderLocation: 8,
+},
+{
+format: 'float32x3',
+offset: 17772,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+
+],
+},
+{
+arrayStride: 10592,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 9016,
+shaderLocation: 14,
+},
+{
+format: 'uint8x2',
+offset: 2978,
+shaderLocation: 7,
+},
+{
+format: 'sint32',
+offset: 8128,
+shaderLocation: 6,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x4942d7a,
+},
+fragment: {
+module: shaderModule27,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+undefined,
+{
+format: 'r32sint',
+writeMask: 0,
+}
+],
+},
+}
+);
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+let texture124 = device9.createTexture(
+{
+label: '\u488b\u{1f808}\uebef\u0dc3\u13f9\u{1fe29}\u0c5b\u0bf6',
+size: [24, 1750, 1],
+mipLevelCount: 8,
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView117 = texture124.createView(
+{
+label: '\u0fce\u9f5f\u02fc\u02a4\u0292',
+dimension: '2d-array',
+baseMipLevel: 6,
+mipLevelCount: 1,
+}
+);
+try {
+await promise49;
+} catch {}
+document.body.prepend(img0);
+let commandEncoder89 = device3.createCommandEncoder(
+{
+label: '\u8f2c\u81de\u0e5e\u0a72\u2b50\ue517\u043d',
+}
+);
+pseudoSubmit(device3, commandEncoder51);
+let textureView118 = texture80.createView(
+{
+baseArrayLayer: 39,
+arrayLayerCount: 60,
+}
+);
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+renderPassEncoder24.setStencilReference(
+808
+);
+} catch {}
+try {
+renderPassEncoder23.setViewport(
+1.332,
+0.9370,
+1.616,
+0.02771,
+0.3566,
+0.4757
+);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(
+34,
+undefined,
+658669914,
+302403487
+);
+} catch {}
+try {
+commandEncoder86.clearBuffer(
+buffer30
+);
+dissociateBuffer(device3, buffer30);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer30,
+11716,
+new Int16Array(20228),
+7661,
+1160
+);
+} catch {}
+try {
+device3.label = '\u37d5\u0aa9\u0b6e\u144a';
+} catch {}
+let bindGroupLayout50 = device3.createBindGroupLayout(
+{
+label: '\u0bea\u00da',
+entries: [
+{
+binding: 1004,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 499,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 1181,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+}
+],
+}
+);
+let querySet92 = device3.createQuerySet({
+label: '\ud4b4\u{1fda3}\u8b7c',
+type: 'occlusion',
+count: 2270,
+});
+let texture125 = device3.createTexture(
+{
+label: '\u87d8\u{1fff8}\u{1f97a}\ucbf4\u0a95\u2391\u6e19\u{1fe83}\uc509',
+size: {width: 46, height: 256, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16float',
+'rg16float',
+'rg16float'
+],
+}
+);
+let computePassEncoder46 = commandEncoder83.beginComputePass(
+{
+label: '\u0f42\u042d\u{1fdc5}\uf330\u4848\ub742\u4625\u0f6e'
+}
+);
+let renderBundle92 = renderBundleEncoder56.finish();
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(
+4,
+bindGroup38
+);
+} catch {}
+try {
+commandEncoder50.copyBufferToBuffer(
+buffer34,
+51512,
+buffer30,
+44124,
+1236
+);
+dissociateBuffer(device3, buffer34);
+dissociateBuffer(device3, buffer30);
+} catch {}
+try {
+commandEncoder50.copyTextureToTexture(
+{
+  texture: texture77,
+  mipLevel: 0,
+  origin: { x: 1265, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture65,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let videoFrame25 = new VideoFrame(imageBitmap1, {timestamp: 0});
+let texture126 = device7.createTexture(
+{
+size: [83, 113, 1],
+mipLevelCount: 5,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth24plus',
+'depth24plus',
+'depth24plus'
+],
+}
+);
+let textureView119 = texture126.createView(
+{
+label: '\u0f01\u{1fc6e}\ua03e\ud727\u71ec\u{1f768}\u0f95\u25e4\ud626\u8355\u0bf8',
+dimension: '2d-array',
+baseMipLevel: 2,
+mipLevelCount: 1,
+}
+);
+try {
+computePassEncoder45.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext1.configure(
+{
+device: device7,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+} catch {}
+gc();
+let commandEncoder90 = device7.createCommandEncoder();
+let sampler75 = device7.createSampler(
+{
+label: '\u0c09\u{1fc46}\u9e9b\uf538\u0c5f\u023b\u78a9\u635b\u{1f86b}\u3a3e',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 48.212,
+lodMaxClamp: 92.654,
+compare: 'not-equal',
+}
+);
+try {
+gpuCanvasContext21.configure(
+{
+device: device7,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8snorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let buffer40 = device8.createBuffer(
+{
+label: '\u07ea\ud31d\u0008',
+size: 64768,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX,
+}
+);
+let textureView120 = texture121.createView(
+{
+label: '\u0075\u{1fc0b}\u934c\u0b04\ucc46',
+arrayLayerCount: 1,
+}
+);
+try {
+commandEncoder87.copyTextureToBuffer(
+{
+  texture: texture121,
+  mipLevel: 0,
+  origin: { x: 359, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 5440 widthInBlocks: 340 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 45360 */
+offset: 45360,
+buffer: buffer40,
+},
+{width: 340, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device8, buffer40);
+} catch {}
+let querySet93 = device9.createQuerySet({
+type: 'occlusion',
+count: 678,
+});
+gc();
+let imageData20 = new ImageData(76, 200);
+let bindGroupLayout51 = device3.createBindGroupLayout(
+{
+entries: [
+{
+binding: 808,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 1438,
+visibility: 0,
+texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+},
+{
+binding: 116,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'uniform', minBindingSize: 38426, hasDynamicOffset: true },
+}
+],
+}
+);
+let querySet94 = device3.createQuerySet({
+label: '\u{1f7d1}\ub739\u30b3\u0cd1',
+type: 'occlusion',
+count: 284,
+});
+try {
+computePassEncoder39.setBindGroup(
+3,
+bindGroup34,
+new Uint32Array(1126),
+1046,
+0
+);
+} catch {}
+try {
+renderPassEncoder24.setBlendConstant({ r: 225.4, g: -733.5, b: -744.9, a: -866.4, });
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(
+78,
+undefined,
+3264387446,
+230396106
+);
+} catch {}
+try {
+commandEncoder61.clearBuffer(
+buffer19,
+13776,
+18148
+);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture91,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 40 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(new ArrayBuffer(64)),
+/* required buffer size: 534931 */{
+offset: 89,
+bytesPerRow: 302,
+rowsPerImage: 253,
+},
+{width: 104, height: 0, depthOrArrayLayers: 8}
+);
+} catch {}
+let sampler76 = device7.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 88.459,
+lodMaxClamp: 93.618,
+}
+);
+let commandEncoder91 = device3.createCommandEncoder(
+{
+label: '\u{1fe58}\u01ff\u{1f7e7}\u3571',
+}
+);
+let computePassEncoder47 = commandEncoder50.beginComputePass(
+{
+label: '\ue1e7\u0089\u{1ff44}\u4f17\u0be7\u{1ffe5}\u0343'
+}
+);
+let renderPassEncoder30 = commandEncoder86.beginRenderPass(
+{
+label: '\u0415\u4e46\u3780\u0107\u{1fc6a}\ue7a7\u0757\u0997',
+colorAttachments: [
+{
+view: textureView96,
+depthSlice: 7,
+clearValue: { r: 645.8, g: -761.5, b: -464.8, a: 195.5, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView96,
+depthSlice: 3,
+clearValue: { r: -675.0, g: -707.5, b: 102.1, a: -503.5, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView96,
+depthSlice: 2,
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView96,
+depthSlice: 0,
+clearValue: { r: 311.9, g: -977.2, b: 788.0, a: -655.6, },
+loadOp: 'load',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet69,
+}
+);
+try {
+computePassEncoder36.setBindGroup(
+7,
+bindGroup27,
+new Uint32Array(5012),
+1283,
+0
+);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(
+3,
+bindGroup38
+);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(
+95,
+undefined
+);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(
+4,
+bindGroup32,
+new Uint32Array(8223),
+3043,
+0
+);
+} catch {}
+let arrayBuffer11 = buffer25.getMappedRange(
+50016,
+84
+);
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let canvas24 = document.createElement('canvas');
+let device10 = await adapter12.requestDevice({
+label: '\u29f7\uab1b\u{1f6ca}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxColorAttachmentBytesPerSample: 42,
+maxVertexAttributes: 19,
+maxVertexBufferArrayStride: 46370,
+maxStorageTexturesPerShaderStage: 33,
+maxStorageBuffersPerShaderStage: 38,
+maxDynamicStorageBuffersPerPipelineLayout: 51442,
+maxBindingsPerBindGroup: 1138,
+maxTextureDimension1D: 15170,
+maxTextureDimension2D: 13044,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 24493039,
+maxUniformBuffersPerShaderStage: 36,
+maxInterStageShaderVariables: 110,
+maxInterStageShaderComponents: 85,
+maxSamplersPerShaderStage: 22,
+},
+});
+let commandBuffer11 = commandEncoder88.finish(
+{
+label: '\u4187\uae72\u{1f999}\u{1fa5d}',
+}
+);
+try {
+renderBundleEncoder65.insertDebugMarker(
+'\u0700'
+);
+} catch {}
+try {
+gpuCanvasContext15.configure(
+{
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+canvas13.height = 470;
+let texture127 = device10.createTexture(
+{
+label: '\u0222\u2dc8\u7dc9\u{1f893}\u447d\u25fe',
+size: [6436],
+dimension: '1d',
+format: 'r32float',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'r32float'
+],
+}
+);
+let textureView121 = texture127.createView(
+{
+label: '\u{1f9e9}\u639a\u{1f8ac}\u0319\u0e13\uf1ff',
+baseArrayLayer: 0,
+}
+);
+let renderBundleEncoder78 = device10.createRenderBundleEncoder(
+{
+label: '\u0569\uebe0\u1109\u{1ffe2}\u6f47',
+colorFormats: [
+'bgra8unorm',
+'rg32float',
+'rg11b10ufloat',
+undefined,
+'rgba8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 301,
+}
+);
+let renderBundle93 = renderBundleEncoder78.finish(
+{
+
+}
+);
+let bindGroupLayout52 = device4.createBindGroupLayout(
+{
+label: '\u2ebd\u021c\ueaa5',
+entries: [
+
+],
+}
+);
+let bindGroup48 = device4.createBindGroup({
+layout: bindGroupLayout52,
+entries: [
+
+],
+});
+let pipelineLayout31 = device4.createPipelineLayout(
+{
+label: '\u06d2\ub67b\u0d74\ue026\u61b0\uaf08\u{1faf1}\u8b6c\u84c2\u0f48\u{1fbec}',
+bindGroupLayouts: [
+bindGroupLayout40,
+bindGroupLayout41
+]
+}
+);
+let texture128 = device4.createTexture(
+{
+label: '\uda89\ua9ff\ue9b6\u3e7e\uaa66\u6598',
+size: [9563],
+dimension: '1d',
+format: 'rg32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+renderPassEncoder28.setBindGroup(
+1,
+bindGroup42
+);
+} catch {}
+try {
+renderPassEncoder17.setScissorRect(
+63,
+0,
+17,
+1
+);
+} catch {}
+try {
+renderPassEncoder26.setStencilReference(
+373
+);
+} catch {}
+try {
+renderPassEncoder27.setViewport(
+10.30,
+0.6343,
+7.620,
+0.2143,
+0.9356,
+0.9907
+);
+} catch {}
+try {
+gpuCanvasContext17.configure(
+{
+device: device4,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'etc2-rgb8a1unorm-srgb'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let pipeline115 = device4.createRenderPipeline(
+{
+label: '\u0076\u{1ff76}\u0cbe\u0778\u4364\ub983\u{1fd3b}',
+layout: pipelineLayout18,
+vertex: {
+module: shaderModule23,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 424,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x2',
+offset: 302,
+shaderLocation: 12,
+},
+{
+format: 'uint32x2',
+offset: 24,
+shaderLocation: 5,
+},
+{
+format: 'float32x2',
+offset: 260,
+shaderLocation: 13,
+},
+{
+format: 'unorm16x4',
+offset: 8,
+shaderLocation: 15,
+},
+{
+format: 'snorm16x4',
+offset: 228,
+shaderLocation: 3,
+},
+{
+format: 'sint16x4',
+offset: 64,
+shaderLocation: 8,
+},
+{
+format: 'uint32x3',
+offset: 316,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 22212,
+attributes: [
+{
+format: 'uint32x3',
+offset: 5496,
+shaderLocation: 7,
+},
+{
+format: 'unorm16x2',
+offset: 10164,
+shaderLocation: 10,
+},
+{
+format: 'float16x4',
+offset: 10304,
+shaderLocation: 14,
+},
+{
+format: 'uint16x4',
+offset: 388,
+shaderLocation: 11,
+},
+{
+format: 'uint32x3',
+offset: 14280,
+shaderLocation: 4,
+},
+{
+format: 'sint8x4',
+offset: 9320,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x4',
+offset: 9188,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 27108,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 18480,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x2',
+offset: 17464,
+shaderLocation: 1,
+},
+{
+format: 'unorm16x2',
+offset: 2772,
+shaderLocation: 9,
+},
+{
+format: 'uint16x2',
+offset: 1776,
+shaderLocation: 2,
+},
+{
+format: 'sint8x2',
+offset: 10174,
+shaderLocation: 17,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule23,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'rgba16sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALL,
+},
+undefined,
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+format: 'r32sint',
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'replace',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilReadMask: 506,
+stencilWriteMask: 3882,
+depthBias: 76,
+depthBiasClamp: 27,
+},
+}
+);
+let sampler77 = device10.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 67.749,
+lodMaxClamp: 79.574,
+}
+);
+let buffer41 = device9.createBuffer(
+{
+label: '\u0ba0\u{1fcf8}\u0270\u6b1c\u{1f788}\u0557',
+size: 8805,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+mappedAtCreation: false,
+}
+);
+let texture129 = device9.createTexture(
+{
+size: [80, 8, 203],
+mipLevelCount: 4,
+dimension: '2d',
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView122 = texture129.createView(
+{
+label: '\u{1fb0d}\u95e8\u534c\u0ad3',
+aspect: 'all',
+baseMipLevel: 1,
+mipLevelCount: 3,
+baseArrayLayer: 190,
+arrayLayerCount: 6,
+}
+);
+let canvas25 = document.createElement('canvas');
+let textureView123 = texture127.createView(
+{
+}
+);
+let renderBundleEncoder79 = device10.createRenderBundleEncoder(
+{
+label: '\u01c9\u0fb0\u4e75\u6d8b\u40ea\u1be3\ucf18\ud52f\u3e72\u020d',
+colorFormats: [
+'r16float',
+'rg8uint',
+'r16float',
+'r32float',
+'r32uint'
+],
+sampleCount: 528,
+}
+);
+let renderBundle94 = renderBundleEncoder78.finish(
+{
+label: '\u08f5\u{1fc05}\u06a2\uae60\u7fc6\u0e41\u5e2d\u967f\u0801\ufc7a\u0438'
+}
+);
+let buffer42 = device10.createBuffer(
+{
+label: '\u2835\u0795\ua81b',
+size: 49867,
+usage: GPUBufferUsage.COPY_SRC,
+}
+);
+let renderBundle95 = renderBundleEncoder79.finish(
+{
+
+}
+);
+let img24 = await imageWithData(222, 161, '#c708392c', '#af0793c7');
+let video19 = await videoWithData();
+try {
+canvas24.getContext('bitmaprenderer');
+} catch {}
+let texture130 = device3.createTexture(
+{
+label: '\u03c7\u0f86\u240e\ufe05\u02b6\u{1f99b}\uc88b\u9105\uf4fe\uf972',
+size: [5003],
+dimension: '1d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'bgra8unorm'
+],
+}
+);
+try {
+renderPassEncoder23.setBindGroup(
+3,
+bindGroup29
+);
+} catch {}
+try {
+renderPassEncoder30.beginOcclusionQuery(672);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(
+0,
+0,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder30.setViewport(
+0.08955,
+0.1641,
+0.2169,
+0.4423,
+0.01135,
+0.4630
+);
+} catch {}
+try {
+commandEncoder89.clearBuffer(
+buffer30
+);
+dissociateBuffer(device3, buffer30);
+} catch {}
+let bindGroup49 = device6.createBindGroup({
+label: '\u{1f6a2}\u01f2\u080b\uedb2\u{1f742}\u0532\u7112\u{1f987}\udedb\u0723',
+layout: bindGroupLayout48,
+entries: [
+
+],
+});
+let commandEncoder92 = device6.createCommandEncoder(
+{
+}
+);
+let sampler78 = device6.createSampler(
+{
+label: '\u6073\u{1f6e3}\u3341\ub59a\u191e',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 17.570,
+lodMaxClamp: 91.674,
+}
+);
+try {
+await buffer37.mapAsync(
+GPUMapMode.READ,
+1488
+);
+} catch {}
+let renderBundle96 = renderBundleEncoder65.finish();
+try {
+computePassEncoder44.end();
+} catch {}
+try {
+renderPassEncoder21.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder29.setBlendConstant({ r: 327.8, g: -991.3, b: -689.5, a: 658.3, });
+} catch {}
+try {
+renderPassEncoder29.setViewport(
+0.5910,
+0.3657,
+0.1746,
+0.1973,
+0.6148,
+0.6913
+);
+} catch {}
+let pipeline116 = await device2.createRenderPipelineAsync(
+{
+layout: 'auto',
+vertex: {
+module: shaderModule31,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 3616,
+shaderLocation: 15,
+},
+{
+format: 'float32x3',
+offset: 9292,
+shaderLocation: 17,
+},
+{
+format: 'uint16x2',
+offset: 11420,
+shaderLocation: 21,
+},
+{
+format: 'sint32x2',
+offset: 10664,
+shaderLocation: 4,
+},
+{
+format: 'unorm8x4',
+offset: 3432,
+shaderLocation: 20,
+},
+{
+format: 'uint32',
+offset: 4796,
+shaderLocation: 13,
+},
+{
+format: 'sint32',
+offset: 14144,
+shaderLocation: 10,
+},
+{
+format: 'uint32x2',
+offset: 14836,
+shaderLocation: 12,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 8124,
+shaderLocation: 19,
+},
+{
+format: 'snorm8x2',
+offset: 5404,
+shaderLocation: 1,
+},
+{
+format: 'float16x2',
+offset: 7476,
+shaderLocation: 11,
+},
+{
+format: 'uint8x4',
+offset: 1948,
+shaderLocation: 16,
+},
+{
+format: 'unorm8x2',
+offset: 14090,
+shaderLocation: 5,
+},
+{
+format: 'snorm8x4',
+offset: 40,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x4',
+offset: 980,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 11992,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 4900,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'back',
+},
+multisample: {
+mask: 0xfa224340,
+},
+fragment: {
+module: shaderModule31,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+undefined
+],
+},
+}
+);
+let img25 = await imageWithData(249, 197, '#67018953', '#be1a03bb');
+let bindGroupLayout53 = device3.createBindGroupLayout(
+{
+label: '\u0c3a\ue1e5\u7289\u905e\u407c\u0c1e\u2909\u{1fa55}',
+entries: [
+{
+binding: 1497,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+let buffer43 = device3.createBuffer(
+{
+label: '\u1875\u3588\u80f1\u613e\udb7d\u87c5\u{1fbde}',
+size: 26379,
+usage: GPUBufferUsage.MAP_READ,
+}
+);
+let texture131 = device3.createTexture(
+{
+label: '\u6f86\u{1fec5}\u{1fc62}\u08f2\u{1fb75}\u8590\u6106\u{1f713}\u{1fd2a}\ud306',
+size: [12649],
+dimension: '1d',
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32uint',
+'r32uint',
+'r32uint'
+],
+}
+);
+let renderBundleEncoder80 = device3.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8sint',
+undefined,
+'rgba32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 476,
+}
+);
+let renderBundle97 = renderBundleEncoder48.finish();
+try {
+renderPassEncoder24.setBindGroup(
+2,
+bindGroup27
+);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(
+3,
+bindGroup28,
+new Uint32Array(8078),
+4457,
+0
+);
+} catch {}
+try {
+commandEncoder89.copyTextureToTexture(
+{
+  texture: texture73,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 44 },
+  aspect: 'all',
+},
+{
+  texture: texture91,
+  mipLevel: 1,
+  origin: { x: 57, y: 0, z: 7 },
+  aspect: 'all',
+},
+{width: 24, height: 1, depthOrArrayLayers: 9}
+);
+} catch {}
+let commandEncoder93 = device0.createCommandEncoder(
+{
+}
+);
+let texture132 = device0.createTexture(
+{
+label: '\ubb8e\u{1fcbc}\u0069\u{1f7d9}\u2ebf\ubd53\u0ea1\u{1fbd1}',
+size: [236, 1, 48],
+mipLevelCount: 7,
+dimension: '3d',
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8unorm'
+],
+}
+);
+let textureView124 = texture32.createView(
+{
+label: '\u0121\u78ff\u303b\ud56a\ue7d2\u1b49\u7335\u4af3\u98d1\u3e2a',
+}
+);
+let renderBundleEncoder81 = device0.createRenderBundleEncoder(
+{
+label: '\ud28b\u11b8',
+colorFormats: [
+'rgba16sint',
+'r16float',
+'r32uint',
+undefined,
+'r16float',
+undefined
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 536,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder5.setBindGroup(
+6,
+bindGroup4,
+new Uint32Array(1297),
+225,
+0
+);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(606);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(
+3,
+1,
+1,
+1
+);
+} catch {}
+try {
+commandEncoder93.resolveQuerySet(
+querySet14,
+575,
+234,
+buffer5,
+6912
+);
+} catch {}
+try {
+gpuCanvasContext27.configure(
+{
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'eac-rg11unorm',
+'rg8uint',
+'bgra8unorm',
+'bgra8unorm'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+let gpuCanvasContext28 = canvas25.getContext('webgpu');
+document.body.prepend(canvas8);
+let bindGroup50 = device2.createBindGroup({
+label: '\u62ca\u{1fd20}\u08eb\u0caf\u3337\u{1fe32}\uf051\ue529\ub8c7\u3daf',
+layout: bindGroupLayout19,
+entries: [
+
+],
+});
+let textureView125 = texture54.createView(
+{
+label: '\u2d7c\u0333\u{1fe7a}\u{1f6f8}\u{1f866}\u3285\u{1f7df}\u{1f63a}\ud4e8\u0256\u0a68',
+dimension: '2d-array',
+baseMipLevel: 2,
+}
+);
+let computePassEncoder48 = commandEncoder45.beginComputePass(
+{
+label: '\u0699\u02c6\u7813\u4e2f\u{1ff04}\uf7a1\u{1fea9}'
+}
+);
+let renderBundle98 = renderBundleEncoder27.finish(
+{
+label: '\u3132\u54a6\u{1fe05}\u75a2'
+}
+);
+try {
+computePassEncoder34.end();
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder29.executeBundles([]);
+} catch {}
+try {
+commandEncoder70.clearBuffer(
+buffer16,
+5512,
+17876
+);
+dissociateBuffer(device2, buffer16);
+} catch {}
+gc();
+let video20 = await videoWithData();
+let buffer44 = device8.createBuffer(
+{
+label: '\u8c00\u0433\u06bd\u2816\ub556\u0bc7',
+size: 65091,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let renderBundleEncoder82 = device8.createRenderBundleEncoder(
+{
+label: '\ue768\u09b6\ue967\u4993\u{1fac7}\u{1fe7f}\u024d\ue56f\u{1fe48}\u{1f999}\u0846',
+colorFormats: [
+'rg8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 373,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+let sampler79 = device8.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 53.253,
+compare: 'less-equal',
+}
+);
+try {
+commandEncoder87.copyTextureToBuffer(
+{
+  texture: texture121,
+  mipLevel: 0,
+  origin: { x: 69, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 8528 widthInBlocks: 533 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 28000 */
+offset: 28000,
+rowsPerImage: 117,
+buffer: buffer40,
+},
+{width: 533, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device8, buffer40);
+} catch {}
+try {
+gpuCanvasContext11.configure(
+{
+device: device8,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device8.queue.writeTexture(
+{
+  texture: texture121,
+  mipLevel: 0,
+  origin: { x: 125, y: 1, z: 0 },
+  aspect: 'all',
+},
+new DataView(arrayBuffer6),
+/* required buffer size: 440 */{
+offset: 440,
+},
+{width: 27, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await adapter5.requestAdapterInfo();
+} catch {}
+let bindGroupLayout54 = device10.createBindGroupLayout(
+{
+label: '\u0184\u0a07\u90e6\u2f72\u8c95\u861a\u{1faf9}\u{1f848}',
+entries: [
+{
+binding: 499,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 574,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+},
+{
+binding: 155,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+}
+],
+}
+);
+let commandEncoder94 = device10.createCommandEncoder(
+{
+label: '\u{1f6e1}\u0184',
+}
+);
+let querySet95 = device10.createQuerySet({
+label: '\u{1fb14}\u0a71\u0f92\u0d66\u0331\u06c8\ua21e',
+type: 'occlusion',
+count: 2060,
+});
+let renderBundleEncoder83 = device10.createRenderBundleEncoder(
+{
+label: '\u{1fa39}\u7cb7\u32fd\u0f70\u6c8e\u5dee\u0f53\ufb76\u21ff',
+colorFormats: [
+'rgb10a2uint',
+'rg32uint',
+'bgra8unorm',
+'rgba8unorm',
+'r16float'
+],
+sampleCount: 27,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder83.setVertexBuffer(
+93,
+undefined,
+935740323,
+2021957461
+);
+} catch {}
+offscreenCanvas7.height = 360;
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+document.body.prepend(video17);
+let canvas26 = document.createElement('canvas');
+let texture133 = device4.createTexture(
+{
+label: '\uce21\ud487\u3ec2\u1a41',
+size: {width: 2096, height: 180, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+sampleCount: 1,
+format: 'etc2-rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'etc2-rgba8unorm',
+'etc2-rgba8unorm',
+'etc2-rgba8unorm-srgb'
+],
+}
+);
+try {
+computePassEncoder43.setBindGroup(
+4,
+bindGroup48
+);
+} catch {}
+try {
+computePassEncoder43.setPipeline(
+pipeline103
+);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(
+7,
+bindGroup37
+);
+} catch {}
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder28.executeBundles([]);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 20, height: 1, depthOrArrayLayers: 16}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 97, y: 309 },
+  flipY: false,
+},
+{
+  texture: texture69,
+  mipLevel: 3,
+  origin: { x: 3, y: 0, z: 4 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 15, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let texture134 = device6.createTexture(
+{
+label: '\u4403\ua475\u{1f681}\u4200\ued49\u{1fc06}\u0a0c\uada9\u{1fefa}',
+size: {width: 202, height: 51, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let textureView126 = texture134.createView(
+{
+format: 'rgba16float',
+baseMipLevel: 1,
+}
+);
+let renderBundleEncoder84 = device6.createRenderBundleEncoder(
+{
+label: '\u856a\u9e59',
+colorFormats: [
+'rg32float',
+'rgba32float'
+],
+sampleCount: 183,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder84.setVertexBuffer(
+15,
+undefined,
+2263567826,
+531285241
+);
+} catch {}
+offscreenCanvas4.height = 948;
+let video21 = await videoWithData();
+let texture135 = device8.createTexture(
+{
+label: '\udac9\u{1fde0}\u07e2',
+size: [70, 1, 229],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+}
+);
+let textureView127 = texture121.createView(
+{
+label: '\u0b53\u{1fc8c}\uc38b\u0f8a\u0361',
+baseArrayLayer: 0,
+}
+);
+let renderBundle99 = renderBundleEncoder82.finish();
+try {
+commandEncoder87.copyTextureToTexture(
+{
+  texture: texture121,
+  mipLevel: 0,
+  origin: { x: 89, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture135,
+  mipLevel: 2,
+  origin: { x: 4, y: 0, z: 24 },
+  aspect: 'all',
+},
+{width: 8, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device8.queue.writeTexture(
+{
+  texture: texture121,
+  mipLevel: 0,
+  origin: { x: 118, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(80),
+/* required buffer size: 7925 */{
+offset: 165,
+},
+{width: 485, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+canvas26.getContext('webgl');
+} catch {}
+let buffer45 = device3.createBuffer(
+{
+size: 63768,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM,
+}
+);
+let commandEncoder95 = device3.createCommandEncoder(
+{
+label: '\ud79e\u80dc\u5b61\u06a7\u9f63\u{1fbe2}\u58f4\u9abc\u{1fffd}\ua435\u095c',
+}
+);
+try {
+computePassEncoder46.setBindGroup(
+3,
+bindGroup23,
+new Uint32Array(8511),
+5252,
+0
+);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([]);
+} catch {}
+try {
+commandEncoder91.clearBuffer(
+buffer25,
+11808,
+25992
+);
+dissociateBuffer(device3, buffer25);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(
+/*
+{width: 7, height: 1, depthOrArrayLayers: 16}
+*/
+{
+  source: imageBitmap12,
+  origin: { x: 53, y: 266 },
+  flipY: true,
+},
+{
+  texture: texture98,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 2, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+canvas5.width = 77;
+let videoFrame26 = new VideoFrame(canvas15, {timestamp: 0});
+let bindGroup51 = device6.createBindGroup({
+layout: bindGroupLayout48,
+entries: [
+
+],
+});
+let commandEncoder96 = device6.createCommandEncoder(
+{
+label: '\ub9af\ub077',
+}
+);
+let texture136 = device6.createTexture(
+{
+label: '\u{1fc5e}\u0ab4\u0063',
+size: {width: 6688, height: 236, depthOrArrayLayers: 1},
+mipLevelCount: 11,
+format: 'etc2-rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'etc2-rgba8unorm-srgb'
+],
+}
+);
+try {
+gpuCanvasContext13.configure(
+{
+device: device6,
+format: 'rgba16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'etc2-rgba8unorm',
+'rgba16float',
+'rgba16float',
+'depth24plus'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(
+/*
+{width: 202, height: 51, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 3, y: 32 },
+  flipY: false,
+},
+{
+  texture: texture134,
+  mipLevel: 0,
+  origin: { x: 5, y: 25, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 77, height: 20, depthOrArrayLayers: 0}
+);
+} catch {}
+let imageBitmap24 = await createImageBitmap(imageData2);
+let bindGroupLayout55 = device6.createBindGroupLayout(
+{
+label: '\u0c76\u{1fc90}\u0ec8\u0236\u{1f73c}\u1780\u{1fbfe}\u0152',
+entries: [
+
+],
+}
+);
+let renderBundleEncoder85 = device6.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba32uint',
+'rg32sint',
+'rgba16float',
+'rgba8unorm-srgb',
+undefined,
+'rgba8uint'
+],
+sampleCount: 687,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let renderBundle100 = renderBundleEncoder84.finish(
+{
+label: '\u0beb\u1b70\u1c4a\u0128\u{1f6c2}\u21e2\u0982'
+}
+);
+let sampler80 = device6.createSampler(
+{
+label: '\u727e\u080e\u88e8\u{1f91f}\uf618\u0c3f\uda95\u{1f6b2}',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 20.790,
+lodMaxClamp: 40.436,
+maxAnisotropy: 17,
+}
+);
+let textureView128 = texture117.createView(
+{
+label: '\ub6e2\u0e9d\ue278\u{1f9fb}\ubd5a\u7cdb',
+mipLevelCount: 1,
+}
+);
+try {
+renderPassEncoder28.setVertexBuffer(
+43,
+undefined
+);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+let pipeline117 = device4.createComputePipeline(
+{
+label: '\u{1f60a}\u9bd6\u{1f87b}\u559e\uf3c8\u08a8\u7f16\ue308\u{1f699}\uef47\u0a86',
+layout: 'auto',
+compute: {
+module: shaderModule24,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let buffer46 = device6.createBuffer(
+{
+label: '\u{1f670}\u2a69\u{1f71a}\u{1fdcb}\u0271\u{1fac0}\u{1f610}\uc580\ua68c\u10f7',
+size: 7229,
+usage: GPUBufferUsage.INDIRECT,
+mappedAtCreation: false,
+}
+);
+let commandEncoder97 = device6.createCommandEncoder(
+{
+label: '\u665b\u66f8\u5e76\u0b2c\u0b7c\uc95e\u3faa\u5bff',
+}
+);
+let renderBundle101 = renderBundleEncoder73.finish(
+{
+label: '\u0757\u{1f733}\u2821\u11f3\u0462\u0dcd'
+}
+);
+let sampler81 = device6.createSampler(
+{
+label: '\u{1ff35}\u01db\u8f33\u0235\u62ca\u3484\uf95b\u{1f96a}\u0c93\ua1d4\uf0f0',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 52.970,
+lodMaxClamp: 64.060,
+}
+);
+try {
+renderBundleEncoder85.setBindGroup(
+2,
+bindGroup47
+);
+} catch {}
+let promise50 = device6.queue.onSubmittedWorkDone();
+let img26 = await imageWithData(211, 186, '#4a85c042', '#8adba85c');
+try {
+renderPassEncoder24.setBlendConstant({ r: -413.6, g: 872.6, b: -650.2, a: 358.7, });
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(
+77,
+undefined,
+1443292045,
+171395671
+);
+} catch {}
+let video22 = await videoWithData();
+let buffer47 = device10.createBuffer(
+{
+label: '\ubfbf\u0152\uad97\u{1fabb}\u27c8\uc6f0\u99fe\u0bb2',
+size: 65200,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let computePassEncoder49 = commandEncoder94.beginComputePass(
+{
+label: '\u{1ffc7}\u0de4\u0dbb\ub3c2\u2244\u{1f631}\u098c\ue17d'
+}
+);
+let renderBundleEncoder86 = device10.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16uint',
+'rgba16float',
+'rgba32float',
+'r8uint',
+'rgba8unorm-srgb',
+'r16uint'
+],
+sampleCount: 957,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let video23 = await videoWithData();
+let textureView129 = texture126.createView(
+{
+label: '\ud64a\u852b\uf2c6\u7664\u{1f676}\u{1f90c}\u01d8\u0f6f\u6846\u{1ffae}\u0b71',
+dimension: '2d-array',
+format: 'depth24plus',
+baseMipLevel: 3,
+mipLevelCount: 1,
+arrayLayerCount: 1,
+}
+);
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let externalTexture11 = device10.importExternalTexture(
+{
+label: '\u3429\uf8b6',
+source: video6,
+}
+);
+try {
+computePassEncoder49.insertDebugMarker(
+'\u33cc'
+);
+} catch {}
+let bindGroup52 = device6.createBindGroup({
+label: '\u{1fe5a}\ufd66\u12ca\u{1fc4c}\u0365\uab02\u{1fc0a}\u05db',
+layout: bindGroupLayout48,
+entries: [
+
+],
+});
+let textureView130 = texture134.createView(
+{
+dimension: '2d-array',
+baseMipLevel: 1,
+baseArrayLayer: 0,
+}
+);
+let externalTexture12 = device6.importExternalTexture(
+{
+source: videoFrame20,
+colorSpace: 'display-p3',
+}
+);
+try {
+renderBundleEncoder85.setBindGroup(
+8,
+bindGroup43
+);
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(
+/*
+{width: 202, height: 51, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas10,
+  origin: { x: 30, y: 32 },
+  flipY: true,
+},
+{
+  texture: texture134,
+  mipLevel: 0,
+  origin: { x: 18, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 18, height: 51, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await promise50;
+} catch {}
+let bindGroupLayout56 = device2.createBindGroupLayout(
+{
+label: '\u0e8c\ub691',
+entries: [
+
+],
+}
+);
+let computePassEncoder50 = commandEncoder70.beginComputePass(
+{
+label: '\u0fb5\uc348\u7b87\ud944'
+}
+);
+try {
+renderPassEncoder29.setBlendConstant({ r: -242.7, g: 553.1, b: 88.79, a: -394.4, });
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(
+68,
+undefined
+);
+} catch {}
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+let buffer48 = device9.createBuffer(
+{
+label: '\u{1f74f}\u{1fcda}\u3c2d\u{1fc5c}',
+size: 13136,
+usage: GPUBufferUsage.INDEX,
+}
+);
+try {
+gpuCanvasContext21.configure(
+{
+device: device9,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rg32uint',
+'astc-5x4-unorm-srgb',
+'rgba16float'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let renderBundleEncoder87 = device3.createRenderBundleEncoder(
+{
+label: '\ue613\u{1fa23}\ua48c\u02ee',
+colorFormats: [
+'bgra8unorm',
+'rg32uint',
+'r16uint',
+'r16float'
+],
+sampleCount: 473,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder46.setBindGroup(
+0,
+bindGroup32
+);
+} catch {}
+try {
+renderPassEncoder23.setBlendConstant({ r: 543.7, g: 634.1, b: 242.8, a: -89.72, });
+} catch {}
+try {
+commandEncoder89.copyTextureToTexture(
+{
+  texture: texture77,
+  mipLevel: 0,
+  origin: { x: 2302, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture65,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder60.clearBuffer(
+buffer30,
+24388
+);
+dissociateBuffer(device3, buffer30);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer30,
+27120,
+new Int16Array(44398),
+2055,
+14824
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture91,
+  mipLevel: 1,
+  origin: { x: 0, y: 1, z: 8 },
+  aspect: 'depth-only',
+},
+new DataView(arrayBuffer2),
+/* required buffer size: 1157312 */{
+offset: 668,
+bytesPerRow: 267,
+rowsPerImage: 38,
+},
+{width: 104, height: 0, depthOrArrayLayers: 115}
+);
+} catch {}
+let imageBitmap25 = await createImageBitmap(offscreenCanvas33);
+let renderBundle102 = renderBundleEncoder79.finish(
+{
+label: '\ub854\u{1fb30}\u66d0\u0c62\u{1ff6c}\ub69b\u0f27\u7d90\u0b01\u0f90\u0aaa'
+}
+);
+let bindGroupLayout57 = device9.createBindGroupLayout(
+{
+label: '\ua682\ub7aa\uf9d7\u0b3c\udb9d\u{1fd5c}',
+entries: [
+
+],
+}
+);
+let bindGroup53 = device9.createBindGroup({
+label: '\ud130\u039a\u{1f7a9}\u{1f94a}\u23ab\u7494\ubc8e\u400f\uf927\u{1ffeb}',
+layout: bindGroupLayout57,
+entries: [
+
+],
+});
+try {
+texture124.destroy();
+} catch {}
+let imageBitmap26 = await createImageBitmap(videoFrame11);
+let texture137 = device8.createTexture(
+{
+size: {width: 738, height: 1, depthOrArrayLayers: 203},
+mipLevelCount: 7,
+sampleCount: 1,
+dimension: '3d',
+format: 'rg16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rg16uint'
+],
+}
+);
+let renderBundle103 = renderBundleEncoder82.finish(
+{
+label: '\u4fe0\u70aa'
+}
+);
+let sampler82 = device8.createSampler(
+{
+label: '\u2f77\u{1ff58}\u8c97\u31da\u01e7\u{1f69c}\u0a84\u0399\ue704\ud161',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 93.732,
+lodMaxClamp: 99.265,
+maxAnisotropy: 17,
+}
+);
+try {
+gpuCanvasContext8.configure(
+{
+device: device8,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm-srgb',
+'bgra8unorm',
+'astc-12x12-unorm',
+'bgra8unorm'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+gc();
+try {
+device9.addEventListener('uncapturederror', e => { log('device9.uncapturederror'); log(e); e.label = device9.label; });
+} catch {}
+try {
+device9.queue.writeBuffer(
+buffer41,
+8284,
+new DataView(new ArrayBuffer(13445)),
+4699,
+0
+);
+} catch {}
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+let img27 = await imageWithData(51, 258, '#2d7af93c', '#0f284350');
+let querySet96 = device8.createQuerySet({
+label: '\ub340\udeed\u1fc2\u29ff\u641e\u71bd\u8034\u0dc5\u5010',
+type: 'occlusion',
+count: 3609,
+});
+let textureView131 = texture137.createView(
+{
+label: '\u87b0\u00c5\ub8b3\u{1fb54}',
+baseMipLevel: 3,
+mipLevelCount: 2,
+baseArrayLayer: 0,
+}
+);
+let renderBundle104 = renderBundleEncoder82.finish(
+{
+label: '\u{1f89c}\u{1fc47}\u03d4\ud625\u{1fb56}\u{1f804}\u0cde\u651a'
+}
+);
+let sampler83 = device8.createSampler(
+{
+label: '\u{1fe12}\ue77e\u{1f9fb}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 67.394,
+maxAnisotropy: 14,
+}
+);
+try {
+buffer44.destroy();
+} catch {}
+let querySet97 = device4.createQuerySet({
+label: '\udc14\u{1f6c1}\u007d\u5ffb\u{1fa5f}\u{1fc9c}\u0b6f\u880c\u{1f770}',
+type: 'occlusion',
+count: 757,
+});
+let sampler84 = device4.createSampler(
+{
+label: '\u1249\uf7a9\u{1feda}\u3a6c\u{1fca2}\ub3fe',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 90.919,
+lodMaxClamp: 94.492,
+compare: 'greater',
+maxAnisotropy: 9,
+}
+);
+try {
+renderPassEncoder16.beginOcclusionQuery(941);
+} catch {}
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(
+4022
+);
+} catch {}
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 164, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 2, y: 50 },
+  flipY: false,
+},
+{
+  texture: texture69,
+  mipLevel: 0,
+  origin: { x: 28, y: 0, z: 77 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 106, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let sampler85 = device7.createSampler(
+{
+label: '\ud230\u1e98\u0458\u5a25\u0ae0\u8ded\uc7e9\uadbd\u7573\ue256',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 87.855,
+lodMaxClamp: 90.333,
+}
+);
+let offscreenCanvas34 = new OffscreenCanvas(907, 873);
+let img28 = await imageWithData(242, 211, '#78cb0d27', '#1402b77d');
+let commandEncoder98 = device2.createCommandEncoder(
+{
+label: '\u{1f900}\u72d0\u{1f753}\ue935\ud88c\uc031\ueff7\u72b5\u3b60\u0a99',
+}
+);
+let renderBundleEncoder88 = device2.createRenderBundleEncoder(
+{
+label: '\u{1f74a}\u0c83\u075b\u1b4e\ub3c4\ub0b0\u77a1\uedbd\u0ecf\u0d31\u4f7d',
+colorFormats: [
+'r16float',
+'rgba16uint',
+'rg8unorm',
+'rg16sint',
+'rgba16uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 179,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let externalTexture13 = device2.importExternalTexture(
+{
+label: '\u451c\uc02f\ua079\u{1f9d7}\u9cf6\u75e2\u09bd\u5e81\ua58c\u48b6',
+source: video2,
+colorSpace: 'display-p3',
+}
+);
+try {
+computePassEncoder21.setBindGroup(
+2,
+bindGroup44,
+new Uint32Array(2858),
+792,
+0
+);
+} catch {}
+try {
+computePassEncoder40.end();
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(
+7,
+bindGroup33,
+new Uint32Array(6625),
+204,
+0
+);
+} catch {}
+try {
+renderPassEncoder29.setBlendConstant({ r: -678.4, g: -687.3, b: -303.4, a: -79.34, });
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(
+0,
+0,
+1,
+0
+);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(
+57,
+undefined
+);
+} catch {}
+try {
+commandEncoder33.copyBufferToBuffer(
+buffer38,
+6876,
+buffer16,
+4320,
+8368
+);
+dissociateBuffer(device2, buffer38);
+dissociateBuffer(device2, buffer16);
+} catch {}
+try {
+gpuCanvasContext15.configure(
+{
+device: device2,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-8x8-unorm',
+'astc-8x8-unorm-srgb',
+'astc-8x8-unorm-srgb',
+'etc2-rgba8unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device2.queue.submit([
+commandBuffer9,
+commandBuffer11,
+]);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img20,
+  origin: { x: 10, y: 152 },
+  flipY: true,
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline118 = await promise41;
+let gpuCanvasContext29 = offscreenCanvas34.getContext('webgpu');
+let canvas27 = document.createElement('canvas');
+let sampler86 = device6.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 81.497,
+lodMaxClamp: 92.665,
+maxAnisotropy: 11,
+}
+);
+try {
+commandEncoder96.copyTextureToTexture(
+{
+  texture: texture134,
+  mipLevel: 1,
+  origin: { x: 24, y: 12, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture134,
+  mipLevel: 1,
+  origin: { x: 34, y: 5, z: 1 },
+  aspect: 'all',
+},
+{width: 36, height: 7, depthOrArrayLayers: 0}
+);
+} catch {}
+let texture138 = device10.createTexture(
+{
+label: '\u{1fc26}\u03af\u0cb4\u888c\u0761\u{1ff01}\u09f1\u08a5\ud82c\u{1fa5b}',
+size: {width: 136, height: 135, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-8x5-unorm-srgb',
+'astc-8x5-unorm-srgb',
+'astc-8x5-unorm'
+],
+}
+);
+let canvas28 = document.createElement('canvas');
+let offscreenCanvas35 = new OffscreenCanvas(931, 420);
+let querySet98 = device10.createQuerySet({
+label: '\u1938\u0b32\u{1fe93}\u0f98\ue4fe\u373b\u{1fcca}\u10f7\u02c0\u{1fe7d}\u38e9',
+type: 'occlusion',
+count: 385,
+});
+let texture139 = device10.createTexture(
+{
+label: '\uff36\u0b25\u{1fafc}\u8c2b\u{1f9aa}\u0b39\ub24a',
+size: {width: 539, height: 1, depthOrArrayLayers: 1539},
+mipLevelCount: 8,
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+renderBundleEncoder83.setVertexBuffer(
+85,
+undefined,
+1553717943
+);
+} catch {}
+try {
+device10.queue.writeTexture(
+{
+  texture: texture139,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 24 },
+  aspect: 'all',
+},
+new ArrayBuffer(0),
+/* required buffer size: 269542 */{
+offset: 166,
+bytesPerRow: 91,
+rowsPerImage: 148,
+},
+{width: 16, height: 1, depthOrArrayLayers: 21}
+);
+} catch {}
+let canvas29 = document.createElement('canvas');
+let commandEncoder99 = device10.createCommandEncoder(
+{
+}
+);
+let textureView132 = texture127.createView(
+{
+label: '\u8d4e\u0a0e\u42ff\u{1fbfb}\u0da8\u73b3',
+}
+);
+let sampler87 = device10.createSampler(
+{
+label: '\u6882\ub536\u5098\u0686\uc668\u0da2\u0cfc',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 93.979,
+maxAnisotropy: 6,
+}
+);
+try {
+device10.addEventListener('uncapturederror', e => { log('device10.uncapturederror'); log(e); e.label = device10.label; });
+} catch {}
+try {
+gpuCanvasContext28.unconfigure();
+} catch {}
+canvas21.height = 850;
+let imageData21 = new ImageData(232, 132);
+let querySet99 = device2.createQuerySet({
+label: '\ue82a\u{1fe7e}\u{1f7f2}\u058d\u06d4\udb6a\u26a5\u6987\u{1f8ad}\u0c4a',
+type: 'occlusion',
+count: 1030,
+});
+let renderPassEncoder31 = commandEncoder33.beginRenderPass(
+{
+label: '\u0ccb\u939e\u0881\u7895\u099c\ua380',
+colorAttachments: [
+undefined,
+{
+view: textureView87,
+clearValue: { r: 995.2, g: -794.5, b: -224.9, a: 695.0, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+undefined
+],
+occlusionQuerySet: querySet71,
+maxDrawCount: 73368,
+}
+);
+let renderBundle105 = renderBundleEncoder42.finish(
+{
+label: '\u87ed\u4820\u{1fe97}\u99b4\u{1f948}\ude01\u031e\u0449\u3c32\u{1f926}\u046d'
+}
+);
+try {
+renderPassEncoder29.setBlendConstant({ r: 688.9, g: 914.9, b: -231.7, a: -177.8, });
+} catch {}
+try {
+renderPassEncoder31.setViewport(
+0.00761,
+0.1176,
+0.8197,
+0.5542,
+0.7284,
+0.7326
+);
+} catch {}
+try {
+computePassEncoder10.insertDebugMarker(
+'\ue335'
+);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer33,
+35308,
+new Int16Array(62138),
+19398,
+28
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame22,
+  origin: { x: 334, y: 80 },
+  flipY: true,
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+let offscreenCanvas36 = new OffscreenCanvas(885, 1003);
+let texture140 = device4.createTexture(
+{
+label: '\u{1f9c2}\u88ce\uee7c\u6e84\u2738\u0a75',
+size: {width: 7250, height: 10, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+sampleCount: 1,
+format: 'astc-10x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+}
+);
+let renderBundle106 = renderBundleEncoder64.finish(
+{
+label: '\ua69d\u54a9\u7567\ue367\u060c\u{1f729}'
+}
+);
+try {
+renderPassEncoder27.end();
+} catch {}
+try {
+computePassEncoder43.insertDebugMarker(
+'\u6b32'
+);
+} catch {}
+let imageData22 = new ImageData(96, 80);
+let texture141 = device7.createTexture(
+{
+label: '\u{1fd36}\u04a8\u14c1',
+size: [84, 124, 1],
+mipLevelCount: 6,
+dimension: '2d',
+format: 'etc2-rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'etc2-rgba8unorm',
+'etc2-rgba8unorm-srgb'
+],
+}
+);
+let bindGroupLayout58 = device4.createBindGroupLayout(
+{
+label: '\u7199\u711a\u0899\u7d3e\uafc1\uf843\u51e9\u0192\u03d7\u9bf0',
+entries: [
+{
+binding: 913,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+},
+{
+binding: 344,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+}
+],
+}
+);
+let pipelineLayout32 = device4.createPipelineLayout(
+{
+label: '\ue445\u{1fcb2}\u{1f9bd}\u02bb\u07c0\uc14a\ua47d\u{1ff7f}\u4c1a\uf39f\u{1f907}',
+bindGroupLayouts: [
+bindGroupLayout41,
+bindGroupLayout52,
+bindGroupLayout39,
+bindGroupLayout49
+]
+}
+);
+let commandEncoder100 = device4.createCommandEncoder();
+pseudoSubmit(device4, commandEncoder81);
+let texture142 = device4.createTexture(
+{
+size: [7688, 4, 1],
+mipLevelCount: 12,
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'etc2-rgb8a1unorm-srgb'
+],
+}
+);
+let renderPassEncoder32 = commandEncoder100.beginRenderPass(
+{
+label: '\u326f\u{1fb98}\uc764\uf4af\ufe18\u4d29',
+colorAttachments: [
+undefined,
+{
+view: textureView74,
+depthSlice: 58,
+clearValue: { r: 302.9, g: 289.7, b: 570.3, a: 879.3, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView74,
+depthSlice: 18,
+clearValue: { r: -800.0, g: -797.4, b: 370.9, a: 100.7, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView74,
+depthSlice: 47,
+clearValue: { r: 493.5, g: 326.3, b: -810.7, a: 614.2, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView74,
+depthSlice: 28,
+clearValue: { r: 787.3, g: -367.4, b: -523.2, a: 528.2, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView74,
+depthSlice: 3,
+clearValue: { r: -698.0, g: 962.3, b: -482.4, a: 529.2, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView74,
+depthSlice: 21,
+clearValue: { r: 900.2, g: -935.8, b: -814.0, a: 91.15, },
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+maxDrawCount: 33976,
+}
+);
+try {
+renderPassEncoder17.setScissorRect(
+38,
+0,
+39,
+1
+);
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer36,
+39408,
+new DataView(new ArrayBuffer(3622)),
+569,
+2860
+);
+} catch {}
+let imageData23 = new ImageData(40, 172);
+let shaderModule32 = device4.createShaderModule(
+{
+label: '\u0eb9\u0015\u0841\u{1fcc3}\ufd9d\ub171\uf3c7\u6a68\u9476',
+code: `@group(2) @binding(2325)
+var<storage, read_write> parameter30: array<u32>;
+@group(3) @binding(221)
+var<storage, read_write> type41: array<u32>;
+@group(0) @binding(221)
+var<storage, read_write> global43: array<u32>;
+@group(4) @binding(221)
+var<storage, read_write> local31: array<u32>;
+@group(0) @binding(3375)
+var<storage, read_write> type42: array<u32>;
+@group(2) @binding(3375)
+var<storage, read_write> type43: array<u32>;
+@group(2) @binding(221)
+var<storage, read_write> global44: array<u32>;
+@group(1) @binding(221)
+var<storage, read_write> parameter31: array<u32>;
+@group(1) @binding(2325)
+var<storage, read_write> type44: array<u32>;
+@group(4) @binding(3375)
+var<storage, read_write> i21: array<u32>;
+@group(3) @binding(2325)
+var<storage, read_write> type45: array<u32>;
+@group(0) @binding(2325)
+var<storage, read_write> local32: array<u32>;
+@group(1) @binding(3375)
+var<storage, read_write> function32: array<u32>;
+@group(4) @binding(2325)
+var<storage, read_write> field42: array<u32>;
+@group(3) @binding(3375)
+var<storage, read_write> global45: array<u32>;
+
+@compute @workgroup_size(6, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S27 {
+@location(2) f0: vec3<f32>,
+@location(18) f1: vec2<f16>,
+@location(22) f2: vec4<f16>,
+@location(29) f3: vec3<f16>,
+@location(17) f4: u32,
+@location(59) f5: u32,
+@location(42) f6: i32,
+@location(43) f7: vec2<u32>,
+@location(14) f8: vec3<f16>,
+@location(12) f9: vec2<u32>,
+@location(45) f10: vec3<i32>,
+@builtin(position) f11: vec4<f32>
+}
+struct FragmentOutput0 {
+@location(0) f0: vec2<u32>,
+@location(4) f1: vec3<f32>,
+@location(7) f2: vec2<i32>
+}
+
+@fragment
+fn fragment0(@location(3) a0: i32, @builtin(front_facing) a1: bool, @location(9) a2: vec4<u32>, @location(28) a3: vec4<u32>, a4: S27, @location(39) a5: vec4<f16>, @location(21) a6: vec3<u32>, @location(20) a7: f16, @location(36) a8: vec2<i32>, @location(46) a9: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S26 {
+@location(13) f0: vec4<f32>,
+@location(9) f1: vec2<i32>,
+@builtin(vertex_index) f2: u32,
+@location(11) f3: f32,
+@location(15) f4: vec3<u32>,
+@location(1) f5: vec3<i32>,
+@location(6) f6: i32,
+@location(16) f7: vec3<u32>,
+@location(0) f8: i32,
+@location(2) f9: vec3<f16>
+}
+struct VertexOutput0 {
+@location(26) f458: u32,
+@location(67) f459: vec2<f16>,
+@location(14) f460: vec3<f16>,
+@builtin(position) f461: vec4<f32>,
+@location(60) f462: i32,
+@location(15) f463: vec2<f32>,
+@location(23) f464: u32,
+@location(39) f465: vec4<f16>,
+@location(42) f466: i32,
+@location(43) f467: vec2<u32>,
+@location(45) f468: vec3<i32>,
+@location(20) f469: f16,
+@location(59) f470: u32,
+@location(2) f471: vec3<f32>,
+@location(44) f472: u32,
+@location(21) f473: vec3<u32>,
+@location(28) f474: vec4<u32>,
+@location(3) f475: i32,
+@location(46) f476: u32,
+@location(36) f477: vec2<i32>,
+@location(47) f478: vec4<i32>,
+@location(12) f479: vec2<u32>,
+@location(9) f480: vec4<u32>,
+@location(29) f481: vec3<f16>,
+@location(18) f482: vec2<f16>,
+@location(48) f483: vec3<i32>,
+@location(31) f484: vec4<u32>,
+@location(22) f485: vec4<f16>,
+@location(17) f486: u32
+}
+
+@vertex
+fn vertex0(@location(17) a0: f32, @location(5) a1: vec3<i32>, @builtin(instance_index) a2: u32, @location(10) a3: vec3<u32>, @location(7) a4: f32, a5: S26, @location(8) a6: vec2<f32>, @location(3) a7: vec2<f32>, @location(14) a8: vec2<i32>, @location(12) a9: vec2<f32>, @location(4) a10: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder101 = device4.createCommandEncoder(
+{
+label: '\u{1fa72}\u0716\u1471\u0867',
+}
+);
+let querySet100 = device4.createQuerySet({
+label: '\u4730\ub2c1\udbbd\u0545\u{1fd19}',
+type: 'occlusion',
+count: 2161,
+});
+let texture143 = device4.createTexture(
+{
+label: '\ub3d8\u201c\ued0a\uc69e\u8a70\u{1fff4}\ua2c7\uba57',
+size: [4242, 246, 1],
+format: 'astc-6x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+}
+);
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 82, height: 1, depthOrArrayLayers: 65}
+*/
+{
+  source: offscreenCanvas26,
+  origin: { x: 96, y: 0 },
+  flipY: true,
+},
+{
+  texture: texture69,
+  mipLevel: 1,
+  origin: { x: 4, y: 0, z: 22 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 65, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline119 = await device4.createComputePipelineAsync(
+{
+label: '\u{1f640}\u458a',
+layout: 'auto',
+compute: {
+module: shaderModule26,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline120 = device4.createRenderPipeline(
+{
+label: '\u{1f7e6}\u0d27\uf63a\u{1fe6c}',
+layout: pipelineLayout31,
+vertex: {
+module: shaderModule32,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 24632,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 4996,
+shaderLocation: 1,
+},
+{
+format: 'float32',
+offset: 1432,
+shaderLocation: 11,
+},
+{
+format: 'unorm16x4',
+offset: 10296,
+shaderLocation: 13,
+},
+{
+format: 'unorm16x2',
+offset: 16500,
+shaderLocation: 3,
+},
+{
+format: 'float32',
+offset: 18008,
+shaderLocation: 4,
+},
+{
+format: 'sint32',
+offset: 3596,
+shaderLocation: 0,
+},
+{
+format: 'sint32x2',
+offset: 8724,
+shaderLocation: 9,
+},
+{
+format: 'uint8x4',
+offset: 18984,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x2',
+offset: 11624,
+shaderLocation: 12,
+},
+{
+format: 'uint32x4',
+offset: 6608,
+shaderLocation: 15,
+},
+{
+format: 'sint16x4',
+offset: 13240,
+shaderLocation: 6,
+},
+{
+format: 'float16x2',
+offset: 9124,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 23892,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x2',
+offset: 5992,
+shaderLocation: 5,
+},
+{
+format: 'unorm16x4',
+offset: 23008,
+shaderLocation: 7,
+},
+{
+format: 'float16x4',
+offset: 15032,
+shaderLocation: 17,
+},
+{
+format: 'unorm16x4',
+offset: 20636,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 14596,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x4',
+offset: 1848,
+shaderLocation: 10,
+},
+{
+format: 'sint8x2',
+offset: 9430,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule32,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+undefined,
+{
+blend: {
+color: {
+operation: 'subtract',
+srcFactor: 'one-minus-src',
+dstFactor: 'one-minus-src'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'src-alpha-saturated',
+dstFactor: 'one-minus-src-alpha'
+},
+},
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+undefined,
+undefined,
+{
+format: 'r8sint',
+writeMask: 0,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+failOp: 'invert',
+depthFailOp: 'decrement-clamp',
+passOp: 'replace',
+},
+stencilReadMask: 2858,
+stencilWriteMask: 2418,
+depthBias: 26,
+depthBiasSlopeScale: 35,
+depthBiasClamp: 90,
+},
+}
+);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageData24 = new ImageData(144, 256);
+let sampler88 = device7.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMaxClamp: 99.355,
+maxAnisotropy: 1,
+}
+);
+try {
+commandEncoder90.copyTextureToTexture(
+{
+  texture: texture141,
+  mipLevel: 5,
+  origin: { x: 0, y: 4, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture141,
+  mipLevel: 1,
+  origin: { x: 36, y: 40, z: 0 },
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let offscreenCanvas37 = new OffscreenCanvas(107, 53);
+let video24 = await videoWithData();
+try {
+computePassEncoder45.insertDebugMarker(
+'\uc017'
+);
+} catch {}
+let video25 = await videoWithData();
+let buffer49 = device3.createBuffer(
+{
+label: '\u{1fd4f}\u7a80\u{1fceb}\u8e8d\u4f75\u{1f8a2}\u9b89\u{1fcc2}',
+size: 43276,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let textureView133 = texture96.createView(
+{
+label: '\u0351\u{1fd54}',
+baseMipLevel: 4,
+baseArrayLayer: 27,
+arrayLayerCount: 29,
+}
+);
+let computePassEncoder51 = commandEncoder89.beginComputePass(
+{
+label: '\u88c3\u2025\u{1fb0e}\u3562\uf12c'
+}
+);
+let sampler89 = device3.createSampler(
+{
+label: '\u0293\u36b2\u{1fa7d}\u01fd\u2596\u0821\u7670\u5012\u044d\u889b',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 61.253,
+lodMaxClamp: 72.623,
+maxAnisotropy: 15,
+}
+);
+let bindGroup54 = device4.createBindGroup({
+layout: bindGroupLayout40,
+entries: [
+{
+binding: 1675,
+resource: sampler72
+}
+],
+});
+let texture144 = device4.createTexture(
+{
+size: {width: 959, height: 1, depthOrArrayLayers: 171},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let sampler90 = device4.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMaxClamp: 70.073,
+}
+);
+try {
+computePassEncoder43.setBindGroup(
+0,
+bindGroup48,
+new Uint32Array(4791),
+463,
+0
+);
+} catch {}
+try {
+computePassEncoder43.setPipeline(
+pipeline119
+);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(
+2,
+bindGroup48,
+new Uint32Array(4278),
+3823,
+0
+);
+} catch {}
+try {
+renderPassEncoder26.setScissorRect(
+17,
+1,
+15,
+0
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture143,
+  mipLevel: 0,
+  origin: { x: 822, y: 6, z: 0 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer3),
+/* required buffer size: 7227 */{
+offset: 251,
+bytesPerRow: 413,
+},
+{width: 138, height: 102, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 164, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: canvas1,
+  origin: { x: 186, y: 133 },
+  flipY: true,
+},
+{
+  texture: texture69,
+  mipLevel: 0,
+  origin: { x: 75, y: 1, z: 11 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 86, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let videoFrame27 = new VideoFrame(canvas15, {timestamp: 0});
+let texture145 = device9.createTexture(
+{
+label: '\ub4fe\uc2c4\u0f5b\u009c',
+size: {width: 8, height: 10, depthOrArrayLayers: 152},
+mipLevelCount: 4,
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-8x5-unorm-srgb',
+'astc-8x5-unorm-srgb',
+'astc-8x5-unorm-srgb'
+],
+}
+);
+let textureView134 = texture145.createView(
+{
+label: '\u083c\u8d6d\u9ac2\u{1fef1}\ud6ca\ubc28\u{1fd81}',
+baseMipLevel: 3,
+baseArrayLayer: 131,
+arrayLayerCount: 7,
+}
+);
+let img29 = await imageWithData(172, 190, '#1bd21fb2', '#5020c730');
+document.body.prepend(video25);
+try {
+renderPassEncoder23.setBindGroup(
+1,
+bindGroup29
+);
+} catch {}
+try {
+renderPassEncoder30.setScissorRect(
+2,
+1,
+1,
+0
+);
+} catch {}
+try {
+commandEncoder60.copyTextureToTexture(
+{
+  texture: texture73,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 62 },
+  aspect: 'all',
+},
+{
+  texture: texture91,
+  mipLevel: 1,
+  origin: { x: 39, y: 0, z: 46 },
+  aspect: 'all',
+},
+{width: 48, height: 0, depthOrArrayLayers: 81}
+);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(
+/*
+{width: 14, height: 2, depthOrArrayLayers: 32}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 307, y: 272 },
+  flipY: true,
+},
+{
+  texture: texture98,
+  mipLevel: 1,
+  origin: { x: 2, y: 0, z: 8 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 12, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let imageBitmap27 = await createImageBitmap(imageData12);
+let videoFrame28 = new VideoFrame(offscreenCanvas12, {timestamp: 0});
+let texture146 = device8.createTexture(
+{
+label: '\u0ad4\ude47\u0f68\u0bc1\u4807',
+size: {width: 4295, height: 115, depthOrArrayLayers: 54},
+mipLevelCount: 9,
+sampleCount: 1,
+format: 'astc-5x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-5x5-unorm-srgb',
+'astc-5x5-unorm'
+],
+}
+);
+let textureView135 = texture146.createView(
+{
+dimension: '2d',
+baseMipLevel: 1,
+mipLevelCount: 6,
+baseArrayLayer: 18,
+}
+);
+let computePassEncoder52 = commandEncoder87.beginComputePass(
+{
+label: '\u07d8\u{1fa1b}\u{1f891}\u7ae9\u5ffa\u0d6e\u0d3e\u0d06\u{1fdd1}\ucea6\u{1fbd3}'
+}
+);
+let renderBundleEncoder89 = device8.createRenderBundleEncoder(
+{
+colorFormats: [
+'r8unorm',
+'rg8uint',
+'rg8uint'
+],
+sampleCount: 865,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+let renderBundle107 = renderBundleEncoder89.finish(
+{
+label: '\u6daf\u3305\u95f6\u718b\u{1ff85}\u5026\u4f4f\u8614\uc584\u02e1\u{1f617}'
+}
+);
+try {
+device8.queue.writeBuffer(
+buffer40,
+20996,
+new Int16Array(56871),
+7024,
+9488
+);
+} catch {}
+try {
+device8.queue.writeTexture(
+{
+  texture: texture121,
+  mipLevel: 0,
+  origin: { x: 691, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer7,
+/* required buffer size: 310 */{
+offset: 102,
+},
+{width: 13, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let offscreenCanvas38 = new OffscreenCanvas(917, 195);
+let gpuCanvasContext30 = canvas28.getContext('webgpu');
+try {
+device8.queue.writeTexture(
+{
+  texture: texture121,
+  mipLevel: 0,
+  origin: { x: 217, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer2),
+/* required buffer size: 198 */{
+offset: 198,
+},
+{width: 463, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await device8.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+let textureView136 = texture118.createView(
+{
+label: '\u95ee\u0197\u6010\ud4de\u8c78\u08d6',
+baseMipLevel: 1,
+}
+);
+let renderPassEncoder33 = commandEncoder98.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+{
+view: textureView87,
+clearValue: { r: -255.2, g: 870.7, b: 936.2, a: 873.5, },
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet62,
+maxDrawCount: 108656,
+}
+);
+let renderBundleEncoder90 = device2.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba32float',
+'bgra8unorm',
+'rg16float',
+undefined,
+'bgra8unorm-srgb',
+'r8uint',
+'rgba16uint'
+],
+sampleCount: 278,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder48.setBindGroup(
+1,
+bindGroup33,
+new Uint32Array(26),
+24,
+0
+);
+} catch {}
+try {
+computePassEncoder21.setPipeline(
+pipeline92
+);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(
+6,
+bindGroup33,
+new Uint32Array(1623),
+1409,
+0
+);
+} catch {}
+try {
+renderPassEncoder33.end();
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(
+93,
+undefined,
+298791043,
+1478130971
+);
+} catch {}
+try {
+renderBundleEncoder46.setBindGroup(
+4,
+bindGroup44,
+new Uint32Array(302),
+75,
+0
+);
+} catch {}
+let querySet101 = device8.createQuerySet({
+label: '\u1b82\uf44e\u0bae\ua3ae\u0e14\u{1fe7e}',
+type: 'occlusion',
+count: 775,
+});
+let texture147 = device8.createTexture(
+{
+label: '\u780e\u3f18\u0466\ue3e1\u53b6\u0d66\u{1fb9c}\ub953\u3306\u{1fe13}',
+size: {width: 487, height: 1, depthOrArrayLayers: 176},
+mipLevelCount: 9,
+dimension: '3d',
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+try {
+computePassEncoder52.insertDebugMarker(
+'\u9b73'
+);
+} catch {}
+try {
+offscreenCanvas35.getContext('webgpu');
+} catch {}
+let renderPassEncoder34 = commandEncoder91.beginRenderPass(
+{
+label: '\u8473\u0227',
+colorAttachments: [
+{
+view: textureView96,
+depthSlice: 3,
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+{
+view: textureView96,
+depthSlice: 2,
+clearValue: { r: 181.6, g: 61.06, b: -333.2, a: -333.8, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView96,
+depthSlice: 0,
+clearValue: { r: -193.9, g: 393.3, b: -66.69, a: -413.4, },
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet58,
+}
+);
+try {
+commandEncoder61.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 31156 */
+offset: 31156,
+buffer: buffer45,
+},
+{
+  texture: texture65,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device3, buffer45);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer30,
+8932,
+new DataView(new ArrayBuffer(36712))
+);
+} catch {}
+let promise51 = device3.queue.onSubmittedWorkDone();
+let img30 = await imageWithData(194, 18, '#f745fb12', '#79d8dc11');
+let querySet102 = device8.createQuerySet({
+type: 'occlusion',
+count: 3463,
+});
+let sampler91 = device8.createSampler(
+{
+label: '\uce3b\u0c62\ue5b7',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 31.878,
+lodMaxClamp: 92.309,
+}
+);
+try {
+device8.queue.writeBuffer(
+buffer40,
+57256,
+new BigUint64Array(45280),
+13821,
+604
+);
+} catch {}
+try {
+await promise51;
+} catch {}
+let pipelineLayout33 = device10.createPipelineLayout(
+{
+label: '\u7377\uae9b\u2a14',
+bindGroupLayouts: [
+bindGroupLayout54,
+bindGroupLayout54
+]
+}
+);
+let textureView137 = texture138.createView(
+{
+label: '\u7d72\u63ef\u0530\u0162\u{1f968}\u4eea\u0a35\u{1fc0b}\u0f7f\u079e',
+aspect: 'all',
+baseMipLevel: 1,
+arrayLayerCount: 1,
+}
+);
+try {
+gpuCanvasContext16.configure(
+{
+device: device10,
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float',
+'eac-r11unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device10.queue.writeTexture(
+{
+  texture: texture138,
+  mipLevel: 0,
+  origin: { x: 32, y: 5, z: 1 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer4),
+/* required buffer size: 472 */{
+offset: 472,
+bytesPerRow: 312,
+},
+{width: 96, height: 130, depthOrArrayLayers: 0}
+);
+} catch {}
+let gpuCanvasContext31 = offscreenCanvas38.getContext('webgpu');
+let offscreenCanvas39 = new OffscreenCanvas(221, 4);
+try {
+canvas27.getContext('bitmaprenderer');
+} catch {}
+let gpuCanvasContext32 = offscreenCanvas36.getContext('webgpu');
+let offscreenCanvas40 = new OffscreenCanvas(484, 255);
+let imageData25 = new ImageData(140, 36);
+let bindGroup55 = device6.createBindGroup({
+label: '\u0628\u32ec\u57a4\u7a7c\u351c\u8cad\u4c18',
+layout: bindGroupLayout55,
+entries: [
+
+],
+});
+let sampler92 = device6.createSampler(
+{
+label: '\u{1fea3}\u{1faf2}\ufd6d\u{1fb96}\u{1fea1}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMaxClamp: 60.794,
+}
+);
+try {
+renderBundleEncoder85.setBindGroup(
+1,
+bindGroup47,
+new Uint32Array(1736),
+469,
+0
+);
+} catch {}
+let bindGroup56 = device2.createBindGroup({
+label: '\u97ba\ue572\u0673\u0c79\u{1fa06}\u3b20',
+layout: bindGroupLayout44,
+entries: [
+{
+binding: 8151,
+resource: {
+buffer: buffer26,
+offset: 3840,
+size: 16292,
+}
+},
+{
+binding: 1110,
+resource: textureView92
+},
+{
+binding: 6348,
+resource: externalTexture13
+}
+],
+});
+let sampler93 = device2.createSampler(
+{
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 84.060,
+lodMaxClamp: 97.759,
+}
+);
+try {
+renderPassEncoder31.setBindGroup(
+5,
+bindGroup35
+);
+} catch {}
+try {
+renderPassEncoder29.setViewport(
+0.8674,
+0.9678,
+0.02874,
+0.02394,
+0.8977,
+0.9184
+);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(
+56,
+undefined,
+3696483927,
+110387846
+);
+} catch {}
+try {
+adapter13.label = '\ubc5d\u9d71\u6ed2';
+} catch {}
+let pipelineLayout34 = device9.createPipelineLayout(
+{
+label: '\u2460\u03ca\u{1feba}\u06e9',
+bindGroupLayouts: [
+bindGroupLayout57
+]
+}
+);
+let querySet103 = device9.createQuerySet({
+label: '\uecdf\u0c2d\u{1fa25}\u07b3\u00f8',
+type: 'occlusion',
+count: 1330,
+});
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let imageData26 = new ImageData(152, 160);
+let querySet104 = device3.createQuerySet({
+label: '\u064b\u25b4\u005d\ud0c3\u0387\u3634',
+type: 'occlusion',
+count: 3404,
+});
+let renderBundleEncoder91 = device3.createRenderBundleEncoder(
+{
+label: '\u99e6\u0c3d\ufa75\u0dd1\u{1faae}\u{1fad4}\u061d\ua818',
+colorFormats: [
+undefined,
+'rg8sint',
+'r16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 865,
+depthReadOnly: true,
+}
+);
+let renderBundle108 = renderBundleEncoder76.finish(
+{
+label: '\ue1f7\u7854\u0cd3'
+}
+);
+try {
+renderPassEncoder23.setBindGroup(
+2,
+bindGroup34
+);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder30.setStencilReference(
+829
+);
+} catch {}
+try {
+await device3.popErrorScope();
+} catch {}
+try {
+commandEncoder61.clearBuffer(
+buffer19,
+28816,
+680
+);
+dissociateBuffer(device3, buffer19);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer30,
+53224,
+new Float32Array(27474),
+25628
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: { x: 1104, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(605),
+/* required buffer size: 605 */{
+offset: 605,
+},
+{width: 555, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let texture148 = device6.createTexture(
+{
+label: '\u9b3a\u{1f9a9}\u7143\udacc\u0953\u596b\u4b7f\u{1f62e}\u83ff',
+size: {width: 2387},
+dimension: '1d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8sint',
+'rg8sint',
+'rg8sint'
+],
+}
+);
+let renderBundleEncoder92 = device6.createRenderBundleEncoder(
+{
+label: '\u0ca5\udac3\u0575\ud069\u{1fa83}\u5df7\u250d\u{1fa09}\u0aba',
+colorFormats: [
+'r32float',
+'r16uint',
+undefined,
+undefined,
+'r32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 595,
+}
+);
+try {
+device6.queue.copyExternalImageToTexture(
+/*
+{width: 202, height: 51, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas8,
+  origin: { x: 329, y: 267 },
+  flipY: true,
+},
+{
+  texture: texture134,
+  mipLevel: 0,
+  origin: { x: 46, y: 21, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 151, height: 17, depthOrArrayLayers: 0}
+);
+} catch {}
+let commandEncoder102 = device4.createCommandEncoder(
+{
+}
+);
+let textureView138 = texture72.createView(
+{
+dimension: '2d-array',
+baseMipLevel: 1,
+mipLevelCount: 5,
+}
+);
+let renderBundleEncoder93 = device4.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 843,
+stencilReadOnly: false,
+}
+);
+try {
+computePassEncoder43.setBindGroup(
+3,
+bindGroup39
+);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(
+3,
+bindGroup36,
+[]
+);
+} catch {}
+try {
+renderPassEncoder17.setViewport(
+27.25,
+0.9271,
+21.38,
+0.03188,
+0.4644,
+0.6685
+);
+} catch {}
+try {
+renderBundleEncoder93.setBindGroup(
+4,
+bindGroup40
+);
+} catch {}
+try {
+commandEncoder101.copyBufferToBuffer(
+buffer39,
+5064,
+buffer36,
+38296,
+488
+);
+dissociateBuffer(device4, buffer39);
+dissociateBuffer(device4, buffer36);
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer36,
+36728,
+new BigUint64Array(55853),
+47752,
+612
+);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 82, height: 1, depthOrArrayLayers: 65}
+*/
+{
+  source: imageBitmap13,
+  origin: { x: 425, y: 612 },
+  flipY: false,
+},
+{
+  texture: texture69,
+  mipLevel: 1,
+  origin: { x: 20, y: 0, z: 19 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 50, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline121 = await device4.createComputePipelineAsync(
+{
+layout: pipelineLayout32,
+compute: {
+module: shaderModule27,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+try {
+textureView100.label = '\u{1ffb1}\u{1fb5c}\u0c93\ue9be';
+} catch {}
+let querySet105 = device3.createQuerySet({
+label: '\u0a35\u09af\u{1f774}\u1c82\u085b\u01d4',
+type: 'occlusion',
+count: 1774,
+});
+let sampler94 = device3.createSampler(
+{
+label: '\u{1f819}\uc470\u83be\ufba3\u{1fa34}\u0d20\u19cc\u{1f99c}\uf9ba\u7a80\u{1f77c}',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+lodMinClamp: 45.643,
+lodMaxClamp: 88.166,
+}
+);
+try {
+computePassEncoder47.setBindGroup(
+4,
+bindGroup32
+);
+} catch {}
+try {
+renderPassEncoder34.beginOcclusionQuery(139);
+} catch {}
+try {
+renderPassEncoder34.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(
+2,
+0,
+0,
+1
+);
+} catch {}
+try {
+renderPassEncoder23.setViewport(
+2.613,
+0.7494,
+0.1170,
+0.1529,
+0.5902,
+0.5999
+);
+} catch {}
+try {
+commandEncoder60.copyTextureToBuffer(
+{
+  texture: texture83,
+  mipLevel: 0,
+  origin: { x: 93, y: 1, z: 0 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 27892 widthInBlocks: 6973 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 55192 */
+offset: 55192,
+buffer: buffer30,
+},
+{width: 6973, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device3, buffer30);
+} catch {}
+try {
+commandEncoder95.clearBuffer(
+buffer30
+);
+dissociateBuffer(device3, buffer30);
+} catch {}
+try {
+gpuCanvasContext6.configure(
+{
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let offscreenCanvas41 = new OffscreenCanvas(602, 203);
+let bindGroupLayout59 = device6.createBindGroupLayout(
+{
+label: '\u43e6\u0c53',
+entries: [
+{
+binding: 2889,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba16uint', access: 'write-only', viewDimension: '2d' },
+},
+{
+binding: 1573,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+},
+{
+binding: 2136,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+}
+],
+}
+);
+let commandEncoder103 = device6.createCommandEncoder(
+{
+}
+);
+try {
+commandEncoder97.copyTextureToTexture(
+{
+  texture: texture134,
+  mipLevel: 1,
+  origin: { x: 10, y: 17, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture134,
+  mipLevel: 1,
+  origin: { x: 5, y: 15, z: 0 },
+  aspect: 'all',
+},
+{width: 28, height: 6, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(
+/*
+{width: 202, height: 51, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas7,
+  origin: { x: 240, y: 302 },
+  flipY: true,
+},
+{
+  texture: texture134,
+  mipLevel: 0,
+  origin: { x: 13, y: 9, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 79, height: 40, depthOrArrayLayers: 0}
+);
+} catch {}
+let texture149 = device8.createTexture(
+{
+size: {width: 177, height: 1, depthOrArrayLayers: 352},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba8uint',
+'rgba8uint',
+'rgba8uint'
+],
+}
+);
+let renderBundle109 = renderBundleEncoder82.finish(
+{
+label: '\u{1fa32}\u0fb6\u0efb\u9216\uf835\u1a55\uceca\u0c83\u{1ff0d}\ue3f3'
+}
+);
+try {
+buffer40.unmap();
+} catch {}
+try {
+await device8.queue.onSubmittedWorkDone();
+} catch {}
+let adapter15 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let videoFrame29 = new VideoFrame(videoFrame8, {timestamp: 0});
+let commandEncoder104 = device10.createCommandEncoder(
+{
+label: '\ub67f\u{1fbba}\u05b8\u0219\u{1fcbc}',
+}
+);
+let commandBuffer12 = commandEncoder99.finish(
+{
+label: '\u00ba\ued1a\ube2d\u{1fb63}',
+}
+);
+let renderBundleEncoder94 = device10.createRenderBundleEncoder(
+{
+label: '\u9de8\ub439\u240e\u44a4',
+colorFormats: [
+'rgba8unorm',
+'rg16sint',
+'rgba8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 227,
+depthReadOnly: true,
+}
+);
+try {
+commandEncoder104.copyBufferToTexture(
+{
+/* bytesInLastRow: 128 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 33744 */
+offset: 33744,
+bytesPerRow: 256,
+buffer: buffer42,
+},
+{
+  texture: texture138,
+  mipLevel: 1,
+  origin: { x: 8, y: 20, z: 0 },
+  aspect: 'all',
+},
+{width: 64, height: 25, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device10, buffer42);
+} catch {}
+let gpuCanvasContext33 = offscreenCanvas41.getContext('webgpu');
+let img31 = await imageWithData(121, 49, '#0fb113ec', '#889ddc9e');
+try {
+gpuCanvasContext23.unconfigure();
+} catch {}
+let buffer50 = device8.createBuffer(
+{
+label: '\u5e50\u05b6\u{1fdc1}\ucb66\uce20\u{1fd53}',
+size: 23711,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let commandEncoder105 = device8.createCommandEncoder(
+{
+label: '\uc3c7\u{1fc86}',
+}
+);
+pseudoSubmit(device8, commandEncoder105);
+let texture150 = device8.createTexture(
+{
+label: '\u2fe6\udc3f\u3cc0\ud26f\u0e33\u937f\u0cfb\u0230\ube55\u{1f8a7}\ua1f1',
+size: [1566, 1, 14],
+mipLevelCount: 8,
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+let querySet106 = device7.createQuerySet({
+label: '\ue060\u{1fdfc}\u05dd\u{1fff8}\ubf35\u313c',
+type: 'occlusion',
+count: 402,
+});
+let texture151 = device7.createTexture(
+{
+label: '\u{1fad5}\u023a\u5625\u3310\uc67d\u{1fb0e}\uc3cd\u{1fa18}',
+size: {width: 8503, height: 2, depthOrArrayLayers: 1},
+mipLevelCount: 13,
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'bgra8unorm-srgb',
+'bgra8unorm',
+'bgra8unorm'
+],
+}
+);
+let texture152 = device7.createTexture(
+{
+label: '\u0621\u6f70\ub510\u07d0\u4951\u07c1',
+size: [9555, 56, 106],
+sampleCount: 1,
+format: 'astc-5x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let video26 = await videoWithData();
+let gpuCanvasContext34 = offscreenCanvas37.getContext('webgpu');
+try {
+computePassEncoder50.setBindGroup(
+5,
+bindGroup46
+);
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(
+0,
+1,
+1,
+0
+);
+} catch {}
+try {
+renderBundleEncoder47.setBindGroup(
+1,
+bindGroup22
+);
+} catch {}
+try {
+device2.queue.writeTexture(
+{
+  texture: texture48,
+  mipLevel: 1,
+  origin: { x: 15, y: 12, z: 11 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer2),
+/* required buffer size: 607 */{
+offset: 607,
+bytesPerRow: 2487,
+rowsPerImage: 149,
+},
+{width: 579, height: 39, depthOrArrayLayers: 0}
+);
+} catch {}
+let texture153 = device8.createTexture(
+{
+label: '\u0556\ub1fa\u0811\u0e19\u{1f795}\u50ac',
+size: {width: 30, height: 16, depthOrArrayLayers: 51},
+mipLevelCount: 4,
+format: 'astc-10x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let sampler95 = device8.createSampler(
+{
+label: '\u01cc\u1213\ueef5\u0892\u{1fe7e}\u82be\u5ad9\u06e7\u{1fd44}\u{1fddd}',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 81.473,
+lodMaxClamp: 97.856,
+compare: 'greater-equal',
+}
+);
+try {
+offscreenCanvas39.getContext('webgpu');
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let querySet107 = device2.createQuerySet({
+type: 'occlusion',
+count: 1464,
+});
+let renderBundleEncoder95 = device2.createRenderBundleEncoder(
+{
+label: '\u0dab\u0981\u{1ffa9}\u45ef\u35a8\u{1f96d}\ub3d8\u{1ffcf}',
+colorFormats: [
+'rgba8uint',
+'rgb10a2unorm',
+'r8unorm'
+],
+sampleCount: 872,
+depthReadOnly: true,
+}
+);
+let renderBundle110 = renderBundleEncoder66.finish(
+{
+
+}
+);
+try {
+computePassEncoder48.setPipeline(
+pipeline98
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 6, y: 5 },
+  flipY: false,
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let querySet108 = device6.createQuerySet({
+label: '\u15a3\u08f1',
+type: 'occlusion',
+count: 1762,
+});
+let textureView139 = texture136.createView(
+{
+label: '\uc524\u24cd\u0019\u93bb\u04d3\uae4e\u{1f784}\u20e8\ucefc',
+dimension: '2d-array',
+baseMipLevel: 10,
+arrayLayerCount: 1,
+}
+);
+let computePassEncoder53 = commandEncoder103.beginComputePass(
+{
+
+}
+);
+let sampler96 = device6.createSampler(
+{
+label: '\u0e3c\u79c4',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 2.546,
+lodMaxClamp: 89.583,
+maxAnisotropy: 1,
+}
+);
+let canvas30 = document.createElement('canvas');
+let canvas31 = document.createElement('canvas');
+let gpuCanvasContext35 = offscreenCanvas40.getContext('webgpu');
+let bindGroupLayout60 = device6.createBindGroupLayout(
+{
+label: '\u{1f8de}\u0436\u{1fb6a}\u6d46\u{1fd09}',
+entries: [
+{
+binding: 1108,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 3160,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'read-only-storage', minBindingSize: 4122, hasDynamicOffset: true },
+},
+{
+binding: 2147,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}
+],
+}
+);
+let renderPassEncoder35 = commandEncoder97.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+{
+view: textureView130,
+clearValue: { r: 759.3, g: 144.9, b: 661.1, a: -945.8, },
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet84,
+maxDrawCount: 47272,
+}
+);
+let renderBundle111 = renderBundleEncoder69.finish(
+{
+label: '\u0dda\u3096\u4f4c\u010b'
+}
+);
+try {
+renderPassEncoder35.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder35.setBlendConstant({ r: 514.6, g: -457.1, b: 716.7, a: -46.94, });
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(
+/*
+{width: 202, height: 51, depthOrArrayLayers: 1}
+*/
+{
+  source: img27,
+  origin: { x: 9, y: 207 },
+  flipY: true,
+},
+{
+  texture: texture134,
+  mipLevel: 0,
+  origin: { x: 129, y: 11, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 3, height: 17, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let renderBundle112 = renderBundleEncoder89.finish();
+let sampler97 = device8.createSampler(
+{
+label: '\u{1f64e}\u05f3\u0d7e\u92d6\u32ba\u095b\u{1fbe0}\uf014',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 91.326,
+lodMaxClamp: 97.525,
+}
+);
+try {
+device8.queue.writeBuffer(
+buffer40,
+26844,
+new BigUint64Array(37629),
+12810,
+4360
+);
+} catch {}
+video16.width = 223;
+let offscreenCanvas42 = new OffscreenCanvas(273, 266);
+try {
+device2.queue.label = '\u{1f754}\udce1\u3a6e';
+} catch {}
+let bindGroupLayout61 = device2.createBindGroupLayout(
+{
+label: '\ua62d\u1bf1\u57db\u06a9\ud05e\u{1ffb1}\u9db9',
+entries: [
+{
+binding: 931,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let querySet109 = device2.createQuerySet({
+label: '\uf1ab\u0f41\uc303\u91ba\u{1f7c8}\u1ea2\u0ae2\u58cb',
+type: 'occlusion',
+count: 1668,
+});
+let renderBundleEncoder96 = device2.createRenderBundleEncoder(
+{
+label: '\u{1ff82}\u956f\u0e84\u{1f7da}\u17a4\u{1fe9d}\u66b2\u7ee6\u7a0f\u{1fdb4}\ua68b',
+colorFormats: [
+'rgba16sint',
+'rg32uint',
+'rgb10a2unorm',
+'rg16sint',
+'r8unorm',
+'bgra8unorm-srgb',
+'rg32sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 271,
+depthReadOnly: true,
+}
+);
+try {
+computePassEncoder21.setBindGroup(
+5,
+bindGroup45,
+new Uint32Array(6590),
+1872,
+0
+);
+} catch {}
+try {
+computePassEncoder48.end();
+} catch {}
+try {
+device2.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder45.copyBufferToTexture(
+{
+/* bytesInLastRow: 35120 widthInBlocks: 2195 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 6944 */
+offset: 6944,
+buffer: buffer23,
+},
+{
+  texture: texture102,
+  mipLevel: 0,
+  origin: { x: 1827, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 2195, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device2, buffer23);
+} catch {}
+try {
+device2.queue.writeBuffer(
+buffer33,
+36256,
+new DataView(new ArrayBuffer(59411)),
+54045,
+56
+);
+} catch {}
+let promise52 = device2.createComputePipelineAsync(
+{
+label: '\u{1f6b5}\ua622\uc2f8\u0ba9',
+layout: 'auto',
+compute: {
+module: shaderModule30,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageBitmap28 = await createImageBitmap(imageData24);
+let querySet110 = device4.createQuerySet({
+label: '\u1e14\u1860\uf567\u{1ff06}\u0fae\u{1fc99}\ue493\u0e74\u7911',
+type: 'occlusion',
+count: 4091,
+});
+let renderPassEncoder36 = commandEncoder101.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+{
+view: textureView74,
+depthSlice: 43,
+clearValue: { r: -38.76, g: 783.0, b: -321.7, a: -461.7, },
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined
+],
+maxDrawCount: 51688,
+}
+);
+let renderBundleEncoder97 = device4.createRenderBundleEncoder(
+{
+label: '\u66dd\ua4ca',
+colorFormats: [
+'rgb10a2uint',
+'bgra8unorm-srgb',
+'rg8uint',
+'rg16uint',
+undefined,
+undefined,
+'rg16float'
+],
+sampleCount: 562,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder43.setBindGroup(
+5,
+bindGroup40,
+[]
+);
+} catch {}
+try {
+renderPassEncoder16.end();
+} catch {}
+try {
+renderBundleEncoder97.setBindGroup(
+4,
+bindGroup36
+);
+} catch {}
+try {
+renderBundleEncoder93.setVertexBuffer(
+26,
+undefined,
+1846921114,
+1986351829
+);
+} catch {}
+try {
+renderPassEncoder32.insertDebugMarker(
+'\u{1f9ca}'
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture72,
+  mipLevel: 0,
+  origin: { x: 36, y: 13, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer9,
+/* required buffer size: 40696 */{
+offset: 836,
+bytesPerRow: 1085,
+},
+{width: 100, height: 37, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 82, height: 1, depthOrArrayLayers: 65}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 7, y: 16 },
+  flipY: false,
+},
+{
+  texture: texture69,
+  mipLevel: 1,
+  origin: { x: 11, y: 1, z: 24 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 13, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline122 = await device4.createComputePipelineAsync(
+{
+label: '\u2563\u{1fdc8}\ua2fb\u2535\u{1f7d5}\u{1fd1e}\u0121\u7d60\u{1f7b7}',
+layout: pipelineLayout30,
+compute: {
+module: shaderModule32,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+let pipelineLayout35 = device4.createPipelineLayout(
+{
+label: '\ue1de\u1f49\udc01\u81e2\u{1ff62}\uc9ef\u0beb',
+bindGroupLayouts: [
+bindGroupLayout39,
+bindGroupLayout49,
+bindGroupLayout58,
+bindGroupLayout41,
+bindGroupLayout58,
+bindGroupLayout58,
+bindGroupLayout40,
+bindGroupLayout40
+]
+}
+);
+let buffer51 = device4.createBuffer(
+{
+label: '\u266f\u89b8',
+size: 63830,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+}
+);
+let texture154 = device4.createTexture(
+{
+size: {width: 3520, height: 16, depthOrArrayLayers: 1},
+mipLevelCount: 9,
+format: 'astc-10x8-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+computePassEncoder43.setBindGroup(
+0,
+bindGroup48
+);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder93.setBindGroup(
+9,
+bindGroup39
+);
+} catch {}
+try {
+renderBundleEncoder97.setBindGroup(
+5,
+bindGroup40,
+new Uint32Array(8832),
+4768,
+0
+);
+} catch {}
+try {
+commandEncoder102.clearBuffer(
+buffer24,
+38380,
+3504
+);
+dissociateBuffer(device4, buffer24);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 10, height: 1, depthOrArrayLayers: 8}
+*/
+{
+  source: videoFrame19,
+  origin: { x: 154, y: 363 },
+  flipY: false,
+},
+{
+  texture: texture69,
+  mipLevel: 4,
+  origin: { x: 3, y: 1, z: 5 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 3, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+video14.height = 13;
+let imageData27 = new ImageData(180, 220);
+let shaderModule33 = device10.createShaderModule(
+{
+label: '\u68e6\u592b\ubebb\uff66\u538c\uf7fa\u{1f85b}\u681e\u4f72',
+code: `@group(0) @binding(499)
+var<storage, read_write> function33: array<u32>;
+@group(1) @binding(155)
+var<storage, read_write> i22: array<u32>;
+@group(0) @binding(155)
+var<storage, read_write> type46: array<u32>;
+@group(1) @binding(499)
+var<storage, read_write> field43: array<u32>;
+@group(0) @binding(574)
+var<storage, read_write> type47: array<u32>;
+
+@compute @workgroup_size(2, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(6) f0: u32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(17) a0: vec4<i32>, @builtin(instance_index) a1: u32, @location(5) a2: f32, @location(7) a3: vec2<f32>, @location(9) a4: i32, @builtin(vertex_index) a5: u32, @location(14) a6: vec3<f16>, @location(0) a7: vec2<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let buffer52 = device10.createBuffer(
+{
+label: '\u06b5\u054c\u0980\ue813\u0190',
+size: 8997,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+}
+);
+let pipeline123 = device10.createRenderPipeline(
+{
+layout: pipelineLayout33,
+vertex: {
+module: shaderModule33,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 37792,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 21324,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 1052,
+shaderLocation: 7,
+},
+{
+format: 'uint16x4',
+offset: 9356,
+shaderLocation: 0,
+},
+{
+format: 'sint8x2',
+offset: 17448,
+shaderLocation: 9,
+},
+{
+format: 'snorm16x2',
+offset: 15228,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'unorm16x4',
+offset: 38064,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 40964,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x4',
+offset: 7512,
+shaderLocation: 17,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+},
+fragment: {
+module: shaderModule33,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'equal',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-wrap',
+},
+stencilWriteMask: 2099,
+},
+}
+);
+let gpuCanvasContext36 = canvas29.getContext('webgpu');
+document.body.prepend(img22);
+try {
+adapter9.label = '\u0961\u0300\u{1fa83}\u262c\u01e3\udf91\u77e6';
+} catch {}
+let commandEncoder106 = device7.createCommandEncoder(
+{
+}
+);
+let computePassEncoder54 = commandEncoder90.beginComputePass();
+try {
+computePassEncoder54.end();
+} catch {}
+try {
+gpuCanvasContext14.configure(
+{
+device: device7,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'depth32float',
+'astc-10x6-unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+canvas3.height = 88;
+try {
+canvas31.getContext('2d');
+} catch {}
+let commandEncoder107 = device8.createCommandEncoder(
+{
+label: '\ue6f1\uc23c\u35b9\u76ed',
+}
+);
+let renderBundle113 = renderBundleEncoder89.finish(
+{
+label: '\u046b\uf378\u002c\u0541\uf9b1'
+}
+);
+try {
+commandEncoder107.copyBufferToBuffer(
+buffer44,
+38616,
+buffer50,
+18240,
+3396
+);
+dissociateBuffer(device8, buffer44);
+dissociateBuffer(device8, buffer50);
+} catch {}
+try {
+commandEncoder107.copyTextureToTexture(
+{
+  texture: texture135,
+  mipLevel: 5,
+  origin: { x: 1, y: 0, z: 7 },
+  aspect: 'all',
+},
+{
+  texture: texture121,
+  mipLevel: 0,
+  origin: { x: 356, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device8.queue.writeBuffer(
+buffer50,
+18996,
+new Float32Array(36205),
+15083,
+660
+);
+} catch {}
+try {
+device8.queue.writeTexture(
+{
+  texture: texture147,
+  mipLevel: 3,
+  origin: { x: 2, y: 0, z: 3 },
+  aspect: 'all',
+},
+arrayBuffer11,
+/* required buffer size: 245367 */{
+offset: 939,
+bytesPerRow: 235,
+rowsPerImage: 208,
+},
+{width: 7, height: 1, depthOrArrayLayers: 6}
+);
+} catch {}
+try {
+bindGroupLayout49.label = '\u530f\u03f3';
+} catch {}
+let textureView140 = texture114.createView(
+{
+label: '\u6084\u92ee\u04fa\u7697\ue097\u6efb\u7585\udfa8\u{1f97e}',
+arrayLayerCount: 1,
+}
+);
+let sampler98 = device4.createSampler(
+{
+label: '\ue0b6\u5441\u3e70\u0a97\ub566\u0acb\u{1f923}\u0a31\ue5cf',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 91.942,
+lodMaxClamp: 96.356,
+}
+);
+try {
+buffer39.unmap();
+} catch {}
+try {
+commandEncoder102.copyTextureToTexture(
+{
+  texture: texture140,
+  mipLevel: 7,
+  origin: { x: 10, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture97,
+  mipLevel: 1,
+  origin: { x: 1100, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 20, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder102.clearBuffer(
+buffer51,
+44912,
+1412
+);
+dissociateBuffer(device4, buffer51);
+} catch {}
+let gpuCanvasContext37 = offscreenCanvas42.getContext('webgpu');
+let commandEncoder108 = device10.createCommandEncoder(
+{
+}
+);
+let renderBundleEncoder98 = device10.createRenderBundleEncoder(
+{
+label: '\u5b41\u{1fa5b}\u0bbb\u0cab\u372f\u7e72',
+colorFormats: [
+'r16sint',
+'r8uint',
+'rg8unorm',
+'rgb10a2uint',
+'rgba32uint',
+'rgba8unorm-srgb',
+'rg8uint'
+],
+sampleCount: 822,
+stencilReadOnly: true,
+}
+);
+let renderBundle114 = renderBundleEncoder79.finish(
+{
+label: '\u0a98\u7dd9\u01fd\u0e42\u{1f87d}\uacc5\u1745\u3861\u6168\ub845'
+}
+);
+let sampler99 = device10.createSampler(
+{
+label: '\u51d2\u632e\ub705\u1e65\u691c\u{1faf8}\u00a6\u916c\ueecd\u8707\u{1f7bf}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 73.634,
+lodMaxClamp: 83.895,
+maxAnisotropy: 16,
+}
+);
+try {
+renderBundleEncoder94.setIndexBuffer(
+buffer52,
+'uint32',
+1300,
+55
+);
+} catch {}
+let pipeline124 = await device10.createComputePipelineAsync(
+{
+label: '\u0a89\ubfb7\u{1ff11}\u77ac\u113c\ud21c\u518c',
+layout: pipelineLayout33,
+compute: {
+module: shaderModule33,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+canvas29.height = 852;
+let commandEncoder109 = device7.createCommandEncoder(
+{
+}
+);
+let commandBuffer13 = commandEncoder109.finish(
+{
+label: '\u54e5\u7f9e\u7e7a\u662a\u5cfe\ubb49\u876a\ufd19\u2df7',
+}
+);
+let texture155 = device7.createTexture(
+{
+label: '\ucac4\u035c\u976c\u1c5e\u047d\u3e8d\u7b5e',
+size: {width: 3747},
+mipLevelCount: 1,
+sampleCount: 1,
+dimension: '1d',
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+document.body.prepend(img7);
+let video27 = await videoWithData();
+let promise53 = device7.queue.onSubmittedWorkDone();
+let pipelineLayout36 = device10.createPipelineLayout(
+{
+label: '\ud127\ua81e\u766f\u{1f8de}\u2a5f\ua958\u{1fbcf}\ub01e\u{1fbb8}\u{1fa80}\u{1f856}',
+bindGroupLayouts: [
+
+]
+}
+);
+try {
+renderBundleEncoder94.setVertexBuffer(
+0,
+undefined,
+1268809303,
+1873017105
+);
+} catch {}
+gc();
+let promise54 = adapter15.requestDevice({
+label: '\uff2d\u{1fa7b}\ue78f\u{1fc7b}\u0116\ue80d\u022f\u{1fb99}\ue258',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 58,
+maxVertexAttributes: 29,
+maxVertexBufferArrayStride: 58422,
+maxStorageTexturesPerShaderStage: 33,
+maxStorageBuffersPerShaderStage: 9,
+maxDynamicStorageBuffersPerPipelineLayout: 40240,
+maxBindingsPerBindGroup: 3489,
+maxTextureDimension1D: 10745,
+maxTextureDimension2D: 11299,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 92763730,
+maxUniformBuffersPerShaderStage: 20,
+maxInterStageShaderVariables: 41,
+maxInterStageShaderComponents: 80,
+maxSamplersPerShaderStage: 22,
+},
+});
+try {
+device4.queue.label = '\u0a2b\u{1f9bd}\uae58\u3847';
+} catch {}
+let commandBuffer14 = commandEncoder102.finish();
+let texture156 = device4.createTexture(
+{
+size: [2583, 128, 237],
+mipLevelCount: 8,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'depth16unorm',
+'depth16unorm',
+'depth16unorm'
+],
+}
+);
+let renderBundle115 = renderBundleEncoder52.finish(
+{
+label: '\u43ab\u0861\u05d0\u{1f688}\u9a84\u{1fbe2}\u8080\u0641\u053a\u0d50'
+}
+);
+try {
+renderPassEncoder28.end();
+} catch {}
+try {
+renderPassEncoder26.setScissorRect(
+50,
+0,
+4,
+0
+);
+} catch {}
+try {
+renderBundleEncoder93.setBindGroup(
+5,
+bindGroup40
+);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 82, height: 1, depthOrArrayLayers: 65}
+*/
+{
+  source: canvas1,
+  origin: { x: 659, y: 141 },
+  flipY: false,
+},
+{
+  texture: texture69,
+  mipLevel: 1,
+  origin: { x: 15, y: 0, z: 65 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 10, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline125 = device4.createComputePipeline(
+{
+layout: pipelineLayout30,
+compute: {
+module: shaderModule23,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let texture157 = device8.createTexture(
+{
+label: '\u0518\u625e\u559e\uaf75\u7936\u0c06\ue40e\u0fa3\u6d34\u{1ffd5}',
+size: {width: 5607},
+dimension: '1d',
+format: 'rg32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+let textureView141 = texture137.createView(
+{
+label: '\u{1fea0}\u{1fc91}\u0b3b\uf5f7\u0d32\u{1f68e}\u8331',
+baseMipLevel: 6,
+}
+);
+try {
+device8.queue.writeTexture(
+{
+  texture: texture153,
+  mipLevel: 2,
+  origin: { x: 10, y: 0, z: 13 },
+  aspect: 'all',
+},
+new ArrayBuffer(40),
+/* required buffer size: 810206 */{
+offset: 231,
+bytesPerRow: 181,
+rowsPerImage: 179,
+},
+{width: 0, height: 0, depthOrArrayLayers: 26}
+);
+} catch {}
+let img32 = await imageWithData(57, 200, '#d1a55b33', '#0532beca');
+let bindGroup57 = device6.createBindGroup({
+label: '\u0289\u04cc\uaad2',
+layout: bindGroupLayout55,
+entries: [
+
+],
+});
+let commandEncoder110 = device6.createCommandEncoder(
+{
+label: '\u{1f908}\u0aad\u3b3e\u00f5\u{1ff30}\ubda9\u61cf\u{1f7c1}\u0d6f\u4fd1',
+}
+);
+let renderPassEncoder37 = commandEncoder92.beginRenderPass(
+{
+label: '\ud0a2\u09b7\uf68b\u0176',
+colorAttachments: [
+undefined,
+{
+view: textureView130,
+clearValue: { r: 828.7, g: 935.6, b: 937.1, a: -840.3, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined,
+undefined,
+undefined,
+undefined
+],
+occlusionQuerySet: querySet84,
+maxDrawCount: 300432,
+}
+);
+try {
+renderPassEncoder37.setVertexBuffer(
+57,
+undefined,
+2375693297
+);
+} catch {}
+let canvas32 = document.createElement('canvas');
+let commandEncoder111 = device9.createCommandEncoder();
+let sampler100 = device9.createSampler(
+{
+label: '\ud4b8\u081b\u{1f99f}\u05ac\u7e7f',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 62.869,
+lodMaxClamp: 85.481,
+}
+);
+try {
+await device9.popErrorScope();
+} catch {}
+let imageData28 = new ImageData(172, 148);
+try {
+renderBundleEncoder98.setVertexBuffer(
+69,
+undefined,
+3544173063,
+411580048
+);
+} catch {}
+try {
+commandEncoder108.clearBuffer(
+buffer52,
+6884,
+2020
+);
+dissociateBuffer(device10, buffer52);
+} catch {}
+try {
+renderBundleEncoder86.insertDebugMarker(
+'\u28d1'
+);
+} catch {}
+let pipeline126 = await device10.createRenderPipelineAsync(
+{
+layout: pipelineLayout33,
+vertex: {
+module: shaderModule33,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 14184,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 6540,
+shaderLocation: 14,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 10960,
+shaderLocation: 5,
+},
+{
+format: 'snorm8x2',
+offset: 4426,
+shaderLocation: 7,
+},
+{
+format: 'sint16x4',
+offset: 9472,
+shaderLocation: 9,
+},
+{
+format: 'uint16x4',
+offset: 6228,
+shaderLocation: 0,
+},
+{
+format: 'sint8x4',
+offset: 10236,
+shaderLocation: 17,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule33,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthCompare: 'always',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'invert',
+depthFailOp: 'replace',
+},
+stencilBack: {
+compare: 'not-equal',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 2124,
+depthBias: 95,
+depthBiasSlopeScale: 60,
+},
+}
+);
+let offscreenCanvas43 = new OffscreenCanvas(127, 84);
+let sampler101 = device9.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 3.474,
+lodMaxClamp: 58.216,
+}
+);
+try {
+device9.queue.writeBuffer(
+buffer41,
+916,
+new Int16Array(41577),
+8954,
+1824
+);
+} catch {}
+let imageData29 = new ImageData(168, 48);
+try {
+device10.addEventListener('uncapturederror', e => { log('device10.uncapturederror'); log(e); e.label = device10.label; });
+} catch {}
+try {
+commandEncoder108.copyBufferToBuffer(
+buffer47,
+55132,
+buffer52,
+8912,
+72
+);
+dissociateBuffer(device10, buffer47);
+dissociateBuffer(device10, buffer52);
+} catch {}
+try {
+commandEncoder108.clearBuffer(
+buffer52,
+304,
+7748
+);
+dissociateBuffer(device10, buffer52);
+} catch {}
+try {
+device10.queue.submit([
+commandBuffer12,
+]);
+} catch {}
+try {
+await device10.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext38 = canvas32.getContext('webgpu');
+offscreenCanvas14.width = 849;
+let canvas33 = document.createElement('canvas');
+let bindGroupLayout62 = device8.createBindGroupLayout(
+{
+label: '\u1220\u{1f779}\u07bd\ue4a0',
+entries: [
+{
+binding: 242,
+visibility: 0,
+texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+},
+{
+binding: 552,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+},
+{
+binding: 104,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let commandEncoder112 = device8.createCommandEncoder(
+{
+label: '\u0529\u8480\u9802\u0833\u1603\u3b3f\ud80a\u07c6',
+}
+);
+let texture158 = device8.createTexture(
+{
+label: '\u2e29\uf6f3\u6b92\u{1f804}\u4cc7\u01b3\u71e2\ud3ac\udd6d\u011a\u0764',
+size: {width: 5770, height: 5, depthOrArrayLayers: 1},
+mipLevelCount: 9,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-5x5-unorm',
+'astc-5x5-unorm',
+'astc-5x5-unorm'
+],
+}
+);
+let renderBundle116 = renderBundleEncoder89.finish(
+{
+label: '\ue411\u89ad\u0ea5\u1bce\u0fd2\u1860\u{1f924}\u0a66\u0228'
+}
+);
+let sampler102 = device8.createSampler(
+{
+label: '\u2010\u{1fdec}\ufac6\u{1fee0}\u4073\u0931\ua256\u{1f8af}\ue666\ud7b3',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 99.809,
+lodMaxClamp: 99.997,
+maxAnisotropy: 6,
+}
+);
+let adapter16 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let canvas34 = document.createElement('canvas');
+let querySet111 = device6.createQuerySet({
+label: '\u9e22\u0010\ua67c\ue34d\uf192\uf3f3\u07e6',
+type: 'occlusion',
+count: 2819,
+});
+let textureView142 = texture107.createView(
+{
+label: '\u2d5d\u{1f64d}\u{1f624}\u5160\u{1f668}\ucbf2\ub5bd\u883b',
+baseMipLevel: 3,
+mipLevelCount: 3,
+}
+);
+let renderBundleEncoder99 = device6.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16sint',
+'rg16float',
+'rg16float'
+],
+sampleCount: 252,
+depthReadOnly: true,
+}
+);
+let renderBundle117 = renderBundleEncoder92.finish(
+{
+
+}
+);
+try {
+renderPassEncoder37.setStencilReference(
+4063
+);
+} catch {}
+try {
+renderBundleEncoder85.setVertexBuffer(
+4,
+undefined
+);
+} catch {}
+try {
+renderBundleEncoder71.pushDebugGroup(
+'\u5019'
+);
+} catch {}
+let gpuCanvasContext39 = offscreenCanvas43.getContext('webgpu');
+let bindGroupLayout63 = device7.createBindGroupLayout(
+{
+label: '\u241a\u04e6\u0a59\u{1fc11}\u{1fbd2}\u{1fd1d}\u0b21\u056f',
+entries: [
+
+],
+}
+);
+try {
+device7.queue.submit([
+]);
+} catch {}
+let gpuCanvasContext40 = canvas30.getContext('webgpu');
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let img33 = await imageWithData(267, 148, '#e0907a78', '#a2112eb5');
+let imageBitmap29 = await createImageBitmap(videoFrame7);
+let externalTexture14 = device9.importExternalTexture(
+{
+label: '\u{1fe56}\u8484\u0bf6\u3607\u{1fb46}\u8ba8',
+source: videoFrame18,
+}
+);
+try {
+commandEncoder111.clearBuffer(
+buffer41,
+6984,
+836
+);
+dissociateBuffer(device9, buffer41);
+} catch {}
+try {
+device9.queue.writeBuffer(
+buffer41,
+7280,
+new DataView(new ArrayBuffer(19379)),
+19263,
+48
+);
+} catch {}
+let canvas35 = document.createElement('canvas');
+let videoFrame30 = videoFrame1.clone();
+try {
+device9.queue.writeTexture(
+{
+  texture: texture145,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 6 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer3),
+/* required buffer size: 53949 */{
+offset: 225,
+bytesPerRow: 44,
+rowsPerImage: 11,
+},
+{width: 0, height: 0, depthOrArrayLayers: 112}
+);
+} catch {}
+let video28 = await videoWithData();
+video3.height = 169;
+let imageBitmap30 = await createImageBitmap(imageData4);
+let bindGroupLayout64 = device3.createBindGroupLayout(
+{
+label: '\uec4e\u00f0\uc400\u0eef',
+entries: [
+
+],
+}
+);
+let bindGroup58 = device3.createBindGroup({
+label: '\u{1fc9b}\u0c00\u29ec\u0e43',
+layout: bindGroupLayout37,
+entries: [
+
+],
+});
+let texture159 = device3.createTexture(
+{
+label: '\ufa8a\u0243\u07c3\ue7c1\u841b\ued65\u0f4e\u{1f71f}\u{1fb41}',
+size: [188, 89, 1],
+mipLevelCount: 5,
+format: 'rg16sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg16sint',
+'rg16sint'
+],
+}
+);
+let textureView143 = texture96.createView(
+{
+label: '\u0db1\u07d8\u07d5\u60de\u6fef\uf0da',
+dimension: '2d',
+baseMipLevel: 1,
+baseArrayLayer: 65,
+}
+);
+let computePassEncoder55 = commandEncoder60.beginComputePass(
+{
+
+}
+);
+try {
+computePassEncoder41.setBindGroup(
+8,
+bindGroup27,
+new Uint32Array(2295),
+1280,
+0
+);
+} catch {}
+try {
+renderPassEncoder30.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder24.setScissorRect(
+0,
+1,
+1,
+0
+);
+} catch {}
+try {
+commandEncoder95.copyBufferToBuffer(
+buffer45,
+62588,
+buffer49,
+43156,
+92
+);
+dissociateBuffer(device3, buffer45);
+dissociateBuffer(device3, buffer49);
+} catch {}
+let texture160 = device5.createTexture(
+{
+label: '\ue950\u{1ff18}\ude07\u1ba3\u0559\u7c35\u0149\u969e\u8af3',
+size: {width: 179, height: 107, depthOrArrayLayers: 209},
+mipLevelCount: 2,
+format: 'depth24plus',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let renderBundle118 = renderBundleEncoder55.finish(
+{
+label: '\u4c25\u4ada\u05b3'
+}
+);
+try {
+gpuCanvasContext35.unconfigure();
+} catch {}
+let imageData30 = new ImageData(180, 76);
+let videoFrame31 = new VideoFrame(offscreenCanvas24, {timestamp: 0});
+let renderPassEncoder38 = commandEncoder95.beginRenderPass(
+{
+label: '\u0868\u6fe0\u{1fdc2}\u{1f9cc}\u{1f6a6}\u7f0a',
+colorAttachments: [
+{
+view: textureView96,
+depthSlice: 5,
+clearValue: { r: 950.9, g: -821.7, b: 317.9, a: -752.6, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView96,
+depthSlice: 1,
+clearValue: { r: -308.7, g: -45.57, b: 325.8, a: 214.6, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView96,
+depthSlice: 2,
+clearValue: { r: -973.1, g: 825.3, b: 255.0, a: -174.5, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView96,
+depthSlice: 4,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView96,
+depthSlice: 3,
+clearValue: { r: 61.56, g: 288.4, b: 267.6, a: 365.0, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView96,
+depthSlice: 7,
+clearValue: { r: -61.12, g: -771.1, b: 174.6, a: -555.0, },
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet104,
+maxDrawCount: 476776,
+}
+);
+let renderBundle119 = renderBundleEncoder60.finish();
+try {
+computePassEncoder36.setBindGroup(
+2,
+bindGroup34
+);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(
+2,
+bindGroup26,
+new Uint32Array(9023),
+8369,
+0
+);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+try {
+await promise53;
+} catch {}
+video11.width = 23;
+let commandEncoder113 = device9.createCommandEncoder(
+{
+label: '\u{1fc5b}\u5ecc\u0b4e\u500f\u0ff1\u01db\u1e20\u0da1',
+}
+);
+let sampler103 = device9.createSampler(
+{
+label: '\ud117\ue70b\u{1feac}\udd73\ud4d9\u63fe\u{1fa2c}',
+addressModeV: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 26.960,
+lodMaxClamp: 93.125,
+compare: 'greater',
+}
+);
+try {
+commandEncoder111.copyTextureToTexture(
+{
+  texture: texture145,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 8 },
+  aspect: 'all',
+},
+{
+  texture: texture145,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 21 },
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 112}
+);
+} catch {}
+try {
+device9.queue.writeBuffer(
+buffer41,
+4048,
+new Float32Array(18742),
+10770,
+904
+);
+} catch {}
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+let imageData31 = new ImageData(16, 148);
+let promise55 = adapter10.requestAdapterInfo();
+let bindGroup59 = device6.createBindGroup({
+label: '\u2efd\ua796\ue953\u2072\u11a3\u09a5\u{1fa1b}\u{1f695}\u693e',
+layout: bindGroupLayout48,
+entries: [
+
+],
+});
+let buffer53 = device6.createBuffer(
+{
+label: '\u112a\uf1f1\ub592\u7abd',
+size: 21491,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+pseudoSubmit(device6, commandEncoder103);
+let sampler104 = device6.createSampler(
+{
+label: '\ubb5b\ueb36\ua58d\u61a5\u523a\u{1f6a0}\u5031\u20e0\u04ab',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 34.289,
+lodMaxClamp: 83.305,
+}
+);
+try {
+renderPassEncoder35.setBindGroup(
+7,
+bindGroup43,
+[]
+);
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture148,
+  mipLevel: 0,
+  origin: { x: 14, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(arrayBuffer7),
+/* required buffer size: 5673 */{
+offset: 935,
+},
+{width: 2369, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let video29 = await videoWithData();
+let canvas36 = document.createElement('canvas');
+try {
+adapter15.label = '\u0de6\u{1fef0}\u0378\u{1f63d}\u4bfa\u{1f9ae}\u0bf2\u{1f81c}\ubaf2';
+} catch {}
+let renderPassEncoder39 = commandEncoder61.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView96,
+depthSlice: 5,
+clearValue: { r: -647.5, g: -263.5, b: 136.7, a: -446.7, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined,
+{
+view: textureView96,
+depthSlice: 1,
+clearValue: { r: -405.4, g: 629.0, b: -196.2, a: 682.9, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined,
+undefined,
+undefined
+],
+occlusionQuerySet: querySet104,
+maxDrawCount: 140712,
+}
+);
+try {
+renderPassEncoder24.end();
+} catch {}
+try {
+renderPassEncoder34.executeBundles([]);
+} catch {}
+try {
+gpuCanvasContext11.configure(
+{
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer30,
+17320,
+new Int16Array(31801),
+26776,
+3448
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture60,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(957),
+/* required buffer size: 957 */{
+offset: 954,
+},
+{width: 3, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+document.body.prepend(video26);
+try {
+await adapter7.requestAdapterInfo();
+} catch {}
+let commandEncoder114 = device9.createCommandEncoder(
+{
+label: '\ufd55\u71d9\u2c7e\u543d',
+}
+);
+try {
+commandEncoder111.copyTextureToBuffer(
+{
+  texture: texture145,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 22 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 2240 */
+offset: 2240,
+bytesPerRow: 0,
+rowsPerImage: 12,
+buffer: buffer41,
+},
+{width: 0, height: 0, depthOrArrayLayers: 125}
+);
+dissociateBuffer(device9, buffer41);
+} catch {}
+try {
+gpuCanvasContext35.configure(
+{
+device: device9,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16float',
+'astc-5x5-unorm-srgb',
+'rgba16float',
+'rgba16float'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let gpuCanvasContext41 = canvas35.getContext('webgpu');
+pseudoSubmit(device10, commandEncoder108);
+let texture161 = device10.createTexture(
+{
+size: [3186, 229, 180],
+mipLevelCount: 7,
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb',
+'rgba8unorm'
+],
+}
+);
+try {
+commandEncoder104.copyBufferToBuffer(
+buffer47,
+41988,
+buffer52,
+5152,
+684
+);
+dissociateBuffer(device10, buffer47);
+dissociateBuffer(device10, buffer52);
+} catch {}
+gc();
+let video30 = await videoWithData();
+let videoFrame32 = new VideoFrame(canvas24, {timestamp: 0});
+try {
+canvas36.getContext('webgl');
+} catch {}
+let commandEncoder115 = device8.createCommandEncoder(
+{
+label: '\u0c62\u8ff7\uc5ff\u143e\u0953\u62ab\u4c69',
+}
+);
+let computePassEncoder56 = commandEncoder115.beginComputePass(
+{
+
+}
+);
+try {
+buffer50.destroy();
+} catch {}
+try {
+commandEncoder112.copyBufferToBuffer(
+buffer44,
+55536,
+buffer40,
+41268,
+3640
+);
+dissociateBuffer(device8, buffer44);
+dissociateBuffer(device8, buffer40);
+} catch {}
+try {
+canvas33.getContext('2d');
+} catch {}
+let bindGroupLayout65 = device10.createBindGroupLayout(
+{
+label: '\ufbb3\u0d6d\u{1fe09}\u2159\u{1fe30}\u0ac6\u0b8c',
+entries: [
+
+],
+}
+);
+let commandBuffer15 = commandEncoder104.finish();
+let sampler105 = device10.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+lodMaxClamp: 48.056,
+}
+);
+try {
+computePassEncoder49.setPipeline(
+pipeline124
+);
+} catch {}
+let pipeline127 = await device10.createComputePipelineAsync(
+{
+label: '\u65db\u0650\u0dfb\u050b\u0d1f\u{1fd91}',
+layout: pipelineLayout33,
+compute: {
+module: shaderModule33,
+entryPoint: 'compute0',
+},
+}
+);
+let bindGroup60 = device5.createBindGroup({
+label: '\u7d5f\u0db6',
+layout: bindGroupLayout38,
+entries: [
+
+],
+});
+let buffer54 = device5.createBuffer(
+{
+label: '\uf1c0\u4200\u53d1\u0b0f\u2175\u4dd0\u09b0\u3d81\u1e9e',
+size: 36261,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let textureView144 = texture119.createView(
+{
+baseMipLevel: 1,
+mipLevelCount: 1,
+baseArrayLayer: 1,
+arrayLayerCount: 1,
+}
+);
+let renderBundle120 = renderBundleEncoder55.finish(
+{
+label: '\u{1fe62}\u0d80\ua800\u7ce3\u60c6\u3d12\uf7e3\u0b83\u4cd2'
+}
+);
+try {
+device5.pushErrorScope('out-of-memory');
+} catch {}
+let offscreenCanvas44 = new OffscreenCanvas(200, 789);
+let commandEncoder116 = device2.createCommandEncoder(
+{
+label: '\u{1fe23}\u{1f704}\ue4c6\ubf24\u0fd6',
+}
+);
+let texture162 = device2.createTexture(
+{
+label: '\u09d1\u0967\u335c\u031e',
+size: {width: 3802, height: 96, depthOrArrayLayers: 95},
+mipLevelCount: 6,
+sampleCount: 1,
+format: 'rg32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg32float',
+'rg32float'
+],
+}
+);
+let renderBundle121 = renderBundleEncoder77.finish(
+{
+
+}
+);
+try {
+renderPassEncoder29.setBindGroup(
+1,
+bindGroup30
+);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(
+84,
+undefined,
+233800179,
+3103715056
+);
+} catch {}
+try {
+commandEncoder116.copyBufferToBuffer(
+buffer23,
+48424,
+buffer33,
+4560,
+100
+);
+dissociateBuffer(device2, buffer23);
+dissociateBuffer(device2, buffer33);
+} catch {}
+gc();
+let commandEncoder117 = device6.createCommandEncoder(
+{
+label: '\u2b54\u{1fad6}\u{1fb63}\u{1fbdd}',
+}
+);
+let renderBundle122 = renderBundleEncoder69.finish(
+{
+
+}
+);
+try {
+renderBundleEncoder85.setBindGroup(
+5,
+bindGroup55
+);
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture148,
+  mipLevel: 0,
+  origin: { x: 309, y: 1, z: 0 },
+  aspect: 'all',
+},
+new Int8Array(arrayBuffer4),
+/* required buffer size: 313 */{
+offset: 313,
+bytesPerRow: 3600,
+},
+{width: 1735, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(
+/*
+{width: 202, height: 51, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData18,
+  origin: { x: 36, y: 8 },
+  flipY: false,
+},
+{
+  texture: texture134,
+  mipLevel: 0,
+  origin: { x: 12, y: 17, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 153, height: 30, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+canvas34.getContext('2d');
+} catch {}
+try {
+await promise55;
+} catch {}
+let videoFrame33 = new VideoFrame(canvas7, {timestamp: 0});
+let pipelineLayout37 = device8.createPipelineLayout(
+{
+label: '\u0029\u3d65\u0639\u395f\ud5bb',
+bindGroupLayouts: [
+bindGroupLayout62
+]
+}
+);
+let textureView145 = texture153.createView(
+{
+label: '\u0f84\uf877\u0479\u59b1\udb0d\u{1fe68}\u{1fe90}\uab9b',
+baseMipLevel: 3,
+baseArrayLayer: 24,
+}
+);
+let renderBundle123 = renderBundleEncoder89.finish(
+{
+label: '\u0a17\u{1f900}\u57db'
+}
+);
+try {
+computePassEncoder56.end();
+} catch {}
+let texture163 = device6.createTexture(
+{
+label: '\u{1feac}\u9c6f\u{1f7cd}\u{1f7fc}\u64cf\u8f4e\uf19e',
+size: {width: 174, height: 1, depthOrArrayLayers: 1866},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder100 = device6.createRenderBundleEncoder(
+{
+label: '\u022a\uc4a1\u0ae8\u{1fe7d}\uedbb\ub892\u{1fb36}\u0d6c\u{1fbc5}\u5f7e\uf964',
+colorFormats: [
+'rg11b10ufloat',
+undefined,
+'rgb10a2uint'
+],
+sampleCount: 430,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder35.beginOcclusionQuery(887);
+} catch {}
+try {
+renderPassEncoder35.endOcclusionQuery();
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer53,
+6244,
+new Int16Array(51316),
+8785,
+6512
+);
+} catch {}
+let texture164 = device9.createTexture(
+{
+label: '\uf139\u7996\u4b26\u4c62\u{1fdde}\u0ef2',
+size: [12700, 168, 189],
+mipLevelCount: 6,
+dimension: '2d',
+format: 'astc-5x4-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+
+],
+}
+);
+try {
+commandEncoder113.copyTextureToBuffer(
+{
+  texture: texture129,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 33 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 240 */
+offset: 240,
+bytesPerRow: 0,
+rowsPerImage: 17,
+buffer: buffer41,
+},
+{width: 0, height: 0, depthOrArrayLayers: 19}
+);
+dissociateBuffer(device9, buffer41);
+} catch {}
+try {
+commandEncoder114.clearBuffer(
+buffer41,
+7620,
+1040
+);
+dissociateBuffer(device9, buffer41);
+} catch {}
+try {
+device9.queue.writeTexture(
+{
+  texture: texture122,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer10,
+/* required buffer size: 854 */{
+offset: 854,
+},
+{width: 0, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let buffer55 = device6.createBuffer(
+{
+label: '\ud03f\u{1fd6a}\u1bb4\u{1fdf8}\u4be4\ue353\u7a12',
+size: 53046,
+usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+}
+);
+let commandEncoder118 = device6.createCommandEncoder(
+{
+label: '\u0ada\u8101\u6956\u{1fc52}',
+}
+);
+let renderBundleEncoder101 = device6.createRenderBundleEncoder(
+{
+label: '\u0bb8\u4250\u{1f796}\u02cb\u1d7a\u{1f86c}\u8c80\u361d',
+colorFormats: [
+'rg11b10ufloat',
+'r8unorm',
+'rgba32sint',
+'r8uint',
+'bgra8unorm',
+'r16sint',
+'rgba8unorm-srgb'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 505,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder37.setBlendConstant({ r: -306.1, g: -797.5, b: 766.3, a: 393.3, });
+} catch {}
+try {
+renderPassEncoder37.setScissorRect(
+71,
+4,
+12,
+10
+);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(
+buffer55,
+'uint16',
+41974,
+1214
+);
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture148,
+  mipLevel: 0,
+  origin: { x: 591, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int16Array(arrayBuffer3),
+/* required buffer size: 4024 */{
+offset: 780,
+},
+{width: 1622, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let imageData32 = new ImageData(192, 20);
+let imageData33 = new ImageData(236, 200);
+let buffer56 = device3.createBuffer(
+{
+label: '\u08b0\u{1f7aa}\ue6f4\u2171',
+size: 6051,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let texture165 = device3.createTexture(
+{
+label: '\u0cb4\u8493\u82c3\u031c\u09ad\u{1fb20}\u0cff\u{1fbae}\uc188\u3acd',
+size: {width: 5301, height: 4, depthOrArrayLayers: 1},
+mipLevelCount: 11,
+dimension: '2d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'bgra8unorm',
+'bgra8unorm-srgb',
+'bgra8unorm-srgb'
+],
+}
+);
+let renderBundleEncoder102 = device3.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8unorm-srgb',
+'rgba8unorm-srgb',
+'r16sint',
+'rgba8sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 952,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder39.setBindGroup(
+8,
+bindGroup29
+);
+} catch {}
+try {
+renderPassEncoder38.end();
+} catch {}
+try {
+renderPassEncoder34.executeBundles([]);
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer30,
+3984,
+new BigUint64Array(1957)
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture98,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 5 },
+  aspect: 'all',
+},
+arrayBuffer8,
+/* required buffer size: 68473 */{
+offset: 1,
+bytesPerRow: 210,
+rowsPerImage: 163,
+},
+{width: 3, height: 1, depthOrArrayLayers: 3}
+);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext23.unconfigure();
+} catch {}
+let texture166 = device10.createTexture(
+{
+size: [160, 155, 1],
+mipLevelCount: 4,
+format: 'astc-10x5-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let sampler106 = device10.createSampler(
+{
+label: '\uaa2e\u2897\uc803\u0a8c\u{1fecd}\u{1fb9d}',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 38.701,
+lodMaxClamp: 94.044,
+}
+);
+try {
+computePassEncoder49.setPipeline(
+pipeline127
+);
+} catch {}
+let arrayBuffer12 = buffer47.getMappedRange(
+27896
+);
+try {
+gpuCanvasContext20.configure(
+{
+device: device10,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32uint',
+'r32uint',
+'astc-6x5-unorm-srgb'
+],
+colorSpace: 'display-p3',
+}
+);
+} catch {}
+try {
+device10.queue.writeBuffer(
+buffer52,
+2368,
+new Int16Array(65515),
+51022,
+2624
+);
+} catch {}
+let pipeline128 = device10.createRenderPipeline(
+{
+label: '\u76f5\u{1f8cb}\u0011\u96f5\u8fe0\u3521\uaf46\u79a2\u0a49\u{1faf1}',
+layout: pipelineLayout33,
+vertex: {
+module: shaderModule33,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 20,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x2',
+offset: 4,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 16596,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 18920,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 9676,
+shaderLocation: 14,
+},
+{
+format: 'uint32x3',
+offset: 8896,
+shaderLocation: 0,
+}
+],
+},
+{
+arrayStride: 22884,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint8x2',
+offset: 12264,
+shaderLocation: 17,
+},
+{
+format: 'float32x4',
+offset: 424,
+shaderLocation: 5,
+},
+{
+format: 'sint8x2',
+offset: 3448,
+shaderLocation: 9,
+}
+],
+}
+]
+},
+multisample: {
+count: 4,
+mask: 0x4d1de86d,
+},
+fragment: {
+module: shaderModule33,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+},
+stencilReadMask: 2363,
+stencilWriteMask: 1221,
+depthBias: 46,
+depthBiasSlopeScale: 23,
+depthBiasClamp: 80,
+},
+}
+);
+let gpuCanvasContext42 = offscreenCanvas44.getContext('webgpu');
+let commandEncoder119 = device10.createCommandEncoder(
+{
+label: '\u{1f971}\uc6a2\u1f49\u{1f6f1}',
+}
+);
+let textureView146 = texture161.createView(
+{
+label: '\u50d1\ufe9c\u2677\u{1f609}\ua446\u{1fe63}\u{1f9af}\u8d29\u5121\u07e0\u651d',
+dimension: '2d',
+baseMipLevel: 6,
+baseArrayLayer: 63,
+}
+);
+try {
+gpuCanvasContext13.configure(
+{
+device: device10,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8unorm'
+],
+}
+);
+} catch {}
+try {
+device10.queue.submit([
+commandBuffer15,
+]);
+} catch {}
+try {
+device10.queue.writeTexture(
+{
+  texture: texture138,
+  mipLevel: 0,
+  origin: { x: 56, y: 60, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer0,
+/* required buffer size: 790 */{
+offset: 790,
+bytesPerRow: 112,
+},
+{width: 16, height: 10, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device10.queue.copyExternalImageToTexture(
+/*
+{width: 49, height: 3, depthOrArrayLayers: 180}
+*/
+{
+  source: imageData2,
+  origin: { x: 18, y: 55 },
+  flipY: false,
+},
+{
+  texture: texture161,
+  mipLevel: 6,
+  origin: { x: 9, y: 2, z: 65 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 40, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let offscreenCanvas45 = new OffscreenCanvas(777, 726);
+let commandEncoder120 = device3.createCommandEncoder(
+{
+}
+);
+let querySet112 = device3.createQuerySet({
+label: '\ue131\ud99b\u00e5\u0eae\u65bd\u003e\u40f4\u08bf\ue193\u9cb8',
+type: 'occlusion',
+count: 817,
+});
+let renderBundleEncoder103 = device3.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8sint'
+],
+sampleCount: 658,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder91.setBindGroup(
+8,
+bindGroup34
+);
+} catch {}
+let texture167 = device9.createTexture(
+{
+label: '\u35da\u6eb2\u{1fc6c}\u750e',
+size: {width: 194, height: 24, depthOrArrayLayers: 195},
+mipLevelCount: 2,
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8snorm'
+],
+}
+);
+try {
+device9.queue.writeBuffer(
+buffer41,
+8432,
+new Float32Array(49831),
+12762,
+56
+);
+} catch {}
+let gpuCanvasContext43 = offscreenCanvas45.getContext('webgpu');
+let img34 = await imageWithData(10, 180, '#05b1b599', '#6d6436b9');
+let bindGroupLayout66 = device6.createBindGroupLayout(
+{
+label: '\u0171\u30eb',
+entries: [
+{
+binding: 4118,
+visibility: 0,
+externalTexture: {},
+}
+],
+}
+);
+let renderBundleEncoder104 = device6.createRenderBundleEncoder(
+{
+label: '\u2af3\u6311\u{1fb67}\u93ba\u0978',
+colorFormats: [
+'rgba32uint',
+undefined,
+'rgba8sint',
+'r8uint',
+'r16sint',
+'r8unorm',
+'rgba32sint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 113,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder37.setBindGroup(
+1,
+bindGroup43,
+new Uint32Array(5867),
+75,
+0
+);
+} catch {}
+try {
+renderPassEncoder37.setViewport(
+26.43,
+8.025,
+29.50,
+9.322,
+0.8498,
+0.8884
+);
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture106,
+  mipLevel: 0,
+  origin: { x: 2471, y: 0, z: 0 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer10),
+/* required buffer size: 81 */{
+offset: 81,
+},
+{width: 807, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let canvas37 = document.createElement('canvas');
+let shaderModule34 = device8.createShaderModule(
+{
+label: '\u0e44\u3fca\u{1fdbe}\u0829\u{1fa40}\u04b5',
+code: `@group(0) @binding(242)
+var<storage, read_write> parameter32: array<u32>;
+@group(0) @binding(104)
+var<storage, read_write> type48: array<u32>;
+
+@compute @workgroup_size(5, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(2) f0: vec4<u32>,
+@location(0) f1: f32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(15) a0: u32, @location(3) a1: vec3<u32>, @location(2) a2: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+}
+);
+let textureView147 = texture158.createView(
+{
+label: '\u3f2b\ud5d8',
+dimension: '2d-array',
+baseMipLevel: 2,
+mipLevelCount: 5,
+baseArrayLayer: 0,
+arrayLayerCount: 1,
+}
+);
+let computePassEncoder57 = commandEncoder107.beginComputePass();
+let sampler107 = device8.createSampler(
+{
+label: '\ue1e5\u02b8\ufc05\u03bd\u0ee8\u6e43\u416a\u91c5',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 67.113,
+lodMaxClamp: 96.079,
+}
+);
+try {
+computePassEncoder52.insertDebugMarker(
+'\u7948'
+);
+} catch {}
+let pipeline129 = device8.createComputePipeline(
+{
+label: '\ud109\u{1f9d1}\uf2b4\u0800\u7961\ua638',
+layout: 'auto',
+compute: {
+module: shaderModule34,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline130 = await device8.createRenderPipelineAsync(
+{
+label: '\u4030\u{1f80e}',
+layout: pipelineLayout37,
+vertex: {
+module: shaderModule34,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1464,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x4',
+offset: 360,
+shaderLocation: 15,
+},
+{
+format: 'snorm16x2',
+offset: 124,
+shaderLocation: 2,
+},
+{
+format: 'uint32x3',
+offset: 872,
+shaderLocation: 3,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule34,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32float',
+},
+undefined,
+{
+format: 'rg16uint',
+}
+],
+},
+}
+);
+let pipelineLayout38 = device7.createPipelineLayout(
+{
+bindGroupLayouts: [
+bindGroupLayout63,
+bindGroupLayout63,
+bindGroupLayout63,
+bindGroupLayout63,
+bindGroupLayout63,
+bindGroupLayout63,
+bindGroupLayout63,
+bindGroupLayout63,
+bindGroupLayout63,
+bindGroupLayout63
+]
+}
+);
+pseudoSubmit(device7, commandEncoder85);
+let renderBundleEncoder105 = device7.createRenderBundleEncoder(
+{
+label: '\u9a76\u{1f600}',
+colorFormats: [
+'rgba16uint',
+'rgb10a2uint',
+'rg8unorm'
+],
+sampleCount: 200,
+depthReadOnly: true,
+}
+);
+let externalTexture15 = device7.importExternalTexture(
+{
+label: '\u{1fe95}\u659c\u514a\u0fc1\u6945\u92ce\u0b15\u0e45',
+source: video16,
+colorSpace: 'display-p3',
+}
+);
+try {
+gpuCanvasContext1.configure(
+{
+device: device7,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-8x8-unorm-srgb',
+'rg16float'
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+adapter13.label = '\u{1fd04}\u0347\uae12\u{1fda4}\u068c\u8616\ufb12\u7cf9\u07c8\u0be1\u1adb';
+} catch {}
+try {
+canvas37.getContext('webgpu');
+} catch {}
+let buffer57 = device6.createBuffer(
+{
+size: 27572,
+usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+mappedAtCreation: true,
+}
+);
+let querySet113 = device6.createQuerySet({
+label: '\u0987\u{1fb1b}\u0355\u045f\u{1f855}\uaed7\u0195',
+type: 'occlusion',
+count: 689,
+});
+let renderBundleEncoder106 = device6.createRenderBundleEncoder(
+{
+label: '\ue2b2\u{1fc9d}\u1819\u89be\u82a2\u5fd6\u28e4',
+colorFormats: [
+'rgb10a2unorm'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 636,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder37.beginOcclusionQuery(1126);
+} catch {}
+try {
+renderBundleEncoder85.setBindGroup(
+0,
+bindGroup47
+);
+} catch {}
+try {
+await device6.popErrorScope();
+} catch {}
+try {
+commandEncoder110.clearBuffer(
+buffer53,
+6364,
+10748
+);
+dissociateBuffer(device6, buffer53);
+} catch {}
+let promise56 = device6.queue.onSubmittedWorkDone();
+try {
+await promise56;
+} catch {}
+canvas21.width = 636;
+let videoFrame34 = new VideoFrame(video27, {timestamp: 0});
+try {
+window.someLabel = device5.queue.label;
+} catch {}
+let pipelineLayout39 = device6.createPipelineLayout(
+{
+label: '\u0480\uafc4\u86d4\u044d\u0384\u{1f81e}\u09f2\u{1fd52}\u05af',
+bindGroupLayouts: [
+bindGroupLayout55,
+bindGroupLayout48,
+bindGroupLayout59,
+bindGroupLayout66,
+bindGroupLayout48
+]
+}
+);
+let renderBundleEncoder107 = device6.createRenderBundleEncoder(
+{
+label: '\u8987\u1560\uff46\ue163',
+colorFormats: [
+'r16uint'
+],
+sampleCount: 736,
+stencilReadOnly: true,
+}
+);
+let sampler108 = device6.createSampler(
+{
+label: '\u0d1e\u0512\u069d\u{1f61b}\u{1f6e0}\u{1fb60}\u14e4',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 54.364,
+lodMaxClamp: 67.799,
+}
+);
+try {
+renderPassEncoder37.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder71.setBindGroup(
+8,
+bindGroup43,
+new Uint32Array(176),
+72,
+0
+);
+} catch {}
+try {
+renderBundleEncoder71.popDebugGroup();
+} catch {}
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+try {
+commandEncoder104.label = '\u01b2\u09b2\u8e99\u0f02\ue436\ud905\u7456\u0d0e\ubb0c\uf626\u4bf8';
+} catch {}
+let renderPassEncoder40 = commandEncoder119.beginRenderPass(
+{
+label: '\u03a5\u0c5d\u762f\u{1fdf0}\u4320\ucf55\u{1fd2c}\u{1f9d6}',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+{
+view: textureView146,
+loadOp: 'load',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet98,
+maxDrawCount: 138440,
+}
+);
+try {
+computePassEncoder49.setPipeline(
+pipeline124
+);
+} catch {}
+try {
+renderPassEncoder40.setStencilReference(
+1666
+);
+} catch {}
+try {
+renderBundleEncoder83.setVertexBuffer(
+34,
+undefined,
+3701247757,
+586526427
+);
+} catch {}
+offscreenCanvas39.width = 15;
+let bindGroup61 = device7.createBindGroup({
+label: '\u0c11\ud099\u0160\u080e\u0313\u6478\u{1f838}\u8007\u0df7\u{1fa3f}\u{1fe6b}',
+layout: bindGroupLayout63,
+entries: [
+
+],
+});
+let querySet114 = device7.createQuerySet({
+label: '\u1350\u6435\u89c5\ub000',
+type: 'occlusion',
+count: 1012,
+});
+try {
+renderBundleEncoder105.setBindGroup(
+9,
+bindGroup61
+);
+} catch {}
+try {
+commandEncoder90.copyTextureToTexture(
+{
+  texture: texture141,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture141,
+  mipLevel: 4,
+  origin: { x: 4, y: 4, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device7.queue.writeTexture(
+{
+  texture: texture141,
+  mipLevel: 2,
+  origin: { x: 16, y: 20, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(24),
+/* required buffer size: 476 */{
+offset: 309,
+bytesPerRow: 151,
+},
+{width: 4, height: 8, depthOrArrayLayers: 1}
+);
+} catch {}
+let bindGroupLayout67 = device10.createBindGroupLayout(
+{
+entries: [
+
+],
+}
+);
+let bindGroup62 = device10.createBindGroup({
+label: '\u345b\ub79e\u0b13\u0e8d\u5a54',
+layout: bindGroupLayout67,
+entries: [
+
+],
+});
+let texture168 = device10.createTexture(
+{
+label: '\u2225\u069f\u07b3\uaaa2\uc12a\u{1f9de}\u{1fe73}\uae41\ufdd0\u084d',
+size: {width: 9196, height: 128, depthOrArrayLayers: 84},
+mipLevelCount: 8,
+format: 'astc-4x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+let renderBundleEncoder108 = device10.createRenderBundleEncoder(
+{
+label: '\uc048\uece3\u0273\u{1f8f8}\u4bd6\ua38f',
+colorFormats: [
+'rg16float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 550,
+stencilReadOnly: true,
+}
+);
+let renderBundle124 = renderBundleEncoder86.finish(
+{
+label: '\u{1fc60}\uf069\u128a\u{1f920}\u297e\u4f60\u{1f754}\u9f95\u2f6e\u94dc\u163c'
+}
+);
+try {
+renderPassEncoder40.setBindGroup(
+2,
+bindGroup62
+);
+} catch {}
+try {
+renderPassEncoder40.setStencilReference(
+1613
+);
+} catch {}
+try {
+renderPassEncoder40.setViewport(
+16.61,
+1.693,
+16.22,
+0.4597,
+0.00357,
+0.2978
+);
+} catch {}
+let bindGroupLayout68 = device9.createBindGroupLayout(
+{
+entries: [
+{
+binding: 5687,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let bindGroup63 = device9.createBindGroup({
+layout: bindGroupLayout57,
+entries: [
+
+],
+});
+let buffer58 = device9.createBuffer(
+{
+size: 19111,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandEncoder121 = device9.createCommandEncoder(
+{
+label: '\u0919\u0129\u4d20',
+}
+);
+let computePassEncoder58 = commandEncoder121.beginComputePass(
+{
+
+}
+);
+try {
+buffer58.unmap();
+} catch {}
+try {
+commandEncoder114.copyBufferToBuffer(
+buffer58,
+15064,
+buffer41,
+984,
+3264
+);
+dissociateBuffer(device9, buffer58);
+dissociateBuffer(device9, buffer41);
+} catch {}
+try {
+commandEncoder111.clearBuffer(
+buffer41,
+316,
+3628
+);
+dissociateBuffer(device9, buffer41);
+} catch {}
+try {
+device9.queue.writeTexture(
+{
+  texture: texture164,
+  mipLevel: 5,
+  origin: { x: 20, y: 4, z: 67 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer1),
+/* required buffer size: 3764803 */{
+offset: 13,
+bytesPerRow: 1322,
+rowsPerImage: 219,
+},
+{width: 330, height: 4, depthOrArrayLayers: 14}
+);
+} catch {}
+try {
+await adapter15.requestAdapterInfo();
+} catch {}
+let video31 = await videoWithData();
+let shaderModule35 = device8.createShaderModule(
+{
+label: '\u7cff\u3624',
+code: `@group(0) @binding(242)
+var<storage, read_write> type49: array<u32>;
+@group(0) @binding(552)
+var<storage, read_write> parameter33: array<u32>;
+
+@compute @workgroup_size(3, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: vec2<i32>,
+@location(6) f1: u32,
+@location(7) f2: vec4<i32>,
+@location(4) f3: i32,
+@location(2) f4: vec4<u32>,
+@builtin(frag_depth) f5: f32,
+@builtin(sample_mask) f6: u32,
+@location(5) f7: vec3<u32>,
+@location(1) f8: vec2<u32>,
+@location(3) f9: vec2<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S28 {
+@location(12) f0: f16,
+@location(5) f1: i32,
+@location(10) f2: f32,
+@location(0) f3: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: f16, @builtin(instance_index) a1: u32, @location(8) a2: f16, @location(3) a3: vec4<u32>, @builtin(vertex_index) a4: u32, @location(6) a5: vec3<i32>, @location(1) a6: i32, @location(7) a7: vec4<i32>, @location(4) a8: vec3<u32>, @location(9) a9: vec2<i32>, @location(2) a10: vec3<i32>, @location(13) a11: i32, @location(11) a12: i32, a13: S28, @location(14) a14: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let buffer59 = device8.createBuffer(
+{
+label: '\u0050\ufa04\ua1e7\u5701\uf0ef\uc81f',
+size: 11603,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let renderPassEncoder41 = commandEncoder115.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+{
+view: textureView141,
+depthSlice: 2,
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView141,
+depthSlice: 0,
+clearValue: { r: -264.3, g: 837.2, b: -697.6, a: -307.1, },
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined,
+{
+view: textureView141,
+depthSlice: 1,
+clearValue: { r: 609.1, g: -165.5, b: -971.2, a: 546.8, },
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined,
+undefined
+],
+maxDrawCount: 274728,
+}
+);
+try {
+computePassEncoder57.end();
+} catch {}
+try {
+renderPassEncoder41.setBlendConstant({ r: -10.48, g: 520.2, b: -891.6, a: -265.5, });
+} catch {}
+try {
+renderPassEncoder41.setViewport(
+8.974,
+0.2492,
+1.363,
+0.7168,
+0.4653,
+0.5137
+);
+} catch {}
+let commandEncoder122 = device9.createCommandEncoder(
+{
+label: '\u{1f9c6}\uc32e',
+}
+);
+let renderBundleEncoder109 = device9.createRenderBundleEncoder(
+{
+label: '\u{1fb19}\u{1f602}\u{1f878}\ueefa\u0d98\u3835\u067b\uffc3\u69a7',
+colorFormats: [
+undefined,
+'r8unorm',
+'rgba32float',
+'r16float',
+undefined,
+'rgba32float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 0,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+commandEncoder114.copyBufferToBuffer(
+buffer58,
+9756,
+buffer41,
+864,
+7612
+);
+dissociateBuffer(device9, buffer58);
+dissociateBuffer(device9, buffer41);
+} catch {}
+try {
+commandEncoder114.clearBuffer(
+buffer41,
+6912,
+1284
+);
+dissociateBuffer(device9, buffer41);
+} catch {}
+offscreenCanvas4.height = 661;
+let imageBitmap31 = await createImageBitmap(offscreenCanvas17);
+let computePassEncoder59 = commandEncoder120.beginComputePass(
+{
+
+}
+);
+let renderBundle125 = renderBundleEncoder57.finish(
+{
+
+}
+);
+try {
+renderPassEncoder39.beginOcclusionQuery(197);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(
+2,
+0,
+1,
+1
+);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(
+38,
+undefined
+);
+} catch {}
+try {
+await device3.popErrorScope();
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture96,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 15 },
+  aspect: 'all',
+},
+new Uint8ClampedArray(arrayBuffer2),
+/* required buffer size: 2061953 */{
+offset: 64,
+bytesPerRow: 219,
+rowsPerImage: 269,
+},
+{width: 4, height: 1, depthOrArrayLayers: 36}
+);
+} catch {}
+let texture169 = device10.createTexture(
+{
+label: '\u08a7\u{1ff75}\u8ddb\u46dd\ue5d8\u{1f9c9}\u07c6',
+size: {width: 811, height: 1, depthOrArrayLayers: 230},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgb10a2uint'
+],
+}
+);
+let textureView148 = texture127.createView(
+{
+}
+);
+let renderBundle126 = renderBundleEncoder83.finish(
+{
+
+}
+);
+try {
+computePassEncoder49.setBindGroup(
+2,
+bindGroup62
+);
+} catch {}
+try {
+computePassEncoder49.setPipeline(
+pipeline124
+);
+} catch {}
+try {
+device10.queue.writeBuffer(
+buffer52,
+3092,
+new BigUint64Array(50461),
+15652,
+552
+);
+} catch {}
+try {
+await device10.queue.onSubmittedWorkDone();
+} catch {}
+let device11 = await adapter16.requestDevice({
+label: '\u{1fc08}\u{1f704}\u0c1e\u0ac7',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+});
+let texture170 = device11.createTexture(
+{
+size: [7953],
+dimension: '1d',
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float',
+'rgba16float',
+'rgba16float'
+],
+}
+);
+let sampler109 = device11.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 93.814,
+lodMaxClamp: 97.402,
+maxAnisotropy: 19,
+}
+);
+try {
+await device11.queue.onSubmittedWorkDone();
+} catch {}
+let texture171 = device10.createTexture(
+{
+label: '\u0933\u0de8',
+size: {width: 8472, height: 8, depthOrArrayLayers: 226},
+mipLevelCount: 11,
+sampleCount: 1,
+dimension: '2d',
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-8x8-unorm'
+],
+}
+);
+let textureView149 = texture169.createView(
+{
+label: '\u68d2\u04ac\u6956\u02c7\u14b5\u{1fe68}\u{1feb6}\u4412\u{1fefb}',
+aspect: 'all',
+mipLevelCount: 1,
+baseArrayLayer: 0,
+}
+);
+try {
+computePassEncoder49.setPipeline(
+pipeline127
+);
+} catch {}
+try {
+renderPassEncoder40.setScissorRect(
+22,
+3,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(
+buffer52,
+'uint32',
+4572
+);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(
+54,
+undefined
+);
+} catch {}
+try {
+device10.queue.writeBuffer(
+buffer52,
+1988,
+new Float32Array(3586),
+400,
+412
+);
+} catch {}
+try {
+device10.queue.copyExternalImageToTexture(
+/*
+{width: 1593, height: 114, depthOrArrayLayers: 180}
+*/
+{
+  source: img9,
+  origin: { x: 55, y: 181 },
+  flipY: true,
+},
+{
+  texture: texture161,
+  mipLevel: 1,
+  origin: { x: 85, y: 74, z: 51 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 31, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let bindGroupLayout69 = device4.createBindGroupLayout(
+{
+label: '\ud170\u036e\u29b5\ue241\u1c0b\u55f1\u5be1\u5fb3\u7f48\u00dd',
+entries: [
+
+],
+}
+);
+let textureView150 = texture142.createView(
+{
+label: '\u3727\u{1f931}\u{1f94b}\uaad0\ufc78\uf2ca\u0185',
+dimension: '2d-array',
+baseMipLevel: 5,
+mipLevelCount: 6,
+}
+);
+try {
+renderPassEncoder32.setVertexBuffer(
+9,
+buffer51,
+50960,
+182
+);
+} catch {}
+try {
+gpuCanvasContext27.configure(
+{
+device: device4,
+format: 'astc-10x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 41, height: 1, depthOrArrayLayers: 32}
+*/
+{
+  source: canvas18,
+  origin: { x: 113, y: 145 },
+  flipY: true,
+},
+{
+  texture: texture69,
+  mipLevel: 2,
+  origin: { x: 0, y: 1, z: 7 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 32, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+video26.height = 284;
+let shaderModule36 = device2.createShaderModule(
+{
+label: '\u03ce\ud4d9\u93a2\u0cf8\u87a0\uc59e\u0006\u1a13\ua9d0\u2fdf',
+code: `@group(3) @binding(6969)
+var<storage, read_write> local33: array<u32>;
+@group(1) @binding(9120)
+var<storage, read_write> local34: array<u32>;
+@group(3) @binding(2398)
+var<storage, read_write> i23: array<u32>;
+@group(4) @binding(6969)
+var<storage, read_write> local35: array<u32>;
+@group(5) @binding(763)
+var<storage, read_write> parameter34: array<u32>;
+@group(1) @binding(7884)
+var<storage, read_write> global46: array<u32>;
+@group(4) @binding(4032)
+var<storage, read_write> i24: array<u32>;
+@group(5) @binding(6440)
+var<storage, read_write> i25: array<u32>;
+@group(1) @binding(5223)
+var<storage, read_write> parameter35: array<u32>;
+
+@compute @workgroup_size(8, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(5) f0: u32,
+@location(3) f1: vec3<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S29 {
+@location(13) f0: vec3<f32>,
+@builtin(instance_index) f1: u32,
+@location(21) f2: vec4<i32>,
+@location(14) f3: i32,
+@location(3) f4: vec4<i32>,
+@location(11) f5: vec4<u32>,
+@location(9) f6: vec3<i32>,
+@location(10) f7: vec3<u32>,
+@location(12) f8: vec3<i32>,
+@location(1) f9: vec3<f16>,
+@location(18) f10: i32,
+@location(19) f11: vec4<u32>,
+@location(8) f12: vec4<u32>,
+@location(15) f13: vec4<i32>,
+@location(0) f14: u32,
+@location(2) f15: vec2<f32>,
+@location(4) f16: u32,
+@location(6) f17: f32,
+@location(7) f18: vec3<i32>,
+@location(5) f19: vec4<f16>,
+@location(16) f20: f32,
+@location(17) f21: vec2<i32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(20) a1: vec4<f16>, a2: S29) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout70 = device2.createBindGroupLayout(
+{
+label: '\u7011\u7be8\u{1fb39}\u07f7\u{1fc77}\u0271\u048f\u604b',
+entries: [
+{
+binding: 2650,
+visibility: 0,
+buffer: { type: 'read-only-storage', minBindingSize: 602193, hasDynamicOffset: true },
+},
+{
+binding: 7633,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '2d' },
+},
+{
+binding: 5727,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+}
+],
+}
+);
+let commandEncoder123 = device2.createCommandEncoder(
+{
+}
+);
+pseudoSubmit(device2, commandEncoder55);
+let renderBundleEncoder110 = device2.createRenderBundleEncoder(
+{
+label: '\ub603\u8625\u2927\u{1f699}\u{1fed8}\u8277\u0e51\ufdad\u0e8f\u2ae5\u61b5',
+colorFormats: [
+'rgb10a2uint',
+'r32sint',
+'rg8uint',
+'r16uint',
+'rgba32uint',
+'rgba8sint',
+'rgba8unorm',
+'r16uint'
+],
+sampleCount: 136,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder32.setPipeline(
+pipeline112
+);
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(
+0,
+0,
+0,
+1
+);
+} catch {}
+try {
+renderBundleEncoder90.setVertexBuffer(
+84,
+undefined,
+955091876,
+53397077
+);
+} catch {}
+let arrayBuffer13 = buffer21.getMappedRange(
+9240,
+764
+);
+try {
+commandEncoder116.resolveQuerySet(
+querySet67,
+4,
+1,
+buffer33,
+2048
+);
+} catch {}
+document.body.prepend(video4);
+let buffer60 = device10.createBuffer(
+{
+label: '\u0bb5\ue131\u{1f85e}\u01eb\u{1fb75}\u{1f8d1}\u{1fad0}\u6ccd\u{1fa4a}\u85c9\u12f0',
+size: 40567,
+usage: GPUBufferUsage.MAP_WRITE,
+}
+);
+let querySet115 = device10.createQuerySet({
+label: '\u11a8\ue7f7\u178e\ua6c1\u072f\u075f\u4d4a\u0830\u7ffe',
+type: 'occlusion',
+count: 3381,
+});
+let texture172 = device10.createTexture(
+{
+label: '\u192b\u1388\u8576\u0675\u0625\u04be',
+size: {width: 84, height: 230, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'astc-12x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+
+],
+}
+);
+let sampler110 = device10.createSampler(
+{
+label: '\u0fc2\u{1ffcf}',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+lodMinClamp: 90.360,
+lodMaxClamp: 97.672,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder40.setScissorRect(
+2,
+3,
+11,
+0
+);
+} catch {}
+try {
+renderPassEncoder40.setStencilReference(
+1367
+);
+} catch {}
+try {
+renderBundleEncoder94.setBindGroup(
+1,
+bindGroup62,
+new Uint32Array(5758),
+2808,
+0
+);
+} catch {}
+gc();
+let imageBitmap32 = await createImageBitmap(imageData3);
+try {
+computePassEncoder50.setPipeline(
+pipeline98
+);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(
+6,
+bindGroup35
+);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder31.setStencilReference(
+3771
+);
+} catch {}
+try {
+renderBundleEncoder88.setBindGroup(
+7,
+bindGroup35,
+new Uint32Array(9897),
+6891,
+0
+);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas25,
+  origin: { x: 253, y: 59 },
+  flipY: true,
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext35.unconfigure();
+} catch {}
+let bindGroup64 = device7.createBindGroup({
+label: '\u{1fbc2}\u{1f7b1}\u{1fa91}\u3a1d\u003c\u6f6a\uef89',
+layout: bindGroupLayout63,
+entries: [
+
+],
+});
+let textureView151 = texture141.createView(
+{
+dimension: '2d-array',
+baseMipLevel: 1,
+mipLevelCount: 3,
+}
+);
+let computePassEncoder60 = commandEncoder90.beginComputePass();
+let renderBundleEncoder111 = device7.createRenderBundleEncoder(
+{
+colorFormats: [
+undefined,
+'rg32sint',
+'rg32sint'
+],
+sampleCount: 375,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+device7.queue.writeTexture(
+{
+  texture: texture141,
+  mipLevel: 1,
+  origin: { x: 0, y: 20, z: 1 },
+  aspect: 'all',
+},
+new BigInt64Array(new ArrayBuffer(16)),
+/* required buffer size: 378 */{
+offset: 378,
+bytesPerRow: 145,
+},
+{width: 20, height: 24, depthOrArrayLayers: 0}
+);
+} catch {}
+let querySet116 = device10.createQuerySet({
+label: '\ud488\u32bd\uee3d\ub531\u0cce\u072e\u4193\u0821\u6453\uf284',
+type: 'occlusion',
+count: 3447,
+});
+let textureView152 = texture166.createView(
+{
+label: '\u8785\ud03d\u{1fd9a}',
+dimension: '2d-array',
+baseMipLevel: 2,
+}
+);
+try {
+computePassEncoder49.setPipeline(
+pipeline124
+);
+} catch {}
+try {
+renderPassEncoder40.setScissorRect(
+17,
+0,
+16,
+0
+);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(
+70,
+undefined,
+3948494091,
+113721123
+);
+} catch {}
+try {
+device10.queue.writeTexture(
+{
+  texture: texture169,
+  mipLevel: 3,
+  origin: { x: 33, y: 0, z: 14 },
+  aspect: 'all',
+},
+new ArrayBuffer(784420),
+/* required buffer size: 784420 */{
+offset: 560,
+bytesPerRow: 491,
+rowsPerImage: 228,
+},
+{width: 56, height: 1, depthOrArrayLayers: 8}
+);
+} catch {}
+let promise57 = device10.queue.onSubmittedWorkDone();
+let video32 = await videoWithData();
+let imageBitmap33 = await createImageBitmap(videoFrame21);
+let texture173 = device8.createTexture(
+{
+size: {width: 113, height: 123, depthOrArrayLayers: 192},
+mipLevelCount: 6,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder112 = device8.createRenderBundleEncoder(
+{
+label: '\ub6c9\uf2ad\u{1fc8b}\u{1fcfc}\u36f3\u05ab\u0529\u{1fb25}\u{1fa7b}',
+colorFormats: [
+undefined,
+'rg16sint',
+'rgb10a2uint',
+'rgba16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 791,
+depthReadOnly: true,
+}
+);
+try {
+renderPassEncoder41.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder41.setBlendConstant({ r: 279.7, g: -362.9, b: 481.7, a: -721.1, });
+} catch {}
+try {
+renderPassEncoder41.setScissorRect(
+4,
+0,
+2,
+1
+);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(
+buffer40,
+'uint16',
+38214,
+21201
+);
+} catch {}
+try {
+renderBundleEncoder112.setVertexBuffer(
+42,
+undefined,
+436423105,
+1896577369
+);
+} catch {}
+try {
+commandEncoder112.copyTextureToTexture(
+{
+  texture: texture146,
+  mipLevel: 1,
+  origin: { x: 870, y: 45, z: 45 },
+  aspect: 'all',
+},
+{
+  texture: texture158,
+  mipLevel: 3,
+  origin: { x: 15, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 640, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+commandEncoder107.clearBuffer(
+buffer40
+);
+dissociateBuffer(device8, buffer40);
+} catch {}
+try {
+computePassEncoder52.insertDebugMarker(
+'\u057f'
+);
+} catch {}
+let adapter17 = await navigator.gpu.requestAdapter(
+{
+powerPreference: 'low-power',
+}
+);
+let buffer61 = device2.createBuffer(
+{
+label: '\u{1f6c8}\u0be9',
+size: 15867,
+usage: GPUBufferUsage.MAP_READ,
+}
+);
+let computePassEncoder61 = commandEncoder123.beginComputePass(
+{
+label: '\uea28\u{1f6d3}\u82b7\u0e1b\ub6f8\ua49b\u029f'
+}
+);
+try {
+renderPassEncoder21.setScissorRect(
+1,
+0,
+0,
+0
+);
+} catch {}
+try {
+renderBundleEncoder96.setVertexBuffer(
+37,
+undefined
+);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+let arrayBuffer14 = buffer21.getMappedRange(
+8168,
+452
+);
+try {
+device2.queue.writeBuffer(
+buffer33,
+34940,
+new BigUint64Array(34142),
+22499,
+36
+);
+} catch {}
+let pipeline131 = device2.createRenderPipeline(
+{
+label: '\u5197\uaf20\u{1fa76}\u{1f696}\u0c35\u8bd4\uca84\u5d7c\u{1f660}',
+layout: pipelineLayout29,
+vertex: {
+module: shaderModule36,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 9448,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 9892,
+attributes: [
+{
+format: 'uint16x4',
+offset: 7264,
+shaderLocation: 4,
+},
+{
+format: 'uint16x4',
+offset: 3276,
+shaderLocation: 8,
+},
+{
+format: 'snorm8x2',
+offset: 5432,
+shaderLocation: 2,
+},
+{
+format: 'float32x4',
+offset: 3756,
+shaderLocation: 20,
+},
+{
+format: 'snorm8x4',
+offset: 8900,
+shaderLocation: 5,
+},
+{
+format: 'uint32x4',
+offset: 7348,
+shaderLocation: 19,
+},
+{
+format: 'unorm16x2',
+offset: 9304,
+shaderLocation: 1,
+},
+{
+format: 'uint16x2',
+offset: 1736,
+shaderLocation: 0,
+},
+{
+format: 'sint32x2',
+offset: 1904,
+shaderLocation: 17,
+}
+],
+},
+{
+arrayStride: 10620,
+attributes: [
+{
+format: 'sint8x4',
+offset: 7972,
+shaderLocation: 12,
+},
+{
+format: 'sint32x4',
+offset: 9272,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 4916,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x3',
+offset: 1204,
+shaderLocation: 11,
+},
+{
+format: 'sint8x4',
+offset: 4560,
+shaderLocation: 14,
+},
+{
+format: 'sint32x3',
+offset: 2008,
+shaderLocation: 7,
+},
+{
+format: 'sint32x4',
+offset: 3632,
+shaderLocation: 21,
+},
+{
+format: 'sint32x4',
+offset: 4340,
+shaderLocation: 3,
+},
+{
+format: 'sint32x4',
+offset: 4416,
+shaderLocation: 18,
+},
+{
+format: 'sint8x4',
+offset: 700,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 0,
+attributes: [
+{
+format: 'snorm8x2',
+offset: 4748,
+shaderLocation: 6,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 7740,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 13344,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 9796,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 2936,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule36,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+{
+format: 'rg8sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilReadMask: 2465,
+stencilWriteMask: 284,
+},
+}
+);
+try {
+await promise57;
+} catch {}
+let sampler111 = device9.createSampler(
+{
+label: '\u{1fad5}\uc554\u5d84',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 95.053,
+lodMaxClamp: 98.582,
+maxAnisotropy: 19,
+}
+);
+try {
+renderBundleEncoder109.setBindGroup(
+3,
+bindGroup53,
+new Uint32Array(6675),
+5448,
+0
+);
+} catch {}
+try {
+commandEncoder113.clearBuffer(
+buffer41,
+972,
+5512
+);
+dissociateBuffer(device9, buffer41);
+} catch {}
+try {
+device9.queue.writeBuffer(
+buffer41,
+5264,
+new BigUint64Array(13906),
+3765,
+188
+);
+} catch {}
+let bindGroup65 = device7.createBindGroup({
+label: '\uf52f\u00a5\uad5f\u{1f621}\u0228',
+layout: bindGroupLayout63,
+entries: [
+
+],
+});
+let buffer62 = device7.createBuffer(
+{
+label: '\ua931\u52ed\u603e\u{1fc10}\u1e9f\u1269\u{1f6fd}',
+size: 62987,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let querySet117 = device7.createQuerySet({
+type: 'occlusion',
+count: 3448,
+});
+let computePassEncoder62 = commandEncoder106.beginComputePass(
+{
+label: '\ub827\u0441\ucfd1\ue7cd\uc914\u92c8\u704b\ueef1\ua6bb\u{1f7e7}\ud316'
+}
+);
+let sampler112 = device7.createSampler(
+{
+label: '\u0257\u03ee\u{1fe4a}\u45a5\u{1f6b3}',
+addressModeU: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 29.361,
+lodMaxClamp: 52.820,
+compare: 'greater-equal',
+maxAnisotropy: 13,
+}
+);
+let device12 = await promise54;
+let querySet118 = device7.createQuerySet({
+label: '\u{1fa6f}\ue9c4',
+type: 'occlusion',
+count: 2446,
+});
+let renderBundleEncoder113 = device7.createRenderBundleEncoder(
+{
+label: '\u00a4\u05e3\ua3a3',
+colorFormats: [
+'r32sint'
+],
+sampleCount: 255,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+let videoFrame35 = new VideoFrame(imageBitmap19, {timestamp: 0});
+let buffer63 = device6.createBuffer(
+{
+label: '\u048d\u{1ff23}\u0f91\u072e\ue5f3\u0739\u9761\u2fcb\u{1fd77}',
+size: 13429,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+}
+);
+let renderBundle127 = renderBundleEncoder99.finish(
+{
+label: '\u{1ff64}\uc9f9\u0caa\u077f'
+}
+);
+try {
+renderPassEncoder35.beginOcclusionQuery(1130);
+} catch {}
+try {
+renderPassEncoder35.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder37.setBlendConstant({ r: -88.65, g: 724.7, b: 98.77, a: 431.1, });
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(
+4,
+buffer57,
+2540,
+21822
+);
+} catch {}
+try {
+renderBundleEncoder85.setVertexBuffer(
+3,
+buffer57,
+4684,
+19072
+);
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer63,
+10868,
+new Int16Array(14592),
+591,
+1140
+);
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture134,
+  mipLevel: 1,
+  origin: { x: 7, y: 24, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer1,
+/* required buffer size: 550 */{
+offset: 550,
+rowsPerImage: 271,
+},
+{width: 69, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let shaderModule37 = device6.createShaderModule(
+{
+label: '\u{1fcae}\ue5dd',
+code: `@group(3) @binding(4118)
+var<storage, read_write> type50: array<u32>;
+@group(2) @binding(2889)
+var<storage, read_write> global47: array<u32>;
+@group(2) @binding(1573)
+var<storage, read_write> type51: array<u32>;
+
+@compute @workgroup_size(6, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S31 {
+@location(42) f0: vec2<f16>,
+@location(17) f1: f16,
+@location(40) f2: vec2<i32>,
+@location(58) f3: vec3<u32>
+}
+struct FragmentOutput0 {
+@location(0) f0: vec2<u32>,
+@location(2) f1: vec4<u32>,
+@location(4) f2: i32,
+@location(6) f3: vec4<u32>,
+@location(5) f4: vec2<f32>,
+@location(1) f5: vec2<i32>,
+@location(7) f6: vec4<u32>,
+@location(3) f7: vec4<f32>,
+@builtin(frag_depth) f8: f32,
+@builtin(sample_mask) f9: u32
+}
+
+@fragment
+fn fragment0(@location(64) a0: vec3<i32>, @location(25) a1: vec4<f32>, @location(51) a2: vec4<f16>, a3: S31, @builtin(front_facing) a4: bool, @location(26) a5: u32, @location(8) a6: vec2<f16>, @location(9) a7: vec2<f16>, @location(36) a8: i32, @location(16) a9: f32, @location(4) a10: vec3<f16>, @location(59) a11: vec2<f16>, @location(78) a12: f16, @location(23) a13: f32, @location(3) a14: vec3<f16>, @location(12) a15: vec3<f32>, @location(66) a16: f16, @location(75) a17: vec3<f32>, @location(53) a18: vec2<i32>, @location(22) a19: vec4<f16>, @location(0) a20: i32, @location(11) a21: vec4<i32>, @location(52) a22: f32, @location(60) a23: vec3<f32>, @location(35) a24: vec3<f16>, @location(33) a25: vec3<f32>, @location(1) a26: vec4<f32>, @location(37) a27: vec4<f16>, @builtin(sample_mask) a28: u32, @location(77) a29: u32, @location(24) a30: f32, @location(69) a31: vec2<u32>, @location(49) a32: f16, @location(15) a33: vec4<i32>, @location(65) a34: u32, @location(5) a35: vec2<f32>, @location(70) a36: vec4<f32>, @location(72) a37: f32, @location(34) a38: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S30 {
+@location(5) f0: vec2<i32>,
+@location(10) f1: vec4<f32>,
+@location(4) f2: vec4<u32>,
+@location(12) f3: vec4<f16>,
+@location(11) f4: vec3<u32>,
+@location(6) f5: vec2<i32>,
+@location(9) f6: vec3<i32>,
+@location(16) f7: u32,
+@location(7) f8: vec2<i32>,
+@location(2) f9: vec4<f16>,
+@location(3) f10: u32,
+@builtin(vertex_index) f11: u32,
+@location(13) f12: vec4<u32>,
+@location(15) f13: vec3<i32>,
+@location(14) f14: vec3<f16>,
+@location(1) f15: vec2<u32>,
+@location(0) f16: u32,
+@location(8) f17: vec2<u32>,
+@builtin(instance_index) f18: u32
+}
+struct VertexOutput0 {
+@location(53) f487: vec2<i32>,
+@location(24) f488: f32,
+@location(75) f489: vec3<f32>,
+@location(52) f490: f32,
+@location(72) f491: f32,
+@location(23) f492: f32,
+@location(36) f493: i32,
+@location(40) f494: vec2<i32>,
+@builtin(position) f495: vec4<f32>,
+@location(69) f496: vec2<u32>,
+@location(15) f497: vec4<i32>,
+@location(5) f498: vec2<f32>,
+@location(42) f499: vec2<f16>,
+@location(9) f500: vec2<f16>,
+@location(22) f501: vec4<f16>,
+@location(58) f502: vec3<u32>,
+@location(13) f503: f16,
+@location(49) f504: f16,
+@location(25) f505: vec4<f32>,
+@location(55) f506: i32,
+@location(35) f507: vec3<f16>,
+@location(37) f508: vec4<f16>,
+@location(19) f509: vec4<i32>,
+@location(70) f510: vec4<f32>,
+@location(78) f511: f16,
+@location(64) f512: vec3<i32>,
+@location(77) f513: u32,
+@location(28) f514: vec3<u32>,
+@location(1) f515: vec4<f32>,
+@location(79) f516: vec4<f16>,
+@location(3) f517: vec3<f16>,
+@location(65) f518: u32,
+@location(20) f519: vec3<u32>,
+@location(8) f520: vec2<f16>,
+@location(34) f521: u32,
+@location(11) f522: vec4<i32>,
+@location(12) f523: vec3<f32>,
+@location(51) f524: vec4<f16>,
+@location(0) f525: i32,
+@location(46) f526: vec2<i32>,
+@location(60) f527: vec3<f32>,
+@location(16) f528: f32,
+@location(33) f529: vec3<f32>,
+@location(17) f530: f16,
+@location(26) f531: u32,
+@location(66) f532: f16,
+@location(31) f533: u32,
+@location(4) f534: vec3<f16>,
+@location(59) f535: vec2<f16>
+}
+
+@vertex
+fn vertex0(a0: S30) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let bindGroupLayout71 = device6.createBindGroupLayout(
+{
+entries: [
+
+],
+}
+);
+let computePassEncoder63 = commandEncoder118.beginComputePass();
+try {
+renderPassEncoder35.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder37.setBlendConstant({ r: -75.46, g: -493.9, b: 889.9, a: 32.03, });
+} catch {}
+try {
+renderPassEncoder35.setViewport(
+1.273,
+4.741,
+68.92,
+15.26,
+0.8981,
+0.9030
+);
+} catch {}
+try {
+renderBundleEncoder100.setVertexBuffer(
+7,
+buffer57,
+11684,
+8899
+);
+} catch {}
+let pipeline132 = device6.createRenderPipeline(
+{
+label: '\u07c4\uce16\u04ff\ua22c\uc17a\u2bad\u{1f61d}',
+layout: pipelineLayout39,
+vertex: {
+module: shaderModule37,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 14292,
+attributes: [
+{
+format: 'sint32x3',
+offset: 652,
+shaderLocation: 9,
+},
+{
+format: 'uint16x4',
+offset: 11076,
+shaderLocation: 4,
+},
+{
+format: 'float32',
+offset: 6780,
+shaderLocation: 2,
+},
+{
+format: 'uint32x4',
+offset: 7956,
+shaderLocation: 8,
+},
+{
+format: 'sint16x2',
+offset: 11992,
+shaderLocation: 15,
+},
+{
+format: 'unorm8x2',
+offset: 840,
+shaderLocation: 14,
+},
+{
+format: 'uint32x4',
+offset: 13048,
+shaderLocation: 16,
+},
+{
+format: 'uint32x2',
+offset: 11888,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 38016,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32',
+offset: 34268,
+shaderLocation: 5,
+},
+{
+format: 'snorm8x4',
+offset: 21060,
+shaderLocation: 10,
+},
+{
+format: 'unorm16x4',
+offset: 27264,
+shaderLocation: 12,
+},
+{
+format: 'uint32x4',
+offset: 32872,
+shaderLocation: 1,
+},
+{
+format: 'uint32x4',
+offset: 10228,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x3',
+offset: 30788,
+shaderLocation: 3,
+},
+{
+format: 'uint32',
+offset: 24516,
+shaderLocation: 0,
+},
+{
+format: 'sint32x4',
+offset: 22632,
+shaderLocation: 7,
+},
+{
+format: 'sint16x2',
+offset: 16548,
+shaderLocation: 6,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x178591fb,
+},
+fragment: {
+module: shaderModule37,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'rgba8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'invert',
+depthFailOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 3946,
+stencilWriteMask: 2876,
+depthBias: 33,
+depthBiasSlopeScale: 78,
+depthBiasClamp: 78,
+},
+}
+);
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let canvas38 = document.createElement('canvas');
+let imageData34 = new ImageData(236, 64);
+try {
+window.someLabel = externalTexture8.label;
+} catch {}
+let textureView153 = texture98.createView(
+{
+label: '\u{1fdd4}\ua257\u{1f805}\u0e54\u0ac7\ucf68\u4fe3\u8ea7',
+baseMipLevel: 2,
+}
+);
+let sampler113 = device3.createSampler(
+{
+label: '\u164f\u6279\ua952\u{1f9da}\u{1f7f1}\u{1ffa6}\u03ef\u{1f976}\u75b1\u2b52\ubfe6',
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 49.349,
+lodMaxClamp: 57.471,
+}
+);
+let gpuCanvasContext44 = canvas38.getContext('webgpu');
+let bindGroupLayout72 = device3.createBindGroupLayout(
+{
+label: '\uc634\udad9\ud9c2\u5370\u06b6\u006d\u{1f9c0}',
+entries: [
+{
+binding: 229,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+},
+{
+binding: 2342,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 2461,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+let texture174 = device3.createTexture(
+{
+size: [4946, 1, 207],
+mipLevelCount: 8,
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rgba32sint',
+'rgba32sint'
+],
+}
+);
+let renderBundle128 = renderBundleEncoder60.finish(
+{
+label: '\u0730\u0d87\u{1fa7c}\u597d\u{1f982}\ua855\u25ee\u092a\ue731\u4cb7\ucd7d'
+}
+);
+let sampler114 = device3.createSampler(
+{
+label: '\u{1f7f0}\u{1fe0c}\u02d1\ua0f6\u4ba5\u4539\u2633\u59e7\uab53\u{1fa3a}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 91.083,
+lodMaxClamp: 96.239,
+maxAnisotropy: 17,
+}
+);
+try {
+renderPassEncoder30.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder23.setStencilReference(
+2591
+);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+canvas23.height = 156;
+try {
+adapter6.label = '\u9d7f\u0a31\u13de';
+} catch {}
+try {
+renderBundleEncoder109.setBindGroup(
+3,
+bindGroup63
+);
+} catch {}
+try {
+commandEncoder113.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 7384 */
+offset: 7384,
+buffer: buffer58,
+},
+{
+  texture: texture122,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device9, buffer58);
+} catch {}
+try {
+commandEncoder114.clearBuffer(
+buffer41,
+228,
+6396
+);
+dissociateBuffer(device9, buffer41);
+} catch {}
+try {
+device9.queue.writeTexture(
+{
+  texture: texture122,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer10,
+/* required buffer size: 914 */{
+offset: 914,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let offscreenCanvas46 = new OffscreenCanvas(443, 461);
+let bindGroupLayout73 = device3.createBindGroupLayout(
+{
+entries: [
+{
+binding: 957,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d' },
+},
+{
+binding: 1702,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'non-filtering' },
+}
+],
+}
+);
+let textureView154 = texture165.createView(
+{
+label: '\ua24e\u9e5d\u{1fbed}\ua096\u61a6\ub499\u2556\u0f95\uaf4d\ue4dc',
+dimension: '2d-array',
+format: 'bgra8unorm-srgb',
+baseMipLevel: 2,
+}
+);
+let renderBundle129 = renderBundleEncoder56.finish(
+{
+label: '\u0d30\ufddc\uf4c7\uba9a\u0dae\u{1fb8c}'
+}
+);
+try {
+renderPassEncoder23.setScissorRect(
+0,
+0,
+1,
+0
+);
+} catch {}
+try {
+renderPassEncoder34.setStencilReference(
+1154
+);
+} catch {}
+try {
+renderPassEncoder34.setViewport(
+1.191,
+0.8048,
+0.4956,
+0.05854,
+0.7231,
+0.7661
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture60,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(176),
+/* required buffer size: 176 */{
+offset: 176,
+bytesPerRow: 118,
+},
+{width: 29, height: 29, depthOrArrayLayers: 0}
+);
+} catch {}
+let buffer64 = device10.createBuffer(
+{
+label: '\u30a6\u139b',
+size: 47695,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: false,
+}
+);
+let commandEncoder124 = device10.createCommandEncoder(
+{
+label: '\u0f6d\ua712\u4941\u937e\u019e\u0786\u{1fc24}\u{1fd0b}',
+}
+);
+let computePassEncoder64 = commandEncoder124.beginComputePass(
+{
+label: '\u{1f688}\u{1fdaa}\u{1fd39}\u3c2c\u0f42\u0678\u{1f86a}'
+}
+);
+try {
+computePassEncoder49.setBindGroup(
+1,
+bindGroup62
+);
+} catch {}
+try {
+renderBundleEncoder98.setBindGroup(
+0,
+bindGroup62,
+new Uint32Array(2561),
+944,
+0
+);
+} catch {}
+try {
+gpuCanvasContext28.unconfigure();
+} catch {}
+gc();
+let commandEncoder125 = device12.createCommandEncoder(
+{
+label: '\ubebd\u8689\uf04b\u{1fb8c}\u9866\u2622\uf4fc\ufffd',
+}
+);
+let computePassEncoder65 = commandEncoder125.beginComputePass(
+{
+label: '\u8772\u06d7\u{1f821}\ubd8b\u9dc2\u{1fa90}\u0087\ua660\ub3bb\u020f'
+}
+);
+let sampler115 = device12.createSampler(
+{
+label: '\u0cae\u1005\u0c4d\u3e2c\u0804\uc00e',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 24.918,
+lodMaxClamp: 28.654,
+maxAnisotropy: 13,
+}
+);
+let texture175 = device11.createTexture(
+{
+label: '\u{1fe7c}\u0368\u0862\u{1fb1d}\u0638\u2fb3\u07d1\u0545',
+size: {width: 5720, height: 8, depthOrArrayLayers: 241},
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-8x8-unorm-srgb',
+'astc-8x8-unorm'
+],
+}
+);
+let textureView155 = texture175.createView(
+{
+label: '\u2fcd\u1acf',
+baseArrayLayer: 152,
+arrayLayerCount: 54,
+}
+);
+let gpuCanvasContext45 = offscreenCanvas46.getContext('webgpu');
+let bindGroup66 = device9.createBindGroup({
+label: '\u4516\u063a\u{1f72e}\u6c7e\ue8e1\u0571\u9e82\uff6a\u06c9\u{1fa1b}',
+layout: bindGroupLayout57,
+entries: [
+
+],
+});
+let querySet119 = device9.createQuerySet({
+type: 'occlusion',
+count: 1764,
+});
+let textureView156 = texture122.createView(
+{
+baseArrayLayer: 0,
+}
+);
+try {
+renderBundleEncoder109.setVertexBuffer(
+37,
+undefined,
+2445793336,
+1803818919
+);
+} catch {}
+try {
+commandEncoder114.clearBuffer(
+buffer41,
+7356,
+1224
+);
+dissociateBuffer(device9, buffer41);
+} catch {}
+try {
+device9.queue.writeBuffer(
+buffer41,
+7932,
+new Float32Array(2312),
+97,
+36
+);
+} catch {}
+try {
+await adapter3.requestAdapterInfo();
+} catch {}
+let texture176 = device4.createTexture(
+{
+size: {width: 7790},
+dimension: '1d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg8unorm',
+'rg8unorm',
+'rg8unorm'
+],
+}
+);
+let textureView157 = texture133.createView(
+{
+label: '\u4360\u7a21\u8964',
+dimension: '2d-array',
+format: 'etc2-rgba8unorm',
+baseMipLevel: 1,
+}
+);
+try {
+renderPassEncoder17.beginOcclusionQuery(1027);
+} catch {}
+try {
+renderBundleEncoder97.setBindGroup(
+5,
+bindGroup37
+);
+} catch {}
+try {
+renderBundleEncoder93.setVertexBuffer(
+9,
+buffer51,
+32104,
+25598
+);
+} catch {}
+let pipeline133 = await device4.createRenderPipelineAsync(
+{
+label: '\u0a3a\u8ffb\u60c8',
+layout: pipelineLayout32,
+vertex: {
+module: shaderModule28,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 25636,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 12052,
+shaderLocation: 3,
+},
+{
+format: 'unorm8x4',
+offset: 1436,
+shaderLocation: 1,
+},
+{
+format: 'snorm16x4',
+offset: 1636,
+shaderLocation: 9,
+},
+{
+format: 'float32x4',
+offset: 15628,
+shaderLocation: 6,
+},
+{
+format: 'float32x2',
+offset: 3568,
+shaderLocation: 16,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 1,
+mask: 0x311ced4c,
+},
+fragment: {
+module: shaderModule28,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one-minus-src-alpha',
+dstFactor: 'zero'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALPHA,
+},
+undefined,
+{
+format: 'r32uint',
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.GREEN,
+},
+undefined,
+undefined,
+undefined,
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'keep',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 2634,
+depthBias: 87,
+depthBiasSlopeScale: 85,
+depthBiasClamp: 60,
+},
+}
+);
+let commandEncoder126 = device11.createCommandEncoder(
+{
+label: '\u05b2\u089c\u5afe\u2cad\u0304',
+}
+);
+let textureView158 = texture170.createView(
+{
+label: '\u08d0\u{1fd67}\u{1fb9f}\u6e7b\u{1f85f}\u2e14\u052c',
+baseMipLevel: 0,
+baseArrayLayer: 0,
+}
+);
+try {
+device11.queue.writeTexture(
+{
+  texture: texture175,
+  mipLevel: 0,
+  origin: { x: 624, y: 0, z: 197 },
+  aspect: 'all',
+},
+arrayBuffer12,
+/* required buffer size: 21902534 */{
+offset: 368,
+bytesPerRow: 8509,
+rowsPerImage: 198,
+},
+{width: 4136, height: 0, depthOrArrayLayers: 14}
+);
+} catch {}
+try {
+await device11.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(
+buffer55,
+'uint16'
+);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(
+1,
+buffer57,
+5396,
+10036
+);
+} catch {}
+try {
+renderBundleEncoder101.setVertexBuffer(
+6,
+buffer57,
+12296
+);
+} catch {}
+try {
+commandEncoder117.copyTextureToTexture(
+{
+  texture: texture134,
+  mipLevel: 0,
+  origin: { x: 61, y: 10, z: 0 },
+  aspect: 'all',
+},
+{
+  texture: texture134,
+  mipLevel: 0,
+  origin: { x: 57, y: 11, z: 0 },
+  aspect: 'all',
+},
+{width: 132, height: 40, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder110.clearBuffer(
+buffer53,
+21368,
+4
+);
+dissociateBuffer(device6, buffer53);
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(
+/*
+{width: 202, height: 51, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame14,
+  origin: { x: 11, y: 0 },
+  flipY: true,
+},
+{
+  texture: texture134,
+  mipLevel: 0,
+  origin: { x: 12, y: 12, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 151, height: 38, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+canvas26.width = 896;
+let bindGroup67 = device9.createBindGroup({
+label: '\u0041\u{1fe5f}\u0968',
+layout: bindGroupLayout57,
+entries: [
+
+],
+});
+let querySet120 = device9.createQuerySet({
+label: '\u5317\u17bc\u9f64\u4ec7\u249f\u64b2\u30dd\u0fa7\u0ce1',
+type: 'occlusion',
+count: 539,
+});
+let texture177 = device9.createTexture(
+{
+label: '\u{1ff5f}\u336f\u85df',
+size: [10820, 216, 79],
+mipLevelCount: 2,
+format: 'astc-4x4-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+renderBundleEncoder109.setBindGroup(
+3,
+bindGroup66
+);
+} catch {}
+try {
+renderBundleEncoder109.setVertexBuffer(
+79,
+undefined,
+3662255671,
+513655964
+);
+} catch {}
+let promise58 = device9.queue.onSubmittedWorkDone();
+try {
+externalTexture6.label = '\u{1feab}\u{1fe0e}\u0958';
+} catch {}
+let renderBundle130 = renderBundleEncoder90.finish(
+{
+
+}
+);
+try {
+renderPassEncoder29.setBindGroup(
+1,
+bindGroup56,
+new Uint32Array(5349),
+2397,
+1
+);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(161);
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+let promise59 = buffer61.mapAsync(
+GPUMapMode.READ,
+15848,
+12
+);
+try {
+commandEncoder45.clearBuffer(
+buffer33,
+12984,
+3392
+);
+dissociateBuffer(device2, buffer33);
+} catch {}
+try {
+computePassEncoder61.insertDebugMarker(
+'\u04aa'
+);
+} catch {}
+try {
+gpuCanvasContext17.configure(
+{
+device: device2,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let pipeline134 = device2.createComputePipeline(
+{
+label: '\u8805\u60c7\u138b\u{1fc28}\u7f89\u0835\ue0e8',
+layout: pipelineLayout25,
+compute: {
+module: shaderModule36,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+device2.destroy();
+} catch {}
+try {
+await promise58;
+} catch {}
+let imageBitmap34 = await createImageBitmap(canvas35);
+let bindGroupLayout74 = device4.createBindGroupLayout(
+{
+label: '\u3e10\u3c9a\u2e3b\u0358',
+entries: [
+{
+binding: 1255,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 1246,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+},
+{
+binding: 853,
+visibility: 0,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+}
+],
+}
+);
+let texture178 = device4.createTexture(
+{
+label: '\u{1fa58}\uc909\u{1fb82}\ub747\u{1f82e}\u0c94\ue828\u093a\u2c0d\ud38e\u{1fa84}',
+size: {width: 120, height: 144, depthOrArrayLayers: 1},
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView159 = texture178.createView(
+{
+label: '\ub018\u8d64\u{1fb7e}\ucf30\ue17e\ua7c9\u7dbe\ufa8c\u0085',
+aspect: 'all',
+}
+);
+let renderBundleEncoder114 = device4.createRenderBundleEncoder(
+{
+label: '\u{1f74b}\ua662\u0001\ub6f3\u{1ff22}\u564b\u01a1\u4049\ubbce',
+colorFormats: [
+'rgba32uint',
+'rg16float',
+'r32float',
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 718,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder43.setPipeline(
+pipeline111
+);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(
+9,
+bindGroup42,
+[]
+);
+} catch {}
+try {
+renderPassEncoder26.beginOcclusionQuery(2328);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([]);
+} catch {}
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 164, height: 1, depthOrArrayLayers: 131}
+*/
+{
+  source: videoFrame34,
+  origin: { x: 0, y: 3 },
+  flipY: false,
+},
+{
+  texture: texture69,
+  mipLevel: 0,
+  origin: { x: 134, y: 1, z: 59 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 16, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let querySet121 = device3.createQuerySet({
+label: '\ub890\u{1fe1d}\u9506\uedc0\u317b\u{1f7a6}\u1efe\u0033\u{1fe6e}\u03c6',
+type: 'occlusion',
+count: 1212,
+});
+let sampler116 = device3.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 88.556,
+lodMaxClamp: 91.563,
+maxAnisotropy: 1,
+}
+);
+try {
+await promise59;
+} catch {}
+document.body.prepend(canvas25);
+let pipelineLayout40 = device8.createPipelineLayout(
+{
+label: '\u0eee\u405e\u05be\ue16e\u30ac\u9653\u5447\u{1f767}',
+bindGroupLayouts: [
+
+]
+}
+);
+let querySet122 = device8.createQuerySet({
+label: '\u5685\u0b18\u10aa\u0619\uf582\u0d63\u09b1\u{1f812}',
+type: 'occlusion',
+count: 1401,
+});
+let texture179 = device8.createTexture(
+{
+label: '\u{1f7d3}\u{1f63b}\u01b0\u42f1\u0a48\u157d\u02d0\u{1faab}',
+size: [146, 146, 1],
+mipLevelCount: 5,
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+try {
+renderPassEncoder41.executeBundles([]);
+} catch {}
+let offscreenCanvas47 = new OffscreenCanvas(987, 94);
+try {
+await adapter16.requestAdapterInfo();
+} catch {}
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+gc();
+let commandEncoder127 = device3.createCommandEncoder(
+{
+label: '\u8b7e\u2f60\u{1f8f7}\u76d4\u0442\u{1fc16}\ue0b3\uae25\u{1fa08}\u05a0',
+}
+);
+try {
+renderPassEncoder39.setBlendConstant({ r: 246.0, g: 717.7, b: 465.1, a: 767.2, });
+} catch {}
+try {
+renderBundleEncoder102.setVertexBuffer(
+15,
+undefined,
+3471475888,
+58752283
+);
+} catch {}
+let arrayBuffer15 = buffer25.getMappedRange(
+0,
+47088
+);
+try {
+commandEncoder127.copyBufferToBuffer(
+buffer56,
+1528,
+buffer25,
+51112,
+1600
+);
+dissociateBuffer(device3, buffer56);
+dissociateBuffer(device3, buffer25);
+} catch {}
+try {
+commandEncoder127.clearBuffer(
+buffer49
+);
+dissociateBuffer(device3, buffer49);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture60,
+  mipLevel: 0,
+  origin: { x: 0, y: 22, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer8,
+/* required buffer size: 586 */{
+offset: 528,
+},
+{width: 58, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let bindGroup68 = device9.createBindGroup({
+label: '\u833f\u4f7a',
+layout: bindGroupLayout68,
+entries: [
+{
+binding: 5687,
+resource: externalTexture10
+}
+],
+});
+let commandBuffer16 = commandEncoder122.finish(
+{
+label: '\uc676\u{1fe31}\u102f\u0340\u0faf\u0641\uabfa\u85da\u0648',
+}
+);
+try {
+computePassEncoder58.setBindGroup(
+4,
+bindGroup66,
+new Uint32Array(9691),
+7868,
+0
+);
+} catch {}
+offscreenCanvas10.width = 1020;
+gc();
+try {
+window.someLabel = device4.queue.label;
+} catch {}
+let buffer65 = device4.createBuffer(
+{
+label: '\u6557\udf8c\u4503\u8973\ufca6',
+size: 22716,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let texture180 = device4.createTexture(
+{
+label: '\u12df\u{1f86f}\u084f\u0f4a\u0896\u04a1\ue99f\u7ae3\u{1f74a}\u0598\u0db3',
+size: [250, 1, 216],
+mipLevelCount: 6,
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8snorm',
+'rg8snorm'
+],
+}
+);
+let renderBundleEncoder115 = device4.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg32sint',
+undefined,
+'rg32uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 693,
+depthReadOnly: false,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder32.setBlendConstant({ r: 828.4, g: 692.4, b: 848.3, a: -318.5, });
+} catch {}
+try {
+renderPassEncoder32.setViewport(
+73.68,
+0.8562,
+5.418,
+0.06658,
+0.2677,
+0.3892
+);
+} catch {}
+try {
+renderBundleEncoder115.setBindGroup(
+3,
+bindGroup36
+);
+} catch {}
+try {
+renderBundleEncoder114.setVertexBuffer(
+5,
+buffer51,
+45048,
+18765
+);
+} catch {}
+let bindGroupLayout75 = device10.createBindGroupLayout(
+{
+label: '\u94ca\u097a\u{1fbaf}\u773a\u0350\ubc55\u{1f820}\u4172\ub948\u0181',
+entries: [
+{
+binding: 193,
+visibility: 0,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 390,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+},
+{
+binding: 1017,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}
+],
+}
+);
+let querySet123 = device10.createQuerySet({
+type: 'occlusion',
+count: 1078,
+});
+try {
+computePassEncoder49.setBindGroup(
+0,
+bindGroup62,
+new Uint32Array(1322),
+752,
+0
+);
+} catch {}
+try {
+renderPassEncoder40.setScissorRect(
+46,
+3,
+2,
+0
+);
+} catch {}
+let arrayBuffer16 = buffer47.getMappedRange(
+10792,
+13432
+);
+try {
+device10.queue.writeTexture(
+{
+  texture: texture172,
+  mipLevel: 4,
+  origin: { x: 12, y: 10, z: 0 },
+  aspect: 'all',
+},
+new DataView(arrayBuffer14),
+/* required buffer size: 959 */{
+offset: 959,
+bytesPerRow: 42,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer15.detached) { new Uint8Array(arrayBuffer15).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas47.getContext('webgpu');
+} catch {}
+let bindGroupLayout76 = device8.createBindGroupLayout(
+{
+label: '\u0e64\u7d99\u0682\u0077\u02f9\ucd55\u0788\u{1f653}\u{1fbdf}',
+entries: [
+{
+binding: 309,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+},
+{
+binding: 987,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+}
+],
+}
+);
+let textureView160 = texture137.createView(
+{
+label: '\uf474\u{1fbac}\u01db\ucccb\u7ef5',
+format: 'rg16uint',
+baseMipLevel: 6,
+arrayLayerCount: 1,
+}
+);
+try {
+computePassEncoder52.setPipeline(
+pipeline129
+);
+} catch {}
+let pipeline135 = await device8.createComputePipelineAsync(
+{
+label: '\u88bd\u1eae\u097e\u{1fec7}\u084d\u5c4c\u9ad6\u{1fddb}\u0ebd',
+layout: pipelineLayout40,
+compute: {
+module: shaderModule35,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let imageData35 = new ImageData(228, 240);
+let videoFrame36 = new VideoFrame(videoFrame26, {timestamp: 0});
+let texture181 = device12.createTexture(
+{
+label: '\uda37\u{1f662}\uec12',
+size: {width: 180, height: 64, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'etc2-rgb8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'etc2-rgb8unorm'
+],
+}
+);
+let textureView161 = texture181.createView(
+{
+dimension: '2d-array',
+baseMipLevel: 3,
+mipLevelCount: 2,
+}
+);
+let renderBundleEncoder116 = device12.createRenderBundleEncoder(
+{
+label: '\ua957\u03be\ud9cb\u7a7a\u08a3\u{1fbc4}\u0395\ue017',
+colorFormats: [
+'rg11b10ufloat',
+'r32uint',
+'rgba8sint',
+'rgba8sint',
+'r8uint',
+'r32uint',
+'rg16uint'
+],
+sampleCount: 374,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler117 = device12.createSampler(
+{
+label: '\u0a24\u2809\u658a\uba5f\u3fa9\u0ee7',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 55.476,
+lodMaxClamp: 98.834,
+maxAnisotropy: 5,
+}
+);
+try {
+renderBundleEncoder116.setVertexBuffer(
+44,
+undefined
+);
+} catch {}
+let shaderModule38 = device10.createShaderModule(
+{
+label: '\u42ce\u6c0c\u{1f6fd}\u{1fe85}\ud8b2',
+code: `@group(1) @binding(574)
+var<storage, read_write> field44: array<u32>;
+@group(0) @binding(499)
+var<storage, read_write> i26: array<u32>;
+@group(1) @binding(155)
+var<storage, read_write> type52: array<u32>;
+@group(1) @binding(499)
+var<storage, read_write> global48: array<u32>;
+@group(0) @binding(574)
+var<storage, read_write> local36: array<u32>;
+
+@compute @workgroup_size(7, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S33 {
+@builtin(front_facing) f0: bool,
+@location(28) f1: u32,
+@location(68) f2: vec2<u32>,
+@builtin(sample_index) f3: u32,
+@builtin(sample_mask) f4: u32,
+@location(88) f5: vec4<u32>,
+@location(13) f6: vec4<f16>,
+@location(56) f7: vec3<f16>,
+@location(33) f8: vec3<u32>,
+@location(0) f9: vec2<f16>,
+@location(48) f10: u32,
+@location(81) f11: vec3<u32>,
+@location(47) f12: vec4<f16>,
+@location(101) f13: vec3<i32>
+}
+struct FragmentOutput0 {
+@location(4) f0: vec2<i32>,
+@location(3) f1: vec4<f32>,
+@location(1) f2: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @location(18) a1: f32, a2: S33, @location(71) a3: f32, @location(86) a4: vec4<f32>, @location(23) a5: vec3<f16>, @location(59) a6: u32, @location(66) a7: i32, @location(79) a8: vec3<f16>, @location(94) a9: vec2<u32>, @location(103) a10: f32, @location(58) a11: vec4<i32>, @location(45) a12: vec2<f16>, @location(4) a13: vec2<i32>, @location(46) a14: vec2<f16>, @location(89) a15: u32, @location(78) a16: f16, @location(34) a17: vec4<u32>, @location(37) a18: vec4<f16>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S32 {
+@location(2) f0: vec2<i32>,
+@location(15) f1: f16,
+@location(7) f2: vec4<f16>,
+@location(0) f3: vec2<i32>,
+@builtin(vertex_index) f4: u32,
+@location(14) f5: i32,
+@location(11) f6: vec3<f16>,
+@builtin(instance_index) f7: u32,
+@location(5) f8: vec4<u32>,
+@location(8) f9: vec3<f16>,
+@location(10) f10: vec3<f16>,
+@location(9) f11: vec3<f16>
+}
+struct VertexOutput0 {
+@location(23) f536: vec3<f16>,
+@location(101) f537: vec3<i32>,
+@location(66) f538: i32,
+@location(13) f539: vec4<f16>,
+@location(85) f540: vec2<i32>,
+@location(39) f541: vec4<f16>,
+@location(4) f542: vec2<i32>,
+@location(59) f543: u32,
+@location(90) f544: vec2<f32>,
+@location(17) f545: vec4<u32>,
+@builtin(position) f546: vec4<f32>,
+@location(58) f547: vec4<i32>,
+@location(46) f548: vec2<f16>,
+@location(73) f549: f16,
+@location(89) f550: u32,
+@location(68) f551: vec2<u32>,
+@location(45) f552: vec2<f16>,
+@location(18) f553: f32,
+@location(37) f554: vec4<f16>,
+@location(34) f555: vec4<u32>,
+@location(94) f556: vec2<u32>,
+@location(33) f557: vec3<u32>,
+@location(91) f558: vec2<f16>,
+@location(81) f559: vec3<u32>,
+@location(0) f560: vec2<f16>,
+@location(78) f561: f16,
+@location(56) f562: vec3<f16>,
+@location(86) f563: vec4<f32>,
+@location(96) f564: vec2<i32>,
+@location(28) f565: u32,
+@location(103) f566: f32,
+@location(88) f567: vec4<u32>,
+@location(71) f568: f32,
+@location(48) f569: u32,
+@location(47) f570: vec4<f16>,
+@location(79) f571: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec3<f32>, @location(17) a1: vec4<u32>, @location(12) a2: vec3<f16>, a3: S32, @location(16) a4: vec3<f32>, @location(18) a5: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+}
+);
+let buffer66 = device10.createBuffer(
+{
+size: 7460,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX,
+}
+);
+let renderBundle131 = renderBundleEncoder94.finish();
+try {
+computePassEncoder49.setBindGroup(
+1,
+bindGroup62,
+new Uint32Array(9259),
+1916,
+0
+);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(
+0,
+bindGroup62
+);
+} catch {}
+try {
+renderPassEncoder40.setStencilReference(
+1448
+);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(
+buffer52,
+'uint16',
+5052,
+3317
+);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(
+6,
+buffer66,
+3836
+);
+} catch {}
+try {
+renderBundleEncoder108.setBindGroup(
+3,
+bindGroup62,
+new Uint32Array(8972),
+7938,
+0
+);
+} catch {}
+try {
+device10.queue.copyExternalImageToTexture(
+/*
+{width: 398, height: 28, depthOrArrayLayers: 180}
+*/
+{
+  source: imageBitmap9,
+  origin: { x: 65, y: 27 },
+  flipY: false,
+},
+{
+  texture: texture161,
+  mipLevel: 3,
+  origin: { x: 312, y: 16, z: 125 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 53, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline136 = device10.createComputePipeline(
+{
+label: '\u0e45\u07e9\u0d0d\u{1f660}',
+layout: 'auto',
+compute: {
+module: shaderModule38,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend(video23);
+gc();
+let bindGroup69 = device6.createBindGroup({
+layout: bindGroupLayout71,
+entries: [
+
+],
+});
+let querySet124 = device6.createQuerySet({
+label: '\ub66d\u0491\uc44d\ub519\u0de0\u9ffb',
+type: 'occlusion',
+count: 3327,
+});
+try {
+renderPassEncoder37.setBindGroup(
+7,
+bindGroup52
+);
+} catch {}
+try {
+renderPassEncoder35.setScissorRect(
+62,
+10,
+37,
+5
+);
+} catch {}
+try {
+renderPassEncoder37.setViewport(
+91.84,
+22.71,
+3.680,
+0.2324,
+0.2204,
+0.3317
+);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(
+3,
+buffer57
+);
+} catch {}
+try {
+renderBundleEncoder106.setVertexBuffer(
+2,
+buffer57,
+8220,
+9862
+);
+} catch {}
+try {
+await device6.popErrorScope();
+} catch {}
+try {
+renderPassEncoder35.setScissorRect(
+90,
+0,
+5,
+8
+);
+} catch {}
+try {
+renderPassEncoder37.setStencilReference(
+3492
+);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(
+8,
+buffer57,
+17268,
+3631
+);
+} catch {}
+let pipeline137 = device6.createRenderPipeline(
+{
+label: '\u{1fbc9}\u0f39',
+layout: pipelineLayout39,
+vertex: {
+module: shaderModule37,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 59596,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x2',
+offset: 19500,
+shaderLocation: 15,
+},
+{
+format: 'float16x2',
+offset: 27072,
+shaderLocation: 14,
+},
+{
+format: 'unorm16x2',
+offset: 15700,
+shaderLocation: 2,
+},
+{
+format: 'sint32x2',
+offset: 2044,
+shaderLocation: 6,
+},
+{
+format: 'sint32x3',
+offset: 42212,
+shaderLocation: 9,
+},
+{
+format: 'uint32x3',
+offset: 7312,
+shaderLocation: 3,
+},
+{
+format: 'sint32',
+offset: 17316,
+shaderLocation: 7,
+},
+{
+format: 'uint32x4',
+offset: 8884,
+shaderLocation: 1,
+},
+{
+format: 'uint8x2',
+offset: 13118,
+shaderLocation: 13,
+},
+{
+format: 'uint16x2',
+offset: 22764,
+shaderLocation: 11,
+},
+{
+format: 'uint32',
+offset: 27316,
+shaderLocation: 0,
+},
+{
+format: 'uint16x4',
+offset: 28180,
+shaderLocation: 16,
+},
+{
+format: 'unorm16x2',
+offset: 41512,
+shaderLocation: 12,
+},
+{
+format: 'sint8x2',
+offset: 2838,
+shaderLocation: 5,
+},
+{
+format: 'uint32x2',
+offset: 33688,
+shaderLocation: 4,
+},
+{
+format: 'uint32',
+offset: 22536,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 40052,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 2904,
+attributes: [
+
+],
+},
+{
+arrayStride: 14344,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 6620,
+shaderLocation: 10,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule37,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg32uint',
+},
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'dst-alpha',
+dstFactor: 'dst-alpha'
+},
+},
+format: 'rgba8unorm',
+},
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.BLUE,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'dst-alpha',
+dstFactor: 'one-minus-src'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one-minus-src-alpha',
+dstFactor: 'zero'
+},
+},
+format: 'rg16float',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'rgba8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilBack: {
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 3320,
+stencilWriteMask: 3973,
+depthBias: 83,
+depthBiasSlopeScale: 56,
+depthBiasClamp: 8,
+},
+}
+);
+let commandEncoder128 = device12.createCommandEncoder(
+{
+label: '\u33b7\uf5bc\ue4e9',
+}
+);
+try {
+gpuCanvasContext4.configure(
+{
+device: device12,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+
+],
+}
+);
+} catch {}
+let offscreenCanvas48 = new OffscreenCanvas(1022, 161);
+try {
+gpuCanvasContext34.configure(
+{
+device: device12,
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16float',
+'rg8uint',
+'etc2-rgb8a1unorm-srgb'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+await device12.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext46 = offscreenCanvas48.getContext('webgpu');
+let texture182 = device8.createTexture(
+{
+label: '\u3378\u08a0\u0e8c\u6215\u0679\u1072',
+size: [205, 5, 236],
+mipLevelCount: 4,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let textureView162 = texture179.createView(
+{
+label: '\ufa34\u9a24\u73ba',
+baseMipLevel: 2,
+}
+);
+try {
+computePassEncoder52.setPipeline(
+pipeline135
+);
+} catch {}
+try {
+commandEncoder107.copyTextureToTexture(
+{
+  texture: texture153,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 3 },
+  aspect: 'all',
+},
+{
+  texture: texture153,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 34}
+);
+} catch {}
+try {
+commandEncoder107.clearBuffer(
+buffer40
+);
+dissociateBuffer(device8, buffer40);
+} catch {}
+try {
+gpuCanvasContext44.configure(
+{
+device: device8,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16sint',
+'depth32float-stencil8',
+'rgba8unorm'
+],
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device8.queue.writeBuffer(
+buffer59,
+548,
+new BigUint64Array(8665),
+892,
+1212
+);
+} catch {}
+let canvas39 = document.createElement('canvas');
+document.body.prepend(canvas32);
+try {
+canvas39.getContext('bitmaprenderer');
+} catch {}
+let renderBundle132 = renderBundleEncoder116.finish();
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+let querySet125 = device4.createQuerySet({
+label: '\ub530\u6081\u0f62\ucb31\ubd00\u{1f954}\uabd1\u09c7\u{1f895}\u5979\ubaff',
+type: 'occlusion',
+count: 2414,
+});
+try {
+computePassEncoder43.setPipeline(
+pipeline90
+);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder26.setScissorRect(
+72,
+0,
+10,
+1
+);
+} catch {}
+try {
+renderPassEncoder36.setStencilReference(
+3044
+);
+} catch {}
+try {
+renderPassEncoder36.setViewport(
+71.65,
+0.7977,
+2.999,
+0.06681,
+0.4672,
+0.9498
+);
+} catch {}
+try {
+renderBundleEncoder93.setBindGroup(
+4,
+bindGroup48
+);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer36,
+36532,
+new Float32Array(65255),
+3004,
+1056
+);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(
+/*
+{width: 41, height: 1, depthOrArrayLayers: 32}
+*/
+{
+  source: offscreenCanvas6,
+  origin: { x: 426, y: 106 },
+  flipY: true,
+},
+{
+  texture: texture69,
+  mipLevel: 2,
+  origin: { x: 4, y: 0, z: 14 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 25, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let offscreenCanvas49 = new OffscreenCanvas(877, 618);
+let computePassEncoder66 = commandEncoder128.beginComputePass(
+{
+label: '\u38dc\u4c8f\u07f0\u6f60\u070a\u0c7d'
+}
+);
+let sampler118 = device12.createSampler(
+{
+label: '\u55ab\u1e37\u20d3\u0f85',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 99.724,
+lodMaxClamp: 99.964,
+maxAnisotropy: 20,
+}
+);
+canvas23.width = 738;
+let querySet126 = device6.createQuerySet({
+label: '\u40c9\u{1f791}\u33a2\u{1f646}\u0a86\u0709\u0ca4\u6799\u0611\u0da3\u01ea',
+type: 'occlusion',
+count: 2191,
+});
+try {
+computePassEncoder63.setBindGroup(
+7,
+bindGroup69,
+new Uint32Array(2884),
+1414,
+0
+);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(
+3,
+bindGroup43
+);
+} catch {}
+try {
+renderPassEncoder37.setScissorRect(
+31,
+5,
+69,
+16
+);
+} catch {}
+try {
+buffer57.unmap();
+} catch {}
+try {
+commandEncoder117.copyTextureToBuffer(
+{
+  texture: texture148,
+  mipLevel: 0,
+  origin: { x: 1717, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 812 widthInBlocks: 406 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 12838 */
+offset: 12838,
+buffer: buffer63,
+},
+{width: 406, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device6, buffer63);
+} catch {}
+try {
+commandEncoder117.clearBuffer(
+buffer63,
+12088,
+528
+);
+dissociateBuffer(device6, buffer63);
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer63,
+7208,
+new BigUint64Array(40515),
+17747,
+292
+);
+} catch {}
+let imageBitmap35 = await createImageBitmap(videoFrame22);
+try {
+adapter13.label = '\uf8f5\u42f0\u06a8\u{1f65f}\u6642\u7238\u0d69\ue391\ue54c';
+} catch {}
+let gpuCanvasContext47 = offscreenCanvas49.getContext('webgpu');
+let imageData36 = new ImageData(108, 180);
+let querySet127 = device9.createQuerySet({
+label: '\u261c\u7b59\u{1f854}\u0d02\u0899\uab75',
+type: 'occlusion',
+count: 3506,
+});
+let computePassEncoder67 = commandEncoder113.beginComputePass(
+{
+label: '\u{1fe9e}\u{1f914}\u{1fa13}\uc921\uf39f\u{1f696}'
+}
+);
+try {
+renderBundleEncoder109.setVertexBuffer(
+74,
+undefined,
+2367241453,
+1241390528
+);
+} catch {}
+try {
+commandEncoder111.copyTextureToTexture(
+{
+  texture: texture145,
+  mipLevel: 0,
+  origin: { x: 8, y: 5, z: 32 },
+  aspect: 'all',
+},
+{
+  texture: texture145,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 29 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 99}
+);
+} catch {}
+try {
+commandEncoder111.clearBuffer(
+buffer41,
+4320,
+196
+);
+dissociateBuffer(device9, buffer41);
+} catch {}
+let imageBitmap36 = await createImageBitmap(imageData18);
+offscreenCanvas47.height = 43;
+document.body.prepend(img29);
+let img35 = await imageWithData(196, 77, '#8297a07d', '#3263a240');
+let texture183 = device12.createTexture(
+{
+size: {width: 8640},
+dimension: '1d',
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16sint',
+'r16sint'
+],
+}
+);
+let renderBundle133 = renderBundleEncoder116.finish();
+try {
+device12.queue.writeTexture(
+{
+  texture: texture181,
+  mipLevel: 1,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(arrayBuffer6),
+/* required buffer size: 440 */{
+offset: 440,
+bytesPerRow: 317,
+},
+{width: 52, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let imageData37 = new ImageData(28, 48);
+let commandEncoder129 = device6.createCommandEncoder(
+{
+label: '\u9bec\ucdb7\u{1f8dd}\u{1fe1b}\u0335\u0290',
+}
+);
+let texture184 = device6.createTexture(
+{
+size: [208, 180, 23],
+mipLevelCount: 7,
+sampleCount: 1,
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'eac-rg11snorm'
+],
+}
+);
+let renderBundle134 = renderBundleEncoder68.finish();
+try {
+renderPassEncoder37.setBindGroup(
+3,
+bindGroup49,
+new Uint32Array(752),
+125,
+0
+);
+} catch {}
+try {
+renderPassEncoder37.setScissorRect(
+90,
+15,
+7,
+7
+);
+} catch {}
+try {
+renderPassEncoder37.setStencilReference(
+1185
+);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(
+4,
+buffer57,
+3476,
+11793
+);
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer63,
+7280,
+new DataView(new ArrayBuffer(2913)),
+2718,
+32
+);
+} catch {}
+let pipeline138 = await device6.createComputePipelineAsync(
+{
+label: '\u6626\u791e\u02b0\udacb\u0740',
+layout: pipelineLayout28,
+compute: {
+module: shaderModule37,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let querySet128 = device9.createQuerySet({
+type: 'occlusion',
+count: 2024,
+});
+try {
+renderBundleEncoder109.setBindGroup(
+1,
+bindGroup66
+);
+} catch {}
+let bindGroup70 = device9.createBindGroup({
+label: '\u05ea\u043a\ub2e9\u0cf9\u0ece\u1c86\u0871',
+layout: bindGroupLayout57,
+entries: [
+
+],
+});
+try {
+computePassEncoder67.setBindGroup(
+1,
+bindGroup67
+);
+} catch {}
+try {
+renderBundleEncoder109.setBindGroup(
+3,
+bindGroup70
+);
+} catch {}
+try {
+renderBundleEncoder109.setIndexBuffer(
+buffer48,
+'uint32',
+1640,
+3211
+);
+} catch {}
+try {
+device9.queue.writeTexture(
+{
+  texture: texture122,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(56),
+/* required buffer size: 55 */{
+offset: 55,
+},
+{width: 1, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+await adapter3.requestAdapterInfo();
+} catch {}
+let commandEncoder130 = device7.createCommandEncoder();
+let textureView163 = texture152.createView(
+{
+dimension: '2d',
+baseArrayLayer: 23,
+}
+);
+let renderBundle135 = renderBundleEncoder105.finish();
+let sampler119 = device7.createSampler(
+{
+label: '\u{1feda}\u0a14\u08b6\u0f11\u{1f9b4}',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 27.108,
+lodMaxClamp: 60.297,
+}
+);
+try {
+renderBundleEncoder111.setBindGroup(
+1,
+bindGroup64,
+new Uint32Array(4539),
+2616,
+0
+);
+} catch {}
+try {
+commandEncoder130.copyBufferToTexture(
+{
+/* bytesInLastRow: 208 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 17488 */
+offset: 17488,
+bytesPerRow: 256,
+buffer: buffer62,
+},
+{
+  texture: texture141,
+  mipLevel: 0,
+  origin: { x: 8, y: 4, z: 0 },
+  aspect: 'all',
+},
+{width: 52, height: 104, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device7, buffer62);
+} catch {}
+try {
+device7.queue.writeTexture(
+{
+  texture: texture141,
+  mipLevel: 2,
+  origin: { x: 0, y: 4, z: 1 },
+  aspect: 'all',
+},
+arrayBuffer13,
+/* required buffer size: 859 */{
+offset: 859,
+bytesPerRow: 115,
+},
+{width: 24, height: 12, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend(canvas0);
+gc();
+let bindGroupLayout77 = device9.createBindGroupLayout(
+{
+label: '\u0354\u{1f7fe}\u0cc9\u0c71\u{1fad4}\u0dac\ued66\u5868',
+entries: [
+
+],
+}
+);
+let textureView164 = texture145.createView(
+{
+label: '\u2901\u44f1\u{1f841}\u0f25\u{1fdc7}\u{1fc0e}\u{1f97b}\u0a29\u3355\u06ce\u{1fb47}',
+dimension: '2d-array',
+baseMipLevel: 3,
+baseArrayLayer: 49,
+arrayLayerCount: 53,
+}
+);
+try {
+renderBundleEncoder109.setIndexBuffer(
+buffer48,
+'uint16',
+4306,
+8668
+);
+} catch {}
+try {
+commandEncoder111.copyBufferToBuffer(
+buffer58,
+18912,
+buffer41,
+3352,
+164
+);
+dissociateBuffer(device9, buffer58);
+dissociateBuffer(device9, buffer41);
+} catch {}
+try {
+gpuCanvasContext6.configure(
+{
+device: device9,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-6x5-unorm'
+],
+colorSpace: 'srgb',
+}
+);
+} catch {}
+try {
+device9.queue.submit([
+]);
+} catch {}
+canvas14.width = 607;
+let querySet129 = device3.createQuerySet({
+label: '\u31f7\u3199\u{1fb73}\u{1f925}\u{1f657}\uc5f4\u9ff4\u9acd\u681e\u3527',
+type: 'occlusion',
+count: 2403,
+});
+let renderBundleEncoder117 = device3.createRenderBundleEncoder(
+{
+label: '\u{1ff6c}\uef8e\u0b6a\u9553\u4ee8',
+colorFormats: [
+'rgba16sint',
+'rgba16float',
+'rg8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 77,
+}
+);
+let sampler120 = device3.createSampler(
+{
+label: '\u0d62\u{1f8ea}\ubff3\ub7a6\uac16\u916c\ufd30\u00a4',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 83.455,
+}
+);
+try {
+renderPassEncoder23.setViewport(
+1.690,
+0.6080,
+0.8341,
+0.1200,
+0.9153,
+0.9178
+);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(
+80,
+undefined,
+57090340,
+4035865622
+);
+} catch {}
+try {
+gpuCanvasContext6.configure(
+{
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgba8snorm',
+'depth16unorm',
+'rg32float',
+'bgra8unorm'
+],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(
+/*
+{width: 14, height: 2, depthOrArrayLayers: 32}
+*/
+{
+  source: imageBitmap15,
+  origin: { x: 9, y: 10 },
+  flipY: false,
+},
+{
+  texture: texture98,
+  mipLevel: 1,
+  origin: { x: 1, y: 2, z: 22 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let bindGroupLayout78 = device6.createBindGroupLayout(
+{
+label: '\u06fd\u0b75\u2fc9\u7bae\u{1f719}\u{1ff3d}\u{1ff30}\u0f20',
+entries: [
+
+],
+}
+);
+let texture185 = device6.createTexture(
+{
+label: '\u0b70\u3ffa\u0e9f\u027c\u099d\u79ed',
+size: {width: 2384, height: 4, depthOrArrayLayers: 98},
+mipLevelCount: 11,
+format: 'astc-4x4-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView165 = texture184.createView(
+{
+label: '\u5193\u0ab9\u{1fced}\u0440\u7a13',
+baseMipLevel: 6,
+baseArrayLayer: 15,
+arrayLayerCount: 2,
+}
+);
+try {
+computePassEncoder63.setBindGroup(
+7,
+bindGroup59,
+new Uint32Array(1904),
+1279,
+0
+);
+} catch {}
+try {
+renderPassEncoder37.setStencilReference(
+2951
+);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(
+buffer55,
+'uint32',
+27772,
+7565
+);
+} catch {}
+let arrayBuffer17 = buffer37.getMappedRange(
+6480,
+2136
+);
+try {
+commandEncoder129.clearBuffer(
+buffer53,
+11616,
+2720
+);
+dissociateBuffer(device6, buffer53);
+} catch {}
+try {
+commandEncoder96.pushDebugGroup(
+'\uef43'
+);
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer53,
+3084,
+new DataView(new ArrayBuffer(63495)),
+27268,
+4120
+);
+} catch {}
+let promise60 = device6.createRenderPipelineAsync(
+{
+layout: pipelineLayout28,
+vertex: {
+module: shaderModule37,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 6540,
+stepMode: 'instance',
+attributes: [
+{
+format: 'snorm8x4',
+offset: 5440,
+shaderLocation: 14,
+},
+{
+format: 'uint16x4',
+offset: 1320,
+shaderLocation: 16,
+},
+{
+format: 'uint16x2',
+offset: 3348,
+shaderLocation: 1,
+},
+{
+format: 'snorm16x2',
+offset: 1832,
+shaderLocation: 10,
+},
+{
+format: 'uint32x3',
+offset: 1028,
+shaderLocation: 4,
+},
+{
+format: 'uint8x2',
+offset: 2098,
+shaderLocation: 8,
+},
+{
+format: 'sint16x4',
+offset: 4016,
+shaderLocation: 6,
+},
+{
+format: 'sint32x4',
+offset: 2796,
+shaderLocation: 7,
+},
+{
+format: 'uint16x2',
+offset: 3568,
+shaderLocation: 11,
+},
+{
+format: 'float16x2',
+offset: 1256,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 27436,
+attributes: [
+{
+format: 'sint16x4',
+offset: 17480,
+shaderLocation: 9,
+},
+{
+format: 'unorm16x2',
+offset: 14548,
+shaderLocation: 2,
+},
+{
+format: 'uint32x2',
+offset: 17272,
+shaderLocation: 13,
+},
+{
+format: 'sint32',
+offset: 17876,
+shaderLocation: 15,
+},
+{
+format: 'uint32',
+offset: 25860,
+shaderLocation: 0,
+},
+{
+format: 'sint32x2',
+offset: 25484,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 43096,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 19024,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x2',
+offset: 3644,
+shaderLocation: 3,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+},
+fragment: {
+module: shaderModule37,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL,
+},
+{
+format: 'r32sint',
+writeMask: 0,
+},
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.ALL,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one-minus-constant',
+dstFactor: 'one-minus-src-alpha'
+},
+},
+format: 'rgb10a2unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'rg16float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+format: 'rgba8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+depthFailOp: 'increment-clamp',
+passOp: 'keep',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+},
+stencilReadMask: 2722,
+stencilWriteMask: 1942,
+depthBias: 60,
+depthBiasSlopeScale: 61,
+depthBiasClamp: 20,
+},
+}
+);
+let promise61 = adapter8.requestAdapterInfo();
+let querySet130 = device12.createQuerySet({
+type: 'occlusion',
+count: 2990,
+});
+let sampler121 = device12.createSampler(
+{
+label: '\ue8c8\u08dc\u{1fca2}\u63c7\u08b6\u{1f8f2}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMaxClamp: 72.977,
+}
+);
+try {
+gpuCanvasContext34.unconfigure();
+} catch {}
+video14.width = 227;
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+let commandEncoder131 = device8.createCommandEncoder(
+{
+label: '\u0b73\u727a\u1426\uf6f3\u017c\u{1f838}\u0f52\u{1fc51}\u{1fdfa}\ue1f3',
+}
+);
+let textureView166 = texture149.createView(
+{
+baseMipLevel: 5,
+mipLevelCount: 1,
+}
+);
+let sampler122 = device8.createSampler(
+{
+label: '\u263f\u{1f626}\u0cd8\u027c\u1a3d\u1143\u5592\u00ec\u37ae\u090c',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 71.608,
+lodMaxClamp: 97.161,
+}
+);
+try {
+commandEncoder107.copyBufferToBuffer(
+buffer44,
+34268,
+buffer59,
+9556,
+944
+);
+dissociateBuffer(device8, buffer44);
+dissociateBuffer(device8, buffer59);
+} catch {}
+try {
+gpuCanvasContext3.configure(
+{
+device: device8,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x5-unorm',
+'bgra8unorm',
+'rgba8unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let pipeline139 = device8.createRenderPipeline(
+{
+layout: pipelineLayout37,
+vertex: {
+module: shaderModule35,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1896,
+attributes: [
+{
+format: 'sint32x4',
+offset: 1040,
+shaderLocation: 1,
+},
+{
+format: 'unorm8x2',
+offset: 216,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x2',
+offset: 1760,
+shaderLocation: 12,
+},
+{
+format: 'sint32x3',
+offset: 1860,
+shaderLocation: 5,
+},
+{
+format: 'uint32',
+offset: 1508,
+shaderLocation: 3,
+},
+{
+format: 'sint32',
+offset: 336,
+shaderLocation: 2,
+},
+{
+format: 'sint16x4',
+offset: 1500,
+shaderLocation: 6,
+},
+{
+format: 'sint8x4',
+offset: 940,
+shaderLocation: 9,
+},
+{
+format: 'uint16x2',
+offset: 152,
+shaderLocation: 4,
+},
+{
+format: 'float32',
+offset: 256,
+shaderLocation: 10,
+},
+{
+format: 'sint8x4',
+offset: 1496,
+shaderLocation: 11,
+},
+{
+format: 'sint32',
+offset: 992,
+shaderLocation: 7,
+},
+{
+format: 'sint32x4',
+offset: 644,
+shaderLocation: 13,
+},
+{
+format: 'unorm8x2',
+offset: 1746,
+shaderLocation: 8,
+},
+{
+format: 'sint32x4',
+offset: 1836,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x2',
+offset: 84,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule35,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'r32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'rgba16uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'constant',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'rg8uint',
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 2113,
+stencilWriteMask: 3404,
+depthBiasSlopeScale: 94,
+depthBiasClamp: 28,
+},
+}
+);
+let bindGroupLayout79 = device4.createBindGroupLayout(
+{
+label: '\u03ec\u08cf\u5ca9\u0637\u{1fc38}\uc2a5\uc95d\u{1f78e}\u8523',
+entries: [
+{
+binding: 2490,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'filtering' },
+},
+{
+binding: 1579,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+},
+{
+binding: 868,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}
+],
+}
+);
+let querySet131 = device4.createQuerySet({
+label: '\uc15c\u0378\u9870\ufa9a\u6e35\uc41b\u5e3c\ud560',
+type: 'occlusion',
+count: 584,
+});
+let texture186 = device4.createTexture(
+{
+label: '\u0304\u078f\u3ed0\u{1fd54}\u0886\u08f2\u51c8\u{1f778}\u7a90',
+size: {width: 2960, height: 185, depthOrArrayLayers: 219},
+mipLevelCount: 9,
+format: 'astc-5x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-5x5-unorm',
+'astc-5x5-unorm-srgb'
+],
+}
+);
+try {
+computePassEncoder43.setBindGroup(
+3,
+bindGroup39,
+new Uint32Array(8278),
+1393,
+0
+);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder115.setVertexBuffer(
+3,
+buffer51,
+18000,
+18068
+);
+} catch {}
+let arrayBuffer18 = buffer32.getMappedRange(
+20776
+);
+let video33 = await videoWithData();
+try {
+computePassEncoder67.setBindGroup(
+4,
+bindGroup68
+);
+} catch {}
+try {
+renderBundleEncoder109.setBindGroup(
+2,
+bindGroup67
+);
+} catch {}
+try {
+device9.pushErrorScope('internal');
+} catch {}
+try {
+buffer48.unmap();
+} catch {}
+try {
+commandEncoder114.copyBufferToBuffer(
+buffer58,
+8492,
+buffer41,
+3220,
+4592
+);
+dissociateBuffer(device9, buffer58);
+dissociateBuffer(device9, buffer41);
+} catch {}
+let bindGroupLayout80 = device11.createBindGroupLayout(
+{
+label: '\uff86\u067f\u406f\u6a9d\ue138\u079b\u7f49\u{1fd6c}',
+entries: [
+
+],
+}
+);
+let sampler123 = device11.createSampler(
+{
+label: '\u{1ffb6}\ue91d\u0b27\u0add\u63a8\u0019\u8f6e\uffb0\u2db5',
+addressModeU: 'repeat',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 65.673,
+lodMaxClamp: 78.918,
+}
+);
+try {
+commandEncoder126.copyTextureToTexture(
+{
+  texture: texture175,
+  mipLevel: 0,
+  origin: { x: 408, y: 0, z: 12 },
+  aspect: 'all',
+},
+{
+  texture: texture175,
+  mipLevel: 0,
+  origin: { x: 64, y: 0, z: 88 },
+  aspect: 'all',
+},
+{width: 5296, height: 0, depthOrArrayLayers: 7}
+);
+} catch {}
+let adapter18 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let texture187 = device12.createTexture(
+{
+size: {width: 1312, height: 1, depthOrArrayLayers: 1606},
+mipLevelCount: 10,
+dimension: '3d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+let renderBundle136 = renderBundleEncoder116.finish(
+{
+label: '\u6983\u1c0a\u00bf\u051f\ua02b\u0b9c'
+}
+);
+try {
+device12.pushErrorScope('internal');
+} catch {}
+try {
+await promise61;
+} catch {}
+let commandBuffer17 = commandEncoder130.finish(
+{
+label: '\u9779\u{1fd88}\u3d42\u3e16\u0897',
+}
+);
+let textureView167 = texture151.createView(
+{
+label: '\u0996\uaec3\u{1f6af}',
+baseMipLevel: 4,
+mipLevelCount: 4,
+}
+);
+let renderBundle137 = renderBundleEncoder111.finish(
+{
+
+}
+);
+try {
+device7.addEventListener('uncapturederror', e => { log('device7.uncapturederror'); log(e); e.label = device7.label; });
+} catch {}
+try {
+device7.queue.writeTexture(
+{
+  texture: texture141,
+  mipLevel: 3,
+  origin: { x: 4, y: 4, z: 0 },
+  aspect: 'all',
+},
+arrayBuffer18,
+/* required buffer size: 634 */{
+offset: 634,
+bytesPerRow: 139,
+},
+{width: 4, height: 8, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend(img22);
+let commandEncoder132 = device4.createCommandEncoder(
+{
+label: '\u439d\u79b6\u0893\u{1fed2}\u88e1\u0c67\u2ca6\u{1f8fd}',
+}
+);
+let renderBundle138 = renderBundleEncoder52.finish(
+{
+label: '\u{1f709}\u9af1\u0b4a\u0a77\u09b6\ua4b9\u{1fa9a}\ua819\u026c'
+}
+);
+try {
+computePassEncoder43.setPipeline(
+pipeline89
+);
+} catch {}
+try {
+renderPassEncoder32.setBlendConstant({ r: 294.7, g: 741.2, b: 793.9, a: -876.0, });
+} catch {}
+try {
+renderPassEncoder26.setScissorRect(
+10,
+0,
+42,
+1
+);
+} catch {}
+try {
+renderBundleEncoder114.setBindGroup(
+8,
+bindGroup39
+);
+} catch {}
+try {
+commandEncoder132.resolveQuerySet(
+querySet63,
+2389,
+153,
+buffer51,
+10752
+);
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer51,
+44228,
+new Int16Array(14798),
+8704,
+5432
+);
+} catch {}
+let pipeline140 = device4.createComputePipeline(
+{
+label: '\u06b6\u00b0\u4181\u0eba\u{1fee6}\u5f35\u0725\u0b24\u07e5\u8c7e',
+layout: pipelineLayout22,
+compute: {
+module: shaderModule27,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let bindGroupLayout81 = device6.createBindGroupLayout(
+{
+label: '\u88c1\u770b\uf7a2\u06ed\u98dd',
+entries: [
+{
+binding: 1155,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+},
+{
+binding: 925,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d-array' },
+},
+{
+binding: 1939,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+try {
+renderPassEncoder35.setIndexBuffer(
+buffer55,
+'uint32',
+40020,
+786
+);
+} catch {}
+let pipeline141 = device6.createComputePipeline(
+{
+layout: pipelineLayout39,
+compute: {
+module: shaderModule37,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let querySet132 = device10.createQuerySet({
+label: '\udfa5\u0cdf\u69f1\u23fa\ue3e6\u0891\u63c1\u0be9',
+type: 'occlusion',
+count: 3527,
+});
+let texture188 = device10.createTexture(
+{
+label: '\ud637\u2b75\ucd7b\u{1f9c0}\u{1fdb3}\u0043\u25f7\u07d7',
+size: {width: 813, height: 1, depthOrArrayLayers: 1759},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+computePassEncoder64.setPipeline(
+pipeline127
+);
+} catch {}
+try {
+renderPassEncoder40.setBlendConstant({ r: 227.4, g: -733.4, b: 870.2, a: -131.2, });
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(
+buffer52,
+'uint32',
+6292
+);
+} catch {}
+try {
+renderBundleEncoder108.setBindGroup(
+0,
+bindGroup62
+);
+} catch {}
+try {
+device10.queue.writeBuffer(
+buffer66,
+512,
+new Int16Array(17011),
+13985
+);
+} catch {}
+let texture189 = device9.createTexture(
+{
+label: '\u35c2\uaaae\u0c1f\u96c7\u0739\u08ec\u93b6\u073f\u{1f665}\ue902\u{1f67a}',
+size: [40, 48, 1],
+mipLevelCount: 4,
+format: 'astc-10x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder68 = commandEncoder111.beginComputePass(
+{
+label: '\u5d05\u0c8b\u5289\u6be6\u6095\u0b8d'
+}
+);
+try {
+computePassEncoder58.setBindGroup(
+3,
+bindGroup66,
+new Uint32Array(9569),
+8581,
+0
+);
+} catch {}
+try {
+renderBundleEncoder109.setBindGroup(
+4,
+bindGroup67,
+new Uint32Array(8650),
+442,
+0
+);
+} catch {}
+try {
+renderBundleEncoder109.setVertexBuffer(
+80,
+undefined
+);
+} catch {}
+gc();
+let offscreenCanvas50 = new OffscreenCanvas(870, 146);
+let commandEncoder133 = device10.createCommandEncoder(
+{
+label: '\u76ed\u06dd\u08ca\u{1fec1}\u85db\u021f',
+}
+);
+let renderPassEncoder42 = commandEncoder133.beginRenderPass(
+{
+label: '\u6775\u{1fd06}\u0d6b\u0e19\u2883\u52e5',
+colorAttachments: [
+{
+view: textureView149,
+depthSlice: 188,
+clearValue: { r: 485.3, g: -523.7, b: 897.8, a: -464.1, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView149,
+depthSlice: 67,
+clearValue: { r: 7.582, g: 795.4, b: 18.44, a: -382.6, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined,
+{
+view: textureView149,
+depthSlice: 96,
+clearValue: { r: 3.603, g: 956.1, b: -281.7, a: 699.1, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView149,
+depthSlice: 3,
+clearValue: { r: -203.9, g: -925.5, b: 596.0, a: -366.2, },
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+maxDrawCount: 188328,
+}
+);
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let img36 = await imageWithData(101, 74, '#7acb05b1', '#6c6613d5');
+let commandBuffer18 = commandEncoder127.finish(
+{
+label: '\u{1f800}\uf082\u07a9\udf1a\u{1fb14}\u{1f8f4}\u2211',
+}
+);
+try {
+renderPassEncoder34.beginOcclusionQuery(81);
+} catch {}
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder23.setStencilReference(
+1901
+);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(
+87,
+undefined,
+1586958692
+);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(
+/*
+{width: 14, height: 2, depthOrArrayLayers: 32}
+*/
+{
+  source: imageBitmap28,
+  origin: { x: 106, y: 164 },
+  flipY: false,
+},
+{
+  texture: texture98,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 13 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 12, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipelineLayout41 = device11.createPipelineLayout(
+{
+label: '\ude95\u0074\u177d\u0d26\u{1fbb4}\u06e6\u05d3\uee42\ucb23\u438e',
+bindGroupLayouts: [
+bindGroupLayout80,
+bindGroupLayout80,
+bindGroupLayout80
+]
+}
+);
+try {
+commandEncoder126.copyTextureToTexture(
+{
+  texture: texture175,
+  mipLevel: 0,
+  origin: { x: 3560, y: 0, z: 168 },
+  aspect: 'all',
+},
+{
+  texture: texture175,
+  mipLevel: 0,
+  origin: { x: 200, y: 0, z: 90 },
+  aspect: 'all',
+},
+{width: 1336, height: 0, depthOrArrayLayers: 22}
+);
+} catch {}
+try {
+gpuCanvasContext40.unconfigure();
+} catch {}
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder34.setBlendConstant({ r: -588.3, g: -367.5, b: -571.0, a: 928.2, });
+} catch {}
+try {
+renderPassEncoder39.setViewport(
+0.3805,
+0.1434,
+1.670,
+0.5554,
+0.7999,
+0.9621
+);
+} catch {}
+try {
+buffer49.unmap();
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: { x: 1309, y: 1, z: 1 },
+  aspect: 'all',
+},
+new Float32Array(arrayBuffer16),
+/* required buffer size: 34 */{
+offset: 34,
+bytesPerRow: 1940,
+rowsPerImage: 221,
+},
+{width: 415, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+document.body.prepend(video18);
+canvas23.height = 407;
+try {
+offscreenCanvas50.getContext('webgl');
+} catch {}
+let bindGroupLayout82 = device9.createBindGroupLayout(
+{
+label: '\u054d\u{1fe1c}',
+entries: [
+{
+binding: 1147,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+},
+{
+binding: 5200,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+}
+],
+}
+);
+let texture190 = device9.createTexture(
+{
+label: '\u{1f792}\uf3a6\u2de6\u04e0\u14a6\ucee7\u{1f712}\u0e4f',
+size: {width: 9473, height: 23, depthOrArrayLayers: 184},
+format: 'r8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8unorm',
+'r8unorm'
+],
+}
+);
+let textureView168 = texture129.createView(
+{
+label: '\ub95c\ub7c5\u0f1f\u0536\u0b75\u{1fbba}\u0afe\u027c\u0fe9\uac71\ufb84',
+dimension: '2d',
+mipLevelCount: 3,
+baseArrayLayer: 84,
+}
+);
+try {
+renderBundleEncoder109.setIndexBuffer(
+buffer48,
+'uint32',
+9024
+);
+} catch {}
+try {
+commandEncoder114.clearBuffer(
+buffer41,
+3220,
+2112
+);
+dissociateBuffer(device9, buffer41);
+} catch {}
+let commandEncoder134 = device12.createCommandEncoder(
+{
+}
+);
+let video34 = await videoWithData();
+let device13 = await promise24;
+let bindGroup71 = device6.createBindGroup({
+label: '\u315d\u01dd\u02ff\u8166\ue89b',
+layout: bindGroupLayout55,
+entries: [
+
+],
+});
+let commandEncoder135 = device6.createCommandEncoder(
+{
+label: '\u0cdd\u13b5\u{1fa21}\u514c',
+}
+);
+try {
+computePassEncoder63.setPipeline(
+pipeline138
+);
+} catch {}
+try {
+renderPassEncoder37.beginOcclusionQuery(971);
+} catch {}
+try {
+renderPassEncoder37.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder35.setViewport(
+17.90,
+16.21,
+43.25,
+8.243,
+0.6157,
+0.6747
+);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(
+68,
+undefined,
+389405395
+);
+} catch {}
+try {
+renderBundleEncoder71.setVertexBuffer(
+2,
+buffer57,
+12500,
+5270
+);
+} catch {}
+try {
+commandEncoder117.clearBuffer(
+buffer53,
+9272,
+3488
+);
+dissociateBuffer(device6, buffer53);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let buffer67 = device11.createBuffer(
+{
+size: 15463,
+usage: GPUBufferUsage.QUERY_RESOLVE,
+}
+);
+let renderBundleEncoder118 = device11.createRenderBundleEncoder(
+{
+label: '\u0709\u0531\u066b\uf656\u01a8\u8b59\u{1f944}\ufdee\ue282\uc330\u{1fa7b}',
+colorFormats: [
+'rgba8uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 765,
+stencilReadOnly: true,
+}
+);
+document.body.prepend(video28);
+let texture191 = device7.createTexture(
+{
+label: '\u05fe\u{1ff6d}\u{1f679}\u03e4\ufcf4\u{1f81a}\ua81e',
+size: [208, 48, 1],
+mipLevelCount: 7,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'astc-8x6-unorm-srgb',
+'astc-8x6-unorm-srgb',
+'astc-8x6-unorm'
+],
+}
+);
+let renderBundle139 = renderBundleEncoder113.finish(
+{
+label: '\u07ed\u669a'
+}
+);
+try {
+adapter3.label = '\u47ae\u48ee\uadac\u611a\u074e\uec81\u02bc\u{1fd63}\uc10f\u9c99\u{1fef3}';
+} catch {}
+let bindGroupLayout83 = device11.createBindGroupLayout(
+{
+entries: [
+{
+binding: 212,
+visibility: 0,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let bindGroup72 = device11.createBindGroup({
+label: '\uf423\ue6ad\u19a8\ubcaf\u{1fed1}\u42ae\u4d72\u4b2e\u9ca2',
+layout: bindGroupLayout80,
+entries: [
+
+],
+});
+let commandEncoder136 = device11.createCommandEncoder(
+{
+label: '\u{1ffda}\ubda0',
+}
+);
+let querySet133 = device11.createQuerySet({
+label: '\u{1f8bb}\u432f\u{1f86d}\u{1fca5}\u989f\u1be6\u3238\ubc35\u6cd9\u67f6\u0bd9',
+type: 'occlusion',
+count: 3107,
+});
+let renderBundle140 = renderBundleEncoder118.finish(
+{
+label: '\u207e\u{1fb50}\ue368\u{1f994}\u8b77\u{1fb5e}\ua2ba\u698b\uefac'
+}
+);
+let querySet134 = device6.createQuerySet({
+label: '\ue853\u2e20\uc2e7',
+type: 'occlusion',
+count: 1205,
+});
+pseudoSubmit(device6, commandEncoder96);
+let texture192 = device6.createTexture(
+{
+label: '\u0f25\u{1f6b0}\u{1f613}\u6242',
+size: {width: 200, height: 208, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-10x8-unorm'
+],
+}
+);
+try {
+renderPassEncoder37.setScissorRect(
+30,
+5,
+33,
+11
+);
+} catch {}
+try {
+renderPassEncoder37.setStencilReference(
+3986
+);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(
+2,
+buffer57,
+25188,
+1281
+);
+} catch {}
+try {
+renderBundleEncoder101.setIndexBuffer(
+buffer55,
+'uint16',
+20630,
+328
+);
+} catch {}
+try {
+renderPassEncoder41.setScissorRect(
+3,
+1,
+2,
+0
+);
+} catch {}
+try {
+renderBundleEncoder112.setIndexBuffer(
+buffer40,
+'uint16',
+19646,
+7100
+);
+} catch {}
+try {
+await device8.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline142 = device8.createRenderPipeline(
+{
+label: '\uc131\u96a4\u0df0\u0654\u6ef0\ub6fb\u0b7c',
+layout: pipelineLayout37,
+vertex: {
+module: shaderModule35,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1048,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint16x2',
+offset: 408,
+shaderLocation: 14,
+},
+{
+format: 'uint32',
+offset: 516,
+shaderLocation: 4,
+},
+{
+format: 'sint16x2',
+offset: 164,
+shaderLocation: 7,
+},
+{
+format: 'sint8x4',
+offset: 972,
+shaderLocation: 2,
+},
+{
+format: 'float16x4',
+offset: 964,
+shaderLocation: 8,
+},
+{
+format: 'unorm8x4',
+offset: 996,
+shaderLocation: 10,
+},
+{
+format: 'sint8x4',
+offset: 0,
+shaderLocation: 9,
+},
+{
+format: 'float32x4',
+offset: 628,
+shaderLocation: 15,
+},
+{
+format: 'sint32x4',
+offset: 560,
+shaderLocation: 6,
+},
+{
+format: 'uint32x3',
+offset: 60,
+shaderLocation: 3,
+},
+{
+format: 'unorm16x4',
+offset: 700,
+shaderLocation: 12,
+},
+{
+format: 'sint32x4',
+offset: 964,
+shaderLocation: 13,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 1024,
+shaderLocation: 0,
+},
+{
+format: 'sint32x2',
+offset: 340,
+shaderLocation: 11,
+},
+{
+format: 'sint8x2',
+offset: 380,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 124,
+attributes: [
+{
+format: 'sint16x4',
+offset: 52,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule35,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'keep',
+depthFailOp: 'keep',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'invert',
+depthFailOp: 'decrement-clamp',
+passOp: 'invert',
+},
+stencilWriteMask: 335,
+depthBias: 11,
+depthBiasSlopeScale: 42,
+depthBiasClamp: 25,
+},
+}
+);
+offscreenCanvas24.height = 244;
+let texture193 = gpuCanvasContext3.getCurrentTexture();
+try {
+device13.queue.writeTexture(
+{
+  texture: texture193,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer12),
+/* required buffer size: 447 */{
+offset: 447,
+},
+{width: 0, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let shaderModule39 = device8.createShaderModule(
+{
+label: '\u0614\u0840\ufdd4\u{1fef9}\ubca9\u02e0\u9d45\u7c53\u015a',
+code: `@group(0) @binding(242)
+var<storage, read_write> global49: array<u32>;
+@group(0) @binding(104)
+var<storage, read_write> parameter36: array<u32>;
+
+@compute @workgroup_size(7, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(0) f0: vec2<i32>,
+@location(4) f1: vec4<f32>,
+@location(7) f2: vec4<i32>,
+@location(6) f3: vec3<f32>,
+@location(1) f4: vec4<f32>,
+@location(3) f5: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(front_facing) a2: bool, @builtin(sample_index) a3: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S34 {
+@location(9) f0: u32,
+@location(5) f1: vec2<i32>,
+@location(15) f2: vec2<u32>,
+@location(14) f3: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec4<i32>, @location(12) a1: vec4<f16>, @location(7) a2: vec4<f16>, @location(2) a3: vec2<i32>, @builtin(instance_index) a4: u32, @location(0) a5: vec4<i32>, @location(3) a6: vec3<u32>, @location(8) a7: u32, @location(6) a8: vec3<u32>, @location(13) a9: vec2<f32>, @location(10) a10: vec3<i32>, @location(1) a11: f32, @location(4) a12: i32, a13: S34, @builtin(vertex_index) a14: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let computePassEncoder69 = commandEncoder131.beginComputePass(
+{
+label: '\u0826\u362f\u{1f9a9}\u5c15\u0812\u4e1c\u0817\u{1ff5d}\u{1fbf5}'
+}
+);
+let renderBundleEncoder119 = device8.createRenderBundleEncoder(
+{
+label: '\u{1ffb2}\u{1f72d}\u07c4\uf567\u0c7a\u{1ffa6}\u{1f652}\u5f59\u0674\u998e',
+colorFormats: [
+undefined
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 948,
+depthReadOnly: true,
+}
+);
+let offscreenCanvas51 = new OffscreenCanvas(909, 319);
+let shaderModule40 = device8.createShaderModule(
+{
+label: '\u{1fd63}\u7e00\u060e\u{1fd83}\u7aa2\u5774',
+code: `@group(0) @binding(242)
+var<storage, read_write> global50: array<u32>;
+@group(0) @binding(552)
+var<storage, read_write> parameter37: array<u32>;
+@group(0) @binding(104)
+var<storage, read_write> type53: array<u32>;
+
+@compute @workgroup_size(7, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@location(7) f0: vec2<f32>,
+@location(1) f1: vec2<u32>,
+@location(2) f2: vec2<i32>,
+@location(6) f3: vec4<i32>,
+@location(3) f4: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S35 {
+@location(3) f0: vec2<u32>,
+@location(2) f1: vec3<f16>,
+@location(11) f2: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: f16, @location(1) a1: vec2<i32>, @location(5) a2: vec3<f32>, @location(7) a3: vec2<u32>, @location(9) a4: vec3<i32>, @location(0) a5: vec4<u32>, @location(13) a6: vec2<i32>, a7: S35, @location(4) a8: u32, @location(6) a9: vec4<i32>, @builtin(instance_index) a10: u32, @location(8) a11: f32, @location(10) a12: vec4<f32>, @location(15) a13: i32, @location(12) a14: f16, @builtin(vertex_index) a15: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+}
+);
+let textureView169 = texture147.createView(
+{
+label: '\u0b8e\ufd11',
+dimension: '3d',
+aspect: 'all',
+baseMipLevel: 5,
+mipLevelCount: 3,
+}
+);
+let renderBundle141 = renderBundleEncoder89.finish(
+{
+
+}
+);
+try {
+computePassEncoder52.setPipeline(
+pipeline135
+);
+} catch {}
+try {
+renderPassEncoder41.executeBundles([]);
+} catch {}
+canvas22.width = 689;
+let texture194 = device10.createTexture(
+{
+label: '\u03ec\uf5fd\u{1fb55}\uc982\u{1fa98}\u0ba4\u{1f613}',
+size: {width: 208, height: 1, depthOrArrayLayers: 775},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+}
+);
+try {
+computePassEncoder64.setPipeline(
+pipeline127
+);
+} catch {}
+try {
+renderPassEncoder42.setScissorRect(
+714,
+1,
+56,
+0
+);
+} catch {}
+try {
+renderPassEncoder42.setStencilReference(
+1914
+);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(
+6,
+buffer66,
+2928,
+534
+);
+} catch {}
+try {
+device10.queue.writeBuffer(
+buffer66,
+2272,
+new BigUint64Array(55350),
+34371,
+628
+);
+} catch {}
+try {
+device10.queue.copyExternalImageToTexture(
+/*
+{width: 398, height: 28, depthOrArrayLayers: 180}
+*/
+{
+  source: imageData32,
+  origin: { x: 6, y: 6 },
+  flipY: true,
+},
+{
+  texture: texture161,
+  mipLevel: 3,
+  origin: { x: 48, y: 19, z: 42 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 116, height: 8, depthOrArrayLayers: 1}
+);
+} catch {}
+let video35 = await videoWithData();
+let commandEncoder137 = device4.createCommandEncoder();
+let texture195 = device4.createTexture(
+{
+label: '\u7535\uf6f8\u{1f7af}',
+size: {width: 51, height: 26, depthOrArrayLayers: 195},
+mipLevelCount: 1,
+format: 'rg32uint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rg32uint',
+'rg32uint',
+'rg32uint'
+],
+}
+);
+try {
+renderPassEncoder32.setBlendConstant({ r: -571.3, g: 370.0, b: -57.40, a: 197.1, });
+} catch {}
+try {
+renderPassEncoder36.setScissorRect(
+63,
+1,
+17,
+0
+);
+} catch {}
+try {
+renderPassEncoder26.setViewport(
+81.74,
+0.5706,
+0.1570,
+0.02957,
+0.01718,
+0.6785
+);
+} catch {}
+try {
+renderBundleEncoder114.setVertexBuffer(
+49,
+undefined,
+3482459,
+3163135790
+);
+} catch {}
+try {
+commandEncoder132.clearBuffer(
+buffer51,
+23112,
+39280
+);
+dissociateBuffer(device4, buffer51);
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer36,
+7728,
+new Float32Array(19713),
+18327,
+628
+);
+} catch {}
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas52 = new OffscreenCanvas(229, 379);
+let canvas40 = document.createElement('canvas');
+let querySet135 = device8.createQuerySet({
+label: '\u0b82\u01aa',
+type: 'occlusion',
+count: 399,
+});
+try {
+computePassEncoder52.setPipeline(
+pipeline135
+);
+} catch {}
+try {
+renderPassEncoder41.setScissorRect(
+1,
+0,
+4,
+0
+);
+} catch {}
+try {
+renderPassEncoder41.setStencilReference(
+3174
+);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(
+buffer40,
+'uint32',
+13140,
+49580
+);
+} catch {}
+try {
+commandEncoder112.copyBufferToBuffer(
+buffer44,
+29040,
+buffer50,
+9640,
+1028
+);
+dissociateBuffer(device8, buffer44);
+dissociateBuffer(device8, buffer50);
+} catch {}
+try {
+commandEncoder112.clearBuffer(
+buffer59,
+7120,
+3744
+);
+dissociateBuffer(device8, buffer59);
+} catch {}
+try {
+gpuCanvasContext41.configure(
+{
+device: device8,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm',
+'rgba8unorm-srgb',
+'rgba16float',
+'r8snorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device8.queue.writeTexture(
+{
+  texture: texture147,
+  mipLevel: 5,
+  origin: { x: 12, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint16Array(arrayBuffer15),
+/* required buffer size: 72751 */{
+offset: 514,
+bytesPerRow: 199,
+rowsPerImage: 121,
+},
+{width: 3, height: 0, depthOrArrayLayers: 4}
+);
+} catch {}
+let pipeline143 = await device8.createRenderPipelineAsync(
+{
+label: '\u8f89\u0d88\u{1f9b9}\u0864\u0c5f\u14ee\u{1fc2b}\u79a9\uef0f\u7138\u0a33',
+layout: 'auto',
+vertex: {
+module: shaderModule35,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 960,
+attributes: [
+{
+format: 'sint8x4',
+offset: 384,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 2008,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x4',
+offset: 1972,
+shaderLocation: 4,
+},
+{
+format: 'float32x2',
+offset: 1260,
+shaderLocation: 10,
+},
+{
+format: 'float32x3',
+offset: 1872,
+shaderLocation: 15,
+},
+{
+format: 'sint32x4',
+offset: 76,
+shaderLocation: 1,
+},
+{
+format: 'sint32',
+offset: 1880,
+shaderLocation: 7,
+},
+{
+format: 'sint32x3',
+offset: 216,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 708,
+attributes: [
+{
+format: 'sint8x2',
+offset: 508,
+shaderLocation: 6,
+},
+{
+format: 'float32',
+offset: 116,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 1448,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x2',
+offset: 444,
+shaderLocation: 11,
+}
+],
+},
+{
+arrayStride: 1924,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float32x4',
+offset: 1664,
+shaderLocation: 0,
+},
+{
+format: 'sint32x3',
+offset: 1636,
+shaderLocation: 14,
+},
+{
+format: 'snorm8x2',
+offset: 1266,
+shaderLocation: 8,
+},
+{
+format: 'sint32',
+offset: 792,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 196,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x2',
+offset: 8,
+shaderLocation: 3,
+},
+{
+format: 'sint32',
+offset: 24,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule35,
+entryPoint: 'fragment0',
+targets: [
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r32uint',
+},
+{
+format: 'r32float',
+writeMask: 0,
+},
+{
+format: 'r8sint',
+},
+{
+format: 'rg8uint',
+},
+{
+format: 'r8uint',
+writeMask: GPUColorWrite.RED,
+},
+{
+format: 'rg8sint',
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+failOp: 'zero',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'invert',
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilReadMask: 3953,
+stencilWriteMask: 762,
+depthBias: 10,
+depthBiasSlopeScale: 44,
+depthBiasClamp: 41,
+},
+}
+);
+let imageBitmap37 = await createImageBitmap(video22);
+let videoFrame37 = new VideoFrame(videoFrame10, {timestamp: 0});
+let texture196 = device7.createTexture(
+{
+label: '\ue422\u{1fb1f}\ud602\u{1fb05}\u{1ff0a}',
+size: {width: 8645, height: 4, depthOrArrayLayers: 1},
+mipLevelCount: 14,
+format: 'astc-5x4-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+await device7.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas4);
+let commandEncoder138 = device11.createCommandEncoder();
+let sampler124 = device11.createSampler(
+{
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 37.884,
+lodMaxClamp: 67.461,
+}
+);
+let externalTexture16 = device11.importExternalTexture(
+{
+label: '\uff74\u23cc\u8740',
+source: videoFrame7,
+colorSpace: 'display-p3',
+}
+);
+let commandEncoder139 = device7.createCommandEncoder(
+{
+label: '\u48ba\u{1f8ea}',
+}
+);
+let querySet136 = device7.createQuerySet({
+label: '\ua680\ucda2\u06c8',
+type: 'occlusion',
+count: 3715,
+});
+let texture197 = device7.createTexture(
+{
+label: '\u01ab\uda77\uc549\u7665\u{1f89f}\u087f\u82dc\u0091',
+size: [10608, 5, 23],
+mipLevelCount: 2,
+format: 'astc-6x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+computePassEncoder62.setBindGroup(
+3,
+bindGroup64,
+new Uint32Array(7755),
+5253,
+0
+);
+} catch {}
+try {
+device7.pushErrorScope('validation');
+} catch {}
+try {
+buffer62.unmap();
+} catch {}
+try {
+commandEncoder139.copyTextureToTexture(
+{
+  texture: texture197,
+  mipLevel: 1,
+  origin: { x: 3774, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture197,
+  mipLevel: 0,
+  origin: { x: 3960, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1416, height: 0, depthOrArrayLayers: 21}
+);
+} catch {}
+let commandEncoder140 = device6.createCommandEncoder(
+{
+label: '\u5247\u{1f73d}\uc775\u{1faf6}\ue30d',
+}
+);
+try {
+renderPassEncoder35.end();
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(
+buffer55,
+'uint16',
+34204,
+4438
+);
+} catch {}
+try {
+renderBundleEncoder100.setIndexBuffer(
+buffer55,
+'uint16',
+4574,
+9631
+);
+} catch {}
+try {
+commandEncoder129.clearBuffer(
+buffer63,
+1760,
+848
+);
+dissociateBuffer(device6, buffer63);
+} catch {}
+let pipeline144 = device6.createComputePipeline(
+{
+label: '\u85de\u9b91',
+layout: pipelineLayout28,
+compute: {
+module: shaderModule37,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder141 = device8.createCommandEncoder(
+{
+label: '\u{1f72d}\u2d3e\u29c2\u2038\u1627',
+}
+);
+let querySet137 = device8.createQuerySet({
+label: '\ud597\u03ba\u0120\uc12b\u1a0f\u0ee4\u0ce8',
+type: 'occlusion',
+count: 2952,
+});
+let computePassEncoder70 = commandEncoder112.beginComputePass();
+let renderBundle142 = renderBundleEncoder112.finish();
+try {
+renderPassEncoder41.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(
+90,
+undefined,
+2710110917,
+590462693
+);
+} catch {}
+try {
+commandEncoder141.copyTextureToTexture(
+{
+  texture: texture153,
+  mipLevel: 1,
+  origin: { x: 10, y: 8, z: 8 },
+  aspect: 'all',
+},
+{
+  texture: texture153,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 12 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 24}
+);
+} catch {}
+let pipeline145 = await device8.createRenderPipelineAsync(
+{
+label: '\u37ff\u6b26\u0de6\uad72\u{1f822}\u{1ffa9}\u145d',
+layout: pipelineLayout40,
+vertex: {
+module: shaderModule40,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 492,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 16,
+shaderLocation: 15,
+},
+{
+format: 'float16x2',
+offset: 348,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x4',
+offset: 388,
+shaderLocation: 12,
+},
+{
+format: 'float32x4',
+offset: 328,
+shaderLocation: 5,
+},
+{
+format: 'unorm8x2',
+offset: 184,
+shaderLocation: 8,
+},
+{
+format: 'unorm16x4',
+offset: 416,
+shaderLocation: 14,
+},
+{
+format: 'uint8x4',
+offset: 268,
+shaderLocation: 0,
+},
+{
+format: 'sint32x4',
+offset: 52,
+shaderLocation: 9,
+},
+{
+format: 'uint16x2',
+offset: 128,
+shaderLocation: 11,
+},
+{
+format: 'uint16x2',
+offset: 52,
+shaderLocation: 4,
+},
+{
+format: 'unorm16x2',
+offset: 136,
+shaderLocation: 10,
+},
+{
+format: 'uint32x2',
+offset: 216,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 1596,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 984,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x3',
+offset: 388,
+shaderLocation: 1,
+},
+{
+format: 'sint8x2',
+offset: 574,
+shaderLocation: 6,
+},
+{
+format: 'uint32x3',
+offset: 912,
+shaderLocation: 3,
+},
+{
+format: 'sint16x4',
+offset: 212,
+shaderLocation: 13,
+}
+],
+}
+]
+},
+multisample: {
+mask: 0xe2f70cd2,
+},
+fragment: {
+module: shaderModule40,
+entryPoint: 'fragment0',
+targets: [
+undefined,
+{
+format: 'rg16uint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+{
+format: 'r16sint',
+writeMask: 0,
+},
+{
+format: 'rg11b10ufloat',
+writeMask: GPUColorWrite.BLUE,
+},
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'not-equal',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'invert',
+},
+stencilReadMask: 3865,
+stencilWriteMask: 1773,
+depthBias: 23,
+depthBiasSlopeScale: 16,
+depthBiasClamp: 44,
+},
+}
+);
+let canvas41 = document.createElement('canvas');
+let promise62 = adapter13.requestAdapterInfo();
+let videoFrame38 = new VideoFrame(imageBitmap17, {timestamp: 0});
+try {
+window.someLabel = device9.label;
+} catch {}
+try {
+renderBundleEncoder109.setVertexBuffer(
+0,
+undefined,
+1618593679
+);
+} catch {}
+try {
+commandEncoder114.copyBufferToBuffer(
+buffer58,
+17896,
+buffer41,
+3904,
+576
+);
+dissociateBuffer(device9, buffer58);
+dissociateBuffer(device9, buffer41);
+} catch {}
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+try {
+offscreenCanvas52.getContext('2d');
+} catch {}
+let bindGroupLayout84 = device12.createBindGroupLayout(
+{
+entries: [
+
+],
+}
+);
+let querySet138 = device12.createQuerySet({
+label: '\uc8bd\u2f92\uf65d\u8d60\u5dd8\u{1f847}\uc95c\u{1fc34}',
+type: 'occlusion',
+count: 2915,
+});
+let textureView170 = texture181.createView(
+{
+label: '\u0d03\u02d2\u01a6\u{1f997}\u2aeb',
+mipLevelCount: 2,
+}
+);
+let renderBundle143 = renderBundleEncoder116.finish(
+{
+label: '\ua220\u0fae'
+}
+);
+let textureView171 = texture187.createView(
+{
+label: '\u{1fd88}\ud50b\ucbac\u6a6a\u1d33',
+format: 'rgba16sint',
+baseMipLevel: 0,
+mipLevelCount: 5,
+}
+);
+let computePassEncoder71 = commandEncoder134.beginComputePass(
+{
+label: '\u004e\u44e4\u202f\u07da\u0bab\u2c45'
+}
+);
+let renderBundle144 = renderBundleEncoder116.finish(
+{
+
+}
+);
+try {
+await promise62;
+} catch {}
+let offscreenCanvas53 = new OffscreenCanvas(962, 506);
+try {
+adapter12.label = '\u{1fa4b}\u{1ff0d}\ufbdd';
+} catch {}
+try {
+renderBundle86.label = '\u85cd\u{1f878}\uf40a';
+} catch {}
+try {
+computePassEncoder63.setPipeline(
+pipeline138
+);
+} catch {}
+try {
+renderPassEncoder37.setStencilReference(
+123
+);
+} catch {}
+try {
+renderPassEncoder37.setViewport(
+17.10,
+5.351,
+32.74,
+9.303,
+0.4057,
+0.9272
+);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(
+buffer55,
+'uint16',
+27778
+);
+} catch {}
+try {
+renderBundleEncoder106.setBindGroup(
+3,
+bindGroup69
+);
+} catch {}
+try {
+commandEncoder110.copyTextureToTexture(
+{
+  texture: texture134,
+  mipLevel: 0,
+  origin: { x: 138, y: 32, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture134,
+  mipLevel: 1,
+  origin: { x: 27, y: 15, z: 0 },
+  aspect: 'all',
+},
+{width: 24, height: 10, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer53,
+8,
+new DataView(new ArrayBuffer(37317)),
+12412,
+13344
+);
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(
+/*
+{width: 101, height: 25, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame26,
+  origin: { x: 2, y: 121 },
+  flipY: false,
+},
+{
+  texture: texture134,
+  mipLevel: 1,
+  origin: { x: 34, y: 4, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 19, height: 12, depthOrArrayLayers: 1}
+);
+} catch {}
+let adapter19 = await navigator.gpu.requestAdapter(
+{
+}
+);
+let commandEncoder142 = device4.createCommandEncoder(
+{
+label: '\u69d0\u{1fcfa}\u4840\ubb2f\u0e6a\u9431\u0ed7\u{1f9bd}',
+}
+);
+let querySet139 = device4.createQuerySet({
+type: 'occlusion',
+count: 1650,
+});
+let textureView172 = texture115.createView(
+{
+label: '\uabb3\u{1fe0f}',
+dimension: '2d-array',
+baseMipLevel: 1,
+mipLevelCount: 2,
+}
+);
+let renderBundleEncoder120 = device4.createRenderBundleEncoder(
+{
+label: '\u7a0f\u4623\u0fa1',
+colorFormats: [
+'rg8sint',
+'r8uint',
+'bgra8unorm-srgb',
+'rg16sint',
+'rgb10a2uint',
+'r16float',
+'r16sint'
+],
+sampleCount: 971,
+stencilReadOnly: true,
+}
+);
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder26.setViewport(
+78.83,
+0.4910,
+2.019,
+0.4014,
+0.8800,
+0.9584
+);
+} catch {}
+try {
+commandEncoder137.copyBufferToTexture(
+{
+/* bytesInLastRow: 1024 widthInBlocks: 64 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 49936 */
+offset: 30480,
+bytesPerRow: 1024,
+rowsPerImage: 241,
+buffer: buffer39,
+},
+{
+  texture: texture133,
+  mipLevel: 1,
+  origin: { x: 76, y: 8, z: 0 },
+  aspect: 'all',
+},
+{width: 256, height: 76, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device4, buffer39);
+} catch {}
+try {
+commandEncoder137.copyTextureToBuffer(
+{
+  texture: texture176,
+  mipLevel: 0,
+  origin: { x: 1828, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 5962 widthInBlocks: 2981 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 9870 */
+offset: 9870,
+buffer: buffer36,
+},
+{width: 2981, height: 1, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device4, buffer36);
+} catch {}
+try {
+gpuCanvasContext47.unconfigure();
+} catch {}
+try {
+device12.queue.label = '\u3740\u{1f8ad}\u{1fc18}\u9d79\u{1fd1c}\ue3af\ube0d\u01dc';
+} catch {}
+let bindGroup73 = device12.createBindGroup({
+label: '\uf4ec\u1a06\u0796\ub94e\u83e2\u6ef1',
+layout: bindGroupLayout84,
+entries: [
+
+],
+});
+let pipelineLayout42 = device12.createPipelineLayout(
+{
+label: '\u0bd9\u{1feeb}\u{1fb40}\u058c',
+bindGroupLayouts: [
+bindGroupLayout84,
+bindGroupLayout84,
+bindGroupLayout84,
+bindGroupLayout84,
+bindGroupLayout84,
+bindGroupLayout84,
+bindGroupLayout84,
+bindGroupLayout84,
+bindGroupLayout84,
+bindGroupLayout84
+]
+}
+);
+let textureView173 = texture187.createView(
+{
+label: '\u00cd\u8871\u0b9e\u{1fc7a}',
+baseMipLevel: 1,
+mipLevelCount: 3,
+}
+);
+try {
+computePassEncoder65.end();
+} catch {}
+let commandEncoder143 = device11.createCommandEncoder();
+let textureView174 = texture170.createView(
+{
+baseMipLevel: 0,
+}
+);
+let sampler125 = device11.createSampler(
+{
+label: '\u0c3e\u096c\ucb58',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 78.276,
+compare: 'greater-equal',
+}
+);
+try {
+commandEncoder143.resolveQuerySet(
+querySet133,
+2808,
+188,
+buffer67,
+7936
+);
+} catch {}
+video17.width = 52;
+let bindGroupLayout85 = device4.createBindGroupLayout(
+{
+label: '\u053c\u279d\u1457\u185e\ud2fc\ua9ff\u6f3c',
+entries: [
+{
+binding: 973,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+},
+{
+binding: 370,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '2d' },
+},
+{
+binding: 3852,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}
+],
+}
+);
+let querySet140 = device4.createQuerySet({
+type: 'occlusion',
+count: 1668,
+});
+let renderBundle145 = renderBundleEncoder61.finish(
+{
+label: '\u{1fdbe}\u547e\u0447\u049d\u08bf\u9bc7\u8126\u40b4'
+}
+);
+try {
+computePassEncoder43.end();
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(
+8,
+bindGroup54,
+new Uint32Array(6692),
+895,
+0
+);
+} catch {}
+try {
+renderPassEncoder26.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder36.setStencilReference(
+3755
+);
+} catch {}
+try {
+renderPassEncoder32.setViewport(
+47.98,
+0.05027,
+2.862,
+0.8202,
+0.2032,
+0.7694
+);
+} catch {}
+try {
+renderBundleEncoder97.setBindGroup(
+5,
+bindGroup36
+);
+} catch {}
+try {
+renderBundleEncoder114.setVertexBuffer(
+5,
+buffer51
+);
+} catch {}
+try {
+commandEncoder132.copyBufferToBuffer(
+buffer39,
+1228,
+buffer24,
+7960,
+3316
+);
+dissociateBuffer(device4, buffer39);
+dissociateBuffer(device4, buffer24);
+} catch {}
+let pipeline146 = device4.createComputePipeline(
+{
+label: '\ub06f\u{1f797}\u044e\u0e7f',
+layout: pipelineLayout31,
+compute: {
+module: shaderModule23,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+document.body.prepend(img4);
+offscreenCanvas5.width = 580;
+let buffer68 = device8.createBuffer(
+{
+label: '\ud76e\ud85e\u{1fe15}\u{1ffff}\ub671\u1122\u019b\u{1f86c}\u088e',
+size: 22168,
+usage: GPUBufferUsage.UNIFORM,
+}
+);
+let computePassEncoder72 = commandEncoder107.beginComputePass(
+{
+label: '\u0849\ua0a2\u05da\u{1fbe9}\u62fc\u{1fdeb}\u0c55\u8a80'
+}
+);
+let renderPassEncoder43 = commandEncoder141.beginRenderPass(
+{
+label: '\ue37b\u0c44\u9120',
+colorAttachments: [
+undefined,
+{
+view: textureView166,
+depthSlice: 5,
+clearValue: { r: -356.0, g: -690.1, b: -749.8, a: 580.6, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView166,
+depthSlice: 4,
+clearValue: { r: -430.9, g: 740.8, b: -943.5, a: 770.3, },
+loadOp: 'clear',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet96,
+maxDrawCount: 194648,
+}
+);
+let renderBundleEncoder121 = device8.createRenderBundleEncoder(
+{
+label: '\u0412\u912f\u95ce\u8ce9\u0176\ud10e\u0c74\u039d',
+colorFormats: [
+'rg16uint',
+'r16uint'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 347,
+}
+);
+let renderBundle146 = renderBundleEncoder121.finish(
+{
+label: '\u{1f821}\u688f'
+}
+);
+try {
+renderBundleEncoder119.setIndexBuffer(
+buffer40,
+'uint32',
+22012
+);
+} catch {}
+let imageBitmap38 = await createImageBitmap(offscreenCanvas26);
+let imageData38 = new ImageData(176, 172);
+let textureView175 = texture193.createView(
+{
+label: '\u0200\u{1f7f2}\u{1feeb}\u240b\u2d17\u{1f960}\u{1fed7}\u{1fb65}',
+mipLevelCount: 1,
+}
+);
+let video36 = await videoWithData();
+try {
+window.someLabel = querySet134.label;
+} catch {}
+let bindGroup74 = device6.createBindGroup({
+label: '\uaa67\ua6ec\u82b0\uea1c\u{1f7c6}\u30a9\u{1fe3c}\ud3f6',
+layout: bindGroupLayout55,
+entries: [
+
+],
+});
+let commandEncoder144 = device6.createCommandEncoder(
+{
+}
+);
+try {
+computePassEncoder63.setPipeline(
+pipeline144
+);
+} catch {}
+try {
+device6.pushErrorScope('out-of-memory');
+} catch {}
+try {
+await buffer53.mapAsync(
+GPUMapMode.READ,
+0,
+13960
+);
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(
+/*
+{width: 202, height: 51, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 42, y: 362 },
+  flipY: true,
+},
+{
+  texture: texture134,
+  mipLevel: 0,
+  origin: { x: 1, y: 11, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+},
+{width: 137, height: 37, depthOrArrayLayers: 1}
+);
+} catch {}
+let img37 = await imageWithData(22, 19, '#0eeae603', '#d4fefcf3');
+let video37 = await videoWithData();
+try {
+await adapter16.requestAdapterInfo();
+} catch {}
+let bindGroupLayout86 = device8.createBindGroupLayout(
+{
+label: '\u0591\u986c\u{1fc64}\u61e0\u{1fb82}',
+entries: [
+
+],
+}
+);
+let renderBundle147 = renderBundleEncoder112.finish(
+{
+
+}
+);
+try {
+computePassEncoder69.setPipeline(
+pipeline135
+);
+} catch {}
+try {
+renderPassEncoder41.setStencilReference(
+3646
+);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(
+buffer40,
+'uint32',
+12776,
+31599
+);
+} catch {}
+let promise63 = device8.queue.onSubmittedWorkDone();
+try {
+await promise63;
+} catch {}
+let videoFrame39 = new VideoFrame(videoFrame35, {timestamp: 0});
+try {
+canvas41.getContext('webgpu');
+} catch {}
+let promise64 = adapter19.requestDevice({
+label: '\u07fa\u09b0',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxBindGroups: 4,
+maxColorAttachmentBytesPerSample: 48,
+maxVertexAttributes: 26,
+maxVertexBufferArrayStride: 34751,
+maxStorageTexturesPerShaderStage: 44,
+maxStorageBuffersPerShaderStage: 43,
+maxDynamicStorageBuffersPerPipelineLayout: 58899,
+maxBindingsPerBindGroup: 5657,
+maxTextureDimension1D: 11384,
+maxTextureDimension2D: 11568,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 141061902,
+maxUniformBuffersPerShaderStage: 38,
+maxInterStageShaderVariables: 93,
+maxInterStageShaderComponents: 112,
+},
+});
+try {
+commandEncoder138.resolveQuerySet(
+querySet133,
+1449,
+1412,
+buffer67,
+768
+);
+} catch {}
+try {
+device11.queue.writeTexture(
+{
+  texture: texture175,
+  mipLevel: 0,
+  origin: { x: 1088, y: 0, z: 107 },
+  aspect: 'all',
+},
+arrayBuffer5,
+/* required buffer size: 5953060 */{
+offset: 505,
+bytesPerRow: 6299,
+rowsPerImage: 63,
+},
+{width: 3008, height: 0, depthOrArrayLayers: 16}
+);
+} catch {}
+let computePassEncoder73 = commandEncoder137.beginComputePass(
+{
+
+}
+);
+let renderBundle148 = renderBundleEncoder64.finish(
+{
+
+}
+);
+try {
+renderPassEncoder32.setVertexBuffer(
+2,
+buffer51,
+24500,
+33401
+);
+} catch {}
+try {
+renderBundleEncoder120.setBindGroup(
+9,
+bindGroup39
+);
+} catch {}
+try {
+renderBundleEncoder120.setVertexBuffer(
+0,
+buffer51,
+9336,
+31225
+);
+} catch {}
+try {
+device4.queue.writeBuffer(
+buffer36,
+1292,
+new BigUint64Array(58327),
+42537,
+496
+);
+} catch {}
+let bindGroup75 = device8.createBindGroup({
+label: '\u54ed\uc62e\u731e\ud40e\u493e\u3fac\u81a2\u064d',
+layout: bindGroupLayout86,
+entries: [
+
+],
+});
+let commandEncoder145 = device8.createCommandEncoder(
+{
+label: '\uc6b8\udf28\u015f\u{1fe3b}\ubbdd\u{1fb74}\ucb05\u0c6d\u08a3\ucc34\u16d8',
+}
+);
+let computePassEncoder74 = commandEncoder145.beginComputePass(
+{
+label: '\u0730\u34e4\u0747\u{1f92d}\u8691\u0268\u2284'
+}
+);
+try {
+renderPassEncoder43.setBindGroup(
+0,
+bindGroup75
+);
+} catch {}
+let pipeline147 = device8.createComputePipeline(
+{
+label: '\ua95b\u7928\u083d\u086b\u3ceb\u{1f67b}\u07a7',
+layout: pipelineLayout37,
+compute: {
+module: shaderModule35,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext31.unconfigure();
+} catch {}
+let imageBitmap39 = await createImageBitmap(img22);
+try {
+offscreenCanvas51.getContext('webgl2');
+} catch {}
+let imageData39 = new ImageData(72, 136);
+let imageBitmap40 = await createImageBitmap(video30);
+let img38 = await imageWithData(290, 135, '#804eba6e', '#bf7c1940');
+let promise65 = adapter7.requestAdapterInfo();
+try {
+device8.label = '\u9fef\u090f\u32b5\u2b7b\u{1fe57}\u4ebe\ud007\u0d2d\u0991';
+} catch {}
+let bindGroupLayout87 = device8.createBindGroupLayout(
+{
+label: '\u{1f7f0}\u436a\u10a2\ub48a',
+entries: [
+{
+binding: 789,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}
+],
+}
+);
+let bindGroup76 = device8.createBindGroup({
+label: '\u3d3b\u{1f834}\u0321\ub5e3\u0e27\ueec5\u{1fcd6}\u0329',
+layout: bindGroupLayout86,
+entries: [
+
+],
+});
+let querySet141 = device8.createQuerySet({
+label: '\u9e80\uc3c7\u0ccc\uf1e2\u0940\u2315\u465b\u{1fd13}\ue9e2\uceef',
+type: 'occlusion',
+count: 3605,
+});
+let textureView176 = texture157.createView(
+{
+arrayLayerCount: 1,
+}
+);
+let renderBundleEncoder122 = device8.createRenderBundleEncoder(
+{
+label: '\u8e84\u2026',
+colorFormats: [
+'rg16uint',
+'r16uint',
+undefined,
+'bgra8unorm-srgb'
+],
+sampleCount: 610,
+depthReadOnly: true,
+stencilReadOnly: false,
+}
+);
+try {
+renderPassEncoder43.setBindGroup(
+0,
+bindGroup76,
+new Uint32Array(9117),
+2160,
+0
+);
+} catch {}
+try {
+device8.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device8.queue.writeBuffer(
+buffer59,
+1116,
+new DataView(new ArrayBuffer(24649)),
+21512,
+288
+);
+} catch {}
+try {
+await promise65;
+} catch {}
+let commandEncoder146 = device3.createCommandEncoder(
+{
+label: '\u0452\ue21b',
+}
+);
+let commandBuffer19 = commandEncoder146.finish(
+{
+label: '\ubae4\u001e\u{1fda9}\u{1fc7f}\u37da\u3918\u{1fa01}\u4f50\ub27b\u5169\u{1fd99}',
+}
+);
+try {
+renderPassEncoder39.setBindGroup(
+4,
+bindGroup29,
+new Uint32Array(6043),
+2512,
+0
+);
+} catch {}
+try {
+renderPassEncoder39.endOcclusionQuery();
+} catch {}
+try {
+device3.queue.writeBuffer(
+buffer30,
+32256,
+new DataView(new ArrayBuffer(17592))
+);
+} catch {}
+try {
+device3.destroy();
+} catch {}
+try {
+if (!arrayBuffer17.detached) { new Uint8Array(arrayBuffer17).fill(0x55) };
+} catch {}
+let img39 = await imageWithData(91, 76, '#661dce43', '#325db4f4');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageBitmap41 = await createImageBitmap(offscreenCanvas24);
+gc();
+let textureView177 = texture187.createView(
+{
+label: '\u015d\u3173\u{1facb}\u0777\u04d1\u2adc',
+baseMipLevel: 7,
+mipLevelCount: 1,
+}
+);
+let renderPassEncoder44 = commandEncoder125.beginRenderPass(
+{
+label: '\u649e\u01c5\u6586\u0ad1\u24d8\uacbc',
+colorAttachments: [
+undefined,
+{
+view: textureView177,
+depthSlice: 8,
+clearValue: { r: -914.4, g: 8.056, b: -564.2, a: -376.2, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView177,
+depthSlice: 9,
+clearValue: { r: 946.2, g: 490.4, b: 171.6, a: -880.5, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView177,
+depthSlice: 0,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView177,
+depthSlice: 11,
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView177,
+depthSlice: 3,
+clearValue: { r: 351.0, g: -105.9, b: 969.7, a: -49.45, },
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet138,
+}
+);
+let renderBundleEncoder123 = device12.createRenderBundleEncoder(
+{
+colorFormats: [
+'r16float',
+'rg32sint'
+],
+sampleCount: 143,
+depthReadOnly: true,
+}
+);
+let sampler126 = device12.createSampler(
+{
+label: '\u6afa\u91ef\u26b4\u062e\u{1fd03}\u{1f9a5}\u95ec\uaf6e\u0af6\u4b2f\ue09e',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 46.302,
+lodMaxClamp: 62.562,
+maxAnisotropy: 19,
+}
+);
+try {
+renderPassEncoder44.setBindGroup(
+2,
+bindGroup73
+);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([]);
+} catch {}
+let promise66 = adapter17.requestAdapterInfo();
+let bindGroup77 = device8.createBindGroup({
+label: '\u5252\u408d\u2d45\ueed3\u33c2\u297f\u255e\u0d49',
+layout: bindGroupLayout87,
+entries: [
+{
+binding: 789,
+resource: {
+buffer: buffer68,
+offset: 20480,
+size: 1544,
+}
+}
+],
+});
+let texture198 = device8.createTexture(
+{
+label: '\uc813\u{1fbc2}\u0737\u020f\u42ec\u{1f6c4}\u02cc',
+size: [123, 1, 102],
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'rgba8unorm'
+],
+}
+);
+let textureView178 = texture149.createView(
+{
+baseMipLevel: 3,
+mipLevelCount: 1,
+}
+);
+try {
+renderPassEncoder41.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(
+buffer40,
+'uint16',
+15682,
+48834
+);
+} catch {}
+let bindGroupLayout88 = device12.createBindGroupLayout(
+{
+entries: [
+{
+binding: 1313,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'uniform', minBindingSize: 592731, hasDynamicOffset: true },
+},
+{
+binding: 2855,
+visibility: GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 744936, hasDynamicOffset: true },
+},
+{
+binding: 1508,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+}
+],
+}
+);
+let commandEncoder147 = device12.createCommandEncoder(
+{
+}
+);
+let commandBuffer20 = commandEncoder147.finish(
+{
+label: '\u03cb\ub043\u0bcc\ud7f3\u088e\u0638',
+}
+);
+let renderBundle149 = renderBundleEncoder116.finish(
+{
+label: '\u0a0b\ua2ad\u4280\u009a\u{1f645}\u44fb\u{1fa63}\u0f7e\ue5e3\u0f9d\u970d'
+}
+);
+try {
+renderPassEncoder44.end();
+} catch {}
+let gpuCanvasContext48 = canvas40.getContext('webgpu');
+let offscreenCanvas54 = new OffscreenCanvas(83, 863);
+let querySet142 = device12.createQuerySet({
+label: '\u{1fe14}\ua3df\u{1f719}\u8c37\u020f\ubf94\uec86\u{1f88e}\u4cf9',
+type: 'occlusion',
+count: 1594,
+});
+try {
+device12.queue.writeTexture(
+{
+  texture: texture181,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(59),
+/* required buffer size: 59 */{
+offset: 59,
+bytesPerRow: 313,
+},
+{width: 20, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await device12.queue.onSubmittedWorkDone();
+} catch {}
+let textureView179 = texture193.createView(
+{
+label: '\u0026\u{1f9bc}\u02f3\u021a\u0a6f\u4093\u9322\u006b\u7c00\ub872',
+dimension: '2d-array',
+format: 'rgba8unorm-srgb',
+}
+);
+let texture199 = device6.createTexture(
+{
+size: [11290, 6, 239],
+mipLevelCount: 14,
+format: 'astc-10x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let textureView180 = texture111.createView(
+{
+label: '\u0c00\u47ae\u0360\u{1fce2}\uf0fc\u2599\u6604\uca4d\u219b',
+mipLevelCount: 1,
+baseArrayLayer: 56,
+arrayLayerCount: 2,
+}
+);
+let renderPassEncoder45 = commandEncoder117.beginRenderPass(
+{
+label: '\u7dd2\u0a3c\u3a6c\u9469\u{1ff2e}\u0e7a\uffd0\u8fc2\u0581\u006c\ufea8',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+undefined,
+undefined,
+{
+view: textureView130,
+clearValue: { r: 965.6, g: -915.6, b: -494.5, a: 671.4, },
+loadOp: 'load',
+storeOp: 'store'
+},
+undefined,
+undefined
+],
+occlusionQuerySet: querySet124,
+maxDrawCount: 78976,
+}
+);
+try {
+renderPassEncoder37.setBlendConstant({ r: -214.5, g: -964.5, b: -430.3, a: 576.4, });
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(
+buffer55,
+'uint32'
+);
+} catch {}
+try {
+commandEncoder110.clearBuffer(
+buffer53,
+17216,
+2152
+);
+dissociateBuffer(device6, buffer53);
+} catch {}
+let videoFrame40 = new VideoFrame(offscreenCanvas41, {timestamp: 0});
+try {
+adapter16.label = '\u051e\u5393\u{1f8cf}\u8b19\u40ed\u307f\u4dbb\u{1f77b}\u{1f739}\u{1f997}\u{1fb4f}';
+} catch {}
+let renderBundleEncoder124 = device9.createRenderBundleEncoder(
+{
+colorFormats: [
+'r8uint',
+'rgba16float',
+'rgba32float',
+'rg8unorm',
+'rgba8unorm',
+undefined,
+'r8sint'
+],
+sampleCount: 34,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder109.setBindGroup(
+0,
+bindGroup53,
+new Uint32Array(8421),
+7254,
+0
+);
+} catch {}
+try {
+renderBundleEncoder109.setVertexBuffer(
+49,
+undefined,
+66731185,
+2636960640
+);
+} catch {}
+let video38 = await videoWithData();
+let imageBitmap42 = await createImageBitmap(offscreenCanvas22);
+let shaderModule41 = device6.createShaderModule(
+{
+label: '\u0aa2\u0f28\u{1f6c0}\u0635\u{1ff9c}',
+code: `@group(3) @binding(4118)
+var<storage, read_write> type54: array<u32>;
+@group(2) @binding(2889)
+var<storage, read_write> function34: array<u32>;
+@group(2) @binding(2136)
+var<storage, read_write> field45: array<u32>;
+
+@compute @workgroup_size(6, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S37 {
+@location(45) f0: vec3<i32>,
+@location(64) f1: vec2<i32>
+}
+struct FragmentOutput0 {
+@location(0) f0: vec4<f32>,
+@location(3) f1: vec2<f32>,
+@location(5) f2: i32,
+@builtin(sample_mask) f3: u32,
+@location(1) f4: u32,
+@location(2) f5: vec2<u32>,
+@location(6) f6: vec2<i32>
+}
+
+@fragment
+fn fragment0(@location(4) a0: u32, @location(13) a1: vec3<f16>, @location(7) a2: i32, @builtin(position) a3: vec4<f32>, @location(37) a4: vec3<u32>, @location(34) a5: vec2<f16>, a6: S37, @location(70) a7: vec4<i32>, @location(80) a8: f32, @location(35) a9: vec4<i32>, @builtin(sample_index) a10: u32, @location(0) a11: vec4<f32>, @location(74) a12: vec4<u32>, @location(77) a13: vec2<f32>, @location(63) a14: vec3<u32>, @location(79) a15: vec4<i32>, @builtin(sample_mask) a16: u32, @location(60) a17: vec4<u32>, @builtin(front_facing) a18: bool, @location(10) a19: vec2<f16>, @location(20) a20: vec2<u32>, @location(15) a21: f16) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S36 {
+@location(8) f0: f16,
+@location(14) f1: vec3<i32>,
+@location(5) f2: vec3<f32>,
+@location(16) f3: vec2<u32>
+}
+struct VertexOutput0 {
+@location(79) f572: vec4<i32>,
+@location(80) f573: f32,
+@location(60) f574: vec4<u32>,
+@location(48) f575: vec4<f16>,
+@location(70) f576: vec4<i32>,
+@location(7) f577: i32,
+@location(45) f578: vec3<i32>,
+@location(15) f579: f16,
+@location(0) f580: vec4<f32>,
+@location(34) f581: vec2<f16>,
+@location(13) f582: vec3<f16>,
+@location(20) f583: vec2<u32>,
+@location(10) f584: vec2<f16>,
+@location(23) f585: vec4<u32>,
+@location(37) f586: vec3<u32>,
+@location(35) f587: vec4<i32>,
+@location(64) f588: vec2<i32>,
+@location(77) f589: vec2<f32>,
+@location(4) f590: u32,
+@builtin(position) f591: vec4<f32>,
+@location(11) f592: vec3<f32>,
+@location(74) f593: vec4<u32>,
+@location(63) f594: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec2<i32>, a1: S36, @location(6) a2: vec2<u32>, @location(9) a3: f32, @location(7) a4: vec2<i32>, @location(13) a5: vec4<u32>, @location(10) a6: vec4<i32>, @location(15) a7: vec3<f16>, @location(12) a8: u32, @builtin(vertex_index) a9: u32, @location(2) a10: vec3<f16>, @location(4) a11: vec3<f16>, @builtin(instance_index) a12: u32, @location(3) a13: f16, @location(11) a14: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+}
+);
+let commandEncoder148 = device6.createCommandEncoder(
+{
+label: '\u05c6\udd76\ua9e6\u0f45\u0667\ubdf1\u{1fcd8}\u5a7a\ua882\u{1ffbc}\u{1f6c7}',
+}
+);
+let renderPassEncoder46 = commandEncoder140.beginRenderPass(
+{
+label: '\ua1f5\u9aeb\u{1fa1e}\u{1f678}\u0fc1\u0a2c\u3f2f\uaed0',
+colorAttachments: [
+{
+view: textureView130,
+clearValue: { r: 86.26, g: 842.0, b: -543.1, a: 278.5, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+undefined
+],
+occlusionQuerySet: querySet124,
+maxDrawCount: 31816,
+}
+);
+let renderBundleEncoder125 = device6.createRenderBundleEncoder(
+{
+label: '\u499e\u8c80',
+colorFormats: [
+'rgba16uint',
+'rg32uint',
+'rgba16sint',
+'rg32float',
+'rg32float',
+'rgba8unorm',
+'rg8uint'
+],
+sampleCount: 426,
+}
+);
+let renderBundle150 = renderBundleEncoder104.finish(
+{
+label: '\u6f21\u07f0\u02d7\u{1ff01}\u0ae9\uc7d5\u1e30\u99ae\ud25f\uccc1'
+}
+);
+try {
+renderPassEncoder45.end();
+} catch {}
+let pipeline148 = await promise60;
+try {
+buffer67.unmap();
+} catch {}
+try {
+offscreenCanvas54.getContext('webgl');
+} catch {}
+let commandEncoder149 = device10.createCommandEncoder(
+{
+label: '\u972f\uc2b0\u080c\u1604\ua126\u{1fc32}',
+}
+);
+let sampler127 = device10.createSampler(
+{
+label: '\u0a7a\u8afd\ua442\u7678\u{1f929}\u0cb4\u{1ffa5}\u{1f6e2}',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 21.768,
+lodMaxClamp: 45.091,
+maxAnisotropy: 9,
+}
+);
+try {
+renderPassEncoder42.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder40.setScissorRect(
+4,
+1,
+43,
+2
+);
+} catch {}
+try {
+renderBundleEncoder108.setVertexBuffer(
+6,
+buffer66
+);
+} catch {}
+try {
+commandEncoder149.copyTextureToTexture(
+{
+  texture: texture188,
+  mipLevel: 4,
+  origin: { x: 13, y: 1, z: 5 },
+  aspect: 'all',
+},
+{
+  texture: texture188,
+  mipLevel: 0,
+  origin: { x: 410, y: 0, z: 1489 },
+  aspect: 'all',
+},
+{width: 33, height: 0, depthOrArrayLayers: 86}
+);
+} catch {}
+try {
+renderPassEncoder42.pushDebugGroup(
+'\uccb0'
+);
+} catch {}
+try {
+device10.queue.writeTexture(
+{
+  texture: texture138,
+  mipLevel: 0,
+  origin: { x: 8, y: 5, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(8),
+/* required buffer size: 674 */{
+offset: 674,
+bytesPerRow: 414,
+},
+{width: 112, height: 125, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline149 = device10.createRenderPipeline(
+{
+label: '\u01a6\u5d18\u0761\u{1f6ea}\u8b7d\uc2cf\u0fc0\u1cf5\u4909\u3dcd',
+layout: pipelineLayout36,
+vertex: {
+module: shaderModule38,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 32428,
+attributes: [
+{
+format: 'snorm16x4',
+offset: 10308,
+shaderLocation: 9,
+},
+{
+format: 'snorm8x4',
+offset: 4896,
+shaderLocation: 12,
+},
+{
+format: 'float16x2',
+offset: 8968,
+shaderLocation: 18,
+},
+{
+format: 'sint16x2',
+offset: 26684,
+shaderLocation: 2,
+},
+{
+format: 'unorm8x2',
+offset: 30186,
+shaderLocation: 7,
+},
+{
+format: 'uint8x2',
+offset: 7472,
+shaderLocation: 5,
+},
+{
+format: 'float16x2',
+offset: 32204,
+shaderLocation: 11,
+},
+{
+format: 'snorm16x4',
+offset: 8656,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 2092,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x2',
+offset: 2072,
+shaderLocation: 0,
+},
+{
+format: 'unorm16x4',
+offset: 1336,
+shaderLocation: 16,
+},
+{
+format: 'sint16x4',
+offset: 1424,
+shaderLocation: 14,
+},
+{
+format: 'float16x4',
+offset: 84,
+shaderLocation: 3,
+},
+{
+format: 'uint32x2',
+offset: 744,
+shaderLocation: 17,
+},
+{
+format: 'float32x4',
+offset: 896,
+shaderLocation: 8,
+},
+{
+format: 'unorm16x2',
+offset: 1956,
+shaderLocation: 15,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0x2e58747a,
+},
+fragment: {
+module: shaderModule38,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.BLUE,
+},
+undefined
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'never',
+failOp: 'invert',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'keep',
+passOp: 'replace',
+},
+stencilReadMask: 1155,
+stencilWriteMask: 1185,
+depthBias: 78,
+depthBiasSlopeScale: 29,
+depthBiasClamp: 49,
+},
+}
+);
+try {
+await promise66;
+} catch {}
+let bindGroup78 = device11.createBindGroup({
+layout: bindGroupLayout80,
+entries: [
+
+],
+});
+let commandEncoder150 = device11.createCommandEncoder(
+{
+}
+);
+let sampler128 = device11.createSampler(
+{
+label: '\u2335\u0fa5\u06cf\u0afa\u{1ff34}\u0b12\ua676\u5be3',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 0.169,
+lodMaxClamp: 0.376,
+maxAnisotropy: 3,
+}
+);
+try {
+gpuCanvasContext2.configure(
+{
+device: device11,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+'bgra8unorm-srgb',
+'astc-8x5-unorm'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device11.queue.writeTexture(
+{
+  texture: texture175,
+  mipLevel: 0,
+  origin: { x: 288, y: 0, z: 198 },
+  aspect: 'all',
+},
+new Int8Array(arrayBuffer14),
+/* required buffer size: 7484650 */{
+offset: 358,
+bytesPerRow: 6026,
+rowsPerImage: 46,
+},
+{width: 2952, height: 0, depthOrArrayLayers: 28}
+);
+} catch {}
+let texture200 = device12.createTexture(
+{
+label: '\u8dbc\u0d82\uc14a',
+size: [145, 27, 96],
+mipLevelCount: 6,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+let renderBundle151 = renderBundleEncoder123.finish(
+{
+label: '\u0058\u{1fd89}\u{1fa50}'
+}
+);
+try {
+texture187.destroy();
+} catch {}
+let promise67 = device12.queue.onSubmittedWorkDone();
+let bindGroupLayout89 = device8.createBindGroupLayout(
+{
+label: '\u0642\u0271\u5e3b\u0ad6',
+entries: [
+{
+binding: 601,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 889,
+visibility: 0,
+sampler: { type: 'filtering' },
+},
+{
+binding: 446,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}
+],
+}
+);
+let renderBundle152 = renderBundleEncoder121.finish(
+{
+label: '\u345d\uc317\u480e\u046a\u1218'
+}
+);
+let sampler129 = device8.createSampler(
+{
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 33.484,
+lodMaxClamp: 91.318,
+maxAnisotropy: 1,
+}
+);
+try {
+renderPassEncoder43.setBindGroup(
+2,
+bindGroup77,
+[]
+);
+} catch {}
+try {
+device8.queue.writeTexture(
+{
+  texture: texture147,
+  mipLevel: 1,
+  origin: { x: 91, y: 0, z: 38 },
+  aspect: 'all',
+},
+new Uint32Array(arrayBuffer14),
+/* required buffer size: 5031919 */{
+offset: 987,
+bytesPerRow: 701,
+rowsPerImage: 156,
+},
+{width: 139, height: 1, depthOrArrayLayers: 47}
+);
+} catch {}
+let gpuCanvasContext49 = offscreenCanvas53.getContext('webgpu');
+let buffer69 = device8.createBuffer(
+{
+label: '\u247a\ua5a2\u{1f9b0}\u{1ff54}\ubf33\u1d4a',
+size: 19382,
+usage: GPUBufferUsage.VERTEX,
+}
+);
+let textureView181 = texture135.createView(
+{
+label: '\u{1fd35}\u{1f603}\u6c40\u4a42\ub9be\u{1f6b8}\u9c66',
+baseMipLevel: 1,
+mipLevelCount: 1,
+}
+);
+try {
+renderPassEncoder41.setBlendConstant({ r: 83.38, g: -504.2, b: 372.4, a: 260.0, });
+} catch {}
+try {
+device8.queue.writeTexture(
+{
+  texture: texture149,
+  mipLevel: 0,
+  origin: { x: 10, y: 0, z: 1 },
+  aspect: 'all',
+},
+new BigUint64Array(arrayBuffer10),
+/* required buffer size: 25984327 */{
+offset: 803,
+bytesPerRow: 549,
+rowsPerImage: 136,
+},
+{width: 113, height: 1, depthOrArrayLayers: 349}
+);
+} catch {}
+try {
+await promise67;
+} catch {}
+canvas17.width = 587;
+try {
+renderPassEncoder43.end();
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(
+buffer40,
+'uint32',
+28900,
+11479
+);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(
+0,
+buffer69,
+820
+);
+} catch {}
+try {
+renderBundleEncoder119.setVertexBuffer(
+2,
+buffer69,
+1804
+);
+} catch {}
+try {
+device8.queue.copyExternalImageToTexture(
+/*
+{width: 123, height: 1, depthOrArrayLayers: 102}
+*/
+{
+  source: imageBitmap18,
+  origin: { x: 24, y: 84 },
+  flipY: true,
+},
+{
+  texture: texture198,
+  mipLevel: 0,
+  origin: { x: 38, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 77, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let pipeline150 = device8.createRenderPipeline(
+{
+layout: 'auto',
+vertex: {
+module: shaderModule40,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 456,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32',
+offset: 276,
+shaderLocation: 3,
+},
+{
+format: 'uint8x4',
+offset: 44,
+shaderLocation: 0,
+},
+{
+format: 'uint32x2',
+offset: 288,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x4',
+offset: 300,
+shaderLocation: 14,
+},
+{
+format: 'uint32x3',
+offset: 436,
+shaderLocation: 4,
+},
+{
+format: 'sint16x4',
+offset: 232,
+shaderLocation: 15,
+},
+{
+format: 'uint16x4',
+offset: 188,
+shaderLocation: 11,
+},
+{
+format: 'unorm16x4',
+offset: 84,
+shaderLocation: 8,
+},
+{
+format: 'unorm16x2',
+offset: 300,
+shaderLocation: 12,
+},
+{
+format: 'sint8x2',
+offset: 364,
+shaderLocation: 13,
+},
+{
+format: 'sint8x2',
+offset: 16,
+shaderLocation: 9,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 268,
+shaderLocation: 10,
+},
+{
+format: 'snorm8x4',
+offset: 372,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 2008,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 228,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 984,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 592,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 128,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x4',
+offset: 60,
+shaderLocation: 6,
+}
+],
+},
+{
+arrayStride: 1784,
+attributes: [
+
+],
+},
+{
+arrayStride: 152,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 116,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint16x4',
+offset: 20,
+shaderLocation: 1,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+cullMode: 'front',
+unclippedDepth: true,
+},
+multisample: {
+count: 4,
+mask: 0xea54b32d,
+},
+fragment: {
+module: shaderModule40,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'rg8uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+},
+{
+format: 'rg16sint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+{
+format: 'r32float',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+let bindGroupLayout90 = device6.createBindGroupLayout(
+{
+entries: [
+{
+binding: 2721,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 361,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+},
+{
+binding: 86,
+visibility: 0,
+storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '2d' },
+}
+],
+}
+);
+let buffer70 = device6.createBuffer(
+{
+label: '\u013e\u7f88\u2eb5\uf3c5\u0b47\u6bb0\u{1f9c7}\ueaf1\u{1fc75}\u{1f91d}\u04f4',
+size: 40664,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: true,
+}
+);
+let commandEncoder151 = device6.createCommandEncoder(
+{
+}
+);
+let renderBundleEncoder126 = device6.createRenderBundleEncoder(
+{
+label: '\u{1fc18}\u055c',
+colorFormats: [
+'rgb10a2uint',
+'rg32float',
+'rgba8uint',
+'rgba32float',
+'rg8sint',
+'rgba32float'
+],
+depthStencilFormat: 'depth32float-stencil8',
+sampleCount: 380,
+depthReadOnly: true,
+}
+);
+let renderBundle153 = renderBundleEncoder69.finish(
+{
+label: '\ub0ad\u35b1\u03f5\u07b7\ub58a\u{1fa47}\u0173\u1f28\u16d0\u6fe7'
+}
+);
+try {
+computePassEncoder63.setBindGroup(
+7,
+bindGroup51,
+new Uint32Array(7664),
+314,
+0
+);
+} catch {}
+try {
+renderPassEncoder46.setViewport(
+67.04,
+0.5898,
+9.025,
+24.28,
+0.7683,
+0.9468
+);
+} catch {}
+try {
+renderBundleEncoder126.setVertexBuffer(
+1,
+buffer57,
+13704,
+6623
+);
+} catch {}
+try {
+commandEncoder135.copyBufferToBuffer(
+buffer70,
+8276,
+buffer63,
+4048,
+5216
+);
+dissociateBuffer(device6, buffer70);
+dissociateBuffer(device6, buffer63);
+} catch {}
+let pipeline151 = device6.createComputePipeline(
+{
+label: '\u{1fabe}\u0c86\u747b\u0d17\u1479\u{1f6cf}\uc77d\u6ccd',
+layout: pipelineLayout39,
+compute: {
+module: shaderModule41,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let imageBitmap43 = await createImageBitmap(offscreenCanvas42);
+let videoFrame41 = new VideoFrame(offscreenCanvas7, {timestamp: 0});
+let renderBundleEncoder127 = device12.createRenderBundleEncoder(
+{
+label: '\u{1faba}\u{1feea}\u0c58\uf92e',
+colorFormats: [
+'r32float',
+'rgba32uint',
+'r32sint'
+],
+sampleCount: 575,
+}
+);
+let renderBundle154 = renderBundleEncoder116.finish(
+{
+
+}
+);
+let textureView182 = texture169.createView(
+{
+label: '\u061b\u{1f8d4}\u4697\u158c\u{1f60c}\u71eb\u{1fad1}\u{1f9ed}',
+mipLevelCount: 1,
+baseArrayLayer: 0,
+}
+);
+let renderPassEncoder47 = commandEncoder149.beginRenderPass(
+{
+label: '\u{1f6b0}\u3077',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+{
+view: textureView146,
+clearValue: { r: 946.4, g: 332.2, b: -339.1, a: -673.3, },
+loadOp: 'clear',
+storeOp: 'store'
+}
+],
+occlusionQuerySet: querySet123,
+maxDrawCount: 47696,
+}
+);
+let sampler130 = device10.createSampler(
+{
+label: '\u0785\u03de\u9926\u4bdd\u{1ffa3}',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 65.996,
+maxAnisotropy: 6,
+}
+);
+try {
+renderPassEncoder47.setBindGroup(
+3,
+bindGroup62
+);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder40.setBlendConstant({ r: 821.7, g: 220.8, b: -936.6, a: -459.5, });
+} catch {}
+try {
+renderPassEncoder47.setScissorRect(
+24,
+0,
+7,
+1
+);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(
+6,
+buffer66,
+168
+);
+} catch {}
+try {
+device10.queue.copyExternalImageToTexture(
+/*
+{width: 99, height: 7, depthOrArrayLayers: 180}
+*/
+{
+  source: imageBitmap5,
+  origin: { x: 2, y: 11 },
+  flipY: false,
+},
+{
+  texture: texture161,
+  mipLevel: 5,
+  origin: { x: 37, y: 2, z: 134 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 14, height: 3, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+renderBundleEncoder127.setBindGroup(
+4,
+bindGroup73
+);
+} catch {}
+offscreenCanvas34.height = 182;
+let adapter20 = await navigator.gpu.requestAdapter();
+let img40 = await imageWithData(280, 200, '#74173164', '#e9a0125a');
+try {
+window.someLabel = device4.queue.label;
+} catch {}
+let textureView183 = texture81.createView(
+{
+label: '\ub712\u5d81',
+dimension: '2d',
+mipLevelCount: 1,
+baseArrayLayer: 69,
+arrayLayerCount: 1,
+}
+);
+try {
+renderPassEncoder26.beginOcclusionQuery(2600);
+} catch {}
+try {
+renderPassEncoder26.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(
+buffer65,
+12956,
+buffer24,
+44836,
+228
+);
+dissociateBuffer(device4, buffer65);
+dissociateBuffer(device4, buffer24);
+} catch {}
+try {
+device4.queue.submit([
+commandBuffer10,
+commandBuffer14,
+]);
+} catch {}
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout91 = device12.createBindGroupLayout(
+{
+entries: [
+{
+binding: 2517,
+visibility: 0,
+externalTexture: {},
+},
+{
+binding: 369,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '2d-array' },
+},
+{
+binding: 472,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '3d' },
+}
+],
+}
+);
+let querySet143 = device12.createQuerySet({
+type: 'occlusion',
+count: 3859,
+});
+let renderBundleEncoder128 = device12.createRenderBundleEncoder(
+{
+colorFormats: [
+'rg16uint',
+'r16float',
+'rg8sint',
+'rg8unorm',
+undefined,
+'rg32float',
+'r32sint',
+'r8uint'
+],
+sampleCount: 638,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder127.setBindGroup(
+0,
+bindGroup73
+);
+} catch {}
+let video39 = await videoWithData();
+let imageData40 = new ImageData(216, 256);
+let offscreenCanvas55 = new OffscreenCanvas(107, 822);
+let imageData41 = new ImageData(152, 232);
+let querySet144 = device6.createQuerySet({
+type: 'occlusion',
+count: 2732,
+});
+let sampler131 = device6.createSampler(
+{
+label: '\ud1a2\u7d2a\u0208\uc93b\u70e3\u{1fd14}\u{1fcb3}\u{1fa08}\u0abb',
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 42.642,
+lodMaxClamp: 91.032,
+}
+);
+try {
+renderPassEncoder46.setBindGroup(
+2,
+bindGroup49,
+new Uint32Array(6749),
+3936,
+0
+);
+} catch {}
+try {
+renderBundleEncoder126.setIndexBuffer(
+buffer55,
+'uint16',
+8094,
+21290
+);
+} catch {}
+try {
+commandEncoder151.copyBufferToBuffer(
+buffer70,
+10220,
+buffer63,
+416,
+12016
+);
+dissociateBuffer(device6, buffer70);
+dissociateBuffer(device6, buffer63);
+} catch {}
+try {
+gpuCanvasContext25.configure(
+{
+device: device6,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba8unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer63,
+3628,
+new Int16Array(833),
+789,
+24
+);
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(
+/*
+{width: 202, height: 51, depthOrArrayLayers: 1}
+*/
+{
+  source: video33,
+  origin: { x: 1, y: 6 },
+  flipY: false,
+},
+{
+  texture: texture134,
+  mipLevel: 0,
+  origin: { x: 145, y: 13, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+},
+{width: 5, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let pipeline152 = device6.createComputePipeline(
+{
+label: '\uc0bf\u734a\u0c0f\u{1ff6d}',
+layout: pipelineLayout28,
+compute: {
+module: shaderModule37,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let commandEncoder152 = device12.createCommandEncoder(
+{
+label: '\u{1ffa7}\ubdeb\ufc15\u0775\u131e\ud0a4',
+}
+);
+let textureView184 = texture200.createView(
+{
+aspect: 'stencil-only',
+baseMipLevel: 1,
+mipLevelCount: 1,
+baseArrayLayer: 83,
+}
+);
+let renderPassEncoder48 = commandEncoder152.beginRenderPass(
+{
+colorAttachments: [
+{
+view: textureView177,
+depthSlice: 1,
+clearValue: { r: 469.4, g: 88.13, b: -670.1, a: 293.6, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+{
+view: textureView177,
+depthSlice: 9,
+clearValue: { r: -889.1, g: 45.78, b: -719.0, a: -12.14, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+{
+view: textureView177,
+depthSlice: 6,
+clearValue: { r: 342.5, g: 140.7, b: 128.6, a: -595.9, },
+loadOp: 'load',
+storeOp: 'discard'
+},
+undefined
+],
+occlusionQuerySet: querySet143,
+maxDrawCount: 100040,
+}
+);
+let renderBundleEncoder129 = device12.createRenderBundleEncoder(
+{
+label: '\u9793\u0f5f\u75a8\u7853\u2ef3\u5470\u88eb\u0122\udc85\u0344',
+colorFormats: [
+'rg16uint',
+'bgra8unorm'
+],
+sampleCount: 472,
+}
+);
+let renderBundle155 = renderBundleEncoder127.finish(
+{
+label: '\u0679\u0ccd\u45b5\u0709\uc853\ucd54\uaf65'
+}
+);
+try {
+renderPassEncoder48.setScissorRect(
+4,
+1,
+6,
+0
+);
+} catch {}
+try {
+renderPassEncoder48.setStencilReference(
+27
+);
+} catch {}
+try {
+gpuCanvasContext23.configure(
+{
+device: device12,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'rgba16float'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device12.queue.submit([
+commandBuffer20,
+]);
+} catch {}
+let pipelineLayout43 = device8.createPipelineLayout(
+{
+label: '\u0d29\u3194\ucfaa',
+bindGroupLayouts: [
+bindGroupLayout87
+]
+}
+);
+let texture201 = device8.createTexture(
+{
+label: '\u58cc\u60cd\ud6fb\u7438\uc71d\u0f92\u820f\u30a5\uaf69\u52f4',
+size: [332],
+dimension: '1d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST,
+}
+);
+try {
+renderPassEncoder41.setBindGroup(
+3,
+bindGroup76
+);
+} catch {}
+try {
+renderPassEncoder41.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder41.setViewport(
+7.830,
+0.1517,
+3.146,
+0.4975,
+0.6226,
+0.9382
+);
+} catch {}
+try {
+await buffer59.mapAsync(
+GPUMapMode.READ,
+0,
+3100
+);
+} catch {}
+let pipeline153 = await device8.createRenderPipelineAsync(
+{
+label: '\u0b57\ua442\u{1f9a4}\u0e45\u5768',
+layout: pipelineLayout40,
+vertex: {
+module: shaderModule39,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1552,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint32x3',
+offset: 32,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 1884,
+shaderLocation: 12,
+},
+{
+format: 'snorm8x4',
+offset: 1080,
+shaderLocation: 13,
+},
+{
+format: 'unorm8x4',
+offset: 1024,
+shaderLocation: 7,
+},
+{
+format: 'sint32x2',
+offset: 1712,
+shaderLocation: 4,
+},
+{
+format: 'sint8x4',
+offset: 792,
+shaderLocation: 11,
+},
+{
+format: 'sint16x2',
+offset: 928,
+shaderLocation: 10,
+},
+{
+format: 'sint8x4',
+offset: 1432,
+shaderLocation: 5,
+},
+{
+format: 'uint32x2',
+offset: 1184,
+shaderLocation: 8,
+},
+{
+format: 'float16x2',
+offset: 404,
+shaderLocation: 1,
+},
+{
+format: 'uint32x2',
+offset: 548,
+shaderLocation: 3,
+},
+{
+format: 'uint32',
+offset: 96,
+shaderLocation: 9,
+},
+{
+format: 'uint8x2',
+offset: 1748,
+shaderLocation: 6,
+},
+{
+format: 'sint8x2',
+offset: 1210,
+shaderLocation: 0,
+},
+{
+format: 'uint32x2',
+offset: 1852,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x2',
+offset: 1232,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule39,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+format: 'rg16sint',
+writeMask: 0,
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'one-minus-src-alpha',
+dstFactor: 'one-minus-src'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'zero',
+dstFactor: 'one-minus-src-alpha'
+},
+},
+format: 'bgra8unorm-srgb',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'bgra8unorm-srgb',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+},
+{
+blend: {
+color: {
+operation: 'reverse-subtract',
+srcFactor: 'one-minus-src',
+dstFactor: 'one-minus-src-alpha'
+},
+alpha: {
+operation: 'reverse-subtract',
+srcFactor: 'src',
+dstFactor: 'dst'
+},
+},
+format: 'bgra8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'invert',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 214,
+stencilWriteMask: 2313,
+depthBias: 15,
+depthBiasSlopeScale: 4,
+depthBiasClamp: 60,
+},
+}
+);
+video32.width = 184;
+offscreenCanvas26.width = 382;
+let imageBitmap44 = await createImageBitmap(offscreenCanvas13);
+let videoFrame42 = new VideoFrame(videoFrame29, {timestamp: 0});
+let bindGroupLayout92 = device12.createBindGroupLayout(
+{
+label: '\u088a\u026f\ucf33\u0840\u091c\u{1fbc3}\ud05b',
+entries: [
+{
+binding: 229,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+},
+{
+binding: 117,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+},
+{
+binding: 1074,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '1d' },
+}
+],
+}
+);
+let texture202 = device12.createTexture(
+{
+label: '\u9f09\u{1ff16}\u0b52\u1980\udccb\ub410\uab1c\u0db4',
+size: [256, 6, 129],
+mipLevelCount: 1,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+'astc-8x6-unorm'
+],
+}
+);
+try {
+renderPassEncoder48.setBlendConstant({ r: 988.8, g: -63.00, b: -318.3, a: -47.17, });
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(
+53,
+undefined
+);
+} catch {}
+try {
+offscreenCanvas55.getContext('webgl2');
+} catch {}
+pseudoSubmit(device8, commandEncoder87);
+let textureView185 = texture157.createView(
+{
+}
+);
+try {
+renderPassEncoder41.setStencilReference(
+1619
+);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(
+5,
+buffer69,
+18084
+);
+} catch {}
+try {
+renderBundleEncoder119.setIndexBuffer(
+buffer40,
+'uint32',
+46484,
+2582
+);
+} catch {}
+let canvas42 = document.createElement('canvas');
+let buffer71 = device8.createBuffer(
+{
+label: '\u{1fc53}\uc319\ud3b0\u3c6f',
+size: 14537,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandEncoder153 = device8.createCommandEncoder(
+{
+label: '\u{1f7f8}\u{1f8f2}\u0c70\u4ffe\ufc35\u022d\u6124\ua1ad\u{1fb5c}\u{1f627}\u{1f845}',
+}
+);
+let renderBundle156 = renderBundleEncoder122.finish(
+{
+label: '\u603e\u{1ffb5}\u841a\uf795\u{1f7d7}\u{1f9e0}\u669e\u8f34\ubbd8\uf39b\uf8c2'
+}
+);
+try {
+renderBundleEncoder119.setBindGroup(
+0,
+bindGroup77,
+new Uint32Array(8924),
+7561,
+0
+);
+} catch {}
+try {
+renderBundleEncoder119.setIndexBuffer(
+buffer40,
+'uint16',
+50456,
+7345
+);
+} catch {}
+try {
+commandEncoder153.clearBuffer(
+buffer50,
+13972,
+8424
+);
+dissociateBuffer(device8, buffer50);
+} catch {}
+try {
+device8.queue.writeBuffer(
+buffer40,
+61808,
+new Float32Array(63329),
+32606,
+576
+);
+} catch {}
+let commandEncoder154 = device12.createCommandEncoder(
+{
+label: '\u{1f631}\udf4e\ua132\uab58\u2321\u9e10',
+}
+);
+pseudoSubmit(device12, commandEncoder154);
+let texture203 = device12.createTexture(
+{
+label: '\u{1f74f}\u0737\u{1fa26}\u{1fabd}\u6e4a\ucdc1\u76f8',
+size: [200, 249, 1],
+mipLevelCount: 2,
+format: 'r8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+let textureView186 = texture200.createView(
+{
+label: '\ubba4\u1895\u0b5e\u2605\u95c4\u{1fa43}\u9378\u0541\u97b1\u{1fecc}\u9043',
+dimension: '2d',
+mipLevelCount: 4,
+baseArrayLayer: 9,
+}
+);
+let externalTexture17 = device12.importExternalTexture(
+{
+source: videoFrame28,
+colorSpace: 'display-p3',
+}
+);
+try {
+renderBundleEncoder129.setBindGroup(
+5,
+bindGroup73
+);
+} catch {}
+try {
+renderBundleEncoder129.insertDebugMarker(
+'\u4e2f'
+);
+} catch {}
+try {
+device12.queue.writeTexture(
+{
+  texture: texture203,
+  mipLevel: 1,
+  origin: { x: 89, y: 6, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(32),
+/* required buffer size: 156 */{
+offset: 156,
+bytesPerRow: 247,
+},
+{width: 8, height: 107, depthOrArrayLayers: 0}
+);
+} catch {}
+let gpuCanvasContext50 = canvas42.getContext('webgpu');
+let texture204 = device10.createTexture(
+{
+label: '\u5164\u3b8b',
+size: {width: 132, height: 1, depthOrArrayLayers: 187},
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2unorm',
+'rgb10a2unorm',
+'rgb10a2unorm'
+],
+}
+);
+let textureView187 = texture204.createView(
+{
+label: '\u{1f84d}\u2d00\u6c09\ua76b\u572a\u03dc\u{1ffe7}\u{1f7db}\ud797',
+mipLevelCount: 5,
+}
+);
+try {
+renderPassEncoder42.setViewport(
+309.1,
+0.8704,
+466.4,
+0.1130,
+0.7415,
+0.8086
+);
+} catch {}
+try {
+device10.queue.writeTexture(
+{
+  texture: texture138,
+  mipLevel: 0,
+  origin: { x: 8, y: 45, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(arrayBuffer7),
+/* required buffer size: 718 */{
+offset: 718,
+bytesPerRow: 248,
+},
+{width: 104, height: 85, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+gpuCanvasContext37.unconfigure();
+} catch {}
+let imageBitmap45 = await createImageBitmap(imageData34);
+let texture205 = device6.createTexture(
+{
+label: '\u006e\u94f0\uc856\uf7d1\u02ee\udab0\uad12\u{1fb03}',
+size: [12765, 60, 1],
+mipLevelCount: 9,
+sampleCount: 1,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'depth32float',
+'depth32float',
+'depth32float'
+],
+}
+);
+let computePassEncoder75 = commandEncoder144.beginComputePass(
+{
+label: '\u37b2\u0837\u{1f6ef}\u0710'
+}
+);
+let renderBundle157 = renderBundleEncoder73.finish();
+let sampler132 = device6.createSampler(
+{
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 63.589,
+maxAnisotropy: 10,
+}
+);
+try {
+renderPassEncoder46.beginOcclusionQuery(1548);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(
+6,
+buffer57,
+23928,
+1352
+);
+} catch {}
+try {
+commandEncoder151.copyBufferToBuffer(
+buffer70,
+18216,
+buffer53,
+14064,
+388
+);
+dissociateBuffer(device6, buffer70);
+dissociateBuffer(device6, buffer53);
+} catch {}
+let videoFrame43 = new VideoFrame(video30, {timestamp: 0});
+let buffer72 = device0.createBuffer(
+{
+size: 38765,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX,
+}
+);
+let texture206 = device0.createTexture(
+{
+label: '\u41af\u2bfe\u0458\u{1f6c1}\u3c43\u8807',
+size: {width: 1064, height: 1, depthOrArrayLayers: 1159},
+mipLevelCount: 11,
+dimension: '3d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+}
+);
+let sampler133 = device0.createSampler(
+{
+label: '\u{1fbd9}\uf40e\ub449',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 77.317,
+lodMaxClamp: 89.050,
+maxAnisotropy: 20,
+}
+);
+try {
+renderPassEncoder8.setBindGroup(
+1,
+bindGroup8
+);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(
+9,
+buffer20,
+7364
+);
+} catch {}
+try {
+renderBundleEncoder81.setVertexBuffer(
+0,
+buffer20,
+15180,
+1670
+);
+} catch {}
+let pipeline154 = device0.createComputePipeline(
+{
+label: '\u{1fe7d}\u20e5\u{1facd}\u381d\u0e0b\u6214\u769c\uaeae\ufeab',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+try {
+gpuCanvasContext44.unconfigure();
+} catch {}
+let sampler134 = device11.createSampler(
+{
+label: '\u0fa5\u8273\u645e',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 23.998,
+lodMaxClamp: 59.114,
+compare: 'greater',
+maxAnisotropy: 3,
+}
+);
+gc();
+let imageBitmap46 = await createImageBitmap(offscreenCanvas36);
+let bindGroupLayout93 = device12.createBindGroupLayout(
+{
+label: '\u0608\uee21\uc5c5\u1120\u253d\u4ba9\u0d00\u12b3\u3b98\uce63',
+entries: [
+
+],
+}
+);
+let commandEncoder155 = device12.createCommandEncoder(
+{
+label: '\u0073\u3665\u{1ffb2}\u{1fbb3}\uaa92\u0577\u{1f758}\u{1f6ea}\u63c4\u681b',
+}
+);
+let computePassEncoder76 = commandEncoder155.beginComputePass(
+{
+label: '\u0473\u{1ffae}\u{1fbe5}\u0ac4\u{1f93b}\ua355\u{1ff9c}\u550e\ua03d\u0723\u1194'
+}
+);
+let renderBundleEncoder130 = device12.createRenderBundleEncoder(
+{
+label: '\u0c9b\ud8d5\u{1fd92}\u52c1\ua208\u78b2\u0905',
+colorFormats: [
+'r8unorm',
+'r8sint',
+undefined,
+'rg8sint',
+'rgba16float',
+'r32sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 744,
+stencilReadOnly: true,
+}
+);
+let renderBundle158 = renderBundleEncoder130.finish(
+{
+label: '\u858b\u0070\u{1fff1}'
+}
+);
+let externalTexture18 = device12.importExternalTexture(
+{
+source: videoFrame12,
+colorSpace: 'display-p3',
+}
+);
+try {
+renderPassEncoder48.setBindGroup(
+3,
+bindGroup73,
+new Uint32Array(5604),
+4930,
+0
+);
+} catch {}
+try {
+renderPassEncoder48.setBlendConstant({ r: -136.5, g: -347.2, b: -327.6, a: -225.8, });
+} catch {}
+try {
+renderBundleEncoder128.setBindGroup(
+4,
+bindGroup73
+);
+} catch {}
+document.body.prepend(canvas26);
+let shaderModule42 = device6.createShaderModule(
+{
+label: '\ua4c9\u{1f9e2}\u{1ff13}\u039f\u14ea\u095e\u7959\u1ad1\u0493\u{1fdbe}',
+code: `@group(2) @binding(1573)
+var<storage, read_write> field46: array<u32>;
+@group(3) @binding(4118)
+var<storage, read_write> global51: array<u32>;
+
+@compute @workgroup_size(3, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+@builtin(frag_depth) f0: f32,
+@location(7) f1: vec4<i32>,
+@location(6) f2: u32
+}
+
+@fragment
+fn fragment0(@location(79) a0: vec3<f16>) -> FragmentOutput0 {
+return FragmentOutput0();
+}
+
+struct S38 {
+@location(14) f0: vec3<f32>,
+@location(9) f1: vec2<f32>,
+@builtin(instance_index) f2: u32,
+@location(4) f3: f16,
+@location(2) f4: vec4<f16>,
+@location(13) f5: vec2<f32>,
+@builtin(vertex_index) f6: u32,
+@location(10) f7: vec4<f32>,
+@location(8) f8: vec2<i32>,
+@location(1) f9: vec2<u32>,
+@location(0) f10: vec3<u32>,
+@location(12) f11: f32,
+@location(3) f12: u32,
+@location(6) f13: vec4<f16>
+}
+struct VertexOutput0 {
+@location(44) f595: vec2<i32>,
+@location(37) f596: vec3<f32>,
+@location(45) f597: vec4<i32>,
+@location(53) f598: vec2<u32>,
+@location(43) f599: f16,
+@location(67) f600: vec4<u32>,
+@location(6) f601: vec3<f16>,
+@location(13) f602: vec3<f16>,
+@location(79) f603: vec3<f16>,
+@location(15) f604: f32,
+@location(12) f605: vec3<f32>,
+@location(74) f606: i32,
+@location(4) f607: vec3<f32>,
+@location(28) f608: vec2<i32>,
+@location(39) f609: vec2<f32>,
+@location(64) f610: vec3<f32>,
+@location(73) f611: vec2<u32>,
+@location(21) f612: f16,
+@location(63) f613: vec2<f32>,
+@location(40) f614: f16,
+@location(30) f615: f16,
+@location(1) f616: u32,
+@location(80) f617: f16,
+@location(17) f618: f16,
+@location(58) f619: vec3<f16>,
+@location(68) f620: vec2<u32>,
+@location(62) f621: vec3<f32>,
+@location(0) f622: vec4<u32>,
+@location(33) f623: vec2<f32>,
+@location(32) f624: vec3<u32>,
+@location(50) f625: vec4<f32>,
+@location(8) f626: vec2<u32>,
+@location(25) f627: vec3<u32>,
+@location(36) f628: vec3<f32>,
+@location(7) f629: u32,
+@location(16) f630: vec3<u32>,
+@location(24) f631: vec2<f16>,
+@location(26) f632: vec2<u32>,
+@location(66) f633: vec2<i32>,
+@builtin(position) f634: vec4<f32>,
+@location(57) f635: vec4<f32>,
+@location(78) f636: vec3<i32>,
+@location(34) f637: vec2<f16>,
+@location(70) f638: u32,
+@location(56) f639: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec4<f16>, a1: S38, @location(5) a2: vec3<f32>, @location(15) a3: vec3<i32>, @location(7) a4: vec3<f16>, @location(16) a5: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+}
+);
+let querySet145 = device6.createQuerySet({
+type: 'occlusion',
+count: 2616,
+});
+let sampler135 = device6.createSampler(
+{
+label: '\u8a4a\u155e\u2c3e\ucab5\u052d\u0dc7',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 1.522,
+lodMaxClamp: 96.048,
+}
+);
+try {
+renderPassEncoder46.setBindGroup(
+1,
+bindGroup47
+);
+} catch {}
+try {
+renderPassEncoder46.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder46.setBlendConstant({ r: -638.0, g: -220.1, b: -340.7, a: 478.3, });
+} catch {}
+let img41 = await imageWithData(81, 260, '#2758d064', '#01710d4d');
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+let pipelineLayout44 = device7.createPipelineLayout(
+{
+label: '\u0398\u{1f960}\u{1fe7a}\ucd18\u{1f9be}\u{1f81f}',
+bindGroupLayouts: [
+bindGroupLayout63,
+bindGroupLayout63,
+bindGroupLayout63,
+bindGroupLayout63,
+bindGroupLayout63
+]
+}
+);
+let querySet146 = device7.createQuerySet({
+type: 'occlusion',
+count: 2334,
+});
+let textureView188 = texture152.createView(
+{
+label: '\u{1ff34}\u5bca\u45e3\u6fec\u05a6\u8fd6\ue50f\u014c\u0486\u0eb0\u884f',
+baseArrayLayer: 64,
+arrayLayerCount: 39,
+}
+);
+try {
+gpuCanvasContext26.unconfigure();
+} catch {}
+let offscreenCanvas56 = new OffscreenCanvas(79, 257);
+try {
+renderBundleEncoder128.pushDebugGroup(
+'\u{1f852}'
+);
+} catch {}
+let img42 = await imageWithData(149, 292, '#a7ba4795', '#874aa6de');
+let buffer73 = device11.createBuffer(
+{
+label: '\u{1f90e}\u{1fff5}\u0789\u0194\u0bcf\u022a\u0805\u5638\uef58\u{1f652}',
+size: 51724,
+usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+mappedAtCreation: true,
+}
+);
+try {
+buffer73.destroy();
+} catch {}
+try {
+commandEncoder136.copyTextureToBuffer(
+{
+  texture: texture170,
+  mipLevel: 0,
+  origin: { x: 1203, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 45272 widthInBlocks: 5659 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 43648 */
+offset: 43648,
+buffer: buffer73,
+},
+{width: 5659, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device11, buffer73);
+} catch {}
+try {
+commandEncoder150.copyTextureToTexture(
+{
+  texture: texture175,
+  mipLevel: 0,
+  origin: { x: 2456, y: 0, z: 48 },
+  aspect: 'all',
+},
+{
+  texture: texture175,
+  mipLevel: 0,
+  origin: { x: 2784, y: 0, z: 206 },
+  aspect: 'all',
+},
+{width: 2672, height: 8, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder150.pushDebugGroup(
+'\ua5a0'
+);
+} catch {}
+try {
+device11.queue.writeTexture(
+{
+  texture: texture175,
+  mipLevel: 0,
+  origin: { x: 608, y: 0, z: 37 },
+  aspect: 'all',
+},
+new ArrayBuffer(19023875),
+/* required buffer size: 19023875 */{
+offset: 275,
+bytesPerRow: 6640,
+rowsPerImage: 191,
+},
+{width: 3296, height: 0, depthOrArrayLayers: 16}
+);
+} catch {}
+let device14 = await adapter20.requestDevice({
+label: '\uf1ad\ua814',
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 62,
+maxVertexAttributes: 23,
+maxVertexBufferArrayStride: 55140,
+maxStorageTexturesPerShaderStage: 8,
+maxStorageBuffersPerShaderStage: 19,
+maxDynamicStorageBuffersPerPipelineLayout: 4861,
+maxBindingsPerBindGroup: 3556,
+maxTextureDimension1D: 14721,
+maxTextureDimension2D: 8906,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 189146624,
+maxUniformBuffersPerShaderStage: 28,
+maxInterStageShaderVariables: 42,
+maxInterStageShaderComponents: 89,
+maxSamplersPerShaderStage: 18,
+},
+});
+let computePassEncoder77 = commandEncoder135.beginComputePass(
+{
+label: '\u0484\u7563\u33e9\u3404\u{1fd23}'
+}
+);
+let sampler136 = device6.createSampler(
+{
+label: '\u947e\u{1fd9f}\u176a\uc026\uda95',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 23.949,
+lodMaxClamp: 92.781,
+}
+);
+try {
+renderPassEncoder46.beginOcclusionQuery(661);
+} catch {}
+try {
+renderPassEncoder37.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder37.setViewport(
+2.438,
+21.92,
+69.90,
+2.362,
+0.2489,
+0.8533
+);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(
+buffer55,
+'uint16',
+6356
+);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(
+4,
+buffer57,
+21188,
+5881
+);
+} catch {}
+try {
+commandEncoder110.clearBuffer(
+buffer63,
+1944,
+10376
+);
+dissociateBuffer(device6, buffer63);
+} catch {}
+let promise68 = device6.createRenderPipelineAsync(
+{
+label: '\u0a50\u5744\u4874\u0f1c\u02eb',
+layout: pipelineLayout28,
+vertex: {
+module: shaderModule41,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 55932,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 29016,
+shaderLocation: 2,
+},
+{
+format: 'float32x4',
+offset: 21104,
+shaderLocation: 15,
+},
+{
+format: 'unorm16x2',
+offset: 53332,
+shaderLocation: 4,
+},
+{
+format: 'sint32x2',
+offset: 24764,
+shaderLocation: 7,
+},
+{
+format: 'snorm8x2',
+offset: 35772,
+shaderLocation: 5,
+},
+{
+format: 'float16x4',
+offset: 12044,
+shaderLocation: 8,
+},
+{
+format: 'sint32x3',
+offset: 3756,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x3',
+offset: 15932,
+shaderLocation: 9,
+},
+{
+format: 'unorm8x4',
+offset: 53192,
+shaderLocation: 11,
+},
+{
+format: 'sint32x4',
+offset: 35516,
+shaderLocation: 1,
+},
+{
+format: 'sint32x2',
+offset: 6800,
+shaderLocation: 10,
+},
+{
+format: 'uint32x2',
+offset: 18012,
+shaderLocation: 16,
+},
+{
+format: 'uint8x4',
+offset: 1200,
+shaderLocation: 13,
+},
+{
+format: 'uint16x2',
+offset: 30536,
+shaderLocation: 12,
+}
+],
+},
+{
+arrayStride: 41456,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x4',
+offset: 16364,
+shaderLocation: 6,
+},
+{
+format: 'snorm16x4',
+offset: 17608,
+shaderLocation: 3,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule41,
+entryPoint: 'fragment0',
+targets: [
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one-minus-src',
+dstFactor: 'one-minus-src-alpha'
+},
+},
+format: 'rgba16float',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+{
+format: 'r8uint',
+writeMask: 0,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one',
+dstFactor: 'one-minus-constant'
+},
+},
+format: 'rg8unorm',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'r16sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+},
+{
+format: 'rg16sint',
+}
+],
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2117,
+depthBias: 44,
+depthBiasSlopeScale: 71,
+},
+}
+);
+let gpuCanvasContext51 = offscreenCanvas56.getContext('webgpu');
+let video40 = await videoWithData();
+let texture207 = device7.createTexture(
+{
+label: '\u5684\u0bba\u{1fed7}\u722e\u{1f68e}',
+size: [144, 232, 1],
+mipLevelCount: 7,
+format: 'eac-r11unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'eac-r11unorm',
+'eac-r11unorm',
+'eac-r11unorm'
+],
+}
+);
+let renderBundleEncoder131 = device7.createRenderBundleEncoder(
+{
+colorFormats: [
+'r32uint',
+'rgb10a2unorm',
+'bgra8unorm',
+'rgba8unorm'
+],
+sampleCount: 422,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder131.setBindGroup(
+3,
+bindGroup64,
+new Uint32Array(6181),
+966,
+0
+);
+} catch {}
+try {
+commandEncoder139.copyTextureToTexture(
+{
+  texture: texture141,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+  texture: texture141,
+  mipLevel: 0,
+  origin: { x: 44, y: 88, z: 1 },
+  aspect: 'all',
+},
+{width: 4, height: 4, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+commandEncoder139.insertDebugMarker(
+'\ue812'
+);
+} catch {}
+let bindGroup79 = device9.createBindGroup({
+label: '\u{1fcdf}\u{1fe35}\u{1f969}',
+layout: bindGroupLayout57,
+entries: [
+
+],
+});
+let buffer74 = device9.createBuffer(
+{
+size: 15252,
+usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+}
+);
+let texture208 = device9.createTexture(
+{
+label: '\ue40a\u{1fd71}\udb53\u2d7d\u09b6\u{1fa38}',
+size: {width: 519, height: 1, depthOrArrayLayers: 1088},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+}
+);
+let renderBundleEncoder132 = device9.createRenderBundleEncoder(
+{
+colorFormats: [
+'r8sint',
+'rg16sint'
+],
+sampleCount: 903,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+try {
+computePassEncoder67.setBindGroup(
+3,
+bindGroup67,
+new Uint32Array(2151),
+567,
+0
+);
+} catch {}
+let videoFrame44 = new VideoFrame(imageBitmap42, {timestamp: 0});
+let promise69 = adapter15.requestAdapterInfo();
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+await promise69;
+} catch {}
+document.body.prepend(canvas4);
+let textureView189 = texture178.createView(
+{
+label: '\u{1f62e}\u09cb\u96c9',
+dimension: '2d-array',
+}
+);
+let computePassEncoder78 = commandEncoder142.beginComputePass(
+{
+label: '\u5b97\ud8f9\u5dc9\u0fbc\u{1fde3}\u{1ffa1}'
+}
+);
+let renderPassEncoder49 = commandEncoder74.beginRenderPass(
+{
+label: '\u{1faf6}\ua713\u{1fcf9}\u04a4\ucf69\ub8b9\u8d79\u1981\u0191\u0f7a',
+colorAttachments: [
+undefined,
+{
+view: textureView80,
+depthSlice: 9,
+clearValue: { r: 790.5, g: 648.7, b: 673.9, a: 172.5, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+{
+view: textureView80,
+depthSlice: 12,
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView80,
+depthSlice: 27,
+clearValue: { r: 915.4, g: -580.8, b: -920.1, a: -160.3, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined,
+{
+view: textureView80,
+depthSlice: 16,
+clearValue: { r: 770.8, g: -329.1, b: -31.80, a: -50.64, },
+loadOp: 'load',
+storeOp: 'store'
+},
+{
+view: textureView80,
+depthSlice: 7,
+clearValue: { r: -883.8, g: 90.10, b: 372.0, a: 311.8, },
+loadOp: 'clear',
+storeOp: 'discard'
+},
+{
+view: textureView80,
+depthSlice: 15,
+clearValue: { r: -982.3, g: 196.2, b: -431.2, a: -381.1, },
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet83,
+}
+);
+let sampler137 = device4.createSampler(
+{
+label: '\ubfbf\u{1fc86}\u90f1',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 47.617,
+lodMaxClamp: 88.195,
+maxAnisotropy: 3,
+}
+);
+try {
+renderPassEncoder49.beginOcclusionQuery(107);
+} catch {}
+try {
+renderPassEncoder49.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder36.setScissorRect(
+40,
+0,
+35,
+0
+);
+} catch {}
+try {
+renderBundleEncoder93.setVertexBuffer(
+2,
+buffer51,
+49884,
+13936
+);
+} catch {}
+try {
+commandEncoder132.copyBufferToBuffer(
+buffer39,
+49464,
+buffer24,
+35300,
+2000
+);
+dissociateBuffer(device4, buffer39);
+dissociateBuffer(device4, buffer24);
+} catch {}
+let pipeline155 = await device4.createComputePipelineAsync(
+{
+label: '\u0abc\u2492',
+layout: pipelineLayout31,
+compute: {
+module: shaderModule25,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let promise70 = device4.createRenderPipelineAsync(
+{
+label: '\u1e1d\u{1f661}\u1b76\u0b58\u55b3\u0674\u021b\u15dd\u30e3\uaeb9',
+layout: pipelineLayout22,
+vertex: {
+module: shaderModule24,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 28876,
+stepMode: 'instance',
+attributes: [
+{
+format: 'unorm8x4',
+offset: 2300,
+shaderLocation: 8,
+},
+{
+format: 'uint8x2',
+offset: 8562,
+shaderLocation: 17,
+},
+{
+format: 'unorm16x2',
+offset: 28564,
+shaderLocation: 4,
+},
+{
+format: 'uint8x2',
+offset: 15866,
+shaderLocation: 10,
+},
+{
+format: 'snorm16x4',
+offset: 13444,
+shaderLocation: 2,
+},
+{
+format: 'float32x4',
+offset: 12900,
+shaderLocation: 16,
+}
+],
+},
+{
+arrayStride: 22508,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x4',
+offset: 3536,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule24,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+},
+undefined,
+{
+format: 'rg32uint',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+},
+undefined,
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'dst-alpha',
+dstFactor: 'one-minus-dst-alpha'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one-minus-constant',
+dstFactor: 'one-minus-dst'
+},
+},
+format: 'rg8unorm',
+writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+}
+);
+let commandEncoder156 = device4.createCommandEncoder(
+{
+label: '\u1430\u263b\u{1faea}\u87c9\u{1f68c}\u{1f9c4}\u5209\u{1f7b1}\uada3\u0e90\u020c',
+}
+);
+let commandBuffer21 = commandEncoder132.finish(
+{
+label: '\u0fd0\u0a30\u63a5\ua4c5\u02d2\uf88e\u13a4',
+}
+);
+let renderPassEncoder50 = commandEncoder156.beginRenderPass(
+{
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+{
+view: textureView74,
+depthSlice: 26,
+clearValue: { r: -749.8, g: 502.4, b: -837.6, a: 739.0, },
+loadOp: 'clear',
+storeOp: 'store'
+},
+undefined
+],
+occlusionQuerySet: querySet83,
+maxDrawCount: 3712,
+}
+);
+try {
+computePassEncoder78.setBindGroup(
+8,
+bindGroup40
+);
+} catch {}
+try {
+computePassEncoder24.insertDebugMarker(
+'\u0d1e'
+);
+} catch {}
+try {
+gpuCanvasContext16.configure(
+{
+device: device4,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'etc2-rgba8unorm',
+'bgra8unorm-srgb'
+],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture143,
+  mipLevel: 0,
+  origin: { x: 1218, y: 174, z: 0 },
+  aspect: 'all',
+},
+new Float64Array(arrayBuffer12),
+/* required buffer size: 4794 */{
+offset: 523,
+bytesPerRow: 2223,
+},
+{width: 768, height: 12, depthOrArrayLayers: 1}
+);
+} catch {}
+let querySet147 = device9.createQuerySet({
+label: '\u{1f925}\ue1df\ub4b8\u{1f749}\u{1fa42}\u{1f9ab}\u{1fa53}\u0f8c\u0484\u61e4',
+type: 'occlusion',
+count: 1507,
+});
+let renderBundle159 = renderBundleEncoder132.finish(
+{
+
+}
+);
+try {
+renderBundleEncoder124.setBindGroup(
+0,
+bindGroup67,
+new Uint32Array(341),
+54,
+0
+);
+} catch {}
+try {
+commandEncoder114.resolveQuerySet(
+querySet120,
+299,
+75,
+buffer74,
+1024
+);
+} catch {}
+let querySet148 = device10.createQuerySet({
+label: '\u0e10\ua91c\u007b\u669c\u{1fcac}\u0910\u0b53\ue01e\u42e3\ucc3d\u{1fab0}',
+type: 'occlusion',
+count: 3668,
+});
+let texture209 = device10.createTexture(
+{
+label: '\ubf16\ucb6e\u836e\u0dfd\u0bc7\u8be5\u39eb\u{1f7a8}\u8b77',
+size: {width: 4518},
+dimension: '1d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r8snorm'
+],
+}
+);
+try {
+renderPassEncoder47.beginOcclusionQuery(752);
+} catch {}
+try {
+renderPassEncoder47.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder47.setStencilReference(
+799
+);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(
+buffer52,
+'uint16',
+1038,
+2447
+);
+} catch {}
+try {
+renderBundleEncoder98.setBindGroup(
+1,
+bindGroup62
+);
+} catch {}
+try {
+renderBundleEncoder108.setVertexBuffer(
+1,
+buffer66,
+8
+);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let querySet149 = device8.createQuerySet({
+type: 'occlusion',
+count: 868,
+});
+let textureView190 = texture137.createView(
+{
+baseMipLevel: 6,
+}
+);
+let computePassEncoder79 = commandEncoder153.beginComputePass();
+try {
+computePassEncoder79.setBindGroup(
+0,
+bindGroup76
+);
+} catch {}
+try {
+computePassEncoder79.setPipeline(
+pipeline147
+);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(
+2,
+bindGroup76
+);
+} catch {}
+try {
+renderPassEncoder41.setViewport(
+1.602,
+0.7226,
+8.058,
+0.2635,
+0.6316,
+0.6417
+);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(
+6,
+buffer69,
+8764
+);
+} catch {}
+try {
+renderBundleEncoder119.setBindGroup(
+1,
+bindGroup75
+);
+} catch {}
+try {
+renderBundleEncoder119.setVertexBuffer(
+7,
+buffer69,
+17168
+);
+} catch {}
+let pipeline156 = await device8.createComputePipelineAsync(
+{
+label: '\u{1fcc6}\u0a2c\u{1fcf5}\uc587\u001f\u4b8a\u{1ff49}\uaa3c\u0e10\u{1fae5}\ua372',
+layout: pipelineLayout40,
+compute: {
+module: shaderModule35,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let videoFrame45 = new VideoFrame(imageBitmap26, {timestamp: 0});
+let texture210 = device14.createTexture(
+{
+label: '\ub259\u0a1b\ud01c\u09fc\u{1f73a}\ubd4e\u02c2\u0ea4\u8d9a\u65ec\u3f1a',
+size: {width: 3684},
+dimension: '1d',
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2unorm',
+'rgb10a2unorm',
+'rgb10a2unorm'
+],
+}
+);
+let textureView191 = texture210.createView(
+{
+baseMipLevel: 0,
+}
+);
+document.body.prepend(img23);
+document.body.prepend(img42);
+let canvas43 = document.createElement('canvas');
+try {
+window.someLabel = externalTexture4.label;
+} catch {}
+let texture211 = device13.createTexture(
+{
+label: '\uff3b\u0057\u00af\u03a7',
+size: {width: 1128},
+dimension: '1d',
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgb10a2unorm'
+],
+}
+);
+try {
+device13.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video30,
+  origin: { x: 1, y: 12 },
+  flipY: true,
+},
+{
+  texture: texture193,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 1, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+try {
+canvas43.getContext('webgpu');
+} catch {}
+let buffer75 = device9.createBuffer(
+{
+label: '\u{1fa22}\ud6cd\u993d\u{1fbf9}\uba10\u4004\u{1f8c7}\u{1fbf2}',
+size: 15963,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: false,
+}
+);
+let textureView192 = texture190.createView(
+{
+label: '\u{1fda8}\uf515\u{1f78f}\u6b7e\u5dcb\u8585\u904b\u07dc\u0515',
+dimension: '2d',
+baseArrayLayer: 127,
+}
+);
+try {
+renderBundleEncoder109.setIndexBuffer(
+buffer48,
+'uint16',
+6732,
+2126
+);
+} catch {}
+try {
+renderBundleEncoder109.setVertexBuffer(
+8,
+buffer74,
+10000,
+3211
+);
+} catch {}
+try {
+await device9.popErrorScope();
+} catch {}
+try {
+commandEncoder114.copyBufferToTexture(
+{
+/* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 15956 */
+offset: 15952,
+buffer: buffer75,
+},
+{
+  texture: texture122,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 1}
+);
+dissociateBuffer(device9, buffer75);
+} catch {}
+let bindGroupLayout94 = device7.createBindGroupLayout(
+{
+label: '\u{1fb24}\u65b4\u0c86\u{1fb34}\u06a0\u41f0\ucec4\u0b34\u{1f602}\u{1fc61}\uf556',
+entries: [
+{
+binding: 849,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}
+],
+}
+);
+try {
+renderBundleEncoder131.setBindGroup(
+8,
+bindGroup65
+);
+} catch {}
+try {
+renderBundleEncoder131.setVertexBuffer(
+41,
+undefined,
+159943936,
+943821474
+);
+} catch {}
+try {
+texture155.destroy();
+} catch {}
+let video41 = await videoWithData();
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+let imageBitmap47 = await createImageBitmap(img4);
+let bindGroupLayout95 = device6.createBindGroupLayout(
+{
+label: '\u03ac\u1572\u0cf5\ued70\ued96\ue46f\uceb6\u{1fd21}',
+entries: [
+{
+binding: 2546,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}
+],
+}
+);
+let commandBuffer22 = commandEncoder129.finish();
+let texture212 = device6.createTexture(
+{
+label: '\u027b\u{1fab4}\u{1ff05}\u{1f8ca}\u0b2c\u0578\u5f71\uf10c\u5a94',
+size: {width: 9396},
+dimension: '1d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rg8snorm'
+],
+}
+);
+let renderPassEncoder51 = commandEncoder110.beginRenderPass(
+{
+label: '\uf5fa\u00c4',
+colorAttachments: [
+undefined,
+undefined,
+undefined,
+{
+view: textureView126,
+clearValue: { r: 372.1, g: -749.6, b: -375.5, a: 289.5, },
+loadOp: 'load',
+storeOp: 'discard'
+}
+],
+occlusionQuerySet: querySet126,
+maxDrawCount: 123680,
+}
+);
+let sampler138 = device6.createSampler(
+{
+label: '\u40b7\u4bb0\u23ed\ud4bd\u{1f918}\u4bd9\u735b\u6593\u5fbc',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 53.953,
+lodMaxClamp: 62.950,
+}
+);
+try {
+renderPassEncoder37.setBlendConstant({ r: -519.2, g: -672.2, b: 800.8, a: 606.8, });
+} catch {}
+try {
+renderPassEncoder37.setScissorRect(
+13,
+7,
+48,
+15
+);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(
+buffer55,
+'uint16'
+);
+} catch {}
+try {
+renderBundleEncoder126.setVertexBuffer(
+10,
+undefined
+);
+} catch {}
+let arrayBuffer19 = buffer70.getMappedRange(
+0,
+33360
+);
+try {
+commandEncoder151.clearBuffer(
+buffer53,
+15604,
+228
+);
+dissociateBuffer(device6, buffer53);
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer63,
+3312,
+new DataView(new ArrayBuffer(14641)),
+8266,
+5808
+);
+} catch {}
+let pipeline157 = device6.createRenderPipeline(
+{
+layout: pipelineLayout28,
+vertex: {
+module: shaderModule42,
+entryPoint: 'vertex0',
+constants: {},
+buffers: [
+{
+arrayStride: 8060,
+attributes: [
+{
+format: 'unorm16x4',
+offset: 5100,
+shaderLocation: 14,
+},
+{
+format: 'float32x4',
+offset: 5188,
+shaderLocation: 9,
+},
+{
+format: 'sint32',
+offset: 1236,
+shaderLocation: 16,
+},
+{
+format: 'sint32x2',
+offset: 3564,
+shaderLocation: 15,
+},
+{
+format: 'float16x4',
+offset: 7444,
+shaderLocation: 11,
+},
+{
+format: 'float32x3',
+offset: 1340,
+shaderLocation: 7,
+},
+{
+format: 'float32',
+offset: 6016,
+shaderLocation: 13,
+},
+{
+format: 'snorm16x4',
+offset: 2564,
+shaderLocation: 4,
+},
+{
+format: 'uint32x4',
+offset: 864,
+shaderLocation: 0,
+},
+{
+format: 'float16x4',
+offset: 6948,
+shaderLocation: 6,
+},
+{
+format: 'float32x4',
+offset: 5668,
+shaderLocation: 5,
+},
+{
+format: 'uint8x2',
+offset: 972,
+shaderLocation: 3,
+},
+{
+format: 'sint16x2',
+offset: 7820,
+shaderLocation: 8,
+},
+{
+format: 'uint16x4',
+offset: 6588,
+shaderLocation: 1,
+},
+{
+format: 'float32x4',
+offset: 6200,
+shaderLocation: 12,
+},
+{
+format: 'unorm16x2',
+offset: 416,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 10164,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 14400,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 1036,
+shaderLocation: 2,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+multisample: {
+mask: 0x5e216883,
+},
+fragment: {
+module: shaderModule42,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+undefined,
+undefined,
+undefined,
+undefined
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+},
+stencilReadMask: 1081,
+stencilWriteMask: 1023,
+depthBias: 85,
+depthBiasClamp: 12,
+},
+}
+);
+let canvas44 = document.createElement('canvas');
+let imageData42 = new ImageData(172, 24);
+try {
+canvas44.getContext('2d');
+} catch {}
+let buffer76 = device9.createBuffer(
+{
+label: '\ufaab\u{1f98f}\u1187\u05b8\u{1f6bc}\u{1fa60}\u0ae6',
+size: 58659,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandEncoder157 = device9.createCommandEncoder(
+{
+label: '\u{1f633}\u{1fc6f}\u{1fb7e}\u6d49',
+}
+);
+try {
+renderBundleEncoder109.setBindGroup(
+4,
+bindGroup70
+);
+} catch {}
+try {
+commandEncoder114.copyBufferToBuffer(
+buffer75,
+15288,
+buffer41,
+1320,
+644
+);
+dissociateBuffer(device9, buffer75);
+dissociateBuffer(device9, buffer41);
+} catch {}
+try {
+commandEncoder114.clearBuffer(
+buffer41,
+1492,
+1872
+);
+dissociateBuffer(device9, buffer41);
+} catch {}
+try {
+device9.queue.writeBuffer(
+buffer41,
+2008,
+new Int16Array(23767),
+4987,
+3052
+);
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let videoFrame46 = new VideoFrame(img14, {timestamp: 0});
+let querySet150 = device6.createQuerySet({
+type: 'occlusion',
+count: 224,
+});
+let textureView193 = texture111.createView(
+{
+dimension: '2d-array',
+format: 'astc-6x5-unorm-srgb',
+baseMipLevel: 1,
+baseArrayLayer: 45,
+arrayLayerCount: 9,
+}
+);
+try {
+computePassEncoder75.setBindGroup(
+3,
+bindGroup57,
+new Uint32Array(8536),
+6627,
+0
+);
+} catch {}
+try {
+renderPassEncoder51.end();
+} catch {}
+try {
+renderPassEncoder37.beginOcclusionQuery(234);
+} catch {}
+try {
+renderPassEncoder46.setBlendConstant({ r: -558.3, g: -667.9, b: 450.5, a: -657.8, });
+} catch {}
+try {
+renderPassEncoder37.setStencilReference(
+3754
+);
+} catch {}
+try {
+renderPassEncoder37.setViewport(
+71.22,
+24.94,
+26.78,
+0.04167,
+0.3934,
+0.8787
+);
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(
+/*
+{width: 101, height: 25, depthOrArrayLayers: 1}
+*/
+{
+  source: video26,
+  origin: { x: 4, y: 2 },
+  flipY: false,
+},
+{
+  texture: texture134,
+  mipLevel: 1,
+  origin: { x: 56, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+},
+{width: 7, height: 2, depthOrArrayLayers: 0}
+);
+} catch {}
+gc();
+let texture213 = gpuCanvasContext21.getCurrentTexture();
+try {
+buffer62.unmap();
+} catch {}
+try {
+computePassEncoder63.setPipeline(
+pipeline152
+);
+} catch {}
+try {
+renderPassEncoder46.setStencilReference(
+1082
+);
+} catch {}
+try {
+renderBundleEncoder125.setVertexBuffer(
+5,
+buffer57,
+6140,
+8518
+);
+} catch {}
+try {
+commandEncoder151.copyBufferToBuffer(
+buffer70,
+9820,
+buffer63,
+888,
+4728
+);
+dissociateBuffer(device6, buffer70);
+dissociateBuffer(device6, buffer63);
+} catch {}
+try {
+commandEncoder151.copyTextureToTexture(
+{
+  texture: texture199,
+  mipLevel: 2,
+  origin: { x: 1270, y: 0, z: 33 },
+  aspect: 'all',
+},
+{
+  texture: texture199,
+  mipLevel: 6,
+  origin: { x: 10, y: 0, z: 36 },
+  aspect: 'all',
+},
+{width: 140, height: 0, depthOrArrayLayers: 118}
+);
+} catch {}
+try {
+device6.queue.writeBuffer(
+buffer63,
+10676,
+new BigUint64Array(63025),
+52571,
+84
+);
+} catch {}
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+canvas29.height = 426;
+let texture214 = device14.createTexture(
+{
+label: '\u{1fb5a}\u0eef\u9dd5\u29c9\u953c\u63f3',
+size: [319, 17, 1],
+mipLevelCount: 6,
+format: 'r16uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r16uint',
+'r16uint',
+'r16uint'
+],
+}
+);
+let textureView194 = texture210.createView(
+{
+label: '\u55bc\u133e\u44ab\ue2ad\u4730\u9ba9\u922f\ua7f3\u0040',
+}
+);
+let sampler139 = device14.createSampler(
+{
+label: '\u481a\u2bde\u0841\u021a\u1822',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 43.884,
+lodMaxClamp: 85.393,
+}
+);
+try {
+gpuCanvasContext16.configure(
+{
+device: device14,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+alphaMode: 'premultiplied',
+}
+);
+} catch {}
+let commandEncoder158 = device9.createCommandEncoder(
+{
+label: '\ue7ae\u0bb4\u{1fa36}',
+}
+);
+let textureView195 = texture145.createView(
+{
+label: '\u{1f75a}\u0f60\u{1fd4b}\u1581\udefa\u34f8\u8cde\uc8a6\u9499',
+dimension: '2d',
+baseMipLevel: 0,
+mipLevelCount: 3,
+baseArrayLayer: 19,
+}
+);
+let sampler140 = device9.createSampler(
+{
+label: '\u{1fc35}\uf35c',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 89.668,
+lodMaxClamp: 98.558,
+}
+);
+try {
+commandEncoder157.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 6320 */
+offset: 6320,
+bytesPerRow: 0,
+rowsPerImage: 204,
+buffer: buffer75,
+},
+{
+  texture: texture145,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 98 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 13}
+);
+dissociateBuffer(device9, buffer75);
+} catch {}
+try {
+gpuCanvasContext24.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let buffer77 = device13.createBuffer(
+{
+label: '\u78c2\u{1f6ec}',
+size: 5690,
+usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+}
+);
+let commandEncoder159 = device13.createCommandEncoder(
+{
+}
+);
+let texture215 = device13.createTexture(
+{
+label: '\u{1fe1f}\u7f42\u0a45\u80e3\u{1f7f5}\u86d6\u{1f813}\u{1fe3b}\u52bd\u493b',
+size: [5603],
+sampleCount: 1,
+dimension: '1d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'rg11b10ufloat',
+'rg11b10ufloat'
+],
+}
+);
+let textureView196 = texture211.createView(
+{
+label: '\u073c\u0482\u5475\u{1fb02}\u{1fec9}\u{1fc46}\u8742\u0217\ud26a\ub2b7\u0780',
+}
+);
+try {
+device13.queue.writeTexture(
+{
+  texture: texture211,
+  mipLevel: 0,
+  origin: { x: 891, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Uint32Array(new ArrayBuffer(0)),
+/* required buffer size: 487 */{
+offset: 391,
+},
+{width: 24, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+gc();
+document.body.prepend(canvas12);
+let textureView197 = texture203.createView(
+{
+label: '\u0ad8\ucef6\u0608\u0f47\u8407\u457d\ufe58',
+mipLevelCount: 1,
+}
+);
+try {
+renderPassEncoder48.executeBundles([]);
+} catch {}
+let imageBitmap48 = await createImageBitmap(imageBitmap31);
+let bindGroup80 = device10.createBindGroup({
+label: '\u00fd\u{1fbb2}\ub670\uda92\u0b80\u0554\u{1ff50}',
+layout: bindGroupLayout67,
+entries: [
+
+],
+});
+let textureView198 = texture138.createView(
+{
+dimension: '2d-array',
+}
+);
+try {
+renderPassEncoder40.setBlendConstant({ r: -91.87, g: -870.8, b: 77.75, a: 314.6, });
+} catch {}
+try {
+renderPassEncoder42.setStencilReference(
+3518
+);
+} catch {}
+try {
+renderPassEncoder47.setViewport(
+22.79,
+1.591,
+11.38,
+1.082,
+0.6413,
+0.6762
+);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(
+3,
+buffer66,
+1848,
+4849
+);
+} catch {}
+try {
+renderBundleEncoder108.setIndexBuffer(
+buffer52,
+'uint16',
+3062,
+4293
+);
+} catch {}
+try {
+device10.queue.writeTexture(
+{
+  texture: texture188,
+  mipLevel: 1,
+  origin: { x: 194, y: 1, z: 174 },
+  aspect: 'all',
+},
+new BigInt64Array(arrayBuffer15),
+/* required buffer size: 5862455 */{
+offset: 755,
+bytesPerRow: 835,
+rowsPerImage: 117,
+},
+{width: 48, height: 0, depthOrArrayLayers: 61}
+);
+} catch {}
+let pipeline158 = device10.createComputePipeline(
+{
+label: '\u0294\u3ada\u0117\ued79\u3893\u18a2\u2946\ufdfc\u{1fb82}',
+layout: 'auto',
+compute: {
+module: shaderModule38,
+entryPoint: 'compute0',
+},
+}
+);
+let offscreenCanvas57 = new OffscreenCanvas(672, 679);
+let videoFrame47 = new VideoFrame(offscreenCanvas27, {timestamp: 0});
+let gpuCanvasContext52 = offscreenCanvas57.getContext('webgpu');
+let texture216 = device6.createTexture(
+{
+label: '\u{1fbc1}\u8898\ue5df\u0bca',
+size: {width: 111, height: 1, depthOrArrayLayers: 196},
+mipLevelCount: 6,
+dimension: '3d',
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [
+
+],
+}
+);
+let computePassEncoder80 = commandEncoder151.beginComputePass(
+{
+
+}
+);
+try {
+renderPassEncoder37.setBindGroup(
+7,
+bindGroup43,
+new Uint32Array(9807),
+208,
+0
+);
+} catch {}
+try {
+renderPassEncoder37.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder37.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder101.setBindGroup(
+3,
+bindGroup52,
+new Uint32Array(9681),
+6145,
+0
+);
+} catch {}
+try {
+device6.queue.writeTexture(
+{
+  texture: texture148,
+  mipLevel: 0,
+  origin: { x: 353, y: 0, z: 0 },
+  aspect: 'all',
+},
+new ArrayBuffer(917),
+/* required buffer size: 917 */{
+offset: 917,
+},
+{width: 443, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let bindGroupLayout96 = device8.createBindGroupLayout(
+{
+label: '\u54f3\u3979\ufa9e\u5c1e',
+entries: [
+{
+binding: 334,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'r32uint', access: 'write-only', viewDimension: '2d-array' },
+},
+{
+binding: 392,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+}
+],
+}
+);
+let querySet151 = device8.createQuerySet({
+label: '\u{1fa6f}\u5318',
+type: 'occlusion',
+count: 2005,
+});
+let renderBundle160 = renderBundleEncoder121.finish(
+{
+label: '\uf51b\u377c\u03c9\u06a6\u{1f662}\uf8f7\u6167\u{1f72c}'
+}
+);
+try {
+renderPassEncoder41.setBindGroup(
+3,
+bindGroup75
+);
+} catch {}
+try {
+renderPassEncoder41.executeBundles([]);
+} catch {}
+try {
+buffer69.unmap();
+} catch {}
+try {
+computePassEncoder79.insertDebugMarker(
+'\u0183'
+);
+} catch {}
+try {
+gpuCanvasContext41.configure(
+{
+device: device8,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba32float',
+'bgra8unorm',
+'bgra8unorm-srgb',
+'astc-4x4-unorm-srgb'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let pipeline159 = await device8.createComputePipelineAsync(
+{
+label: '\ua487\u0575\u5c15\u1a27\u{1f8d0}\u93c9\u342a\u{1fd8c}\u4299\u{1fc7c}\u{1fc8e}',
+layout: pipelineLayout43,
+compute: {
+module: shaderModule39,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline160 = device8.createRenderPipeline(
+{
+label: '\u{1f8c7}\u{1f938}\u0a36\ue9f2\u667b\u90f5\u1c8f',
+layout: pipelineLayout40,
+vertex: {
+module: shaderModule40,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 1832,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 52,
+shaderLocation: 3,
+},
+{
+format: 'float16x2',
+offset: 912,
+shaderLocation: 12,
+},
+{
+format: 'float32x3',
+offset: 216,
+shaderLocation: 2,
+},
+{
+format: 'sint32x3',
+offset: 1388,
+shaderLocation: 1,
+},
+{
+format: 'sint32x2',
+offset: 468,
+shaderLocation: 6,
+},
+{
+format: 'sint32x3',
+offset: 1044,
+shaderLocation: 9,
+},
+{
+format: 'float16x4',
+offset: 1552,
+shaderLocation: 8,
+},
+{
+format: 'sint8x2',
+offset: 770,
+shaderLocation: 13,
+},
+{
+format: 'uint16x4',
+offset: 236,
+shaderLocation: 4,
+},
+{
+format: 'uint16x4',
+offset: 1156,
+shaderLocation: 7,
+}
+],
+},
+{
+arrayStride: 1976,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 1032,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'unorm16x4',
+offset: 760,
+shaderLocation: 14,
+},
+{
+format: 'snorm16x4',
+offset: 676,
+shaderLocation: 5,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint16x4',
+offset: 1012,
+shaderLocation: 0,
+},
+{
+format: 'unorm8x4',
+offset: 1264,
+shaderLocation: 10,
+},
+{
+format: 'sint32x3',
+offset: 2012,
+shaderLocation: 15,
+}
+],
+},
+{
+arrayStride: 1940,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 116,
+attributes: [
+
+],
+},
+{
+arrayStride: 472,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint8x4',
+offset: 420,
+shaderLocation: 11,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+},
+multisample: {
+},
+fragment: {
+module: shaderModule40,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 2877,
+stencilWriteMask: 3298,
+depthBiasSlopeScale: 7,
+depthBiasClamp: 35,
+},
+}
+);
+document.body.prepend(img32);
+try {
+await device13.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device13.queue.copyExternalImageToTexture(
+/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame43,
+  origin: { x: 10, y: 6 },
+  flipY: false,
+},
+{
+  texture: texture193,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+try {
+await adapter18.requestAdapterInfo();
+} catch {}
+try {
+gpuCanvasContext45.unconfigure();
+} catch {}
+try {
+adapter4.label = '\u230d\u{1f8e7}\u6fc7';
+} catch {}
+let querySet152 = device7.createQuerySet({
+label: '\u2287\u{1fc48}\u{1fc8a}',
+type: 'occlusion',
+count: 1541,
+});
+let texture217 = device7.createTexture(
+{
+label: '\u{1f78a}\ua825\u0568\uac1b\ud11d\u60e6\uc1cf\ubdae',
+size: [10324, 244, 181],
+mipLevelCount: 6,
+format: 'etc2-rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'etc2-rgba8unorm',
+'etc2-rgba8unorm',
+'etc2-rgba8unorm'
+],
+}
+);
+let renderBundleEncoder133 = device7.createRenderBundleEncoder(
+{
+label: '\u2e6f\ub43d\u009e\u9d06\u{1fe79}\u0085\u736c\u05c7\u36ab\u3909\u{1fefb}',
+colorFormats: [
+'r16sint',
+'rg32float',
+'r32float',
+'rg16uint'
+],
+sampleCount: 945,
+}
+);
+try {
+computePassEncoder60.setBindGroup(
+2,
+bindGroup65
+);
+} catch {}
+try {
+computePassEncoder62.end();
+} catch {}
+try {
+renderBundleEncoder131.setBindGroup(
+8,
+bindGroup61
+);
+} catch {}
+try {
+commandEncoder139.copyBufferToTexture(
+{
+/* bytesInLastRow: 128 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 3440 */
+offset: 3440,
+bytesPerRow: 256,
+rowsPerImage: 216,
+buffer: buffer62,
+},
+{
+  texture: texture191,
+  mipLevel: 0,
+  origin: { x: 48, y: 0, z: 1 },
+  aspect: 'all',
+},
+{width: 64, height: 42, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device7, buffer62);
+} catch {}
+let promise71 = navigator.gpu.requestAdapter(
+{
+}
+);
+let canvas45 = document.createElement('canvas');
+let renderBundle161 = renderBundleEncoder103.finish(
+{
+label: '\u0592\u061d'
+}
+);
+try {
+renderPassEncoder34.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder23.setStencilReference(
+3828
+);
+} catch {}
+try {
+device3.queue.writeTexture(
+{
+  texture: texture60,
+  mipLevel: 2,
+  origin: { x: 0, y: 8, z: 1 },
+  aspect: 'stencil-only',
+},
+arrayBuffer5,
+/* required buffer size: 549 */{
+offset: 549,
+rowsPerImage: 35,
+},
+{width: 14, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let canvas46 = document.createElement('canvas');
+let videoFrame48 = new VideoFrame(videoFrame31, {timestamp: 0});
+let sampler141 = device14.createSampler(
+{
+label: '\u{1faaf}\ueb22\u{1fb72}\u3a63\u0f5f\uf024',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 51.517,
+lodMaxClamp: 89.956,
+maxAnisotropy: 18,
+}
+);
+let gpuCanvasContext53 = canvas45.getContext('webgpu');
+try {
+computePassEncoder78.setPipeline(
+pipeline121
+);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(
+8,
+bindGroup42,
+new Uint32Array(5278),
+1521,
+0
+);
+} catch {}
+try {
+renderPassEncoder36.setStencilReference(
+1647
+);
+} catch {}
+try {
+renderBundleEncoder97.setVertexBuffer(
+1,
+buffer51,
+6712,
+4810
+);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture97,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+},
+new BigInt64Array(new ArrayBuffer(8)),
+/* required buffer size: 718 */{
+offset: 718,
+},
+{width: 1840, height: 10, depthOrArrayLayers: 0}
+);
+} catch {}
+let querySet153 = device10.createQuerySet({
+label: '\u08b3\u04df\u833a\u{1f7c6}\u87fb\u0b64\uefbf\udae2\u0375\u3cb1',
+type: 'occlusion',
+count: 1572,
+});
+try {
+renderPassEncoder40.setIndexBuffer(
+buffer52,
+'uint32'
+);
+} catch {}
+let pipeline161 = device10.createRenderPipeline(
+{
+label: '\u1c04\u{1fee0}\u0a9b\u0700\u989b\u731e\u38e7\ud389\u0030\u06cd\uc864',
+layout: pipelineLayout36,
+vertex: {
+module: shaderModule33,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 28844,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32',
+offset: 2152,
+shaderLocation: 7,
+},
+{
+format: 'snorm16x4',
+offset: 11916,
+shaderLocation: 14,
+}
+],
+},
+{
+arrayStride: 19752,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 31616,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'sint32x3',
+offset: 1648,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 28000,
+stepMode: 'instance',
+attributes: [
+{
+format: 'sint8x2',
+offset: 8984,
+shaderLocation: 17,
+},
+{
+format: 'unorm16x2',
+offset: 6228,
+shaderLocation: 5,
+},
+{
+format: 'uint16x4',
+offset: 27504,
+shaderLocation: 0,
+}
+],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'keep',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 2974,
+stencilWriteMask: 1585,
+depthBias: 32,
+depthBiasSlopeScale: 90,
+depthBiasClamp: 43,
+},
+}
+);
+let gpuCanvasContext54 = canvas46.getContext('webgpu');
+let pipelineLayout45 = device12.createPipelineLayout(
+{
+label: '\uf086\u07d1\u3c7e',
+bindGroupLayouts: [
+bindGroupLayout91,
+bindGroupLayout93,
+bindGroupLayout92,
+bindGroupLayout92
+]
+}
+);
+let querySet154 = device12.createQuerySet({
+label: '\u{1fd55}\u0721\u0c7f',
+type: 'occlusion',
+count: 3665,
+});
+let texture218 = device12.createTexture(
+{
+size: {width: 9955, height: 80, depthOrArrayLayers: 53},
+mipLevelCount: 9,
+format: 'astc-5x4-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'astc-5x4-unorm'
+],
+}
+);
+let textureView199 = texture187.createView(
+{
+label: '\u{1f641}\u5439\u0155\u9956\u504b\ub1e0',
+mipLevelCount: 1,
+}
+);
+offscreenCanvas16.height = 992;
+gc();
+try {
+commandEncoder126.resolveQuerySet(
+querySet133,
+2563,
+59,
+buffer67,
+256
+);
+} catch {}
+try {
+await device11.queue.onSubmittedWorkDone();
+} catch {}
+let querySet155 = device14.createQuerySet({
+label: '\u045c\ubb3a\u2a25\u0139\u0b6e\u0075',
+type: 'occlusion',
+count: 1431,
+});
+let texture219 = device14.createTexture(
+{
+label: '\u9d7b\u023d\u2eb4\u3cdf\u04ac',
+size: {width: 232, height: 1, depthOrArrayLayers: 1031},
+dimension: '3d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [
+
+],
+}
+);
+let renderBundleEncoder134 = device14.createRenderBundleEncoder(
+{
+label: '\u0721\u{1fb25}\ud33f\u3d0e\u{1f743}\u{1fdc9}\u{1fed3}\u05d6\u0ce4\u2e25\u094e',
+colorFormats: [
+'rgba32float',
+'rg32uint',
+'r8sint',
+undefined,
+'bgra8unorm-srgb',
+'rgba16sint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 653,
+}
+);
+let sampler142 = device14.createSampler(
+{
+label: '\ua6f4\u{1ff8f}\u0ed7\u13c7\u8e5d',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 86.326,
+lodMaxClamp: 86.876,
+}
+);
+try {
+texture210.destroy();
+} catch {}
+try {
+renderBundleEncoder134.insertDebugMarker(
+'\u29e7'
+);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(
+4,
+bindGroup73
+);
+} catch {}
+try {
+renderPassEncoder48.setBlendConstant({ r: 500.6, g: 193.2, b: -543.4, a: 331.6, });
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(
+53,
+undefined
+);
+} catch {}
+try {
+renderBundleEncoder129.setBindGroup(
+9,
+bindGroup73
+);
+} catch {}
+offscreenCanvas11.height = 449;
+let buffer78 = device14.createBuffer(
+{
+label: '\u004a\u059d\u84a2\u01a2\u063a\u032c\u0dad\u0e07',
+size: 42304,
+usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+}
+);
+let texture220 = device14.createTexture(
+{
+label: '\uf891\u7b64\uf25a\uf6b3',
+size: {width: 6760, height: 142, depthOrArrayLayers: 1},
+mipLevelCount: 9,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+
+],
+}
+);
+try {
+renderBundleEncoder134.setIndexBuffer(
+buffer78,
+'uint32',
+9696,
+7065
+);
+} catch {}
+let promise72 = device14.popErrorScope();
+try {
+gpuCanvasContext51.configure(
+{
+device: device14,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+let offscreenCanvas58 = new OffscreenCanvas(811, 309);
+try {
+offscreenCanvas58.getContext('2d');
+} catch {}
+let buffer79 = device6.createBuffer(
+{
+label: '\u9241\u0afc\ua9e7\ub458\ud5bb\u0338\ud853\u0fb7\u4914\u32da',
+size: 16318,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let texture221 = device6.createTexture(
+{
+label: '\u07da\u{1f61a}\u023a\uad31\u{1fbfd}\u0f6e\u{1fc82}',
+size: [189, 121, 1],
+mipLevelCount: 3,
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'rgba16sint',
+'rgba16sint'
+],
+}
+);
+let textureView200 = texture134.createView(
+{
+label: '\u0b90\u{1f94c}\u{1f6ca}\u8e5a',
+format: 'rgba16float',
+}
+);
+try {
+renderPassEncoder46.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder37.setBlendConstant({ r: 424.4, g: 861.2, b: -593.5, a: 76.43, });
+} catch {}
+try {
+commandEncoder148.copyBufferToBuffer(
+buffer70,
+15924,
+buffer63,
+6336,
+4644
+);
+dissociateBuffer(device6, buffer70);
+dissociateBuffer(device6, buffer63);
+} catch {}
+let pipeline162 = device6.createComputePipeline(
+{
+label: '\u27eb\u784d\u0683',
+layout: pipelineLayout39,
+compute: {
+module: shaderModule42,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline163 = device6.createRenderPipeline(
+{
+layout: pipelineLayout39,
+vertex: {
+module: shaderModule41,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 61608,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint32x2',
+offset: 25916,
+shaderLocation: 6,
+},
+{
+format: 'unorm16x4',
+offset: 11480,
+shaderLocation: 2,
+},
+{
+format: 'unorm16x2',
+offset: 56764,
+shaderLocation: 3,
+},
+{
+format: 'uint32',
+offset: 1636,
+shaderLocation: 13,
+},
+{
+format: 'float32x2',
+offset: 4544,
+shaderLocation: 9,
+}
+],
+},
+{
+arrayStride: 18828,
+stepMode: 'instance',
+attributes: [
+{
+format: 'float16x4',
+offset: 15648,
+shaderLocation: 4,
+}
+],
+},
+{
+arrayStride: 49260,
+attributes: [
+
+],
+},
+{
+arrayStride: 19776,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float32x2',
+offset: 15512,
+shaderLocation: 15,
+},
+{
+format: 'float32',
+offset: 2596,
+shaderLocation: 5,
+},
+{
+format: 'float32x2',
+offset: 6724,
+shaderLocation: 8,
+},
+{
+format: 'uint8x4',
+offset: 10228,
+shaderLocation: 16,
+},
+{
+format: 'sint16x2',
+offset: 10276,
+shaderLocation: 10,
+},
+{
+format: 'sint16x4',
+offset: 18932,
+shaderLocation: 7,
+},
+{
+format: 'float32x3',
+offset: 4304,
+shaderLocation: 11,
+},
+{
+format: 'uint32x3',
+offset: 15056,
+shaderLocation: 12,
+},
+{
+format: 'sint32x4',
+offset: 17000,
+shaderLocation: 1,
+},
+{
+format: 'sint16x2',
+offset: 11840,
+shaderLocation: 14,
+}
+],
+}
+]
+},
+multisample: {
+mask: 0xddb7f332,
+},
+fragment: {
+module: shaderModule41,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'add',
+srcFactor: 'one-minus-src-alpha',
+dstFactor: 'one-minus-constant'
+},
+},
+format: 'rgba8unorm',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+format: 'r8uint',
+writeMask: 0,
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALL,
+},
+{
+blend: {
+color: {
+operation: 'add',
+srcFactor: 'constant',
+dstFactor: 'one-minus-dst-alpha'
+},
+alpha: {
+operation: 'subtract',
+srcFactor: 'one-minus-dst-alpha',
+dstFactor: 'constant'
+},
+},
+format: 'r16float',
+writeMask: GPUColorWrite.ALPHA,
+}
+],
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'greater-equal',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilReadMask: 2379,
+stencilWriteMask: 3768,
+depthBias: 68,
+depthBiasSlopeScale: 53,
+depthBiasClamp: 90,
+},
+}
+);
+let textureView201 = texture186.createView(
+{
+label: '\u{1f711}\u0ade\u15a0',
+dimension: '2d',
+baseMipLevel: 6,
+baseArrayLayer: 192,
+}
+);
+try {
+renderPassEncoder49.setBlendConstant({ r: -109.2, g: 684.7, b: 400.7, a: -618.9, });
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(
+5,
+buffer51
+);
+} catch {}
+try {
+renderBundleEncoder93.setVertexBuffer(
+9,
+buffer51,
+50848,
+6191
+);
+} catch {}
+try {
+device4.queue.submit([
+commandBuffer21,
+]);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture186,
+  mipLevel: 6,
+  origin: { x: 5, y: 0, z: 58 },
+  aspect: 'all',
+},
+new Int32Array(new ArrayBuffer(64)),
+/* required buffer size: 2972638 */{
+offset: 613,
+bytesPerRow: 175,
+rowsPerImage: 153,
+},
+{width: 10, height: 0, depthOrArrayLayers: 112}
+);
+} catch {}
+gc();
+let offscreenCanvas59 = new OffscreenCanvas(161, 100);
+let bindGroup81 = device8.createBindGroup({
+label: '\u0fb2\u4b7f\u56db\u099a\u7ea0\u011b\u{1fed6}',
+layout: bindGroupLayout87,
+entries: [
+{
+binding: 789,
+resource: {
+buffer: buffer68,
+offset: 2304,
+size: 14648,
+}
+}
+],
+});
+let sampler143 = device8.createSampler(
+{
+label: '\u{1fdf9}\u3eea\u0c09\u0d87\ue3c9\u{1fad5}',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 55.986,
+lodMaxClamp: 76.407,
+maxAnisotropy: 14,
+}
+);
+try {
+renderPassEncoder41.setBindGroup(
+0,
+bindGroup75,
+[]
+);
+} catch {}
+let gpuCanvasContext55 = offscreenCanvas59.getContext('webgpu');
+try {
+gpuCanvasContext39.unconfigure();
+} catch {}
+let bindGroupLayout97 = pipeline89.getBindGroupLayout(2);
+let commandEncoder160 = device4.createCommandEncoder();
+let querySet156 = device4.createQuerySet({
+label: '\uece0\u0cb4',
+type: 'occlusion',
+count: 945,
+});
+let renderBundleEncoder135 = device4.createRenderBundleEncoder(
+{
+label: '\ue425\u09c9\u1c24\u0a47\u{1f750}\u{1f6f0}',
+colorFormats: [
+'rg32float',
+'rg32sint',
+'r8unorm',
+undefined,
+'rg8unorm',
+'rgb10a2unorm',
+'rgba16uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 489,
+stencilReadOnly: true,
+}
+);
+let renderBundle162 = renderBundleEncoder115.finish();
+try {
+renderPassEncoder36.setBindGroup(
+4,
+bindGroup37,
+new Uint32Array(8734),
+7337,
+0
+);
+} catch {}
+try {
+renderPassEncoder49.beginOcclusionQuery(1860);
+} catch {}
+try {
+renderPassEncoder32.setBlendConstant({ r: -811.7, g: -974.5, b: -428.7, a: 379.2, });
+} catch {}
+try {
+renderPassEncoder50.setStencilReference(
+26
+);
+} catch {}
+try {
+commandEncoder160.clearBuffer(
+buffer51,
+53384,
+648
+);
+dissociateBuffer(device4, buffer51);
+} catch {}
+try {
+device4.queue.writeTexture(
+{
+  texture: texture186,
+  mipLevel: 7,
+  origin: { x: 15, y: 5, z: 23 },
+  aspect: 'all',
+},
+arrayBuffer2,
+/* required buffer size: 1194604 */{
+offset: 178,
+bytesPerRow: 303,
+rowsPerImage: 27,
+},
+{width: 5, height: 0, depthOrArrayLayers: 147}
+);
+} catch {}
+let renderBundleEncoder136 = device13.createRenderBundleEncoder(
+{
+label: '\u9547\ue471\u07a0\u{1f620}\ub4da',
+colorFormats: [
+'rg8unorm',
+'rgba32sint',
+'rg32uint',
+'r16uint',
+'r8sint',
+undefined
+],
+sampleCount: 712,
+stencilReadOnly: true,
+}
+);
+try {
+renderBundleEncoder136.setIndexBuffer(
+buffer77,
+'uint32'
+);
+} catch {}
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+let querySet157 = device5.createQuerySet({
+label: '\u{1f77d}\uf186\u{1fb36}\u50b1\u043c\ucb48\u47f6\u149e',
+type: 'occlusion',
+count: 2915,
+});
+let texture222 = device5.createTexture(
+{
+label: '\u0119\u237e\u{1fa3b}\u{1f979}\u1f17',
+size: [5424, 184, 1],
+mipLevelCount: 13,
+dimension: '2d',
+format: 'eac-rg11unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [
+'eac-rg11unorm',
+'eac-rg11unorm'
+],
+}
+);
+let renderBundleEncoder137 = device5.createRenderBundleEncoder(
+{
+label: '\u09c6\u{1f9ba}',
+colorFormats: [
+'rg16uint'
+],
+sampleCount: 516,
+}
+);
+try {
+renderBundleEncoder137.setVertexBuffer(
+82,
+undefined,
+1555626275,
+1071267080
+);
+} catch {}
+try {
+commandEncoder84.copyTextureToBuffer(
+{
+  texture: texture222,
+  mipLevel: 9,
+  origin: { x: 4, y: 0, z: 1 },
+  aspect: 'all',
+},
+{
+/* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 29552 */
+offset: 29552,
+buffer: buffer54,
+},
+{width: 4, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device5, buffer54);
+} catch {}
+document.body.prepend(canvas45);
+let commandEncoder161 = device10.createCommandEncoder(
+{
+label: '\uc08e\u{1f8b2}',
+}
+);
+let texture223 = device10.createTexture(
+{
+size: [9136, 6, 1],
+mipLevelCount: 4,
+dimension: '2d',
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+}
+);
+let computePassEncoder81 = commandEncoder161.beginComputePass(
+{
+label: '\uf251\u031f\u{1fcd9}\u92a5\u032c\u1855'
+}
+);
+let renderBundleEncoder138 = device10.createRenderBundleEncoder(
+{
+colorFormats: [
+'rgba8unorm'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 234,
+depthReadOnly: true,
+stencilReadOnly: true,
+}
+);
+let sampler144 = device10.createSampler(
+{
+label: '\u4994\uef35\uf4e8\u{1ff5e}\u5b1a\u0365',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 99.309,
+maxAnisotropy: 16,
+}
+);
+try {
+computePassEncoder64.setPipeline(
+pipeline158
+);
+} catch {}
+try {
+renderPassEncoder40.beginOcclusionQuery(225);
+} catch {}
+try {
+renderPassEncoder47.setBlendConstant({ r: -272.3, g: -138.9, b: -435.3, a: -203.5, });
+} catch {}
+try {
+renderPassEncoder40.setStencilReference(
+3270
+);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(
+4,
+buffer66,
+776,
+5388
+);
+} catch {}
+try {
+renderBundleEncoder108.setVertexBuffer(
+5,
+buffer66,
+6352,
+1072
+);
+} catch {}
+try {
+await device10.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device10.queue.copyExternalImageToTexture(
+/*
+{width: 199, height: 14, depthOrArrayLayers: 180}
+*/
+{
+  source: offscreenCanvas45,
+  origin: { x: 26, y: 224 },
+  flipY: false,
+},
+{
+  texture: texture161,
+  mipLevel: 4,
+  origin: { x: 15, y: 11, z: 104 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 144, height: 1, depthOrArrayLayers: 0}
+);
+} catch {}
+let buffer80 = device6.createBuffer(
+{
+label: '\uc896\u2e2c\ube32\u0dde\u008c\u7336\ufe92\u0cc9\u1d4b',
+size: 32339,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+}
+);
+let commandEncoder162 = device6.createCommandEncoder(
+{
+label: '\u6d4c\u0f79\u4e67\ufde3\ub48e\u0efd\u1b3b\u{1fd68}',
+}
+);
+try {
+renderPassEncoder37.setBindGroup(
+8,
+bindGroup55
+);
+} catch {}
+try {
+renderPassEncoder37.setStencilReference(
+1477
+);
+} catch {}
+try {
+commandEncoder162.clearBuffer(
+buffer53,
+7220,
+8944
+);
+dissociateBuffer(device6, buffer53);
+} catch {}
+let pipeline164 = await device6.createComputePipelineAsync(
+{
+label: '\u256e\u0173\u086d\u010c\u7c21\u{1ffb5}\u0173\u{1f9e8}',
+layout: pipelineLayout39,
+compute: {
+module: shaderModule37,
+entryPoint: 'compute0',
+constants: {},
+},
+}
+);
+let pipeline165 = device6.createRenderPipeline(
+{
+label: '\u57dd\u{1fce2}\u{1fa67}\u0717\uc63e\ud1e2\ucda0\u64cd',
+layout: pipelineLayout39,
+vertex: {
+module: shaderModule41,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 7776,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint8x2',
+offset: 6080,
+shaderLocation: 16,
+},
+{
+format: 'sint8x4',
+offset: 3368,
+shaderLocation: 10,
+},
+{
+format: 'sint32x2',
+offset: 2220,
+shaderLocation: 14,
+},
+{
+format: 'float16x4',
+offset: 3612,
+shaderLocation: 5,
+},
+{
+format: 'snorm16x4',
+offset: 1912,
+shaderLocation: 8,
+},
+{
+format: 'sint16x2',
+offset: 1200,
+shaderLocation: 1,
+}
+],
+},
+{
+arrayStride: 59352,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x3',
+offset: 7964,
+shaderLocation: 13,
+}
+],
+},
+{
+arrayStride: 11320,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'snorm16x2',
+offset: 1652,
+shaderLocation: 2,
+},
+{
+format: 'float32x2',
+offset: 4828,
+shaderLocation: 9,
+},
+{
+format: 'sint8x2',
+offset: 5156,
+shaderLocation: 7,
+},
+{
+format: 'uint32x3',
+offset: 10404,
+shaderLocation: 12,
+},
+{
+format: 'uint8x2',
+offset: 7392,
+shaderLocation: 6,
+},
+{
+format: 'unorm10-10-10-2',
+offset: 572,
+shaderLocation: 11,
+},
+{
+format: 'float32',
+offset: 5784,
+shaderLocation: 4,
+},
+{
+format: 'unorm16x4',
+offset: 8840,
+shaderLocation: 3,
+}
+],
+},
+{
+arrayStride: 49672,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 0,
+attributes: [
+
+],
+},
+{
+arrayStride: 54076,
+attributes: [
+{
+format: 'snorm8x4',
+offset: 6452,
+shaderLocation: 15,
+}
+],
+}
+]
+},
+fragment: {
+module: shaderModule41,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+{
+blend: {
+color: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'min',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rg8unorm',
+},
+{
+format: 'r32uint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+},
+{
+format: 'r16uint',
+writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+},
+{
+blend: {
+color: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+alpha: {
+operation: 'max',
+srcFactor: 'one',
+dstFactor: 'one'
+},
+},
+format: 'rg16float',
+writeMask: 0,
+},
+undefined,
+{
+format: 'r8sint',
+writeMask: GPUColorWrite.GREEN,
+},
+{
+format: 'rg32sint',
+writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}
+],
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 2732,
+stencilWriteMask: 79,
+depthBiasSlopeScale: 3,
+depthBiasClamp: 36,
+},
+}
+);
+try {
+device13.label = '\u{1f79c}\uace1\u02e1\u0a76\u010e';
+} catch {}
+let querySet158 = device13.createQuerySet({
+label: '\u{1f880}\u5ed6\u0d7f\u1ab3\u{1f654}\u0fef\ub9db\uad15\ua8e2',
+type: 'occlusion',
+count: 1104,
+});
+let textureView202 = texture193.createView(
+{
+label: '\u{1fee3}\u2dd6',
+format: 'rgba8unorm-srgb',
+baseArrayLayer: 0,
+}
+);
+let computePassEncoder82 = commandEncoder159.beginComputePass(
+{
+label: '\u396a\u2b75\u6fa5\u162e\u1cc9'
+}
+);
+try {
+device13.queue.writeTexture(
+{
+  texture: texture211,
+  mipLevel: 0,
+  origin: { x: 916, y: 0, z: 0 },
+  aspect: 'all',
+},
+new Int8Array(new ArrayBuffer(24)),
+/* required buffer size: 1006 */{
+offset: 558,
+},
+{width: 112, height: 1, depthOrArrayLayers: 1}
+);
+} catch {}
+let offscreenCanvas60 = new OffscreenCanvas(951, 538);
+let commandEncoder163 = device12.createCommandEncoder();
+let querySet159 = device12.createQuerySet({
+label: '\u68eb\u64a3\u1910',
+type: 'occlusion',
+count: 2277,
+});
+let renderBundleEncoder139 = device12.createRenderBundleEncoder(
+{
+label: '\u1b43\u{1f8e1}\u19dd\u6629',
+colorFormats: [
+'rgba8unorm-srgb',
+'rg8sint',
+'rg16uint',
+'rg8sint',
+'rg8uint',
+'rgba16sint',
+'rgba8unorm',
+'rg8uint'
+],
+depthStencilFormat: 'depth24plus-stencil8',
+sampleCount: 862,
+depthReadOnly: true,
+}
+);
+let renderBundle163 = renderBundleEncoder139.finish(
+{
+label: '\u09f1\u5ba2\ue2e9\u0faa\u{1f9f6}\u5fe5\u{1fde6}\u0723\u31e4'
+}
+);
+let sampler145 = device12.createSampler(
+{
+label: '\u00df\u00a7\ub420\u0ff9\u3622\u3bc7\u{1ff87}\uf51d\u493d\u0af3\u3ec3',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMaxClamp: 34.608,
+}
+);
+try {
+renderPassEncoder48.setViewport(
+8.035,
+0.5021,
+0.2010,
+0.09386,
+0.8048,
+0.9104
+);
+} catch {}
+let gpuCanvasContext56 = offscreenCanvas60.getContext('webgpu');
+canvas37.height = 370;
+let commandEncoder164 = device14.createCommandEncoder(
+{
+label: '\u{1f79e}\uc67d',
+}
+);
+pseudoSubmit(device14, commandEncoder164);
+let texture224 = device14.createTexture(
+{
+label: '\u51e1\u0c76',
+size: {width: 11618},
+dimension: '1d',
+format: 'r32uint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [
+'r32uint',
+'r32uint',
+'r32uint'
+],
+}
+);
+try {
+device14.queue.copyExternalImageToTexture(
+/*
+{width: 232, height: 1, depthOrArrayLayers: 1031}
+*/
+{
+  source: offscreenCanvas29,
+  origin: { x: 72, y: 24 },
+  flipY: true,
+},
+{
+  texture: texture219,
+  mipLevel: 0,
+  origin: { x: 2, y: 1, z: 63 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+},
+{width: 213, height: 0, depthOrArrayLayers: 1}
+);
+} catch {}
+let bindGroup82 = device7.createBindGroup({
+label: '\u773a\u{1ff39}\u81a2\u054c\u{1f650}\u4f07',
+layout: bindGroupLayout63,
+entries: [
+
+],
+});
+let commandEncoder165 = device7.createCommandEncoder(
+{
+label: '\u0cdd\uab33\u{1f89e}\u6f4a',
+}
+);
+try {
+commandEncoder139.copyBufferToTexture(
+{
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 33872 */
+offset: 33872,
+buffer: buffer62,
+},
+{
+  texture: texture213,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0}
+);
+dissociateBuffer(device7, buffer62);
+} catch {}
+try {
+device7.queue.writeTexture(
+{
+  texture: texture196,
+  mipLevel: 1,
+  origin: { x: 670, y: 0, z: 1 },
+  aspect: 'all',
+},
+new ArrayBuffer(740),
+/* required buffer size: 740 */{
+offset: 740,
+},
+{width: 2990, height: 0, depthOrArrayLayers: 0}
+);
+} catch {}
+let canvas47 = document.createElement('canvas');
+let buffer81 = device4.createBuffer(
+{
+label: '\u1f31\u05a8\ufb6c\u0674\u033e\u58e7\u0e5b\u7d3e',
+size: 63187,
+usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+mappedAtCreation: false,
+}
+);
+let computePassEncoder83 = commandEncoder160.beginComputePass(
+{
+label: '\ubfd1\ue189\u0714\u1200\u0622\u{1f97d}\u38ef'
+}
+);
+try {
+computePassEncoder73.end();
+} catch {}
+try {
+commandEncoder137.resolveQuerySet(
+querySet100,
+1640,
+371,
+buffer51,
+54272
+);
+} catch {}
+let pipeline166 = device4.createRenderPipeline(
+{
+label: '\u{1faf2}\u06b4\u08c4\u{1fe83}\u057a\u55f2\u6251\u03b2\udba6\u0294\u9f22',
+layout: pipelineLayout31,
+vertex: {
+module: shaderModule24,
+entryPoint: 'vertex0',
+buffers: [
+{
+arrayStride: 26776,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 10888,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 11260,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'float16x4',
+offset: 1776,
+shaderLocation: 16,
+},
+{
+format: 'snorm8x4',
+offset: 6308,
+shaderLocation: 4,
+},
+{
+format: 'snorm8x4',
+offset: 11216,
+shaderLocation: 2,
+}
+],
+},
+{
+arrayStride: 14748,
+stepMode: 'vertex',
+attributes: [
+
+],
+},
+{
+arrayStride: 2640,
+stepMode: 'instance',
+attributes: [
+{
+format: 'uint16x4',
+offset: 1752,
+shaderLocation: 17,
+},
+{
+format: 'uint16x4',
+offset: 968,
+shaderLocation: 10,
+}
+],
+},
+{
+arrayStride: 5168,
+attributes: [
+{
+format: 'unorm8x2',
+offset: 636,
+shaderLocation: 8,
+}
+],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 5912,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 14128,
+stepMode: 'instance',
+attributes: [
+
+],
+},
+{
+arrayStride: 1284,
+stepMode: 'vertex',
+attributes: [
+{
+format: 'uint32x3',
+offset: 48,
+shaderLocation: 7,
+}
+],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+fragment: {
+module: shaderModule24,
+entryPoint: 'fragment0',
+constants: {},
+targets: [
+
+],
+},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'never',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'zero',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 155,
+stencilWriteMask: 6,
+depthBias: 9,
+depthBiasSlopeScale: 52,
+depthBiasClamp: 33,
+},
+}
+);
+canvas35.width = 142;
+let bindGroup83 = device6.createBindGroup({
+label: '\uba51\u04ce\u83cf\u0b9d\u4b47\u877f\u{1f99c}\u039d',
+layout: bindGroupLayout95,
+entries: [
+{
+binding: 2546,
+resource: externalTexture12
+}
+],
+});
+let querySet160 = device6.createQuerySet({
+label: '\u{1ffd7}\u2506',
+type: 'occlusion',
+count: 1441,
+});
+let textureView203 = texture205.createView(
+{
+dimension: '2d-array',
+baseMipLevel: 7,
+mipLevelCount: 1,
+}
+);
+let computePassEncoder84 = commandEncoder148.beginComputePass(
+{
+label: '\ue841\ud9ae\u{1f801}\uf1df\u{1fa64}\uf3ca\uf4fb\uef7b\u0259\u0a33\u{1ff35}'
+}
+);
+try {
+renderPassEncoder46.setScissorRect(
+93,
+23,
+0,
+0
+);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(
+4,
+buffer57
+);
+} catch {}
+try {
+renderBundleEncoder85.setVertexBuffer(
+2,
+buffer57,
+23988,
+1901
+);
+} catch {}
+try {
+commandEncoder162.copyBufferToBuffer(
+buffer70,
+37732,
+buffer53,
+7384,
+908
+);
+dissociateBuffer(device6, buffer70);
+dissociateBuffer(device6, buffer53);
+} catch {}
+try {
+commandEncoder162.copyTextureToTexture(
+{
+  texture: texture185,
+  mipLevel: 0,
+  origin: { x: 1228, y: 0, z: 19 },
+  aspect: 'all',
+},
+{
+  texture: texture185,
+  mipLevel: 1,
+  origin: { x: 144, y: 0, z: 13 },
+  aspect: 'all',
+},
+{width: 116, height: 0, depthOrArrayLayers: 60}
+);
+} catch {}
+try {
+gpuCanvasContext20.configure(
+{
+device: device6,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [
+'rgba16float',
+'astc-12x12-unorm',
+'astc-6x6-unorm-srgb'
+],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+}
+);
+} catch {}
+try {
+device6.queue.submit([
+]);
+} catch {}
+let promise73 = device6.createComputePipelineAsync(
+{
+label: '\u50f3\u0db3\u0b02\u868e\u436c\u4753\u38a1\u04b5',
+layout: pipelineLayout28,
+compute: {
+module: shaderModule41,
+entryPoint: 'compute0',
+},
+}
+);
+let img43 = await imageWithData(92, 105, '#3488bd6d', '#fbec3671');
+try {
+await adapter13.requestAdapterInfo();
+} catch {}
+let querySet161 = device14.createQuerySet({
+label: '\u0f59\u8fb2\u2a93\ub870\u{1f908}\u0719',
+type: 'occlusion',
+count: 2167,
+});
+let renderBundle164 = renderBundleEncoder134.finish(
+{
+label: '\u61bb\ube5a\u{1fb1f}\u86f4'
+}
+);
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame40.close();
+videoFrame41.close();
+videoFrame42.close();
+videoFrame43.close();
+videoFrame44.close();
+videoFrame45.close();
+videoFrame46.close();
+videoFrame47.close();
+videoFrame48.close();
+  log('the end')
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>


### PR DESCRIPTION
#### 1c194cc6e82c4f336bd5817c7f17d3f3d744efad
<pre>
[WebGPU] CommandEncoder::beginRenderPass can fail metal validation for destroyed textures
<a href="https://bugs.webkit.org/show_bug.cgi?id=273503">https://bugs.webkit.org/show_bug.cgi?id=273503</a>
&lt;radar://127229769&gt;

Reviewed by Dan Glastonbury.

Destroyed textures have one mip level and one slice.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-273503-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-273503.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::beginRenderPass):

Canonical link: <a href="https://commits.webkit.org/278346@main">https://commits.webkit.org/278346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24f25cc1efae0c543e9f6b45eea2626ad102f729

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53520 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/590 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43256 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22110 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/24632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/508 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8639 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55105 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25357 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/26620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43440 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47433 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11023 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27482 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/26350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->