### PR TITLE
Benchmark runners should leave devices in the failure state if a benchmark raises an exception

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
@@ -177,14 +177,17 @@ class BenchmarkRunner(object):
                         results.append(run_result)
                     else:
                         raise Exception('Plan does not contain entry_point or test_files')
-
-                finally:
+                except Exception as error:
+                    raise error
+                else:
                     self._browser_driver.restore_env()
                 if self._pgo_profile_output_dir:
                     shutil.copytree(self._pgo_profile_output_dir, self._diagnose_dir, dirs_exist_ok=True)
 
                 _log.info('End the iteration {current_iteration} of {iterations} for current benchmark'.format(current_iteration=iteration, iterations=count))
-        finally:
+        except Exception as error:
+            raise error
+        else:
             self._browser_driver.restore_env_after_all_testing()
 
         results = self._wrap(results)

--- a/Tools/Scripts/webkitpy/benchmark_runner/webdriver_benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/webdriver_benchmark_runner.py
@@ -7,7 +7,6 @@ from webkitpy.benchmark_runner.benchmark_runner import BenchmarkRunner
 
 _log = logging.getLogger(__name__)
 
-
 class WebDriverBenchmarkRunner(BenchmarkRunner):
     name = 'webdriver'
 
@@ -28,7 +27,7 @@ class WebDriverBenchmarkRunner(BenchmarkRunner):
     def _run_one_test(self, web_root, test_file, iteration):
         from selenium.webdriver.support.ui import WebDriverWait
         try:
-            url = 'file://{root}/{plan_name}/{test_file}{subtest_url}'.format(root=web_root, plan_name=self._plan_name, test_file=test_file, subtest_url=self._construct_subtest_url(self.subtests))
+            url = 'file://{root}/{plan_name}/{test_file}{subtest_url}'.format(root=web_root, plan_name=self._plan_name, test_file=test_file, subtest_url=self._construct_subtest_url(self._subtests))
             driver = self._browser_driver.launch_driver(url, self._plan['options'], self._build_dir, self._browser_path)
             _log.info('Waiting on results from web browser')
             result = WebDriverWait(driver, self._plan['timeout'], poll_frequency=1.0).until(self._get_result)
@@ -36,7 +35,7 @@ class WebDriverBenchmarkRunner(BenchmarkRunner):
         except Exception as error:
             self._browser_driver.diagnose_test_failure(self._diagnose_dir, error)
             raise error
-        finally:
+        else:
             self._browser_driver.close_browsers()
 
         return json.loads(result)

--- a/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
@@ -63,7 +63,8 @@ class WebServerBenchmarkRunner(BenchmarkRunner):
         except Exception as error:
             self._browser_driver.diagnose_test_failure(self._diagnose_dir, error)
             raise error
-        finally:
+        else:
             self._browser_driver.close_browsers()
+        finally:
             self._http_server_driver.kill_server()
         return json.loads(result)


### PR DESCRIPTION
#### 746c96e72ec343dd57994e7ce673884aefdb0aec
<pre>
Benchmark runners should leave devices in the failure state if a benchmark raises an exception
<a href="https://rdar.apple.com/127382173">rdar://127382173</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=273571">https://bugs.webkit.org/show_bug.cgi?id=273571</a>

Reviewed by Dewei Zhu.

- When an exception occurs in `_run_one_test()` and `_run_benchmark()` process and environment clean up should be skipped.
- Changed `self.subtests` to `self._subtests` since `self.subtest` is not a property of WebDriverBenchmarkRunner

* Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py:
(BenchmarkRunner._run_benchmark):
* Tools/Scripts/webkitpy/benchmark_runner/webdriver_benchmark_runner.py:
(WebDriverBenchmarkRunner._run_one_test):
* Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py:
(WebServerBenchmarkRunner._run_one_test):

Canonical link: <a href="https://commits.webkit.org/278420@main">https://commits.webkit.org/278420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/422c324bb134d7145198bc1d34556635fd1c0166

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2784 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53739 "Hash 422c324b for PR 28007 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1170 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52783 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/820 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/53739 "Hash 422c324b for PR 28007 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52579 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27444 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/43465 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/53739 "Hash 422c324b for PR 28007 does not build (failure)") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/50331 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/24852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/723 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8858 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/784 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55328 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/704 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48580 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26839 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/43620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47625 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27703 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7307 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26571 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->