### PR TITLE
[WebGPU] RenderBundleEncoder::setPipeline replay command should call into RenderPassEncoder

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2112,10 +2112,10 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-273573.html [ Pass Failure Timeout ]
 [ Debug ] fast/webgpu/fuzz-273570.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-273570.html [ Pass Failure Timeout ]
-[ Debug ] fast/webgpu/fuzz-273505.html [ Skip ]
-[ Release ] fast/webgpu/fuzz-273505.html [ Pass Failure Timeout ]
 [ Debug ] fast/webgpu/fuzz-273503.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-273503.html [ Pass Failure Timeout ]
+[ Debug ] fast/webgpu/fuzz-273578.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-273578.html [ Pass Failure Timeout ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-273578-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-273578-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-273578.html
+++ b/LayoutTests/fast/webgpu/fuzz-273578.html
@@ -1,0 +1,30034 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter({
+});
+let device0 = await adapter0.requestDevice({
+label: '\u0d0f\u8431\u0de4\u4c95',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 9,
+maxColorAttachmentBytesPerSample: 42,
+maxVertexAttributes: 25,
+maxVertexBufferArrayStride: 29394,
+maxStorageTexturesPerShaderStage: 30,
+maxStorageBuffersPerShaderStage: 26,
+maxDynamicStorageBuffersPerPipelineLayout: 26475,
+maxBindingsPerBindGroup: 6299,
+maxTextureDimension1D: 9414,
+maxTextureDimension2D: 9555,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 51757869,
+maxUniformBuffersPerShaderStage: 44,
+maxInterStageShaderVariables: 89,
+maxInterStageShaderComponents: 84,
+maxSamplersPerShaderStage: 20,
+},
+});
+let bindGroupLayout0 = device0.createBindGroupLayout({
+label: '\u0740\u610c\u9f35\ud3ec\u24c5',
+entries: [],
+});
+let bindGroup0 = device0.createBindGroup({
+layout: bindGroupLayout0,
+entries: [],
+});
+let pipelineLayout0 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0]
+});
+let promise0 = device0.queue.onSubmittedWorkDone();
+let offscreenCanvas0 = new OffscreenCanvas(788, 699);
+let commandEncoder0 = device0.createCommandEncoder({label: '\u7b37\ue085\u{1f7cf}\u{1f722}\u0b7e\u573c\u{1fa81}'});
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise0;
+} catch {}
+let video0 = await videoWithData();
+let bindGroupLayout1 = device0.createBindGroupLayout({
+label: '\u025e\u0883\ua6b5\u8a4d\u50c4\u986d\u{1f936}\u746e\uefe9\u0e24\uece9',
+entries: [],
+});
+let texture0 = device0.createTexture({
+label: '\u030c\ud084\uc0f2\ua659\u9216\u991c\u{1f95a}\ufe52',
+size: {width: 7432, height: 5, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x5-unorm', 'astc-8x5-unorm-srgb'],
+});
+offscreenCanvas0.height = 365;
+let commandBuffer0 = commandEncoder0.finish({
+label: '\u001a\ubc7f\u{1faf9}\u4aa2\ub6e8\uf257\u54cb',
+});
+let texture1 = device0.createTexture({
+label: '\u0ba3\u091c\u0bf8\u568a\u{1f7d8}\u67fc\u01dd',
+size: {width: 240, height: 32, depthOrArrayLayers: 61},
+mipLevelCount: 1,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [],
+});
+let textureView0 = texture1.createView({aspect: 'depth-only', mipLevelCount: 1, baseArrayLayer: 34, arrayLayerCount: 4});
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+let bindGroup1 = device0.createBindGroup({
+label: '\u476f\u0fcc\u0db9\u0a71\u0247\ua7b5\ubf2b\u290b\u{1fa4a}\u{1fc90}\u02ef',
+layout: bindGroupLayout1,
+entries: [],
+});
+let texture2 = device0.createTexture({
+label: '\u0220\u00df\u9c11\u9a80\u0727\ub2e7\u05c2\u00bf\u9857\u049f',
+size: [6520, 185, 1],
+mipLevelCount: 13,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x5-unorm-srgb', 'astc-8x5-unorm', 'astc-8x5-unorm-srgb'],
+});
+let sampler0 = device0.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 95.785,
+maxAnisotropy: 16,
+});
+let commandEncoder1 = device0.createCommandEncoder({label: '\uc738\u09d0\u008a\u2633\u{1f729}\uad64'});
+let querySet0 = device0.createQuerySet({
+label: '\u{1fc24}\udf81\u{1ffe6}\uf9ba\u0f17\u8d0d\u7fdb\u02dd\u0a7c',
+type: 'occlusion',
+count: 4039,
+});
+try {
+commandEncoder1.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 7,
+  origin: { x: 8, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 4,
+  origin: { x: 208, y: 5, z: 1 },
+  aspect: 'all',
+}, {width: 48, height: 0, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas0.height = 588;
+let promise1 = navigator.gpu.requestAdapter();
+let bindGroup2 = device0.createBindGroup({
+label: '\u{1f804}\u03ab\u0feb\u0361\u2c30',
+layout: bindGroupLayout0,
+entries: [],
+});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\u590c\u6629\u7370',
+  colorFormats: ['rgba16float', 'r16uint', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let commandEncoder2 = device0.createCommandEncoder();
+let texture3 = device0.createTexture({
+size: {width: 480, height: 36, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'etc2-rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba16float', 'r16uint', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: false,
+  stencilReadOnly: false
+});
+let sampler1 = device0.createSampler({
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 80.831,
+lodMaxClamp: 87.837,
+});
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r16float', 'rgba8unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.prepend(video0);
+let videoFrame0 = new VideoFrame(video0, {timestamp: 0});
+let commandBuffer1 = commandEncoder1.finish({
+label: '\u0368\u6e55\u38c4\ua360',
+});
+let textureView1 = texture0.createView({
+  label: '\ud231\u6e6a\u0546\u{1fdc9}\u760a\u1723\u04d4\ua2ac\u5af5\ud2df\ub4e7',
+  baseMipLevel: 1,
+  mipLevelCount: 3
+});
+let renderBundle0 = renderBundleEncoder1.finish({label: '\u{1fbd2}\u{1f937}\u5eea\u{1f6f8}\u4005\u0d69\u{1fd30}\u4b93'});
+try {
+renderBundleEncoder0.setBindGroup(1, bindGroup1);
+} catch {}
+let imageBitmap0 = await createImageBitmap(video0);
+let texture4 = device0.createTexture({
+size: [240],
+dimension: '1d',
+format: 'r32float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r32float', 'r32float'],
+});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba16float', 'r16uint', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let sampler2 = device0.createSampler({
+label: '\u0b93\u08ce',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 86.533,
+maxAnisotropy: 10,
+});
+let buffer0 = device0.createBuffer({label: '\u3a19\u5210\u8520', size: 55213, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+pseudoSubmit(device0, commandEncoder2);
+let texture5 = device0.createTexture({
+label: '\u{1fbcb}\u0a65\u{1f807}\u05f2\u{1fdc0}',
+size: [240, 18, 1],
+mipLevelCount: 5,
+format: 'depth24plus',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['depth24plus'],
+});
+let externalTexture0 = device0.importExternalTexture({
+label: '\u{1fe1c}\u{1f83e}\uda13\u1eda\u05bb\u41d7\u608a\ufa56\u5a5d\u6042\u0117',
+source: videoFrame0,
+colorSpace: 'display-p3',
+});
+let offscreenCanvas1 = new OffscreenCanvas(958, 120);
+let img0 = await imageWithData(216, 163, '#d2ad04ea', '#7e91b983');
+let bindGroup3 = device0.createBindGroup({
+label: '\ub190\u720d\u99ce\u{1fd15}\u7c58',
+layout: bindGroupLayout1,
+entries: [],
+});
+let buffer1 = device0.createBuffer({label: '\u0a16\ub420\u7211', size: 36858, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder3 = device0.createCommandEncoder({});
+let renderBundle1 = renderBundleEncoder2.finish({});
+try {
+renderBundleEncoder0.setBindGroup(3, bindGroup3, new Uint32Array(3169), 1207, 0);
+} catch {}
+try {
+commandEncoder3.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 7,
+  origin: { x: 32, y: 5, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 30288 */
+offset: 30288,
+bytesPerRow: 256,
+buffer: buffer1,
+}, {width: 16, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder3.clearBuffer(buffer1, 11476, 2744);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+renderBundleEncoder0.insertDebugMarker('\u04c5');
+} catch {}
+let texture6 = device0.createTexture({
+size: [960, 72, 1],
+mipLevelCount: 3,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['depth32float-stencil8'],
+});
+try {
+renderBundleEncoder0.setBindGroup(6, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(6, bindGroup0, new Uint32Array(8458), 224, 0);
+} catch {}
+try {
+querySet0.destroy();
+} catch {}
+try {
+commandEncoder3.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 1,
+  origin: { x: 0, y: 33, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 349, y: 21, z: 0 },
+  aspect: 'all',
+}, {width: 480, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder3.clearBuffer(buffer1, 23968, 7128);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'stencil-only',
+}, new DataView(new ArrayBuffer(16)), /* required buffer size: 7035 */
+{offset: 165, bytesPerRow: 390, rowsPerImage: 66}, {width: 240, height: 18, depthOrArrayLayers: 1});
+} catch {}
+let buffer2 = device0.createBuffer({
+  label: '\u{1f992}\u{1fb31}\u0ef8\u4720\uad34\u03a4',
+  size: 57593,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let computePassEncoder0 = commandEncoder3.beginComputePass({label: '\u4858\u67f0'});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\u0cf8\ue139\u07f6\u0dab\u0361\u6dca',
+  colorFormats: ['rgba16float', 'r16uint', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler3 = device0.createSampler({
+label: '\ua62f\u071b\u0af2\u57d8\uf624\u077b\u8b99',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 94.786,
+lodMaxClamp: 95.242,
+});
+let externalTexture1 = device0.importExternalTexture({
+label: '\u0268\u0166\u5084\u5c25\u{1faeb}\u{1f9e7}\u{1ffc5}',
+source: video0,
+colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder0.setVertexBuffer(48, undefined, 3387785169, 692222089);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 3,
+  origin: { x: 192, y: 0, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 560 */
+{offset: 560, rowsPerImage: 9}, {width: 648, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas0 = document.createElement('canvas');
+let commandEncoder4 = device0.createCommandEncoder({});
+let textureView2 = texture0.createView({label: '\u1e28\ucba9\u49d0\u0788\u2366\u6930', dimension: '2d-array', baseMipLevel: 2, mipLevelCount: 5});
+let computePassEncoder1 = commandEncoder4.beginComputePass({label: '\u0419\u{1ff70}\u4870\u20b9\u4c38\u0fb9\u{1fcc1}\u0578\u3726\ucc4c'});
+try {
+computePassEncoder0.setBindGroup(5, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint16', 5340, 35641);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-10x5-unorm-srgb', 'rgba16float', 'rgba16float', 'rgba32float'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let renderBundle2 = renderBundleEncoder1.finish({});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let canvas1 = document.createElement('canvas');
+try {
+device0.queue.label = '\u3b2b\u{1ffb8}\u11e1\uda0f\u6a14\u509a\ud010';
+} catch {}
+let bindGroupLayout2 = device0.createBindGroupLayout({
+label: '\ud423\u423d\u71f5',
+entries: [{
+binding: 6043,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+}, {
+binding: 4081,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+try {
+renderBundleEncoder3.setBindGroup(0, bindGroup1);
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({
+entries: [{
+binding: 4981,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}, {
+binding: 5174,
+visibility: 0,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+}],
+});
+let renderBundle3 = renderBundleEncoder1.finish();
+let sampler4 = device0.createSampler({
+label: '\u{1fe90}\u0595\u9a15\uc359\u019b',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 7.200,
+lodMaxClamp: 70.107,
+maxAnisotropy: 19,
+});
+try {
+device0.queue.submit([
+commandBuffer0,
+]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 5,
+  origin: { x: 168, y: 0, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 523 */
+{offset: 523, bytesPerRow: 156}, {width: 56, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup4 = device0.createBindGroup({
+label: '\u3880\u3efd\u1272\u65b5',
+layout: bindGroupLayout1,
+entries: [],
+});
+let sampler5 = device0.createSampler({
+label: '\ueef0\u47de\uddc2\u53f9\ueee6\u{1f996}\ua2a1\u03a1',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 45.439,
+lodMaxClamp: 58.514,
+maxAnisotropy: 5,
+});
+try {
+renderBundleEncoder0.setIndexBuffer(buffer0, 'uint32', 28396, 15584);
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+let pipelineLayout1 = device0.createPipelineLayout({
+  label: '\u6fd1\u370d\u5503\u0e7c',
+  bindGroupLayouts: [bindGroupLayout2, bindGroupLayout2, bindGroupLayout1]
+});
+let renderBundle4 = renderBundleEncoder1.finish();
+try {
+renderBundleEncoder0.setBindGroup(6, bindGroup4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'stencil-only',
+}, new Uint8ClampedArray(new ArrayBuffer(0)), /* required buffer size: 23 */
+{offset: 23, bytesPerRow: 1053}, {width: 960, height: 72, depthOrArrayLayers: 0});
+} catch {}
+canvas1.height = 864;
+let texture7 = device0.createTexture({
+label: '\u0135\u1e25\ua579\uc0ed',
+size: [56, 110, 1],
+dimension: '2d',
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x5-unorm-srgb', 'astc-8x5-unorm-srgb'],
+});
+try {
+computePassEncoder0.setBindGroup(8, bindGroup3, new Uint32Array(3673), 2816, 0);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let img1 = await imageWithData(124, 215, '#d7eb83b1', '#f8b93498');
+try {
+canvas1.getContext('webgpu');
+} catch {}
+let querySet1 = device0.createQuerySet({
+label: '\u3dee\ub9f8\u{1fc05}',
+type: 'occlusion',
+count: 3422,
+});
+let imageData0 = new ImageData(244, 148);
+let textureView3 = texture0.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 2, arrayLayerCount: 1});
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+let video1 = await videoWithData();
+let bindGroupLayout4 = device0.createBindGroupLayout({
+label: '\u{1fb1d}\u{1fedc}\u0bb3\u24f3\u{1fc32}',
+entries: [],
+});
+let bindGroup5 = device0.createBindGroup({
+label: '\u0279\u04d4\u{1ff6c}\u0507\u0721\ua2b3\ue9b0\u{1f8ec}',
+layout: bindGroupLayout0,
+entries: [],
+});
+let pipelineLayout2 = device0.createPipelineLayout({
+  label: '\uad3f\u0904\uc3b6\u{1fe7d}\ue292\ub3fa',
+  bindGroupLayouts: [bindGroupLayout3, bindGroupLayout4, bindGroupLayout3, bindGroupLayout2, bindGroupLayout1, bindGroupLayout4, bindGroupLayout0, bindGroupLayout3]
+});
+let buffer3 = device0.createBuffer({size: 60620, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let textureView4 = texture6.createView({
+  label: '\u174a\u0439\u0f3f\u{1fc6a}\u4de7\u1507\u{1fd2a}',
+  aspect: 'depth-only',
+  baseMipLevel: 0,
+  mipLevelCount: 1
+});
+try {
+renderBundleEncoder0.setBindGroup(0, bindGroup2);
+} catch {}
+let promise3 = buffer1.mapAsync(GPUMapMode.READ, 29032, 3116);
+document.body.prepend(canvas1);
+try {
+adapter0.label = '\u0918\uddc6\u0070\u{1f866}\u{1f79d}\u6ee1\u4e50\u{1f94f}\uca85\u1315';
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder();
+try {
+commandEncoder5.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 2,
+  origin: { x: 0, y: 6, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 216, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 240, height: 1, depthOrArrayLayers: 1});
+} catch {}
+video0.width = 78;
+try {
+commandEncoder5.copyBufferToTexture({
+/* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 26208 */
+offset: 26208,
+bytesPerRow: 256,
+buffer: buffer2,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: { x: 0, y: 5, z: 1 },
+  aspect: 'all',
+}, {width: 16, height: 95, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder5.clearBuffer(buffer1, 20032, 14692);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 214 */
+{offset: 214}, {width: 56, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView5 = texture0.createView({
+  label: '\u0508\u0002\u{1f8f0}',
+  dimension: '2d-array',
+  format: 'astc-8x5-unorm',
+  baseMipLevel: 2,
+  mipLevelCount: 4
+});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\u091a\u91bb\ucf4b\u{1fc9a}\u3957\u0f27\u04be',
+  colorFormats: ['rgba16float', 'r16uint', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let renderBundle5 = renderBundleEncoder2.finish({});
+try {
+renderBundleEncoder3.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+commandEncoder5.copyBufferToBuffer(buffer2, 19836, buffer1, 19608, 16536);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder5.copyBufferToTexture({
+/* bytesInLastRow: 240 widthInBlocks: 240 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 33028 */
+offset: 32788,
+buffer: buffer2,
+}, {
+  texture: texture6,
+  mipLevel: 2,
+  origin: { x: 0, y: 9, z: 0 },
+  aspect: 'stencil-only',
+}, {width: 240, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+  await promise2;
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+label: '\u{1fa0a}\u2f45\u{1f8a8}\u0255\u{1f649}\u{1f67c}\u{1f74a}\u{1fc31}\u71fa\u0eb6\u097a',
+code: `@group(0) @binding(5174)
+var<storage, read_write> i0: array<u32>;
+@group(7) @binding(5174)
+var<storage, read_write> parameter0: array<u32>;
+@group(2) @binding(5174)
+var<storage, read_write> local0: array<u32>;
+@group(3) @binding(4081)
+var<storage, read_write> parameter1: array<u32>;
+@group(7) @binding(4981)
+var<storage, read_write> local1: array<u32>;
+@group(3) @binding(6043)
+var<storage, read_write> type0: array<u32>;
+@group(0) @binding(4981)
+var<storage, read_write> parameter2: array<u32>;
+@group(2) @binding(4981)
+var<storage, read_write> local2: array<u32>;
+
+@compute @workgroup_size(4, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(frag_depth) f0: f32,
+  @location(0) f1: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(11) a0: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let querySet2 = device0.createQuerySet({
+label: '\u0b31\ubf58\u9719\u09d5\udc80\uda1e\u0fee\u0636\u0393',
+type: 'occlusion',
+count: 2095,
+});
+let texture8 = device0.createTexture({
+label: '\u4f6f\u{1fc4e}\u0b21',
+size: {width: 920, height: 5, depthOrArrayLayers: 209},
+mipLevelCount: 6,
+format: 'astc-10x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x5-unorm-srgb', 'astc-10x5-unorm-srgb'],
+});
+let computePassEncoder2 = commandEncoder5.beginComputePass();
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  label: '\u0ffe\u8e22\u5149\u{1fabf}\u78f1\u338d\ucaf2\u0259\u{1fb0c}',
+  colorFormats: ['rgba16float', 'r16uint', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle6 = renderBundleEncoder3.finish({label: '\u0e21\u532d'});
+let sampler6 = device0.createSampler({
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 91.833,
+lodMaxClamp: 95.704,
+compare: 'less-equal',
+maxAnisotropy: 17,
+});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup4, new Uint32Array(9824), 9047, 0);
+} catch {}
+let bindGroupLayout5 = device0.createBindGroupLayout({
+entries: [{
+binding: 302,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+}],
+});
+let texture9 = device0.createTexture({
+label: '\u5ac0\u0443\u6515\u6e36\uee53\u60b3\u{1f6e4}\u028b\u3c05\u3517',
+size: {width: 120, height: 9, depthOrArrayLayers: 119},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  label: '\u9f6c\u62d0\u{1fe34}\u4bf5\u1a07\u0909\u5947',
+  colorFormats: ['rgba16float', 'r16uint', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder6.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer0, 'uint16');
+} catch {}
+try {
+renderBundleEncoder4.pushDebugGroup('\u0b3b');
+} catch {}
+try {
+renderBundleEncoder4.popDebugGroup();
+} catch {}
+let commandEncoder6 = device0.createCommandEncoder({label: '\u{1f762}\u7098\u3389\u0ff8\u9681\u{1f758}'});
+let sampler7 = device0.createSampler({
+label: '\ue40b\ub0f6\uc030\u{1fe9b}\u36c8\u0d22\u3db9\ud5a8',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 37.722,
+lodMaxClamp: 58.142,
+maxAnisotropy: 2,
+});
+let promise4 = buffer2.mapAsync(GPUMapMode.WRITE, 15088, 1672);
+try {
+commandEncoder6.copyBufferToBuffer(buffer2, 14192, buffer1, 536, 8140);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+offscreenCanvas1.height = 55;
+let bindGroup6 = device0.createBindGroup({
+label: '\u0c62\u07c7\ucd11\u{1f9a4}\uabdc',
+layout: bindGroupLayout1,
+entries: [],
+});
+let commandEncoder7 = device0.createCommandEncoder({label: '\u15c7\u812f\ua77b'});
+let querySet3 = device0.createQuerySet({
+type: 'occlusion',
+count: 2944,
+});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u042d\u412a\u4076',
+  colorFormats: [],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let pipeline0 = device0.createComputePipeline({
+label: '\u{1f89e}\ub058\u{1fdae}\uc7c0\u{1fad0}\u0831\u0be6\u0d25\u{1fda8}\u477a\u7244',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+adapter0.label = '\u8b8b\ud90d\ub58b\ua9b9\u073d\uf0de\ue79c\ufe4a\u275b\u63f8';
+} catch {}
+let renderPassEncoder0 = commandEncoder6.beginRenderPass({
+label: '\u{1fdad}\u2091\ubda1\u0e83\u00e9\u614a\u0ab2',
+colorAttachments: [],
+depthStencilAttachment: {
+view: textureView4,
+depthClearValue: -4.2074581452249005,
+depthReadOnly: true,
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet0,
+maxDrawCount: 948984580,
+});
+try {
+renderPassEncoder0.setBindGroup(7, bindGroup1);
+} catch {}
+try {
+texture1.destroy();
+} catch {}
+let querySet4 = device0.createQuerySet({
+type: 'occlusion',
+count: 1398,
+});
+try {
+computePassEncoder0.setBindGroup(4, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(7, bindGroup6);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline1 = device0.createRenderPipeline({
+label: '\u156f\u{1feb4}\u08e2\ua8ae\u7480',
+layout: pipelineLayout1,
+multisample: {
+mask: 0x477168db,
+},
+fragment: {module: shaderModule0, entryPoint: 'fragment0', targets: []},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+},
+stencilReadMask: 3135,
+stencilWriteMask: 663,
+depthBiasSlopeScale: 2,
+depthBiasClamp: 64,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 24108,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 18348,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x4',
+offset: 6096,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let shaderModule1 = device0.createShaderModule({
+label: '\u0684\u{1f65d}\u6610\u{1fd55}\u232f\u218f\u0d5d',
+code: `@group(3) @binding(4081)
+var<storage, read_write> local3: array<u32>;
+@group(3) @binding(6043)
+var<storage, read_write> type1: array<u32>;
+@group(2) @binding(4981)
+var<storage, read_write> field0: array<u32>;
+@group(2) @binding(5174)
+var<storage, read_write> parameter3: array<u32>;
+@group(7) @binding(4981)
+var<storage, read_write> type2: array<u32>;
+@group(7) @binding(5174)
+var<storage, read_write> parameter4: array<u32>;
+
+@compute @workgroup_size(6, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S1 {
+  @builtin(sample_mask) f0: u32,
+  @builtin(position) f1: vec4<f32>,
+  @builtin(front_facing) f2: bool,
+  @builtin(sample_index) f3: u32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @builtin(sample_mask) f1: u32,
+  @builtin(frag_depth) f2: f32,
+  @location(1) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(a0: S1) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S0 {
+  @location(22) f0: vec4<f16>,
+  @builtin(vertex_index) f1: u32,
+  @location(3) f2: vec4<i32>,
+  @location(2) f3: vec2<i32>,
+  @location(11) f4: vec2<u32>,
+  @location(4) f5: vec4<i32>,
+  @builtin(instance_index) f6: u32,
+  @location(14) f7: f32
+}
+
+@vertex
+fn vertex0(a0: S0, @location(12) a1: vec2<i32>, @location(24) a2: i32, @location(20) a3: i32, @location(8) a4: vec3<u32>, @location(16) a5: vec4<f16>, @location(19) a6: vec3<u32>, @location(21) a7: f32, @location(17) a8: vec2<f32>, @location(15) a9: vec4<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroupLayout6 = device0.createBindGroupLayout({
+label: '\u93d0\u{1ff2b}\ua6df\u097c',
+entries: [{
+binding: 3386,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rg32sint', access: 'write-only', viewDimension: '3d' },
+}],
+});
+let querySet5 = device0.createQuerySet({
+label: '\u0bd3\uff89\u{1faf9}\u378d\u2ef0\u809f\uea72\u64de\u3a5f\ua0f2\u{1f96f}',
+type: 'occlusion',
+count: 1869,
+});
+let textureView6 = texture6.createView({label: '\u0901\u395f\u9f7e\u8e3f\u4e05\u{1fe29}\u089b\u04a1\u088c\u0caf\u{1fd4a}', baseMipLevel: 2});
+let renderBundle7 = renderBundleEncoder2.finish();
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setViewport(718.3, 17.34, 240.7, 22.59, 0.07631, 0.5407);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(4, bindGroup3, new Uint32Array(2653), 2340, 0);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer0, 'uint32');
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer4 = device0.createBuffer({
+  label: '\u{1f96b}\u042b\u11dd\u2b72\u{1f643}\u61e6\u0859',
+  size: 46216,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX
+});
+let texture10 = device0.createTexture({
+label: '\ua69a\ue3e9\u07fe\u56f1\ud0f4\u0599\u58b3\u1104',
+size: {width: 120, height: 16, depthOrArrayLayers: 61},
+mipLevelCount: 2,
+format: 'astc-4x4-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-4x4-unorm-srgb', 'astc-4x4-unorm', 'astc-4x4-unorm'],
+});
+let textureView7 = texture3.createView({
+  label: '\u099c\ueafc',
+  dimension: '2d-array',
+  format: 'etc2-rgba8unorm-srgb',
+  baseMipLevel: 2,
+  mipLevelCount: 2
+});
+let renderBundle8 = renderBundleEncoder2.finish({label: '\u02df\uab4e\ub422\u5ce9\u9db7\u{1fb80}'});
+let sampler8 = device0.createSampler({
+label: '\u326c\u05ed\u080d',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 38.910,
+lodMaxClamp: 63.798,
+compare: 'not-equal',
+maxAnisotropy: 10,
+});
+try {
+renderPassEncoder0.beginOcclusionQuery(3033);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setViewport(455.7, 64.15, 192.9, 4.809, 0.3600, 0.7625);
+} catch {}
+let imageBitmap1 = await createImageBitmap(canvas1);
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  label: '\u{1fd0a}\u{1f707}',
+  colorFormats: ['rgba16float', 'r16uint', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderPassEncoder0.setViewport(441.1, 14.28, 408.9, 5.878, 0.5709, 0.9767);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer0, 'uint16', 37712, 15730);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer1,
+]);
+} catch {}
+let pipeline2 = await device0.createRenderPipelineAsync({
+label: '\u{1f8bd}\u9b01\u{1f707}\u7993\u7ceb',
+layout: pipelineLayout2,
+multisample: {
+mask: 0x51a53eb0,
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'always',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'replace',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 4023,
+stencilWriteMask: 900,
+depthBias: 54,
+depthBiasClamp: 78,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 26816,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 8512,
+attributes: [{
+format: 'sint8x4',
+offset: 6500,
+shaderLocation: 3,
+}, {
+format: 'unorm8x4',
+offset: 236,
+shaderLocation: 17,
+}, {
+format: 'unorm10-10-10-2',
+offset: 1196,
+shaderLocation: 22,
+}, {
+format: 'uint16x2',
+offset: 4040,
+shaderLocation: 8,
+}, {
+format: 'snorm16x2',
+offset: 2248,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 2204,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x4',
+offset: 852,
+shaderLocation: 2,
+}, {
+format: 'uint16x2',
+offset: 1052,
+shaderLocation: 11,
+}, {
+format: 'uint32x3',
+offset: 32,
+shaderLocation: 19,
+}, {
+format: 'sint16x2',
+offset: 20,
+shaderLocation: 24,
+}],
+},
+{
+arrayStride: 20300,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 17672,
+shaderLocation: 15,
+}, {
+format: 'sint32x4',
+offset: 12488,
+shaderLocation: 20,
+}, {
+format: 'sint32x3',
+offset: 9916,
+shaderLocation: 12,
+}, {
+format: 'snorm16x4',
+offset: 18800,
+shaderLocation: 16,
+}, {
+format: 'sint32x4',
+offset: 6292,
+shaderLocation: 4,
+}, {
+format: 'snorm8x4',
+offset: 18524,
+shaderLocation: 21,
+}],
+}
+]
+},
+});
+let buffer5 = device0.createBuffer({
+  label: '\u37dd\u8a7b\u1936\u{1ff3f}\u1001\u5246\u0cb9\u1591',
+  size: 63563,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let computePassEncoder3 = commandEncoder7.beginComputePass({label: '\u947c\u{1ff6b}\ucc80\u{1f603}\u{1fe11}\u62a6\u0d14\u{1f604}\ubcc3\u9ef7'});
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(333, 61, 370, 9);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(727);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer0, 'uint16');
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(74, undefined, 396892438, 3480923392);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 32424, new BigUint64Array(2459), 1356, 1100);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let renderPassEncoder1 = commandEncoder4.beginRenderPass({
+label: '\u9968\u0aca',
+colorAttachments: [],
+depthStencilAttachment: {
+view: textureView6,
+depthClearValue: 0.5432599367529617,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+stencilLoadOp: 'load',
+stencilStoreOp: 'discard',
+},
+occlusionQuerySet: querySet1,
+maxDrawCount: 191673128,
+});
+try {
+computePassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(2175);
+} catch {}
+try {
+renderPassEncoder1.setViewport(85.66, 15.70, 10.28, 1.174, 0.09218, 0.2526);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline1);
+} catch {}
+let gpuCanvasContext1 = canvas0.getContext('webgpu');
+let textureView8 = texture4.createView({label: '\u0edf\u{1f851}\u{1fc5e}\u6ec6\u7fc6\u08bf'});
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(44, 3, 111, 6);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer5, 225008);
+} catch {}
+try {
+renderBundleEncoder0.setIndexBuffer(buffer0, 'uint16', 20682, 5265);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 34 },
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 184501 */
+{offset: 496, bytesPerRow: 87, rowsPerImage: 141}, {width: 0, height: 4, depthOrArrayLayers: 16});
+} catch {}
+let pipeline3 = await device0.createRenderPipelineAsync({
+label: '\u48d3\u{1f907}\u53f8\u0868\u0434\u038a\ua2b3\u5c0d\u7ead\u5c96',
+layout: pipelineLayout2,
+fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'less-equal',
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'zero',
+depthFailOp: 'keep',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 1423,
+depthBias: 65,
+depthBiasSlopeScale: 80,
+depthBiasClamp: 90,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1224,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 7352,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 3880,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+gc();
+try {
+computePassEncoder2.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(8, bindGroup0, new Uint32Array(794), 78, 0);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setViewport(466.5, 18.43, 402.2, 12.60, 0.5667, 0.6699);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer0, 'uint16');
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout({label: '\u{1ff1f}\u{1f8a0}', bindGroupLayouts: [bindGroupLayout5, bindGroupLayout3, bindGroupLayout3]});
+let texture11 = device0.createTexture({
+label: '\u2b56\u2b03\u{1fd77}',
+size: {width: 2696, height: 5, depthOrArrayLayers: 36},
+mipLevelCount: 6,
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(162, 28, 624, 10);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(2, bindGroup4, []);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 3136, new Int16Array(15947), 15429, 100);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap2 = await createImageBitmap(canvas1);
+let imageData1 = new ImageData(64, 240);
+let bindGroupLayout7 = device0.createBindGroupLayout({
+entries: [{
+binding: 6216,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 1458,
+visibility: 0,
+storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+}, {
+binding: 5204,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+}],
+});
+try {
+renderPassEncoder0.setStencilReference(1361);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer0, 180464);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 26052, new Int16Array(48188), 34678, 4564);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'stencil-only',
+}, new ArrayBuffer(24), /* required buffer size: 21071 */
+{offset: 606, bytesPerRow: 571}, {width: 480, height: 36, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas1.getContext('webgpu');
+try {
+  await promise3;
+} catch {}
+let bindGroup7 = device0.createBindGroup({
+label: '\ubfaa\udf2b\u1487\u{1fb09}\u993b',
+layout: bindGroupLayout4,
+entries: [],
+});
+let querySet6 = device0.createQuerySet({
+label: '\ueed8\u1d83\u0bc6\ub834\u589e\ua3c4',
+type: 'occlusion',
+count: 1060,
+});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(2568);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 884.4, g: -784.3, b: 181.5, a: 104.1, });
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(32, 8, 40, 296, 32);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(6, bindGroup7, new Uint32Array(4886), 3849, 0);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(40, undefined);
+} catch {}
+let pipeline4 = await device0.createComputePipelineAsync({
+label: '\u032d\ud907\u163f',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let promise5 = navigator.gpu.requestAdapter({
+});
+let textureView9 = texture11.createView({
+  label: '\u0373\u042b\u0197\u{1fe9a}\u5ec7',
+  baseMipLevel: 4,
+  mipLevelCount: 2,
+  baseArrayLayer: 14,
+  arrayLayerCount: 20
+});
+let renderBundle9 = renderBundleEncoder0.finish();
+let sampler9 = device0.createSampler({
+label: '\u{1fbb7}\ud407\ueef4\ucf8f\u0664\uf721\u089c\u0673\u981e',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 88.951,
+lodMaxClamp: 96.277,
+maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder4.setVertexBuffer(23, undefined, 4184367915, 43710869);
+} catch {}
+let pipeline5 = device0.createRenderPipeline({
+label: '\u63c1\ubd2d\u02d8\u01e2\ua0d7',
+layout: pipelineLayout2,
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.ALL}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'replace',
+},
+stencilReadMask: 2030,
+stencilWriteMask: 2758,
+depthBias: 25,
+depthBiasSlopeScale: 34,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 23520,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x4',
+offset: 12860,
+shaderLocation: 24,
+}, {
+format: 'sint16x2',
+offset: 7384,
+shaderLocation: 12,
+}, {
+format: 'unorm16x2',
+offset: 17736,
+shaderLocation: 22,
+}, {
+format: 'snorm16x2',
+offset: 18168,
+shaderLocation: 17,
+}, {
+format: 'unorm8x4',
+offset: 14644,
+shaderLocation: 21,
+}, {
+format: 'uint32x3',
+offset: 824,
+shaderLocation: 19,
+}, {
+format: 'float32x2',
+offset: 5200,
+shaderLocation: 15,
+}, {
+format: 'float32x4',
+offset: 21036,
+shaderLocation: 16,
+}, {
+format: 'sint32',
+offset: 13516,
+shaderLocation: 20,
+}, {
+format: 'sint16x2',
+offset: 13664,
+shaderLocation: 3,
+}, {
+format: 'sint32x4',
+offset: 17136,
+shaderLocation: 4,
+}, {
+format: 'sint8x4',
+offset: 12268,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 24548,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32',
+offset: 18488,
+shaderLocation: 11,
+}, {
+format: 'uint32x3',
+offset: 3740,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 6232,
+attributes: [],
+},
+{
+arrayStride: 22816,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 5760,
+shaderLocation: 14,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let imageBitmap3 = await createImageBitmap(video1);
+let bindGroup8 = device0.createBindGroup({
+layout: bindGroupLayout1,
+entries: [],
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u682c\u9d40\ubbcd\u9fa4\u{1fe7b}\u0ee3\u2d72\u{1fa97}\u18e2',
+  colorFormats: ['rgba16float', 'r16uint', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+let renderBundle10 = renderBundleEncoder3.finish({label: '\u{1f9d4}\ufde0\ue406\u157a\u{1fab1}\u2784\u9c41\uc60e\ua4b1'});
+try {
+renderPassEncoder0.beginOcclusionQuery(829);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 145.2, g: -150.6, b: -341.9, a: -690.2, });
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 13600, new DataView(new ArrayBuffer(17658)), 5485, 7620);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 1,
+  origin: { x: 0, y: 16, z: 0 },
+  aspect: 'stencil-only',
+}, new ArrayBuffer(301), /* required buffer size: 301 */
+{offset: 301, bytesPerRow: 769}, {width: 480, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(838, 477);
+pseudoSubmit(device0, commandEncoder7);
+let texture12 = device0.createTexture({
+label: '\uce37\u0b4c\u0abf\u5800\u0a3c\ud4b8\u0bc2\u5b26\u{1f7d4}\u4b3d',
+size: {width: 480, height: 64, depthOrArrayLayers: 61},
+mipLevelCount: 8,
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgba32sint', 'rgba32sint', 'rgba32sint'],
+});
+try {
+renderPassEncoder0.setBindGroup(8, bindGroup8);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer5, 187688);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer3, 97440);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(4, bindGroup6);
+} catch {}
+gc();
+let img2 = await imageWithData(68, 222, '#49d8027c', '#0f07ec30');
+let bindGroup9 = device0.createBindGroup({
+label: '\ub651\u774c\u29b6\ud00a\ub6bc\u0b3f\u2ea1',
+layout: bindGroupLayout5,
+entries: [{
+binding: 302,
+resource: sampler2
+}],
+});
+try {
+renderPassEncoder1.setBindGroup(7, bindGroup1);
+} catch {}
+try {
+renderPassEncoder1.setViewport(185.3, 11.30, 53.88, 6.334, 0.4950, 0.8586);
+} catch {}
+try {
+renderPassEncoder1.draw(40, 64);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(80, 80);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer4, 'uint16', 39832, 4665);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['bgra8unorm-srgb', 'astc-5x4-unorm-srgb', 'depth24plus', 'astc-5x5-unorm-srgb'],
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+  await promise4;
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(64, 80, 40, -544, 0);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer0, 'uint32');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 5,
+  origin: { x: 10, y: 0, z: 80 },
+  aspect: 'all',
+}, new Uint16Array(new ArrayBuffer(32)), /* required buffer size: 259309 */
+{offset: 739, bytesPerRow: 45, rowsPerImage: 169}, {width: 10, height: 0, depthOrArrayLayers: 35});
+} catch {}
+let pipeline6 = await device0.createRenderPipelineAsync({
+label: '\ubf6b\u{1fa05}',
+layout: pipelineLayout3,
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'src-alpha', dstFactor: 'src-alpha-saturated'},
+},
+  writeMask: 0
+}, {format: 'r16uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'replace',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilReadMask: 3527,
+stencilWriteMask: 1671,
+depthBiasSlopeScale: 80,
+depthBiasClamp: 40,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 9924,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x4',
+offset: 2904,
+shaderLocation: 4,
+}, {
+format: 'sint8x4',
+offset: 5904,
+shaderLocation: 12,
+}, {
+format: 'snorm8x4',
+offset: 5196,
+shaderLocation: 16,
+}, {
+format: 'sint16x2',
+offset: 9740,
+shaderLocation: 3,
+}, {
+format: 'uint8x4',
+offset: 8400,
+shaderLocation: 19,
+}, {
+format: 'uint32x2',
+offset: 3596,
+shaderLocation: 11,
+}, {
+format: 'float32x3',
+offset: 6192,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 6560,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 4776,
+shaderLocation: 17,
+}, {
+format: 'float32x2',
+offset: 2108,
+shaderLocation: 21,
+}],
+},
+{
+arrayStride: 17236,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 9012,
+shaderLocation: 20,
+}, {
+format: 'float16x2',
+offset: 11932,
+shaderLocation: 15,
+}, {
+format: 'sint16x2',
+offset: 416,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 612,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 17692,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x4',
+offset: 13520,
+shaderLocation: 8,
+}, {
+format: 'float32',
+offset: 14936,
+shaderLocation: 22,
+}, {
+format: 'sint32x2',
+offset: 11136,
+shaderLocation: 24,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'none',
+},
+});
+let bindGroupLayout8 = device0.createBindGroupLayout({
+label: '\u76fc\uba16\uf05f\u{1fe0e}\u07b1\u84b5\u059e',
+entries: [{
+binding: 5077,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+}],
+});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\u0b8e\u0589\u{1fb86}\u00b9\u07c2\uc3d8\u059d',
+  colorFormats: [],
+  depthStencilFormat: 'depth32float-stencil8'
+});
+try {
+computePassEncoder0.setBindGroup(4, bindGroup7, new Uint32Array(9374), 5694, 0);
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer0, 39512);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(92, undefined, 3499914502);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(7, bindGroup8, new Uint32Array(7439), 5786, 0);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(715, 12, 148, 51);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer0, 'uint16', 3426);
+} catch {}
+try {
+offscreenCanvas2.getContext('webgl2');
+} catch {}
+let buffer6 = device0.createBuffer({
+  label: '\u75ae\u0f12\u130f\u0a96\u0962\u199c\u{1fc87}',
+  size: 17302,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX
+});
+let querySet7 = device0.createQuerySet({
+label: '\u4386\u5145\u1777\u4810\ua73f\u0c64\u09ac\ue007\u{1f6a2}\ue74c\u{1fd09}',
+type: 'occlusion',
+count: 2187,
+});
+pseudoSubmit(device0, commandEncoder6);
+let textureView10 = texture12.createView({baseMipLevel: 2, mipLevelCount: 4, baseArrayLayer: 60});
+try {
+renderPassEncoder0.setScissorRect(68, 14, 413, 7);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer0, 159168);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer6, 16948, 0);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(8, buffer6, 7464, 4131);
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+label: '\uf95b\u{1f644}\uaeb1\u09b3\u{1fc75}\u{1fa2f}\uab67\u056a\u08b1\u095a\u0015',
+code: `@group(3) @binding(6043)
+var<storage, read_write> field1: array<u32>;
+@group(7) @binding(4981)
+var<storage, read_write> type3: array<u32>;
+@group(2) @binding(5174)
+var<storage, read_write> global0: array<u32>;
+@group(0) @binding(4981)
+var<storage, read_write> global1: array<u32>;
+@group(0) @binding(5174)
+var<storage, read_write> global2: array<u32>;
+@group(3) @binding(4081)
+var<storage, read_write> function0: array<u32>;
+
+@compute @workgroup_size(2, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S3 {
+  @location(9) f0: vec3<u32>,
+  @location(4) f1: vec2<f32>,
+  @location(78) f2: vec2<f16>,
+  @location(80) f3: f16,
+  @location(29) f4: vec3<u32>,
+  @location(27) f5: vec3<u32>,
+  @location(10) f6: u32,
+  @location(8) f7: vec3<u32>,
+  @location(65) f8: f16,
+  @location(15) f9: vec4<i32>,
+  @builtin(front_facing) f10: bool,
+  @location(2) f11: f32,
+  @builtin(position) f12: vec4<f32>,
+  @location(18) f13: vec2<f16>,
+  @location(70) f14: vec3<f16>,
+  @location(6) f15: f16,
+  @location(84) f16: vec2<u32>,
+  @location(74) f17: i32,
+  @location(79) f18: vec3<f32>,
+  @location(23) f19: vec2<f16>,
+  @location(46) f20: vec4<f16>,
+  @location(47) f21: vec3<i32>,
+  @location(87) f22: vec3<f16>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(1) f1: vec3<u32>,
+  @location(5) f2: vec2<u32>,
+  @builtin(frag_depth) f3: f32
+}
+
+@fragment
+fn fragment0(@location(20) a0: vec2<f32>, a1: S3, @location(61) a2: vec2<f16>, @location(52) a3: vec4<u32>, @location(83) a4: vec3<i32>, @builtin(sample_mask) a5: u32, @location(34) a6: i32, @location(17) a7: vec2<f32>, @builtin(sample_index) a8: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S2 {
+  @location(9) f0: vec2<f16>,
+  @location(3) f1: vec2<i32>,
+  @location(2) f2: f32,
+  @location(14) f3: vec3<u32>,
+  @location(22) f4: vec3<f32>,
+  @location(24) f5: vec2<u32>,
+  @builtin(vertex_index) f6: u32
+}
+struct VertexOutput0 {
+  @location(27) f0: vec3<u32>,
+  @location(65) f1: f16,
+  @location(4) f2: vec2<f32>,
+  @location(87) f3: vec3<f16>,
+  @location(18) f4: vec2<f16>,
+  @location(84) f5: vec2<u32>,
+  @location(20) f6: vec2<f32>,
+  @location(46) f7: vec4<f16>,
+  @location(52) f8: vec4<u32>,
+  @location(70) f9: vec3<f16>,
+  @location(34) f10: i32,
+  @location(83) f11: vec3<i32>,
+  @location(15) f12: vec4<i32>,
+  @builtin(position) f13: vec4<f32>,
+  @location(8) f14: vec3<u32>,
+  @location(79) f15: vec3<f32>,
+  @location(74) f16: i32,
+  @location(10) f17: u32,
+  @location(29) f18: vec3<u32>,
+  @location(47) f19: vec3<i32>,
+  @location(9) f20: vec3<u32>,
+  @location(80) f21: f16,
+  @location(2) f22: f32,
+  @location(6) f23: f16,
+  @location(23) f24: vec2<f16>,
+  @location(17) f25: vec2<f32>,
+  @location(61) f26: vec2<f16>,
+  @location(78) f27: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(11) a0: i32, @location(10) a1: vec4<u32>, @location(4) a2: vec2<u32>, @location(1) a3: vec3<i32>, @builtin(instance_index) a4: u32, @location(7) a5: vec3<f16>, a6: S2, @location(13) a7: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder8 = device0.createCommandEncoder({label: '\u0024\u5aa1\u9c10'});
+let texture13 = device0.createTexture({
+label: '\u2797\uf801\u96e8\ube2b\uea0f',
+size: {width: 60, height: 8, depthOrArrayLayers: 61},
+mipLevelCount: 6,
+dimension: '2d',
+format: 'etc2-rgb8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['etc2-rgb8unorm-srgb', 'etc2-rgb8unorm-srgb'],
+});
+let renderBundle11 = renderBundleEncoder1.finish({label: '\u{1fac5}\u{1ff7f}\ufd2a\u{1fa25}'});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup9, new Uint32Array(9450), 1290, 0);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 90.07, g: -369.6, b: 45.80, a: 657.9, });
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(40, 80);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(7, bindGroup1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 45780, new DataView(new ArrayBuffer(3695)), 2608, 312);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 3,
+  origin: { x: 328, y: 0, z: 1 },
+  aspect: 'all',
+}, new BigInt64Array(new ArrayBuffer(80)), /* required buffer size: 125 */
+{offset: 125, bytesPerRow: 345}, {width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline7 = device0.createRenderPipeline({
+layout: pipelineLayout0,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'src', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, undefined]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'invert',
+},
+stencilReadMask: 568,
+stencilWriteMask: 2971,
+depthBias: 88,
+depthBiasClamp: 56,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 24292,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 6428,
+shaderLocation: 3,
+}, {
+format: 'uint16x2',
+offset: 20000,
+shaderLocation: 10,
+}, {
+format: 'float32x2',
+offset: 5188,
+shaderLocation: 13,
+}, {
+format: 'uint32',
+offset: 22780,
+shaderLocation: 14,
+}, {
+format: 'uint16x2',
+offset: 1972,
+shaderLocation: 24,
+}, {
+format: 'float32x3',
+offset: 21900,
+shaderLocation: 9,
+}, {
+format: 'unorm16x2',
+offset: 19468,
+shaderLocation: 2,
+}, {
+format: 'snorm8x4',
+offset: 6148,
+shaderLocation: 22,
+}, {
+format: 'uint16x4',
+offset: 5436,
+shaderLocation: 4,
+}, {
+format: 'sint16x2',
+offset: 15792,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 24656,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 28912,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x4',
+offset: 11636,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 1040,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 13408,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 13260,
+shaderLocation: 1,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+try {
+adapter0.label = '\u0b7e\u0e79';
+} catch {}
+let pipelineLayout4 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout5, bindGroupLayout7, bindGroupLayout1, bindGroupLayout4, bindGroupLayout7, bindGroupLayout0, bindGroupLayout0]
+});
+let renderPassEncoder2 = commandEncoder8.beginRenderPass({
+label: '\u0873\u{1f829}\u4ab2\u{1fe4f}\u{1f718}\u6fd8\u43d7\u0496\u{1f745}\u9540',
+colorAttachments: [],
+depthStencilAttachment: {
+view: textureView4,
+depthClearValue: 0.836225720367683,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+depthReadOnly: false,
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet3,
+maxDrawCount: 520208062,
+});
+let renderBundle12 = renderBundleEncoder2.finish({label: '\u037d\u1209\ue4ba\u876a\u{1fdab}\u5fa8'});
+try {
+renderPassEncoder2.setBindGroup(7, bindGroup5);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(243);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 169.0, g: 789.1, b: -294.8, a: -435.8, });
+} catch {}
+try {
+renderPassEncoder1.draw(64, 40, 80, 72);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer5, 446952);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer5, 258784);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(2, buffer6, 9092, 1160);
+} catch {}
+try {
+renderBundleEncoder10.insertDebugMarker('\u0c04');
+} catch {}
+let pipeline8 = device0.createRenderPipeline({
+label: '\u{1fdc6}\u5857\u0c17\u066e\u6466',
+layout: pipelineLayout4,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: 0}, {format: 'r16uint'}, undefined]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'keep',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'invert',
+},
+stencilReadMask: 3855,
+stencilWriteMask: 3873,
+depthBiasSlopeScale: 36,
+depthBiasClamp: 23,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 20184,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1788,
+attributes: [{
+format: 'snorm8x4',
+offset: 980,
+shaderLocation: 7,
+}, {
+format: 'sint8x4',
+offset: 548,
+shaderLocation: 1,
+}, {
+format: 'sint32x4',
+offset: 480,
+shaderLocation: 3,
+}, {
+format: 'snorm8x2',
+offset: 822,
+shaderLocation: 9,
+}, {
+format: 'snorm16x2',
+offset: 960,
+shaderLocation: 22,
+}, {
+format: 'uint32x3',
+offset: 164,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 28832,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x2',
+offset: 92,
+shaderLocation: 2,
+}, {
+format: 'uint32x3',
+offset: 16712,
+shaderLocation: 14,
+}, {
+format: 'uint32',
+offset: 25632,
+shaderLocation: 24,
+}, {
+format: 'uint16x4',
+offset: 13472,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 9208,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 3488,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 6812,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 2668,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x2',
+offset: 580,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 9220,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 22508,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x4',
+offset: 16272,
+shaderLocation: 13,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'none',
+unclippedDepth: true,
+},
+});
+let buffer7 = device0.createBuffer({label: '\u0e7c\u{1f830}\u7e42\uc3f7\u0ebe\ucdf9\u1ee9', size: 26386, usage: GPUBufferUsage.MAP_READ});
+let querySet8 = device0.createQuerySet({
+label: '\u49a4\u{1fca9}',
+type: 'occlusion',
+count: 2999,
+});
+let texture14 = device0.createTexture({
+label: '\ucfad\u0265\u{1fa82}\u0e1c\u50dc\u9522\uaba3\u{1fb06}',
+size: {width: 60, height: 8, depthOrArrayLayers: 61},
+mipLevelCount: 2,
+format: 'astc-10x8-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x8-unorm', 'astc-10x8-unorm-srgb', 'astc-10x8-unorm-srgb'],
+});
+let renderBundle13 = renderBundleEncoder5.finish({});
+try {
+renderPassEncoder0.setScissorRect(268, 52, 466, 9);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(32, 16, 80);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer7, 53856);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline6);
+} catch {}
+let pipeline9 = device0.createComputePipeline({
+label: '\u47a8\ubf81',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let imageData2 = new ImageData(124, 120);
+let videoFrame1 = new VideoFrame(canvas1, {timestamp: 0});
+let bindGroupLayout9 = device0.createBindGroupLayout({
+label: '\u043a\u{1fcac}\u5654\u0120\ua4c1',
+entries: [{
+binding: 716,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+}, {
+binding: 4018,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+}],
+});
+try {
+renderPassEncoder1.draw(56, 48, 0, 24);
+} catch {}
+try {
+renderBundleEncoder10.draw(0, 80, 0, 32);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexed(80, 40, 24, -744, 24);
+} catch {}
+let promise6 = device0.popErrorScope();
+try {
+renderPassEncoder1.pushDebugGroup('\u8e56');
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(934, 666);
+try {
+adapter0.label = '\u{1f9d8}\u{1f739}\u01ba\u{1feed}\u0d79\u0f13\u6d7c';
+} catch {}
+let commandEncoder9 = device0.createCommandEncoder({label: '\u1404\u9604\u{1f997}\u5122'});
+let texture15 = device0.createTexture({
+label: '\u{1f9b4}\u{1f94c}\u27a7',
+size: {width: 120, height: 16, depthOrArrayLayers: 61},
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['etc2-rgb8a1unorm-srgb', 'etc2-rgb8a1unorm'],
+});
+let texture16 = gpuCanvasContext1.getCurrentTexture();
+let textureView11 = texture8.createView({dimension: '2d', baseMipLevel: 5, baseArrayLayer: 2});
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -636.6, g: 78.67, b: -863.7, a: -249.0, });
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(682);
+} catch {}
+try {
+renderBundleEncoder10.draw(16);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer4, 'uint32', 8812, 8425);
+} catch {}
+try {
+commandEncoder9.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 517, y: 34, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture6,
+  mipLevel: 2,
+  origin: { x: 0, y: 16, z: 1 },
+  aspect: 'all',
+}, {width: 240, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder8.insertDebugMarker('\uffed');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 43 },
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 18095 */
+{offset: 327, bytesPerRow: 185, rowsPerImage: 32}, {width: 4, height: 4, depthOrArrayLayers: 4});
+} catch {}
+let imageData3 = new ImageData(220, 140);
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({
+  label: '\u0fc8\ud53d\u{1f7dd}\ub5d8\ub52d',
+  colorFormats: ['rgba16float', 'r16uint', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup8, new Uint32Array(6956), 3701, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(32, 24, 48, -552, 40);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(2, bindGroup6, new Uint32Array(5421), 4878, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 18420, new Int16Array(49948), 45344, 2116);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup4, new Uint32Array(2898), 1868, 0);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 400.1, g: 329.4, b: 204.4, a: 940.1, });
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(2236);
+} catch {}
+try {
+renderPassEncoder1.draw(64, 48, 80);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder10.draw(72, 72, 80, 16);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer0, 'uint16', 51374);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(5, buffer6, 40, 14079);
+} catch {}
+try {
+commandEncoder9.clearBuffer(buffer5, 43052, 1836);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(querySet0, 1537, 2059, buffer6, 768);
+} catch {}
+let pipeline10 = await device0.createComputePipelineAsync({
+label: '\u5eba\u45ca\u74f8\u0df4\u0a94\u1b4e\ufe83\u04a5\u{1fc12}\u7af4',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let img3 = await imageWithData(244, 251, '#3581311f', '#50119eef');
+try {
+offscreenCanvas3.getContext('webgpu');
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(1020);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(0, 48, 56, -472, 48);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(5, buffer6, 13932, 1898);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(4, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder10.draw(80, 40, 56, 0);
+} catch {}
+let canvas2 = document.createElement('canvas');
+let imageBitmap4 = await createImageBitmap(video0);
+let textureView12 = texture0.createView({dimension: '2d-array', baseMipLevel: 4});
+let computePassEncoder4 = commandEncoder9.beginComputePass({label: '\ue8ae\u5f6a\u7d3a\u279b\u0375\u4667'});
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer0, 104432);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer4, 17872);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer4, 'uint32', 30896);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer6, 1840, 10081);
+} catch {}
+let pipeline11 = await device0.createRenderPipelineAsync({
+label: '\u40ca\u{1fc45}\u9176\uac6d\u{1f696}\uaf67\u8207',
+layout: pipelineLayout2,
+multisample: {
+count: 4,
+mask: 0x738140f8,
+},
+fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'zero',
+depthFailOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'zero',
+},
+stencilReadMask: 2079,
+stencilWriteMask: 3576,
+depthBias: 73,
+depthBiasSlopeScale: 80,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 20332,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 17936,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x2',
+offset: 1964,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+canvas2.getContext('bitmaprenderer');
+} catch {}
+let bindGroup10 = device0.createBindGroup({
+label: '\u{1f812}\u8bb1\u999d\ue588\u47da\u3ed4\uc2ea',
+layout: bindGroupLayout5,
+entries: [{
+binding: 302,
+resource: sampler3
+}],
+});
+let querySet9 = device0.createQuerySet({
+label: '\u53d9\u5e5f\ud6ef\u1d21\u070f\u{1fadf}',
+type: 'occlusion',
+count: 1896,
+});
+let renderBundle14 = renderBundleEncoder0.finish({});
+let externalTexture2 = device0.importExternalTexture({
+source: video1,
+colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(3350);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer6, 224808);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder10.draw(80, 72, 56, 64);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer0, 'uint32');
+} catch {}
+gc();
+let commandEncoder10 = device0.createCommandEncoder({label: '\u362e\u0b45\u{1f9f1}\u{1fb26}'});
+let textureView13 = texture7.createView({label: '\u0078\uee02\u335b', format: 'astc-8x5-unorm-srgb', arrayLayerCount: 1});
+let computePassEncoder5 = commandEncoder10.beginComputePass({label: '\u6cbb\ub77c\u61f2\u8ac4\u6755\ue738\ubb5e\u31ff\u{1ffc9}'});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  label: '\u3822\u52bb\u1db7\u6d2e\u75be\u59d4\u0518\u058e',
+  colorFormats: ['rgba8unorm-srgb', 'r8sint', 'rgba32uint', 'rgba8sint', 'r16uint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true
+});
+try {
+computePassEncoder0.setBindGroup(6, bindGroup5);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(1285);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.draw(0, 16);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexed(8, 16, 32, 688, 24);
+} catch {}
+try {
+texture0.destroy();
+} catch {}
+let pipeline12 = device0.createComputePipeline({
+layout: pipelineLayout4,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let texture17 = device0.createTexture({
+label: '\u496e\u011d\u{1f809}\u9e21\u0846\u{1faa6}\uf3ae\ub038\u3529\u2529\u48f2',
+size: [96, 95, 1],
+mipLevelCount: 3,
+format: 'astc-6x5-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-6x5-unorm'],
+});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup0, new Uint32Array(9882), 3187, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer3, 504208);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer1, 118264);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder10.draw(64, 72, 0);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexed(40, 64, 8);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 6240, new BigUint64Array(21047), 2903, 5600);
+} catch {}
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'depth32float-stencil8', depthReadOnly: true});
+try {
+renderPassEncoder0.setBindGroup(6, bindGroup2);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: -792.4, g: 650.8, b: 936.3, a: -780.4, });
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer4, 'uint32', 13508, 13295);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(7, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder10.draw(32, 32, 8);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer0, 'uint32', 36384);
+} catch {}
+try {
+  await buffer2.mapAsync(GPUMapMode.WRITE, 0, 13528);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 1194 */
+{offset: 746, bytesPerRow: 108, rowsPerImage: 152}, {width: 8, height: 25, depthOrArrayLayers: 1});
+} catch {}
+let querySet10 = device0.createQuerySet({
+label: '\ua19a\u{1f600}\u05da\ubc7e\u03db\u{1f890}\u9387\u{1f688}\ud52f',
+type: 'occlusion',
+count: 1785,
+});
+try {
+renderPassEncoder1.setBlendConstant({ r: 471.5, g: -763.0, b: -58.63, a: 500.5, });
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(48, 64);
+} catch {}
+try {
+renderBundleEncoder10.draw(48, 24, 56, 16);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexed(64, 64);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(591), /* required buffer size: 591 */
+{offset: 587}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let promise7 = device0.createComputePipelineAsync({
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+},
+});
+gc();
+let canvas3 = document.createElement('canvas');
+let commandEncoder11 = device0.createCommandEncoder({label: '\u0071\u{1fecb}\u{1fd99}\u{1feda}\ud14e\u98b4'});
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setViewport(683.8, 17.64, 151.4, 22.49, 0.6541, 0.7172);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(5, buffer6);
+} catch {}
+try {
+commandEncoder11.copyBufferToBuffer(buffer4, 44728, buffer1, 35500, 736);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder11.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 4,
+  origin: { x: 48, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 704 widthInBlocks: 44 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 30336 */
+offset: 28864,
+bytesPerRow: 768,
+buffer: buffer5,
+}, {width: 352, height: 10, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 29208, new DataView(new ArrayBuffer(16602)), 14847, 956);
+} catch {}
+try {
+  await promise6;
+} catch {}
+let adapter1 = await navigator.gpu.requestAdapter({
+});
+let buffer8 = device0.createBuffer({
+  label: '\ue1cb\u{1f74e}\u{1f93d}\u0bbf\u1d39\u0272\u5b73\ud04a',
+  size: 52011,
+  usage: GPUBufferUsage.UNIFORM
+});
+let querySet11 = device0.createQuerySet({
+label: '\u{1f8de}\u6d17\u{1fd09}\u0f93\u{1fc7f}\u{1f66a}\u9c73\u{1f717}\u2f78\u{1f723}\u{1fd17}',
+type: 'occlusion',
+count: 53,
+});
+try {
+renderPassEncoder2.setBindGroup(8, bindGroup3);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(546, 49, 142, 10);
+} catch {}
+try {
+renderPassEncoder2.setViewport(613.8, 64.31, 312.3, 4.591, 0.4517, 0.4918);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(8, buffer6, 9880);
+} catch {}
+try {
+commandEncoder11.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 5,
+  origin: { x: 3, y: 1, z: 59 },
+  aspect: 'all',
+}, {
+  texture: texture12,
+  mipLevel: 4,
+  origin: { x: 11, y: 1, z: 11 },
+  aspect: 'all',
+}, {width: 12, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['depth24plus', 'depth24plus', 'depth24plus', 'rgb9e5ufloat'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 26680, new BigUint64Array(36599), 17918, 2840);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise8 = device0.createComputePipelineAsync({
+layout: pipelineLayout2,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+document.body.prepend(canvas3);
+let videoFrame2 = new VideoFrame(imageBitmap2, {timestamp: 0});
+let commandEncoder12 = device0.createCommandEncoder();
+let renderPassEncoder3 = commandEncoder11.beginRenderPass({
+label: '\u4d1a\u1e42',
+colorAttachments: [],
+depthStencilAttachment: {
+view: textureView4,
+depthLoadOp: 'load',
+depthStoreOp: 'discard',
+},
+occlusionQuerySet: querySet1,
+maxDrawCount: 173233801,
+});
+try {
+renderPassEncoder3.beginOcclusionQuery(665);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(1126);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer4, 'uint16', 7026, 14640);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(8, buffer6, 14916, 1246);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer0, 'uint16', 38264, 364);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(996, 546);
+let video2 = await videoWithData();
+let imageData4 = new ImageData(36, 144);
+try {
+canvas3.getContext('bitmaprenderer');
+} catch {}
+let sampler10 = device0.createSampler({
+label: '\u5853\u057e\u9ae0\u033e',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 9.774,
+lodMaxClamp: 10.659,
+maxAnisotropy: 20,
+});
+try {
+computePassEncoder2.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(3552);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(80);
+} catch {}
+try {
+commandEncoder12.clearBuffer(buffer1, 2248, 17696);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout10 = pipeline6.getBindGroupLayout(2);
+let buffer9 = device0.createBuffer({
+  label: '\u0c1f\u0f21\u0b65\u6493\u32d6\u0fe3\u87ea\ud71a\ud4d8\u6d06',
+  size: 16381,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE
+});
+let commandEncoder13 = device0.createCommandEncoder({label: '\u4daa\u8541\u{1fe42}\u034e\u3c9b\u{1ff3f}\ud84e\u03b8'});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({
+  label: '\u{1f71d}\u{1fe72}\uac87\u06a2\ue41a\u8638\u179d\u42ae\u0dd1\ufa84\u0e21',
+  colorFormats: [],
+  depthStencilFormat: 'depth32float-stencil8',
+  stencilReadOnly: true
+});
+let renderBundle15 = renderBundleEncoder5.finish({label: '\u{1fe61}\u62d7\ud057\u2d90\u0b2f\u09ba\u0de2\u0e9a'});
+try {
+renderPassEncoder1.drawIndirect(buffer1, 12392);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(7, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder10.draw(0, 56, 48, 16);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexed(64, 40);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['astc-10x8-unorm', 'r16uint'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: { x: 8, y: 15, z: 0 },
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(80)), /* required buffer size: 2580 */
+{offset: 668, bytesPerRow: 229}, {width: 40, height: 45, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext3 = offscreenCanvas4.getContext('webgpu');
+let imageBitmap5 = await createImageBitmap(video0);
+let commandBuffer2 = commandEncoder12.finish({
+label: '\u{1fa94}\uf235\u{1fc86}\ueb8e\u043e\u6c78\u{1f6b7}\u0abb\u0533\u2583',
+});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({
+  label: '\u6380\uba75\u83bf\u{1f668}\u206a\u0384',
+  colorFormats: ['rgba8unorm-srgb', 'r8sint', 'rgba32uint', 'rgba8sint', 'r16uint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+try {
+computePassEncoder2.setBindGroup(5, bindGroup10, new Uint32Array(8586), 1575, 0);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -124.6, g: -669.6, b: 542.7, a: 654.8, });
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer1, 89432);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexed(16, 56);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(4, buffer6, 17040, 113);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+commandEncoder13.copyBufferToTexture({
+/* bytesInLastRow: 336 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 25952 */
+offset: 25952,
+buffer: buffer4,
+}, {
+  texture: texture0,
+  mipLevel: 5,
+  origin: { x: 8, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 168, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+computePassEncoder5.pushDebugGroup('\u5c64');
+} catch {}
+try {
+commandEncoder13.insertDebugMarker('\ubac5');
+} catch {}
+let pipeline13 = device0.createComputePipeline({
+layout: pipelineLayout0,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+pseudoSubmit(device0, commandEncoder11);
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  label: '\u0bcc\uf3cc\u{1f84b}\u5ea3\uc622\u2ee9\u700f',
+  colorFormats: [],
+  depthStencilFormat: 'depth32float-stencil8',
+  stencilReadOnly: true
+});
+try {
+computePassEncoder2.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder0.setViewport(859.5, 63.92, 95.63, 5.370, 0.4282, 0.4460);
+} catch {}
+try {
+renderPassEncoder1.draw(64, 40, 80, 72);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer9, 31184);
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(querySet6, 578, 277, buffer9, 11264);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 32868, new DataView(new ArrayBuffer(60245)), 49463, 2588);
+} catch {}
+video1.height = 25;
+let bindGroup11 = device0.createBindGroup({
+layout: bindGroupLayout2,
+entries: [{
+binding: 6043,
+resource: textureView8
+}, {
+binding: 4081,
+resource: externalTexture1
+}],
+});
+let computePassEncoder6 = commandEncoder13.beginComputePass({label: '\u{1fa1b}\u{1f851}\u7c83\ud974\u1985'});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({
+  label: '\uec35\ua688\u007c\u6852',
+  colorFormats: ['rgba16float', 'r16uint', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderPassEncoder1.draw(16, 56, 72, 24);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(8, buffer6, 7080, 7663);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexed(0);
+} catch {}
+let arrayBuffer0 = buffer2.getMappedRange(0, 10456);
+try {
+gpuCanvasContext2.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 6852, new Int16Array(29711), 22760, 5764);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 878 */
+{offset: 878}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(326, 1000);
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({
+  label: '\ua8c7\u9176\ud663\u0b1d\ua50b\u{1fe5b}\u336a\ub50e\u{1fec9}\u9f17\u35d2',
+  colorFormats: ['rgb10a2uint'],
+  depthReadOnly: true
+});
+let renderBundle16 = renderBundleEncoder13.finish({label: '\u{1f949}\u5e2f\u0a78\u0693\u{1fa28}\u19cc\u{1fe89}\ubd8e\u{1f7e3}'});
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(47, 6, 18, 7);
+} catch {}
+try {
+renderPassEncoder1.setViewport(76.06, 0.6833, 74.68, 3.844, 0.1763, 0.5831);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(83, undefined, 1781853188);
+} catch {}
+let promise9 = device0.createComputePipelineAsync({
+label: '\u089b\uad33\u1fda\u{1fcb9}',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline14 = device0.createRenderPipeline({
+layout: pipelineLayout4,
+multisample: {
+mask: 0x4319ee90,
+},
+fragment: {module: shaderModule0, entryPoint: 'fragment0', targets: []},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'less',
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'keep',
+depthFailOp: 'replace',
+passOp: 'replace',
+},
+stencilReadMask: 3226,
+depthBias: 88,
+depthBiasSlopeScale: 92,
+depthBiasClamp: 27,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 23452,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 20804,
+attributes: [{
+format: 'float32x2',
+offset: 19864,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let buffer10 = device0.createBuffer({size: 39868, usage: GPUBufferUsage.COPY_DST, mappedAtCreation: true});
+let textureView14 = texture11.createView({dimension: '2d-array', baseMipLevel: 4, mipLevelCount: 1, baseArrayLayer: 32, arrayLayerCount: 2});
+try {
+renderPassEncoder2.setBlendConstant({ r: 851.1, g: 322.3, b: 854.0, a: 785.0, });
+} catch {}
+try {
+renderBundleEncoder10.drawIndexed(64, 56);
+} catch {}
+try {
+offscreenCanvas5.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder();
+let externalTexture3 = device0.importExternalTexture({
+label: '\ud4d7\u0a51\uc41c',
+source: video1,
+colorSpace: 'srgb',
+});
+try {
+computePassEncoder6.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(5, bindGroup5, new Uint32Array(1395), 431, 0);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(3614);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -758.8, g: 133.3, b: 736.2, a: 365.8, });
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(7, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder10.draw(0, 64, 40);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 2820, new Float32Array(48264), 11471, 8304);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 103 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 3578234 */
+{offset: 561, bytesPerRow: 179, rowsPerImage: 253}, {width: 80, height: 0, depthOrArrayLayers: 80});
+} catch {}
+let bindGroup12 = device0.createBindGroup({
+label: '\u078c\u0ed2\u31d7\u{1fd08}\u{1f8f9}\u84b5\ub0b9',
+layout: bindGroupLayout4,
+entries: [],
+});
+let querySet12 = device0.createQuerySet({
+label: '\u0c6b\ud5d8',
+type: 'occlusion',
+count: 1034,
+});
+let sampler11 = device0.createSampler({
+label: '\u2f25\u6257\u19a1\u62c1\u0fab\ue0b8\u4b30',
+addressModeU: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 72.845,
+lodMaxClamp: 77.121,
+});
+try {
+renderPassEncoder3.setStencilReference(1447);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(72, 24, 16, 120);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer6, 185072);
+} catch {}
+video2.height = 220;
+let video3 = await videoWithData();
+let shaderModule3 = device0.createShaderModule({
+label: '\u5f2d\u{1f746}\u{1f853}\u0934\u{1fe52}\u{1f784}\u067b\u0cdf\u123c\u{1fbaa}\u32d3',
+code: `@group(4) @binding(5204)
+var<storage, read_write> parameter5: array<u32>;
+@group(4) @binding(1458)
+var<storage, read_write> function1: array<u32>;
+@group(1) @binding(1458)
+var<storage, read_write> global3: array<u32>;
+@group(1) @binding(5204)
+var<storage, read_write> field2: array<u32>;
+@group(4) @binding(6216)
+var<storage, read_write> parameter6: array<u32>;
+@group(1) @binding(6216)
+var<storage, read_write> parameter7: array<u32>;
+
+@compute @workgroup_size(6, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_mask) a1: u32) {
+
+}
+
+struct S4 {
+  @location(7) f0: vec4<f32>,
+  @location(21) f1: vec3<u32>,
+  @location(19) f2: vec3<f32>,
+  @location(0) f3: vec4<f32>,
+  @builtin(instance_index) f4: u32,
+  @location(18) f5: u32,
+  @location(3) f6: i32,
+  @location(23) f7: vec2<u32>,
+  @location(13) f8: f32,
+  @location(17) f9: vec2<i32>,
+  @location(16) f10: vec2<f16>,
+  @location(4) f11: vec4<f32>,
+  @location(1) f12: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec4<u32>, @location(5) a1: vec2<i32>, @location(9) a2: vec4<i32>, @location(6) a3: vec2<f16>, @location(22) a4: vec4<i32>, @builtin(vertex_index) a5: u32, @location(15) a6: f16, a7: S4, @location(14) a8: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+let bindGroupLayout11 = device0.createBindGroupLayout({
+entries: [],
+});
+let texture18 = device0.createTexture({
+label: '\u2860\ub895\ub26a\u9caa\u{1fbcb}\u8ce9',
+size: {width: 240},
+dimension: '1d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView15 = texture10.createView({dimension: '2d', format: 'astc-4x4-unorm-srgb', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 13});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({
+  label: '\ucb07\u0b2c\u020f\u{1fa5d}\u5d45\u9a29\u7542\uec2b\ube5c\u0ae1\u0eed',
+  colorFormats: ['rgba8unorm-srgb', 'r8sint', 'rgba32uint', 'rgba8sint', 'r16uint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 1,
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+let renderBundle17 = renderBundleEncoder6.finish({label: '\u3573\u0335\uf08a\u3429\u15ad\uf792\u0b4a\ubabf\ucf63\u6019'});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup12, []);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(2439);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(72, 56, 32);
+} catch {}
+try {
+commandEncoder14.copyTextureToTexture({
+  texture: texture2,
+  mipLevel: 8,
+  origin: { x: 16, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture0,
+  mipLevel: 7,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder5.pushDebugGroup('\ue4da');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 21480, new DataView(new ArrayBuffer(50095)), 2357, 7192);
+} catch {}
+let textureView16 = texture12.createView({
+  label: '\ua7c7\u586a\u0b4f\u0a88\u1552\u{1fbcc}\u4ec2\ucad0\u02e3\u3734\ue1b4',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+  baseArrayLayer: 47,
+  arrayLayerCount: 6
+});
+try {
+renderPassEncoder2.beginOcclusionQuery(1226);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(18, 6, 182, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer6, 96240);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer0, 'uint32');
+} catch {}
+try {
+commandEncoder14.resolveQuerySet(querySet2, 1991, 37, buffer6, 8448);
+} catch {}
+video3.height = 100;
+let video4 = await videoWithData();
+let bindGroupLayout12 = device0.createBindGroupLayout({
+label: '\u9ebd\uf2d9\u0012\u192e\u{1fae5}\u0730',
+entries: [],
+});
+let commandEncoder15 = device0.createCommandEncoder({label: '\u9eee\u5e2f\ua1ca\u0fda\u{1f91d}'});
+try {
+renderPassEncoder1.setIndexBuffer(buffer4, 'uint16');
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer6, 9544, 5424);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexed(24, 48);
+} catch {}
+try {
+commandEncoder14.copyBufferToBuffer(buffer4, 35604, buffer1, 8968, 3068);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 24356, new DataView(new ArrayBuffer(27180)), 729, 12192);
+} catch {}
+let pipeline15 = await device0.createRenderPipelineAsync({
+label: '\u{1f9b7}\u0d32',
+layout: pipelineLayout3,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-dst-alpha'},
+alpha: {operation: 'add', srcFactor: 'src', dstFactor: 'one-minus-src-alpha'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE}, undefined]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'keep',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 409,
+stencilWriteMask: 3158,
+depthBias: 63,
+depthBiasClamp: 32,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 17996,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x4',
+offset: 15020,
+shaderLocation: 7,
+}, {
+format: 'float32x2',
+offset: 9704,
+shaderLocation: 9,
+}, {
+format: 'uint32',
+offset: 5660,
+shaderLocation: 10,
+}, {
+format: 'uint32x3',
+offset: 10860,
+shaderLocation: 24,
+}, {
+format: 'float32x4',
+offset: 3120,
+shaderLocation: 22,
+}],
+},
+{
+arrayStride: 9584,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 15432,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 12060,
+shaderLocation: 4,
+}, {
+format: 'snorm8x4',
+offset: 11536,
+shaderLocation: 13,
+}, {
+format: 'sint8x4',
+offset: 14720,
+shaderLocation: 3,
+}, {
+format: 'sint32x3',
+offset: 15368,
+shaderLocation: 1,
+}, {
+format: 'unorm8x2',
+offset: 6710,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 5232,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x3',
+offset: 3352,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32',
+offset: 23580,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+gc();
+let shaderModule4 = device0.createShaderModule({
+label: '\u{1f623}\u{1f6f0}\uc0ef\ucea4\u85f7\uc5ea\u0605\u{1f7a8}',
+code: `@group(7) @binding(4981)
+var<storage, read_write> type4: array<u32>;
+@group(3) @binding(6043)
+var<storage, read_write> type5: array<u32>;
+@group(0) @binding(4981)
+var<storage, read_write> field3: array<u32>;
+@group(2) @binding(4981)
+var<storage, read_write> local4: array<u32>;
+@group(0) @binding(5174)
+var<storage, read_write> function2: array<u32>;
+
+@compute @workgroup_size(1, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(6) f0: vec4<u32>,
+  @location(5) f1: vec3<f32>,
+  @location(0) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S5 {
+  @location(4) f0: vec2<i32>,
+  @location(2) f1: vec2<f32>,
+  @location(0) f2: vec4<i32>,
+  @location(13) f3: vec2<f32>,
+  @location(7) f4: vec2<f16>,
+  @location(14) f5: vec3<u32>,
+  @location(3) f6: f16,
+  @location(16) f7: vec4<f32>,
+  @location(12) f8: vec3<f32>,
+  @builtin(vertex_index) f9: u32,
+  @location(10) f10: vec2<f16>,
+  @location(17) f11: i32,
+  @builtin(instance_index) f12: u32,
+  @location(5) f13: vec2<u32>,
+  @location(23) f14: i32,
+  @location(24) f15: vec2<f16>,
+  @location(8) f16: vec4<f16>,
+  @location(22) f17: vec4<f32>,
+  @location(11) f18: vec3<f16>,
+  @location(19) f19: i32,
+  @location(21) f20: vec2<i32>,
+  @location(1) f21: vec2<f32>,
+  @location(9) f22: vec3<u32>,
+  @location(6) f23: vec2<i32>,
+  @location(18) f24: vec4<u32>,
+  @location(20) f25: f32,
+  @location(15) f26: vec2<i32>
+}
+
+@vertex
+fn vertex0(a0: S5) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+let querySet13 = device0.createQuerySet({
+label: '\u{1fc29}\u8ccf\u{1fff5}\u9e7b\ubb6d\u06e0\u{1fb64}\u170e\u3423\u3bbd\u{1f92a}',
+type: 'occlusion',
+count: 3034,
+});
+let texture19 = gpuCanvasContext2.getCurrentTexture();
+let textureView17 = texture2.createView({
+  label: '\u0a2b\u0fe3\u{1fd68}\u0310\u{1f85d}\u0d10\u{1fc3d}\u0c65\ue383\u0d97\u9bbf',
+  dimension: '2d-array'
+});
+try {
+renderPassEncoder1.drawIndirect(buffer2, 653008);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer0, 'uint16', 20440, 22551);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer6, 3204, 4699);
+} catch {}
+try {
+renderBundleEncoder10.draw(32, 8, 48);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexed(0, 40, 8, 672, 48);
+} catch {}
+try {
+commandEncoder15.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 393, y: 15, z: 35 },
+  aspect: 'all',
+}, {
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 44, y: 0, z: 6 },
+  aspect: 'all',
+}, {width: 60, height: 4, depthOrArrayLayers: 26});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 128, new BigUint64Array(136), 26, 16);
+} catch {}
+let pipeline16 = await device0.createRenderPipelineAsync({
+label: '\u1edc\ub4be\ua70b\u{1f965}\ub344\ubf94\u{1fd4f}\u81bc\u4018',
+layout: pipelineLayout2,
+fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'keep',
+depthFailOp: 'decrement-wrap',
+passOp: 'zero',
+},
+stencilBack: {
+failOp: 'increment-clamp',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 1996,
+depthBias: 93,
+depthBiasSlopeScale: 42,
+depthBiasClamp: 47,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 11108,
+attributes: [],
+},
+{
+arrayStride: 17428,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 13776,
+shaderLocation: 11,
+}],
+}
+]
+},
+});
+video4.width = 20;
+let device1 = await adapter1.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 48,
+maxVertexAttributes: 20,
+maxVertexBufferArrayStride: 29655,
+maxStorageTexturesPerShaderStage: 16,
+maxStorageBuffersPerShaderStage: 29,
+maxDynamicStorageBuffersPerPipelineLayout: 46913,
+maxBindingsPerBindGroup: 8673,
+maxTextureDimension1D: 9304,
+maxTextureDimension2D: 10206,
+maxVertexBuffers: 11,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 67857779,
+maxUniformBuffersPerShaderStage: 12,
+maxInterStageShaderVariables: 96,
+maxInterStageShaderComponents: 118,
+maxSamplersPerShaderStage: 21,
+},
+});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({
+  label: '\u00aa\u424e\uf951\u4fc0\u0785\u1bfc\u{1f7cd}\u{1f67e}\u8bbb\u0f49',
+  colorFormats: ['rgba16float', 'r16uint', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderPassEncoder1.setBindGroup(7, bindGroup1, new Uint32Array(6212), 4237, 0);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(1661);
+} catch {}
+try {
+renderPassEncoder1.draw(56, 0, 80, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(8, buffer6, 12772, 2907);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexed(16, 16, 8, 232, 16);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(0, buffer6, 7872, 4452);
+} catch {}
+try {
+commandEncoder14.copyBufferToBuffer(buffer4, 8964, buffer10, 31412, 3000);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let imageData5 = new ImageData(248, 4);
+let texture20 = device0.createTexture({
+label: '\ubdc8\u05d4\u{1f791}\u31ea\u0fbd\u{1f6f2}',
+size: [480, 64, 61],
+mipLevelCount: 2,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder7 = commandEncoder14.beginComputePass({label: '\u07bb\u{1fc6f}\u826d\uf5c9'});
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(8, 8, 64, 208, 16);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer0, 33392);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexed(40, 40, 72, -320, 16);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(4, buffer6, 3432, 1278);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer4, 26496, buffer5, 29064, 19716);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+adapter0.label = '\u5f39\ua1d7\u0ca7';
+} catch {}
+try {
+device1.destroy();
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(194, 121);
+let imageBitmap6 = await createImageBitmap(offscreenCanvas6);
+let buffer11 = device0.createBuffer({
+  label: '\u0320\u0ee8\u{1fe3c}\ua433\u{1fc79}\ucf78\ub1c8',
+  size: 20304,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true
+});
+pseudoSubmit(device0, commandEncoder8);
+let textureView18 = texture17.createView({label: '\u2a04\uad7a\ua8a9\u55cf\u{1fcb9}\u{1fd23}', aspect: 'all', baseMipLevel: 2});
+try {
+computePassEncoder0.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder1.draw(24, 56, 40);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer8, 327016);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer3, 32152);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder10.draw(16);
+} catch {}
+try {
+renderBundleEncoder10.drawIndirect(buffer11, 7944);
+} catch {}
+let promise10 = buffer5.mapAsync(GPUMapMode.READ, 54792, 2768);
+try {
+commandEncoder15.copyBufferToBuffer(buffer4, 35724, buffer10, 34996, 4452);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer1, 10800, 2772);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 64, y: 48, z: 33 },
+  aspect: 'all',
+}, new ArrayBuffer(18535), /* required buffer size: 18535 */
+{offset: 204, bytesPerRow: 797, rowsPerImage: 1}, {width: 328, height: 0, depthOrArrayLayers: 24});
+} catch {}
+let img4 = await imageWithData(278, 79, '#cb14ab28', '#4fdbe1a0');
+let shaderModule5 = device0.createShaderModule({
+code: `@group(0) @binding(302)
+var<storage, read_write> i1: array<u32>;
+@group(2) @binding(5174)
+var<storage, read_write> type6: array<u32>;
+@group(2) @binding(4981)
+var<storage, read_write> function3: array<u32>;
+@group(1) @binding(5174)
+var<storage, read_write> type7: array<u32>;
+@group(1) @binding(4981)
+var<storage, read_write> function4: array<u32>;
+
+@compute @workgroup_size(7, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(frag_depth) f0: f32,
+  @location(1) f1: vec2<u32>,
+  @location(0) f2: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder16 = device0.createCommandEncoder({label: '\uc378\u{1f916}\ubf66\uf743\ubd88\uf6b5\ua79d\uffc6\u{1fb52}\u0a50\u7a3f'});
+let computePassEncoder8 = commandEncoder16.beginComputePass({label: '\ucd46\u843d\u338b\u02c8\u{1fa27}\ud2d2\u7b87\u0558\u7221\u{1f74b}'});
+let renderBundle18 = renderBundleEncoder6.finish({});
+try {
+renderPassEncoder2.setScissorRect(592, 48, 258, 24);
+} catch {}
+try {
+renderPassEncoder1.setViewport(74.45, 5.763, 153.6, 11.83, 0.1065, 0.2002);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexed(48);
+} catch {}
+try {
+renderBundleEncoder10.drawIndirect(buffer11, 14916);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(4, buffer11);
+} catch {}
+try {
+commandEncoder15.copyBufferToTexture({
+/* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 30944 */
+offset: 30944,
+buffer: buffer4,
+}, {
+  texture: texture0,
+  mipLevel: 6,
+  origin: { x: 16, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder15.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 0, y: 8, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 0, y: 38, z: 1 },
+  aspect: 'all',
+}, {width: 960, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer10);
+dissociateBuffer(device0, buffer10);
+} catch {}
+offscreenCanvas0.height = 39;
+try {
+offscreenCanvas6.getContext('webgl2');
+} catch {}
+try {
+window.someLabel = externalTexture1.label;
+} catch {}
+let buffer12 = device0.createBuffer({
+  label: '\u827e\ube6d\u0b19\u0b48',
+  size: 47355,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: false
+});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({
+  label: '\u0c5f\ub247\u{1f982}',
+  colorFormats: ['rgba8unorm-srgb', 'r8sint', 'rgba32uint', 'rgba8sint', 'r16uint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(3613);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer12, 158344);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(6, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup9, new Uint32Array(6355), 920, 0);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexedIndirect(buffer11, 11640);
+} catch {}
+try {
+renderBundleEncoder10.drawIndirect(buffer11, 14940);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer0, 'uint16');
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer2, 11264, buffer12, 8388, 19280);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder15.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 2,
+  origin: { x: 0, y: 12, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture6,
+  mipLevel: 2,
+  origin: { x: 0, y: 17, z: 0 },
+  aspect: 'all',
+}, {width: 240, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['bgra8unorm', 'etc2-rgb8unorm', 'bgra8unorm-srgb', 'bgra8unorm-srgb'],
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 27752, new BigUint64Array(8104), 4715, 2292);
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+label: '\u7517\uee21\ubbca\u{1fea3}\ue3d8\u{1fe66}\u0530\ua0fb',
+code: `@group(1) @binding(6043)
+var<storage, read_write> function5: array<u32>;
+
+@compute @workgroup_size(8, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec3<u32>,
+  @location(0) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S6 {
+  @location(3) f0: vec4<f16>,
+  @location(21) f1: vec2<f16>,
+  @location(16) f2: vec3<f32>,
+  @location(11) f3: vec2<i32>,
+  @location(7) f4: vec3<i32>,
+  @location(1) f5: vec4<u32>,
+  @location(10) f6: vec2<u32>,
+  @location(6) f7: vec4<u32>,
+  @location(2) f8: vec4<u32>,
+  @location(8) f9: vec2<f32>,
+  @location(23) f10: vec3<i32>,
+  @location(4) f11: i32,
+  @location(24) f12: vec2<u32>,
+  @location(19) f13: vec3<f16>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(5) a1: vec3<f32>, @location(13) a2: vec2<f32>, @location(12) a3: vec2<i32>, @location(0) a4: vec3<f16>, @location(20) a5: vec4<i32>, a6: S6, @location(9) a7: vec4<i32>, @location(15) a8: vec2<u32>, @location(18) a9: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(1028);
+} catch {}
+try {
+renderPassEncoder1.setViewport(28.00, 16.85, 27.11, 0.4379, 0.1852, 0.3579);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer11, 27424);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexed(40, 32);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexedIndirect(buffer11, 15488);
+} catch {}
+try {
+renderBundleEncoder10.drawIndirect(buffer11, 6616);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer4, 41748, buffer10, 32568, 3940);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer10);
+} catch {}
+video2.height = 56;
+let adapter2 = await navigator.gpu.requestAdapter();
+let img5 = await imageWithData(146, 297, '#89839f3c', '#2d2e694a');
+let querySet14 = device0.createQuerySet({
+label: '\u236e\u03ca\u0bb8\u224e\uffad\uefbc\u2c8f\u841d\u0c6c',
+type: 'occlusion',
+count: 1316,
+});
+let commandBuffer3 = commandEncoder5.finish();
+let renderBundle19 = renderBundleEncoder18.finish();
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer9, 'uint16', 14416, 1872);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(8, buffer6, 5916, 3848);
+} catch {}
+try {
+renderBundleEncoder10.draw(72, 24, 8, 80);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexedIndirect(buffer11, 6912);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline15);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer4, 10748, buffer1, 28728, 6648);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let promise11 = device0.createComputePipelineAsync({
+label: '\u{1fc65}\u0199\u{1feb9}\u00bf\u{1fb35}\u{1fd23}\u5a34\u0d48',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let computePassEncoder9 = commandEncoder15.beginComputePass({label: '\u4a5d\ufbb5'});
+try {
+renderPassEncoder1.beginOcclusionQuery(2277);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer9, 'uint32', 11712, 1294);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexedIndirect(buffer11, 4304);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: { x: 24, y: 0, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 1154345 */
+{offset: 677, bytesPerRow: 306, rowsPerImage: 145}, {width: 24, height: 4, depthOrArrayLayers: 27});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+  await promise10;
+} catch {}
+let offscreenCanvas7 = new OffscreenCanvas(519, 380);
+try {
+adapter2.label = '\ub0d8\u0129\u120c\u0039\u{1fef4}\uc014\uc5d0\ue558\u5922';
+} catch {}
+let bindGroup13 = device0.createBindGroup({
+label: '\uda99\u29da\u{1fd28}\u0885\ud3c7\u{1fa9f}\u0d1f\u1606\u{1fa42}\u34fa',
+layout: bindGroupLayout5,
+entries: [{
+binding: 302,
+resource: sampler10
+}],
+});
+let commandEncoder17 = device0.createCommandEncoder({label: '\u85d2\uf1ea'});
+let textureView19 = texture10.createView({label: '\ucdc0\u9505\uba20\u{1f8a2}\u08c4', baseMipLevel: 1, baseArrayLayer: 7, arrayLayerCount: 26});
+let sampler12 = device0.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 26.842,
+lodMaxClamp: 73.245,
+compare: 'not-equal',
+maxAnisotropy: 1,
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle16, renderBundle16, renderBundle16, renderBundle16, renderBundle16, renderBundle16, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(163, 17, 47, 1);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer4, 19008);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(6, bindGroup9, new Uint32Array(5236), 5037, 0);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer11, 12620);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(4, buffer11, 12248, 1745);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+let gpuCanvasContext4 = offscreenCanvas7.getContext('webgpu');
+let shaderModule7 = device0.createShaderModule({
+label: '\u0eba\u4091\uc884\u138b\u77e7\u0b9c\u859c\u002e\u6343',
+code: `@group(3) @binding(6043)
+var<storage, read_write> i2: array<u32>;
+@group(2) @binding(4981)
+var<storage, read_write> type8: array<u32>;
+@group(7) @binding(4981)
+var<storage, read_write> global4: array<u32>;
+@group(2) @binding(5174)
+var<storage, read_write> field4: array<u32>;
+@group(3) @binding(4081)
+var<storage, read_write> local5: array<u32>;
+@group(0) @binding(4981)
+var<storage, read_write> i3: array<u32>;
+
+@compute @workgroup_size(2, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S7 {
+  @location(46) f0: f16,
+  @location(18) f1: f32,
+  @location(26) f2: vec2<u32>,
+  @location(45) f3: vec2<f16>,
+  @location(88) f4: vec4<u32>,
+  @location(55) f5: vec3<f32>,
+  @location(23) f6: vec2<u32>,
+  @location(35) f7: vec2<f16>,
+  @location(32) f8: vec4<f16>,
+  @location(77) f9: vec2<f32>,
+  @location(49) f10: vec2<u32>,
+  @location(0) f11: vec3<u32>,
+  @location(75) f12: vec2<i32>,
+  @location(40) f13: vec3<u32>
+}
+
+@fragment
+fn fragment0(@location(21) a0: i32, @location(16) a1: vec3<f32>, @location(22) a2: vec2<i32>, @location(9) a3: f16, @location(70) a4: f16, @location(54) a5: vec2<f16>, @location(61) a6: vec3<f32>, @location(74) a7: vec3<f32>, @location(51) a8: u32, @location(5) a9: vec2<f32>, @location(57) a10: vec4<f32>, @location(85) a11: vec3<f32>, @location(44) a12: vec4<i32>, @location(12) a13: vec3<u32>, @location(14) a14: vec4<f32>, @location(64) a15: vec4<f16>, @location(36) a16: u32, @location(38) a17: vec2<u32>, @location(20) a18: vec2<u32>, @location(27) a19: vec4<f32>, a20: S7, @location(50) a21: i32, @builtin(position) a22: vec4<f32>, @builtin(sample_mask) a23: u32, @builtin(front_facing) a24: bool, @builtin(sample_index) a25: u32) {
+
+}
+
+struct VertexOutput0 {
+  @location(16) f28: vec3<f32>,
+  @location(70) f29: f16,
+  @location(49) f30: vec2<u32>,
+  @location(50) f31: i32,
+  @location(5) f32: vec2<f32>,
+  @location(46) f33: f16,
+  @location(27) f34: vec4<f32>,
+  @location(77) f35: vec2<f32>,
+  @location(55) f36: vec3<f32>,
+  @location(88) f37: vec4<u32>,
+  @location(18) f38: f32,
+  @location(21) f39: i32,
+  @location(85) f40: vec3<f32>,
+  @location(64) f41: vec4<f16>,
+  @location(36) f42: u32,
+  @location(61) f43: vec3<f32>,
+  @location(44) f44: vec4<i32>,
+  @location(23) f45: vec2<u32>,
+  @location(75) f46: vec2<i32>,
+  @location(14) f47: vec4<f32>,
+  @builtin(position) f48: vec4<f32>,
+  @location(54) f49: vec2<f16>,
+  @location(51) f50: u32,
+  @location(32) f51: vec4<f16>,
+  @location(20) f52: vec2<u32>,
+  @location(45) f53: vec2<f16>,
+  @location(35) f54: vec2<f16>,
+  @location(74) f55: vec3<f32>,
+  @location(57) f56: vec4<f32>,
+  @location(9) f57: f16,
+  @location(0) f58: vec3<u32>,
+  @location(22) f59: vec2<i32>,
+  @location(38) f60: vec2<u32>,
+  @location(26) f61: vec2<u32>,
+  @location(40) f62: vec3<u32>,
+  @location(12) f63: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: i32, @location(8) a1: f16, @location(3) a2: vec2<u32>, @location(4) a3: vec2<u32>, @location(6) a4: vec3<i32>, @location(21) a5: vec3<i32>, @builtin(instance_index) a6: u32, @location(10) a7: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+});
+let querySet15 = device0.createQuerySet({
+label: '\u0ebc\u07fc\u8802',
+type: 'occlusion',
+count: 2699,
+});
+try {
+renderPassEncoder2.setVertexBuffer(6, buffer11, 10292, 3061);
+} catch {}
+try {
+renderBundleEncoder9.draw(56, 48);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(24, 8, 56, 664);
+} catch {}
+try {
+commandEncoder17.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 1,
+  origin: { x: 0, y: 22, z: 0 },
+  aspect: 'depth-only',
+}, {
+/* bytesInLastRow: 1920 widthInBlocks: 480 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 24208 */
+offset: 24208,
+buffer: buffer12,
+}, {width: 480, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+let pipeline17 = device0.createComputePipeline({
+label: '\u{1f9dc}\u041a\u{1fa69}\u0fb1\u24b6\u{1f694}\u{1fe25}\u{1fbe7}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let bindGroup14 = device0.createBindGroup({
+label: '\u{1ff19}\ude34\ue257\u4ce8\u2747\u0f6b\u01fe\u13fe\u7e9c\ue56c',
+layout: bindGroupLayout5,
+entries: [{
+binding: 302,
+resource: sampler7
+}],
+});
+let querySet16 = device0.createQuerySet({
+label: '\u0ff9\u087b\u7184\uae43\uc615',
+type: 'occlusion',
+count: 85,
+});
+let computePassEncoder10 = commandEncoder17.beginComputePass({label: '\u{1ff69}\ubbf1'});
+let renderBundle20 = renderBundleEncoder5.finish({});
+let sampler13 = device0.createSampler({
+label: '\u03b5\u06f5\u{1fb5f}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 62.936,
+maxAnisotropy: 3,
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle16, renderBundle16, renderBundle16, renderBundle16, renderBundle16, renderBundle16, renderBundle16, renderBundle16, renderBundle16, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(3453);
+} catch {}
+try {
+renderPassEncoder1.draw(56, 64, 8, 32);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer6, 257872);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer0, 'uint32', 30412, 13089);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: { x: 0, y: 60, z: 0 },
+  aspect: 'all',
+}, new Int32Array(arrayBuffer0), /* required buffer size: 1419 */
+{offset: 348, bytesPerRow: 195, rowsPerImage: 35}, {width: 48, height: 30, depthOrArrayLayers: 1});
+} catch {}
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let textureView20 = texture1.createView({baseArrayLayer: 19, arrayLayerCount: 25});
+let renderBundle21 = renderBundleEncoder20.finish({label: '\u2452\u703a\u5a77\u{1f7bd}\ud9be\u0257\u0ce2\u0894\u0e82\u4e9a'});
+try {
+computePassEncoder5.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.draw(56, 48, 32, 48);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer4, 317040);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer6);
+} catch {}
+let renderBundle22 = renderBundleEncoder19.finish({label: '\u356a\u{1f8c1}\uf3ca\u{1fa07}'});
+let externalTexture4 = device0.importExternalTexture({
+label: '\ud6e1\u{1fbee}\u{1fe2d}\u{1fb25}\u7f9f\ud946\u8a05',
+source: video1,
+colorSpace: 'display-p3',
+});
+try {
+computePassEncoder0.setBindGroup(6, bindGroup1);
+} catch {}
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 554.6, g: 737.3, b: -189.6, a: -42.78, });
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(3257);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(6, buffer11, 1668, 11435);
+} catch {}
+try {
+commandEncoder13.insertDebugMarker('\u{1fc85}');
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer2,
+]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 1,
+  origin: { x: 80, y: 0, z: 96 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 2254652 */
+{offset: 302, bytesPerRow: 665, rowsPerImage: 113}, {width: 240, height: 0, depthOrArrayLayers: 31});
+} catch {}
+let pipeline18 = await device0.createRenderPipelineAsync({
+layout: pipelineLayout0,
+fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}]
+},
+vertex: {
+  module: shaderModule4,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+attributes: [{
+format: 'sint32x3',
+offset: 28484,
+shaderLocation: 23,
+}, {
+format: 'sint16x4',
+offset: 23028,
+shaderLocation: 4,
+}, {
+format: 'sint32',
+offset: 28796,
+shaderLocation: 19,
+}, {
+format: 'sint32',
+offset: 1304,
+shaderLocation: 17,
+}, {
+format: 'uint16x4',
+offset: 25708,
+shaderLocation: 14,
+}, {
+format: 'sint32x2',
+offset: 22572,
+shaderLocation: 15,
+}, {
+format: 'sint32x3',
+offset: 3380,
+shaderLocation: 21,
+}],
+},
+{
+arrayStride: 604,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 392,
+shaderLocation: 10,
+}, {
+format: 'float32',
+offset: 532,
+shaderLocation: 1,
+}, {
+format: 'float32x2',
+offset: 12,
+shaderLocation: 20,
+}, {
+format: 'sint32',
+offset: 480,
+shaderLocation: 0,
+}, {
+format: 'uint32x4',
+offset: 8,
+shaderLocation: 5,
+}, {
+format: 'unorm10-10-10-2',
+offset: 16,
+shaderLocation: 13,
+}, {
+format: 'snorm16x4',
+offset: 280,
+shaderLocation: 7,
+}, {
+format: 'uint32x2',
+offset: 516,
+shaderLocation: 9,
+}, {
+format: 'float16x2',
+offset: 348,
+shaderLocation: 8,
+}, {
+format: 'float16x2',
+offset: 416,
+shaderLocation: 2,
+}, {
+format: 'unorm8x4',
+offset: 52,
+shaderLocation: 16,
+}, {
+format: 'snorm16x4',
+offset: 44,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x2',
+offset: 11388,
+shaderLocation: 3,
+}, {
+format: 'uint32',
+offset: 8436,
+shaderLocation: 18,
+}],
+},
+{
+arrayStride: 14436,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x4',
+offset: 1872,
+shaderLocation: 6,
+}, {
+format: 'float16x4',
+offset: 10900,
+shaderLocation: 24,
+}, {
+format: 'unorm16x4',
+offset: 5828,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 22444,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 11592,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm16x4',
+offset: 4100,
+shaderLocation: 22,
+}],
+}
+]
+},
+});
+let commandEncoder18 = device0.createCommandEncoder({label: '\ucf52\u{1f769}\u{1fe67}'});
+let querySet17 = device0.createQuerySet({
+type: 'occlusion',
+count: 2581,
+});
+let computePassEncoder11 = commandEncoder18.beginComputePass({});
+let sampler14 = device0.createSampler({
+label: '\u{1fb11}\ue117\u{1f962}\u{1ffe0}\ue0e7\u{1ffcd}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 12.654,
+lodMaxClamp: 22.673,
+});
+try {
+renderPassEncoder2.setStencilReference(2326);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexedIndirect(buffer11, 128);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer9, 'uint32', 12864, 2974);
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(querySet10, 353, 1209, buffer6, 4608);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let pipeline19 = await device0.createComputePipelineAsync({
+label: '\u019a\uac05\u{1fecd}\u02e7\u{1f722}\u7acc\u0505\uf733\u{1f7c6}\u4d56',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let offscreenCanvas8 = new OffscreenCanvas(288, 347);
+let querySet18 = device0.createQuerySet({
+label: '\u054d\u0ecb\uf3b3\u3368\ua213\u0b05\u0aad\u9ec0\u{1ff81}',
+type: 'occlusion',
+count: 2625,
+});
+let renderBundle23 = renderBundleEncoder5.finish({label: '\u{1fde5}\u420c\u{1f927}\u723a\u0e35\u505c\u859a\u03db'});
+let sampler15 = device0.createSampler({
+label: '\u{1f7bf}\u10d6\u0b5f',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 35.541,
+lodMaxClamp: 39.784,
+maxAnisotropy: 10,
+});
+try {
+renderPassEncoder2.setStencilReference(2794);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4, buffer6);
+} catch {}
+try {
+renderBundleEncoder9.draw(16, 40, 32, 72);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(2, buffer11, 16348);
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 4,
+  origin: { x: 2, y: 0, z: 14 },
+  aspect: 'all',
+}, {
+  texture: texture12,
+  mipLevel: 5,
+  origin: { x: 1, y: 0, z: 2 },
+  aspect: 'all',
+}, {width: 13, height: 2, depthOrArrayLayers: 40});
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(querySet4, 532, 590, buffer6, 5888);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['astc-4x4-unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline20 = await promise7;
+let pipeline21 = device0.createRenderPipeline({
+label: '\ud5d2\u58cf',
+layout: pipelineLayout2,
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+}
+}, {format: 'r16uint'}, undefined]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilReadMask: 1825,
+depthBias: 100,
+depthBiasSlopeScale: 46,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 28024,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x4',
+offset: 14716,
+shaderLocation: 2,
+}, {
+format: 'float32',
+offset: 6208,
+shaderLocation: 22,
+}, {
+format: 'sint32x3',
+offset: 7680,
+shaderLocation: 4,
+}, {
+format: 'float32',
+offset: 13096,
+shaderLocation: 14,
+}, {
+format: 'uint32x3',
+offset: 25324,
+shaderLocation: 19,
+}],
+},
+{
+arrayStride: 20288,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x2',
+offset: 17028,
+shaderLocation: 8,
+}, {
+format: 'sint32x4',
+offset: 9028,
+shaderLocation: 24,
+}, {
+format: 'unorm8x2',
+offset: 8126,
+shaderLocation: 16,
+}, {
+format: 'uint16x4',
+offset: 4288,
+shaderLocation: 11,
+}, {
+format: 'float32x2',
+offset: 19196,
+shaderLocation: 21,
+}, {
+format: 'sint8x2',
+offset: 13332,
+shaderLocation: 3,
+}, {
+format: 'sint32',
+offset: 1560,
+shaderLocation: 12,
+}, {
+format: 'sint16x4',
+offset: 5108,
+shaderLocation: 20,
+}, {
+format: 'unorm8x4',
+offset: 5632,
+shaderLocation: 17,
+}],
+},
+{
+arrayStride: 0,
+attributes: [],
+},
+{
+arrayStride: 12124,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 18232,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 6232,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 23876,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 10872,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 19504,
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 7720,
+shaderLocation: 15,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+gc();
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+try {
+offscreenCanvas8.getContext('2d');
+} catch {}
+let img6 = await imageWithData(92, 2, '#e766da96', '#716eac41');
+let bindGroup15 = device0.createBindGroup({
+label: '\u1b75\u{1f913}',
+layout: bindGroupLayout2,
+entries: [{
+binding: 4081,
+resource: externalTexture3
+}, {
+binding: 6043,
+resource: textureView8
+}],
+});
+try {
+computePassEncoder7.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder2.setViewport(480.5, 30.90, 405.2, 32.02, 0.02174, 0.8174);
+} catch {}
+try {
+renderPassEncoder1.draw(40, 56, 24, 56);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(32, 32, 72, -720, 56);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer9, 202400);
+} catch {}
+try {
+renderBundleEncoder10.draw(56, 24, 48, 72);
+} catch {}
+let offscreenCanvas9 = new OffscreenCanvas(521, 973);
+try {
+window.someLabel = device1.queue.label;
+} catch {}
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+let commandEncoder19 = device0.createCommandEncoder({label: '\u032b\u696f\u9fc8\u0224\u{1fe90}\u018d\ubf43\u{1fff7}\u0be2\u0209'});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2uint', 'rgba32uint', 'rg32sint', 'rg16uint', 'rg16sint', undefined],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+let renderBundle24 = renderBundleEncoder12.finish();
+try {
+renderPassEncoder2.setViewport(647.1, 55.00, 30.25, 9.455, 0.5741, 0.8113);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(72, 48, 48);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(8, buffer6, 11652, 1340);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexed(16, 32, 16, -144);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(0, buffer11, 13244, 4811);
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(querySet0, 2211, 1433, buffer9, 4096);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 575 */
+{offset: 575}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline22 = await device0.createRenderPipelineAsync({
+label: '\u{1ff9f}\u4343',
+layout: pipelineLayout2,
+multisample: {
+mask: 0x76048139,
+},
+fragment: {module: shaderModule7, entryPoint: 'fragment0', targets: []},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'invert',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilBack: {
+failOp: 'decrement-wrap',
+passOp: 'invert',
+},
+stencilReadMask: 0,
+stencilWriteMask: 3466,
+depthBiasClamp: 79,
+},
+vertex: {
+  module: shaderModule7,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 18628,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 15642,
+shaderLocation: 8,
+}, {
+format: 'uint32',
+offset: 7132,
+shaderLocation: 4,
+}, {
+format: 'sint32x3',
+offset: 14568,
+shaderLocation: 6,
+}, {
+format: 'sint32',
+offset: 924,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 360,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 15712,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 12596,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 1864,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 1324,
+shaderLocation: 21,
+}],
+},
+{
+arrayStride: 15428,
+attributes: [{
+format: 'sint32',
+offset: 15016,
+shaderLocation: 1,
+}],
+}
+]
+},
+});
+let adapter3 = await navigator.gpu.requestAdapter({
+});
+let video5 = await videoWithData();
+canvas2.width = 378;
+let imageData6 = new ImageData(188, 132);
+let texture21 = device0.createTexture({
+size: [120, 16, 61],
+mipLevelCount: 6,
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rg8snorm', 'rg8snorm', 'rg8snorm'],
+});
+let textureView21 = texture7.createView({label: '\u887f\udd8f\u7b0c\uc90e', dimension: '2d-array'});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({
+  label: '\u1f37\u7e02',
+  colorFormats: [],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer11);
+} catch {}
+try {
+renderBundleEncoder9.draw(32, 72, 48, 56);
+} catch {}
+try {
+commandEncoder19.clearBuffer(buffer5, 12972, 22376);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(querySet14, 79, 732, buffer9, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 44536, new DataView(new ArrayBuffer(8554)), 2855, 1584);
+} catch {}
+document.body.prepend(video5);
+let canvas4 = document.createElement('canvas');
+let renderPassEncoder4 = commandEncoder13.beginRenderPass({
+label: '\u4885\ubab8\u3935\u0d0a\ua4b6',
+colorAttachments: [],
+depthStencilAttachment: {
+view: textureView6,
+depthClearValue: 0.513837064217905,
+depthLoadOp: 'clear',
+depthStoreOp: 'store',
+stencilClearValue: 46201,
+stencilLoadOp: 'load',
+stencilStoreOp: 'store',
+},
+occlusionQuerySet: querySet7,
+maxDrawCount: 1146872427,
+});
+let sampler16 = device0.createSampler({
+label: '\uc5d5\u{1faa2}\u0746\ubfe8\u{1f864}\u057b\u0cd1\ue09d',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 24.134,
+});
+try {
+renderPassEncoder1.setBlendConstant({ r: 846.7, g: 451.1, b: -983.2, a: 614.0, });
+} catch {}
+try {
+renderPassEncoder1.draw(40, 64, 8, 80);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(40, 80, 8, -104, 8);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexed(0);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer11, 20236);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(4, buffer11, 5184, 546);
+} catch {}
+try {
+commandEncoder19.resolveQuerySet(querySet5, 1300, 112, buffer6, 5120);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 13800, new Float32Array(10118), 5912, 3216);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 14 },
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer0), /* required buffer size: 213456 */
+{offset: 48, bytesPerRow: 36, rowsPerImage: 152}, {width: 12, height: 0, depthOrArrayLayers: 40});
+} catch {}
+let img7 = await imageWithData(234, 183, '#0127ac28', '#46991ab7');
+let video6 = await videoWithData();
+let querySet19 = device0.createQuerySet({
+label: '\u094b\uf02d\u{1f848}\uab63\u{1fe32}\u077c\u902c\u070b\u1b8f',
+type: 'occlusion',
+count: 3235,
+});
+let texture22 = device0.createTexture({
+label: '\u08ee\ub461\u{1f718}\uea24',
+size: [480, 36, 1],
+mipLevelCount: 5,
+dimension: '2d',
+format: 'astc-10x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x6-unorm-srgb', 'astc-10x6-unorm', 'astc-10x6-unorm'],
+});
+let computePassEncoder12 = commandEncoder19.beginComputePass();
+try {
+computePassEncoder0.setBindGroup(4, bindGroup6);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder1.draw(24, 56, 48);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer4, 'uint16', 4180);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder10.draw(72, 64, 80, 16);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer11, 2740);
+} catch {}
+try {
+computePassEncoder8.pushDebugGroup('\u00d4');
+} catch {}
+let pipeline23 = device0.createRenderPipeline({
+label: '\u{1fb0c}\u{1f68c}\u{1f992}\u{1fad8}\u234b\ucc72\u06e9\u0d81\u0e91\u985e\ua41c',
+layout: pipelineLayout3,
+multisample: {
+count: 4,
+mask: 0x44e07efa,
+},
+fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'keep',
+depthFailOp: 'increment-wrap',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-wrap',
+},
+stencilWriteMask: 362,
+depthBias: 47,
+depthBiasSlopeScale: 55,
+depthBiasClamp: 100,
+},
+vertex: {
+  module: shaderModule4,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 26736,
+attributes: [{
+format: 'sint8x4',
+offset: 21796,
+shaderLocation: 23,
+}, {
+format: 'sint32x4',
+offset: 17904,
+shaderLocation: 21,
+}, {
+format: 'snorm8x2',
+offset: 26702,
+shaderLocation: 22,
+}, {
+format: 'sint8x4',
+offset: 16140,
+shaderLocation: 0,
+}, {
+format: 'float32x3',
+offset: 19320,
+shaderLocation: 12,
+}, {
+format: 'snorm16x2',
+offset: 19000,
+shaderLocation: 20,
+}, {
+format: 'sint32',
+offset: 17112,
+shaderLocation: 6,
+}, {
+format: 'uint16x2',
+offset: 16544,
+shaderLocation: 5,
+}, {
+format: 'sint16x4',
+offset: 24708,
+shaderLocation: 19,
+}, {
+format: 'uint32',
+offset: 3000,
+shaderLocation: 14,
+}, {
+format: 'uint16x2',
+offset: 14368,
+shaderLocation: 9,
+}, {
+format: 'unorm8x4',
+offset: 11588,
+shaderLocation: 13,
+}, {
+format: 'snorm8x4',
+offset: 9256,
+shaderLocation: 11,
+}, {
+format: 'sint32x2',
+offset: 19424,
+shaderLocation: 17,
+}, {
+format: 'snorm8x2',
+offset: 19846,
+shaderLocation: 2,
+}, {
+format: 'snorm8x2',
+offset: 4548,
+shaderLocation: 1,
+}, {
+format: 'snorm16x4',
+offset: 4240,
+shaderLocation: 8,
+}, {
+format: 'sint32x4',
+offset: 11696,
+shaderLocation: 15,
+}, {
+format: 'unorm10-10-10-2',
+offset: 8352,
+shaderLocation: 24,
+}, {
+format: 'unorm10-10-10-2',
+offset: 460,
+shaderLocation: 7,
+}, {
+format: 'uint32',
+offset: 18892,
+shaderLocation: 18,
+}, {
+format: 'sint32x2',
+offset: 16776,
+shaderLocation: 4,
+}, {
+format: 'float16x2',
+offset: 12932,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 5236,
+attributes: [{
+format: 'float16x2',
+offset: 1560,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 996,
+attributes: [{
+format: 'float16x2',
+offset: 544,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let buffer13 = device0.createBuffer({
+  size: 48049,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX
+});
+try {
+renderPassEncoder1.setBlendConstant({ r: -860.0, g: -991.3, b: -847.5, a: -816.6, });
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(64);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer0, 'uint16');
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(2, buffer6);
+} catch {}
+try {
+renderBundleEncoder9.draw(40, 0, 32, 32);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(7, buffer13, 16472);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 0, y: 54, z: 1 },
+  aspect: 'stencil-only',
+}, new ArrayBuffer(24), /* required buffer size: 573 */
+{offset: 573}, {width: 960, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageData7 = new ImageData(216, 64);
+try {
+renderPassEncoder1.drawIndirect(buffer2, 417648);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexedIndirect(buffer11, 3520);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 28252, new Int16Array(42031), 27803, 5204);
+} catch {}
+document.body.prepend(canvas0);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img8 = await imageWithData(189, 9, '#7469ee52', '#f1406de0');
+let querySet20 = device0.createQuerySet({
+label: '\u0997\u2cd4\uf317\u132e\u38c5\u0d75',
+type: 'occlusion',
+count: 701,
+});
+let texture23 = device0.createTexture({
+size: {width: 480, height: 36, depthOrArrayLayers: 1},
+format: 'astc-10x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x6-unorm', 'astc-10x6-unorm-srgb'],
+});
+let sampler17 = device0.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 89.506,
+lodMaxClamp: 99.174,
+});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder1.draw(56, 0, 40);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer13, 12320, 35539);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(4, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexed(24);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer11, 17408);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(0, buffer13);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+document.body.prepend(img5);
+offscreenCanvas5.width = 650;
+offscreenCanvas8.height = 180;
+let shaderModule8 = device0.createShaderModule({
+label: '\u{1f6f9}\u{1f9bf}\udcbd\uf8d9\u2a25\ufe98\u0636\u50af\ubcd8\u0b91',
+code: `@group(0) @binding(6043)
+var<storage, read_write> field5: array<u32>;
+@group(0) @binding(4081)
+var<storage, read_write> global5: array<u32>;
+@group(1) @binding(4081)
+var<storage, read_write> parameter8: array<u32>;
+@group(1) @binding(6043)
+var<storage, read_write> parameter9: array<u32>;
+
+@compute @workgroup_size(7, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S9 {
+  @builtin(sample_index) f0: u32
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec2<i32>,
+  @builtin(frag_depth) f1: f32,
+  @location(4) f2: vec2<i32>,
+  @location(0) f3: vec4<u32>,
+  @location(3) f4: vec2<u32>,
+  @location(1) f5: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, a1: S9) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S8 {
+  @location(16) f0: vec2<u32>,
+  @location(0) f1: vec2<f32>,
+  @location(11) f2: vec3<f16>,
+  @location(4) f3: vec2<f16>,
+  @location(2) f4: vec3<f16>,
+  @builtin(instance_index) f5: u32,
+  @location(22) f6: vec2<u32>,
+  @location(12) f7: vec2<f16>,
+  @location(20) f8: vec4<i32>,
+  @location(8) f9: vec2<f32>,
+  @location(13) f10: vec3<i32>,
+  @location(18) f11: vec2<f32>,
+  @location(21) f12: f32,
+  @location(9) f13: u32,
+  @location(7) f14: i32,
+  @location(5) f15: u32,
+  @location(23) f16: vec3<i32>,
+  @location(1) f17: vec3<i32>,
+  @location(19) f18: vec2<f32>,
+  @location(17) f19: vec2<f16>,
+  @builtin(vertex_index) f20: u32
+}
+
+@vertex
+fn vertex0(@location(14) a0: f32, @location(10) a1: vec4<f32>, @location(3) a2: vec4<f16>, @location(24) a3: vec2<i32>, @location(6) a4: f16, a5: S8, @location(15) a6: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let renderBundle25 = renderBundleEncoder19.finish({label: '\ud1ac\u24d1'});
+try {
+renderPassEncoder2.setStencilReference(2010);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(8, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer9, 'uint16', 1372, 1447);
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+let pipeline24 = await device0.createComputePipelineAsync({
+layout: pipelineLayout3,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+},
+});
+document.body.prepend(img1);
+try {
+canvas4.getContext('bitmaprenderer');
+} catch {}
+let bindGroup16 = device0.createBindGroup({
+layout: bindGroupLayout2,
+entries: [{
+binding: 6043,
+resource: textureView8
+}, {
+binding: 4081,
+resource: externalTexture3
+}],
+});
+let querySet21 = device0.createQuerySet({
+label: '\u{1fcd5}\u5b99\uc8f8\ud029',
+type: 'occlusion',
+count: 999,
+});
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline24);
+} catch {}
+try {
+renderPassEncoder1.draw(80, 0, 24);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(6, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(64, 16);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer0, 'uint16', 34094, 10947);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(8, buffer13, 30080, 2470);
+} catch {}
+try {
+buffer4.destroy();
+} catch {}
+try {
+commandEncoder18.clearBuffer(buffer13, 14940, 23936);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba32float', 'rg8unorm', 'rgba8unorm-srgb', 'rgba8unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 701 */
+{offset: 701}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline25 = device0.createComputePipeline({
+layout: pipelineLayout3,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline26 = device0.createRenderPipeline({
+label: '\u0eb8\u43e0\u044b\u0655\ued77\u2236\u9126\u8ef4',
+layout: pipelineLayout2,
+fragment: {module: shaderModule3, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less-equal',
+depthFailOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'invert',
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+stencilReadMask: 2106,
+stencilWriteMask: 3412,
+depthBiasSlopeScale: 62,
+depthBiasClamp: 42,
+},
+vertex: {
+  module: shaderModule3,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x3',
+offset: 26616,
+shaderLocation: 13,
+}, {
+format: 'float32x2',
+offset: 17984,
+shaderLocation: 6,
+}, {
+format: 'unorm16x2',
+offset: 15924,
+shaderLocation: 16,
+}, {
+format: 'uint32x4',
+offset: 19368,
+shaderLocation: 23,
+}, {
+format: 'sint32x2',
+offset: 776,
+shaderLocation: 17,
+}, {
+format: 'uint8x4',
+offset: 28372,
+shaderLocation: 21,
+}, {
+format: 'unorm8x2',
+offset: 14114,
+shaderLocation: 4,
+}, {
+format: 'float16x4',
+offset: 19720,
+shaderLocation: 19,
+}, {
+format: 'sint32x2',
+offset: 28756,
+shaderLocation: 22,
+}, {
+format: 'sint32',
+offset: 9724,
+shaderLocation: 9,
+}, {
+format: 'sint32x2',
+offset: 14104,
+shaderLocation: 5,
+}, {
+format: 'float32x3',
+offset: 3500,
+shaderLocation: 1,
+}, {
+format: 'float32x4',
+offset: 20748,
+shaderLocation: 14,
+}, {
+format: 'uint8x4',
+offset: 26844,
+shaderLocation: 18,
+}],
+},
+{
+arrayStride: 15060,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x2',
+offset: 8110,
+shaderLocation: 15,
+}, {
+format: 'unorm8x4',
+offset: 13672,
+shaderLocation: 7,
+}, {
+format: 'uint8x4',
+offset: 4804,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 26304,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 5252,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x4',
+offset: 308,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 11516,
+attributes: [{
+format: 'float16x2',
+offset: 6536,
+shaderLocation: 0,
+}],
+}
+]
+},
+});
+let imageBitmap7 = await createImageBitmap(imageBitmap5);
+let renderPassEncoder5 = commandEncoder18.beginRenderPass({
+label: '\u91c6\u80a7\u7a59\u4457',
+colorAttachments: [],
+depthStencilAttachment: {
+view: textureView6,
+depthReadOnly: true,
+stencilLoadOp: 'clear',
+stencilStoreOp: 'discard',
+stencilReadOnly: false,
+},
+occlusionQuerySet: querySet12,
+maxDrawCount: 936874339,
+});
+let sampler18 = device0.createSampler({
+label: '\uf89f\ua572\u{1fa92}\u1eba\ub255',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 29.354,
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle16, renderBundle16, renderBundle16, renderBundle16, renderBundle16, renderBundle16, renderBundle16, renderBundle16, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer0, 245376);
+} catch {}
+try {
+renderBundleEncoder9.draw(40, 64, 72, 56);
+} catch {}
+try {
+renderBundleEncoder10.drawIndexedIndirect(buffer11, 7040);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer11, 11876);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(6, buffer13);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 42940, new Float32Array(5132), 4256, 864);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: { x: 130, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(490), /* required buffer size: 490 */
+{offset: 490, bytesPerRow: 592, rowsPerImage: 150}, {width: 230, height: 12, depthOrArrayLayers: 0});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext5 = offscreenCanvas9.getContext('webgpu');
+try {
+  await promise12;
+} catch {}
+pseudoSubmit(device0, commandEncoder16);
+let texture24 = device0.createTexture({
+label: '\u0eca\u4aa1\ub7d3\u{1f866}\u08a9\u00bc',
+size: {width: 120},
+dimension: '1d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup14, []);
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(2097);
+} catch {}
+try {
+renderPassEncoder2.setViewport(693.3, 34.13, 127.3, 13.33, 0.7340, 0.9164);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer3, 4816);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer0, 'uint16', 52308, 559);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder10.insertDebugMarker('\u{1fd3e}');
+} catch {}
+let bindGroupLayout13 = device0.createBindGroupLayout({
+label: '\ueeb6\u5941',
+entries: [{
+binding: 3183,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+}, {
+binding: 2166,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+let texture25 = device0.createTexture({
+label: '\u0b03\u{1feae}\u5434\u094e\uc55c\uaf6d',
+size: [120, 9, 1],
+mipLevelCount: 7,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['depth24plus', 'depth24plus'],
+});
+let externalTexture5 = device0.importExternalTexture({
+label: '\u7099\u{1fcbe}\ua382\u0b3d\u0630\ub6fe\u9b95\u5ac7',
+source: video6,
+colorSpace: 'display-p3',
+});
+try {
+computePassEncoder9.setPipeline(pipeline24);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(131, 5, 42, 8);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(8);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder10.draw(64);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer11, 19832);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer11, 6608);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+let bindGroupLayout14 = device0.createBindGroupLayout({
+label: '\ube05\u{1faa5}\uf819\u030c\uaddd\u8c59\ub5ed',
+entries: [{
+binding: 239,
+visibility: 0,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+}, {
+binding: 4312,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+}],
+});
+let pipelineLayout5 = device0.createPipelineLayout({
+  label: '\u{1fe58}\u0133\u782e\u{1f824}\u2351\u34ee\u{1fd3a}\u3c30',
+  bindGroupLayouts: [bindGroupLayout5, bindGroupLayout5, bindGroupLayout5]
+});
+let renderBundle26 = renderBundleEncoder10.finish({label: '\u646e\u{1ffb2}\u9fab\ue503\u{1f887}\ude75\uad53'});
+try {
+computePassEncoder4.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle26, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 159.4, g: -712.4, b: -165.5, a: -380.6, });
+} catch {}
+try {
+renderPassEncoder1.setViewport(173.7, 10.64, 62.79, 0.8048, 0.8257, 0.8636);
+} catch {}
+try {
+renderPassEncoder1.draw(64, 64, 24, 24);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(3, buffer13);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(5, bindGroup7, new Uint32Array(7818), 4226, 0);
+} catch {}
+try {
+renderBundleEncoder17.draw(0, 48, 72, 48);
+} catch {}
+let arrayBuffer1 = buffer10.getMappedRange();
+try {
+device0.queue.submit([
+]);
+} catch {}
+let canvas5 = document.createElement('canvas');
+try {
+window.someLabel = externalTexture5.label;
+} catch {}
+let bindGroupLayout15 = device0.createBindGroupLayout({
+entries: [],
+});
+let buffer14 = device0.createBuffer({
+  label: '\u0fc9\u8bca\u6d36\ue19f\u{1fe48}',
+  size: 19938,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let texture26 = device0.createTexture({
+label: '\uaab9\u{1fc61}\u{1fcfc}',
+size: [235, 15, 185],
+mipLevelCount: 2,
+dimension: '2d',
+format: 'astc-5x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-5x5-unorm-srgb', 'astc-5x5-unorm-srgb', 'astc-5x5-unorm-srgb'],
+});
+let textureView22 = texture19.createView({label: '\u073f\u{1f791}\u29ed\u0ab8\u3767\u{1fe4a}', dimension: '2d-array'});
+try {
+renderPassEncoder1.drawIndexed(56, 8, 64, 504, 32);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(8, 16);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(7, buffer11, 14940, 3636);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: { x: 160, y: 6, z: 0 },
+  aspect: 'all',
+}, new Int16Array(arrayBuffer0), /* required buffer size: 993 */
+{offset: 993}, {width: 310, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext6 = canvas5.getContext('webgpu');
+gc();
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2uint', 'rgba32uint', 'rg32sint', 'rg16uint', 'rg16sint', undefined],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(72, 64, 40);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(2, buffer11, 17780, 208);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(16, 72);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer11, 16664);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer11, 18672);
+} catch {}
+try {
+renderBundleEncoder21.insertDebugMarker('\u5879');
+} catch {}
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({
+  label: '\u070b\u59b6\u0dbd\u{1f966}',
+  colorFormats: [],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderPassEncoder2.setBindGroup(4, bindGroup8, new Uint32Array(8458), 6885, 0);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(2467);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer9, 127880);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer0, 'uint32', 40396, 9738);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer6, 15112, 464);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext6.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 28768, new BigUint64Array(42255), 38065, 1832);
+} catch {}
+let pipeline27 = await device0.createComputePipelineAsync({
+layout: pipelineLayout2,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+},
+});
+canvas5.height = 243;
+let commandEncoder20 = device0.createCommandEncoder({label: '\u0fca\u6ceb'});
+let computePassEncoder13 = commandEncoder20.beginComputePass({label: '\u61f1\u0dd2\u{1f65f}\u0838\u0be0\uac4a\u35e1\u24db\u92be\u1ed8'});
+try {
+computePassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: 507.9, g: 249.9, b: -903.4, a: 158.6, });
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\u0826');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 1860, new Int16Array(65249), 5485, 14476);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: -936.8, g: -761.5, b: 237.5, a: -346.2, });
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup12, new Uint32Array(4819), 1708, 0);
+} catch {}
+try {
+renderBundleEncoder17.draw(8, 48, 32, 16);
+} catch {}
+try {
+querySet10.destroy();
+} catch {}
+let querySet22 = device0.createQuerySet({
+label: '\u9006\u0bd7\u1670\u{1f880}\u3fc6',
+type: 'occlusion',
+count: 1203,
+});
+let renderBundle27 = renderBundleEncoder5.finish();
+try {
+computePassEncoder12.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -97.93, g: -524.6, b: -272.5, a: 821.6, });
+} catch {}
+try {
+renderPassEncoder5.setViewport(197.4, 12.79, 4.094, 0.08769, 0.05220, 0.2502);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder17.draw(0, 48, 72, 72);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer11, 5652);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(8, buffer6, 10616);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let shaderModule9 = device0.createShaderModule({
+label: '\ufa28\u24ab\u2fba\uef1a',
+code: `@group(7) @binding(5174)
+var<storage, read_write> global6: array<u32>;
+@group(7) @binding(4981)
+var<storage, read_write> type9: array<u32>;
+@group(2) @binding(4981)
+var<storage, read_write> global7: array<u32>;
+@group(3) @binding(6043)
+var<storage, read_write> local6: array<u32>;
+@group(0) @binding(4981)
+var<storage, read_write> parameter10: array<u32>;
+@group(3) @binding(4081)
+var<storage, read_write> field6: array<u32>;
+
+@compute @workgroup_size(6, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S11 {
+  @location(22) f0: f16,
+  @location(9) f1: u32
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec2<f32>,
+  @location(0) f1: vec3<i32>,
+  @location(4) f2: vec3<i32>,
+  @location(5) f3: vec3<i32>,
+  @location(1) f4: vec3<u32>,
+  @location(3) f5: vec3<u32>
+}
+
+@fragment
+fn fragment0(@location(21) a0: vec3<f32>, @location(27) a1: f32, @location(75) a2: vec2<f16>, a3: S11, @location(82) a4: u32, @builtin(sample_mask) a5: u32, @location(78) a6: vec3<u32>, @location(86) a7: vec3<f32>, @location(85) a8: vec2<f32>, @location(63) a9: vec3<u32>, @location(74) a10: vec3<f32>, @location(71) a11: vec4<u32>, @location(8) a12: u32, @location(10) a13: vec3<i32>, @location(50) a14: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S10 {
+  @location(12) f0: vec3<f16>,
+  @location(16) f1: vec2<u32>,
+  @location(8) f2: vec4<i32>,
+  @location(18) f3: vec2<u32>,
+  @builtin(vertex_index) f4: u32,
+  @location(3) f5: vec3<i32>,
+  @location(7) f6: vec4<u32>,
+  @location(13) f7: vec4<i32>,
+  @location(9) f8: vec4<i32>
+}
+struct VertexOutput0 {
+  @location(82) f64: u32,
+  @location(50) f65: vec4<f32>,
+  @builtin(position) f66: vec4<f32>,
+  @location(71) f67: vec4<u32>,
+  @location(75) f68: vec2<f16>,
+  @location(74) f69: vec3<f32>,
+  @location(78) f70: vec3<u32>,
+  @location(21) f71: vec3<f32>,
+  @location(8) f72: u32,
+  @location(22) f73: f16,
+  @location(81) f74: vec3<i32>,
+  @location(63) f75: vec3<u32>,
+  @location(10) f76: vec3<i32>,
+  @location(9) f77: u32,
+  @location(27) f78: f32,
+  @location(85) f79: vec2<f32>,
+  @location(86) f80: vec3<f32>
+}
+
+@vertex
+fn vertex0(a0: S10, @location(15) a1: vec2<u32>, @location(1) a2: vec2<u32>, @location(4) a3: vec4<f16>, @builtin(instance_index) a4: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let textureView23 = texture16.createView({
+  label: '\u3250\u85fd\u4aff\ua477\ubbb3\u0e6a\u4a85\u0ea3\uc132\u{1f9d1}',
+  dimension: '2d-array',
+  format: 'bgra8unorm-srgb'
+});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({
+  label: '\ufd7d\u{1f6a2}\u04ae\u{1fb72}\u{1f8fe}\u{1fd63}\u{1f95e}\u953b',
+  colorFormats: ['rgba16float', 'r16uint', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder7.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(4018);
+} catch {}
+try {
+renderPassEncoder5.draw(40, 48, 24, 0);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline16);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 18576, new DataView(new ArrayBuffer(11412)), 7562, 148);
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+let video7 = await videoWithData();
+let querySet23 = device0.createQuerySet({
+label: '\u4a0a\u{1fde7}\u{1fbc0}',
+type: 'occlusion',
+count: 1801,
+});
+let texture27 = device0.createTexture({
+label: '\u01f8\ua783\u{1f706}\u03a7\uf022\u6cc2\u{1fc01}',
+size: [56, 230, 1],
+mipLevelCount: 2,
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-8x5-unorm-srgb', 'astc-8x5-unorm'],
+});
+let textureView24 = texture20.createView({label: '\u{1ffd4}\u0d76\u3531\u15be\u6e65', baseMipLevel: 1, baseArrayLayer: 48, arrayLayerCount: 12});
+try {
+renderPassEncoder5.setBlendConstant({ r: -185.1, g: 726.4, b: 926.2, a: -92.87, });
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(1087);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer9, 'uint32', 15788, 204);
+} catch {}
+let promise14 = device0.createComputePipelineAsync({
+label: '\u00c8\u000d\u{1f932}\uf9c0',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let buffer15 = device0.createBuffer({size: 58072, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: true});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'r8sint', 'rgba32uint', 'rgba8sint', 'r16uint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true
+});
+try {
+computePassEncoder12.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderPassEncoder4.draw(48, 40, 48, 16);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer3, 47864);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer9, 64984);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(4, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer0, 'uint32');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 25300, new DataView(new ArrayBuffer(24033)), 4436, 11844);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({
+  label: '\u4717\u93db\u33d9\u0309\uc4ed\u904d\u02a0',
+  colorFormats: ['rgba16float', 'r16uint', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer14, 5112);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer11, 7656);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(1, buffer13, 9860);
+} catch {}
+let pipeline28 = await device0.createComputePipelineAsync({
+layout: pipelineLayout0,
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let querySet24 = device0.createQuerySet({
+type: 'occlusion',
+count: 591,
+});
+let texture28 = device0.createTexture({
+label: '\u{1fa10}\u0fb9\u0839\u0341\uc74f\ueb65\u{1ffbe}\u4dd9\u30e0\u008e\u5bf5',
+size: [120],
+sampleCount: 1,
+dimension: '1d',
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r16uint', 'r16uint'],
+});
+let renderBundle28 = renderBundleEncoder24.finish();
+let sampler19 = device0.createSampler({
+label: '\u1aec\u0ebb\u0c4f\u087c',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+});
+try {
+computePassEncoder12.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(1636);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle26, renderBundle16, renderBundle26, renderBundle26, renderBundle16, renderBundle16, renderBundle26]);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer2, 55456);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(5, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder9.draw(16, 56, 64, 64);
+} catch {}
+try {
+  await promise13;
+} catch {}
+let video8 = await videoWithData();
+let renderBundle29 = renderBundleEncoder21.finish({});
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup6, new Uint32Array(1631), 1190, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer15, 38680);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(48, 24);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 43704, new BigUint64Array(25680), 14651, 304);
+} catch {}
+let device2 = await adapter2.requestDevice({
+label: '\ub71d\ue56b\u463b\u2bfc\u377c\u1817\u0b26',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxColorAttachmentBytesPerSample: 46,
+maxVertexAttributes: 18,
+maxVertexBufferArrayStride: 13431,
+maxStorageTexturesPerShaderStage: 41,
+maxStorageBuffersPerShaderStage: 35,
+maxDynamicStorageBuffersPerPipelineLayout: 55253,
+maxBindingsPerBindGroup: 2983,
+maxTextureDimension1D: 8988,
+maxTextureDimension2D: 14818,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 251101953,
+maxUniformBuffersPerShaderStage: 38,
+maxInterStageShaderVariables: 47,
+maxInterStageShaderComponents: 88,
+maxSamplersPerShaderStage: 19,
+},
+});
+let texture29 = device0.createTexture({
+label: '\u0555\u8874\u0954\u{1fe5a}\u{1f827}\u{1f6c5}\u9cca',
+size: {width: 240, height: 32, depthOrArrayLayers: 896},
+mipLevelCount: 8,
+dimension: '3d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let sampler20 = device0.createSampler({
+label: '\uf0b0\uebb1\uf113\u00b9\u039c\u5d31\u9ae1\ud9b2',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 45.479,
+lodMaxClamp: 91.483,
+});
+try {
+renderPassEncoder5.setBlendConstant({ r: 804.6, g: 617.3, b: -814.2, a: 899.9, });
+} catch {}
+try {
+renderPassEncoder5.draw(8, 24, 16, 48);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer12, 85720);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(3, buffer13, 34504);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(2, bindGroup3, []);
+} catch {}
+try {
+renderBundleEncoder9.draw(56, 72, 80, 72);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(80, 72, 40, 776, 8);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexedIndirect(buffer11, 14924);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer11, 11096);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 43804, new BigUint64Array(59639), 58978, 252);
+} catch {}
+let querySet25 = device2.createQuerySet({
+label: '\u0ef2\u7cf7\u{1fb88}\u9629\u32fd\u22d0\u354b\u0abd',
+type: 'occlusion',
+count: 1507,
+});
+let texture30 = device2.createTexture({
+size: {width: 275, height: 1, depthOrArrayLayers: 1589},
+mipLevelCount: 11,
+dimension: '3d',
+format: 'rg16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundleEncoder29 = device2.createRenderBundleEncoder({
+  label: '\u0bcb\u3e74\ua64e\u395e\u05ca\u327c\u0510\u0904',
+  colorFormats: ['rg16uint', 'rgba32float', 'r32uint', 'bgra8unorm', 'r32sint', 'r16uint', undefined],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+let renderBundle30 = renderBundleEncoder29.finish({label: '\u7325\u452b\u21c2\u55b0\u{1facf}\u6f50\u19e4\u8cf9\uc933'});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let offscreenCanvas10 = new OffscreenCanvas(14, 780);
+let renderBundleEncoder30 = device2.createRenderBundleEncoder({
+  label: '\u5986\u6785\u{1f7cc}\udaa1\u0a85\u65fa\u{1f75c}',
+  colorFormats: ['rg16uint', 'rgba32float', 'r32uint', 'bgra8unorm', 'r32sint', 'r16uint', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+document.body.prepend(img2);
+try {
+offscreenCanvas10.getContext('bitmaprenderer');
+} catch {}
+let buffer16 = device0.createBuffer({label: '\u61a8\ud680\u0878\u0f64\u10e5', size: 62278, usage: GPUBufferUsage.MAP_READ});
+let texture31 = device0.createTexture({
+label: '\u9a63\u2c2c\u8be0\u0160\u0e3e\u{1fd8d}\u{1fd61}\u0964\u0fd1\ue793',
+size: [240, 32, 61],
+mipLevelCount: 6,
+dimension: '2d',
+format: 'astc-5x4-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView25 = texture21.createView({
+  label: '\u0306\u{1fb5c}\u3b2f\u057a',
+  dimension: '2d',
+  format: 'rg8snorm',
+  mipLevelCount: 5,
+  baseArrayLayer: 3
+});
+let renderBundle31 = renderBundleEncoder7.finish({label: '\u{1f7bb}\ue6c6\u{1fa16}\u70ce\u0b68\u{1fb45}\u{1f8e4}\u011a\u{1fb01}'});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(110, 12, 61, 2);
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(2248);
+} catch {}
+try {
+renderPassEncoder4.draw(80, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer2, 82824);
+} catch {}
+try {
+renderBundleEncoder9.drawIndexed(8, 0, 40, 0);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer11, 9076);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(3, buffer6, 1080, 4344);
+} catch {}
+try {
+commandEncoder19.copyBufferToBuffer(buffer2, 3784, buffer12, 34040, 2328);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder19.clearBuffer(buffer13, 13168, 5516);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder19.resolveQuerySet(querySet21, 808, 175, buffer6, 14336);
+} catch {}
+try {
+await adapter3.requestAdapterInfo();
+} catch {}
+let renderBundle32 = renderBundleEncoder8.finish({label: '\u19ec\u082f\u40fb\u4469'});
+try {
+renderPassEncoder1.setScissorRect(26, 17, 99, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer15, 3472);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(3, buffer13, 5600, 16108);
+} catch {}
+try {
+commandEncoder19.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: { x: 376, y: 0, z: 9 },
+  aspect: 'all',
+}, {
+  texture: texture27,
+  mipLevel: 1,
+  origin: { x: 0, y: 10, z: 1 },
+  aspect: 'all',
+}, {width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder19.clearBuffer(buffer13, 41100, 4892);
+dissociateBuffer(device0, buffer13);
+} catch {}
+let video9 = await videoWithData();
+let querySet26 = device0.createQuerySet({
+type: 'occlusion',
+count: 3495,
+});
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({
+  label: '\u02ff\u98ed\u5fd1\u0c80\u5444\uc960\ua0e9\u046c\u1428\u020f\u6dbf',
+  colorFormats: ['r8sint', 'rg32uint', 'rg16float', 'r32uint', 'r32sint', 'r8sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderPassEncoder2.setViewport(291.5, 40.69, 209.7, 23.97, 0.2638, 0.3956);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(0, 8, 40, -416, 56);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer1, 4784);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer0, 81456);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer9, 'uint32', 9356, 6939);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(64, 0, 80, -616, 8);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer11, 12216);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder19.copyBufferToBuffer(buffer2, 10848, buffer1, 30520, 5020);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+computePassEncoder5.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 1,
+  origin: { x: 20, y: 5, z: 93 },
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer0), /* required buffer size: 2408595 */
+{offset: 849, bytesPerRow: 382, rowsPerImage: 191}, {width: 95, height: 0, depthOrArrayLayers: 34});
+} catch {}
+gc();
+pseudoSubmit(device0, commandEncoder4);
+let textureView26 = texture31.createView({
+  label: '\u0981\u0dbb',
+  format: 'astc-5x4-unorm-srgb',
+  baseMipLevel: 3,
+  baseArrayLayer: 25,
+  arrayLayerCount: 7
+});
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({
+  label: '\u1708\u5e45\ubfb8',
+  colorFormats: ['rgba16float', 'r16uint', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+renderPassEncoder2.beginOcclusionQuery(2794);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder9.drawIndirect(buffer11, 18864);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(3, buffer13);
+} catch {}
+let arrayBuffer2 = buffer2.getMappedRange(10456, 2052);
+try {
+commandEncoder19.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: { x: 320, y: 0, z: 25 },
+  aspect: 'all',
+}, {
+  texture: texture20,
+  mipLevel: 1,
+  origin: { x: 24, y: 8, z: 5 },
+  aspect: 'all',
+}, {width: 72, height: 16, depthOrArrayLayers: 34});
+} catch {}
+try {
+commandEncoder19.resolveQuerySet(querySet7, 457, 689, buffer9, 4096);
+} catch {}
+let promise15 = device0.queue.onSubmittedWorkDone();
+let pipeline29 = await promise9;
+let pipeline30 = await device0.createRenderPipelineAsync({
+label: '\u75dc\u{1f793}\u4dbb\u{1f95a}',
+layout: 'auto',
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+color: {operation: 'add', srcFactor: 'dst-alpha', dstFactor: 'one-minus-src-alpha'},
+alpha: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'zero'},
+},
+  writeMask: 0
+}, {
+  format: 'r16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater-equal',
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'keep',
+depthFailOp: 'zero',
+},
+stencilReadMask: 2761,
+stencilWriteMask: 1038,
+depthBias: 30,
+depthBiasSlopeScale: 16,
+depthBiasClamp: 66,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 20912,
+shaderLocation: 22,
+}, {
+format: 'float32',
+offset: 11232,
+shaderLocation: 17,
+}, {
+format: 'sint8x2',
+offset: 1830,
+shaderLocation: 4,
+}, {
+format: 'uint32',
+offset: 2572,
+shaderLocation: 8,
+}, {
+format: 'float32x2',
+offset: 18492,
+shaderLocation: 16,
+}, {
+format: 'uint8x2',
+offset: 2228,
+shaderLocation: 19,
+}, {
+format: 'unorm16x2',
+offset: 28044,
+shaderLocation: 15,
+}, {
+format: 'snorm8x2',
+offset: 17734,
+shaderLocation: 14,
+}, {
+format: 'snorm16x4',
+offset: 22164,
+shaderLocation: 21,
+}],
+},
+{
+arrayStride: 23676,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 19996,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x4',
+offset: 6084,
+shaderLocation: 3,
+}, {
+format: 'sint16x4',
+offset: 3548,
+shaderLocation: 20,
+}, {
+format: 'uint8x2',
+offset: 6260,
+shaderLocation: 11,
+}, {
+format: 'sint16x2',
+offset: 4636,
+shaderLocation: 2,
+}, {
+format: 'sint8x2',
+offset: 998,
+shaderLocation: 24,
+}, {
+format: 'sint32x3',
+offset: 19180,
+shaderLocation: 12,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let offscreenCanvas11 = new OffscreenCanvas(193, 103);
+let video10 = await videoWithData();
+let videoFrame3 = new VideoFrame(video6, {timestamp: 0});
+let querySet27 = device2.createQuerySet({
+label: '\u{1f85a}\u{1f694}\u{1fef6}\u0ae0',
+type: 'occlusion',
+count: 915,
+});
+let texture32 = device2.createTexture({
+label: '\u05cc\u06e3\ue0cd\ua90d\u{1ffa8}\u0f0e\u02d0\ubf51',
+size: [5856, 72, 1],
+mipLevelCount: 11,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle33 = renderBundleEncoder29.finish({label: '\ucf22\u0273\u5fdd\u0bbd\ueb4a\u1833\u0283\u{1f6d3}\u09d4'});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let videoFrame4 = new VideoFrame(img1, {timestamp: 0});
+gc();
+try {
+adapter3.label = '\ubf53\u{1fa31}\u{1fbb4}\u72c4';
+} catch {}
+try {
+offscreenCanvas11.getContext('webgl2');
+} catch {}
+let texture33 = device2.createTexture({
+label: '\u00ce\u{1fcbb}\u66fd\u{1f8e3}\u0445\u0744\u0b91\u3b37',
+size: {width: 48, height: 96, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView27 = texture33.createView({label: '\u0e19\u{1fe53}', baseMipLevel: 4});
+try {
+renderBundleEncoder30.setVertexBuffer(39, undefined, 1310691164, 1016419888);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 3,
+  origin: { x: 4, y: 5, z: 0 },
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer0), /* required buffer size: 632 */
+{offset: 200, bytesPerRow: 72}, {width: 0, height: 7, depthOrArrayLayers: 1});
+} catch {}
+let buffer17 = device0.createBuffer({
+  label: '\u{1ffea}\u{1fa5a}\u{1fcfb}\u3558\u799f\ub115\u{1fdd3}\u0964',
+  size: 29654,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM
+});
+let renderBundle34 = renderBundleEncoder9.finish({label: '\u{1ff72}\uac04\u35c9\u9c3b\u0a03\ub51f\u2ddc\u7eda\u8ee9\uf476'});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup13, new Uint32Array(2769), 1527, 0);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(142, 17, 22, 1);
+} catch {}
+try {
+renderPassEncoder5.draw(40, 40, 8, 32);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(72, 40, 48, -64, 24);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(3, bindGroup1);
+} catch {}
+let canvas6 = document.createElement('canvas');
+let texture34 = device2.createTexture({
+label: '\u{1f8f2}\u{1fe58}\u0d2e\u0d5a\u0e0b\u4cdd\u{1fdf5}',
+size: [96, 192, 3],
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rg32float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg32float', 'rg32float'],
+});
+let textureView28 = texture32.createView({
+  label: '\u{1f708}\u{1f6cc}\u9377\u7583\u{1f9e7}\u29c7\u17d2\u{1fa29}\u024a\u075b',
+  dimension: '2d-array',
+  format: 'astc-8x8-unorm-srgb',
+  baseMipLevel: 9
+});
+let renderBundleEncoder33 = device2.createRenderBundleEncoder({
+  label: '\u9d7e\u{1fc6d}\u0e0b\u0c08\u3fd3\u0583\u01a9',
+  colorFormats: ['rg16uint', 'rgba32float', 'r32uint', 'bgra8unorm', 'r32sint', 'r16uint', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true
+});
+let renderBundle35 = renderBundleEncoder30.finish();
+document.body.prepend(canvas5);
+let renderBundle36 = renderBundleEncoder12.finish({label: '\u3168\u56a2\u0c43\u7c47'});
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(114);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder2.setViewport(910.2, 23.71, 36.89, 14.24, 0.1883, 0.5918);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(32, 0, 64);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer4, 'uint16');
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer11, 8380, 7834);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(24, 24);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer11, 7268);
+} catch {}
+try {
+commandEncoder20.clearBuffer(buffer10);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+  await promise15;
+} catch {}
+let querySet28 = device0.createQuerySet({
+label: '\u0f50\u0510\u021f',
+type: 'occlusion',
+count: 1940,
+});
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.draw(72, 48, 80, 32);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(40);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer3, 448912);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(0, buffer13, 37668);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(6, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder17.draw(56, 72, 56, 24);
+} catch {}
+try {
+commandEncoder19.copyBufferToBuffer(buffer17, 8860, buffer1, 30264, 1048);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 33824, new Int16Array(23427), 23411, 16);
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+let promise17 = device0.createRenderPipelineAsync({
+label: '\ub091\ub075\u9785\u0cb5\u6683\u075b\u8c89\u0e8e',
+layout: pipelineLayout3,
+multisample: {
+count: 4,
+mask: 0x25470470,
+},
+fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rg32uint', writeMask: 0}, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'one-minus-src-alpha', dstFactor: 'constant'},
+},
+  writeMask: GPUColorWrite.BLUE
+}, {format: 'r32uint', writeMask: 0}, {format: 'r32sint', writeMask: GPUColorWrite.ALL}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'replace',
+passOp: 'replace',
+},
+depthBias: 76,
+depthBiasSlopeScale: 95,
+depthBiasClamp: 81,
+},
+vertex: {
+  module: shaderModule9,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 11580,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32',
+offset: 6512,
+shaderLocation: 7,
+}, {
+format: 'sint32x3',
+offset: 2544,
+shaderLocation: 3,
+}, {
+format: 'uint32x4',
+offset: 7224,
+shaderLocation: 16,
+}, {
+format: 'sint32x3',
+offset: 4256,
+shaderLocation: 8,
+}, {
+format: 'float32',
+offset: 588,
+shaderLocation: 4,
+}, {
+format: 'sint32x4',
+offset: 9232,
+shaderLocation: 13,
+}, {
+format: 'uint8x4',
+offset: 3476,
+shaderLocation: 1,
+}, {
+format: 'uint8x4',
+offset: 1748,
+shaderLocation: 15,
+}, {
+format: 'sint32x3',
+offset: 3980,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 13068,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x4',
+offset: 4324,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 13260,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x2',
+offset: 630,
+shaderLocation: 18,
+}],
+}
+]
+},
+primitive: {
+unclippedDepth: true,
+},
+});
+let gpuCanvasContext7 = canvas6.getContext('webgpu');
+let bindGroup17 = device0.createBindGroup({
+label: '\uedd6\ub8dd\u{1fa74}\u{1fafe}\u0719',
+layout: bindGroupLayout2,
+entries: [{
+binding: 4081,
+resource: externalTexture1
+}, {
+binding: 6043,
+resource: textureView8
+}],
+});
+let querySet29 = device0.createQuerySet({
+label: '\uaf5d\u{1fd30}\uca98\u05a6',
+type: 'occlusion',
+count: 416,
+});
+let sampler21 = device0.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 8.524,
+lodMaxClamp: 61.484,
+maxAnisotropy: 6,
+});
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: -63.06, g: -994.1, b: 486.9, a: -973.7, });
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(0, 80, 40, 416, 48);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer6, 25048);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer11, 2144);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer11, 9716);
+} catch {}
+let promise18 = buffer7.mapAsync(GPUMapMode.READ, 0, 17476);
+try {
+commandEncoder19.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 64 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 21744 */
+offset: 21744,
+buffer: buffer13,
+}, {width: 32, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline31 = device0.createRenderPipeline({
+label: '\u267d\u{1fb34}\uf47c\u2093\ub045\u00ce\u8d80\ue657\u{1ffc5}\u3676\ua043',
+layout: pipelineLayout4,
+multisample: {
+count: 1,
+mask: 0x924e39d3,
+},
+fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8sint', writeMask: 0}, {format: 'rg32uint'}, {format: 'rg16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r32uint'}, {format: 'r32sint', writeMask: GPUColorWrite.GREEN}, {format: 'r8sint', writeMask: 0}]
+},
+vertex: {
+  module: shaderModule9,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 12204,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32',
+offset: 136,
+shaderLocation: 9,
+}, {
+format: 'uint32x2',
+offset: 6936,
+shaderLocation: 7,
+}, {
+format: 'sint32',
+offset: 10232,
+shaderLocation: 13,
+}, {
+format: 'uint16x2',
+offset: 3016,
+shaderLocation: 18,
+}, {
+format: 'uint32x2',
+offset: 4792,
+shaderLocation: 16,
+}, {
+format: 'sint8x2',
+offset: 9508,
+shaderLocation: 8,
+}, {
+format: 'float32x2',
+offset: 5216,
+shaderLocation: 12,
+}, {
+format: 'uint16x2',
+offset: 6452,
+shaderLocation: 1,
+}, {
+format: 'uint32x3',
+offset: 3764,
+shaderLocation: 15,
+}, {
+format: 'float32x4',
+offset: 4344,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 12492,
+attributes: [],
+},
+{
+arrayStride: 10888,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x3',
+offset: 6468,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+  await promise18;
+} catch {}
+let video11 = await videoWithData();
+try {
+  await promise16;
+} catch {}
+let device3 = await adapter3.requestDevice({
+label: '\u8e5a\u0c21\uf41e\u19d7\ub53c\u7b00\uc8a4\u2e0a\u{1f9d4}',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 49,
+maxVertexBufferArrayStride: 60953,
+maxStorageTexturesPerShaderStage: 8,
+maxStorageBuffersPerShaderStage: 37,
+maxDynamicStorageBuffersPerPipelineLayout: 10576,
+maxBindingsPerBindGroup: 6514,
+maxTextureDimension1D: 9875,
+maxTextureDimension2D: 12211,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 148535938,
+maxUniformBuffersPerShaderStage: 43,
+maxInterStageShaderVariables: 100,
+maxInterStageShaderComponents: 108,
+maxSamplersPerShaderStage: 19,
+},
+});
+let sampler22 = device2.createSampler({
+label: '\ufd2e\u0e5e\u07c9',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 19.692,
+});
+try {
+device2.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 6,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(453), /* required buffer size: 453 */
+{offset: 453, rowsPerImage: 10}, {width: 80, height: 0, depthOrArrayLayers: 1});
+} catch {}
+pseudoSubmit(device0, commandEncoder13);
+let texture35 = gpuCanvasContext6.getCurrentTexture();
+try {
+renderPassEncoder5.executeBundles([renderBundle16]);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer11, 6108);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer11, 12324);
+} catch {}
+let video12 = await videoWithData();
+let bindGroup18 = device0.createBindGroup({
+layout: bindGroupLayout15,
+entries: [],
+});
+let textureView29 = texture14.createView({label: '\u849e\uf9cc\u2344', dimension: '2d', mipLevelCount: 2, baseArrayLayer: 49});
+let renderBundle37 = renderBundleEncoder23.finish({label: '\u{1fea1}\u2059\u{1f92b}\u7300'});
+try {
+computePassEncoder10.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer2, 7048);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(6, bindGroup10);
+} catch {}
+try {
+commandEncoder3.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 1,
+  origin: { x: 91, y: 27, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture6,
+  mipLevel: 2,
+  origin: { x: 0, y: 13, z: 0 },
+  aspect: 'all',
+}, {width: 240, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder5.popDebugGroup();
+} catch {}
+pseudoSubmit(device0, commandEncoder10);
+try {
+renderPassEncoder2.setBindGroup(5, bindGroup9);
+} catch {}
+try {
+renderPassEncoder1.draw(64);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(72, 64, 64, 744, 80);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer11, 228840);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(6, buffer13, 27380, 6591);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer11, 540);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(3, buffer11, 8524, 3738);
+} catch {}
+let sampler23 = device3.createSampler({
+label: '\u30b1\u0d5a\u6d91\u035e\uc20b\uf65c',
+addressModeU: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 5.562,
+lodMaxClamp: 81.420,
+});
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let canvas7 = document.createElement('canvas');
+let textureView30 = texture33.createView({label: '\uec2f\ub5dd\u830d\u0152\u{1ffb1}', dimension: '3d', baseMipLevel: 2});
+try {
+await device2.popErrorScope();
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.label = '\u0cb1\ubb87\u0933\ufa57\u775d\u903b\u193e\ua2a2\u{1fad9}';
+} catch {}
+let renderBundleEncoder34 = device2.createRenderBundleEncoder({colorFormats: ['r32sint', 'r8sint'], sampleCount: 4, stencilReadOnly: true});
+let renderBundle38 = renderBundleEncoder30.finish({label: '\u{1f96d}\u0a58\u09bd\u87be\u3a1a'});
+try {
+device2.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 3,
+  origin: { x: 2, y: 2, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 31 */
+{offset: 31, bytesPerRow: 299}, {width: 0, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let promise19 = device2.queue.onSubmittedWorkDone();
+let gpuCanvasContext8 = canvas7.getContext('webgpu');
+let videoFrame5 = new VideoFrame(imageBitmap2, {timestamp: 0});
+let renderBundle39 = renderBundleEncoder30.finish({label: '\uc20a\u03fb\u04a6\ub641\u0115\u0e2e\u77a3'});
+let sampler24 = device2.createSampler({
+label: '\ud293\u{1f870}\ue247',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 29.273,
+lodMaxClamp: 55.311,
+compare: 'less',
+maxAnisotropy: 16,
+});
+let texture36 = device0.createTexture({
+label: '\uaf00\u8b30\u{1fd30}\u0ed7',
+size: [120, 9, 1],
+mipLevelCount: 3,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let sampler25 = device0.createSampler({
+label: '\u{1fb77}\u1015',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 9.440,
+lodMaxClamp: 19.297,
+maxAnisotropy: 4,
+});
+try {
+renderPassEncoder2.setBindGroup(5, bindGroup2);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle37, renderBundle16, renderBundle26, renderBundle16, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder5.setViewport(0.09229, 3.649, 36.33, 0.1153, 0.07817, 0.3215);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer11, 14296);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer11, 8156);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer11, 1240);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer9, 'uint16', 5650, 4017);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(5, buffer11, 796, 18634);
+} catch {}
+try {
+commandEncoder19.copyTextureToBuffer({
+  texture: texture19,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 6280 */
+offset: 6280,
+rowsPerImage: 162,
+buffer: buffer13,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 16 },
+  aspect: 'all',
+}, new Int32Array(arrayBuffer1), /* required buffer size: 151054 */
+{offset: 718, bytesPerRow: 162, rowsPerImage: 32}, {width: 2, height: 0, depthOrArrayLayers: 30});
+} catch {}
+try {
+  await promise19;
+} catch {}
+document.body.prepend(img2);
+let videoFrame6 = new VideoFrame(canvas7, {timestamp: 0});
+let computePassEncoder14 = commandEncoder20.beginComputePass({});
+try {
+renderPassEncoder1.setScissorRect(121, 12, 90, 4);
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(806);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(7, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder17.draw(64, 32, 80, 72);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer11, 13936);
+} catch {}
+let arrayBuffer3 = buffer2.getMappedRange(12512, 660);
+try {
+commandEncoder3.clearBuffer(buffer1, 23300, 9968);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\uff02');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 4,
+  origin: { x: 8, y: 0, z: 13 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 2843145 */
+{offset: 745, bytesPerRow: 475, rowsPerImage: 272}, {width: 144, height: 0, depthOrArrayLayers: 23});
+} catch {}
+let pipeline32 = await device0.createComputePipelineAsync({
+label: '\u9e63\u07e6\u{1fd66}\u{1f6ec}\u4cf8\u2a5f\ufba3',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule6,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let adapter4 = await promise5;
+let videoFrame7 = new VideoFrame(canvas4, {timestamp: 0});
+let texture37 = device3.createTexture({
+label: '\u0f28\u{1f933}\u{1f6c9}\u9a7c\u{1f8de}\u068c\udbb1\u3c0c\u1356\ucd17\u51ea',
+size: [144, 145, 1],
+dimension: '2d',
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler26 = device3.createSampler({
+label: '\u{1ffae}\u{1f831}\u91a5\ueda4\u0915\u00f6\u0438\u{1f6e7}\u{1fd68}',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMaxClamp: 89.439,
+});
+let canvas8 = document.createElement('canvas');
+let gpuCanvasContext9 = canvas8.getContext('webgpu');
+let img9 = await imageWithData(9, 254, '#b84b7be3', '#7c130f33');
+let shaderModule10 = device0.createShaderModule({
+label: '\u07b5\u0dd3\u{1faa4}\ud7e1\u{1f8fd}\u{1f682}\u0c0f\u07c6',
+code: `@group(1) @binding(302)
+var<storage, read_write> i4: array<u32>;
+@group(2) @binding(302)
+var<storage, read_write> global8: array<u32>;
+@group(0) @binding(302)
+var<storage, read_write> type10: array<u32>;
+
+@compute @workgroup_size(4, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(frag_depth) f0: f32,
+  @builtin(sample_mask) f1: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32, @builtin(position) a2: vec4<f32>, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S12 {
+  @location(6) f0: vec4<f16>,
+  @location(5) f1: u32,
+  @location(18) f2: vec2<f16>,
+  @location(2) f3: u32,
+  @location(24) f4: vec2<f32>,
+  @location(15) f5: vec4<u32>,
+  @location(4) f6: vec3<i32>,
+  @location(11) f7: vec2<u32>,
+  @location(22) f8: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec2<f32>, @builtin(instance_index) a1: u32, @builtin(vertex_index) a2: u32, @location(0) a3: vec3<i32>, @location(17) a4: vec3<f32>, @location(21) a5: u32, @location(9) a6: f32, @location(23) a7: f16, @location(14) a8: u32, @location(12) a9: vec2<f32>, @location(7) a10: vec2<f16>, @location(1) a11: f16, @location(3) a12: u32, @location(13) a13: vec3<i32>, @location(20) a14: vec4<i32>, @location(10) a15: f16, @location(19) a16: vec3<f32>, @location(16) a17: vec2<u32>, a18: S12) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+let bindGroup19 = device0.createBindGroup({
+label: '\u0bcf\u{1fc90}\u8096\u90ac\u886f\u0d0d\u{1f922}\uf065',
+layout: bindGroupLayout5,
+entries: [{
+binding: 302,
+resource: sampler11
+}],
+});
+let computePassEncoder15 = commandEncoder19.beginComputePass({label: '\u029c\u{1fef2}\ua8bb\u1be6\u02ec\uc9b9\u{1ffe8}'});
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({
+  label: '\u22f7\u4453\u{1fbb2}\u5f87\ubf0c\u8836\u{1fa0d}\udd86',
+  colorFormats: ['rgb10a2uint', 'rgba32uint', 'rg32sint', 'rg16uint', 'rg16sint', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder14.setBindGroup(4, bindGroup9);
+} catch {}
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(145, 6, 91, 5);
+} catch {}
+try {
+renderPassEncoder1.draw(48);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer13, 329672);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer1, 79152);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+commandEncoder19.copyBufferToBuffer(buffer14, 14396, buffer10, 30456, 300);
+dissociateBuffer(device0, buffer14);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder19.copyBufferToTexture({
+/* bytesInLastRow: 448 widthInBlocks: 28 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 20080 */
+offset: 20080,
+bytesPerRow: 512,
+rowsPerImage: 78,
+buffer: buffer4,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: { x: 80, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 280, height: 18, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 85, y: 5, z: 21 },
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(0)), /* required buffer size: 2539495 */
+{offset: 702, bytesPerRow: 5693, rowsPerImage: 207}, {width: 338, height: 32, depthOrArrayLayers: 3});
+} catch {}
+let adapter5 = await promise1;
+let querySet30 = device3.createQuerySet({
+label: '\u{1fbac}\u896f\u{1fa5a}\u5c0e\u72c6\u0b54',
+type: 'occlusion',
+count: 3560,
+});
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 3, height: 6, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas1,
+  origin: { x: 285, y: 310 },
+  flipY: false,
+}, {
+  texture: texture33,
+  mipLevel: 4,
+  origin: { x: 1, y: 3, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 3, depthOrArrayLayers: 1});
+} catch {}
+let querySet31 = device3.createQuerySet({
+label: '\udbaa\u0374\u84b7\u75c4\u0e7b\u{1fa2e}\uf2f5\u533c\u{1fd6d}\u81dd',
+type: 'occlusion',
+count: 2279,
+});
+let texture38 = device3.createTexture({
+label: '\u9225\u191e\u1346\u3c8f\u{1fd25}',
+size: {width: 1920, height: 6, depthOrArrayLayers: 38},
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgba8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let externalTexture6 = device3.importExternalTexture({
+source: videoFrame4,
+});
+try {
+device3.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 2,
+  origin: { x: 10, y: 0, z: 6 },
+  aspect: 'all',
+}, new ArrayBuffer(644533), /* required buffer size: 644533 */
+{offset: 533, bytesPerRow: 2000, rowsPerImage: 161}, {width: 459, height: 0, depthOrArrayLayers: 3});
+} catch {}
+let bindGroupLayout16 = device0.createBindGroupLayout({
+label: '\u{1fed7}\uf59f\u0898\u4533\u32c4\u2147\u0cad\u56db\u072a\u0926',
+entries: [{
+binding: 5340,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+}],
+});
+let computePassEncoder16 = commandEncoder3.beginComputePass();
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({label: '\ua47a\u079d', colorFormats: ['rgba8unorm'], stencilReadOnly: true});
+try {
+computePassEncoder10.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer7, 426824);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer4, 'uint32');
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer11, 7844);
+} catch {}
+try {
+commandEncoder19.copyBufferToTexture({
+/* bytesInLastRow: 960 widthInBlocks: 960 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 21540 */
+offset: 21540,
+bytesPerRow: 1024,
+buffer: buffer17,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'stencil-only',
+}, {width: 960, height: 72, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer17);
+} catch {}
+let pipeline33 = await device0.createComputePipelineAsync({
+label: '\u09a5\u4330\u0e84\u{1f9be}\u004a\u{1f854}\u03c8\u0365\u3744',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+await adapter5.requestAdapterInfo();
+} catch {}
+gc();
+let textureView31 = texture33.createView({mipLevelCount: 4});
+try {
+device2.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 9,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 435 */
+{offset: 435, bytesPerRow: 52}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let img10 = await imageWithData(257, 101, '#589f2b07', '#4ecfa14d');
+let bindGroupLayout17 = device2.createBindGroupLayout({
+label: '\u07b7\u0306\u0376\u0d19',
+entries: [{
+binding: 2596,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}],
+});
+let pipelineLayout6 = device2.createPipelineLayout({bindGroupLayouts: [bindGroupLayout17, bindGroupLayout17]});
+let texture39 = device2.createTexture({
+label: '\u0a1b\u0db4\u{1f6c5}\u0254\u{1fe8b}\u14df\u{1fe6d}\uc039\u046a\uc4a8',
+size: [1560, 1, 1],
+mipLevelCount: 3,
+format: 'r32uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r32uint'],
+});
+let sampler27 = device2.createSampler({
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMaxClamp: 64.587,
+compare: 'less-equal',
+maxAnisotropy: 1,
+});
+let renderBundle40 = renderBundleEncoder7.finish({label: '\ub42c\ua2e0\u04d1\u03e0\u{1f9a5}'});
+let sampler28 = device0.createSampler({
+label: '\ue984\u{1f737}\u049c\u0ad2\u04f6\u057a\ued38\u78f4\u098e\u00a9\u{1fbf5}',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 11.523,
+lodMaxClamp: 84.837,
+maxAnisotropy: 9,
+});
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(2558);
+} catch {}
+try {
+renderPassEncoder4.draw(0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(80, 64, 8);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(4, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder17.draw(8);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(32, 32, 56, -592, 80);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer11, 3024);
+} catch {}
+try {
+commandEncoder19.copyBufferToBuffer(buffer4, 16296, buffer5, 38224, 5104);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 1,
+  origin: { x: 12, y: 4, z: 9 },
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(32)), /* required buffer size: 426369 */
+{offset: 129, bytesPerRow: 148, rowsPerImage: 180}, {width: 0, height: 0, depthOrArrayLayers: 17});
+} catch {}
+let adapter6 = await navigator.gpu.requestAdapter();
+let shaderModule11 = device2.createShaderModule({
+code: `@group(0) @binding(2596)
+var<storage, read_write> field7: array<u32>;
+
+@compute @workgroup_size(1, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec4<i32>,
+  @location(3) f1: vec2<f32>,
+  @location(5) f2: vec2<i32>,
+  @location(0) f3: vec4<u32>,
+  @location(2) f4: vec3<f32>,
+  @location(1) f5: vec3<f32>,
+  @location(6) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S13 {
+  @location(11) f0: vec3<f16>,
+  @location(8) f1: vec3<u32>,
+  @builtin(vertex_index) f2: u32,
+  @location(1) f3: vec3<u32>,
+  @location(17) f4: vec2<u32>,
+  @location(3) f5: vec2<i32>,
+  @location(6) f6: vec2<u32>,
+  @location(15) f7: vec4<u32>,
+  @location(7) f8: vec4<f32>,
+  @location(13) f9: vec2<f32>,
+  @location(2) f10: vec2<f32>,
+  @location(5) f11: vec3<u32>,
+  @location(10) f12: f16
+}
+
+@vertex
+fn vertex0(@location(16) a0: f16, @location(0) a1: vec4<u32>, @location(9) a2: i32, @location(12) a3: vec4<f16>, a4: S13, @builtin(instance_index) a5: u32, @location(4) a6: vec3<i32>, @location(14) a7: vec4<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let querySet32 = device2.createQuerySet({
+label: '\ub689\u4e7a\u0ca1\u4c10\u0ac4\uc983\u1825\u0e8f\u{1fccc}',
+type: 'occlusion',
+count: 362,
+});
+let textureView32 = texture39.createView({
+  label: '\u060f\u0231\u7910\u0f29\u{1fb55}\u{1fb84}\u48de\ud1b2\udcb2\u379a\u8314',
+  dimension: '2d-array'
+});
+let pipeline34 = await device2.createComputePipelineAsync({
+layout: pipelineLayout6,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(20);
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(2381);
+} catch {}
+try {
+renderPassEncoder5.setViewport(222.8, 8.943, 5.930, 4.981, 0.05031, 0.9306);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(72, 16, 40, 232, 24);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer13, 33452);
+} catch {}
+try {
+commandEncoder19.copyBufferToBuffer(buffer15, 4068, buffer13, 15456, 28380);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder19.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 290, y: 24, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture22,
+  mipLevel: 2,
+  origin: { x: 40, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 50, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder19.resolveQuerySet(querySet12, 698, 221, buffer9, 13568);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['r32sint', 'rgba16uint'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+adapter1.label = '\u0605\u5602\u{1fb2c}\uffcf\u{1f825}';
+} catch {}
+let bindGroup20 = device0.createBindGroup({
+label: '\u0888\u30b4\ud448\u89b0\u{1f699}',
+layout: bindGroupLayout2,
+entries: [{
+binding: 4081,
+resource: externalTexture5
+}, {
+binding: 6043,
+resource: textureView8
+}],
+});
+let commandEncoder21 = device0.createCommandEncoder();
+try {
+renderPassEncoder1.setStencilReference(4026);
+} catch {}
+try {
+renderPassEncoder1.draw(32);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer4, 'uint16', 32894);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder17.draw(24);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(64, 48, 32, 400, 64);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer11, 5868);
+} catch {}
+try {
+commandEncoder21.copyBufferToBuffer(buffer2, 12432, buffer5, 55064, 2976);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+device: device3,
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgb9e5ufloat', 'r16sint', 'rgba8unorm-srgb'],
+alphaMode: 'premultiplied',
+});
+} catch {}
+let offscreenCanvas12 = new OffscreenCanvas(11, 359);
+let querySet33 = device0.createQuerySet({
+label: '\u0d93\ufc72\ub3b6\u0882\u7104\u0e02',
+type: 'occlusion',
+count: 2565,
+});
+try {
+renderPassEncoder4.beginOcclusionQuery(1110);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.draw(24, 48, 8, 8);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer13, 141816);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer11, 104);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer11, 14480);
+} catch {}
+try {
+commandEncoder21.copyBufferToTexture({
+/* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 19344 */
+offset: 19344,
+bytesPerRow: 256,
+buffer: buffer14,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: { x: 0, y: 70, z: 1 },
+  aspect: 'all',
+}, {width: 40, height: 60, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder21.clearBuffer(buffer12, 22040, 1000);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder19.resolveQuerySet(querySet11, 10, 15, buffer9, 14080);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 22020, new DataView(new ArrayBuffer(41978)), 41551, 108);
+} catch {}
+let promise20 = device0.createRenderPipelineAsync({
+label: '\u3cac\ud8f0',
+layout: pipelineLayout2,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA
+}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA}, undefined]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'not-equal',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 1720,
+stencilWriteMask: 1685,
+depthBias: 75,
+depthBiasSlopeScale: 59,
+depthBiasClamp: 55,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 14080,
+attributes: [{
+format: 'float32x2',
+offset: 11080,
+shaderLocation: 7,
+}, {
+format: 'float32x4',
+offset: 8000,
+shaderLocation: 22,
+}, {
+format: 'unorm8x4',
+offset: 3320,
+shaderLocation: 9,
+}, {
+format: 'uint16x4',
+offset: 1836,
+shaderLocation: 14,
+}, {
+format: 'float32x3',
+offset: 10960,
+shaderLocation: 13,
+}, {
+format: 'sint32x2',
+offset: 2540,
+shaderLocation: 1,
+}, {
+format: 'float32x2',
+offset: 12708,
+shaderLocation: 2,
+}, {
+format: 'sint16x2',
+offset: 9744,
+shaderLocation: 11,
+}, {
+format: 'sint32',
+offset: 5272,
+shaderLocation: 3,
+}, {
+format: 'uint32x3',
+offset: 13076,
+shaderLocation: 4,
+}, {
+format: 'uint32x2',
+offset: 1304,
+shaderLocation: 10,
+}, {
+format: 'uint8x4',
+offset: 5144,
+shaderLocation: 24,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let querySet34 = device3.createQuerySet({
+label: '\uac0a\uf94d\u092b\u8c27\u{1ff78}\uc44b\uc625\u0dd6\u{1fa70}\u7f95\u07ce',
+type: 'occlusion',
+count: 224,
+});
+let texture40 = device3.createTexture({
+label: '\u0d99\ud275\u8379\u09b6\u2f2a\u09cd\u667f\u5a24\u{1fa7e}\ua833',
+size: [60, 220, 145],
+mipLevelCount: 8,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x10-unorm-srgb', 'astc-10x10-unorm', 'astc-10x10-unorm'],
+});
+let textureView33 = texture38.createView({mipLevelCount: 1});
+try {
+gpuCanvasContext0.configure({
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb', 'rg8snorm'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 4,
+  origin: { x: 37, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 993 */
+{offset: 993}, {width: 76, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let querySet35 = device2.createQuerySet({
+label: '\u{1fdb0}\u02d2\u{1fb1e}\udbf3\u08a2\u2ee2\u14c2\u0752\u{1fdbe}',
+type: 'occlusion',
+count: 463,
+});
+try {
+renderBundleEncoder34.setVertexBuffer(41, undefined, 4225013687, 48136201);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let canvas9 = document.createElement('canvas');
+let texture41 = device0.createTexture({
+size: [960, 72, 1],
+mipLevelCount: 3,
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8a1unorm-srgb', 'etc2-rgb8a1unorm', 'etc2-rgb8a1unorm'],
+});
+let computePassEncoder17 = commandEncoder19.beginComputePass({});
+let renderBundleEncoder37 = device0.createRenderBundleEncoder({
+  label: '\u08f8\u3479\u0d79\u68f0\u0d7e\u90b5\u{1f7d5}\u{1f78c}\u40ae',
+  colorFormats: [],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true
+});
+let renderBundle41 = renderBundleEncoder20.finish({});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer0, 'uint32', 44464, 8724);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(32, 40, 72, 392, 64);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer11, 17812);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(5, buffer11);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+commandEncoder21.clearBuffer(buffer10);
+dissociateBuffer(device0, buffer10);
+} catch {}
+let querySet36 = device3.createQuerySet({
+label: '\u8e15\u08e5\u6d07\u5231\u1c89\u0a96\u5044\u9914\u0756',
+type: 'occlusion',
+count: 3275,
+});
+let texture42 = device3.createTexture({
+label: '\u6676\u0a31\ufc46',
+size: {width: 4800, height: 1, depthOrArrayLayers: 254},
+mipLevelCount: 2,
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8unorm', 'r8unorm'],
+});
+let textureView34 = texture42.createView({dimension: '2d', baseMipLevel: 1, baseArrayLayer: 248, arrayLayerCount: 1});
+try {
+device3.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 4,
+  origin: { x: 10, y: 0, z: 5 },
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer0), /* required buffer size: 8005113 */
+{offset: 489, bytesPerRow: 262, rowsPerImage: 223}, {width: 0, height: 20, depthOrArrayLayers: 138});
+} catch {}
+try {
+offscreenCanvas12.getContext('webgpu');
+} catch {}
+let bindGroup21 = device0.createBindGroup({
+label: '\ua851\u0359',
+layout: bindGroupLayout2,
+entries: [{
+binding: 4081,
+resource: externalTexture3
+}, {
+binding: 6043,
+resource: textureView8
+}],
+});
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(2139);
+} catch {}
+try {
+renderPassEncoder4.setViewport(143.4, 2.936, 50.01, 3.073, 0.1527, 0.8054);
+} catch {}
+try {
+renderBundleEncoder17.draw(72, 8, 48, 32);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(0, buffer6);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer4, 40424, buffer1, 29432, 1596);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder15.resolveQuerySet(querySet1, 2730, 627, buffer6, 0);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline35 = device0.createRenderPipeline({
+layout: pipelineLayout3,
+multisample: {
+},
+fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r8sint'}, {format: 'rg32uint', writeMask: GPUColorWrite.GREEN}, {format: 'rg16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r32uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r32sint', writeMask: 0}, {format: 'r8sint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+failOp: 'invert',
+depthFailOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 587,
+stencilWriteMask: 541,
+depthBias: 74,
+depthBiasSlopeScale: 13,
+depthBiasClamp: 70,
+},
+vertex: {
+  module: shaderModule9,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 8744,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 4588,
+shaderLocation: 9,
+}, {
+format: 'uint16x2',
+offset: 2164,
+shaderLocation: 7,
+}, {
+format: 'uint8x2',
+offset: 6638,
+shaderLocation: 15,
+}, {
+format: 'sint8x2',
+offset: 3672,
+shaderLocation: 13,
+}, {
+format: 'uint8x2',
+offset: 7432,
+shaderLocation: 1,
+}, {
+format: 'unorm8x4',
+offset: 152,
+shaderLocation: 4,
+}, {
+format: 'sint32x4',
+offset: 7376,
+shaderLocation: 8,
+}, {
+format: 'sint16x4',
+offset: 2744,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 1336,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x4',
+offset: 804,
+shaderLocation: 12,
+}, {
+format: 'uint16x2',
+offset: 856,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 12104,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 21572,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x2',
+offset: 5028,
+shaderLocation: 18,
+}],
+}
+]
+},
+primitive: {
+unclippedDepth: true,
+},
+});
+let commandEncoder22 = device2.createCommandEncoder({label: '\u{1fda8}\u0136\uaa67\u28c7\u{1fc14}'});
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture32,
+  mipLevel: 6,
+  origin: { x: 40, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture32,
+  mipLevel: 5,
+  origin: { x: 136, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 32, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline36 = device2.createRenderPipeline({
+label: '\uc073\u00ea\u5606',
+layout: pipelineLayout6,
+fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint'}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'dst', dstFactor: 'one-minus-src'},
+alpha: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'src-alpha'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN
+}, {format: 'r8unorm', writeMask: 0}, {format: 'r32float', writeMask: GPUColorWrite.RED}, {format: 'rgba32sint', writeMask: GPUColorWrite.ALL}, {format: 'rg32sint'}, {
+  format: 'rgb10a2unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'src'},
+alpha: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'dst'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE
+}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'replace',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2043,
+stencilWriteMask: 1732,
+depthBias: 32,
+depthBiasSlopeScale: 7,
+},
+vertex: {
+  module: shaderModule11,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 6628,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x4',
+offset: 4944,
+shaderLocation: 5,
+}, {
+format: 'float32',
+offset: 6028,
+shaderLocation: 7,
+}, {
+format: 'float32x2',
+offset: 3356,
+shaderLocation: 10,
+}, {
+format: 'sint32x4',
+offset: 1616,
+shaderLocation: 9,
+}, {
+format: 'snorm8x4',
+offset: 3932,
+shaderLocation: 13,
+}, {
+format: 'uint32',
+offset: 864,
+shaderLocation: 17,
+}, {
+format: 'uint32x4',
+offset: 1780,
+shaderLocation: 6,
+}, {
+format: 'sint32x2',
+offset: 1096,
+shaderLocation: 4,
+}, {
+format: 'uint32x2',
+offset: 1600,
+shaderLocation: 8,
+}, {
+format: 'uint32',
+offset: 4728,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 4432,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 2916,
+shaderLocation: 2,
+}, {
+format: 'uint16x2',
+offset: 3736,
+shaderLocation: 1,
+}, {
+format: 'float32',
+offset: 2028,
+shaderLocation: 14,
+}, {
+format: 'unorm8x4',
+offset: 660,
+shaderLocation: 16,
+}, {
+format: 'float32x2',
+offset: 1620,
+shaderLocation: 11,
+}, {
+format: 'uint16x2',
+offset: 4188,
+shaderLocation: 15,
+}, {
+format: 'sint32',
+offset: 2472,
+shaderLocation: 3,
+}, {
+format: 'float32x4',
+offset: 540,
+shaderLocation: 12,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+gc();
+let commandEncoder23 = device2.createCommandEncoder({label: '\u0fa7\u{1fa4a}'});
+let texture43 = gpuCanvasContext7.getCurrentTexture();
+let renderBundleEncoder38 = device2.createRenderBundleEncoder({
+  colorFormats: [undefined, 'rgba8unorm-srgb', 'rgb10a2uint', 'rg32sint', 'rgba32float', 'rg16float'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+gpuCanvasContext2.configure({
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'etc2-rgba8unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer2), /* required buffer size: 803 */
+{offset: 803}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+offscreenCanvas12.width = 871;
+gc();
+let querySet37 = device2.createQuerySet({
+type: 'occlusion',
+count: 1031,
+});
+let texture44 = device2.createTexture({
+label: '\u3402\u0cdb\u{1f907}\u0e1a\u9957\uebae\u9b39\u4fb1\u53ab\u43be',
+size: {width: 96, height: 192, depthOrArrayLayers: 3},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'r8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8sint', 'r8sint', 'r8sint'],
+});
+let sampler29 = device2.createSampler({
+label: '\u83fe\u8786\u417b\uda6a',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 81.797,
+lodMaxClamp: 95.162,
+maxAnisotropy: 20,
+});
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture43,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap8 = await createImageBitmap(imageBitmap0);
+let videoFrame8 = new VideoFrame(videoFrame1, {timestamp: 0});
+let offscreenCanvas13 = new OffscreenCanvas(828, 390);
+let bindGroup22 = device0.createBindGroup({
+label: '\u0c8b\ub2f0\uaadd\u2574\uc5cb\u{1fbe8}\u3bb0\u{1fd17}',
+layout: bindGroupLayout1,
+entries: [],
+});
+let querySet38 = device0.createQuerySet({
+type: 'occlusion',
+count: 157,
+});
+let textureView35 = texture24.createView({});
+let renderPassEncoder6 = commandEncoder15.beginRenderPass({
+label: '\ubee4\u0a01\u9ee9\u{1ffbc}\u02d1\u7ebb\u0d32\u0d31',
+colorAttachments: [],
+depthStencilAttachment: {
+view: textureView4,
+depthClearValue: 0.8824538602238625,
+depthLoadOp: 'clear',
+depthStoreOp: 'discard',
+depthReadOnly: false,
+stencilClearValue: 32714,
+},
+maxDrawCount: 1201558201,
+});
+try {
+renderPassEncoder4.beginOcclusionQuery(1525);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle40, renderBundle31, renderBundle26, renderBundle26, renderBundle40, renderBundle31]);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer11, 10752);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer11, 19224);
+} catch {}
+try {
+commandEncoder21.copyBufferToTexture({
+/* bytesInLastRow: 96 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 14560 */
+offset: 9344,
+bytesPerRow: 256,
+buffer: buffer17,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 48, height: 105, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer17);
+} catch {}
+try {
+commandEncoder21.copyTextureToTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 4, y: 0, z: 4 },
+  aspect: 'all',
+}, {
+  texture: texture41,
+  mipLevel: 1,
+  origin: { x: 380, y: 32, z: 0 },
+  aspect: 'all',
+}, {width: 72, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder21.resolveQuerySet(querySet38, 33, 91, buffer6, 5376);
+} catch {}
+let promise21 = device0.createComputePipelineAsync({
+label: '\ubd14\u{1fe99}\uf623\u{1fd5d}\u{1fa01}\u73d3\ud7ed\u338b\u070c',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+},
+});
+let buffer18 = device0.createBuffer({
+  label: '\u0f9c\u{1f699}\u363f\u0a18\u{1fc39}\u1125\ud180',
+  size: 44000,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT
+});
+let commandEncoder24 = device0.createCommandEncoder({});
+let commandBuffer4 = commandEncoder21.finish({
+label: '\u06aa\u4e8f\uba45\u5e2b',
+});
+let texture45 = device0.createTexture({
+label: '\uc0d7\u0cfb\u{1fd87}\u8a61\ua529\u78eb',
+size: {width: 7800, height: 10, depthOrArrayLayers: 1},
+format: 'astc-12x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x10-unorm', 'astc-12x10-unorm'],
+});
+let textureView36 = texture12.createView({
+  label: '\u5a19\u39c0\uff4c\u1035\u3023\u4dc4\u00d0\u{1fdea}',
+  dimension: '2d',
+  baseMipLevel: 0,
+  mipLevelCount: 5,
+  baseArrayLayer: 10
+});
+try {
+renderPassEncoder5.setStencilReference(3013);
+} catch {}
+try {
+renderPassEncoder1.draw(8, 72);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(24, 32, 48, 104);
+} catch {}
+try {
+renderBundleEncoder37.setPipeline(pipeline16);
+} catch {}
+try {
+commandEncoder24.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 4,
+  origin: { x: 10, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 10848 */
+offset: 10848,
+buffer: buffer13,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder24.resolveQuerySet(querySet22, 197, 293, buffer9, 5120);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 180, new BigUint64Array(7156), 3422, 552);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 1,
+  origin: { x: 10, y: 5, z: 44 },
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 7703 */
+{offset: 305, bytesPerRow: 294, rowsPerImage: 25}, {width: 15, height: 5, depthOrArrayLayers: 2});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageData8 = new ImageData(16, 228);
+let texture46 = device2.createTexture({
+label: '\u{1faf0}\u0daa\u4769\uf88d',
+size: {width: 5856, height: 72, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+dimension: '2d',
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-8x6-unorm'],
+});
+try {
+renderBundleEncoder38.setVertexBuffer(85, undefined);
+} catch {}
+let promise22 = device2.createComputePipelineAsync({
+label: '\u7277\u9cd0\u0897',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let videoFrame9 = new VideoFrame(canvas6, {timestamp: 0});
+let imageBitmap9 = await createImageBitmap(offscreenCanvas9);
+try {
+adapter3.label = '\u99f6\u0d28\u{1fb8d}\u0d6b\u13de\uf7a5\u09bb\u2731\u{1f9a1}\u6076';
+} catch {}
+let video13 = await videoWithData();
+let bindGroupLayout18 = device3.createBindGroupLayout({
+entries: [{
+binding: 4167,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '2d-array' },
+}],
+});
+let commandEncoder25 = device3.createCommandEncoder({label: '\u07f6\uf0db\u{1fa8a}'});
+let imageBitmap10 = await createImageBitmap(imageData8);
+let pipelineLayout7 = device3.createPipelineLayout({
+  label: '\uc47a\u519e',
+  bindGroupLayouts: [bindGroupLayout18, bindGroupLayout18, bindGroupLayout18, bindGroupLayout18]
+});
+pseudoSubmit(device3, commandEncoder25);
+let renderBundleEncoder39 = device3.createRenderBundleEncoder({
+  label: '\uddea\u38a8\ua67a\u{1fb79}\u5898\u6f1d\u{1fc66}',
+  colorFormats: ['rgba32float', 'rg8sint', undefined],
+  stencilReadOnly: true
+});
+try {
+device3.destroy();
+} catch {}
+let shaderModule12 = device2.createShaderModule({
+label: '\u0cf0\uc297\uf1c7\u027b\u{1fc2c}\u4649\u39d4\u{1f9a5}\u{1f92d}\u0c89',
+code: `@group(1) @binding(2596)
+var<storage, read_write> i5: array<u32>;
+@group(0) @binding(2596)
+var<storage, read_write> field8: array<u32>;
+
+@compute @workgroup_size(3, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec3<f32>,
+  @location(2) f1: vec4<f32>,
+  @location(6) f2: vec4<f32>,
+  @location(4) f3: vec4<i32>,
+  @location(5) f4: vec2<i32>,
+  @location(1) f5: vec2<f32>,
+  @location(0) f6: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(10) a0: vec3<i32>, @builtin(instance_index) a1: u32, @location(2) a2: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let texture47 = device2.createTexture({
+label: '\u5b1b\u0f66\u1bb7',
+size: [195, 1, 17],
+dimension: '3d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let commandEncoder26 = device0.createCommandEncoder({});
+let texture48 = device0.createTexture({
+label: '\u023a\u0b2e\u7c42\u508f',
+size: {width: 960, height: 72, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+sampleCount: 1,
+format: 'astc-10x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-10x8-unorm-srgb', 'astc-10x8-unorm', 'astc-10x8-unorm-srgb'],
+});
+try {
+computePassEncoder4.setBindGroup(4, bindGroup20, new Uint32Array(1108), 602, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle16, renderBundle26, renderBundle37, renderBundle31, renderBundle37, renderBundle37, renderBundle16, renderBundle31, renderBundle31, renderBundle37]);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 289.8, g: -346.1, b: -874.0, a: -5.891, });
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer16, 148752);
+} catch {}
+try {
+renderBundleEncoder37.drawIndirect(buffer11, 7444);
+} catch {}
+try {
+renderPassEncoder1.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext6.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'astc-10x5-unorm-srgb'],
+alphaMode: 'opaque',
+});
+} catch {}
+offscreenCanvas0.width = 356;
+let img11 = await imageWithData(201, 296, '#d2236a3e', '#0a0f0e69');
+try {
+offscreenCanvas13.getContext('webgpu');
+} catch {}
+let video14 = await videoWithData();
+try {
+renderBundle24.label = '\u5893\u{1fda6}';
+} catch {}
+let shaderModule13 = device0.createShaderModule({
+label: '\u{1f62b}\u729e\u{1ffae}',
+code: `@group(4) @binding(5204)
+var<storage, read_write> local7: array<u32>;
+@group(4) @binding(6216)
+var<storage, read_write> type11: array<u32>;
+@group(1) @binding(1458)
+var<storage, read_write> i6: array<u32>;
+@group(4) @binding(1458)
+var<storage, read_write> type12: array<u32>;
+@group(1) @binding(5204)
+var<storage, read_write> field9: array<u32>;
+@group(0) @binding(302)
+var<storage, read_write> function6: array<u32>;
+
+@compute @workgroup_size(6, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S14 {
+  @location(1) f0: vec4<u32>,
+  @location(22) f1: vec4<f16>,
+  @builtin(position) f2: vec4<f32>,
+  @location(8) f3: i32,
+  @location(46) f4: f32,
+  @location(64) f5: vec2<i32>,
+  @location(20) f6: vec2<u32>,
+  @location(10) f7: vec3<u32>,
+  @location(61) f8: vec4<f16>,
+  @location(58) f9: vec4<f32>,
+  @location(68) f10: vec4<f16>,
+  @location(69) f11: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @location(38) a1: vec2<i32>, @location(76) a2: vec3<f32>, @location(51) a3: vec2<u32>, @location(25) a4: vec4<i32>, @location(36) a5: vec4<f32>, @builtin(sample_index) a6: u32, @location(55) a7: vec3<i32>, @location(66) a8: vec4<u32>, @location(77) a9: vec2<f16>, @location(17) a10: vec4<f32>, a11: S14, @location(26) a12: vec2<u32>, @location(15) a13: vec2<u32>, @location(63) a14: vec4<i32>, @location(60) a15: vec3<f16>, @builtin(sample_mask) a16: u32, @location(71) a17: vec3<i32>, @location(12) a18: vec2<f32>, @location(67) a19: vec4<f16>, @location(13) a20: vec3<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(26) f81: vec2<u32>,
+  @location(10) f82: vec3<u32>,
+  @location(76) f83: vec3<f32>,
+  @location(22) f84: vec4<f16>,
+  @location(17) f85: vec4<f32>,
+  @location(13) f86: vec3<u32>,
+  @location(69) f87: vec4<f32>,
+  @location(66) f88: vec4<u32>,
+  @location(38) f89: vec2<i32>,
+  @location(60) f90: vec3<f16>,
+  @location(67) f91: vec4<f16>,
+  @location(51) f92: vec2<u32>,
+  @builtin(position) f93: vec4<f32>,
+  @location(20) f94: vec2<u32>,
+  @location(71) f95: vec3<i32>,
+  @location(58) f96: vec4<f32>,
+  @location(1) f97: vec4<u32>,
+  @location(15) f98: vec2<u32>,
+  @location(61) f99: vec4<f16>,
+  @location(64) f100: vec2<i32>,
+  @location(36) f101: vec4<f32>,
+  @location(12) f102: vec2<f32>,
+  @location(63) f103: vec4<i32>,
+  @location(68) f104: vec4<f16>,
+  @location(8) f105: i32,
+  @location(46) f106: f32,
+  @location(25) f107: vec4<i32>,
+  @location(77) f108: vec2<f16>,
+  @location(55) f109: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(5) a0: u32, @location(16) a1: vec2<f16>, @location(2) a2: vec4<f32>, @location(20) a3: f16, @location(21) a4: vec4<f16>, @location(7) a5: vec4<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let texture49 = device0.createTexture({
+label: '\u{1f949}\u3ee5\ubb58\ud68c\u4d69\u0bd9\u5b63\u{1f6fe}\ud699\u9a87',
+size: {width: 120, height: 16, depthOrArrayLayers: 61},
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: 535.0, g: -756.9, b: 36.72, a: -306.7, });
+} catch {}
+try {
+renderPassEncoder5.setViewport(113.5, 2.211, 21.42, 6.748, 0.7762, 0.8204);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer3, 31352);
+} catch {}
+try {
+renderBundleEncoder37.drawIndexedIndirect(buffer18, 7784);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer18, 12896);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer0, 'uint32', 50900, 840);
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer14, 17228, buffer12, 40416, 1124);
+dissociateBuffer(device0, buffer14);
+dissociateBuffer(device0, buffer12);
+} catch {}
+let pipelineLayout8 = device0.createPipelineLayout({label: '\u3c74\u0b3f', bindGroupLayouts: [bindGroupLayout15]});
+let renderBundleEncoder40 = device0.createRenderBundleEncoder({
+  label: '\u5885\uc3c4\u{1f802}\u6a14\ud770\uaa68\ud859',
+  colorFormats: ['rgba16float', 'r16uint', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+try {
+computePassEncoder4.setPipeline(pipeline33);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.draw(0, 0, 16, 24);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(8, buffer11, 16444, 3739);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(64);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline15);
+} catch {}
+let promise23 = buffer16.mapAsync(GPUMapMode.READ, 0, 50356);
+try {
+commandEncoder26.copyTextureToBuffer({
+  texture: texture17,
+  mipLevel: 2,
+  origin: { x: 6, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 10192 */
+offset: 10192,
+bytesPerRow: 256,
+buffer: buffer13,
+}, {width: 6, height: 15, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 4,
+  origin: { x: 64, y: 0, z: 20 },
+  aspect: 'all',
+}, new Int32Array(arrayBuffer2), /* required buffer size: 573658 */
+{offset: 958, bytesPerRow: 345, rowsPerImage: 166}, {width: 56, height: 0, depthOrArrayLayers: 11});
+} catch {}
+let texture50 = device2.createTexture({
+label: '\u9646\u18d3',
+size: [1100, 1, 244],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float'],
+});
+let textureView37 = texture46.createView({
+  label: '\u4b0c\u6817\ueafe\ud46c\u{1f989}\ue089\u028e\u{1fffa}\u2d33\u0362\uf254',
+  baseMipLevel: 5,
+  mipLevelCount: 1
+});
+let pipeline37 = device2.createComputePipeline({
+label: '\u6ba8\u0c5f\uf5f5\u{1f726}\u{1fbc7}\u{1f9b6}\u6cfb\u{1f798}\u1fde\u60f4',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let textureView38 = texture41.createView({format: 'etc2-rgb8a1unorm', baseMipLevel: 2, baseArrayLayer: 0});
+let renderBundleEncoder41 = device0.createRenderBundleEncoder({
+  label: '\uef89\ud8c2\u{1fd82}\u{1f8ae}\u{1f7e0}\u242b\udc85\u{1fd4f}',
+  colorFormats: ['rgb10a2uint', 'rgba32uint', 'rg32sint', 'rg16uint', 'rg16sint', undefined],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+try {
+computePassEncoder4.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(0, buffer6);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(0);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer11, 1344);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 19 },
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer2), /* required buffer size: 201703 */
+{offset: 234, bytesPerRow: 159, rowsPerImage: 7}, {width: 10, height: 5, depthOrArrayLayers: 182});
+} catch {}
+let pipeline38 = await device0.createRenderPipelineAsync({
+label: '\ubfdc\u00ac\u8ed2\u3ff1\u0688\u0610\u{1f764}',
+layout: pipelineLayout0,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: 0}, {format: 'r16uint'}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'invert',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 115,
+stencilWriteMask: 2296,
+depthBiasSlopeScale: 2,
+depthBiasClamp: 31,
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 3468,
+attributes: [{
+format: 'sint32x2',
+offset: 948,
+shaderLocation: 4,
+}, {
+format: 'snorm16x4',
+offset: 3392,
+shaderLocation: 5,
+}, {
+format: 'float32x2',
+offset: 3440,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 20344,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x2',
+offset: 5660,
+shaderLocation: 18,
+}, {
+format: 'uint16x2',
+offset: 8676,
+shaderLocation: 24,
+}],
+},
+{
+arrayStride: 1020,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 924,
+shaderLocation: 19,
+}, {
+format: 'uint32x3',
+offset: 172,
+shaderLocation: 6,
+}, {
+format: 'sint32x3',
+offset: 128,
+shaderLocation: 11,
+}, {
+format: 'uint16x4',
+offset: 32,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 7376,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 7344,
+shaderLocation: 23,
+}, {
+format: 'uint32x3',
+offset: 4580,
+shaderLocation: 2,
+}, {
+format: 'sint32x4',
+offset: 5296,
+shaderLocation: 12,
+}, {
+format: 'uint16x2',
+offset: 2940,
+shaderLocation: 1,
+}, {
+format: 'sint16x2',
+offset: 40,
+shaderLocation: 9,
+}, {
+format: 'unorm8x4',
+offset: 5880,
+shaderLocation: 0,
+}, {
+format: 'snorm8x4',
+offset: 4052,
+shaderLocation: 8,
+}, {
+format: 'snorm8x2',
+offset: 664,
+shaderLocation: 3,
+}, {
+format: 'unorm10-10-10-2',
+offset: 5148,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 2076,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 1724,
+shaderLocation: 20,
+}],
+},
+{
+arrayStride: 25952,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 14786,
+shaderLocation: 21,
+}],
+},
+{
+arrayStride: 24580,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x3',
+offset: 6800,
+shaderLocation: 7,
+}, {
+format: 'uint16x4',
+offset: 5852,
+shaderLocation: 15,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let computePassEncoder18 = commandEncoder23.beginComputePass({label: '\u0cce\u7591\ubc97\uca31'});
+try {
+renderBundleEncoder34.pushDebugGroup('\u6de5');
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 275, height: 1, depthOrArrayLayers: 61}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 384, y: 48 },
+  flipY: false,
+}, {
+  texture: texture50,
+  mipLevel: 2,
+  origin: { x: 136, y: 0, z: 4 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 130, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let texture51 = device2.createTexture({
+label: '\ud277\uf04c\u{1f8db}\u0b04\u04bb',
+size: [1560, 1, 250],
+mipLevelCount: 5,
+format: 'rg16sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView39 = texture46.createView({baseMipLevel: 4, mipLevelCount: 1});
+try {
+await device2.popErrorScope();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device2,
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['eac-rg11snorm', 'rgba32sint', 'r16uint', 'astc-4x4-unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+await adapter3.requestAdapterInfo();
+} catch {}
+try {
+canvas9.getContext('webgpu');
+} catch {}
+let bindGroupLayout19 = device2.createBindGroupLayout({
+label: '\u1610\u0187\u0527\u1897\u0917\u0961\u003b\ue4c4\u{1f6d8}',
+entries: [{
+binding: 290,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}, {
+binding: 18,
+visibility: 0,
+texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+}, {
+binding: 1528,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '2d-array' },
+}],
+});
+let textureView40 = texture43.createView({
+  label: '\u0582\u3087\u04a7\u{1fe39}\u477b\u0bfe',
+  dimension: '2d-array',
+  format: 'r32sint',
+  mipLevelCount: 1
+});
+let renderBundleEncoder42 = device2.createRenderBundleEncoder({
+  label: '\u0ad8\u5af2',
+  colorFormats: ['bgra8unorm', 'r8sint', 'rgba16float', 'rg32sint'],
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder34.popDebugGroup();
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture44,
+  mipLevel: 3,
+  origin: { x: 6, y: 17, z: 1 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 118 */
+{offset: 118, bytesPerRow: 170, rowsPerImage: 146}, {width: 5, height: 7, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+let device4 = await adapter5.requestDevice({
+label: '\u0c23\u077b',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxColorAttachmentBytesPerSample: 59,
+maxVertexAttributes: 17,
+maxVertexBufferArrayStride: 13838,
+maxStorageTexturesPerShaderStage: 25,
+maxStorageBuffersPerShaderStage: 43,
+maxDynamicStorageBuffersPerPipelineLayout: 21637,
+maxBindingsPerBindGroup: 5163,
+maxTextureDimension1D: 13944,
+maxTextureDimension2D: 8571,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 137072517,
+maxUniformBuffersPerShaderStage: 27,
+maxInterStageShaderVariables: 105,
+maxInterStageShaderComponents: 95,
+maxSamplersPerShaderStage: 17,
+},
+});
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let video15 = await videoWithData();
+let querySet39 = device2.createQuerySet({
+label: '\u1f03\u2c10\u{1f72f}\ue90d\u09e3\u{1faf7}',
+type: 'occlusion',
+count: 3648,
+});
+let renderBundle42 = renderBundleEncoder33.finish({label: '\u38c6\u0f58\u0cd6\u{1fbad}\u0dd8\u43f6\u0e8e\u9d4b\u06ea\u192a'});
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture32,
+  mipLevel: 2,
+  origin: { x: 1440, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture32,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 16, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 9,
+  origin: { x: 8, y: 0, z: 0 },
+  aspect: 'all',
+}, new Int16Array(arrayBuffer0), /* required buffer size: 163 */
+{offset: 163}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise24 = device2.createComputePipelineAsync({
+label: '\u7667\u622d\u060d\u{1fa6e}\uef37\u4db9',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let img12 = await imageWithData(67, 213, '#ce45204f', '#479fa5fc');
+try {
+renderPassEncoder6.setBindGroup(5, bindGroup14);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup10, new Uint32Array(9033), 5609, 0);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(52, 5, 7, 5);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(2715);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(40, 24, 16, -776, 80);
+} catch {}
+try {
+renderBundleEncoder37.drawIndexed(8, 40, 56, 648, 72);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder24.resolveQuerySet(querySet8, 360, 1910, buffer6, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 5472, new Int16Array(47951), 31249, 16176);
+} catch {}
+let buffer19 = device0.createBuffer({
+  label: '\uaaf5\u{1f680}\u0c49\u{1fff2}\u8369\u01cd\u30cf\u0d01\ube1e',
+  size: 50980,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true
+});
+let querySet40 = device0.createQuerySet({
+type: 'occlusion',
+count: 3665,
+});
+let texture52 = device0.createTexture({
+label: '\u{1fb18}\u{1f6e2}\ud0c5\u31c5\u09a6',
+size: {width: 480, height: 36, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'astc-10x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x6-unorm-srgb', 'astc-10x6-unorm-srgb', 'astc-10x6-unorm-srgb'],
+});
+try {
+renderPassEncoder6.setBlendConstant({ r: -753.7, g: -572.1, b: -100.1, a: 206.9, });
+} catch {}
+try {
+renderPassEncoder6.setViewport(168.3, 56.70, 416.1, 12.53, 0.9180, 0.9836);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(16, 72, 80, -320, 40);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer19, 25720);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer4, 'uint16', 4614, 313);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer11, 13044, 4550);
+} catch {}
+try {
+renderBundleEncoder37.drawIndexedIndirect(buffer11, 6120);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(5, buffer11, 7580, 9146);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder24.resolveQuerySet(querySet24, 263, 134, buffer9, 256);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 33008, new BigUint64Array(7915), 7280, 504);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 55, y: 10, z: 42 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 3720375 */
+{offset: 503, bytesPerRow: 526, rowsPerImage: 104}, {width: 150, height: 0, depthOrArrayLayers: 69});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let sampler30 = device0.createSampler({
+label: '\u{1fff4}\u2ea5\u{1fed0}\ub3d1\u0040\u{1fa5d}\u03f0\u{1f7d6}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 23.889,
+lodMaxClamp: 34.162,
+compare: 'less',
+maxAnisotropy: 9,
+});
+try {
+computePassEncoder14.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle40, renderBundle40, renderBundle31]);
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(3607);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(56, 0, 40, 112, 24);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer18, 7076);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(8, buffer13, 31048);
+} catch {}
+let promise25 = device0.popErrorScope();
+let arrayBuffer4 = buffer11.getMappedRange(2000);
+try {
+commandEncoder24.copyBufferToTexture({
+/* bytesInLastRow: 5200 widthInBlocks: 325 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 5568 */
+offset: 5568,
+buffer: buffer4,
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: { x: 3732, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 3900, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer4);
+} catch {}
+let pipeline39 = await device0.createRenderPipelineAsync({
+layout: pipelineLayout3,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+color: {operation: 'add', srcFactor: 'dst', dstFactor: 'src-alpha'},
+alpha: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'constant'},
+},
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined]
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 4052,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x4',
+offset: 988,
+shaderLocation: 5,
+}, {
+format: 'sint8x4',
+offset: 19012,
+shaderLocation: 7,
+}, {
+format: 'sint32x3',
+offset: 208,
+shaderLocation: 12,
+}, {
+format: 'uint32',
+offset: 23888,
+shaderLocation: 2,
+}, {
+format: 'uint16x2',
+offset: 13900,
+shaderLocation: 6,
+}, {
+format: 'float32',
+offset: 204,
+shaderLocation: 13,
+}, {
+format: 'sint32x2',
+offset: 7304,
+shaderLocation: 11,
+}, {
+format: 'uint16x2',
+offset: 352,
+shaderLocation: 24,
+}],
+},
+{
+arrayStride: 24388,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 11800,
+shaderLocation: 15,
+}, {
+format: 'uint32',
+offset: 8184,
+shaderLocation: 10,
+}, {
+format: 'uint32x2',
+offset: 6892,
+shaderLocation: 1,
+}, {
+format: 'sint32',
+offset: 3444,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 7044,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 6336,
+shaderLocation: 19,
+}, {
+format: 'sint32x2',
+offset: 6928,
+shaderLocation: 9,
+}, {
+format: 'sint8x2',
+offset: 6480,
+shaderLocation: 18,
+}, {
+format: 'float32x2',
+offset: 3364,
+shaderLocation: 8,
+}, {
+format: 'unorm16x2',
+offset: 5920,
+shaderLocation: 0,
+}, {
+format: 'snorm16x2',
+offset: 1456,
+shaderLocation: 21,
+}],
+},
+{
+arrayStride: 13644,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x4',
+offset: 472,
+shaderLocation: 20,
+}, {
+format: 'snorm8x4',
+offset: 6932,
+shaderLocation: 3,
+}, {
+format: 'snorm8x4',
+offset: 11908,
+shaderLocation: 16,
+}, {
+format: 'sint16x4',
+offset: 11352,
+shaderLocation: 23,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'front',
+},
+});
+document.body.prepend(canvas1);
+let bindGroupLayout20 = device2.createBindGroupLayout({
+entries: [{
+binding: 131,
+visibility: 0,
+externalTexture: {},
+}, {
+binding: 2157,
+visibility: 0,
+storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '2d' },
+}, {
+binding: 2944,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+}],
+});
+let texture53 = device2.createTexture({
+label: '\u915a\u13b5\u{1fba3}',
+size: {width: 13440, height: 96, depthOrArrayLayers: 238},
+mipLevelCount: 3,
+format: 'eac-rg11unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['eac-rg11unorm', 'eac-rg11unorm', 'eac-rg11unorm'],
+});
+let computePassEncoder19 = commandEncoder22.beginComputePass({label: '\u09ea\u{1fcb0}\u56e9\u2ceb\u0816\ub11b'});
+let img13 = await imageWithData(53, 208, '#65e6d810', '#5451f60f');
+offscreenCanvas3.width = 531;
+let texture54 = device4.createTexture({
+size: [256, 4, 1],
+mipLevelCount: 2,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['stencil8'],
+});
+let buffer20 = device2.createBuffer({label: '\u7f08\u9d26\u{1f6b9}', size: 29273, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let renderBundleEncoder43 = device2.createRenderBundleEncoder({
+  label: '\u9722\ud139\u5e88\u0951\uadd4\uaf51\u616f\u{1fe77}',
+  colorFormats: [undefined, 'rgba8unorm-srgb', 'rgb10a2uint', 'rg32sint', 'rgba32float', 'rg16float'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let promise26 = buffer20.mapAsync(GPUMapMode.WRITE, 12072, 14952);
+try {
+renderBundleEncoder42.insertDebugMarker('\uaecc');
+} catch {}
+let buffer21 = device0.createBuffer({size: 56457, usage: GPUBufferUsage.INDIRECT});
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle37, renderBundle40, renderBundle31, renderBundle26, renderBundle26, renderBundle31, renderBundle31]);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(63, 10, 18, 6);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer4, 41584);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer18, 'uint32', 20972, 9336);
+} catch {}
+try {
+renderBundleEncoder37.drawIndirect(buffer11, 64);
+} catch {}
+try {
+buffer4.destroy();
+} catch {}
+try {
+commandEncoder24.resolveQuerySet(querySet18, 2139, 426, buffer6, 8192);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 5,
+  origin: { x: 24, y: 0, z: 14 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 20001 */
+{offset: 513, bytesPerRow: 116, rowsPerImage: 14}, {width: 56, height: 0, depthOrArrayLayers: 13});
+} catch {}
+let computePassEncoder20 = commandEncoder26.beginComputePass({label: '\u5768\u43c5\ucef2'});
+let renderBundle43 = renderBundleEncoder8.finish();
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder37.draw(8, 8, 56, 32);
+} catch {}
+try {
+renderBundleEncoder37.drawIndexed(0, 40, 0, -736, 8);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer21, 29912);
+} catch {}
+try {
+renderBundleEncoder37.drawIndirect(buffer11, 8928);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(1, buffer6, 2980, 4143);
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 32, y: 0, z: 21 },
+  aspect: 'all',
+}, {
+  texture: texture41,
+  mipLevel: 1,
+  origin: { x: 20, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 20, height: 12, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder24.clearBuffer(buffer10);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder24.resolveQuerySet(querySet26, 1467, 315, buffer9, 6400);
+} catch {}
+video5.width = 277;
+let adapter7 = await navigator.gpu.requestAdapter({
+powerPreference: 'low-power',
+});
+pseudoSubmit(device0, commandEncoder3);
+let textureView41 = texture19.createView({label: '\u4df5\u{1f80b}\u0880\u5e67\u3821\u04e5\u245c', dimension: '2d-array', baseMipLevel: 0});
+try {
+renderPassEncoder1.executeBundles([renderBundle31, renderBundle37, renderBundle40, renderBundle26, renderBundle31, renderBundle31]);
+} catch {}
+try {
+renderPassEncoder5.draw(64, 56, 56, 48);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer2, 1320);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer12, 52760);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup4, []);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(8, 8, 8, 104);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer18, 12256);
+} catch {}
+try {
+buffer5.destroy();
+} catch {}
+try {
+commandEncoder24.copyBufferToBuffer(buffer19, 47800, buffer1, 11416, 3000);
+dissociateBuffer(device0, buffer19);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder24.resolveQuerySet(querySet19, 503, 206, buffer6, 1280);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new Float32Array(arrayBuffer3), /* required buffer size: 914 */
+{offset: 914, bytesPerRow: 121, rowsPerImage: 236}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise27 = device0.queue.onSubmittedWorkDone();
+let pipeline40 = device0.createRenderPipeline({
+label: '\u0454\u2ba1\u9e8c\u6a5b\u{1fc04}\u0ef0\u{1f6e8}',
+layout: pipelineLayout2,
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float'}, {format: 'r16uint', writeMask: 0}, undefined]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+failOp: 'increment-clamp',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 410,
+stencilWriteMask: 3595,
+depthBias: 91,
+depthBiasSlopeScale: 49,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x4',
+offset: 1432,
+shaderLocation: 10,
+}, {
+format: 'float16x2',
+offset: 12368,
+shaderLocation: 13,
+}, {
+format: 'float32x2',
+offset: 26812,
+shaderLocation: 22,
+}, {
+format: 'sint32x4',
+offset: 24696,
+shaderLocation: 3,
+}, {
+format: 'snorm8x4',
+offset: 27044,
+shaderLocation: 2,
+}, {
+format: 'uint32x3',
+offset: 12624,
+shaderLocation: 4,
+}, {
+format: 'float32x2',
+offset: 20136,
+shaderLocation: 9,
+}, {
+format: 'unorm16x2',
+offset: 28200,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 9436,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 4676,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x3',
+offset: 748,
+shaderLocation: 1,
+}, {
+format: 'sint32x2',
+offset: 3212,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 1060,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 6180,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 0,
+attributes: [{
+format: 'uint32',
+offset: 16532,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 12592,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 16032,
+attributes: [],
+},
+{
+arrayStride: 10832,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x4',
+offset: 3016,
+shaderLocation: 24,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+  await promise27;
+} catch {}
+let promise28 = adapter6.requestDevice({
+label: '\uc5f4\uc6e4\u7c34\ua757\u{1ff89}\u54a8\ufac3\u0cf7\u2593\ue8e8\u0ae3',
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 51,
+maxVertexAttributes: 28,
+maxVertexBufferArrayStride: 42849,
+maxStorageTexturesPerShaderStage: 12,
+maxStorageBuffersPerShaderStage: 37,
+maxDynamicStorageBuffersPerPipelineLayout: 19915,
+maxBindingsPerBindGroup: 6327,
+maxTextureDimension1D: 16124,
+maxTextureDimension2D: 9991,
+maxVertexBuffers: 12,
+maxUniformBufferBindingSize: 94652875,
+maxInterStageShaderVariables: 76,
+maxInterStageShaderComponents: 106,
+maxSamplersPerShaderStage: 17,
+},
+});
+let pipelineLayout9 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout8, bindGroupLayout5, bindGroupLayout6, bindGroupLayout2, bindGroupLayout5, bindGroupLayout16, bindGroupLayout8, bindGroupLayout1]
+});
+let querySet41 = device0.createQuerySet({
+label: '\u1424\u7f1c\u2551\ud352',
+type: 'occlusion',
+count: 1494,
+});
+try {
+renderPassEncoder6.setIndexBuffer(buffer17, 'uint16', 22786, 2517);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(4, buffer11, 15032, 3732);
+} catch {}
+try {
+renderBundleEncoder37.drawIndexed(64, 8);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let pipeline41 = await device0.createComputePipelineAsync({
+label: '\ufd56\u2e4f\uefb5\ua6d4\u{1f938}\u000d\u4887\u2690\ue91e',
+layout: 'auto',
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+video8.width = 186;
+let texture55 = device0.createTexture({
+label: '\uec38\u0b9d\ua9d7',
+size: {width: 7816, height: 195, depthOrArrayLayers: 9},
+mipLevelCount: 11,
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+try {
+renderPassEncoder4.setBindGroup(7, bindGroup12, []);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(82);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(1584);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer18, 59632);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer21, 2464);
+} catch {}
+try {
+renderBundleEncoder37.drawIndirect(buffer18, 34936);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder24.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 20776 */
+offset: 20776,
+bytesPerRow: 0,
+rowsPerImage: 183,
+buffer: buffer17,
+}, {
+  texture: texture13,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 44});
+dissociateBuffer(device0, buffer17);
+} catch {}
+let buffer22 = device4.createBuffer({
+  label: '\u0510\u4dad\u56f8\u{1f6ff}\u1524\u{1f76e}\uccd3\u1947\u7309\ue877\u1d77',
+  size: 50668,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true
+});
+try {
+gpuCanvasContext7.configure({
+device: device4,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-5x5-unorm', 'bgra8unorm'],
+alphaMode: 'premultiplied',
+});
+} catch {}
+let textureView42 = texture54.createView({
+  label: '\ua056\u0d37\u{1f947}\u612e\u2632\u850b\uda40\u913c\u8b16\u4cd3\u{1fb75}',
+  aspect: 'stencil-only'
+});
+let sampler31 = device4.createSampler({
+label: '\ud46b\u24ca\ub45d',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMaxClamp: 93.757,
+});
+let sampler32 = device0.createSampler({
+label: '\u0293\u0e19',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 90.966,
+maxAnisotropy: 8,
+});
+try {
+renderPassEncoder1.drawIndexed(64, 40, 80);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer14, 64760);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer9, 'uint32', 8516, 1812);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(2, buffer13, 44592, 2967);
+} catch {}
+try {
+renderBundleEncoder40.draw(64, 0, 32, 80);
+} catch {}
+try {
+buffer16.destroy();
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 1,
+  origin: { x: 110, y: 12, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture22,
+  mipLevel: 4,
+  origin: { x: 0, y: 6, z: 0 },
+  aspect: 'all',
+}, {width: 20, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext7.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+video8.height = 8;
+let img14 = await imageWithData(49, 6, '#182e49c6', '#ff248b05');
+let buffer23 = device4.createBuffer({label: '\uef5c\u{1fbb6}', size: 3145, usage: GPUBufferUsage.INDIRECT});
+let texture56 = device4.createTexture({
+label: '\u{1fdd5}\u{1fb2f}\uffca',
+size: {width: 1360, height: 480, depthOrArrayLayers: 1},
+mipLevelCount: 11,
+format: 'astc-5x4-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let sampler33 = device4.createSampler({
+label: '\u2d08\u11ce\u2979\ud20d\u0880\uca4a\u57db\ucb1c\u{1fac4}\u8188',
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'linear',
+lodMinClamp: 84.306,
+lodMaxClamp: 94.833,
+compare: 'equal',
+});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let bindGroupLayout21 = pipeline27.getBindGroupLayout(6);
+let buffer24 = device0.createBuffer({label: '\u74c1\u09c4\u2ca2', size: 12247, usage: GPUBufferUsage.MAP_WRITE});
+let texture57 = device0.createTexture({
+label: '\u001c\u01a9\u6c1a\u0993\u033d\u{1f92b}',
+size: [480, 64, 61],
+mipLevelCount: 2,
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['r8uint', 'r8uint'],
+});
+let textureView43 = texture8.createView({label: '\u5320\u47c9', dimension: '2d', baseMipLevel: 0, mipLevelCount: 4, baseArrayLayer: 107});
+let renderBundle44 = renderBundleEncoder0.finish({label: '\u{1fe7d}\u{1f97f}\u0509\u{1f707}\u19eb\u{1fd0f}\u{1fcb5}\u08a0\u{1ff9d}\u0210\u7919'});
+let sampler34 = device0.createSampler({
+label: '\u2a81\u8a86',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 38.447,
+lodMaxClamp: 43.072,
+});
+try {
+renderPassEncoder5.executeBundles([renderBundle31, renderBundle16, renderBundle26, renderBundle37, renderBundle37, renderBundle26, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: -727.1, g: 282.7, b: -541.2, a: 974.4, });
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(409, 67, 80, 4);
+} catch {}
+try {
+renderPassEncoder5.setViewport(205.5, 16.38, 12.69, 0.7895, 0.2390, 0.9566);
+} catch {}
+try {
+renderPassEncoder5.draw(8);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer5, 62816);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer6, 15972, 818);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup3, new Uint32Array(8100), 6660, 0);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer18, 30136);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(3, buffer13, 19024, 27169);
+} catch {}
+try {
+  await buffer14.mapAsync(GPUMapMode.WRITE, 0, 10848);
+} catch {}
+try {
+commandEncoder24.resolveQuerySet(querySet20, 491, 185, buffer6, 9984);
+} catch {}
+let pipeline42 = device0.createRenderPipeline({
+label: '\u008b\u{1f6c4}\u0370\uf12a',
+layout: pipelineLayout2,
+multisample: {
+count: 4,
+},
+fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilReadMask: 1397,
+stencilWriteMask: 2543,
+depthBias: 87,
+depthBiasSlopeScale: 4,
+depthBiasClamp: 3,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 15008,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 9452,
+attributes: [],
+},
+{
+arrayStride: 26900,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x2',
+offset: 7516,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let commandEncoder27 = device0.createCommandEncoder();
+let renderBundle45 = renderBundleEncoder9.finish({});
+try {
+renderPassEncoder4.setBindGroup(4, bindGroup7);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(208, 6, 10, 8);
+} catch {}
+try {
+renderPassEncoder4.setViewport(73.65, 1.130, 73.49, 1.222, 0.3964, 0.6325);
+} catch {}
+try {
+renderPassEncoder5.draw(40, 80, 16, 64);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(8, 64, 56, 320, 32);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer17, 550264);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(16, 80, 64);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer18, 24556);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(8, buffer6);
+} catch {}
+try {
+commandEncoder27.copyTextureToTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 56, y: 0, z: 34 },
+  aspect: 'all',
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: { x: 100, y: 16, z: 1 },
+  aspect: 'all',
+}, {width: 60, height: 12, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 1,
+  origin: { x: 28, y: 0, z: 39 },
+  aspect: 'all',
+}, new Int32Array(arrayBuffer1), /* required buffer size: 57673 */
+{offset: 941, bytesPerRow: 70, rowsPerImage: 45}, {width: 8, height: 4, depthOrArrayLayers: 19});
+} catch {}
+document.body.prepend(img11);
+video1.width = 45;
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise25;
+} catch {}
+let textureView44 = texture0.createView({
+  label: '\uf153\u{1f790}\u0143\u50ce\u0c11\u39d1\u04c0\u{1fb7b}\u{1f7b5}\ua407',
+  format: 'astc-8x5-unorm-srgb',
+  baseMipLevel: 3,
+  mipLevelCount: 2
+});
+let computePassEncoder21 = commandEncoder24.beginComputePass({label: '\u{1fc00}\u{1f6fa}\uc6b4\ufe98'});
+try {
+computePassEncoder10.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder1.draw(48, 72, 0, 48);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(40, 32, 56, -64);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer4, 103488);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer13, 14836);
+} catch {}
+try {
+renderBundleEncoder37.drawIndexed(72, 40, 16, 544, 56);
+} catch {}
+let promise29 = buffer12.mapAsync(GPUMapMode.READ, 0, 25884);
+try {
+commandEncoder27.resolveQuerySet(querySet5, 238, 350, buffer6, 5376);
+} catch {}
+try {
+computePassEncoder8.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: { x: 333, y: 15, z: 19 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 319851 */
+{offset: 709, bytesPerRow: 73, rowsPerImage: 188}, {width: 59, height: 48, depthOrArrayLayers: 24});
+} catch {}
+gc();
+let img15 = await imageWithData(261, 61, '#0ad6a18e', '#7cc1d65f');
+let querySet42 = device2.createQuerySet({
+label: '\u60f0\u4b7c\u0638\u{1fff7}\u060c\u{1f615}',
+type: 'occlusion',
+count: 3278,
+});
+let texture58 = device2.createTexture({
+label: '\u0268\u9910\ua683\ue53f\u{1f8b9}\u5635\u0fdd\u0b23\u3409\u496e',
+size: {width: 1560, height: 1, depthOrArrayLayers: 153},
+mipLevelCount: 11,
+dimension: '3d',
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgb9e5ufloat', 'rgb9e5ufloat'],
+});
+try {
+renderBundleEncoder42.setVertexBuffer(12, undefined, 3982385059, 222747934);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+let pipeline43 = device2.createComputePipeline({
+label: '\ufc5e\ua6cf\ud9a5',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let querySet43 = device0.createQuerySet({
+label: '\u35b8\uccc2\uc8f2\u01e8\u070e\ue41e\u6865\u975e\ub5bd\u{1fead}\u3343',
+type: 'occlusion',
+count: 114,
+});
+let texture59 = device0.createTexture({
+size: [240, 32, 1971],
+dimension: '3d',
+format: 'r32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['r32float'],
+});
+let computePassEncoder22 = commandEncoder27.beginComputePass({label: '\u2791\u01b0\u{1f9bb}\u{1fbd3}\u00cf\u06b8\u{1fd62}\ucbde\ubddc'});
+let renderBundleEncoder44 = device0.createRenderBundleEncoder({
+  label: '\u03aa\u522b\u{1fab2}',
+  colorFormats: ['r32float', 'rgba32float', 'bgra8unorm-srgb', 'rgba8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle46 = renderBundleEncoder31.finish({label: '\uda55\u512d\u898a\u1aad'});
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer17, 89952);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer13, 279256);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer18, 'uint32');
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer18, 1116);
+} catch {}
+try {
+renderBundleEncoder37.drawIndirect(buffer21, 27792);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline44 = await promise14;
+try {
+  await promise23;
+} catch {}
+gc();
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let bindGroupLayout22 = device4.createBindGroupLayout({
+label: '\ue27e\u03d0',
+entries: [{
+binding: 3927,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}],
+});
+let texture60 = device4.createTexture({
+label: '\u7355\uf55f\u0789\ud4d4\ub010\u{1fcb9}\u73b8\u0ffc\u{1fab3}',
+size: {width: 30},
+dimension: '1d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+try {
+buffer23.unmap();
+} catch {}
+let renderBundleEncoder45 = device0.createRenderBundleEncoder({label: '\u{1feea}\u092b\u1b97\u54c5\u{1fe31}', colorFormats: ['rgb10a2uint'], depthReadOnly: true});
+let renderBundle47 = renderBundleEncoder7.finish({label: '\u4f1b\u47f8\u9d5d\ub5d7'});
+try {
+renderPassEncoder4.drawIndexed(16, 48, 80, -168, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer18, 'uint32', 27888, 8653);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder37.draw(32, 56, 8, 64);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(7, buffer11, 14900, 2289);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer4,
+]);
+} catch {}
+let bindGroup23 = device0.createBindGroup({
+layout: bindGroupLayout2,
+entries: [{
+binding: 4081,
+resource: externalTexture1
+}, {
+binding: 6043,
+resource: textureView8
+}],
+});
+let buffer25 = device0.createBuffer({
+  label: '\u{1fb2d}\udafb\u2d23\u01cd\u7d7d\ude3e\u0e83\u{1f74b}\u3005\ua198',
+  size: 48985,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let commandEncoder28 = device0.createCommandEncoder({label: '\uf553\ubc50\u0cb2\u5a83\u9c8a\u1c15\u9ba8'});
+pseudoSubmit(device0, commandEncoder28);
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle31, renderBundle40, renderBundle37]);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: -825.8, g: -18.05, b: 693.2, a: 972.6, });
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer18, 113768);
+} catch {}
+try {
+renderBundleEncoder17.draw(64, 16, 80);
+} catch {}
+let promise30 = buffer24.mapAsync(GPUMapMode.WRITE, 0, 2976);
+try {
+gpuCanvasContext8.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgb10a2unorm', 'astc-12x12-unorm', 'bgra8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer3,
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 3304, new DataView(new ArrayBuffer(22850)), 411, 20340);
+} catch {}
+let pipeline45 = device0.createComputePipeline({
+label: '\ue5bd\u0fb4\u0e25\u0aab\uf0d6\uab2a\u{1f6b2}\u{1f8af}',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule10,
+entryPoint: 'compute0',
+},
+});
+let img16 = await imageWithData(64, 20, '#b3999004', '#4eb66cb4');
+let renderBundleEncoder46 = device0.createRenderBundleEncoder({
+  label: '\u057a\u{1fc0a}',
+  colorFormats: ['rgba8unorm-srgb', 'r8sint', 'rgba32uint', 'rgba8sint', 'r16uint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  stencilReadOnly: false
+});
+try {
+renderPassEncoder6.setBindGroup(8, bindGroup14);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(56, 56, 72, 160, 64);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer8, 3776);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer21, 13708);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(5, buffer13, 45512, 667);
+} catch {}
+try {
+renderBundleEncoder14.insertDebugMarker('\u{1fcea}');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 14080, new Float32Array(2570), 1720, 80);
+} catch {}
+try {
+  await promise29;
+} catch {}
+let commandEncoder29 = device4.createCommandEncoder({});
+pseudoSubmit(device4, commandEncoder29);
+let querySet44 = device4.createQuerySet({
+label: '\u5d7f\u67c8\u783f\u0a92\u9ef8\u0336\u41c4',
+type: 'occlusion',
+count: 720,
+});
+let sampler35 = device4.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 5.157,
+lodMaxClamp: 67.371,
+});
+try {
+texture54.destroy();
+} catch {}
+let promise31 = device4.queue.onSubmittedWorkDone();
+try {
+  await promise31;
+} catch {}
+let videoFrame10 = new VideoFrame(videoFrame2, {timestamp: 0});
+let bindGroupLayout23 = device2.createBindGroupLayout({
+label: '\u03d6\u{1f885}',
+entries: [{
+binding: 2177,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 580,
+visibility: 0,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}],
+});
+let commandEncoder30 = device2.createCommandEncoder();
+let textureView45 = texture32.createView({
+  label: '\u67c8\u{1f71d}\ubc2e\u078a\u{1fd66}\ua52b\ud3e6',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+  mipLevelCount: 2
+});
+let renderBundleEncoder47 = device2.createRenderBundleEncoder({
+  label: '\ud067\u{1feaf}\u{1fc43}\u9449',
+  colorFormats: ['rgba8uint', 'rg8unorm', 'r8unorm', 'r32float', 'rgba32sint', 'rg32sint', 'rgb10a2unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+try {
+  await promise26;
+} catch {}
+let texture61 = device0.createTexture({
+label: '\uf51e\uef31',
+size: {width: 240, height: 32, depthOrArrayLayers: 61},
+mipLevelCount: 5,
+dimension: '2d',
+format: 'eac-rg11snorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView46 = texture27.createView({label: '\u4df2\u30be', dimension: '2d-array', baseMipLevel: 1});
+try {
+computePassEncoder21.setBindGroup(2, bindGroup2, new Uint32Array(7150), 2542, 0);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(445);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: -683.7, g: -990.2, b: 567.4, a: 821.6, });
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(32, 12, 33, 5);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(987);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer16, 2680);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer18, 42376);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let canvas10 = document.createElement('canvas');
+let textureView47 = texture11.createView({label: '\u0dc1\u9afd\u5572\u5179', baseMipLevel: 1, mipLevelCount: 4, arrayLayerCount: 29});
+try {
+computePassEncoder20.setBindGroup(6, bindGroup20, new Uint32Array(5137), 1313, 0);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(617);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer12, 97568);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(2, bindGroup9);
+} catch {}
+let textureView48 = texture58.createView({format: 'rgb9e5ufloat', baseMipLevel: 2, mipLevelCount: 3, arrayLayerCount: 1});
+try {
+computePassEncoder19.pushDebugGroup('\u{1ff1e}');
+} catch {}
+try {
+window.someLabel = texture38.label;
+} catch {}
+let promise32 = navigator.gpu.requestAdapter({
+});
+let videoFrame11 = new VideoFrame(video9, {timestamp: 0});
+let videoFrame12 = new VideoFrame(videoFrame5, {timestamp: 0});
+let textureView49 = texture33.createView({label: '\uf5d1\u{1f99a}\u0377\u5fcf\u{1fa85}\u{1f7ab}\u0518\u{1fe8c}\u0a91\u{1f8ad}', baseMipLevel: 4});
+try {
+computePassEncoder19.setPipeline(pipeline43);
+} catch {}
+let pipeline46 = await promise24;
+let promise33 = device2.createRenderPipelineAsync({
+layout: pipelineLayout6,
+multisample: {
+mask: 0x398949ce,
+},
+fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'zero'},
+alpha: {operation: 'add', srcFactor: 'src', dstFactor: 'one-minus-src-alpha'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32float'}, {format: 'rgba32sint', writeMask: GPUColorWrite.RED}, {format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {
+  format: 'rgb10a2unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'constant', dstFactor: 'dst-alpha'},
+}
+}]
+},
+vertex: {
+  module: shaderModule12,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 13200,
+attributes: [{
+format: 'float32x2',
+offset: 12524,
+shaderLocation: 2,
+}, {
+format: 'sint32x2',
+offset: 724,
+shaderLocation: 10,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let commandEncoder31 = device4.createCommandEncoder({label: '\u08f7\u0763\u0374\ue565'});
+let texture62 = device4.createTexture({
+label: '\u510d\u{1f82c}\u840b\ufe89\u1a4e',
+size: [320],
+dimension: '1d',
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba32sint', 'rgba32sint'],
+});
+let textureView50 = texture60.createView({});
+let renderBundleEncoder48 = device4.createRenderBundleEncoder({
+  colorFormats: ['r8uint', undefined, undefined, undefined, undefined, 'rgba16uint', undefined],
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+buffer22.unmap();
+} catch {}
+let gpuCanvasContext10 = canvas10.getContext('webgpu');
+video15.width = 144;
+let videoFrame13 = new VideoFrame(imageBitmap7, {timestamp: 0});
+try {
+renderPassEncoder5.setBindGroup(7, bindGroup6, new Uint32Array(1649), 1216, 0);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(84, 7, 134, 1);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(32, 40);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer10, 29032);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(0, 56, 56, 504, 48);
+} catch {}
+try {
+renderBundleEncoder37.drawIndexedIndirect(buffer11, 14704);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 12476, new Int16Array(28172), 10691, 11800);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let img17 = await imageWithData(271, 286, '#849bf03a', '#008915d3');
+let commandEncoder32 = device2.createCommandEncoder({label: '\u0149\u{1fd18}\u{1fd36}\u0fe1'});
+pseudoSubmit(device2, commandEncoder30);
+let computePassEncoder23 = commandEncoder32.beginComputePass({});
+let renderBundleEncoder49 = device2.createRenderBundleEncoder({
+  label: '\u0674\u31b6\u0929\u827e\u02af\u{1fc03}\u78d4\ueb3f\u0b84\ufa53\u4891',
+  colorFormats: ['bgra8unorm', 'r8sint', 'rgba16float', 'rg32sint'],
+  stencilReadOnly: true
+});
+try {
+device2.queue.writeTexture({
+  texture: texture44,
+  mipLevel: 2,
+  origin: { x: 9, y: 12, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(5302), /* required buffer size: 5302 */
+{offset: 202, bytesPerRow: 283}, {width: 6, height: 19, depthOrArrayLayers: 1});
+} catch {}
+let canvas11 = document.createElement('canvas');
+try {
+window.someLabel = externalTexture6.label;
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let img18 = await imageWithData(132, 47, '#f7a62fa7', '#60e0bde5');
+let renderBundle48 = renderBundleEncoder22.finish({});
+try {
+computePassEncoder4.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle47, renderBundle26, renderBundle26, renderBundle26, renderBundle47]);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(4, buffer11, 9636, 4714);
+} catch {}
+try {
+canvas11.getContext('webgl2');
+} catch {}
+let pipelineLayout10 = device2.createPipelineLayout({label: '\u1f26\u{1f9f6}\uc280\u09f2\u0a90', bindGroupLayouts: [bindGroupLayout17]});
+pseudoSubmit(device2, commandEncoder32);
+let texture63 = device2.createTexture({
+label: '\u06be\u045c\u{1f96f}\u70c3\udd72\u{1fb2c}\u0b9f',
+size: [550, 1, 682],
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16sint', 'rgba16sint', 'rgba16sint'],
+});
+let renderBundleEncoder50 = device2.createRenderBundleEncoder({colorFormats: ['r32sint', 'r8sint'], sampleCount: 4, depthReadOnly: false});
+let sampler36 = device2.createSampler({
+label: '\u05a1\ua666\u0095\uf6bd\u{1ff3a}\u0175',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 90.495,
+lodMaxClamp: 92.839,
+compare: 'never',
+});
+try {
+renderBundleEncoder38.setVertexBuffer(66, undefined, 2228964709, 359321627);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture47,
+  mipLevel: 0,
+  origin: { x: 13, y: 0, z: 4 },
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 21067 */
+{offset: 539, bytesPerRow: 1215, rowsPerImage: 16}, {width: 136, height: 1, depthOrArrayLayers: 2});
+} catch {}
+let canvas12 = document.createElement('canvas');
+try {
+window.someLabel = sampler8.label;
+} catch {}
+let querySet45 = device0.createQuerySet({
+label: '\u01e7\ue156\u8911\u5ebb\u5cc1\u72dc\u128c\ua23f\ud716\ua0b4\u0334',
+type: 'occlusion',
+count: 234,
+});
+let texture64 = device0.createTexture({
+label: '\u22ce\u1565\ue29e\ue578\u16ed\u0868\u1fa8\u1849\u0b38\u0d4d\u0803',
+size: [480, 64, 61],
+mipLevelCount: 8,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth24plus', 'depth24plus'],
+});
+try {
+renderPassEncoder1.setViewport(14.56, 12.50, 84.30, 3.788, 0.9924, 0.9965);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(56);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer3, 9752);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer11, 7316);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(24, 64, 72);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST,
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 2772, new Int16Array(3176), 2091, 1028);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData9 = new ImageData(244, 80);
+let textureView51 = texture54.createView({
+  label: '\u170b\u02f6\u0a44\u{1ffd9}\u0a06\u3010\u5c39\u{1fa6a}\u7be1\u{1f9b8}',
+  baseMipLevel: 1,
+  baseArrayLayer: 0
+});
+let renderBundle49 = renderBundleEncoder48.finish({});
+try {
+commandEncoder31.copyBufferToTexture({
+/* bytesInLastRow: 56 widthInBlocks: 28 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 13514 */
+offset: 13514,
+buffer: buffer22,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: { x: 2, y: 1, z: 1 },
+  aspect: 'all',
+}, {width: 28, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device4, buffer22);
+} catch {}
+let video16 = await videoWithData();
+let bindGroup24 = device0.createBindGroup({
+label: '\ue17d\ufa71\u6d5b\uece6\u64e7\u4a15\u{1febb}\u6de1\u060b\u{1fb21}\uab8b',
+layout: bindGroupLayout0,
+entries: [],
+});
+let textureView52 = texture11.createView({
+  label: '\u{1fb2c}\ub3c9\u01fd\u08da\u2ab4\ua2e3\u0aa0\ufdc1\uf9cf\u6576\u4fa7',
+  dimension: '2d',
+  format: 'astc-8x5-unorm-srgb',
+  mipLevelCount: 3,
+  baseArrayLayer: 1
+});
+let renderBundleEncoder51 = device0.createRenderBundleEncoder({
+  label: '\uf2c4\u58a2',
+  colorFormats: ['rgba16float', 'r16uint', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle50 = renderBundleEncoder16.finish({label: '\u14fc\u5866\u{1fbe9}\u0b09\u53f6\u2e31'});
+try {
+renderPassEncoder5.setStencilReference(3470);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(1, buffer6, 1152, 13949);
+} catch {}
+try {
+computePassEncoder17.insertDebugMarker('\u299e');
+} catch {}
+try {
+gpuCanvasContext6.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+canvas12.getContext('2d');
+} catch {}
+try {
+window.someLabel = device1.label;
+} catch {}
+let texture65 = device2.createTexture({
+label: '\ufb18\u{1fd1b}\u{1fe79}\u218a\u2ee6\ua45d\u1843\ubb04\u0494',
+size: {width: 3360, height: 24, depthOrArrayLayers: 238},
+mipLevelCount: 2,
+format: 'astc-4x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-4x4-unorm'],
+});
+try {
+computePassEncoder19.insertDebugMarker('\u4944');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture53,
+  mipLevel: 1,
+  origin: { x: 1488, y: 12, z: 202 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 11976889 */
+{offset: 361, bytesPerRow: 16916, rowsPerImage: 59}, {width: 4180, height: 0, depthOrArrayLayers: 13});
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let querySet46 = device4.createQuerySet({
+label: '\u56b4\u0a28\u{1fbfc}\u27d0',
+type: 'occlusion',
+count: 551,
+});
+let textureView53 = texture60.createView({label: '\u09f7\u1646\u0ff4\u0e4d'});
+let computePassEncoder24 = commandEncoder31.beginComputePass({label: '\u01c5\ue1c9\u0f58\u1ed3\u{1f811}'});
+canvas2.height = 989;
+let pipelineLayout11 = device4.createPipelineLayout({label: '\u{1fd22}\u0163', bindGroupLayouts: [bindGroupLayout22, bindGroupLayout22]});
+let texture66 = device4.createTexture({
+label: '\u20db\u{1fb9a}\u4036\u8136\u{1f98c}\ucde0\u{1f823}\u0dbc',
+size: {width: 60, height: 40, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'r8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8sint', 'r8sint', 'r8sint'],
+});
+let textureView54 = texture66.createView({label: '\u{1fe53}\u0c01\u06d8\u9243\u{1fc58}', dimension: '2d-array', baseMipLevel: 4});
+let renderBundleEncoder52 = device4.createRenderBundleEncoder({
+  label: '\u{1fae5}\u0b1a\uc267\u63e7\udec5\u049c\u{1fae9}\u415c\u0317',
+  colorFormats: ['r8uint', undefined, undefined, undefined, undefined, 'rgba16uint', undefined],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder52.setVertexBuffer(68, undefined);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 419 */
+{offset: 419, bytesPerRow: 63}, {width: 29, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u{1fa7b}\u390b\u0539\u{1f8e0}\ua152\u90e7\u6091\uda47\u833e';
+} catch {}
+let imageBitmap11 = await createImageBitmap(imageBitmap2);
+let buffer26 = device0.createBuffer({
+  label: '\u9f42\u3fc3\u1dff\uc427\u94a2\u86e3\u1c38',
+  size: 46030,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer13, 180168);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer0, 291184);
+} catch {}
+try {
+renderBundleEncoder37.setPipeline(pipeline16);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16sint', 'astc-12x10-unorm-srgb', 'astc-4x4-unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline47 = await promise11;
+canvas6.height = 53;
+gc();
+document.body.prepend(img10);
+let promise34 = adapter6.requestAdapterInfo();
+let shaderModule14 = device0.createShaderModule({
+label: '\u6a5f\u182b\u{1f904}\u502b\uf1fa\u4adc\u{1fe52}\u3682\u55e0\u0078\u3ccd',
+code: `@group(2) @binding(5174)
+var<storage, read_write> type13: array<u32>;
+@group(1) @binding(5174)
+var<storage, read_write> parameter11: array<u32>;
+@group(2) @binding(4981)
+var<storage, read_write> field10: array<u32>;
+
+@compute @workgroup_size(7, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4<f32>,
+  @location(1) f2: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S15 {
+  @location(16) f0: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(22) a0: vec2<u32>, @location(14) a1: vec3<i32>, a2: S15, @location(10) a3: vec3<u32>, @location(13) a4: vec4<u32>, @location(19) a5: vec4<f32>, @location(21) a6: vec2<u32>, @location(2) a7: vec3<u32>, @location(24) a8: u32, @location(1) a9: f16, @location(9) a10: u32, @location(3) a11: vec2<u32>, @location(7) a12: vec3<f32>, @location(8) a13: vec3<f32>, @location(23) a14: vec2<f16>, @location(18) a15: f16, @location(0) a16: f32, @location(4) a17: vec2<i32>, @location(11) a18: vec4<u32>, @location(20) a19: i32, @location(15) a20: vec2<f16>, @location(17) a21: vec2<u32>, @location(12) a22: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let commandEncoder33 = device0.createCommandEncoder();
+let sampler37 = device0.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 41.923,
+lodMaxClamp: 68.562,
+});
+try {
+computePassEncoder10.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder6.setViewport(781.4, 65.18, 60.80, 4.695, 0.6686, 0.7956);
+} catch {}
+try {
+renderBundleEncoder37.draw(32, 64, 8, 80);
+} catch {}
+try {
+commandEncoder33.copyTextureToBuffer({
+  texture: texture27,
+  mipLevel: 1,
+  origin: { x: 0, y: 40, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 3584 */
+offset: 3584,
+bytesPerRow: 0,
+buffer: buffer26,
+}, {width: 0, height: 60, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder9.clearBuffer(buffer1, 34908, 1508);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let textureView55 = texture5.createView({label: '\ufd01\u0fde', dimension: '2d-array', aspect: 'depth-only', baseMipLevel: 3, mipLevelCount: 1});
+let renderBundleEncoder53 = device0.createRenderBundleEncoder({
+  label: '\uf1dc\u0acf\u0fe8\u8a70',
+  colorFormats: ['r32float', 'rgba32float', 'bgra8unorm-srgb', 'rgba8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+let sampler38 = device0.createSampler({
+label: '\u00fa\u3665\u02bc\u{1fbba}\u23bc\u0e9d\u{1f8cd}\u45e0\u1dde',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 68.117,
+lodMaxClamp: 78.934,
+maxAnisotropy: 6,
+});
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: -637.6, g: 540.7, b: 223.7, a: -668.3, });
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(64);
+} catch {}
+try {
+renderBundleEncoder37.drawIndexed(80, 32);
+} catch {}
+try {
+renderBundleEncoder37.drawIndexedIndirect(buffer11, 2856);
+} catch {}
+try {
+renderBundleEncoder37.drawIndirect(buffer18, 26220);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(8, buffer13, 9812);
+} catch {}
+try {
+commandEncoder33.copyBufferToBuffer(buffer17, 6780, buffer12, 14632, 2428);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder9.copyTextureToTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: { x: 111, y: 43, z: 31 },
+  aspect: 'all',
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: { x: 150, y: 29, z: 0 },
+  aspect: 'all',
+}, {width: 82, height: 8, depthOrArrayLayers: 29});
+} catch {}
+let pipeline48 = device0.createRenderPipeline({
+label: '\u77ac\u7307',
+layout: pipelineLayout9,
+multisample: {
+count: 4,
+mask: 0xa4f00203,
+},
+fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater-equal',
+depthFailOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 812,
+stencilWriteMask: 582,
+depthBias: 88,
+depthBiasSlopeScale: 34,
+depthBiasClamp: 67,
+},
+vertex: {
+  module: shaderModule4,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 3240,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x2',
+offset: 1632,
+shaderLocation: 22,
+}, {
+format: 'float16x2',
+offset: 376,
+shaderLocation: 2,
+}, {
+format: 'sint32x3',
+offset: 308,
+shaderLocation: 21,
+}, {
+format: 'unorm16x4',
+offset: 1132,
+shaderLocation: 1,
+}, {
+format: 'unorm8x4',
+offset: 2836,
+shaderLocation: 11,
+}, {
+format: 'sint8x4',
+offset: 1148,
+shaderLocation: 0,
+}, {
+format: 'uint16x2',
+offset: 588,
+shaderLocation: 14,
+}, {
+format: 'sint32x3',
+offset: 68,
+shaderLocation: 15,
+}, {
+format: 'unorm8x4',
+offset: 2824,
+shaderLocation: 13,
+}, {
+format: 'unorm8x2',
+offset: 1108,
+shaderLocation: 8,
+}, {
+format: 'sint16x4',
+offset: 568,
+shaderLocation: 19,
+}, {
+format: 'sint8x4',
+offset: 1608,
+shaderLocation: 23,
+}, {
+format: 'sint8x2',
+offset: 2558,
+shaderLocation: 17,
+}, {
+format: 'sint32x2',
+offset: 1428,
+shaderLocation: 4,
+}, {
+format: 'unorm8x4',
+offset: 2892,
+shaderLocation: 3,
+}, {
+format: 'uint32',
+offset: 984,
+shaderLocation: 18,
+}, {
+format: 'float16x4',
+offset: 1492,
+shaderLocation: 16,
+}, {
+format: 'unorm16x4',
+offset: 1336,
+shaderLocation: 12,
+}, {
+format: 'float32x4',
+offset: 2680,
+shaderLocation: 24,
+}, {
+format: 'float32',
+offset: 1276,
+shaderLocation: 7,
+}, {
+format: 'uint8x4',
+offset: 968,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 17072,
+attributes: [{
+format: 'float16x2',
+offset: 2064,
+shaderLocation: 20,
+}],
+},
+{
+arrayStride: 17972,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 8364,
+shaderLocation: 10,
+}, {
+format: 'sint16x4',
+offset: 4740,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 26416,
+attributes: [],
+},
+{
+arrayStride: 24996,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 9892,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32',
+offset: 1236,
+shaderLocation: 9,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let sampler39 = device0.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 65.568,
+lodMaxClamp: 67.665,
+});
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: -803.0, g: -956.6, b: -925.1, a: 38.04, });
+} catch {}
+try {
+renderPassEncoder1.setViewport(197.0, 13.05, 1.047, 4.126, 0.3438, 0.3819);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer18, 38212);
+} catch {}
+try {
+renderBundleEncoder45.setPipeline(pipeline18);
+} catch {}
+try {
+commandEncoder9.clearBuffer(buffer13, 19964, 26724);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(querySet38, 139, 14, buffer9, 7680);
+} catch {}
+document.body.prepend(canvas6);
+let commandEncoder34 = device2.createCommandEncoder({});
+let querySet47 = device2.createQuerySet({
+label: '\u{1fb73}\u0250\u6a50\u3840\u{1fd78}\u5164\u{1fc72}\u9002',
+type: 'occlusion',
+count: 902,
+});
+try {
+computePassEncoder19.setPipeline(pipeline46);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(36, undefined);
+} catch {}
+try {
+computePassEncoder19.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext9.configure({
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 1,
+  origin: { x: 592, y: 6, z: 0 },
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 861 */
+{offset: 861, rowsPerImage: 13}, {width: 2328, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let img19 = await imageWithData(180, 292, '#55724443', '#099489c3');
+let shaderModule15 = device4.createShaderModule({
+label: '\u4dc0\u0247\u04f3\u7ce6\u61a3\ue5da\u0c50\u77f0\u{1fa27}',
+code: `@group(1) @binding(3927)
+var<storage, read_write> i7: array<u32>;
+@group(0) @binding(3927)
+var<storage, read_write> local8: array<u32>;
+
+@compute @workgroup_size(8, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S17 {
+  @builtin(position) f0: vec4<f32>,
+  @location(95) f1: vec2<u32>,
+  @location(59) f2: i32,
+  @location(9) f3: vec3<u32>,
+  @location(30) f4: vec3<u32>,
+  @location(42) f5: vec4<u32>,
+  @location(26) f6: vec3<i32>,
+  @location(74) f7: vec3<f16>,
+  @location(28) f8: f32,
+  @location(19) f9: u32,
+  @location(49) f10: vec4<f32>,
+  @location(16) f11: i32,
+  @location(80) f12: vec2<f16>,
+  @location(102) f13: vec2<i32>,
+  @location(81) f14: u32,
+  @location(101) f15: vec4<f32>,
+  @location(82) f16: vec2<f16>,
+  @builtin(sample_mask) f17: u32,
+  @location(53) f18: vec4<i32>,
+  @builtin(front_facing) f19: bool,
+  @location(47) f20: f32,
+  @location(29) f21: vec4<f16>,
+  @location(92) f22: vec2<f16>,
+  @location(48) f23: vec3<i32>,
+  @location(61) f24: vec3<u32>,
+  @location(98) f25: vec2<u32>,
+  @location(40) f26: u32
+}
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(2) f1: vec3<i32>,
+  @location(3) f2: vec3<u32>,
+  @location(0) f3: u32,
+  @location(5) f4: vec4<u32>,
+  @location(6) f5: u32
+}
+
+@fragment
+fn fragment0(@location(65) a0: vec2<f32>, @location(44) a1: i32, @location(100) a2: vec2<u32>, a3: S17, @location(104) a4: vec4<f16>, @location(64) a5: vec2<f32>, @builtin(sample_index) a6: u32, @location(46) a7: vec3<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S16 {
+  @location(0) f0: i32,
+  @location(16) f1: u32
+}
+struct VertexOutput0 {
+  @location(49) f110: vec4<f32>,
+  @location(59) f111: i32,
+  @builtin(position) f112: vec4<f32>,
+  @location(29) f113: vec4<f16>,
+  @location(92) f114: vec2<f16>,
+  @location(82) f115: vec2<f16>,
+  @location(48) f116: vec3<i32>,
+  @location(74) f117: vec3<f16>,
+  @location(19) f118: u32,
+  @location(80) f119: vec2<f16>,
+  @location(44) f120: i32,
+  @location(40) f121: u32,
+  @location(81) f122: u32,
+  @location(102) f123: vec2<i32>,
+  @location(9) f124: vec3<u32>,
+  @location(28) f125: f32,
+  @location(64) f126: vec2<f32>,
+  @location(95) f127: vec2<u32>,
+  @location(65) f128: vec2<f32>,
+  @location(46) f129: vec3<u32>,
+  @location(100) f130: vec2<u32>,
+  @location(104) f131: vec4<f16>,
+  @location(98) f132: vec2<u32>,
+  @location(101) f133: vec4<f32>,
+  @location(42) f134: vec4<u32>,
+  @location(16) f135: i32,
+  @location(30) f136: vec3<u32>,
+  @location(47) f137: f32,
+  @location(26) f138: vec3<i32>,
+  @location(61) f139: vec3<u32>,
+  @location(53) f140: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec2<f16>, a1: S16, @location(15) a2: vec3<i32>, @location(13) a3: i32, @location(5) a4: vec4<i32>, @location(7) a5: vec2<u32>, @builtin(instance_index) a6: u32, @location(12) a7: vec4<i32>, @location(2) a8: i32, @location(11) a9: vec3<u32>, @location(14) a10: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let buffer27 = device4.createBuffer({size: 34649, usage: GPUBufferUsage.STORAGE});
+let texture67 = device4.createTexture({
+label: '\u0c7d\u5b2e\ub6d8\u{1ffd8}\ud756\u1a36',
+size: [116, 36, 151],
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder54 = device4.createRenderBundleEncoder({
+  label: '\u{1ff11}\u01bc\uf441',
+  colorFormats: ['r8uint', undefined, undefined, undefined, undefined, 'rgba16uint', undefined],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+adapter0.label = '\ud1dc\u3148\u4f85\u01d0\ua8ac\u06c1\u57aa\u{1f67b}';
+} catch {}
+let pipelineLayout12 = device4.createPipelineLayout({
+  label: '\u{1fb64}\ub689\uf7e4\u1897\u080f\u435e\u1b32',
+  bindGroupLayouts: [bindGroupLayout22, bindGroupLayout22, bindGroupLayout22]
+});
+let querySet48 = device4.createQuerySet({
+label: '\u{1feb0}\u{1fcbe}\u0f6f\u64f1',
+type: 'occlusion',
+count: 1320,
+});
+pseudoSubmit(device4, commandEncoder31);
+let texture68 = device4.createTexture({
+label: '\uaec5\u{1fdb8}\u{1fe60}\u0d7d',
+size: [340, 120, 1],
+mipLevelCount: 4,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView56 = texture60.createView({label: '\u{1f930}\ua8f0\u0da9\u092e\ufa26\uf3fc\u02ce\u1a5d\u3eb4'});
+try {
+buffer22.unmap();
+} catch {}
+let commandEncoder35 = device2.createCommandEncoder();
+let texture69 = device2.createTexture({
+label: '\u{1fd4d}\u{1fec4}\u0888\u0ff8\u2073\u373f\u{1fc23}\ud7a7\u3e96\ubd77',
+size: [192, 384, 91],
+mipLevelCount: 7,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x6-unorm', 'astc-8x6-unorm'],
+});
+let textureView57 = texture51.createView({label: '\ub35d\ua72c', baseMipLevel: 1, baseArrayLayer: 108, arrayLayerCount: 117});
+let computePassEncoder25 = commandEncoder34.beginComputePass({});
+let sampler40 = device2.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 15.611,
+lodMaxClamp: 73.161,
+maxAnisotropy: 18,
+});
+try {
+computePassEncoder18.setPipeline(pipeline34);
+} catch {}
+canvas12.height = 512;
+let promise35 = adapter6.requestAdapterInfo();
+let texture70 = device2.createTexture({
+label: '\u0918\u43ed\u9e31\u95ff\uaa38\ub916\ufd37',
+size: {width: 6660, height: 185, depthOrArrayLayers: 60},
+mipLevelCount: 5,
+format: 'astc-10x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+});
+let textureView58 = texture43.createView({
+  label: '\ucbb7\ubfb1\uc7ea\uddfd\u6b42\u0352\ub60d\u0db2\ube28\u{1fdea}\u00d0',
+  mipLevelCount: 1,
+  arrayLayerCount: 1
+});
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture43,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise34;
+} catch {}
+let offscreenCanvas14 = new OffscreenCanvas(441, 290);
+let bindGroup25 = device4.createBindGroup({
+label: '\u9c38\u{1fef0}\u02ca\u04ec\u{1fb0f}\u0209\u40c1\u{1ff8b}\u0cc2\ubc68',
+layout: bindGroupLayout22,
+entries: [{
+binding: 3927,
+resource: {
+buffer: buffer27,
+offset: 12032,
+size: 16324,
+}
+}],
+});
+try {
+renderBundleEncoder52.setVertexBuffer(55, undefined, 1698426829, 1016975960);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture66,
+  mipLevel: 1,
+  origin: { x: 1, y: 17, z: 0 },
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 348 */
+{offset: 319, rowsPerImage: 280}, {width: 29, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline49 = device4.createRenderPipeline({
+label: '\u84f8\uc911\u{1fa9a}\u{1fa0d}\ub13f\u4289',
+layout: 'auto',
+multisample: {
+count: 4,
+mask: 0x6137c886,
+},
+fragment: {
+  module: shaderModule15,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, undefined, undefined, undefined, undefined, {format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA}, undefined]
+},
+vertex: {
+  module: shaderModule15,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 11508,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 3314,
+shaderLocation: 13,
+}, {
+format: 'sint8x4',
+offset: 10748,
+shaderLocation: 2,
+}, {
+format: 'unorm8x2',
+offset: 2718,
+shaderLocation: 3,
+}, {
+format: 'sint32x3',
+offset: 1984,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 4668,
+shaderLocation: 11,
+}, {
+format: 'uint32x3',
+offset: 8328,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 10616,
+shaderLocation: 7,
+}, {
+format: 'sint16x4',
+offset: 580,
+shaderLocation: 0,
+}, {
+format: 'sint16x4',
+offset: 252,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 7912,
+attributes: [{
+format: 'uint8x2',
+offset: 1380,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 8164,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 8560,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 11716,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 13252,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 2496,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32',
+offset: 2080,
+shaderLocation: 15,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+  await promise35;
+} catch {}
+let adapter8 = await promise32;
+let shaderModule16 = device2.createShaderModule({
+code: `@group(0) @binding(2596)
+var<storage, read_write> parameter12: array<u32>;
+
+@compute @workgroup_size(1, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec2<i32>,
+  @location(0) f1: vec4<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S18 {
+  @location(11) f0: f16,
+  @location(1) f1: f32,
+  @location(15) f2: vec4<f32>,
+  @location(0) f3: i32,
+  @location(9) f4: vec3<f16>,
+  @location(10) f5: vec3<i32>,
+  @builtin(instance_index) f6: u32,
+  @location(13) f7: vec4<f32>,
+  @builtin(vertex_index) f8: u32,
+  @location(16) f9: vec3<f16>,
+  @location(8) f10: u32,
+  @location(17) f11: f16,
+  @location(2) f12: f32
+}
+
+@vertex
+fn vertex0(@location(4) a0: i32, @location(3) a1: vec3<f32>, @location(14) a2: vec3<f16>, @location(5) a3: i32, a4: S18, @location(6) a5: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+});
+let textureView59 = texture34.createView({aspect: 'all', baseMipLevel: 4});
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: { x: 324, y: 0, z: 66 },
+  aspect: 'all',
+}, {
+  texture: texture63,
+  mipLevel: 1,
+  origin: { x: 37, y: 1, z: 1 },
+  aspect: 'all',
+}, {width: 207, height: 0, depthOrArrayLayers: 325});
+} catch {}
+let promise36 = device2.createRenderPipelineAsync({
+label: '\u{1f9fa}\u{1fe51}\u56f2\u07db\uff2e',
+layout: pipelineLayout10,
+multisample: {
+count: 4,
+mask: 0x4438acdd,
+},
+fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32sint', writeMask: 0}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+stencilBack: {
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilReadMask: 3067,
+stencilWriteMask: 3426,
+depthBias: 94,
+depthBiasSlopeScale: 80,
+depthBiasClamp: 64,
+},
+vertex: {
+  module: shaderModule16,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1000,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x4',
+offset: 720,
+shaderLocation: 5,
+}, {
+format: 'unorm8x4',
+offset: 192,
+shaderLocation: 16,
+}, {
+format: 'float16x2',
+offset: 664,
+shaderLocation: 15,
+}, {
+format: 'sint8x2',
+offset: 990,
+shaderLocation: 0,
+}, {
+format: 'unorm8x4',
+offset: 884,
+shaderLocation: 3,
+}, {
+format: 'float32',
+offset: 844,
+shaderLocation: 2,
+}, {
+format: 'snorm16x2',
+offset: 900,
+shaderLocation: 11,
+}, {
+format: 'unorm8x2',
+offset: 380,
+shaderLocation: 1,
+}, {
+format: 'sint8x4',
+offset: 188,
+shaderLocation: 6,
+}, {
+format: 'snorm8x4',
+offset: 580,
+shaderLocation: 14,
+}, {
+format: 'uint16x2',
+offset: 280,
+shaderLocation: 8,
+}, {
+format: 'sint8x4',
+offset: 528,
+shaderLocation: 4,
+}, {
+format: 'snorm16x4',
+offset: 404,
+shaderLocation: 17,
+}],
+},
+{
+arrayStride: 9872,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 9868,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x3',
+offset: 9344,
+shaderLocation: 10,
+}, {
+format: 'snorm8x4',
+offset: 7852,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 7720,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm16x2',
+offset: 3308,
+shaderLocation: 9,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let imageData10 = new ImageData(52, 120);
+let querySet49 = device2.createQuerySet({
+label: '\u58e9\u78d3\u{1f741}\u2707\u2c02\u0016',
+type: 'occlusion',
+count: 3589,
+});
+let textureView60 = texture47.createView({label: '\u040f\u266d\u{1f975}\u0e96\u94c4\ud67d\ua484\u0bf6\u2388\udcdc\u{1ffe3}'});
+try {
+computePassEncoder23.insertDebugMarker('\ud6d2');
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline50 = await device2.createComputePipelineAsync({
+label: '\u{1faf0}\u{1fa0a}\ua7a2\ue1bc\u5c0b\u{1f9b7}\u{1f9f9}\u86f7\u0841',
+layout: pipelineLayout6,
+compute: {
+module: shaderModule11,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline51 = await device2.createRenderPipelineAsync({
+label: '\u08e9\uda0c',
+layout: pipelineLayout6,
+multisample: {
+mask: 0xf926ecda,
+},
+fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'zero',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 704,
+depthBias: 70,
+depthBiasClamp: 87,
+},
+vertex: {
+  module: shaderModule16,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 8852,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 5552,
+shaderLocation: 4,
+}, {
+format: 'sint16x4',
+offset: 2640,
+shaderLocation: 10,
+}, {
+format: 'sint8x4',
+offset: 3352,
+shaderLocation: 0,
+}, {
+format: 'unorm16x2',
+offset: 8760,
+shaderLocation: 13,
+}, {
+format: 'sint8x4',
+offset: 1096,
+shaderLocation: 6,
+}, {
+format: 'sint8x4',
+offset: 116,
+shaderLocation: 5,
+}, {
+format: 'float32x3',
+offset: 5716,
+shaderLocation: 11,
+}, {
+format: 'float16x4',
+offset: 5744,
+shaderLocation: 1,
+}, {
+format: 'unorm8x4',
+offset: 2724,
+shaderLocation: 17,
+}, {
+format: 'float16x4',
+offset: 6168,
+shaderLocation: 2,
+}, {
+format: 'unorm16x4',
+offset: 3204,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 7548,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x2',
+offset: 2604,
+shaderLocation: 8,
+}, {
+format: 'float16x2',
+offset: 3360,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 0,
+attributes: [{
+format: 'snorm16x4',
+offset: 12580,
+shaderLocation: 15,
+}, {
+format: 'float32',
+offset: 2364,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 8820,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x2',
+offset: 4748,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+let gpuCanvasContext11 = offscreenCanvas14.getContext('webgpu');
+let bindGroup26 = device0.createBindGroup({
+label: '\u052b\u892e\u50d5\uaa10\u05ad',
+layout: bindGroupLayout4,
+entries: [],
+});
+let renderBundleEncoder55 = device0.createRenderBundleEncoder({
+  label: '\u{1feb0}\u0e16',
+  colorFormats: ['rgba8unorm-srgb', 'r8sint', 'rgba32uint', 'rgba8sint', 'r16uint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder10.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(540, 19, 371, 7);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer0, 39864);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(0, bindGroup1, new Uint32Array(4230), 2958, 0);
+} catch {}
+try {
+renderBundleEncoder45.drawIndirect(buffer18, 23780);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(4, buffer11, 13488);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let pipeline52 = await device0.createRenderPipelineAsync({
+label: '\u22c2\ue787\u0f04\u4c56\uae7a\u07a6\ub1fe\uece5\u9ed0',
+layout: 'auto',
+fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba32uint'}, {format: 'rg32sint', writeMask: GPUColorWrite.BLUE}, {format: 'rg16uint', writeMask: 0}, {
+  format: 'rg16sint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, undefined]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-wrap',
+},
+stencilReadMask: 3994,
+depthBias: 92,
+depthBiasSlopeScale: 79,
+depthBiasClamp: 50,
+},
+vertex: {
+  module: shaderModule8,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 11212,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x4',
+offset: 5276,
+shaderLocation: 16,
+}, {
+format: 'float16x4',
+offset: 8248,
+shaderLocation: 12,
+}, {
+format: 'snorm8x2',
+offset: 7370,
+shaderLocation: 15,
+}, {
+format: 'uint16x4',
+offset: 5940,
+shaderLocation: 22,
+}, {
+format: 'unorm8x2',
+offset: 10938,
+shaderLocation: 10,
+}, {
+format: 'sint32x2',
+offset: 8856,
+shaderLocation: 13,
+}, {
+format: 'sint8x4',
+offset: 2956,
+shaderLocation: 23,
+}, {
+format: 'sint8x2',
+offset: 2666,
+shaderLocation: 7,
+}, {
+format: 'uint16x4',
+offset: 10932,
+shaderLocation: 9,
+}, {
+format: 'float16x4',
+offset: 328,
+shaderLocation: 11,
+}, {
+format: 'unorm10-10-10-2',
+offset: 2904,
+shaderLocation: 6,
+}, {
+format: 'unorm16x2',
+offset: 6860,
+shaderLocation: 8,
+}, {
+format: 'unorm16x4',
+offset: 8384,
+shaderLocation: 3,
+}, {
+format: 'sint32',
+offset: 900,
+shaderLocation: 20,
+}, {
+format: 'float32x2',
+offset: 5636,
+shaderLocation: 4,
+}, {
+format: 'sint32',
+offset: 632,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 9128,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 8908,
+shaderLocation: 5,
+}, {
+format: 'unorm16x4',
+offset: 2196,
+shaderLocation: 19,
+}],
+},
+{
+arrayStride: 1492,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint16x2',
+offset: 304,
+shaderLocation: 24,
+}, {
+format: 'snorm8x2',
+offset: 1408,
+shaderLocation: 0,
+}, {
+format: 'float32x2',
+offset: 276,
+shaderLocation: 17,
+}, {
+format: 'float16x4',
+offset: 1044,
+shaderLocation: 2,
+}, {
+format: 'unorm8x2',
+offset: 192,
+shaderLocation: 18,
+}, {
+format: 'snorm16x4',
+offset: 956,
+shaderLocation: 21,
+}, {
+format: 'unorm16x2',
+offset: 824,
+shaderLocation: 14,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+},
+});
+try {
+  await promise30;
+} catch {}
+let buffer28 = device0.createBuffer({
+  label: '\u3ad4\u{1fb74}\u0358\u{1f951}\ub022\ufbf0\u{1fd4f}\u6f57\u0976\uc22e',
+  size: 33104,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT
+});
+let querySet50 = device0.createQuerySet({
+label: '\u4262\u{1fbf7}\u066f\u0183\u732e\u0cc6\ue782',
+type: 'occlusion',
+count: 2597,
+});
+let renderBundle51 = renderBundleEncoder27.finish({label: '\u2180\u7c5b\u0c3b\u{1f70f}'});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup15, []);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline29);
+} catch {}
+try {
+renderPassEncoder4.setViewport(125.3, 16.03, 2.997, 0.08055, 0.1149, 0.3974);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(80, 64);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer10, 144064);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer18, 'uint16', 3220);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(48, 0);
+} catch {}
+try {
+renderBundleEncoder35.setVertexBuffer(5, buffer13, 38332, 9223);
+} catch {}
+let arrayBuffer5 = buffer2.getMappedRange(13176, 264);
+try {
+device0.queue.writeBuffer(buffer26, 24788, new BigUint64Array(12853), 4266, 2252);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 240, height: 32, depthOrArrayLayers: 1971}
+*/
+{
+  source: video4,
+  origin: { x: 2, y: 6 },
+  flipY: false,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: { x: 57, y: 3, z: 590 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 11, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame14 = new VideoFrame(img11, {timestamp: 0});
+let promise37 = navigator.gpu.requestAdapter();
+pseudoSubmit(device0, commandEncoder20);
+let textureView61 = texture29.createView({
+  label: '\uade6\u0e22\u0077\u6cab\u{1fe94}\u4675\u{1fb2e}\u2d36\u{1fe18}',
+  format: 'r8snorm',
+  baseMipLevel: 2,
+  mipLevelCount: 2
+});
+try {
+renderPassEncoder5.executeBundles([renderBundle50, renderBundle16, renderBundle50]);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(369, 29, 580, 21);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer3, 3544);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer12, 14872);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(0, bindGroup19, new Uint32Array(8927), 3619, 0);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer11, 9612);
+} catch {}
+try {
+renderBundleEncoder51.setVertexBuffer(0, buffer13, 22456, 12520);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 4,
+  origin: { x: 24, y: 0, z: 18 },
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 67588 */
+{offset: 708, bytesPerRow: 440, rowsPerImage: 19}, {width: 80, height: 0, depthOrArrayLayers: 9});
+} catch {}
+let promise38 = device0.queue.onSubmittedWorkDone();
+offscreenCanvas5.height = 767;
+let commandBuffer5 = commandEncoder33.finish({
+label: '\u{1fc0d}\ub116\u875f\u{1f6d1}\ua329\u0969',
+});
+try {
+renderPassEncoder5.beginOcclusionQuery(281);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(314);
+} catch {}
+try {
+renderPassEncoder5.setViewport(8.538, 1.592, 185.6, 1.171, 0.5308, 0.6028);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder40.draw(48, 0, 48, 24);
+} catch {}
+try {
+commandEncoder9.clearBuffer(buffer1, 2288, 33692);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+video9.width = 95;
+try {
+computePassEncoder10.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(12);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(354, 7, 163, 26);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(40, 80, 32, 624);
+} catch {}
+try {
+renderBundleEncoder45.drawIndexed(56, 72);
+} catch {}
+try {
+renderBundleEncoder37.drawIndexedIndirect(buffer28, 19684);
+} catch {}
+try {
+renderBundleEncoder55.setVertexBuffer(1, buffer11);
+} catch {}
+let pipeline53 = device0.createComputePipeline({
+label: '\u0487\u0b24\u{1ff4d}\ua3c5\uc2ff\u0acf\u03bb\u0c23',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule9,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+gc();
+let adapter9 = await navigator.gpu.requestAdapter({
+});
+let commandEncoder36 = device0.createCommandEncoder({label: '\u01c3\u0c93\ue5e3\u{1fc35}\u0c47\u3518\u{1f69e}\u{1fb4d}\u0833\u{1ffbf}'});
+let querySet51 = device0.createQuerySet({
+label: '\ud097\u0817\u{1f7dd}',
+type: 'occlusion',
+count: 783,
+});
+let textureView62 = texture11.createView({
+  label: '\u00d8\u1a67\u698b\u469b\u{1f685}\uaeae',
+  baseMipLevel: 3,
+  mipLevelCount: 2,
+  baseArrayLayer: 32,
+  arrayLayerCount: 3
+});
+let renderBundleEncoder56 = device0.createRenderBundleEncoder({
+  label: '\uddf2\ua000\u5321\u08ee\udeb0\u0aab\ub982\u50cc\u2845\udb16\u0e03',
+  colorFormats: ['rgba8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle52 = renderBundleEncoder32.finish({label: '\u{1f813}\ucd94\u84fd\u0d5c\u427b'});
+let sampler41 = device0.createSampler({
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 32.000,
+lodMaxClamp: 50.253,
+maxAnisotropy: 11,
+});
+try {
+computePassEncoder21.setBindGroup(5, bindGroup8, []);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup10, []);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup2, new Uint32Array(3855), 3183, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(80, 32, 48, 72);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(72, 72);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer12, 123184);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(1, buffer13, 43872, 2629);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(6, buffer11, 292, 11621);
+} catch {}
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let renderBundle53 = renderBundleEncoder52.finish();
+try {
+renderBundleEncoder54.setBindGroup(2, bindGroup25, []);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup21, new Uint32Array(4858), 2362, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(64, 48, 48, -520);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer11, 14468);
+} catch {}
+try {
+commandEncoder36.insertDebugMarker('\u99ce');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: { x: 0, y: 15, z: 0 },
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer5), /* required buffer size: 1265 */
+{offset: 3, bytesPerRow: 123}, {width: 16, height: 55, depthOrArrayLayers: 1});
+} catch {}
+let pipeline54 = device0.createRenderPipeline({
+label: '\u{1fe7d}\u73cb\u090f\u0888\u{1fa9b}\u1363\u01d4\u2de7\u0adb',
+layout: 'auto',
+multisample: {
+count: 4,
+mask: 0x487ddc5c,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r16uint', writeMask: 0}, undefined]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-wrap',
+depthFailOp: 'replace',
+passOp: 'replace',
+},
+stencilReadMask: 566,
+stencilWriteMask: 1771,
+depthBiasSlopeScale: 18,
+depthBiasClamp: 7,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 11196,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 6524,
+shaderLocation: 24,
+}, {
+format: 'float32x4',
+offset: 2288,
+shaderLocation: 22,
+}, {
+format: 'unorm16x2',
+offset: 9796,
+shaderLocation: 14,
+}, {
+format: 'uint8x2',
+offset: 7622,
+shaderLocation: 8,
+}, {
+format: 'sint32x3',
+offset: 7608,
+shaderLocation: 4,
+}, {
+format: 'sint8x2',
+offset: 2424,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 5684,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 8644,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x4',
+offset: 2184,
+shaderLocation: 2,
+}, {
+format: 'uint16x2',
+offset: 576,
+shaderLocation: 19,
+}, {
+format: 'float32x2',
+offset: 1912,
+shaderLocation: 17,
+}, {
+format: 'float32',
+offset: 5976,
+shaderLocation: 21,
+}, {
+format: 'uint8x4',
+offset: 4520,
+shaderLocation: 11,
+}, {
+format: 'sint16x4',
+offset: 4296,
+shaderLocation: 20,
+}, {
+format: 'snorm8x4',
+offset: 2348,
+shaderLocation: 16,
+}, {
+format: 'float16x4',
+offset: 6192,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 3620,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 12832,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 17284,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 13744,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 2584,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+try {
+  await promise38;
+} catch {}
+let textureView63 = texture66.createView({
+  label: '\u0975\u5450\u{1fdd8}\u0ac8\u55c3\u4149\u7f45\uee7a\u3357\u3c47\u88ea',
+  baseMipLevel: 3,
+  mipLevelCount: 1
+});
+let renderBundleEncoder57 = device4.createRenderBundleEncoder({
+  label: '\u0d8c\u87ae',
+  colorFormats: ['r8uint', undefined, undefined, undefined, undefined, 'rgba16uint', undefined],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder54.setPipeline(pipeline49);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+try {
+gpuCanvasContext11.configure({
+device: device4,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let bindGroupLayout24 = device2.createBindGroupLayout({
+entries: [],
+});
+let pipelineLayout13 = device2.createPipelineLayout({
+  label: '\u{1f71e}\ufe98\u{1fb29}\u{1fc7e}\u08ce\u0515\u0f7e\u0705\u{1fe7d}\ua731\u5f1e',
+  bindGroupLayouts: [bindGroupLayout23]
+});
+let textureView64 = texture34.createView({label: '\u{1f934}\u0e49\u74d6\u0a46\u0deb\u10ee', aspect: 'all', baseMipLevel: 6});
+try {
+computePassEncoder18.setPipeline(pipeline34);
+} catch {}
+let pipeline55 = device2.createComputePipeline({
+layout: pipelineLayout10,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline56 = await device2.createRenderPipelineAsync({
+label: '\u0ccd\u5e92\u4a4a\ua7e3\u01df\u3287\u060d\u1236\ub807',
+layout: pipelineLayout6,
+fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba8uint'}, {format: 'rg8unorm', writeMask: 0}, {
+  format: 'r8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-dst-alpha'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED
+}, {format: 'r32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba32sint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rg32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}]
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'invert',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2641,
+stencilWriteMask: 1705,
+depthBiasSlopeScale: 31,
+},
+vertex: {
+  module: shaderModule11,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1744,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm16x2',
+offset: 1524,
+shaderLocation: 2,
+}, {
+format: 'uint16x2',
+offset: 976,
+shaderLocation: 5,
+}, {
+format: 'float16x2',
+offset: 948,
+shaderLocation: 11,
+}, {
+format: 'float16x4',
+offset: 696,
+shaderLocation: 7,
+}, {
+format: 'sint16x2',
+offset: 960,
+shaderLocation: 3,
+}, {
+format: 'uint32x2',
+offset: 788,
+shaderLocation: 8,
+}, {
+format: 'sint8x4',
+offset: 752,
+shaderLocation: 4,
+}, {
+format: 'uint8x2',
+offset: 1270,
+shaderLocation: 6,
+}, {
+format: 'float32x2',
+offset: 1224,
+shaderLocation: 12,
+}, {
+format: 'uint32',
+offset: 132,
+shaderLocation: 1,
+}, {
+format: 'unorm10-10-10-2',
+offset: 400,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 4220,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x2',
+offset: 3784,
+shaderLocation: 0,
+}, {
+format: 'sint8x4',
+offset: 1236,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 12016,
+shaderLocation: 16,
+}, {
+format: 'snorm8x4',
+offset: 10712,
+shaderLocation: 14,
+}, {
+format: 'uint16x2',
+offset: 11884,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 2604,
+attributes: [{
+format: 'float32x4',
+offset: 768,
+shaderLocation: 13,
+}, {
+format: 'uint32x2',
+offset: 912,
+shaderLocation: 17,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+document.body.prepend(img12);
+let pipelineLayout14 = device2.createPipelineLayout({label: '\u0ba8\u42d9\u62c6', bindGroupLayouts: [bindGroupLayout23, bindGroupLayout17]});
+let textureView65 = texture44.createView({label: '\u{1faff}\u{1fc14}\u0d46', baseMipLevel: 1});
+try {
+computePassEncoder19.setPipeline(pipeline43);
+} catch {}
+let pipeline57 = device2.createRenderPipeline({
+layout: pipelineLayout14,
+multisample: {
+mask: 0x12f5afbf,
+},
+fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'r32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rgba32sint'}, {format: 'rg32sint'}, {format: 'rgb10a2unorm'}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'zero',
+depthFailOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'always',
+failOp: 'decrement-clamp',
+depthFailOp: 'invert',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2499,
+stencilWriteMask: 1694,
+depthBias: 71,
+},
+vertex: {
+  module: shaderModule12,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 2484,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 10112,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 11720,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x4',
+offset: 9112,
+shaderLocation: 10,
+}, {
+format: 'snorm16x4',
+offset: 2656,
+shaderLocation: 2,
+}],
+}
+]
+},
+});
+let img20 = await imageWithData(127, 129, '#4a09b1f2', '#d9c26b09');
+let buffer29 = device2.createBuffer({
+  label: '\ud6b4\u1dbb\ud93d\u{1fe77}',
+  size: 42837,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let texture71 = device2.createTexture({
+label: '\u1b00\u0da9',
+size: [1680, 12, 238],
+mipLevelCount: 2,
+sampleCount: 1,
+format: 'etc2-rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgba8unorm', 'etc2-rgba8unorm-srgb', 'etc2-rgba8unorm'],
+});
+try {
+gpuCanvasContext1.configure({
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST,
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+canvas4.width = 756;
+let bindGroup27 = device0.createBindGroup({
+label: '\u000e\u4433\u{1fbb6}\u9792\u0028',
+layout: bindGroupLayout0,
+entries: [],
+});
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.draw(72, 64, 56, 40);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer2, 308688);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer6, 28952);
+} catch {}
+try {
+renderBundleEncoder45.drawIndexed(40);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(1, buffer13, 34876, 10139);
+} catch {}
+offscreenCanvas6.width = 303;
+gc();
+let video17 = await videoWithData();
+let texture72 = device2.createTexture({
+label: '\u{1f6f5}\ue6fc\u9f18',
+size: {width: 275, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg8sint', 'rg8sint', 'rg8sint'],
+});
+let computePassEncoder26 = commandEncoder35.beginComputePass({label: '\u0304\u1f4f\u19b2\ua4bd\u0934\ua8de'});
+let renderBundle54 = renderBundleEncoder30.finish({label: '\u9c84\u2ef5\u0dff\u5798\u8a2d\u{1fbd4}\ue079'});
+let sampler42 = device2.createSampler({
+label: '\u7422\u5d39',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMaxClamp: 87.823,
+});
+let commandEncoder37 = device0.createCommandEncoder();
+let querySet52 = device0.createQuerySet({
+label: '\u931c\u30b1\u0ac3\u1af8\u0335\u{1faae}\ue685',
+type: 'occlusion',
+count: 2500,
+});
+try {
+renderPassEncoder6.setBindGroup(5, bindGroup1);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(1166);
+} catch {}
+try {
+renderPassEncoder5.setViewport(188.3, 0.4482, 26.53, 14.87, 0.7486, 0.7653);
+} catch {}
+try {
+renderPassEncoder5.draw(64, 24, 80, 72);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(8, buffer13, 32268, 10574);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(7, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(40);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(5, buffer13, 33600, 5902);
+} catch {}
+try {
+commandEncoder9.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 1,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture6,
+  mipLevel: 1,
+  origin: { x: 0, y: 16, z: 0 },
+  aspect: 'all',
+}, {width: 480, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder37.clearBuffer(buffer10);
+dissociateBuffer(device0, buffer10);
+} catch {}
+let video18 = await videoWithData();
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer0, 351936);
+} catch {}
+try {
+renderBundleEncoder17.draw(72, 64);
+} catch {}
+try {
+renderBundleEncoder45.drawIndexed(48, 8, 0, 784, 16);
+} catch {}
+let arrayBuffer6 = buffer7.getMappedRange(13840, 2392);
+try {
+commandEncoder36.resolveQuerySet(querySet4, 117, 984, buffer9, 4608);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer25, 48440, new Float32Array(24966), 1019, 68);
+} catch {}
+let promise39 = device0.queue.onSubmittedWorkDone();
+let imageData11 = new ImageData(32, 68);
+let renderBundleEncoder58 = device0.createRenderBundleEncoder({
+  label: '\u0dbf\u1021\u0947\u{1ffe1}\u{1f84e}\u02d6\u{1f924}',
+  colorFormats: ['rgba16uint', 'rgb10a2uint', undefined, 'rgba8unorm-srgb', undefined],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle55 = renderBundleEncoder6.finish({label: '\ud2f6\ue6cb\u{1f62b}\u9d6f\u{1fcf8}\u9cbd\ubaed\u80bb\ua360\u{1ff8e}'});
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle50, renderBundle16, renderBundle50]);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer9, 23184);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(8, buffer11);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder37.drawIndexedIndirect(buffer11, 6192);
+} catch {}
+try {
+commandEncoder37.clearBuffer(buffer1, 136, 34112);
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder37.insertDebugMarker('\u32c0');
+} catch {}
+try {
+computePassEncoder16.insertDebugMarker('\u{1f7e9}');
+} catch {}
+try {
+gpuCanvasContext9.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap12 = await createImageBitmap(videoFrame14);
+let texture73 = device4.createTexture({
+size: [240],
+dimension: '1d',
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['r16uint', 'r16uint'],
+});
+let renderBundle56 = renderBundleEncoder54.finish();
+try {
+renderBundleEncoder57.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+device4.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let canvas13 = document.createElement('canvas');
+let bindGroup28 = device0.createBindGroup({
+label: '\u{1fb70}\u0347',
+layout: bindGroupLayout21,
+entries: [],
+});
+let querySet53 = device0.createQuerySet({
+label: '\ueb75\u{1f6cc}\u6fb0\u3047\u79b2\u{1fba8}',
+type: 'occlusion',
+count: 3376,
+});
+let sampler43 = device0.createSampler({
+label: '\u84ba\u5d36\u5438\uf7bc\u0838\u{1fd72}\u05eb',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 31.910,
+compare: 'less-equal',
+});
+let externalTexture7 = device0.importExternalTexture({
+source: videoFrame2,
+colorSpace: 'srgb',
+});
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: 177.9, g: 533.3, b: -631.7, a: -590.0, });
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(0, 48);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer13, 46660, 903);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(5, bindGroup18);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(1, buffer11, 8772, 3023);
+} catch {}
+try {
+commandEncoder37.clearBuffer(buffer1, 13336, 6132);
+dissociateBuffer(device0, buffer1);
+} catch {}
+let canvas14 = document.createElement('canvas');
+let offscreenCanvas15 = new OffscreenCanvas(574, 253);
+let texture74 = device2.createTexture({
+label: '\u{1f97d}\u{1fea0}\u{1fa1a}\u{1f671}\u8630',
+size: {width: 1680, height: 12, depthOrArrayLayers: 238},
+mipLevelCount: 3,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder59 = device2.createRenderBundleEncoder({
+  label: '\u{1f64a}\u5a4e',
+  colorFormats: ['rg16uint', 'rgba32float', 'r32uint', 'bgra8unorm', 'r32sint', 'r16uint', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1,
+  stencilReadOnly: false
+});
+let renderBundle57 = renderBundleEncoder59.finish({label: '\ua13a\uaa45\u19d7\u969c\u0c44\ud7ca\u0cc1\u4299\u49ca'});
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 137, height: 1, depthOrArrayLayers: 30}
+*/
+{
+  source: offscreenCanvas6,
+  origin: { x: 223, y: 96 },
+  flipY: false,
+}, {
+  texture: texture50,
+  mipLevel: 3,
+  origin: { x: 20, y: 0, z: 13 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 59, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext12 = canvas13.getContext('webgpu');
+offscreenCanvas14.width = 742;
+let adapter10 = await navigator.gpu.requestAdapter();
+let commandEncoder38 = device4.createCommandEncoder({label: '\u4fb5\u{1fda0}\u0631\u0488\u{1fe51}\u04d2\u029a\u7f76'});
+let textureView66 = texture62.createView({label: '\u{1f875}\u05fe\u0c48\u05ab\u51a8\u715a\u{1f991}\u{1fc04}'});
+let renderBundle58 = renderBundleEncoder52.finish({});
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: { x: 3, y: 0, z: 0 },
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer2), /* required buffer size: 196 */
+{offset: 166, bytesPerRow: 77, rowsPerImage: 159}, {width: 15, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let texture75 = device4.createTexture({
+label: '\u7e39\u334e\u7733\u0c2f\u77e5\uc6a4\u808d\u31e0',
+size: [60, 40, 1],
+mipLevelCount: 6,
+format: 'astc-12x10-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundle59 = renderBundleEncoder57.finish({label: '\u5fd5\ua323\u{1f758}\ub535\ud97e\u81dc\u9f6d\uc691'});
+try {
+device4.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 5,
+  origin: { x: 5, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 463 */
+{offset: 463}, {width: 15, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let texture76 = device4.createTexture({
+label: '\u{1f84f}\u{1fde3}\u6cad\u5707\u0679\u63ba\ue065\u{1f83c}\u{1f71a}\u0f00',
+size: [524, 1, 106],
+mipLevelCount: 5,
+format: 'r8uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [],
+});
+let renderBundle60 = renderBundleEncoder57.finish({label: '\u0aef\u0f1e\u0487'});
+let img21 = await imageWithData(291, 225, '#aca529e6', '#8d49c8dd');
+try {
+renderBundleEncoder49.setVertexBuffer(37, undefined, 3828431466);
+} catch {}
+try {
+  await promise39;
+} catch {}
+let commandEncoder39 = device0.createCommandEncoder({label: '\u{1fd9f}\uad31\u0444\u9ff6\u{1f67b}\uba17\u{1f9f3}\u692d\ueaf5'});
+try {
+computePassEncoder21.setBindGroup(8, bindGroup24, new Uint32Array(1092), 1051, 0);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(206);
+} catch {}
+try {
+renderPassEncoder6.setViewport(577.7, 48.87, 164.8, 16.57, 0.8438, 0.8568);
+} catch {}
+try {
+renderPassEncoder5.draw(40, 8, 16, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer25, 37648);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer8, 198280);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer18, 'uint32', 2584, 5298);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(1, buffer13, 29640, 9011);
+} catch {}
+try {
+renderBundleEncoder17.draw(56, 64, 24);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(40, 32, 64, 440, 16);
+} catch {}
+try {
+renderPassEncoder5.insertDebugMarker('\u95b8');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 19388, new Int16Array(39644), 14943, 728);
+} catch {}
+let renderBundleEncoder60 = device2.createRenderBundleEncoder({
+  label: '\u081a\u08c1\u3a0a\u09f5\ub7b5\u16ab\u8e50\u0b7e\ub973\u15dc\ud40e',
+  colorFormats: ['rg16uint', 'rgba32float', 'r32uint', 'bgra8unorm', 'r32sint', 'r16uint', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+let renderBundle61 = renderBundleEncoder43.finish();
+let sampler44 = device2.createSampler({
+label: '\u0afd\u{1f754}\uaa77\u{1fa72}\u{1ffbb}\u71d0\u0938\u{1faf6}',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 56.673,
+lodMaxClamp: 62.541,
+});
+try {
+device2.destroy();
+} catch {}
+document.body.prepend(img13);
+let texture77 = device4.createTexture({
+size: [170, 60, 168],
+mipLevelCount: 2,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['stencil8', 'stencil8', 'stencil8'],
+});
+let textureView67 = texture60.createView({label: '\u08a4\ue64a\u6034\u{1fa32}\u{1fcb0}\u{1f7a0}'});
+let renderBundleEncoder61 = device4.createRenderBundleEncoder({
+  label: '\u{1fa53}\u07b3\ua9cc\u0a3a\u{1f99d}\u{1fc4a}\u0825\u023b\u0643',
+  colorFormats: ['r8uint', undefined, undefined, undefined, undefined, 'rgba16uint', undefined],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+device4.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 924 */
+{offset: 924}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData12 = new ImageData(124, 92);
+let buffer30 = device0.createBuffer({size: 26060, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: true});
+let renderBundleEncoder62 = device0.createRenderBundleEncoder({
+  label: '\uf83d\u{1fb5e}\u05e9\u{1fff8}\u0e02\u9bf0\u0152',
+  colorFormats: ['rgb10a2uint', 'rgba32uint', 'rg32sint', 'rg16uint', 'rg16sint', undefined],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+let renderBundle62 = renderBundleEncoder4.finish();
+let sampler45 = device0.createSampler({
+label: '\uc4f5\u049d\u0641\ue014\u044b\u7412',
+addressModeW: 'repeat',
+minFilter: 'linear',
+lodMinClamp: 30.606,
+});
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: 389.2, g: 207.0, b: 589.2, a: -325.7, });
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer28, 'uint32');
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(0, bindGroup11, new Uint32Array(1833), 1567, 0);
+} catch {}
+let promise40 = buffer26.mapAsync(GPUMapMode.READ, 3928, 31468);
+try {
+commandEncoder37.resolveQuerySet(querySet28, 1693, 121, buffer9, 14080);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8unorm', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 3,
+  origin: { x: 152, y: 0, z: 32 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 16906 */
+{offset: 250, bytesPerRow: 341, rowsPerImage: 16}, {width: 144, height: 5, depthOrArrayLayers: 4});
+} catch {}
+let pipeline58 = device0.createRenderPipeline({
+label: '\u3888\u8509\u57f1\u02c4\u7f15\u{1f7b5}\u0f7b\uaa59',
+layout: pipelineLayout9,
+fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'one-minus-dst'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'one-minus-dst'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r16uint', writeMask: GPUColorWrite.GREEN}, undefined]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'invert',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 3360,
+stencilWriteMask: 3473,
+depthBias: 71,
+depthBiasSlopeScale: 64,
+depthBiasClamp: 75,
+},
+vertex: {module: shaderModule5, entryPoint: 'vertex0', buffers: [
+
+]},
+primitive: {
+topology: 'line-list',
+unclippedDepth: true,
+},
+});
+pseudoSubmit(device4, commandEncoder38);
+let textureView68 = texture75.createView({dimension: '2d-array', mipLevelCount: 5});
+let bindGroup29 = device4.createBindGroup({
+label: '\u0b11\u0b0c',
+layout: bindGroupLayout22,
+entries: [{
+binding: 3927,
+resource: {
+buffer: buffer27,
+offset: 21440,
+size: 10456,
+}
+}],
+});
+try {
+renderBundleEncoder61.setPipeline(pipeline49);
+} catch {}
+try {
+renderBundleEncoder61.setVertexBuffer(54, undefined, 3689785405, 391998161);
+} catch {}
+let pipeline59 = await device4.createRenderPipelineAsync({
+layout: pipelineLayout12,
+fragment: {
+  module: shaderModule15,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, undefined, undefined, undefined, undefined, {format: 'rgba16uint', writeMask: 0}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilWriteMask: 472,
+depthBiasSlopeScale: 7,
+depthBiasClamp: 8,
+},
+vertex: {
+  module: shaderModule15,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 8784,
+attributes: [{
+format: 'uint32x4',
+offset: 3000,
+shaderLocation: 7,
+}, {
+format: 'sint8x2',
+offset: 1322,
+shaderLocation: 13,
+}, {
+format: 'uint16x4',
+offset: 3676,
+shaderLocation: 16,
+}, {
+format: 'unorm10-10-10-2',
+offset: 8488,
+shaderLocation: 3,
+}, {
+format: 'sint8x4',
+offset: 5304,
+shaderLocation: 15,
+}, {
+format: 'sint32x3',
+offset: 4604,
+shaderLocation: 2,
+}, {
+format: 'uint16x4',
+offset: 6672,
+shaderLocation: 14,
+}, {
+format: 'uint16x2',
+offset: 2000,
+shaderLocation: 11,
+}, {
+format: 'sint8x2',
+offset: 2972,
+shaderLocation: 5,
+}, {
+format: 'sint8x4',
+offset: 5560,
+shaderLocation: 12,
+}, {
+format: 'sint32',
+offset: 8244,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+canvas11.height = 144;
+let querySet54 = device0.createQuerySet({
+label: '\u{1fe42}\u546c\ufbc6\u4d8a\u1b03\u0f19\u0e12\u{1f940}\uc0dd',
+type: 'occlusion',
+count: 4085,
+});
+let sampler46 = device0.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 50.452,
+lodMaxClamp: 93.911,
+});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(77, 4, 113, 7);
+} catch {}
+try {
+renderPassEncoder6.setViewport(916.7, 20.16, 6.124, 28.80, 0.8518, 0.8639);
+} catch {}
+try {
+renderPassEncoder5.draw(0, 56, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(72);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer8, 17072);
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(querySet15, 1493, 991, buffer6, 1536);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let img22 = await imageWithData(97, 136, '#d8ff2850', '#46acd487');
+let commandEncoder40 = device4.createCommandEncoder({});
+let texture78 = device4.createTexture({
+label: '\u5f54\u79b1',
+size: [96, 42, 1],
+mipLevelCount: 3,
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let textureView69 = texture76.createView({dimension: '2d-array', baseMipLevel: 1, baseArrayLayer: 47, arrayLayerCount: 27});
+let sampler47 = device4.createSampler({
+label: '\u0877\u6ded\u{1f7aa}\u52ce\u20bf\u040f\u5500\ud63f\ua406\u{1f615}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 25.062,
+lodMaxClamp: 90.261,
+compare: 'less-equal',
+maxAnisotropy: 12,
+});
+try {
+renderBundleEncoder61.draw(32);
+} catch {}
+let canvas15 = document.createElement('canvas');
+let video19 = await videoWithData();
+let videoFrame15 = new VideoFrame(video19, {timestamp: 0});
+try {
+adapter0.label = '\u{1fc26}\u9bc6\u7506\ue49e\u122f\u0555\u27d2\u{1ff01}\u2905';
+} catch {}
+let shaderModule17 = device4.createShaderModule({
+label: '\u0fb0\u6c1f\u7397\u0db4\u6a76\u5b2a\ue00b\u{1fe7e}\u{1f752}',
+code: `@group(0) @binding(3927)
+var<storage, read_write> field11: array<u32>;
+@group(1) @binding(3927)
+var<storage, read_write> global9: array<u32>;
+
+@compute @workgroup_size(8, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S19 {
+  @location(55) f0: u32,
+  @location(68) f1: u32,
+  @location(14) f2: vec2<f32>,
+  @location(22) f3: vec2<u32>,
+  @builtin(sample_mask) f4: u32,
+  @location(99) f5: vec3<u32>,
+  @location(94) f6: vec3<u32>,
+  @location(33) f7: f32,
+  @location(65) f8: u32,
+  @location(35) f9: vec2<f32>,
+  @location(77) f10: vec4<f16>,
+  @location(84) f11: u32,
+  @location(13) f12: vec4<f32>,
+  @location(34) f13: vec3<f32>,
+  @location(1) f14: vec2<f16>,
+  @location(67) f15: vec2<f32>,
+  @location(88) f16: u32,
+  @location(93) f17: vec3<f32>,
+  @location(52) f18: f32,
+  @location(72) f19: vec4<i32>,
+  @location(80) f20: vec4<f16>,
+  @location(23) f21: f16,
+  @location(96) f22: vec3<f32>,
+  @location(102) f23: vec2<u32>,
+  @location(83) f24: vec2<f32>,
+  @location(38) f25: vec4<f32>,
+  @location(48) f26: f16,
+  @location(11) f27: f16,
+  @location(54) f28: vec2<i32>,
+  @location(8) f29: vec3<f32>,
+  @location(3) f30: vec2<f32>,
+  @location(15) f31: vec2<u32>,
+  @builtin(sample_index) f32: u32
+}
+struct FragmentOutput0 {
+  @builtin(frag_depth) f0: f32,
+  @location(6) f1: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(75) a0: vec4<f16>, @location(61) a1: i32, @builtin(position) a2: vec4<f32>, @location(71) a3: i32, @location(25) a4: vec4<u32>, @location(85) a5: vec2<f16>, @builtin(front_facing) a6: bool, a7: S19, @location(30) a8: i32, @location(41) a9: vec3<u32>, @location(81) a10: vec2<f16>, @location(76) a11: vec2<u32>, @location(2) a12: vec3<i32>, @location(28) a13: f16, @location(47) a14: vec3<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(85) f141: vec2<f16>,
+  @location(65) f142: u32,
+  @location(76) f143: vec2<u32>,
+  @location(23) f144: f16,
+  @location(28) f145: f16,
+  @builtin(position) f146: vec4<f32>,
+  @location(88) f147: u32,
+  @location(22) f148: vec2<u32>,
+  @location(38) f149: vec4<f32>,
+  @location(35) f150: vec2<f32>,
+  @location(55) f151: u32,
+  @location(94) f152: vec3<u32>,
+  @location(71) f153: i32,
+  @location(72) f154: vec4<i32>,
+  @location(1) f155: vec2<f16>,
+  @location(2) f156: vec3<i32>,
+  @location(30) f157: i32,
+  @location(54) f158: vec2<i32>,
+  @location(47) f159: vec3<f32>,
+  @location(41) f160: vec3<u32>,
+  @location(34) f161: vec3<f32>,
+  @location(11) f162: f16,
+  @location(99) f163: vec3<u32>,
+  @location(77) f164: vec4<f16>,
+  @location(93) f165: vec3<f32>,
+  @location(8) f166: vec3<f32>,
+  @location(96) f167: vec3<f32>,
+  @location(61) f168: i32,
+  @location(15) f169: vec2<u32>,
+  @location(68) f170: u32,
+  @location(33) f171: f32,
+  @location(48) f172: f16,
+  @location(102) f173: vec2<u32>,
+  @location(84) f174: u32,
+  @location(67) f175: vec2<f32>,
+  @location(83) f176: vec2<f32>,
+  @location(52) f177: f32,
+  @location(81) f178: vec2<f16>,
+  @location(75) f179: vec4<f16>,
+  @location(80) f180: vec4<f16>,
+  @location(25) f181: vec4<u32>,
+  @location(14) f182: vec2<f32>,
+  @location(13) f183: vec4<f32>,
+  @location(3) f184: vec2<f32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(13) a1: f16, @location(9) a2: vec3<f32>, @location(15) a3: f16, @location(12) a4: vec2<f32>, @location(0) a5: vec2<i32>, @location(4) a6: vec3<u32>, @location(14) a7: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let textureView70 = texture62.createView({label: '\ucd20\ud686\u{1f814}\ubbdf\u4e1a\u08a1'});
+let externalTexture8 = device4.importExternalTexture({
+label: '\u0c32\u6357\ub2d6\u{1f824}\u0de2\u0e3d\u7899\ued0a\u{1fd4f}',
+source: videoFrame14,
+colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder61.setBindGroup(3, bindGroup25, new Uint32Array(8999), 4348, 0);
+} catch {}
+try {
+renderBundleEncoder61.drawIndexed(40);
+} catch {}
+try {
+renderBundleEncoder61.drawIndirect(buffer23, 76);
+} catch {}
+try {
+renderBundleEncoder61.setPipeline(pipeline49);
+} catch {}
+try {
+renderBundleEncoder61.setVertexBuffer(42, undefined, 829129087);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer2), /* required buffer size: 520 */
+{offset: 468}, {width: 26, height: 1, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let imageBitmap13 = await createImageBitmap(offscreenCanvas7);
+try {
+adapter6.label = '\u{1ff66}\uf16e\u0e93\u803d\udd70\uc25d\u13f7\ub1fc\u09f4\u63bd\u2fff';
+} catch {}
+document.body.prepend(video8);
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let device5 = await adapter4.requestDevice({
+label: '\u{1f92a}\u4725\u65ef\u9e94\uf867\u5b0d\u9609\u{1f961}\u9bbf\u0c78',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-astc',
+'shader-f16',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 9,
+maxColorAttachmentBytesPerSample: 57,
+maxVertexAttributes: 17,
+maxVertexBufferArrayStride: 31493,
+maxStorageTexturesPerShaderStage: 23,
+maxStorageBuffersPerShaderStage: 10,
+maxDynamicStorageBuffersPerPipelineLayout: 52393,
+maxBindingsPerBindGroup: 7262,
+maxTextureDimension1D: 8863,
+maxTextureDimension2D: 16091,
+maxVertexBuffers: 12,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 165089198,
+maxUniformBuffersPerShaderStage: 17,
+maxInterStageShaderVariables: 119,
+maxInterStageShaderComponents: 89,
+maxSamplersPerShaderStage: 20,
+},
+});
+let renderBundleEncoder63 = device0.createRenderBundleEncoder({
+  label: '\udc07\ua1a2\u{1fe4e}\u2737\uae14\u0dbf\u2ae9\u442d\u07b8\u7689',
+  colorFormats: ['rgb10a2uint', 'rgba32uint', 'rg32sint', 'rg16uint', 'rg16sint', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: false,
+  stencilReadOnly: false
+});
+let renderBundle63 = renderBundleEncoder58.finish({label: '\u077f\u387a\u04c5'});
+try {
+renderPassEncoder5.drawIndexed(40, 80, 24, 616, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer1, 79192);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(8, buffer13, 23544, 2589);
+} catch {}
+try {
+renderBundleEncoder40.draw(40, 32, 16, 56);
+} catch {}
+try {
+renderBundleEncoder37.drawIndexed(0, 24, 64, 152, 64);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(8, buffer11);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 240, height: 32, depthOrArrayLayers: 1971}
+*/
+{
+  source: imageData0,
+  origin: { x: 177, y: 113 },
+  flipY: false,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: { x: 120, y: 8, z: 464 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 58, height: 19, depthOrArrayLayers: 1});
+} catch {}
+let renderBundle64 = renderBundleEncoder26.finish();
+try {
+computePassEncoder21.setBindGroup(8, bindGroup12);
+} catch {}
+try {
+computePassEncoder22.setBindGroup(3, bindGroup21, new Uint32Array(4442), 294, 0);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline53);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(4, bindGroup24);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(165, 6, 28, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(64);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer6, 30672);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(4, bindGroup27);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer28, 9000);
+} catch {}
+try {
+commandEncoder9.copyBufferToBuffer(buffer2, 54936, buffer5, 4160, 2192);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+gpuCanvasContext12.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let bindGroupLayout25 = device5.createBindGroupLayout({
+label: '\u{1f667}\u{1fed7}\u{1f657}\u0060\u6c7d\u6fdf',
+entries: [{
+binding: 1407,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}],
+});
+let pipelineLayout15 = device5.createPipelineLayout({
+  label: '\u{1fa1e}\u5ef9\u44fa\u{1f8c1}\u554d\u45b7\u{1f8dd}',
+  bindGroupLayouts: [bindGroupLayout25, bindGroupLayout25, bindGroupLayout25, bindGroupLayout25]
+});
+let buffer31 = device5.createBuffer({
+  size: 50836,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true
+});
+let commandEncoder41 = device5.createCommandEncoder();
+let texture79 = device5.createTexture({
+label: '\u6743\u{1fd5e}',
+size: {width: 1728, height: 240, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'astc-12x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture80 = gpuCanvasContext1.getCurrentTexture();
+try {
+  await promise40;
+} catch {}
+let sampler48 = device4.createSampler({
+label: '\ude08\u{1f733}\u{1f91f}\u0c8a',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 44.314,
+lodMaxClamp: 60.525,
+compare: 'less',
+});
+try {
+renderBundleEncoder61.draw(8, 72, 48, 48);
+} catch {}
+try {
+renderBundleEncoder61.drawIndexed(24, 40, 16);
+} catch {}
+try {
+renderBundleEncoder61.drawIndirect(buffer23, 420);
+} catch {}
+let gpuCanvasContext13 = canvas15.getContext('webgpu');
+offscreenCanvas3.width = 60;
+let texture81 = device5.createTexture({
+size: [216, 30, 1],
+mipLevelCount: 7,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm'],
+});
+try {
+commandEncoder41.insertDebugMarker('\u7682');
+} catch {}
+try {
+adapter4.label = '\u0fb3\u0667\uffb1\ub77d\ude77\u{1ff47}\u0e9c\u3d9a\ued35';
+} catch {}
+try {
+offscreenCanvas15.getContext('webgl');
+} catch {}
+let offscreenCanvas16 = new OffscreenCanvas(1019, 773);
+let bindGroup30 = device4.createBindGroup({
+label: '\u97e2\u558d\u06b0\u4016\u0b8b\ufebc\u02e9\u4c02\u06fb\u711e',
+layout: bindGroupLayout22,
+entries: [{
+binding: 3927,
+resource: {
+buffer: buffer27,
+offset: 32384,
+size: 1596,
+}
+}],
+});
+let commandEncoder42 = device4.createCommandEncoder({label: '\u{1fb99}\u8a38\ud31f\u0dc2\u2ebe\ud209'});
+let texture82 = device4.createTexture({
+label: '\u03d8\u{1f990}\u9f6c\u{1f812}\u4609\u01f3\u9e74',
+size: {width: 680, height: 240, depthOrArrayLayers: 167},
+mipLevelCount: 2,
+format: 'astc-5x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-5x4-unorm-srgb'],
+});
+let computePassEncoder27 = commandEncoder40.beginComputePass({label: '\u07fd\ucda8\u7f79\ue3fb\u0dcb\ub0cd\u{1fd74}\u{1f7ce}'});
+let renderBundle65 = renderBundleEncoder52.finish();
+try {
+renderBundleEncoder61.draw(24, 0, 64);
+} catch {}
+try {
+renderBundleEncoder61.drawIndexed(56, 0);
+} catch {}
+try {
+renderBundleEncoder61.setVertexBuffer(84, undefined);
+} catch {}
+try {
+computePassEncoder24.insertDebugMarker('\u0614');
+} catch {}
+let pipeline60 = await device4.createComputePipelineAsync({
+layout: pipelineLayout12,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let gpuCanvasContext14 = canvas14.getContext('webgpu');
+let texture83 = device0.createTexture({
+label: '\ud1fd\u8950\u0df6\uf462\u{1f6ea}\ubcfa\u03aa\u0d3f\u08ed',
+size: {width: 480, height: 36, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'astc-12x12-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundle66 = renderBundleEncoder19.finish({label: '\u{1fb15}\u0d19\u99de\u0fbe\uc9b8\ud725\u{1fce0}\u29b2\u0f40'});
+let sampler49 = device0.createSampler({
+label: '\u0160\u0ca2\u08c1\u{1fd8b}\u0013\u9cfa\u2d6a\u0cf5\uae0a\u0f61\uc707',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMaxClamp: 49.858,
+compare: 'greater-equal',
+});
+try {
+renderPassEncoder5.setScissorRect(145, 14, 16, 3);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer21, 66120);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer16, 52664);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(2, buffer13, 4016, 2052);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(16, 72);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer21, 35600);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer0, 'uint32', 19760, 23897);
+} catch {}
+try {
+commandEncoder36.copyBufferToBuffer(buffer14, 1480, buffer13, 3120, 3472);
+dissociateBuffer(device0, buffer14);
+dissociateBuffer(device0, buffer13);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer5,
+]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 24 },
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 2075648 */
+{offset: 806, bytesPerRow: 499, rowsPerImage: 297}, {width: 232, height: 0, depthOrArrayLayers: 15});
+} catch {}
+let bindGroup31 = device0.createBindGroup({
+label: '\u695d\ucb76\u8c37\u{1feaa}\ue7d8\ue635\u4781\u4e4e\u0043\ue825\u04c5',
+layout: bindGroupLayout4,
+entries: [],
+});
+let commandBuffer6 = commandEncoder37.finish({
+});
+let textureView71 = texture55.createView({
+  label: '\u0b8b\u0cf0\ue0af\u22aa\ub81d\uc511\u345b',
+  baseMipLevel: 2,
+  mipLevelCount: 6,
+  baseArrayLayer: 1,
+  arrayLayerCount: 3
+});
+let computePassEncoder28 = commandEncoder39.beginComputePass({label: '\u6cb7\u4a59\u01e3\ufc66\uc528\u{1f71c}\u{1fce6}\u3409\uc8b1\u5532\u{1f7a4}'});
+try {
+renderPassEncoder5.beginOcclusionQuery(981);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(56, 64, 64, 624);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(7, bindGroup26, new Uint32Array(7084), 1243, 0);
+} catch {}
+try {
+renderBundleEncoder45.draw(56);
+} catch {}
+let promise41 = device0.createRenderPipelineAsync({
+label: '\u0500\ua1dc\u3436',
+layout: pipelineLayout2,
+multisample: {
+count: 4,
+mask: 0x28102fd7,
+},
+fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8sint', writeMask: 0}, {format: 'rg32uint', writeMask: 0}, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'add', srcFactor: 'src', dstFactor: 'one-minus-src'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {format: 'r32uint'}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8sint', writeMask: 0}]
+},
+vertex: {
+  module: shaderModule9,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32',
+offset: 6440,
+shaderLocation: 12,
+}, {
+format: 'uint32x4',
+offset: 1860,
+shaderLocation: 16,
+}, {
+format: 'uint8x4',
+offset: 1140,
+shaderLocation: 15,
+}, {
+format: 'uint8x4',
+offset: 28060,
+shaderLocation: 1,
+}, {
+format: 'uint32',
+offset: 13184,
+shaderLocation: 7,
+}, {
+format: 'sint32x2',
+offset: 29364,
+shaderLocation: 3,
+}, {
+format: 'snorm8x4',
+offset: 21740,
+shaderLocation: 4,
+}, {
+format: 'uint32x4',
+offset: 1124,
+shaderLocation: 18,
+}, {
+format: 'sint8x4',
+offset: 18732,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 4456,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 24736,
+attributes: [],
+},
+{
+arrayStride: 148,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x4',
+offset: 44,
+shaderLocation: 13,
+}, {
+format: 'sint16x4',
+offset: 24,
+shaderLocation: 8,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+let promise42 = adapter2.requestAdapterInfo();
+let commandEncoder43 = device5.createCommandEncoder({label: '\u01fa\u39e6\u81cc\uc358\uc741\u1134\u0ace\u5e90'});
+let img23 = await imageWithData(150, 216, '#7fdeb283', '#1ca24889');
+let offscreenCanvas17 = new OffscreenCanvas(665, 702);
+let texture84 = device5.createTexture({
+label: '\u08c2\u7862\u159f\u98b3\u0723\u05f5\u82b0\u0a96\u0d7a',
+size: {width: 2221, height: 32, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView72 = texture81.createView({
+  label: '\u95ae\u0ed7\u{1f894}\u{1fcec}\u5c2e\u76e6',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+  mipLevelCount: 1
+});
+let arrayBuffer7 = buffer31.getMappedRange(2496);
+try {
+device5.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 5,
+  origin: { x: 36, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(600), /* required buffer size: 600 */
+{offset: 584, bytesPerRow: 176, rowsPerImage: 72}, {width: 12, height: 10, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(video8);
+video2.height = 21;
+let shaderModule18 = device5.createShaderModule({
+label: '\u85dd\u0a2d\u023c',
+code: `@group(3) @binding(1407)
+var<storage, read_write> global10: array<u32>;
+@group(1) @binding(1407)
+var<storage, read_write> type14: array<u32>;
+@group(2) @binding(1407)
+var<storage, read_write> global11: array<u32>;
+
+@compute @workgroup_size(3, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: f32,
+  @location(2) f1: vec4<u32>,
+  @builtin(sample_mask) f2: u32,
+  @builtin(frag_depth) f3: f32,
+  @location(1) f4: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(7) a0: u32, @location(12) a1: vec2<f32>, @location(5) a2: vec3<f32>, @location(14) a3: vec4<f32>, @location(11) a4: vec3<u32>, @location(6) a5: vec3<i32>, @location(16) a6: vec4<f16>, @location(4) a7: u32, @location(3) a8: vec2<f32>, @location(2) a9: vec3<i32>, @location(13) a10: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+let textureView73 = texture84.createView({label: '\u0ea5\u0915\u34b7\u0278', dimension: '2d-array', baseMipLevel: 4, mipLevelCount: 2});
+try {
+gpuCanvasContext12.configure({
+device: device5,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device5.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 707 */
+{offset: 707}, {width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline61 = await device5.createComputePipelineAsync({
+label: '\u7a59\ue785\u026f\ufff8\u2a1c\u078b',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule18,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let videoFrame16 = new VideoFrame(videoFrame7, {timestamp: 0});
+let commandEncoder44 = device5.createCommandEncoder({label: '\uc48b\u85ea\u0659\u05a1\u0277\u6a78\ud74a\ub234'});
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture84,
+  mipLevel: 0,
+  origin: { x: 2129, y: 26, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture84,
+  mipLevel: 5,
+  origin: { x: 18, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 45, height: 0, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(img4);
+let commandEncoder45 = device1.createCommandEncoder();
+offscreenCanvas0.width = 714;
+try {
+offscreenCanvas16.getContext('webgpu');
+} catch {}
+try {
+window.someLabel = computePassEncoder18.label;
+} catch {}
+let gpuCanvasContext15 = offscreenCanvas17.getContext('webgpu');
+gc();
+let imageBitmap14 = await createImageBitmap(imageBitmap1);
+let videoFrame17 = new VideoFrame(video18, {timestamp: 0});
+canvas13.height = 464;
+gc();
+video4.width = 59;
+let shaderModule19 = device5.createShaderModule({
+label: '\u931e\u{1fa9e}\u09ae',
+code: `@group(1) @binding(1407)
+var<storage, read_write> i8: array<u32>;
+@group(0) @binding(1407)
+var<storage, read_write> field12: array<u32>;
+@group(3) @binding(1407)
+var<storage, read_write> local9: array<u32>;
+
+@compute @workgroup_size(8, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<u32>,
+  @location(1) f1: vec3<u32>,
+  @builtin(frag_depth) f2: f32,
+  @location(3) f3: f32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S20 {
+  @location(14) f0: vec4<u32>,
+  @location(1) f1: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(16) a0: vec2<f32>, @location(7) a1: vec2<u32>, @location(4) a2: vec4<i32>, @location(8) a3: vec2<f32>, @location(11) a4: vec3<i32>, @location(13) a5: f16, @location(0) a6: vec2<i32>, @location(12) a7: vec2<f16>, @builtin(vertex_index) a8: u32, a9: S20, @location(10) a10: f16, @location(6) a11: vec3<f16>, @location(5) a12: vec3<u32>, @location(9) a13: f16, @location(2) a14: vec4<i32>, @location(3) a15: vec2<f32>, @location(15) a16: vec3<f32>, @builtin(instance_index) a17: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandBuffer7 = commandEncoder43.finish({
+label: '\uc152\u3e0d\u{1fb42}\u0ddf\u53f2\u3050\u{1fe92}\uee18',
+});
+let texture85 = device5.createTexture({
+size: {width: 864},
+dimension: '1d',
+format: 'rg32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture86 = gpuCanvasContext1.getCurrentTexture();
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture84,
+  mipLevel: 3,
+  origin: { x: 107, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture84,
+  mipLevel: 2,
+  origin: { x: 228, y: 2, z: 0 },
+  aspect: 'all',
+}, {width: 71, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let pipeline62 = await device5.createRenderPipelineAsync({
+label: '\ue8b4\ue63b',
+layout: pipelineLayout15,
+multisample: {
+count: 4,
+mask: 0xc935d037,
+},
+fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [undefined, {format: 'rg32uint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r8unorm', writeMask: GPUColorWrite.ALL}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 3230,
+stencilWriteMask: 2972,
+depthBiasSlopeScale: 23,
+depthBiasClamp: 76,
+},
+vertex: {
+  module: shaderModule19,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 21116,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x2',
+offset: 14212,
+shaderLocation: 8,
+}, {
+format: 'unorm16x2',
+offset: 8948,
+shaderLocation: 6,
+}, {
+format: 'unorm8x2',
+offset: 3938,
+shaderLocation: 12,
+}, {
+format: 'snorm16x2',
+offset: 14996,
+shaderLocation: 13,
+}, {
+format: 'uint32x2',
+offset: 4228,
+shaderLocation: 14,
+}, {
+format: 'snorm16x4',
+offset: 12692,
+shaderLocation: 15,
+}, {
+format: 'sint32x2',
+offset: 13180,
+shaderLocation: 1,
+}, {
+format: 'sint32x2',
+offset: 17772,
+shaderLocation: 11,
+}, {
+format: 'sint16x2',
+offset: 13424,
+shaderLocation: 4,
+}, {
+format: 'sint16x4',
+offset: 12564,
+shaderLocation: 2,
+}, {
+format: 'uint32',
+offset: 6904,
+shaderLocation: 7,
+}, {
+format: 'snorm16x4',
+offset: 4588,
+shaderLocation: 16,
+}, {
+format: 'unorm16x4',
+offset: 18900,
+shaderLocation: 10,
+}, {
+format: 'uint32',
+offset: 5032,
+shaderLocation: 5,
+}, {
+format: 'unorm16x4',
+offset: 12720,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 7212,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 4684,
+shaderLocation: 9,
+}, {
+format: 'sint8x2',
+offset: 3122,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let renderBundle67 = renderBundleEncoder54.finish({});
+try {
+renderBundleEncoder61.drawIndirect(buffer23, 320);
+} catch {}
+try {
+commandEncoder42.copyTextureToTexture({
+  texture: texture82,
+  mipLevel: 1,
+  origin: { x: 130, y: 24, z: 146 },
+  aspect: 'all',
+}, {
+  texture: texture82,
+  mipLevel: 0,
+  origin: { x: 265, y: 100, z: 74 },
+  aspect: 'all',
+}, {width: 185, height: 88, depthOrArrayLayers: 6});
+} catch {}
+let pipeline63 = device4.createComputePipeline({
+label: '\u652a\u{1f78b}\u423f\u32e3\ue0dc\u2e5d\u06af\u073f',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+document.body.prepend(video12);
+try {
+window.someLabel = device3.queue.label;
+} catch {}
+let imageData13 = new ImageData(160, 20);
+let textureView74 = texture27.createView({format: 'astc-8x5-unorm-srgb', mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder29 = commandEncoder36.beginComputePass({});
+try {
+renderPassEncoder5.drawIndirect(buffer26, 565784);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(8, buffer13, 16668, 10727);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(6, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder45.draw(40, 56, 40);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(4, buffer6, 2312, 8062);
+} catch {}
+try {
+commandEncoder9.copyBufferToTexture({
+/* bytesInLastRow: 208 widthInBlocks: 26 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 3944 */
+offset: 3944,
+bytesPerRow: 256,
+buffer: buffer4,
+}, {
+  texture: texture41,
+  mipLevel: 1,
+  origin: { x: 248, y: 12, z: 0 },
+  aspect: 'all',
+}, {width: 104, height: 16, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder9.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 2,
+  origin: { x: 50, y: 12, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture22,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder26.resolveQuerySet(querySet14, 1116, 63, buffer6, 1536);
+} catch {}
+try {
+computePassEncoder28.insertDebugMarker('\u{1faae}');
+} catch {}
+try {
+gpuCanvasContext7.configure({
+device: device0,
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+let renderBundleEncoder64 = device0.createRenderBundleEncoder({
+  colorFormats: ['r32float', 'rgba32float', 'bgra8unorm-srgb', 'rgba8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+renderPassEncoder6.setBlendConstant({ r: -348.7, g: -69.80, b: 890.6, a: -284.1, });
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder45.draw(48, 32, 56, 48);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(7, buffer6, 10436, 4878);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let canvas16 = document.createElement('canvas');
+gc();
+pseudoSubmit(device5, commandEncoder44);
+let renderBundleEncoder65 = device5.createRenderBundleEncoder({
+  label: '\ud0d5\u{1f9ff}',
+  colorFormats: [undefined, 'rg32uint', 'rgba8uint', 'r8unorm', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let sampler50 = device5.createSampler({
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 99.347,
+lodMaxClamp: 99.632,
+});
+let promise43 = device5.createComputePipelineAsync({
+layout: pipelineLayout15,
+compute: {
+module: shaderModule19,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+  await promise42;
+} catch {}
+document.body.prepend(img18);
+let video20 = await videoWithData();
+let video21 = await videoWithData();
+try {
+canvas16.getContext('webgl2');
+} catch {}
+let video22 = await videoWithData();
+let videoFrame18 = new VideoFrame(videoFrame11, {timestamp: 0});
+let texture87 = device4.createTexture({
+label: '\u4d95\u{1fc07}\u{1fb2b}\ufc6e\u{1f881}\u7b5b',
+size: [240, 160, 502],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture88 = gpuCanvasContext12.getCurrentTexture();
+let sampler51 = device4.createSampler({
+label: '\ufe4e\ue25a\u110f\ubde5\ue302\u08e0\u66b7',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 52.687,
+lodMaxClamp: 57.657,
+maxAnisotropy: 16,
+});
+try {
+renderBundleEncoder61.drawIndirect(buffer23, 2776);
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+let promise44 = device4.createRenderPipelineAsync({
+label: '\u42fa\u81be\u{1fd9b}\ud0de',
+layout: pipelineLayout11,
+multisample: {
+count: 4,
+},
+fragment: {module: shaderModule17, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'never',
+failOp: 'zero',
+depthFailOp: 'increment-wrap',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 109,
+stencilWriteMask: 3655,
+depthBiasClamp: 40,
+},
+vertex: {
+  module: shaderModule17,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 9732,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32',
+offset: 5600,
+shaderLocation: 14,
+}, {
+format: 'float16x2',
+offset: 9300,
+shaderLocation: 12,
+}, {
+format: 'float32x2',
+offset: 7200,
+shaderLocation: 9,
+}, {
+format: 'uint16x4',
+offset: 8352,
+shaderLocation: 4,
+}, {
+format: 'snorm8x4',
+offset: 3032,
+shaderLocation: 13,
+}, {
+format: 'float16x4',
+offset: 9412,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 316,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32',
+offset: 248,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let canvas17 = document.createElement('canvas');
+let gpuCanvasContext16 = canvas17.getContext('webgpu');
+let adapter11 = await promise37;
+let bindGroupLayout26 = device4.createBindGroupLayout({
+entries: [{
+binding: 141,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+}],
+});
+let textureView75 = texture76.createView({dimension: '2d', baseMipLevel: 3, baseArrayLayer: 21});
+try {
+computePassEncoder27.setPipeline(pipeline60);
+} catch {}
+try {
+renderBundleEncoder61.draw(72, 0);
+} catch {}
+try {
+renderBundleEncoder61.drawIndirect(buffer23, 524);
+} catch {}
+try {
+buffer27.destroy();
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: { x: 3, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 556 */
+{offset: 556, rowsPerImage: 43}, {width: 9, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 297, y: 405 },
+  flipY: false,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline64 = await device4.createComputePipelineAsync({
+label: '\u{1fc62}\ub474\uc714\ucf1d\u08b2\u033e\u30ad',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule17,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let shaderModule20 = device4.createShaderModule({
+label: '\u0464\u07c6\u0ea5\u2b0f\ua2ab\u{1fd00}\uc6ac\u1928\u9f69\u0fd4\u0384',
+code: `@group(1) @binding(3927)
+var<storage, read_write> field13: array<u32>;
+@group(0) @binding(3927)
+var<storage, read_write> type15: array<u32>;
+@group(2) @binding(3927)
+var<storage, read_write> function7: array<u32>;
+
+@compute @workgroup_size(5, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S21 {
+  @location(69) f0: f32,
+  @location(12) f1: vec4<f32>,
+  @location(82) f2: vec3<u32>,
+  @location(92) f3: vec2<u32>,
+  @location(74) f4: vec4<f32>,
+  @location(0) f5: vec3<i32>,
+  @location(97) f6: vec3<u32>,
+  @location(35) f7: f16,
+  @location(77) f8: vec3<f32>,
+  @location(91) f9: vec3<f32>,
+  @location(21) f10: vec2<u32>,
+  @location(87) f11: f32,
+  @location(4) f12: f16,
+  @location(59) f13: vec3<u32>,
+  @location(32) f14: vec2<u32>,
+  @location(66) f15: vec4<f16>,
+  @location(28) f16: vec2<i32>,
+  @location(62) f17: vec4<i32>,
+  @location(93) f18: vec4<f32>,
+  @location(54) f19: vec4<i32>,
+  @location(102) f20: f32,
+  @builtin(front_facing) f21: bool,
+  @location(44) f22: vec4<f16>,
+  @location(13) f23: u32,
+  @location(22) f24: vec4<u32>,
+  @location(83) f25: vec2<f32>,
+  @location(94) f26: vec3<f16>,
+  @location(80) f27: vec4<f16>,
+  @location(18) f28: vec2<u32>,
+  @location(24) f29: f16,
+  @location(19) f30: u32,
+  @location(23) f31: vec3<i32>,
+  @location(95) f32: vec2<i32>,
+  @location(56) f33: vec2<f16>,
+  @location(34) f34: vec4<u32>,
+  @builtin(sample_index) f35: u32,
+  @location(58) f36: vec2<f32>,
+  @location(103) f37: u32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, a1: S21, @location(15) a2: vec4<f32>, @builtin(position) a3: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(21) f185: vec2<u32>,
+  @location(23) f186: vec3<i32>,
+  @builtin(position) f187: vec4<f32>,
+  @location(58) f188: vec2<f32>,
+  @location(82) f189: vec3<u32>,
+  @location(4) f190: f16,
+  @location(94) f191: vec3<f16>,
+  @location(12) f192: vec4<f32>,
+  @location(80) f193: vec4<f16>,
+  @location(28) f194: vec2<i32>,
+  @location(91) f195: vec3<f32>,
+  @location(93) f196: vec4<f32>,
+  @location(44) f197: vec4<f16>,
+  @location(62) f198: vec4<i32>,
+  @location(35) f199: f16,
+  @location(13) f200: u32,
+  @location(92) f201: vec2<u32>,
+  @location(15) f202: vec4<f32>,
+  @location(97) f203: vec3<u32>,
+  @location(83) f204: vec2<f32>,
+  @location(87) f205: f32,
+  @location(56) f206: vec2<f16>,
+  @location(66) f207: vec4<f16>,
+  @location(69) f208: f32,
+  @location(24) f209: f16,
+  @location(32) f210: vec2<u32>,
+  @location(0) f211: vec3<i32>,
+  @location(34) f212: vec4<u32>,
+  @location(102) f213: f32,
+  @location(77) f214: vec3<f32>,
+  @location(54) f215: vec4<i32>,
+  @location(22) f216: vec4<u32>,
+  @location(18) f217: vec2<u32>,
+  @location(59) f218: vec3<u32>,
+  @location(74) f219: vec4<f32>,
+  @location(103) f220: u32,
+  @location(95) f221: vec2<i32>,
+  @location(19) f222: u32
+}
+
+@vertex
+fn vertex0(@location(4) a0: vec4<f32>, @builtin(instance_index) a1: u32, @location(8) a2: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let pipelineLayout16 = device4.createPipelineLayout({bindGroupLayouts: []});
+pseudoSubmit(device4, commandEncoder40);
+let computePassEncoder30 = commandEncoder42.beginComputePass();
+try {
+renderBundleEncoder61.draw(32, 40, 40);
+} catch {}
+try {
+renderBundleEncoder61.drawIndexed(0, 56, 8, 16, 72);
+} catch {}
+let pipeline65 = await device4.createComputePipelineAsync({
+label: '\u1eab\ucd4b\u52aa\u0454\u038b\ue368\u01d2\u06d2',
+layout: pipelineLayout12,
+compute: {
+module: shaderModule20,
+entryPoint: 'compute0',
+},
+});
+gc();
+video17.width = 81;
+offscreenCanvas10.width = 845;
+let video23 = await videoWithData();
+let shaderModule21 = device0.createShaderModule({
+label: '\u0635\uf9a8\u{1fd70}\u0cce\u{1fd1b}\u7280\u01d8',
+code: `@group(2) @binding(302)
+var<storage, read_write> global12: array<u32>;
+
+@compute @workgroup_size(6, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S23 {
+  @location(36) f0: vec2<f32>,
+  @location(84) f1: vec3<u32>,
+  @location(63) f2: vec4<f16>,
+  @builtin(front_facing) f3: bool,
+  @location(68) f4: vec2<i32>,
+  @location(65) f5: vec3<f16>,
+  @location(6) f6: vec4<f16>,
+  @location(13) f7: vec4<i32>,
+  @location(76) f8: vec2<i32>,
+  @location(66) f9: vec4<i32>,
+  @location(43) f10: vec3<f16>,
+  @location(44) f11: i32
+}
+struct FragmentOutput0 {
+  @location(5) f0: vec4<i32>,
+  @location(0) f1: vec2<i32>,
+  @location(1) f2: vec4<u32>,
+  @builtin(frag_depth) f3: f32,
+  @location(4) f4: i32,
+  @location(3) f5: u32,
+  @location(2) f6: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(22) a0: f16, @location(0) a1: vec3<i32>, @location(25) a2: vec2<i32>, @builtin(sample_mask) a3: u32, @location(17) a4: vec4<f16>, @location(78) a5: vec2<u32>, @location(7) a6: vec4<i32>, @location(45) a7: i32, @location(60) a8: vec3<f32>, @location(21) a9: vec2<i32>, @location(4) a10: i32, a11: S23, @location(50) a12: vec4<i32>, @location(79) a13: vec4<i32>, @location(54) a14: vec2<u32>, @builtin(position) a15: vec4<f32>, @location(62) a16: vec3<f32>, @location(29) a17: vec2<u32>, @location(31) a18: vec2<f16>, @location(28) a19: f32, @location(69) a20: vec3<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S22 {
+  @location(23) f0: f16,
+  @location(1) f1: f32,
+  @location(5) f2: vec4<i32>,
+  @location(2) f3: i32,
+  @location(21) f4: f32,
+  @location(14) f5: vec4<f32>,
+  @location(19) f6: vec4<f32>,
+  @builtin(vertex_index) f7: u32,
+  @location(12) f8: vec4<i32>,
+  @location(0) f9: vec4<i32>,
+  @location(13) f10: vec2<f16>,
+  @location(24) f11: vec2<i32>,
+  @builtin(instance_index) f12: u32,
+  @location(6) f13: vec3<i32>
+}
+struct VertexOutput0 {
+  @location(55) f223: vec3<f16>,
+  @location(13) f224: vec4<i32>,
+  @location(4) f225: i32,
+  @location(43) f226: vec3<f16>,
+  @location(79) f227: vec4<i32>,
+  @location(78) f228: vec2<u32>,
+  @location(44) f229: i32,
+  @location(60) f230: vec3<f32>,
+  @location(29) f231: vec2<u32>,
+  @location(28) f232: f32,
+  @builtin(position) f233: vec4<f32>,
+  @location(63) f234: vec4<f16>,
+  @location(77) f235: vec4<i32>,
+  @location(47) f236: u32,
+  @location(62) f237: vec3<f32>,
+  @location(17) f238: vec4<f16>,
+  @location(6) f239: vec4<f16>,
+  @location(36) f240: vec2<f32>,
+  @location(25) f241: vec2<i32>,
+  @location(45) f242: i32,
+  @location(65) f243: vec3<f16>,
+  @location(31) f244: vec2<f16>,
+  @location(7) f245: vec4<i32>,
+  @location(0) f246: vec3<i32>,
+  @location(21) f247: vec2<i32>,
+  @location(50) f248: vec4<i32>,
+  @location(66) f249: vec4<i32>,
+  @location(84) f250: vec3<u32>,
+  @location(69) f251: vec3<f32>,
+  @location(22) f252: f16,
+  @location(68) f253: vec2<i32>,
+  @location(76) f254: vec2<i32>,
+  @location(54) f255: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(22) a0: vec2<u32>, @location(9) a1: vec4<u32>, a2: S22, @location(10) a3: vec3<u32>, @location(15) a4: vec4<i32>, @location(18) a5: vec2<i32>, @location(20) a6: vec2<i32>, @location(3) a7: vec2<i32>, @location(4) a8: vec3<f16>, @location(17) a9: vec4<f16>, @location(8) a10: vec3<u32>, @location(16) a11: vec4<u32>, @location(11) a12: vec4<f32>, @location(7) a13: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let texture89 = device0.createTexture({
+label: '\uffb2\u065d\u0597\u0b6c\u3045\u0ca7\ud09b\u6524\u5314',
+size: {width: 120, height: 9, depthOrArrayLayers: 1933},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder37.drawIndexed(32, 72, 72, 496, 8);
+} catch {}
+let promise45 = device0.popErrorScope();
+try {
+commandEncoder26.clearBuffer(buffer5, 17888, 11932);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 3,
+  origin: { x: 264, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 1095019 */
+{offset: 37, bytesPerRow: 174, rowsPerImage: 203}, {width: 48, height: 0, depthOrArrayLayers: 32});
+} catch {}
+let pipeline66 = device0.createComputePipeline({
+label: '\u{1f600}\u6205\uf6aa\u045a\ud6da\u1f94\uc437\u0a02',
+layout: pipelineLayout8,
+compute: {
+module: shaderModule13,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let img24 = await imageWithData(240, 216, '#90fb215c', '#6613a667');
+let commandEncoder46 = device5.createCommandEncoder({label: '\u{1f97d}\u039d\u9465\uc688\u{1f8c4}\u{1f815}\u{1fa49}\u516e'});
+let querySet55 = device5.createQuerySet({
+label: '\u4c13\u01f8\u7ead\uad22\u0d48\u0473',
+type: 'occlusion',
+count: 1947,
+});
+let texture90 = device5.createTexture({
+label: '\u4cad\u{1f7d2}\ud32f\u7ead\uff52\u0c19\u6049\u0454\u037f\u9a2a\u04f0',
+size: {width: 432, height: 60, depthOrArrayLayers: 1},
+mipLevelCount: 9,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-12x12-unorm', 'astc-12x12-unorm', 'astc-12x12-unorm'],
+});
+try {
+renderBundleEncoder65.setVertexBuffer(8, buffer31, 11356);
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+let pipeline67 = await device5.createRenderPipelineAsync({
+label: '\u7409\u{1f743}\u{1f87b}\u3fe9\ud931\u{1fd0a}\u{1fac9}\u23b0\u6544\u0134\u{1fad7}',
+layout: pipelineLayout15,
+fragment: {
+  module: shaderModule18,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [undefined, {format: 'rg32uint'}, {format: 'rgba8uint'}, {format: 'r8unorm', writeMask: GPUColorWrite.GREEN}, undefined]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater-equal',
+depthFailOp: 'zero',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'greater',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilReadMask: 3077,
+stencilWriteMask: 1238,
+depthBias: 94,
+depthBiasSlopeScale: 63,
+depthBiasClamp: 70,
+},
+vertex: {
+  module: shaderModule18,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 29404,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 27592,
+shaderLocation: 7,
+}, {
+format: 'float16x2',
+offset: 19736,
+shaderLocation: 5,
+}, {
+format: 'uint32x3',
+offset: 20604,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 29204,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x4',
+offset: 4984,
+shaderLocation: 14,
+}, {
+format: 'sint8x4',
+offset: 27760,
+shaderLocation: 2,
+}, {
+format: 'snorm8x4',
+offset: 2516,
+shaderLocation: 16,
+}, {
+format: 'snorm8x2',
+offset: 19042,
+shaderLocation: 3,
+}, {
+format: 'sint32x2',
+offset: 15500,
+shaderLocation: 6,
+}, {
+format: 'uint32x4',
+offset: 20848,
+shaderLocation: 4,
+}, {
+format: 'float32x3',
+offset: 19888,
+shaderLocation: 12,
+}, {
+format: 'sint32x3',
+offset: 18880,
+shaderLocation: 13,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+cullMode: 'back',
+},
+});
+let canvas18 = document.createElement('canvas');
+let img25 = await imageWithData(188, 115, '#b6d2c808', '#2e3323c5');
+let adapter12 = await navigator.gpu.requestAdapter({
+});
+try {
+canvas18.getContext('webgl2');
+} catch {}
+let offscreenCanvas18 = new OffscreenCanvas(39, 568);
+let texture91 = device0.createTexture({
+size: [480, 36, 1],
+mipLevelCount: 6,
+sampleCount: 1,
+format: 'astc-10x6-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let renderBundle68 = renderBundleEncoder44.finish({label: '\ucdb9\u{1fa7a}\u5fb8\u0fe0\u8c76\u2dc3\u335d'});
+try {
+renderPassEncoder6.setBindGroup(7, bindGroup2, new Uint32Array(6615), 6078, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer30, 39680);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer11, 8812, 7493);
+} catch {}
+try {
+renderBundleEncoder45.drawIndirect(buffer18, 2072);
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer15, 28060, buffer25, 19052, 5060);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer25);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer25, 46456, new Int16Array(20404), 18661, 1116);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 3,
+  origin: { x: 0, y: 16, z: 0 },
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 310 */
+{offset: 310}, {width: 40, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let bindGroupLayout27 = device0.createBindGroupLayout({
+label: '\u{1fc9d}\ucee0\u16d1\u1b18\u{1fb18}',
+entries: [],
+});
+let textureView76 = texture24.createView({label: '\u099a\u0f45\u6339\uf3e1\uf90c\u34d5\u0a2b\uac72\u032c\u0117\u{1fd0e}', aspect: 'all'});
+try {
+renderPassEncoder5.setBindGroup(4, bindGroup3, new Uint32Array(2339), 900, 0);
+} catch {}
+try {
+renderPassEncoder6.setViewport(10.80, 49.47, 508.0, 13.48, 0.5356, 0.7852);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer11, 68064);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(5, bindGroup5, new Uint32Array(4537), 3068, 0);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer18, 31284);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(7, buffer6, 11052, 4319);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 48 },
+  aspect: 'all',
+}, new Int16Array(arrayBuffer3), /* required buffer size: 254968 */
+{offset: 938, bytesPerRow: 191, rowsPerImage: 133}, {width: 0, height: 4, depthOrArrayLayers: 11});
+} catch {}
+let buffer32 = device4.createBuffer({label: '\u04e8\u{1f7e1}', size: 18900, usage: GPUBufferUsage.INDEX});
+try {
+renderBundleEncoder61.drawIndexedIndirect(buffer23, 2512);
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video10,
+  origin: { x: 0, y: 8 },
+  flipY: false,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline68 = await device4.createRenderPipelineAsync({
+label: '\u0203\ufbaf\u53dd\u00e2\u672f\u0a83\u9f92\u0b3b\u0143\u5488',
+layout: pipelineLayout16,
+multisample: {
+mask: 0x9595569,
+},
+fragment: {
+  module: shaderModule15,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint'}, undefined, undefined, undefined, undefined, {format: 'rgba16uint', writeMask: GPUColorWrite.BLUE}, undefined]
+},
+vertex: {
+  module: shaderModule15,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 13684,
+attributes: [{
+format: 'sint8x4',
+offset: 12828,
+shaderLocation: 5,
+}, {
+format: 'uint16x4',
+offset: 6228,
+shaderLocation: 16,
+}, {
+format: 'sint16x2',
+offset: 4780,
+shaderLocation: 12,
+}, {
+format: 'sint32x2',
+offset: 5468,
+shaderLocation: 13,
+}, {
+format: 'uint32x2',
+offset: 13220,
+shaderLocation: 11,
+}, {
+format: 'float32x3',
+offset: 12652,
+shaderLocation: 3,
+}, {
+format: 'sint16x2',
+offset: 4160,
+shaderLocation: 15,
+}, {
+format: 'sint8x2',
+offset: 5046,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 3276,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 12588,
+attributes: [],
+},
+{
+arrayStride: 3076,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 2990,
+shaderLocation: 14,
+}, {
+format: 'uint32',
+offset: 3044,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 6108,
+attributes: [{
+format: 'sint32x4',
+offset: 3812,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+try {
+device4.destroy();
+} catch {}
+document.body.prepend(img5);
+let texture92 = device5.createTexture({
+label: '\u{1fc43}\u{1f963}\u30a2',
+size: [432, 60, 1],
+format: 'astc-6x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-6x5-unorm', 'astc-6x5-unorm-srgb', 'astc-6x5-unorm-srgb'],
+});
+try {
+commandEncoder46.copyTextureToTexture({
+  texture: texture90,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture90,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 12, height: 0, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(img2);
+let offscreenCanvas19 = new OffscreenCanvas(847, 930);
+let img26 = await imageWithData(91, 35, '#75d95851', '#0a89af9c');
+let video24 = await videoWithData();
+let renderBundle69 = renderBundleEncoder65.finish({label: '\u0ffb\u{1fc57}\u0c50\u8a5f\u{1fabf}'});
+try {
+device5.queue.writeTexture({
+  texture: texture90,
+  mipLevel: 2,
+  origin: { x: 0, y: 12, z: 1 },
+  aspect: 'all',
+}, new Int8Array(arrayBuffer5), /* required buffer size: 401 */
+{offset: 401}, {width: 84, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+await device5.queue.onSubmittedWorkDone();
+} catch {}
+let adapter13 = await navigator.gpu.requestAdapter({
+powerPreference: 'low-power',
+});
+let device6 = await adapter7.requestDevice({
+label: '\u{1fdcb}\ub405',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 60,
+maxVertexAttributes: 24,
+maxVertexBufferArrayStride: 33566,
+maxStorageTexturesPerShaderStage: 28,
+maxStorageBuffersPerShaderStage: 16,
+maxDynamicStorageBuffersPerPipelineLayout: 27074,
+maxBindingsPerBindGroup: 6050,
+maxTextureDimension1D: 12316,
+maxTextureDimension2D: 9926,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 57223013,
+maxUniformBuffersPerShaderStage: 14,
+maxInterStageShaderVariables: 87,
+maxInterStageShaderComponents: 80,
+maxSamplersPerShaderStage: 20,
+},
+});
+let gpuCanvasContext17 = offscreenCanvas19.getContext('webgpu');
+try {
+  await promise45;
+} catch {}
+let device7 = await adapter12.requestDevice({
+label: '\u{1fadb}\u056a\u0054\u0afd\u07d2',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxColorAttachmentBytesPerSample: 63,
+maxVertexBufferArrayStride: 21991,
+maxStorageTexturesPerShaderStage: 19,
+maxStorageBuffersPerShaderStage: 26,
+maxDynamicStorageBuffersPerPipelineLayout: 44024,
+maxBindingsPerBindGroup: 5697,
+maxTextureArrayLayers: 256,
+maxTextureDimension1D: 14939,
+maxTextureDimension2D: 9151,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 122519496,
+maxUniformBuffersPerShaderStage: 44,
+maxInterStageShaderVariables: 109,
+maxInterStageShaderComponents: 104,
+maxSamplersPerShaderStage: 17,
+},
+});
+let commandEncoder47 = device0.createCommandEncoder({label: '\u{1f62c}\u8dc1\u{1fea1}\u{1f783}\ubf90\u1264'});
+try {
+renderBundleEncoder45.drawIndexed(56, 72);
+} catch {}
+try {
+commandEncoder9.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 3,
+  origin: { x: 16, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 50864 */
+offset: 50864,
+rowsPerImage: 27,
+buffer: buffer5,
+}, {width: 12, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+let pipeline69 = await promise17;
+let img27 = await imageWithData(152, 222, '#2c7cb7bc', '#b7f204d1');
+let texture93 = device6.createTexture({
+label: '\u{1faff}\u{1fa93}\ucc27\u0a6e\u0178\u3f3a\uf90b\u9f7d\u8755',
+size: {width: 108, height: 192, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+dimension: '2d',
+format: 'astc-12x12-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-12x12-unorm', 'astc-12x12-unorm-srgb'],
+});
+let textureView77 = texture93.createView({
+  label: '\u74cd\u0f81\u508b\u558c',
+  dimension: '2d-array',
+  format: 'astc-12x12-unorm-srgb',
+  mipLevelCount: 5
+});
+try {
+device6.queue.writeTexture({
+  texture: texture93,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 403 */
+{offset: 403}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas20 = new OffscreenCanvas(796, 736);
+let imageData14 = new ImageData(240, 168);
+let commandEncoder48 = device6.createCommandEncoder({label: '\u9722\u7bbe\u{1fb29}\u23da\u{1fc4c}\uc577\uc748\udc5b\u8292\u07d4\u034e'});
+let renderBundleEncoder66 = device6.createRenderBundleEncoder({
+  label: '\ucd0f\u{1fe0d}\u7324\ud2dd\u{1f60b}\ue4d3',
+  colorFormats: ['rg8unorm', 'rg16sint', 'rgba8unorm-srgb', 'rg32float', undefined, 'r16float', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  stencilReadOnly: false
+});
+try {
+renderBundleEncoder66.setVertexBuffer(80, undefined, 3408916737);
+} catch {}
+try {
+await device6.popErrorScope();
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture({
+  texture: texture93,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture93,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 12, depthOrArrayLayers: 0});
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture93,
+  mipLevel: 3,
+  origin: { x: 12, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 920 */
+{offset: 904}, {width: 12, height: 12, depthOrArrayLayers: 1});
+} catch {}
+video0.width = 239;
+let video25 = await videoWithData();
+let promise46 = adapter10.requestAdapterInfo();
+let imageData15 = new ImageData(44, 36);
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+try {
+textureView58.label = '\u{1f601}\u5031\u0813\u8960\uc12c\u0bf2\u006f\u0275';
+} catch {}
+try {
+  await promise46;
+} catch {}
+let texture94 = device0.createTexture({
+label: '\uf5c6\u{1fee7}\u6392\uf021\u0c0a\u0cb5\ud50f\u0604\u00b6',
+size: {width: 120, height: 9, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+dimension: '2d',
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth16unorm', 'depth16unorm', 'depth16unorm'],
+});
+try {
+renderPassEncoder6.setBindGroup(5, bindGroup26, []);
+} catch {}
+try {
+renderPassEncoder5.draw(32, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer15, 182088);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(7, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder45.draw(72, 8, 80, 48);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(2, buffer6);
+} catch {}
+let arrayBuffer8 = buffer7.getMappedRange(0, 4504);
+try {
+commandEncoder47.copyTextureToBuffer({
+  texture: texture94,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'depth-only',
+}, {
+/* bytesInLastRow: 14 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 31124 */
+offset: 31124,
+bytesPerRow: 256,
+buffer: buffer28,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer28);
+} catch {}
+try {
+commandEncoder26.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 6,
+  origin: { x: 24, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: { x: 1392, y: 5, z: 21 },
+  aspect: 'all',
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap15 = await createImageBitmap(offscreenCanvas7);
+let videoFrame19 = new VideoFrame(offscreenCanvas7, {timestamp: 0});
+let bindGroupLayout28 = device0.createBindGroupLayout({
+label: '\u{1fd20}\u17f9\uc581\ufdc6\uf0e5',
+entries: [{
+binding: 1957,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}, {
+binding: 28,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}, {
+binding: 2961,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}],
+});
+let commandEncoder49 = device0.createCommandEncoder();
+let querySet56 = device0.createQuerySet({
+label: '\ubfe4\ud1b5\u3638\u{1fadf}\u19d3\u{1fe76}\u{1f9e3}\u8c9c',
+type: 'occlusion',
+count: 250,
+});
+let computePassEncoder31 = commandEncoder47.beginComputePass();
+let renderBundle70 = renderBundleEncoder14.finish({label: '\u{1f794}\u7f6c\u76c1\u{1fd63}\u{1fc8d}\u{1f64f}\u0f0b\u{1fa58}\u0cee\u07af'});
+try {
+computePassEncoder31.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderBundleEncoder37.drawIndexed(64, 56, 32);
+} catch {}
+try {
+renderBundleEncoder37.drawIndexedIndirect(buffer18, 8476);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer21, 34948);
+} catch {}
+let pipeline70 = await device0.createRenderPipelineAsync({
+label: '\ubdd9\uc625\ucbbb\u{1fccc}\u2b7f\u4e95\u{1fa7b}\u1283',
+layout: 'auto',
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'src-alpha-saturated'},
+},
+  writeMask: GPUColorWrite.RED
+}, {
+  format: 'r16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'zero',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'equal',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 1659,
+depthBiasSlopeScale: 94,
+depthBiasClamp: 50,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 21420,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 12888,
+shaderLocation: 11,
+}, {
+format: 'snorm16x2',
+offset: 11216,
+shaderLocation: 7,
+}, {
+format: 'snorm8x4',
+offset: 15460,
+shaderLocation: 22,
+}, {
+format: 'uint32x2',
+offset: 12148,
+shaderLocation: 10,
+}, {
+format: 'sint32x2',
+offset: 13216,
+shaderLocation: 3,
+}, {
+format: 'unorm16x4',
+offset: 12908,
+shaderLocation: 2,
+}, {
+format: 'sint8x2',
+offset: 19560,
+shaderLocation: 1,
+}, {
+format: 'uint32x3',
+offset: 19200,
+shaderLocation: 24,
+}],
+},
+{
+arrayStride: 0,
+attributes: [{
+format: 'uint32x4',
+offset: 8504,
+shaderLocation: 14,
+}, {
+format: 'uint8x4',
+offset: 27312,
+shaderLocation: 4,
+}, {
+format: 'unorm16x4',
+offset: 12976,
+shaderLocation: 9,
+}, {
+format: 'float16x2',
+offset: 19256,
+shaderLocation: 13,
+}],
+}
+]
+},
+});
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let canvas19 = document.createElement('canvas');
+let promise47 = adapter6.requestAdapterInfo();
+let adapter14 = await navigator.gpu.requestAdapter({
+});
+let sampler52 = device7.createSampler({
+label: '\u057f\u537a',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 69.909,
+lodMaxClamp: 80.117,
+maxAnisotropy: 11,
+});
+let canvas20 = document.createElement('canvas');
+let video26 = await videoWithData();
+let imageBitmap16 = await createImageBitmap(canvas8);
+let commandEncoder50 = device6.createCommandEncoder({label: '\u{1fd84}\u2b93\u1175\ub088'});
+let querySet57 = device6.createQuerySet({
+label: '\u1415\u051d\u7e12\u{1fd96}\ue07b\u3077\ue031\u{1f7d2}\ufb98\u9ada\u05c0',
+type: 'occlusion',
+count: 832,
+});
+let renderBundle71 = renderBundleEncoder66.finish({label: '\ue951\u9903\u{1ff7c}\u0d2a\u{1f6c7}\ufbc3\u9413\u{1f715}\ubb20\u0067'});
+let externalTexture9 = device6.importExternalTexture({
+label: '\u0fb2\ue571',
+source: videoFrame16,
+});
+try {
+texture93.destroy();
+} catch {}
+try {
+commandEncoder50.copyTextureToTexture({
+  texture: texture93,
+  mipLevel: 3,
+  origin: { x: 0, y: 12, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture93,
+  mipLevel: 0,
+  origin: { x: 84, y: 72, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise48 = device6.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let commandBuffer8 = commandEncoder49.finish({
+label: '\u0455\ub092\u2f0c',
+});
+let renderBundleEncoder67 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16sint', 'r8uint', 'rgba8unorm-srgb'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 1,
+  depthReadOnly: true
+});
+let sampler53 = device0.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 32.584,
+lodMaxClamp: 88.492,
+maxAnisotropy: 1,
+});
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(7, bindGroup0, new Uint32Array(4052), 2711, 0);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(924);
+} catch {}
+try {
+renderPassEncoder6.setViewport(581.9, 48.64, 298.3, 19.73, 0.2757, 0.8613);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer9, 'uint16', 2992, 10469);
+} catch {}
+try {
+renderBundleEncoder45.draw(32, 56);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(24, 8, 64);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer18, 2064);
+} catch {}
+try {
+renderBundleEncoder37.drawIndirect(buffer18, 32524);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(7, buffer13, 23840);
+} catch {}
+let device8 = await promise28;
+let textureView78 = texture79.createView({dimension: '2d-array', aspect: 'all', baseMipLevel: 6, mipLevelCount: 1});
+try {
+commandEncoder46.copyTextureToTexture({
+  texture: texture84,
+  mipLevel: 6,
+  origin: { x: 4, y: 1, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture84,
+  mipLevel: 1,
+  origin: { x: 1079, y: 2, z: 1 },
+  aspect: 'all',
+}, {width: 27, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext15.configure({
+device: device5,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rg32uint', 'astc-6x6-unorm-srgb', 'rg8unorm', 'bgra8unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let querySet58 = device5.createQuerySet({
+label: '\ubf38\u{1f8dc}\u098a\uee79\u757c\u44a0\uc773\uc450\ufffc\u{1fe1a}',
+type: 'occlusion',
+count: 3537,
+});
+let textureView79 = texture80.createView({label: '\u58b0\u{1fb66}\u21b0\u3b57\u983e\u0348', dimension: '2d-array'});
+let renderBundle72 = renderBundleEncoder65.finish();
+let sampler54 = device5.createSampler({
+label: '\u0ff8\u0acd',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+lodMinClamp: 92.879,
+lodMaxClamp: 94.695,
+});
+let externalTexture10 = device5.importExternalTexture({
+source: video5,
+colorSpace: 'srgb',
+});
+try {
+commandEncoder46.copyTextureToTexture({
+  texture: texture84,
+  mipLevel: 1,
+  origin: { x: 799, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture84,
+  mipLevel: 0,
+  origin: { x: 1716, y: 23, z: 1 },
+  aspect: 'all',
+}, {width: 283, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext18 = canvas19.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let renderBundleEncoder68 = device5.createRenderBundleEncoder({
+  label: '\u03bc\u32c8\u0fc0\u86bd\u{1fce9}',
+  colorFormats: [undefined, 'rg32uint', 'rgba8uint', 'r8unorm', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder68.setVertexBuffer(8, buffer31, 2688, 8822);
+} catch {}
+let gpuCanvasContext19 = offscreenCanvas18.getContext('webgpu');
+try {
+canvas20.getContext('webgpu');
+} catch {}
+let buffer33 = device0.createBuffer({label: '\uff0d\ubd82\u0f02\u{1fd93}\u0088\u8336\u18f8', size: 19273, usage: GPUBufferUsage.COPY_DST});
+let commandEncoder51 = device0.createCommandEncoder({label: '\u4725\u0172\u6755\ubef9'});
+let textureView80 = texture3.createView({label: '\u0c34\u0c81', dimension: '2d-array', baseMipLevel: 5});
+let renderBundleEncoder69 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16sint', 'r8uint', 'rgba8unorm-srgb'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle73 = renderBundleEncoder16.finish({label: '\u{1fc94}\ue604\u5d2c\u{1feab}\u07a5\u68e2\u8336\u4b51'});
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer21, 10628);
+} catch {}
+try {
+commandEncoder26.clearBuffer(buffer30);
+dissociateBuffer(device0, buffer30);
+} catch {}
+let pipeline71 = await device0.createComputePipelineAsync({
+label: '\u03b5\u{1fbbc}\u0f61\u{1f903}\uc87b',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule21,
+entryPoint: 'compute0',
+},
+});
+let gpuCanvasContext20 = offscreenCanvas20.getContext('webgpu');
+let commandEncoder52 = device5.createCommandEncoder({label: '\u{1f8ff}\u0dd0\u14e8'});
+let renderBundle74 = renderBundleEncoder65.finish({label: '\u{1fab6}\u03d4\u0a94\u436f\u0447\ud6e1\u{1ffaa}\u677f\u7a48'});
+try {
+commandEncoder41.pushDebugGroup('\u0a6e');
+} catch {}
+let pipeline72 = await promise43;
+try {
+  await promise47;
+} catch {}
+let video27 = await videoWithData();
+let texture95 = device8.createTexture({
+size: {width: 160, height: 7, depthOrArrayLayers: 230},
+mipLevelCount: 6,
+format: 'depth16unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['depth16unorm'],
+});
+let textureView81 = texture95.createView({
+  label: '\u1086\u9bbd\u{1feac}\u092c\u0d28\u{1ff36}\u0397\u{1ff53}\u{1feaf}\u{1f7db}\uccce',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  mipLevelCount: 3,
+  baseArrayLayer: 190,
+  arrayLayerCount: 19
+});
+document.body.prepend(video5);
+let buffer34 = device7.createBuffer({size: 26022, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let promise49 = device7.popErrorScope();
+try {
+await device7.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext13.configure({
+device: device7,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'bgra8unorm', 'rg11b10ufloat', 'r32float'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer35 = device8.createBuffer({
+  label: '\u31be\u3029\u7f4b\u8ad6\u05b8\u0c2b\u{1fbc6}\u057e\u09c0\u30a6\u6e90',
+  size: 20947,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let querySet59 = device8.createQuerySet({
+label: '\uc41e\u{1fd45}\u33bf\u72f7\u3cf3\u0da3\u{1fb3d}',
+type: 'occlusion',
+count: 2908,
+});
+let promise50 = buffer35.mapAsync(GPUMapMode.WRITE, 20536, 384);
+let texture96 = device0.createTexture({
+size: [240, 32, 61],
+mipLevelCount: 7,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-8x8-unorm-srgb'],
+});
+let textureView82 = texture15.createView({
+  label: '\u{1f853}\u0e63\u{1ffb8}\u048c\u7552\u0b4d\u0c15\ue70a\u{1ff19}',
+  dimension: '2d',
+  baseArrayLayer: 23
+});
+let renderBundle75 = renderBundleEncoder32.finish({label: '\u593e\ub8cf\ua60a\u0e39\uf80f\u0783\u097b\uf11e\u77ee'});
+try {
+computePassEncoder31.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer18, 'uint16', 41284);
+} catch {}
+try {
+renderBundleEncoder37.draw(40, 48, 24, 48);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(16, 0, 56, 616, 32);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer11, 18140);
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(querySet4, 1109, 67, buffer9, 8448);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer8,
+commandBuffer6,
+]);
+} catch {}
+let pipeline73 = await device0.createRenderPipelineAsync({
+label: '\ue5e3\ua4d6\ud56d\u{1f791}\u{1f75c}\u77e0',
+layout: pipelineLayout2,
+fragment: {
+  module: shaderModule13,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: 0}]
+},
+vertex: {
+  module: shaderModule13,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 16160,
+attributes: [{
+format: 'uint32x3',
+offset: 9932,
+shaderLocation: 7,
+}, {
+format: 'float32x4',
+offset: 7460,
+shaderLocation: 21,
+}, {
+format: 'unorm8x4',
+offset: 14360,
+shaderLocation: 2,
+}, {
+format: 'uint32x2',
+offset: 12320,
+shaderLocation: 5,
+}, {
+format: 'float32x2',
+offset: 11036,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 2724,
+attributes: [{
+format: 'unorm16x2',
+offset: 2648,
+shaderLocation: 20,
+}],
+}
+]
+},
+});
+let querySet60 = device7.createQuerySet({
+label: '\u6e89\u65f1\u{1f616}\ub97e\u0b51\u0ced',
+type: 'occlusion',
+count: 1116,
+});
+try {
+device7.queue.writeBuffer(buffer34, 608, new Int16Array(33219), 29582, 2008);
+} catch {}
+let commandEncoder53 = device6.createCommandEncoder({label: '\u{1f6c1}\u0111'});
+try {
+  await promise49;
+} catch {}
+let imageData16 = new ImageData(48, 40);
+let computePassEncoder32 = commandEncoder48.beginComputePass();
+let renderBundle76 = renderBundleEncoder66.finish({});
+try {
+  await promise48;
+} catch {}
+let canvas21 = document.createElement('canvas');
+let renderBundleEncoder70 = device8.createRenderBundleEncoder({
+  label: '\u457b\u{1fdb6}\u0cef\u2628\u6f4b\ue4eb\u0272\u1f22',
+  colorFormats: ['rgb10a2unorm', 'r32float', undefined, 'r8sint', 'r8uint', 'bgra8unorm'],
+  depthReadOnly: true
+});
+let renderBundle77 = renderBundleEncoder70.finish({label: '\u{1fd4b}\u85c0\u5414\u73df\ub765\u0f98\u0f91\u016c\u848a\u0178\u3dda'});
+try {
+gpuCanvasContext8.configure({
+device: device8,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let promise51 = device8.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+try {
+canvas21.getContext('webgpu');
+} catch {}
+try {
+window.someLabel = texture86.label;
+} catch {}
+let shaderModule22 = device5.createShaderModule({
+label: '\u0d44\u0ee3\ucd25\u090c\u0bed\ueab9\uffaf\u1349\u05ab',
+code: `@group(0) @binding(1407)
+var<storage, read_write> field14: array<u32>;
+@group(1) @binding(1407)
+var<storage, read_write> local10: array<u32>;
+
+@compute @workgroup_size(8, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S24 {
+  @location(79) f0: vec2<f32>,
+  @location(81) f1: vec2<i32>,
+  @location(96) f2: vec3<u32>,
+  @location(6) f3: vec2<f32>,
+  @location(24) f4: vec4<i32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @location(1) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(83) a0: f16, a1: S24, @location(15) a2: vec2<f16>, @location(108) a3: f32, @location(107) a4: vec4<u32>, @location(20) a5: vec2<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(114) f256: vec4<i32>,
+  @location(15) f257: vec2<f16>,
+  @location(35) f258: f16,
+  @location(83) f259: f16,
+  @location(61) f260: vec4<u32>,
+  @location(90) f261: vec4<u32>,
+  @builtin(position) f262: vec4<f32>,
+  @location(107) f263: vec4<u32>,
+  @location(20) f264: vec2<u32>,
+  @location(49) f265: vec3<f16>,
+  @location(97) f266: vec4<f32>,
+  @location(6) f267: vec2<f32>,
+  @location(24) f268: vec4<i32>,
+  @location(79) f269: vec2<f32>,
+  @location(45) f270: vec4<f32>,
+  @location(108) f271: f32,
+  @location(99) f272: i32,
+  @location(93) f273: vec4<u32>,
+  @location(0) f274: u32,
+  @location(105) f275: vec4<f16>,
+  @location(81) f276: vec2<i32>,
+  @location(73) f277: i32,
+  @location(32) f278: vec4<f16>,
+  @location(96) f279: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec3<i32>, @location(7) a1: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder54 = device5.createCommandEncoder({label: '\u{1f647}\u{1f789}\u0dbd\u34fe\u4b36\ufc33\u01ee\u02a4'});
+let texture97 = device5.createTexture({
+label: '\u9e46\u0f76\u0089\u0ad8',
+size: {width: 864, height: 120, depthOrArrayLayers: 1},
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+renderBundleEncoder68.setVertexBuffer(3, buffer31, 38576, 11944);
+} catch {}
+try {
+commandEncoder52.copyTextureToTexture({
+  texture: texture84,
+  mipLevel: 0,
+  origin: { x: 1967, y: 2, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture84,
+  mipLevel: 0,
+  origin: { x: 1036, y: 1, z: 1 },
+  aspect: 'all',
+}, {width: 169, height: 23, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let canvas22 = document.createElement('canvas');
+let imageData17 = new ImageData(188, 100);
+let texture98 = gpuCanvasContext6.getCurrentTexture();
+let canvas23 = document.createElement('canvas');
+let computePassEncoder33 = commandEncoder50.beginComputePass({label: '\u{1f680}\u{1fbd2}\u0d51\u581c\u1167\u24ec\u0c94\u0315\ubdaa\u9fb2\u{1f701}'});
+let renderBundleEncoder71 = device6.createRenderBundleEncoder({
+  label: '\u0ccb\u018b\u{1fc8c}\u{1f982}\uce0e\u0bc4',
+  colorFormats: ['rg8unorm', 'rg16sint', 'rgba8unorm-srgb', 'rg32float', undefined, 'r16float', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  stencilReadOnly: true
+});
+video19.width = 139;
+let device9 = await adapter11.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxBindGroups: 9,
+maxColorAttachmentBytesPerSample: 59,
+maxVertexAttributes: 24,
+maxVertexBufferArrayStride: 50420,
+maxStorageTexturesPerShaderStage: 16,
+maxStorageBuffersPerShaderStage: 37,
+maxDynamicStorageBuffersPerPipelineLayout: 54980,
+maxBindingsPerBindGroup: 3066,
+maxTextureDimension1D: 12125,
+maxTextureDimension2D: 9568,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 41482479,
+maxUniformBuffersPerShaderStage: 27,
+maxInterStageShaderVariables: 72,
+maxInterStageShaderComponents: 62,
+},
+});
+let video28 = await videoWithData();
+let commandEncoder55 = device0.createCommandEncoder({});
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(266);
+} catch {}
+try {
+renderBundleEncoder62.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder37.drawIndexed(64, 48, 64, 376, 72);
+} catch {}
+try {
+renderBundleEncoder45.setPipeline(pipeline18);
+} catch {}
+let gpuCanvasContext21 = canvas23.getContext('webgpu');
+gc();
+let img28 = await imageWithData(206, 251, '#7c1627c8', '#8bfa058f');
+try {
+canvas22.getContext('bitmaprenderer');
+} catch {}
+let sampler55 = device8.createSampler({
+label: '\u11f1\ued17\u1c69\u{1f849}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 16.081,
+lodMaxClamp: 63.564,
+maxAnisotropy: 4,
+});
+let imageData18 = new ImageData(188, 120);
+let shaderModule23 = device0.createShaderModule({
+label: '\u{1ff73}\u9a72\u{1fd6a}\u{1f688}\u957d\u01fc\u9769\u{1fb05}\u{1fe9c}',
+code: `@group(0) @binding(302)
+var<storage, read_write> field15: array<u32>;
+@group(1) @binding(4981)
+var<storage, read_write> i9: array<u32>;
+@group(2) @binding(5174)
+var<storage, read_write> local11: array<u32>;
+@group(2) @binding(4981)
+var<storage, read_write> parameter13: array<u32>;
+@group(1) @binding(5174)
+var<storage, read_write> function8: array<u32>;
+
+@compute @workgroup_size(5, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S26 {
+  @location(26) f0: f32,
+  @location(2) f1: vec4<i32>,
+  @builtin(sample_mask) f2: u32,
+  @location(73) f3: vec3<u32>,
+  @location(52) f4: vec4<f16>,
+  @location(68) f5: vec2<u32>,
+  @location(3) f6: vec2<u32>,
+  @location(64) f7: vec2<u32>,
+  @builtin(position) f8: vec4<f32>,
+  @location(51) f9: u32,
+  @location(13) f10: f16
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(1) f1: vec4<f32>,
+  @location(3) f2: vec4<u32>,
+  @location(0) f3: vec3<f32>
+}
+
+@fragment
+fn fragment0(a0: S26, @location(38) a1: i32, @location(83) a2: vec2<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S25 {
+  @location(6) f0: vec4<u32>,
+  @location(16) f1: vec3<u32>,
+  @builtin(vertex_index) f2: u32,
+  @location(5) f3: f16,
+  @builtin(instance_index) f4: u32,
+  @location(21) f5: f16,
+  @location(10) f6: vec2<i32>,
+  @location(19) f7: vec4<i32>,
+  @location(14) f8: f16,
+  @location(8) f9: vec4<u32>,
+  @location(4) f10: f16,
+  @location(12) f11: f16,
+  @location(18) f12: vec2<u32>,
+  @location(15) f13: f32,
+  @location(7) f14: vec2<i32>,
+  @location(11) f15: f16
+}
+struct VertexOutput0 {
+  @location(75) f280: vec3<u32>,
+  @location(26) f281: f32,
+  @location(65) f282: vec2<f16>,
+  @location(31) f283: f32,
+  @location(55) f284: vec2<f32>,
+  @location(7) f285: vec3<f32>,
+  @location(78) f286: vec3<f16>,
+  @location(47) f287: i32,
+  @location(28) f288: vec3<i32>,
+  @location(52) f289: vec4<f16>,
+  @location(68) f290: vec2<u32>,
+  @location(59) f291: vec3<u32>,
+  @location(14) f292: vec2<i32>,
+  @location(83) f293: vec2<f32>,
+  @location(81) f294: vec3<i32>,
+  @location(13) f295: f16,
+  @location(49) f296: vec3<f32>,
+  @location(35) f297: vec3<u32>,
+  @location(64) f298: vec2<u32>,
+  @location(41) f299: vec4<u32>,
+  @location(11) f300: vec2<f32>,
+  @location(51) f301: u32,
+  @location(38) f302: i32,
+  @builtin(position) f303: vec4<f32>,
+  @location(3) f304: vec2<u32>,
+  @location(22) f305: vec2<f32>,
+  @location(8) f306: vec2<u32>,
+  @location(84) f307: vec4<u32>,
+  @location(2) f308: vec4<i32>,
+  @location(12) f309: i32,
+  @location(77) f310: vec2<i32>,
+  @location(73) f311: vec3<u32>,
+  @location(72) f312: vec3<f16>,
+  @location(15) f313: i32,
+  @location(9) f314: i32,
+  @location(60) f315: vec3<f16>,
+  @location(74) f316: vec2<f16>,
+  @location(63) f317: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(22) a0: vec3<u32>, @location(17) a1: vec2<i32>, @location(2) a2: vec3<f16>, @location(24) a3: vec4<i32>, a4: S25, @location(23) a5: vec2<f16>, @location(3) a6: vec4<f32>, @location(1) a7: f32, @location(9) a8: i32, @location(20) a9: vec2<f32>, @location(13) a10: vec3<u32>, @location(0) a11: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroupLayout29 = device0.createBindGroupLayout({
+label: '\uca5f\u0040\u709f',
+entries: [],
+});
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(1775);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(2, buffer13, 29592, 1658);
+} catch {}
+try {
+renderBundleEncoder63.setVertexBuffer(7, buffer11, 1156);
+} catch {}
+try {
+commandEncoder51.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 230, y: 12, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture22,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 180, height: 12, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 4,
+  origin: { x: 10, y: 2, z: 2 },
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 1593915 */
+{offset: 647, bytesPerRow: 443, rowsPerImage: 62}, {width: 15, height: 1, depthOrArrayLayers: 59});
+} catch {}
+let sampler56 = device9.createSampler({
+label: '\ub6f3\u{1fc41}\ue7dc\u{1f7ea}\u00dc\uece0\u{1f63b}\ue501\ud7b6\u05fb',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+lodMinClamp: 61.219,
+lodMaxClamp: 71.357,
+});
+let offscreenCanvas21 = new OffscreenCanvas(594, 955);
+let videoFrame20 = new VideoFrame(video5, {timestamp: 0});
+let bindGroupLayout30 = device9.createBindGroupLayout({
+entries: [{
+binding: 1453,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+}, {
+binding: 1665,
+visibility: 0,
+texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+}],
+});
+let texture99 = device9.createTexture({
+label: '\u32e7\u{1fac7}',
+size: {width: 234, height: 60, depthOrArrayLayers: 1},
+format: 'astc-6x5-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-6x5-unorm-srgb'],
+});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+offscreenCanvas9.height = 704;
+let buffer36 = device5.createBuffer({label: '\ue55a\u253b', size: 5702, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let sampler57 = device5.createSampler({
+label: '\u0cf4\ufac8\u474d\u9a35',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 82.292,
+lodMaxClamp: 94.153,
+});
+try {
+renderBundleEncoder68.setVertexBuffer(3, buffer31);
+} catch {}
+let promise52 = buffer36.mapAsync(GPUMapMode.READ, 0, 5568);
+let gpuCanvasContext22 = offscreenCanvas21.getContext('webgpu');
+let commandEncoder56 = device0.createCommandEncoder({label: '\u{1f983}\u03c2\u{1f8f5}\ud32f\u0268\uceeb\u60fe\u{1f6cd}'});
+let querySet61 = device0.createQuerySet({
+label: '\uf0fb\u{1fbff}\uf404\uc9e0\u{1f953}\u0c41',
+type: 'occlusion',
+count: 3868,
+});
+let texture100 = device0.createTexture({
+label: '\u{1f7ff}\u0aa1\u06bb\u248b',
+size: {width: 240, height: 18, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+sampleCount: 1,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x6-unorm-srgb', 'astc-8x6-unorm-srgb'],
+});
+let renderBundle78 = renderBundleEncoder26.finish({label: '\u0f67\u562e'});
+try {
+renderPassEncoder6.setViewport(187.5, 62.55, 639.6, 4.166, 0.4357, 0.5372);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(3, buffer6, 316);
+} catch {}
+try {
+renderBundleEncoder37.drawIndexed(32);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 43092, new BigUint64Array(16584), 14000, 476);
+} catch {}
+document.body.prepend(video10);
+offscreenCanvas7.width = 855;
+let img29 = await imageWithData(147, 190, '#cca1430f', '#df38139e');
+let commandEncoder57 = device7.createCommandEncoder({label: '\u053a\u5f0f\uedeb\u{1f9f3}\u037b\u{1fac3}\u038e\u0c63\u{1faa8}'});
+let buffer37 = device9.createBuffer({
+  label: '\ud6c8\u9038\u0e81\u1eea\uddbb\u{1fc39}\u{1fe3f}\u0ac0\u5b28',
+  size: 48219,
+  usage: GPUBufferUsage.VERTEX
+});
+let querySet62 = device9.createQuerySet({
+label: '\u12aa\ufcfb\u{1ff03}',
+type: 'occlusion',
+count: 1940,
+});
+let textureView83 = texture99.createView({label: '\u2783\ua55e\u{1f867}\u2dc7', dimension: '2d-array', aspect: 'all', mipLevelCount: 1});
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise51;
+} catch {}
+let shaderModule24 = device5.createShaderModule({
+code: `@group(1) @binding(1407)
+var<storage, read_write> function9: array<u32>;
+@group(0) @binding(1407)
+var<storage, read_write> local12: array<u32>;
+@group(3) @binding(1407)
+var<storage, read_write> field16: array<u32>;
+@group(2) @binding(1407)
+var<storage, read_write> field17: array<u32>;
+
+@compute @workgroup_size(2, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S28 {
+  @location(65) f0: vec2<i32>,
+  @location(36) f1: vec3<u32>,
+  @location(59) f2: vec3<f32>,
+  @location(15) f3: vec4<f16>,
+  @location(108) f4: vec4<f16>,
+  @location(9) f5: f32,
+  @location(64) f6: vec2<i32>,
+  @location(22) f7: vec4<u32>,
+  @location(45) f8: vec4<f16>,
+  @location(25) f9: vec4<u32>,
+  @location(33) f10: vec3<f32>,
+  @location(28) f11: f16,
+  @location(12) f12: u32,
+  @location(77) f13: vec4<f16>,
+  @location(34) f14: vec2<f16>,
+  @location(23) f15: vec4<f32>,
+  @location(106) f16: vec3<i32>,
+  @location(50) f17: vec3<f16>,
+  @location(76) f18: vec4<u32>,
+  @location(62) f19: f32,
+  @location(47) f20: vec4<i32>,
+  @location(38) f21: vec4<f16>
+}
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(3) f1: vec3<f32>,
+  @location(2) f2: vec4<u32>,
+  @location(5) f3: u32,
+  @location(1) f4: vec3<u32>
+}
+
+@fragment
+fn fragment0(a0: S28, @location(73) a1: i32, @location(89) a2: vec2<u32>, @location(86) a3: vec2<f16>, @location(44) a4: vec3<f16>, @location(40) a5: vec3<i32>, @builtin(position) a6: vec4<f32>, @location(49) a7: vec3<i32>, @location(8) a8: vec2<i32>, @location(94) a9: vec3<i32>, @location(87) a10: f32, @location(14) a11: vec4<u32>, @builtin(front_facing) a12: bool, @builtin(sample_index) a13: u32, @builtin(sample_mask) a14: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S27 {
+  @builtin(instance_index) f0: u32,
+  @location(1) f1: vec4<f32>,
+  @builtin(vertex_index) f2: u32,
+  @location(10) f3: vec4<u32>,
+  @location(3) f4: vec2<i32>,
+  @location(13) f5: vec2<f16>,
+  @location(4) f6: u32,
+  @location(2) f7: f32,
+  @location(8) f8: f16,
+  @location(14) f9: vec4<f16>
+}
+struct VertexOutput0 {
+  @location(62) f318: f32,
+  @location(36) f319: vec3<u32>,
+  @location(28) f320: f16,
+  @location(38) f321: vec4<f16>,
+  @location(22) f322: vec4<u32>,
+  @location(59) f323: vec3<f32>,
+  @location(23) f324: vec4<f32>,
+  @location(45) f325: vec4<f16>,
+  @location(15) f326: vec4<f16>,
+  @location(64) f327: vec2<i32>,
+  @location(44) f328: vec3<f16>,
+  @builtin(position) f329: vec4<f32>,
+  @location(86) f330: vec2<f16>,
+  @location(73) f331: i32,
+  @location(106) f332: vec3<i32>,
+  @location(47) f333: vec4<i32>,
+  @location(33) f334: vec3<f32>,
+  @location(87) f335: f32,
+  @location(14) f336: vec4<u32>,
+  @location(65) f337: vec2<i32>,
+  @location(50) f338: vec3<f16>,
+  @location(49) f339: vec3<i32>,
+  @location(8) f340: vec2<i32>,
+  @location(25) f341: vec4<u32>,
+  @location(89) f342: vec2<u32>,
+  @location(76) f343: vec4<u32>,
+  @location(94) f344: vec3<i32>,
+  @location(12) f345: u32,
+  @location(9) f346: f32,
+  @location(34) f347: vec2<f16>,
+  @location(40) f348: vec3<i32>,
+  @location(108) f349: vec4<f16>,
+  @location(77) f350: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec4<f32>, a1: S27, @location(16) a2: vec3<f16>, @location(9) a3: vec2<f16>, @location(12) a4: vec4<u32>, @location(7) a5: vec4<f16>, @location(6) a6: vec4<i32>, @location(0) a7: vec2<f32>, @location(11) a8: vec2<f16>, @location(15) a9: f16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let computePassEncoder34 = commandEncoder54.beginComputePass();
+let sampler58 = device5.createSampler({
+label: '\u07d1\u95d1\u0572\u018e\ud0a9',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 40.153,
+lodMaxClamp: 62.503,
+});
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture84,
+  mipLevel: 2,
+  origin: { x: 215, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture84,
+  mipLevel: 1,
+  origin: { x: 953, y: 7, z: 0 },
+  aspect: 'all',
+}, {width: 137, height: 8, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device5,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let videoFrame21 = new VideoFrame(video6, {timestamp: 0});
+let videoFrame22 = new VideoFrame(img12, {timestamp: 0});
+let buffer38 = device6.createBuffer({label: '\u{1feda}\u0dea\u0ab2\u0c05\u008a\ua24d', size: 8895, usage: GPUBufferUsage.QUERY_RESOLVE});
+let querySet63 = device6.createQuerySet({
+label: '\u{1f776}\u{1fe6d}\u098b\uc3c5',
+type: 'occlusion',
+count: 2179,
+});
+let renderBundleEncoder72 = device6.createRenderBundleEncoder({
+  label: '\u3361\u{1fe5e}\u0b01',
+  colorFormats: ['rg8unorm', 'rg16sint', 'rgba8unorm-srgb', 'rg32float', undefined, 'r16float', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true
+});
+try {
+commandEncoder53.copyTextureToTexture({
+  texture: texture93,
+  mipLevel: 3,
+  origin: { x: 12, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture93,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder53.resolveQuerySet(querySet57, 85, 114, buffer38, 1536);
+} catch {}
+let imageBitmap17 = await createImageBitmap(imageData16);
+let videoFrame23 = new VideoFrame(img2, {timestamp: 0});
+let canvas24 = document.createElement('canvas');
+let img30 = await imageWithData(76, 10, '#2dde249a', '#ea14be99');
+let imageBitmap18 = await createImageBitmap(offscreenCanvas14);
+let renderBundle79 = renderBundleEncoder16.finish();
+let externalTexture11 = device0.importExternalTexture({
+label: '\ub073\u03c8\u0ae7\u31bd\ucbb5\u0aa9\u3075',
+source: videoFrame9,
+colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder56.setBindGroup(2, bindGroup27);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer28, 17556);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(73, undefined, 3795132101, 23106327);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let pipeline74 = await promise41;
+let gpuCanvasContext23 = canvas24.getContext('webgpu');
+document.body.prepend(video13);
+offscreenCanvas4.height = 817;
+let commandEncoder58 = device0.createCommandEncoder();
+let textureView84 = texture9.createView({baseMipLevel: 1, baseArrayLayer: 0});
+try {
+computePassEncoder29.setBindGroup(2, bindGroup3, new Uint32Array(4505), 2059, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup28, new Uint32Array(1219), 158, 0);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: -458.1, g: 899.5, b: 744.6, a: -576.1, });
+} catch {}
+try {
+renderBundleEncoder37.drawIndexedIndirect(buffer18, 35324);
+} catch {}
+try {
+renderBundleEncoder37.drawIndirect(buffer11, 16676);
+} catch {}
+try {
+commandEncoder56.insertDebugMarker('\u{1f7e3}');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer25, 45356, new BigUint64Array(44316), 7696, 448);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 1,
+  origin: { x: 17, y: 3, z: 6 },
+  aspect: 'all',
+}, new Uint32Array(new ArrayBuffer(0)), /* required buffer size: 1722446 */
+{offset: 64, bytesPerRow: 245, rowsPerImage: 190}, {width: 16, height: 1, depthOrArrayLayers: 38});
+} catch {}
+let pipeline75 = device0.createRenderPipeline({
+layout: pipelineLayout2,
+multisample: {
+},
+fragment: {
+  module: shaderModule21,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r8sint'}, {format: 'rg32uint', writeMask: GPUColorWrite.BLUE}, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'src'},
+},
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r8sint'}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'less-equal',
+depthFailOp: 'replace',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater',
+failOp: 'zero',
+depthFailOp: 'decrement-clamp',
+passOp: 'invert',
+},
+stencilReadMask: 1895,
+stencilWriteMask: 1258,
+depthBias: 74,
+depthBiasSlopeScale: 61,
+},
+vertex: {
+  module: shaderModule21,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 26360,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32',
+offset: 4812,
+shaderLocation: 9,
+}, {
+format: 'sint8x2',
+offset: 4496,
+shaderLocation: 2,
+}, {
+format: 'snorm8x4',
+offset: 16480,
+shaderLocation: 1,
+}, {
+format: 'uint32x3',
+offset: 25164,
+shaderLocation: 22,
+}, {
+format: 'snorm8x4',
+offset: 7520,
+shaderLocation: 14,
+}, {
+format: 'float32',
+offset: 22412,
+shaderLocation: 17,
+}, {
+format: 'uint16x4',
+offset: 6172,
+shaderLocation: 16,
+}, {
+format: 'float16x2',
+offset: 3856,
+shaderLocation: 21,
+}, {
+format: 'sint8x2',
+offset: 23546,
+shaderLocation: 5,
+}, {
+format: 'sint32',
+offset: 7392,
+shaderLocation: 12,
+}, {
+format: 'float32x3',
+offset: 16312,
+shaderLocation: 11,
+}, {
+format: 'sint16x4',
+offset: 20784,
+shaderLocation: 18,
+}, {
+format: 'float32x4',
+offset: 7888,
+shaderLocation: 13,
+}, {
+format: 'sint32x4',
+offset: 2084,
+shaderLocation: 20,
+}, {
+format: 'float32x2',
+offset: 5800,
+shaderLocation: 19,
+}, {
+format: 'sint32x2',
+offset: 21680,
+shaderLocation: 3,
+}, {
+format: 'float32',
+offset: 112,
+shaderLocation: 23,
+}, {
+format: 'uint8x2',
+offset: 16576,
+shaderLocation: 10,
+}, {
+format: 'sint32x4',
+offset: 9240,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 17088,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 14222,
+shaderLocation: 7,
+}, {
+format: 'sint16x4',
+offset: 13148,
+shaderLocation: 15,
+}, {
+format: 'sint8x2',
+offset: 7246,
+shaderLocation: 24,
+}, {
+format: 'float32x4',
+offset: 10004,
+shaderLocation: 4,
+}, {
+format: 'uint32x4',
+offset: 1372,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 3656,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x2',
+offset: 1680,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+frontFace: 'cw',
+unclippedDepth: true,
+},
+});
+try {
+  await promise50;
+} catch {}
+let renderPassEncoder7 = commandEncoder9.beginRenderPass({
+label: '\u1e4f\u{1f856}\u{1f933}\u{1f92c}',
+colorAttachments: [],
+depthStencilAttachment: {
+view: textureView55,
+depthClearValue: 0.9977942929646083,
+depthLoadOp: 'clear',
+depthStoreOp: 'discard',
+},
+occlusionQuerySet: querySet2,
+maxDrawCount: 761212995,
+});
+let renderBundle80 = renderBundleEncoder46.finish({label: '\uf8ee\u0cbf\u8d22\uc276\u1b05\u62f8\u1fcd\u083e\u{1fd67}\u{1fce7}'});
+try {
+computePassEncoder29.setBindGroup(6, bindGroup13);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(8, bindGroup10, []);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(4, buffer6, 16332);
+} catch {}
+try {
+renderBundleEncoder62.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+querySet21.destroy();
+} catch {}
+try {
+commandEncoder51.copyTextureToTexture({
+  texture: texture100,
+  mipLevel: 2,
+  origin: { x: 16, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture100,
+  mipLevel: 0,
+  origin: { x: 88, y: 6, z: 0 },
+  aspect: 'all',
+}, {width: 24, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer28, 124, new DataView(new ArrayBuffer(62307)), 21398, 6336);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 1,
+  origin: { x: 8, y: 0, z: 14 },
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 197463 */
+{offset: 567, bytesPerRow: 424, rowsPerImage: 66}, {width: 80, height: 24, depthOrArrayLayers: 8});
+} catch {}
+try {
+  await promise52;
+} catch {}
+let adapter15 = await navigator.gpu.requestAdapter({
+});
+let bindGroupLayout31 = device5.createBindGroupLayout({
+label: '\u1082\u07d2\ua86e',
+entries: [],
+});
+let texture101 = device5.createTexture({
+label: '\u6cae\u4821\ube83\ufcf8\udf92\u{1f72b}\u1b5e\uf6df',
+size: {width: 1110, height: 16, depthOrArrayLayers: 1193},
+mipLevelCount: 8,
+dimension: '3d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [],
+});
+let textureView85 = texture92.createView({
+  label: '\u0549\uf53b\u6922\u{1f8c4}\u059c\u49a4\ud75a\u0912',
+  dimension: '2d-array',
+  format: 'astc-6x5-unorm-srgb'
+});
+let arrayBuffer9 = buffer36.getMappedRange(2480, 1188);
+let pipeline76 = device5.createRenderPipeline({
+label: '\u7f4f\uacc6\u7096\ueb20',
+layout: pipelineLayout15,
+fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [undefined, {format: 'rg32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'rgba8uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {
+  format: 'r8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, undefined]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 1009,
+stencilWriteMask: 3671,
+depthBiasSlopeScale: 82,
+depthBiasClamp: 81,
+},
+vertex: {
+  module: shaderModule19,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 26136,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32',
+offset: 17592,
+shaderLocation: 11,
+}, {
+format: 'sint8x4',
+offset: 7644,
+shaderLocation: 2,
+}, {
+format: 'sint32x4',
+offset: 8400,
+shaderLocation: 4,
+}, {
+format: 'sint8x4',
+offset: 18116,
+shaderLocation: 1,
+}, {
+format: 'uint16x4',
+offset: 16640,
+shaderLocation: 7,
+}, {
+format: 'unorm16x2',
+offset: 5984,
+shaderLocation: 13,
+}, {
+format: 'sint16x4',
+offset: 11576,
+shaderLocation: 0,
+}, {
+format: 'float32x3',
+offset: 1212,
+shaderLocation: 3,
+}, {
+format: 'uint32',
+offset: 8708,
+shaderLocation: 5,
+}, {
+format: 'snorm16x4',
+offset: 7544,
+shaderLocation: 6,
+}, {
+format: 'unorm8x4',
+offset: 22188,
+shaderLocation: 8,
+}, {
+format: 'unorm16x2',
+offset: 18472,
+shaderLocation: 16,
+}, {
+format: 'float32x4',
+offset: 13756,
+shaderLocation: 9,
+}, {
+format: 'uint16x4',
+offset: 22716,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 20708,
+attributes: [{
+format: 'float32x3',
+offset: 8904,
+shaderLocation: 10,
+}, {
+format: 'float32',
+offset: 18444,
+shaderLocation: 15,
+}, {
+format: 'unorm16x4',
+offset: 18716,
+shaderLocation: 12,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let promise53 = adapter15.requestDevice({
+label: '\u15ab\ud8e4',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 33,
+maxVertexAttributes: 21,
+maxVertexBufferArrayStride: 46156,
+maxStorageTexturesPerShaderStage: 29,
+maxStorageBuffersPerShaderStage: 15,
+maxDynamicStorageBuffersPerPipelineLayout: 22933,
+maxBindingsPerBindGroup: 8327,
+maxTextureDimension1D: 13935,
+maxTextureDimension2D: 11556,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 78607737,
+maxUniformBuffersPerShaderStage: 13,
+maxInterStageShaderVariables: 69,
+maxInterStageShaderComponents: 97,
+},
+});
+let querySet64 = device8.createQuerySet({
+type: 'occlusion',
+count: 144,
+});
+let renderBundle81 = renderBundleEncoder70.finish({label: '\ude79\u010a\u067b\u{1fd0b}\u{1fe41}\u0c91'});
+let commandEncoder59 = device0.createCommandEncoder();
+let computePassEncoder35 = commandEncoder26.beginComputePass({label: '\uf35c\ud16d\u082c'});
+let renderBundleEncoder73 = device0.createRenderBundleEncoder({
+  label: '\ue35f\u0920\u{1facf}\u1d60\u0d8f\u{1fee8}\u{1fd30}',
+  colorFormats: ['r32float', 'rgba32float', 'bgra8unorm-srgb', 'rgba8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder21.setPipeline(pipeline24);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(471, 72, 455, 0);
+} catch {}
+try {
+renderBundleEncoder37.draw(56, 24, 32, 48);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer28, 20208);
+} catch {}
+try {
+renderBundleEncoder67.setIndexBuffer(buffer28, 'uint16');
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline15);
+} catch {}
+try {
+commandEncoder58.copyBufferToBuffer(buffer15, 22476, buffer30, 1328, 10116);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer30);
+} catch {}
+try {
+commandEncoder58.resolveQuerySet(querySet14, 403, 125, buffer6, 14080);
+} catch {}
+let img31 = await imageWithData(140, 192, '#9b5f8284', '#6e595743');
+let querySet65 = device6.createQuerySet({
+label: '\ubc87\ua3ad',
+type: 'occlusion',
+count: 1352,
+});
+try {
+buffer38.destroy();
+} catch {}
+video2.width = 290;
+let bindGroupLayout32 = device7.createBindGroupLayout({
+label: '\u0e02\u{1fd6d}\u4b09\u8115\u{1f68f}\u4cc1',
+entries: [],
+});
+let commandEncoder60 = device7.createCommandEncoder({label: '\u{1fd73}\u9091\u{1fd4d}\uc34e\u0f25\uc5c7\u0746\u0350\u{1f6b8}\ub897\u993c'});
+let renderBundleEncoder74 = device7.createRenderBundleEncoder({
+  colorFormats: ['r32float', 'rgba16sint', 'r16uint', 'rg16sint', undefined, 'rg16float', 'r16float', 'rgba16sint'],
+  stencilReadOnly: true
+});
+let sampler59 = device7.createSampler({
+label: '\u{1f6de}\u68f6\u04da\u091d\u1675\u{1f7aa}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 5.790,
+lodMaxClamp: 89.452,
+});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+try {
+await adapter3.requestAdapterInfo();
+} catch {}
+try {
+externalTexture10.label = '\u0cff\u{1f7d0}\u{1fac6}\u5cba\u{1fcf6}';
+} catch {}
+let promise54 = device5.popErrorScope();
+try {
+commandEncoder41.copyBufferToTexture({
+/* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 5732 */
+offset: 5732,
+bytesPerRow: 256,
+buffer: buffer31,
+}, {
+  texture: texture81,
+  mipLevel: 3,
+  origin: { x: 16, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 4, height: 2, depthOrArrayLayers: 0});
+dissociateBuffer(device5, buffer31);
+} catch {}
+try {
+commandEncoder41.pushDebugGroup('\uaaa3');
+} catch {}
+try {
+device5.queue.writeTexture({
+  texture: texture84,
+  mipLevel: 1,
+  origin: { x: 220, y: 3, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(17529), /* required buffer size: 17529 */
+{offset: 801, bytesPerRow: 2396}, {width: 294, height: 7, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device5.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(/*
+{width: 1110, height: 16, depthOrArrayLayers: 1193}
+*/
+{
+  source: img19,
+  origin: { x: 26, y: 126 },
+  flipY: false,
+}, {
+  texture: texture101,
+  mipLevel: 0,
+  origin: { x: 356, y: 2, z: 137 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 147, height: 13, depthOrArrayLayers: 1});
+} catch {}
+let pipeline77 = device5.createComputePipeline({
+label: '\u0df0\u02f1\u2685\u{1fabf}\u0d36\u{1fd03}\u{1f991}',
+layout: 'auto',
+compute: {
+module: shaderModule22,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let video29 = await videoWithData();
+try {
+  await promise54;
+} catch {}
+let video30 = await videoWithData();
+let video31 = await videoWithData();
+let bindGroupLayout33 = device2.createBindGroupLayout({
+label: '\u0633\u0eb7',
+entries: [{
+binding: 437,
+visibility: 0,
+storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '1d' },
+}, {
+binding: 1620,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+}],
+});
+let renderBundle82 = renderBundleEncoder34.finish({});
+try {
+renderBundleEncoder49.insertDebugMarker('\u0ea1');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 1,
+  origin: { x: 8, y: 0, z: 32 },
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 154673696 */
+{offset: 684, bytesPerRow: 2190, rowsPerImage: 298}, {width: 259, height: 1, depthOrArrayLayers: 238});
+} catch {}
+let img32 = await imageWithData(114, 254, '#4a58e04f', '#19f84812');
+let img33 = await imageWithData(154, 150, '#560740cc', '#bc2a973a');
+let video32 = await videoWithData();
+canvas4.width = 812;
+let offscreenCanvas22 = new OffscreenCanvas(134, 371);
+pseudoSubmit(device7, commandEncoder57);
+let renderBundle83 = renderBundleEncoder74.finish({label: '\u2941\u0cec\u{1fb31}\uead6\u468b\u4b86\u{1ff6a}\u0dba\u{1fd02}'});
+let sampler60 = device7.createSampler({
+label: '\u{1f7ec}\u{1fd7c}\u08be\u0acc\u3c77\u0eda\u0376',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 25.841,
+lodMaxClamp: 65.695,
+compare: 'not-equal',
+});
+try {
+commandEncoder60.insertDebugMarker('\u078b');
+} catch {}
+try {
+device7.queue.writeBuffer(buffer34, 1492, new BigUint64Array(28072), 27734, 120);
+} catch {}
+let video33 = await videoWithData();
+let commandEncoder61 = device6.createCommandEncoder({label: '\u7e33\u{1f937}\ud26d\u3d7f\u005e\u212e\u693d'});
+let computePassEncoder36 = commandEncoder53.beginComputePass({label: '\u0cde\u{1fb73}'});
+let renderBundle84 = renderBundleEncoder71.finish({label: '\u99ee\u60cd\udf26\u51b4\ua88c\u{1f84f}\u02b4\u062c\ude20'});
+let sampler61 = device6.createSampler({
+label: '\u0874\u0cb6\u{1fbc6}\u{1f884}\ub66f\u700e\ub171\u7315\u{1fef4}\u8001\u392a',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 88.271,
+lodMaxClamp: 97.178,
+compare: 'greater-equal',
+});
+let externalTexture12 = device6.importExternalTexture({
+source: video5,
+});
+try {
+buffer38.destroy();
+} catch {}
+try {
+commandEncoder61.resolveQuerySet(querySet63, 1275, 752, buffer38, 0);
+} catch {}
+let device10 = await adapter9.requestDevice({
+label: '\u7ff8\u0461\u{1f953}\u{1ff0c}\uba92\u{1f697}\u0f0a\u0d0f\u2177\uf107\u4d91',
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 51,
+maxVertexAttributes: 29,
+maxVertexBufferArrayStride: 3736,
+maxStorageTexturesPerShaderStage: 6,
+maxStorageBuffersPerShaderStage: 44,
+maxDynamicStorageBuffersPerPipelineLayout: 60296,
+maxBindingsPerBindGroup: 4761,
+maxTextureDimension1D: 16192,
+maxTextureDimension2D: 14390,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 240290832,
+maxUniformBuffersPerShaderStage: 19,
+maxInterStageShaderVariables: 78,
+maxInterStageShaderComponents: 91,
+maxSamplersPerShaderStage: 20,
+},
+});
+let canvas25 = document.createElement('canvas');
+let imageData19 = new ImageData(212, 220);
+let textureView86 = texture93.createView({label: '\u077e\u7f7e\u1df1\u09f0', format: 'astc-12x12-unorm', baseMipLevel: 6, arrayLayerCount: 1});
+try {
+offscreenCanvas22.getContext('bitmaprenderer');
+} catch {}
+let textureView87 = texture99.createView({label: '\uaf09\u6c3a\ua890'});
+let sampler62 = device9.createSampler({
+label: '\u7d75\u0a2f\u004b\ue9c0\u0c4f\uac6a\u0f36\u0d19\uf775\uaf77',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 80.834,
+compare: 'greater',
+maxAnisotropy: 19,
+});
+try {
+buffer37.unmap();
+} catch {}
+let gpuCanvasContext24 = canvas25.getContext('webgpu');
+let computePassEncoder37 = commandEncoder60.beginComputePass({label: '\u1bc1\u7b71\u7703\u05b5\u020d\u{1fd4d}'});
+let renderBundle85 = renderBundleEncoder74.finish({label: '\u{1f78f}\ua3cf\ubf9b\u1106\u{1f7dd}'});
+let renderBundle86 = renderBundleEncoder23.finish({label: '\u02d4\u0390\u72ca\u{1fa4e}\u085e\u4e69\u02a3\u7229'});
+try {
+renderPassEncoder7.setBindGroup(4, bindGroup27);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder7.setViewport(14.77, 0.9723, 10.83, 0.5546, 0.1138, 0.6037);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(7, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder37.drawIndexed(8, 64, 16, 792, 80);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexedIndirect(buffer28, 25788);
+} catch {}
+try {
+renderBundleEncoder37.drawIndirect(buffer28, 20292);
+} catch {}
+try {
+commandEncoder55.copyTextureToTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 68, y: 8, z: 42 },
+  aspect: 'all',
+}, {
+  texture: texture41,
+  mipLevel: 1,
+  origin: { x: 356, y: 8, z: 1 },
+  aspect: 'all',
+}, {width: 36, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder56.clearBuffer(buffer25, 24852, 12956);
+dissociateBuffer(device0, buffer25);
+} catch {}
+let imageData20 = new ImageData(164, 196);
+try {
+commandEncoder61.resolveQuerySet(querySet57, 132, 455, buffer38, 4096);
+} catch {}
+let sampler63 = device10.createSampler({
+label: '\uadae\u{1fa02}\u491b\u0389\u0bff\ub1a2\ua9df\u49ae',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 73.611,
+lodMaxClamp: 91.483,
+compare: 'less',
+});
+try {
+await device10.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas23 = new OffscreenCanvas(220, 662);
+let bindGroup32 = device5.createBindGroup({
+label: '\u{1fbb8}\u07c5',
+layout: bindGroupLayout31,
+entries: [],
+});
+let commandEncoder62 = device5.createCommandEncoder({label: '\u{1f796}\uee29\uf7b9\u{1f97e}\ud330\u026a\u{1fbf9}\ue3df\u892d\u0e09\u0885'});
+let querySet66 = device5.createQuerySet({
+label: '\u0f84\u076f\ubf60\u04f7\u0a77\uee95\u0d03',
+type: 'occlusion',
+count: 3148,
+});
+try {
+device5.queue.copyExternalImageToTexture(/*
+{width: 277, height: 4, depthOrArrayLayers: 298}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 20, y: 754 },
+  flipY: false,
+}, {
+  texture: texture101,
+  mipLevel: 2,
+  origin: { x: 0, y: 4, z: 207 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 273, height: 0, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas16.height = 234;
+document.body.prepend(img7);
+gc();
+let canvas26 = document.createElement('canvas');
+let promise55 = adapter14.requestAdapterInfo();
+let texture102 = device9.createTexture({
+label: '\u99e5\u{1f813}\ua162\u0d37\u268b',
+size: [51, 1, 464],
+mipLevelCount: 8,
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba32float', 'rgba32float'],
+});
+let textureView88 = texture102.createView({label: '\u0706\u075e\u0d7c\u6825\u0c0a\u{1fa40}\u{1f90a}\u{1fc11}\u0e6f\u8336', baseMipLevel: 7});
+try {
+device9.queue.writeTexture({
+  texture: texture102,
+  mipLevel: 5,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, arrayBuffer8, /* required buffer size: 17084 */
+{offset: 956, bytesPerRow: 32, rowsPerImage: 168}, {width: 1, height: 0, depthOrArrayLayers: 4});
+} catch {}
+offscreenCanvas20.width = 1005;
+let texture103 = device0.createTexture({
+label: '\u8393\u{1ffa0}\u020b\u{1fe59}\u133b\u3ade\u0f69\u{1fe2c}\uca3f',
+size: {width: 20, height: 20, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-10x10-unorm-srgb', 'astc-10x10-unorm', 'astc-10x10-unorm-srgb'],
+});
+let renderBundleEncoder75 = device0.createRenderBundleEncoder({
+  label: '\u0cd1\u{1f872}\u0e4b\u4b46',
+  colorFormats: ['rgba8unorm-srgb'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder22.setPipeline(pipeline12);
+} catch {}
+try {
+gpuCanvasContext15.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [],
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer28, 17404, new BigUint64Array(29605), 8972, 1824);
+} catch {}
+let commandEncoder63 = device10.createCommandEncoder();
+let canvas27 = document.createElement('canvas');
+let bindGroup33 = device7.createBindGroup({
+layout: bindGroupLayout32,
+entries: [],
+});
+let texture104 = device7.createTexture({
+label: '\uf4d7\u{1fb5a}\u004f\uf2a0\u{1fb3b}\u5536\u0c60\ued94',
+size: [1123, 22, 1],
+mipLevelCount: 9,
+format: 'rgba16sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16sint'],
+});
+try {
+device7.queue.writeBuffer(buffer34, 16896, new BigUint64Array(23960), 6215, 316);
+} catch {}
+let video34 = await videoWithData();
+let commandEncoder64 = device10.createCommandEncoder();
+let querySet67 = device10.createQuerySet({
+label: '\u0a9b\u4a81\u{1ff90}',
+type: 'occlusion',
+count: 1792,
+});
+let computePassEncoder38 = commandEncoder64.beginComputePass({label: '\u0795\u43ed\ud829\u5f80\u{1f662}\u43fd\uabdf'});
+let bindGroup34 = device7.createBindGroup({
+label: '\u3dc2\u28a2\ued29\ue449\ufa8b\u00c4\ucf2a\ud477\u07e7\u339f\u{1fd05}',
+layout: bindGroupLayout32,
+entries: [],
+});
+let commandEncoder65 = device7.createCommandEncoder({});
+let querySet68 = device7.createQuerySet({
+label: '\u{1f774}\u0783\u0276\u17a9',
+type: 'occlusion',
+count: 1290,
+});
+let commandBuffer9 = commandEncoder65.finish({
+});
+try {
+buffer34.unmap();
+} catch {}
+let adapter16 = await navigator.gpu.requestAdapter({
+powerPreference: 'low-power',
+});
+video32.height = 124;
+canvas23.height = 424;
+let offscreenCanvas24 = new OffscreenCanvas(697, 345);
+let buffer39 = device10.createBuffer({size: 36269, usage: GPUBufferUsage.MAP_READ});
+let commandEncoder66 = device10.createCommandEncoder({label: '\ucac9\u0d35\u0ab8\u9147\u01cb'});
+let commandBuffer10 = commandEncoder63.finish({
+label: '\u0d84\u{1f88f}\uc9a0\ubdad\ue9eb\u073b\u0ca5\u017a\u00e4',
+});
+pseudoSubmit(device10, commandEncoder64);
+let texture105 = device10.createTexture({
+label: '\u0b4e\u07e3\ud00a\u9be5\u8ea0\u{1fad3}\u34d4\u8c4e\u0eb8\u65cb',
+size: {width: 1997, height: 1, depthOrArrayLayers: 243},
+mipLevelCount: 6,
+sampleCount: 1,
+dimension: '2d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['r8snorm', 'r8snorm', 'r8snorm'],
+});
+let computePassEncoder39 = commandEncoder66.beginComputePass({label: '\u{1fca1}\u{1fc25}\u0134\u0de3\u0c93\u029b'});
+let sampler64 = device10.createSampler({
+label: '\ua034\u{1feb3}\u010f\ub446\uffe9',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 83.094,
+lodMaxClamp: 88.742,
+maxAnisotropy: 12,
+});
+pseudoSubmit(device10, commandEncoder66);
+let texture106 = gpuCanvasContext0.getCurrentTexture();
+try {
+gpuCanvasContext1.configure({
+device: device10,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgb10a2unorm', 'rgba8unorm', 'rgba8unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let gpuCanvasContext25 = canvas27.getContext('webgpu');
+canvas10.height = 468;
+try {
+device10.queue.submit([
+commandBuffer10,
+]);
+} catch {}
+try {
+device10.queue.writeTexture({
+  texture: texture105,
+  mipLevel: 1,
+  origin: { x: 384, y: 1, z: 33 },
+  aspect: 'all',
+}, new ArrayBuffer(2878194), /* required buffer size: 2878194 */
+{offset: 549, bytesPerRow: 439, rowsPerImage: 95}, {width: 207, height: 0, depthOrArrayLayers: 70});
+} catch {}
+let videoFrame24 = new VideoFrame(img6, {timestamp: 0});
+let buffer40 = device8.createBuffer({
+  label: '\u32d7\u05cf\ubdab\ufcf9\udc39\u6067\u{1f9d6}\ufcb6\u{1fe80}',
+  size: 57364,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true
+});
+let commandEncoder67 = device8.createCommandEncoder({label: '\u6234\uc1a1\uaf09\u426a\u82ef\u{1f759}\u1ce6\u{1fa28}\u7b44\u{1feb5}'});
+let texture107 = device8.createTexture({
+label: '\u{1f93b}\udc08\u2f00\u{1ff25}\u{1f693}\u{1f96d}\u03e4\u{1fb74}\u{1ff0b}\u0bf5',
+size: {width: 456, height: 1, depthOrArrayLayers: 101},
+mipLevelCount: 8,
+format: 'depth24plus',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth24plus'],
+});
+let texture108 = gpuCanvasContext2.getCurrentTexture();
+try {
+  await promise55;
+} catch {}
+let bindGroupLayout34 = device9.createBindGroupLayout({
+label: '\u016b\u7f50\u2120\ufc08',
+entries: [{
+binding: 1744,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+}],
+});
+let commandEncoder68 = device9.createCommandEncoder();
+let querySet69 = device9.createQuerySet({
+label: '\u0a7f\u574c\u0209\u0bc6',
+type: 'occlusion',
+count: 594,
+});
+let textureView89 = texture99.createView({dimension: '2d-array'});
+try {
+buffer37.unmap();
+} catch {}
+let adapter17 = await navigator.gpu.requestAdapter({
+});
+let offscreenCanvas25 = new OffscreenCanvas(964, 39);
+try {
+offscreenCanvas24.getContext('webgl');
+} catch {}
+let commandBuffer11 = commandEncoder59.finish({
+label: '\u{1fe88}\u{1f800}\u022c\u37b9\u844f\u85b0\uee62',
+});
+try {
+renderPassEncoder6.setBlendConstant({ r: 53.22, g: 992.2, b: 359.9, a: -317.4, });
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(8, buffer11, 212, 14856);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer21, 26324);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline54);
+} catch {}
+try {
+buffer28.destroy();
+} catch {}
+let imageBitmap19 = await createImageBitmap(imageData0);
+let commandEncoder69 = device8.createCommandEncoder({label: '\u05d9\u0036\ud29c\ubbc1\u06bc\uc138\u{1fa16}\ud821\u0e42'});
+let renderBundleEncoder76 = device8.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2unorm', 'r32float', undefined, 'r8sint', 'r8uint', 'bgra8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+commandEncoder69.clearBuffer(buffer40, 54960, 2072);
+dissociateBuffer(device8, buffer40);
+} catch {}
+canvas21.width = 1019;
+let bindGroupLayout35 = device8.createBindGroupLayout({
+label: '\u07da\u6980\u0698\u{1fc85}\u0644\u{1fe4e}\u{1f703}\u052b',
+entries: [],
+});
+let buffer41 = device8.createBuffer({label: '\u384c\u05ce\u02d1', size: 26612, usage: GPUBufferUsage.MAP_READ, mappedAtCreation: true});
+let commandEncoder70 = device8.createCommandEncoder({label: '\u0141\u2e37\u34c2\ue030\u{1f7ae}\ubd75\u0469'});
+try {
+commandEncoder69.copyBufferToBuffer(buffer35, 13408, buffer40, 22824, 2960);
+dissociateBuffer(device8, buffer35);
+dissociateBuffer(device8, buffer40);
+} catch {}
+let buffer42 = device9.createBuffer({size: 22672, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX, mappedAtCreation: true});
+let texture109 = device9.createTexture({
+label: '\u{1f91f}\u1429\u0f2f\uaf3d\u5fc2\u{1fb7a}\u0a75\u03b1\u{1f73d}\ub8a6',
+size: [102, 3, 929],
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [],
+});
+let textureView90 = texture102.createView({label: '\u3c90\u8e7d\u0427\u8c11\u37ea\u0e0e\u4287', baseMipLevel: 1, mipLevelCount: 2});
+try {
+await device9.popErrorScope();
+} catch {}
+try {
+texture102.destroy();
+} catch {}
+let arrayBuffer10 = buffer42.getMappedRange(9768);
+gc();
+let canvas28 = document.createElement('canvas');
+let pipelineLayout17 = device7.createPipelineLayout({
+  label: '\u0f08\u9194\u{1fefb}\u{1fe8e}\u0718\u074b\ud926',
+  bindGroupLayouts: [bindGroupLayout32, bindGroupLayout32]
+});
+try {
+  await buffer34.mapAsync(GPUMapMode.READ, 24952, 236);
+} catch {}
+let device11 = await adapter13.requestDevice({
+label: '\u7c8e\u007c\u6120\u7ee7\uf2c8\u8bf2\ue908\u8b97\u{1f60f}\u382a',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 4,
+maxColorAttachmentBytesPerSample: 50,
+maxVertexAttributes: 21,
+maxVertexBufferArrayStride: 15890,
+maxStorageTexturesPerShaderStage: 25,
+maxStorageBuffersPerShaderStage: 33,
+maxDynamicStorageBuffersPerPipelineLayout: 43755,
+maxBindingsPerBindGroup: 5548,
+maxTextureDimension1D: 9060,
+maxTextureDimension2D: 14446,
+maxVertexBuffers: 9,
+maxUniformBufferBindingSize: 265601916,
+maxUniformBuffersPerShaderStage: 19,
+maxInterStageShaderVariables: 77,
+maxInterStageShaderComponents: 83,
+maxSamplersPerShaderStage: 21,
+},
+});
+let commandEncoder71 = device0.createCommandEncoder({});
+let querySet70 = device0.createQuerySet({
+type: 'occlusion',
+count: 4,
+});
+try {
+renderPassEncoder6.setIndexBuffer(buffer17, 'uint16', 3950, 16680);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(3, buffer11, 11100, 36);
+} catch {}
+try {
+renderBundleEncoder17.drawIndirect(buffer21, 10184);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(0, buffer11, 20188, 82);
+} catch {}
+try {
+commandEncoder71.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture6,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 480, height: 36, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 1,
+  origin: { x: 90, y: 6, z: 0 },
+  aspect: 'all',
+}, new Float32Array(arrayBuffer5), /* required buffer size: 2 */
+{offset: 2}, {width: 120, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.destroy();
+} catch {}
+let commandBuffer12 = commandEncoder70.finish({
+label: '\u03e2\u0f38',
+});
+let texture110 = device8.createTexture({
+label: '\u0792\u009a\u3693\u58ab\uc680\uae69\u0d2a',
+size: {width: 24},
+dimension: '1d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm'],
+});
+let renderBundleEncoder77 = device8.createRenderBundleEncoder({
+  label: '\ub546\u244a\u{1f88a}\u0802\u30ac\u64bf\u0cac\ucce6\u0ec3',
+  colorFormats: ['rgb10a2unorm', 'r32float', undefined, 'r8sint', 'r8uint', 'bgra8unorm']
+});
+let renderBundle87 = renderBundleEncoder70.finish({});
+try {
+commandEncoder67.copyTextureToTexture({
+  texture: texture108,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture110,
+  mipLevel: 0,
+  origin: { x: 15, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder69.pushDebugGroup('\u0118');
+} catch {}
+let renderBundle88 = renderBundleEncoder68.finish({label: '\u5f29\u77c4\u{1f95d}'});
+try {
+commandEncoder62.copyTextureToTexture({
+  texture: texture90,
+  mipLevel: 4,
+  origin: { x: 12, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture90,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder46.clearBuffer(buffer36, 3440, 36);
+dissociateBuffer(device5, buffer36);
+} catch {}
+let pipeline78 = device5.createComputePipeline({
+label: '\u61bc\u{1fd78}\u0eb7',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule24,
+entryPoint: 'compute0',
+},
+});
+let pipeline79 = device5.createRenderPipeline({
+label: '\u0155\u0e79\u0f96\uaaca\ueecc\u8600\u9d0a\u{1feb2}',
+layout: pipelineLayout15,
+multisample: {
+count: 4,
+},
+fragment: {
+  module: shaderModule24,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [undefined, {format: 'rg32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {
+  format: 'r8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'constant'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'zero',
+},
+stencilBack: {
+failOp: 'increment-clamp',
+depthFailOp: 'keep',
+},
+stencilReadMask: 267,
+depthBias: 84,
+depthBiasSlopeScale: 65,
+depthBiasClamp: 81,
+},
+vertex: {
+  module: shaderModule24,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32',
+offset: 7124,
+shaderLocation: 2,
+}, {
+format: 'float32x3',
+offset: 22280,
+shaderLocation: 13,
+}, {
+format: 'uint8x4',
+offset: 23352,
+shaderLocation: 4,
+}, {
+format: 'float16x4',
+offset: 2176,
+shaderLocation: 11,
+}, {
+format: 'float16x2',
+offset: 19508,
+shaderLocation: 7,
+}, {
+format: 'snorm8x2',
+offset: 8912,
+shaderLocation: 16,
+}, {
+format: 'float32',
+offset: 19924,
+shaderLocation: 0,
+}, {
+format: 'snorm8x4',
+offset: 68,
+shaderLocation: 1,
+}, {
+format: 'sint16x4',
+offset: 5480,
+shaderLocation: 3,
+}, {
+format: 'snorm16x2',
+offset: 21708,
+shaderLocation: 9,
+}, {
+format: 'float16x2',
+offset: 4776,
+shaderLocation: 5,
+}, {
+format: 'uint8x2',
+offset: 8032,
+shaderLocation: 12,
+}, {
+format: 'float32x3',
+offset: 16368,
+shaderLocation: 15,
+}, {
+format: 'snorm8x2',
+offset: 17114,
+shaderLocation: 14,
+}, {
+format: 'sint32',
+offset: 29608,
+shaderLocation: 6,
+}, {
+format: 'float32',
+offset: 13564,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 8052,
+attributes: [],
+},
+{
+arrayStride: 22212,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 12912,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 2472,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x2',
+offset: 230,
+shaderLocation: 10,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+try {
+device5.destroy();
+} catch {}
+try {
+offscreenCanvas23.getContext('webgl');
+} catch {}
+let querySet71 = device9.createQuerySet({
+label: '\u{1fb88}\u047a\u4f04\u9be3\uaece\u2d09\u3768\u{1fa53}',
+type: 'occlusion',
+count: 2515,
+});
+let texture111 = device9.createTexture({
+size: {width: 712, height: 480, depthOrArrayLayers: 228},
+mipLevelCount: 4,
+dimension: '2d',
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let querySet72 = device8.createQuerySet({
+type: 'occlusion',
+count: 1691,
+});
+let commandBuffer13 = commandEncoder67.finish({
+label: '\u2f2f\u0707\u09ce\uce7e\u0ee1\u0e20\ud9f1\u0ae0',
+});
+let computePassEncoder40 = commandEncoder69.beginComputePass({label: '\u013b\u{1fbc3}\u1728'});
+let sampler65 = device8.createSampler({
+label: '\u95f4\u0f2a\u083e\ua065\u8140\uca43',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+lodMaxClamp: 86.294,
+});
+let arrayBuffer11 = buffer41.getMappedRange(12792, 10276);
+let promise56 = device8.queue.onSubmittedWorkDone();
+let gpuCanvasContext26 = canvas28.getContext('webgpu');
+let gpuCanvasContext27 = canvas26.getContext('webgpu');
+let offscreenCanvas26 = new OffscreenCanvas(868, 796);
+let commandEncoder72 = device6.createCommandEncoder({});
+let querySet73 = device6.createQuerySet({
+label: '\u4573\u3a96\ua09b\u0e25',
+type: 'occlusion',
+count: 1751,
+});
+pseudoSubmit(device6, commandEncoder48);
+let texture112 = device6.createTexture({
+label: '\ub150\u05ac\u76a8\u0df3',
+size: [4480, 1, 167],
+mipLevelCount: 2,
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgba8uint'],
+});
+let textureView91 = texture93.createView({dimension: '2d-array', baseMipLevel: 3});
+let img34 = await imageWithData(109, 152, '#4e25168f', '#bd7ae8e5');
+try {
+  await promise56;
+} catch {}
+let videoFrame25 = new VideoFrame(img9, {timestamp: 0});
+let pipelineLayout18 = device8.createPipelineLayout({
+  label: '\ubfce\ub4a7',
+  bindGroupLayouts: [bindGroupLayout35, bindGroupLayout35, bindGroupLayout35, bindGroupLayout35, bindGroupLayout35]
+});
+let commandEncoder73 = device8.createCommandEncoder({});
+let querySet74 = device8.createQuerySet({
+type: 'occlusion',
+count: 2207,
+});
+let computePassEncoder41 = commandEncoder73.beginComputePass({label: '\u{1fb1e}\u68f0\u{1f66c}\u4b09\u2639\u5ba3\u0fb9'});
+gc();
+let offscreenCanvas27 = new OffscreenCanvas(878, 735);
+let img35 = await imageWithData(108, 241, '#9d07e14d', '#42f331c2');
+let video35 = await videoWithData();
+let img36 = await imageWithData(102, 158, '#ac31dfb8', '#663dbe58');
+let pipelineLayout19 = device9.createPipelineLayout({bindGroupLayouts: [bindGroupLayout30, bindGroupLayout34]});
+let buffer43 = device9.createBuffer({
+  label: '\u{1fed4}\u514f\u1de3\u1d63\ub039\u708e',
+  size: 38565,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let texture113 = device9.createTexture({
+label: '\u{1f67b}\udbd0\u0ea9\u05f5\u0ca7\u1e43\u{1f6d8}\uddd7\u3f6f\u6856\u0184',
+size: [712, 480, 1],
+mipLevelCount: 6,
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x6-unorm'],
+});
+let renderBundleEncoder78 = device9.createRenderBundleEncoder({
+  label: '\u6b91\u0d01\u4e3e\u{1f7b3}\uddec\u79a3\u0231\u016c\u3203',
+  colorFormats: ['rgba16float', 'rg16sint', 'rgba8uint'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+commandEncoder68.copyBufferToBuffer(buffer43, 21608, buffer42, 268, 14680);
+dissociateBuffer(device9, buffer43);
+dissociateBuffer(device9, buffer42);
+} catch {}
+video35.width = 42;
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let buffer44 = device5.createBuffer({size: 38788, usage: GPUBufferUsage.COPY_DST, mappedAtCreation: true});
+try {
+computePassEncoder34.setBindGroup(2, bindGroup32, new Uint32Array(1421), 609, 0);
+} catch {}
+try {
+commandEncoder62.copyBufferToBuffer(buffer31, 32796, buffer36, 884, 3048);
+dissociateBuffer(device5, buffer31);
+dissociateBuffer(device5, buffer36);
+} catch {}
+try {
+device5.queue.writeTexture({
+  texture: texture101,
+  mipLevel: 7,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(32879), /* required buffer size: 32879 */
+{offset: 735, bytesPerRow: 98, rowsPerImage: 82}, {width: 8, height: 0, depthOrArrayLayers: 5});
+} catch {}
+try {
+await device5.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline80 = await device5.createComputePipelineAsync({
+label: '\u0ad9\ua0b6\u480f\u082c\u3264\u{1ff84}\u6790',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule24,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline81 = device5.createRenderPipeline({
+label: '\uaa45\u7441\u1da6\u0f66\ub1ae\u9d15',
+layout: pipelineLayout15,
+fragment: {
+  module: shaderModule24,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [undefined, {format: 'rg32uint', writeMask: GPUColorWrite.ALL}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL}, {
+  format: 'r8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'dst', dstFactor: 'one-minus-src'},
+},
+  writeMask: 0
+}, undefined]
+},
+depthStencil: {
+format: 'stencil8',
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-wrap',
+},
+stencilWriteMask: 3621,
+depthBias: 66,
+depthBiasSlopeScale: 14,
+depthBiasClamp: 92,
+},
+vertex: {
+  module: shaderModule24,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 380,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32',
+offset: 16,
+shaderLocation: 7,
+}, {
+format: 'snorm16x2',
+offset: 328,
+shaderLocation: 8,
+}, {
+format: 'sint16x4',
+offset: 88,
+shaderLocation: 3,
+}, {
+format: 'uint32x3',
+offset: 360,
+shaderLocation: 10,
+}, {
+format: 'float16x4',
+offset: 128,
+shaderLocation: 5,
+}, {
+format: 'unorm16x4',
+offset: 336,
+shaderLocation: 11,
+}, {
+format: 'float16x2',
+offset: 80,
+shaderLocation: 16,
+}, {
+format: 'sint8x2',
+offset: 338,
+shaderLocation: 6,
+}, {
+format: 'float32x2',
+offset: 324,
+shaderLocation: 2,
+}, {
+format: 'uint16x4',
+offset: 48,
+shaderLocation: 4,
+}, {
+format: 'float32x3',
+offset: 272,
+shaderLocation: 15,
+}, {
+format: 'float32x3',
+offset: 60,
+shaderLocation: 9,
+}, {
+format: 'snorm8x4',
+offset: 188,
+shaderLocation: 1,
+}, {
+format: 'uint16x2',
+offset: 24,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 8608,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 1904,
+shaderLocation: 0,
+}, {
+format: 'snorm8x2',
+offset: 5046,
+shaderLocation: 14,
+}, {
+format: 'float16x4',
+offset: 4200,
+shaderLocation: 13,
+}],
+}
+]
+},
+});
+let device12 = await promise53;
+let imageData21 = new ImageData(128, 96);
+let buffer45 = device11.createBuffer({size: 6163, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let renderBundleEncoder79 = device11.createRenderBundleEncoder({
+  label: '\u8fa7\u8124\u0458\u815e\u087e\ud1bd\u{1fc84}\u4d6b\u7480',
+  colorFormats: ['rgba8sint'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle89 = renderBundleEncoder79.finish({});
+let commandEncoder74 = device12.createCommandEncoder({label: '\u4b31\u{1fee8}\u0e1c\u0810\u00a5\ud045\ua29c\u7b46'});
+let promise57 = device12.queue.onSubmittedWorkDone();
+let img37 = await imageWithData(164, 87, '#5d6a6ef4', '#9ddcf980');
+let sampler66 = device6.createSampler({
+label: '\udc71\u9125\u6f70\u1900\u0531\ueabc\u0111\ucbdc\u1118',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 89.828,
+lodMaxClamp: 99.313,
+compare: 'not-equal',
+});
+try {
+device6.queue.writeTexture({
+  texture: texture112,
+  mipLevel: 1,
+  origin: { x: 626, y: 0, z: 21 },
+  aspect: 'all',
+}, new Float32Array(arrayBuffer3), /* required buffer size: 26759622 */
+{offset: 698, bytesPerRow: 920, rowsPerImage: 277}, {width: 181, height: 1, depthOrArrayLayers: 106});
+} catch {}
+let gpuCanvasContext28 = offscreenCanvas27.getContext('webgpu');
+canvas24.width = 158;
+let adapter18 = await navigator.gpu.requestAdapter({
+});
+let canvas29 = document.createElement('canvas');
+try {
+adapter16.label = '\u{1fa63}\u716c\u0459\ua931\u964d\u{1fee9}\uacc2\u013b\u208b\u{1f69d}\u06b7';
+} catch {}
+gc();
+let imageBitmap20 = await createImageBitmap(canvas9);
+try {
+offscreenCanvas25.getContext('webgl');
+} catch {}
+let bindGroupLayout36 = device6.createBindGroupLayout({
+label: '\u0078\u0576\ufe11\u{1fdd2}\ua2fa\ud737',
+entries: [{
+binding: 939,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}, {
+binding: 2707,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '2d' },
+}],
+});
+let commandBuffer14 = commandEncoder61.finish({
+label: '\udc5c\u{1fc9f}\uf2eb\u542f\u{1ff01}',
+});
+try {
+commandEncoder72.copyTextureToTexture({
+  texture: texture112,
+  mipLevel: 0,
+  origin: { x: 54, y: 0, z: 78 },
+  aspect: 'all',
+}, {
+  texture: texture112,
+  mipLevel: 1,
+  origin: { x: 148, y: 0, z: 109 },
+  aspect: 'all',
+}, {width: 1803, height: 1, depthOrArrayLayers: 32});
+} catch {}
+try {
+device6.queue.submit([
+]);
+} catch {}
+gc();
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let textureView92 = texture95.createView({
+  label: '\u{1f6e5}\u{1f97f}\u817a\ufb0d\u4a5b',
+  aspect: 'depth-only',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 14,
+  arrayLayerCount: 204
+});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let promise58 = navigator.gpu.requestAdapter({
+});
+let querySet75 = device9.createQuerySet({
+label: '\u6c60\u1b46\ud6f8\u01d0\u8d3d\u{1f633}',
+type: 'occlusion',
+count: 594,
+});
+let renderBundleEncoder80 = device9.createRenderBundleEncoder({
+  label: '\uce9a\u{1f880}\u0d76\u1141\ue6a0\u{1f719}\u7138\u0f6a',
+  colorFormats: ['rgba16float', 'rg16sint', 'rgba8uint'],
+  sampleCount: 4
+});
+try {
+renderBundleEncoder78.setVertexBuffer(4, buffer37);
+} catch {}
+let promise59 = device9.queue.onSubmittedWorkDone();
+canvas8.height = 446;
+let shaderModule25 = device9.createShaderModule({
+label: '\u0f38\ufa5d\u{1f73e}\u07f3\u3230\ub070\u05f7\u{1ffd4}\u{1fd92}\ufd56\uaf6d',
+code: `@group(0) @binding(1453)
+var<storage, read_write> field18: array<u32>;
+@group(1) @binding(1744)
+var<storage, read_write> local13: array<u32>;
+@group(0) @binding(1665)
+var<storage, read_write> global13: array<u32>;
+
+@compute @workgroup_size(7, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S30 {
+  @location(32) f0: i32,
+  @location(8) f1: vec4<f16>,
+  @location(1) f2: vec2<i32>,
+  @builtin(sample_index) f3: u32,
+  @location(40) f4: vec3<i32>,
+  @location(52) f5: vec2<f16>,
+  @location(28) f6: vec4<f16>,
+  @location(33) f7: vec4<u32>,
+  @location(9) f8: vec3<u32>,
+  @location(2) f9: vec3<i32>,
+  @location(10) f10: vec2<i32>,
+  @location(69) f11: u32,
+  @location(3) f12: u32,
+  @location(37) f13: vec2<f16>,
+  @location(56) f14: f16,
+  @location(14) f15: vec3<u32>,
+  @location(57) f16: vec2<f16>,
+  @location(4) f17: f16,
+  @location(36) f18: f32,
+  @location(58) f19: f16,
+  @builtin(front_facing) f20: bool,
+  @location(35) f21: vec3<i32>,
+  @location(25) f22: vec3<i32>,
+  @location(65) f23: vec3<f16>,
+  @builtin(sample_mask) f24: u32
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec3<i32>,
+  @location(2) f1: vec4<u32>,
+  @location(0) f2: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(13) a0: vec3<u32>, @location(23) a1: f16, @location(11) a2: vec4<f16>, @location(48) a3: vec3<u32>, @location(59) a4: i32, a5: S30, @builtin(position) a6: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S29 {
+  @location(16) f0: vec3<f16>,
+  @location(9) f1: vec3<i32>,
+  @location(3) f2: u32,
+  @location(6) f3: vec4<f32>,
+  @location(11) f4: vec3<i32>,
+  @location(21) f5: i32
+}
+struct VertexOutput0 {
+  @location(69) f351: u32,
+  @location(35) f352: vec3<i32>,
+  @location(58) f353: f16,
+  @location(3) f354: u32,
+  @location(13) f355: vec3<u32>,
+  @location(4) f356: f16,
+  @location(10) f357: vec2<i32>,
+  @location(36) f358: f32,
+  @location(14) f359: vec3<u32>,
+  @location(37) f360: vec2<f16>,
+  @location(48) f361: vec3<u32>,
+  @location(25) f362: vec3<i32>,
+  @location(23) f363: f16,
+  @location(33) f364: vec4<u32>,
+  @location(32) f365: i32,
+  @location(8) f366: vec4<f16>,
+  @builtin(position) f367: vec4<f32>,
+  @location(9) f368: vec3<u32>,
+  @location(2) f369: vec3<i32>,
+  @location(56) f370: f16,
+  @location(52) f371: vec2<f16>,
+  @location(59) f372: i32,
+  @location(11) f373: vec4<f16>,
+  @location(57) f374: vec2<f16>,
+  @location(65) f375: vec3<f16>,
+  @location(28) f376: vec4<f16>,
+  @location(40) f377: vec3<i32>,
+  @location(1) f378: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec2<f32>, @location(13) a1: vec2<i32>, @location(12) a2: vec4<i32>, @location(7) a3: vec4<u32>, @location(15) a4: vec3<f32>, @location(17) a5: u32, @location(23) a6: vec4<f32>, @location(8) a7: vec4<f32>, @location(1) a8: vec4<f16>, @location(4) a9: u32, @builtin(vertex_index) a10: u32, @location(19) a11: u32, @builtin(instance_index) a12: u32, @location(0) a13: vec4<u32>, @location(22) a14: f16, @location(20) a15: vec4<f16>, @location(10) a16: u32, @location(14) a17: vec4<i32>, @location(18) a18: vec2<i32>, @location(2) a19: vec3<u32>, a20: S29) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+hints: {},
+});
+let commandEncoder75 = device9.createCommandEncoder({label: '\u0df4\u0213\u855f\u{1ff79}\uf6fc\u{1ff13}\uf170\u{1fd5d}\u0ced'});
+let commandBuffer15 = commandEncoder75.finish();
+let computePassEncoder42 = commandEncoder68.beginComputePass({label: '\ud605\u02c4\u{1fab0}\u06df\u0c44\u64ac\uba7f\ube5f\u7079'});
+let video36 = await videoWithData();
+let buffer46 = device9.createBuffer({
+  label: '\uad5e\u0cb1\u083d\ue567\ue87c',
+  size: 52933,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let commandEncoder76 = device9.createCommandEncoder({label: '\u8847\uc0dd\u745a\u8033\ubebb\u27ca\u062c\u7169\ua0c6\u50c1\u74de'});
+let querySet76 = device9.createQuerySet({
+type: 'occlusion',
+count: 3730,
+});
+pseudoSubmit(device9, commandEncoder68);
+let renderBundleEncoder81 = device9.createRenderBundleEncoder({
+  label: '\u6054\u4ff1\uc040',
+  colorFormats: ['rgba16float', 'rg16sint', 'rgba8uint'],
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let renderBundle90 = renderBundleEncoder78.finish();
+try {
+renderBundleEncoder80.setIndexBuffer(buffer42, 'uint16', 13642, 5848);
+} catch {}
+try {
+buffer46.destroy();
+} catch {}
+try {
+commandEncoder76.clearBuffer(buffer42);
+dissociateBuffer(device9, buffer42);
+} catch {}
+let querySet77 = device12.createQuerySet({
+label: '\u1a6f\u5e92\u9fce\u21d0',
+type: 'occlusion',
+count: 2530,
+});
+let renderBundleEncoder82 = device12.createRenderBundleEncoder({
+  label: '\u{1f76e}\u{1f6a7}\u10e4\u9c88\u{1ff4d}\u{1fd98}\u03af\u{1f966}',
+  colorFormats: ['r16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle91 = renderBundleEncoder82.finish({label: '\u0801\u2a56\u0a9c\u99a9\ufae7\u90e4\u90e1\u36fe\ub78c'});
+canvas15.height = 465;
+canvas10.height = 26;
+let promise60 = adapter6.requestAdapterInfo();
+try {
+window.someLabel = renderBundleEncoder79.label;
+} catch {}
+let commandEncoder77 = device11.createCommandEncoder({label: '\u7295\u082d\u{1f90b}\u{1fbe1}\u486e\u{1fe93}\u08fe'});
+let renderBundleEncoder83 = device11.createRenderBundleEncoder({label: '\u680f\u2a6a', colorFormats: ['rgba8sint'], sampleCount: 4, depthReadOnly: true});
+try {
+renderBundleEncoder83.setVertexBuffer(67, undefined);
+} catch {}
+try {
+gpuCanvasContext23.unconfigure();
+} catch {}
+let buffer47 = device11.createBuffer({size: 14733, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let querySet78 = device11.createQuerySet({
+label: '\u{1fc07}\u6500\uf197\u0572\u0645\u0a76\u0d1c\u4f8a\u{1fb4c}\u{1f906}',
+type: 'occlusion',
+count: 1875,
+});
+try {
+await adapter17.requestAdapterInfo();
+} catch {}
+try {
+gpuCanvasContext19.unconfigure();
+} catch {}
+document.body.prepend(canvas5);
+offscreenCanvas15.width = 202;
+gc();
+try {
+offscreenCanvas26.getContext('2d');
+} catch {}
+document.body.prepend(canvas25);
+let videoFrame26 = new VideoFrame(offscreenCanvas9, {timestamp: 0});
+let querySet79 = device10.createQuerySet({
+type: 'occlusion',
+count: 1128,
+});
+let texture114 = device10.createTexture({
+label: '\u3f6b\u1ae2\u8745\u{1fa2f}\u4647\u5087',
+size: {width: 1997, height: 1, depthOrArrayLayers: 363},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler67 = device10.createSampler({
+label: '\u6fa0\u0421\u8763\u004e\u0c88\ub353\u96a4\u7cdf\u062a\u00c1\u7314',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 27.822,
+lodMaxClamp: 90.505,
+compare: 'equal',
+});
+try {
+device10.queue.writeTexture({
+  texture: texture105,
+  mipLevel: 2,
+  origin: { x: 137, y: 0, z: 9 },
+  aspect: 'all',
+}, new DataView(arrayBuffer4), /* required buffer size: 11336385 */
+{offset: 858, bytesPerRow: 303, rowsPerImage: 174}, {width: 297, height: 1, depthOrArrayLayers: 216});
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let commandEncoder78 = device12.createCommandEncoder({label: '\uffeb\uc2fc\ub29c\ufa67\u{1f72f}\u0f33\u0933\u03a9'});
+let querySet80 = device12.createQuerySet({
+label: '\u0b00\u{1feda}\u0c1a\u1cd2\u8fc0\u080b\uc70a\u0364\u43b5',
+type: 'occlusion',
+count: 672,
+});
+try {
+await device12.popErrorScope();
+} catch {}
+try {
+await device12.queue.onSubmittedWorkDone();
+} catch {}
+let pipelineLayout20 = device6.createPipelineLayout({
+  label: '\u0cd1\u01b9',
+  bindGroupLayouts: [bindGroupLayout36, bindGroupLayout36, bindGroupLayout36, bindGroupLayout36]
+});
+let querySet81 = device6.createQuerySet({
+label: '\u{1f7e0}\u18db\u3e7e\ub960\u081a\u0881\u22fc\u01d4\u{1f636}\ue821',
+type: 'occlusion',
+count: 512,
+});
+try {
+computePassEncoder33.end();
+} catch {}
+try {
+commandEncoder50.resolveQuerySet(querySet57, 289, 430, buffer38, 3840);
+} catch {}
+let imageData22 = new ImageData(172, 148);
+gc();
+let videoFrame27 = new VideoFrame(video8, {timestamp: 0});
+try {
+canvas29.getContext('2d');
+} catch {}
+let bindGroupLayout37 = device12.createBindGroupLayout({
+label: '\ua7f2\u049c\u29e1\u{1f657}\u6414\u023f\u0e81\u3c9b\u06c5\ufacd',
+entries: [],
+});
+let commandEncoder79 = device12.createCommandEncoder({label: '\u{1fe67}\u0c0d\u{1fe4e}\udc02\uda75\u16cf\u90ea'});
+let querySet82 = device12.createQuerySet({
+label: '\ucdb4\ua8dd\u6107\u{1f953}\ue835\u00b1\ue1d0\u9f11\u0388\ueaf1',
+type: 'occlusion',
+count: 164,
+});
+let texture115 = device12.createTexture({
+label: '\u{1f931}\u3d36\u{1fdc2}\u9dfc\u{1f8a8}\u{1f6c6}',
+size: [4032],
+dimension: '1d',
+format: 'rg16uint',
+usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView93 = texture115.createView({label: '\u6aca\udc1f\u67cf\u{1fada}'});
+let sampler68 = device12.createSampler({
+label: '\u922f\u0a1e\u985d\u079b\u{1fa94}\u{1fbc7}\ue16e',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 36.716,
+lodMaxClamp: 70.673,
+});
+try {
+await device12.queue.onSubmittedWorkDone();
+} catch {}
+canvas3.height = 277;
+let bindGroupLayout38 = device10.createBindGroupLayout({
+label: '\u8bb4\u7df1',
+entries: [{
+binding: 2862,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}, {
+binding: 1500,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}, {
+binding: 1367,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+let querySet83 = device10.createQuerySet({
+label: '\u5b7d\uf40d\u0b00\u0eb7\u1512',
+type: 'occlusion',
+count: 2665,
+});
+let sampler69 = device10.createSampler({
+label: '\u04fc\uc8b5\u09ef\u262d\u6d95\u{1fe43}\ue334\u7542',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMaxClamp: 36.082,
+});
+let img38 = await imageWithData(126, 270, '#63c096fd', '#d9f6778c');
+try {
+adapter7.label = '\u5d23\u23d5\u{1fe80}\u7e3e\u3337\u08e9\u0880\u4757\u030c';
+} catch {}
+let textureView94 = texture104.createView({dimension: '2d-array', aspect: 'all', baseMipLevel: 6, mipLevelCount: 2});
+try {
+computePassEncoder37.setBindGroup(2, bindGroup33, new Uint32Array(600), 579, 0);
+} catch {}
+let imageData23 = new ImageData(132, 236);
+let offscreenCanvas28 = new OffscreenCanvas(663, 529);
+let bindGroup35 = device8.createBindGroup({
+label: '\u1a5b\u0983\udb07\ubd84\ufd7a\udefb\u9329',
+layout: bindGroupLayout35,
+entries: [],
+});
+let pipelineLayout21 = device8.createPipelineLayout({label: '\u0500\ua63b\u9a30\u26b8\u064a', bindGroupLayouts: [bindGroupLayout35]});
+let commandEncoder80 = device8.createCommandEncoder({label: '\u{1f8e7}\u{1f983}'});
+let textureView95 = texture95.createView({label: '\ud151\ue484\u0a9e', dimension: '2d', aspect: 'depth-only', baseMipLevel: 2, baseArrayLayer: 172});
+let sampler70 = device8.createSampler({
+label: '\u1590\u{1faf3}\u0924\ue0d5\u0bd8\u{1fed4}\u0eb1\u{1f718}\u0a9d',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 90.870,
+});
+try {
+renderBundleEncoder76.setBindGroup(4, bindGroup35, new Uint32Array(9559), 6521, 0);
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+let promise61 = device8.queue.onSubmittedWorkDone();
+try {
+offscreenCanvas28.getContext('2d');
+} catch {}
+let querySet84 = device10.createQuerySet({
+label: '\u{1fe10}\u61ee',
+type: 'occlusion',
+count: 458,
+});
+let renderBundleEncoder84 = device10.createRenderBundleEncoder({
+  label: '\u0abe\u04bb\u0695\u0aaf\u{1fc86}\u33ce\u69c4',
+  colorFormats: ['rg16float', 'rgba32float', 'rgba32float', 'r32uint', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+device10.pushErrorScope('out-of-memory');
+} catch {}
+let commandEncoder81 = device12.createCommandEncoder();
+let textureView96 = texture115.createView({});
+let renderBundleEncoder85 = device9.createRenderBundleEncoder({label: '\ue12b\u50f3\u0085', colorFormats: ['rgba16float', 'rg16sint', 'rgba8uint'], sampleCount: 4});
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundle92 = renderBundleEncoder83.finish({});
+let promise62 = device11.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let renderBundle93 = renderBundleEncoder83.finish();
+let offscreenCanvas29 = new OffscreenCanvas(115, 160);
+try {
+device10.pushErrorScope('internal');
+} catch {}
+try {
+device10.queue.writeTexture({
+  texture: texture105,
+  mipLevel: 3,
+  origin: { x: 56, y: 0, z: 18 },
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 840674 */
+{offset: 874, bytesPerRow: 380, rowsPerImage: 10}, {width: 177, height: 0, depthOrArrayLayers: 222});
+} catch {}
+let video37 = await videoWithData();
+let gpuCanvasContext29 = offscreenCanvas29.getContext('webgpu');
+let textureView97 = texture115.createView({label: '\u{1fa92}\u206a\uaa61\ue936\uadc0\u{1ff38}'});
+let renderBundleEncoder86 = device12.createRenderBundleEncoder({
+  colorFormats: ['r16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+querySet77.destroy();
+} catch {}
+try {
+gpuCanvasContext29.configure({
+device: device12,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+});
+} catch {}
+let computePassEncoder43 = commandEncoder76.beginComputePass({label: '\uf163\ud277\u{1fe89}\u0c40\u0a0e\u01e2\ud7d3\u0d57\u6897\u010d'});
+let renderBundleEncoder87 = device9.createRenderBundleEncoder({
+  label: '\u{1f641}\u0590\u0c40\u6514\uc27d\u093e\u{1f903}',
+  colorFormats: ['rgba16float', 'rg16sint', 'rgba8uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+gpuCanvasContext22.configure({
+device: device9,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+alphaMode: 'opaque',
+});
+} catch {}
+canvas3.height = 498;
+let shaderModule26 = device5.createShaderModule({
+label: '\u{1fbea}\u38b9',
+code: `@group(2) @binding(1407)
+var<storage, read_write> global14: array<u32>;
+@group(0) @binding(1407)
+var<storage, read_write> field19: array<u32>;
+
+@compute @workgroup_size(2, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S31 {
+  @builtin(front_facing) f0: bool,
+  @builtin(position) f1: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(0) f1: vec4<i32>,
+  @builtin(frag_depth) f2: f32
+}
+
+@fragment
+fn fragment0(a0: S31, @builtin(sample_index) a1: u32, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(16) a0: f16, @location(8) a1: vec4<f16>, @location(5) a2: f16, @location(9) a3: vec4<f32>, @location(13) a4: f32, @location(12) a5: f32, @location(3) a6: i32, @builtin(vertex_index) a7: u32, @location(4) a8: vec3<f16>, @location(1) a9: vec4<i32>, @location(6) a10: i32, @location(15) a11: vec4<f32>, @location(11) a12: u32, @location(7) a13: vec2<u32>, @location(14) a14: vec2<i32>, @location(10) a15: vec4<u32>, @location(2) a16: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+try {
+computePassEncoder34.setBindGroup(4, bindGroup32, new Uint32Array(9263), 6539, 0);
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(buffer31, 39456, buffer44, 7448, 624);
+dissociateBuffer(device5, buffer31);
+dissociateBuffer(device5, buffer44);
+} catch {}
+try {
+commandEncoder46.copyTextureToTexture({
+  texture: texture90,
+  mipLevel: 2,
+  origin: { x: 48, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture90,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder52.clearBuffer(buffer44);
+dissociateBuffer(device5, buffer44);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device5,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let pipeline82 = device5.createComputePipeline({
+label: '\u{1fe2a}\u{1fd7b}\u9ae3\u46c7\u72a4\uc214\u{1fb01}',
+layout: pipelineLayout15,
+compute: {
+module: shaderModule19,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let canvas30 = document.createElement('canvas');
+offscreenCanvas11.height = 172;
+let bindGroup36 = device12.createBindGroup({
+label: '\u990f\u202b\u685e\u646b\u0b16\u0c83\u0028',
+layout: bindGroupLayout37,
+entries: [],
+});
+let texture116 = device12.createTexture({
+label: '\ueb32\ud7ae\u{1fafd}\u0fe3\u{1fbdb}\ueb8b\u{1f745}\u2eb6\ucdb1\u4c45\u035c',
+size: [60, 80, 1],
+mipLevelCount: 2,
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8a1unorm-srgb', 'etc2-rgb8a1unorm', 'etc2-rgb8a1unorm-srgb'],
+});
+let renderBundle94 = renderBundleEncoder86.finish();
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+offscreenCanvas9.height = 290;
+let commandBuffer16 = commandEncoder77.finish({
+label: '\ufea8\u{1ff7e}\u0a2a\u83df\u{1fdde}\u{1fcf6}\u01ae\u944b',
+});
+let texture117 = device11.createTexture({
+label: '\ud78e\u{1fef4}\u09a7\u0ecc\u0590\u3264\u09d6\u1345\u{1fed6}\u0295',
+size: {width: 120, height: 10, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'astc-10x5-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView98 = texture117.createView({dimension: '2d-array', baseMipLevel: 4, arrayLayerCount: 1});
+try {
+device11.queue.submit([
+commandBuffer16,
+]);
+} catch {}
+let promise63 = adapter8.requestAdapterInfo();
+let bindGroup37 = device12.createBindGroup({
+label: '\u0972\u0ed1\u{1f7d2}\ufa1b\u501e\u0915\u{1fabf}\u61c0\u614c\u{1f8b8}',
+layout: bindGroupLayout37,
+entries: [],
+});
+let renderBundleEncoder88 = device12.createRenderBundleEncoder({
+  label: '\u185b\u0490\ue42c\ucf22\u1f74',
+  colorFormats: ['r16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+let imageBitmap21 = await createImageBitmap(video9);
+let canvas31 = document.createElement('canvas');
+let querySet85 = device8.createQuerySet({
+label: '\u4510\ufcae\u{1f88b}\ua6ee\ue07c\u037c',
+type: 'occlusion',
+count: 3051,
+});
+let texture118 = device8.createTexture({
+label: '\udf78\ue923\u8f16',
+size: {width: 912},
+dimension: '1d',
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle95 = renderBundleEncoder70.finish({label: '\u28ee\u5820'});
+let promise64 = buffer40.mapAsync(GPUMapMode.READ, 552);
+try {
+commandEncoder80.copyTextureToTexture({
+  texture: texture108,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture110,
+  mipLevel: 0,
+  origin: { x: 4, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder80.clearBuffer(buffer40);
+dissociateBuffer(device8, buffer40);
+} catch {}
+let promise65 = navigator.gpu.requestAdapter({
+});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+pseudoSubmit(device8, commandEncoder80);
+let textureView99 = texture110.createView({label: '\uf5b5\uae87', dimension: '1d', format: 'bgra8unorm'});
+let renderBundleEncoder89 = device8.createRenderBundleEncoder({
+  label: '\ua7ae\u49dd\u{1fc22}\u031f\u662e\uf03d\u82ec',
+  colorFormats: ['rgb10a2unorm', 'r32float', undefined, 'r8sint', 'r8uint', 'bgra8unorm'],
+  stencilReadOnly: false
+});
+try {
+device8.queue.submit([
+commandBuffer12,
+]);
+} catch {}
+let imageBitmap22 = await createImageBitmap(videoFrame10);
+let bindGroupLayout39 = device10.createBindGroupLayout({
+label: '\u076d\u1ed3\u23b1\u46ee',
+entries: [],
+});
+let pipelineLayout22 = device10.createPipelineLayout({
+  label: '\u{1fc70}\u0cef\u6588\uacf3\u{1fa6d}\u2bb6',
+  bindGroupLayouts: [bindGroupLayout38, bindGroupLayout38, bindGroupLayout39, bindGroupLayout38, bindGroupLayout38, bindGroupLayout39, bindGroupLayout39, bindGroupLayout38, bindGroupLayout38, bindGroupLayout38]
+});
+let renderBundleEncoder90 = device10.createRenderBundleEncoder({
+  label: '\ua055\u817b\u0554\ub5f7\u3467\ud317\u{1fce7}\u040d\ua630\u{1f9ab}',
+  colorFormats: ['rg16float', 'rgba32float', 'rgba32float', 'r32uint', undefined],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+let sampler71 = device10.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 52.637,
+compare: 'greater-equal',
+});
+let buffer48 = device9.createBuffer({label: '\u{1fc2b}\u004b\u6fbe', size: 6635, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder82 = device9.createCommandEncoder();
+let computePassEncoder44 = commandEncoder82.beginComputePass({label: '\u555b\u9b2d\u002f\ud609\uc1af\ua2a0\u0df1'});
+let buffer49 = device11.createBuffer({size: 46537, usage: GPUBufferUsage.MAP_WRITE});
+let texture119 = device11.createTexture({
+size: {width: 120, height: 10, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+device11.addEventListener('uncapturederror', e => { log('device11.uncapturederror'); log(e); e.label = device11.label; });
+} catch {}
+let imageBitmap23 = await createImageBitmap(video0);
+let bindGroupLayout40 = device11.createBindGroupLayout({
+label: '\u1126\ud363\u9e6f\u016d\u9d87\u{1f76e}\u{1fb57}\u0731\uecab',
+entries: [],
+});
+let pipelineLayout23 = device11.createPipelineLayout({label: '\ud211\u0378\u8050\u06bd\uf388\u2f8b\u{1f97c}\u5b39', bindGroupLayouts: []});
+let textureView100 = texture119.createView({label: '\u2c2e\ub546', aspect: 'stencil-only', mipLevelCount: 1});
+let gpuCanvasContext30 = canvas30.getContext('webgpu');
+let video38 = await videoWithData();
+let bindGroupLayout41 = device10.createBindGroupLayout({
+entries: [{
+binding: 1273,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}, {
+binding: 2328,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '2d' },
+}],
+});
+let commandEncoder83 = device10.createCommandEncoder({});
+let textureView101 = texture105.createView({baseMipLevel: 5, baseArrayLayer: 203, arrayLayerCount: 24});
+let renderBundleEncoder91 = device10.createRenderBundleEncoder({
+  label: '\u48d7\u7b22\u0339',
+  colorFormats: ['rg16float', 'rgba32float', 'rgba32float', 'r32uint', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1,
+  depthReadOnly: false
+});
+try {
+renderBundleEncoder91.setVertexBuffer(16, undefined, 1958781302);
+} catch {}
+try {
+gpuCanvasContext23.unconfigure();
+} catch {}
+let imageBitmap24 = await createImageBitmap(imageData11);
+document.body.prepend(canvas3);
+let bindGroup38 = device11.createBindGroup({
+label: '\ue5a8\u03ea',
+layout: bindGroupLayout40,
+entries: [],
+});
+let buffer50 = device11.createBuffer({
+  label: '\u0dd9\u{1fc14}\u083e\u0e76\u0e06\u0a9c\u00c7\ubbac\u460f\u0e00',
+  size: 31324,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true
+});
+try {
+gpuCanvasContext3.configure({
+device: device11,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let textureView102 = texture112.createView({
+  label: '\u0ea7\u{1f748}',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 19,
+  arrayLayerCount: 1
+});
+try {
+gpuCanvasContext13.configure({
+device: device6,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device6.queue.submit([
+]);
+} catch {}
+let gpuCanvasContext31 = canvas31.getContext('webgpu');
+let promise66 = adapter17.requestDevice({
+label: '\u8fe9\u4e5d\ueb70',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+});
+let offscreenCanvas30 = new OffscreenCanvas(550, 658);
+let texture120 = device7.createTexture({
+size: [7248, 12, 1],
+mipLevelCount: 13,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let texture121 = gpuCanvasContext13.getCurrentTexture();
+let textureView103 = texture121.createView({label: '\u{1fc9c}\u0747\u2e13\u034c', dimension: '2d-array'});
+try {
+device7.queue.writeTexture({
+  texture: texture121,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(450), /* required buffer size: 450 */
+{offset: 450, bytesPerRow: 256}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let img39 = await imageWithData(270, 153, '#b83bacab', '#044a0bd7');
+try {
+device4.queue.label = '\u07a1\u1676\uaef7\u16dd\u91c2\u01cb\uc1a4\u{1f858}';
+} catch {}
+let gpuCanvasContext32 = offscreenCanvas30.getContext('webgpu');
+try {
+  await promise63;
+} catch {}
+let img40 = await imageWithData(291, 99, '#9560881d', '#bfd2182f');
+try {
+await adapter14.requestAdapterInfo();
+} catch {}
+document.body.prepend(video3);
+let pipelineLayout24 = device6.createPipelineLayout({
+  label: '\u486c\u0f5e\u17f1\ueb61\u{1faed}\u01e6\u2e26\u0d36\u0af5\uf117',
+  bindGroupLayouts: [bindGroupLayout36, bindGroupLayout36, bindGroupLayout36, bindGroupLayout36]
+});
+let commandEncoder84 = device6.createCommandEncoder({label: '\ufc5c\ubf91\ue4e2\u09ad\u{1faa6}'});
+let computePassEncoder45 = commandEncoder84.beginComputePass({});
+try {
+commandEncoder50.copyTextureToTexture({
+  texture: texture112,
+  mipLevel: 1,
+  origin: { x: 980, y: 0, z: 99 },
+  aspect: 'all',
+}, {
+  texture: texture112,
+  mipLevel: 1,
+  origin: { x: 673, y: 0, z: 58 },
+  aspect: 'all',
+}, {width: 1165, height: 0, depthOrArrayLayers: 4});
+} catch {}
+try {
+commandEncoder72.resolveQuerySet(querySet73, 1106, 274, buffer38, 256);
+} catch {}
+document.body.prepend(canvas3);
+let shaderModule27 = device6.createShaderModule({
+label: '\ud297\u04b2\u843e\u09eb\u08d9',
+code: `@group(3) @binding(939)
+var<storage, read_write> local14: array<u32>;
+@group(1) @binding(2707)
+var<storage, read_write> i10: array<u32>;
+@group(2) @binding(2707)
+var<storage, read_write> field20: array<u32>;
+@group(3) @binding(2707)
+var<storage, read_write> field21: array<u32>;
+
+@compute @workgroup_size(6, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(0) f1: vec3<f32>,
+  @location(6) f2: vec4<f32>,
+  @location(3) f3: vec4<f32>,
+  @location(5) f4: vec3<f32>,
+  @location(1) f5: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(0) a0: vec3<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S32 {
+  @location(0) f0: vec3<i32>,
+  @location(13) f1: vec4<i32>,
+  @location(12) f2: vec2<u32>,
+  @location(1) f3: vec2<f16>,
+  @location(8) f4: vec2<f16>,
+  @location(19) f5: vec4<u32>,
+  @location(18) f6: i32,
+  @location(17) f7: vec3<i32>,
+  @location(22) f8: vec4<f16>,
+  @location(23) f9: vec3<i32>,
+  @location(16) f10: vec3<f32>,
+  @location(6) f11: vec2<f32>,
+  @builtin(vertex_index) f12: u32,
+  @location(15) f13: vec3<f32>,
+  @location(7) f14: vec3<f16>
+}
+struct VertexOutput0 {
+  @location(0) f379: vec3<u32>,
+  @location(65) f380: f16,
+  @builtin(position) f381: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec2<i32>, a1: S32, @location(21) a2: vec4<f32>, @location(11) a3: vec2<u32>, @location(20) a4: vec2<f32>, @location(5) a5: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let pipelineLayout25 = device6.createPipelineLayout({
+  label: '\u0b0a\u658f\ub4ca\u096a\u0578\u{1f965}\u36ce\u8292',
+  bindGroupLayouts: [bindGroupLayout36, bindGroupLayout36, bindGroupLayout36, bindGroupLayout36]
+});
+try {
+renderBundleEncoder72.setVertexBuffer(31, undefined, 3419494830, 175142979);
+} catch {}
+try {
+device6.queue.submit([
+]);
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture112,
+  mipLevel: 1,
+  origin: { x: 1535, y: 0, z: 59 },
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 2518783 */
+{offset: 103, bytesPerRow: 2085, rowsPerImage: 151}, {width: 450, height: 0, depthOrArrayLayers: 9});
+} catch {}
+let device13 = await adapter16.requestDevice({
+label: '\u2ad3\u{1fa07}\u0b9f\u91a9\u903e\u95cb\u0a4e\ucbdb\u0f2a',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 50,
+maxVertexAttributes: 25,
+maxVertexBufferArrayStride: 27612,
+maxStorageTexturesPerShaderStage: 29,
+maxStorageBuffersPerShaderStage: 27,
+maxDynamicStorageBuffersPerPipelineLayout: 56340,
+maxBindingsPerBindGroup: 8181,
+maxTextureDimension1D: 9486,
+maxTextureDimension2D: 11990,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 195318183,
+maxUniformBuffersPerShaderStage: 28,
+maxInterStageShaderVariables: 48,
+maxInterStageShaderComponents: 106,
+maxSamplersPerShaderStage: 17,
+},
+});
+let img41 = await imageWithData(110, 171, '#949d6674', '#5e4adcaa');
+let shaderModule28 = device4.createShaderModule({
+code: `@group(0) @binding(3927)
+var<storage, read_write> type16: array<u32>;
+@group(1) @binding(3927)
+var<storage, read_write> function10: array<u32>;
+
+@compute @workgroup_size(8, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S34 {
+  @location(45) f0: vec3<u32>,
+  @location(39) f1: vec2<i32>,
+  @builtin(sample_mask) f2: u32,
+  @location(100) f3: u32,
+  @builtin(front_facing) f4: bool,
+  @location(62) f5: u32,
+  @location(49) f6: i32,
+  @location(61) f7: vec3<u32>,
+  @location(57) f8: f16,
+  @location(103) f9: vec4<i32>
+}
+struct FragmentOutput0 {
+  @location(5) f0: vec4<u32>,
+  @location(4) f1: vec2<f32>,
+  @location(0) f2: vec2<u32>
+}
+
+@fragment
+fn fragment0(@location(68) a0: u32, @location(3) a1: vec2<f32>, a2: S34, @location(30) a3: u32, @location(47) a4: vec2<i32>, @location(81) a5: vec3<i32>, @location(84) a6: vec3<f16>, @location(104) a7: vec2<i32>, @location(91) a8: vec4<f16>, @builtin(position) a9: vec4<f32>, @location(59) a10: vec2<f16>, @location(75) a11: vec3<f32>, @builtin(sample_index) a12: u32, @location(36) a13: vec2<u32>, @location(73) a14: vec3<u32>, @location(102) a15: vec4<i32>, @location(71) a16: u32, @location(94) a17: vec4<i32>, @location(97) a18: vec3<i32>, @location(69) a19: f32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S33 {
+  @location(15) f0: vec4<i32>,
+  @location(16) f1: vec2<i32>,
+  @location(0) f2: vec3<i32>,
+  @location(1) f3: vec2<i32>,
+  @location(3) f4: vec3<f32>,
+  @location(12) f5: i32,
+  @location(7) f6: u32,
+  @location(9) f7: vec4<i32>,
+  @location(14) f8: vec2<u32>,
+  @location(5) f9: vec4<f32>,
+  @location(6) f10: vec3<u32>
+}
+struct VertexOutput0 {
+  @location(61) f382: vec3<u32>,
+  @location(50) f383: vec4<i32>,
+  @location(74) f384: vec3<f16>,
+  @location(23) f385: vec3<u32>,
+  @location(10) f386: vec2<u32>,
+  @location(80) f387: vec3<f16>,
+  @location(84) f388: vec3<f16>,
+  @location(30) f389: u32,
+  @location(68) f390: u32,
+  @location(87) f391: vec2<f16>,
+  @location(57) f392: f16,
+  @location(82) f393: u32,
+  @location(39) f394: vec2<i32>,
+  @location(15) f395: vec2<u32>,
+  @location(66) f396: vec3<f32>,
+  @location(71) f397: u32,
+  @location(45) f398: vec3<u32>,
+  @location(51) f399: vec4<u32>,
+  @location(88) f400: vec2<f16>,
+  @location(81) f401: vec3<i32>,
+  @location(59) f402: vec2<f16>,
+  @location(49) f403: i32,
+  @location(62) f404: u32,
+  @location(75) f405: vec3<f32>,
+  @location(94) f406: vec4<i32>,
+  @location(44) f407: i32,
+  @location(91) f408: vec4<f16>,
+  @location(103) f409: vec4<i32>,
+  @location(7) f410: vec4<u32>,
+  @builtin(position) f411: vec4<f32>,
+  @location(97) f412: vec3<i32>,
+  @location(102) f413: vec4<i32>,
+  @location(32) f414: vec2<i32>,
+  @location(69) f415: f32,
+  @location(104) f416: vec2<i32>,
+  @location(100) f417: u32,
+  @location(40) f418: vec2<f16>,
+  @location(3) f419: vec2<f32>,
+  @location(73) f420: vec3<u32>,
+  @location(47) f421: vec2<i32>,
+  @location(36) f422: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec4<f32>, @location(8) a1: vec4<u32>, a2: S33, @location(10) a3: vec4<i32>, @location(4) a4: vec4<f32>, @location(13) a5: vec2<i32>, @builtin(instance_index) a6: u32, @location(2) a7: vec4<i32>, @builtin(vertex_index) a8: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let querySet86 = device4.createQuerySet({
+label: '\uf1e7\u{1fe1c}\u0d0d',
+type: 'occlusion',
+count: 3265,
+});
+try {
+computePassEncoder30.setPipeline(pipeline63);
+} catch {}
+try {
+renderBundleEncoder61.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder61.draw(24, 56, 64);
+} catch {}
+try {
+renderBundleEncoder61.drawIndexed(24, 24, 64);
+} catch {}
+try {
+renderBundleEncoder61.drawIndexedIndirect(buffer23, 2660);
+} catch {}
+try {
+renderBundleEncoder61.setIndexBuffer(buffer32, 'uint32');
+} catch {}
+try {
+renderBundleEncoder61.setPipeline(pipeline49);
+} catch {}
+try {
+renderBundleEncoder61.setVertexBuffer(39, undefined, 3542595313);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 3,
+  origin: { x: 0, y: 4, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 8803 */
+{offset: 781, bytesPerRow: 751}, {width: 160, height: 44, depthOrArrayLayers: 1});
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video6,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture88,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame28 = new VideoFrame(offscreenCanvas4, {timestamp: 0});
+let renderBundleEncoder92 = device6.createRenderBundleEncoder({
+  label: '\u24e5\u1339\ua650\uaa19\ua40c',
+  colorFormats: ['rg8unorm', 'rg16sint', 'rgba8unorm-srgb', 'rg32float', undefined, 'r16float', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8'
+});
+try {
+commandEncoder72.copyTextureToTexture({
+  texture: texture93,
+  mipLevel: 6,
+  origin: { x: 0, y: 12, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture93,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture112,
+  mipLevel: 1,
+  origin: { x: 123, y: 0, z: 57 },
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 4399603 */
+{offset: 923, bytesPerRow: 7690, rowsPerImage: 52}, {width: 1862, height: 0, depthOrArrayLayers: 12});
+} catch {}
+let bindGroup39 = device8.createBindGroup({
+label: '\u0542\u09f0\u6846\u{1f7b2}\u{1f892}\u0e41\u{1fc84}',
+layout: bindGroupLayout35,
+entries: [],
+});
+let texture122 = device8.createTexture({
+label: '\u0ae1\u{1f9f4}\u5ab4\u{1fd42}\u{1f690}\u07b5',
+size: [120],
+dimension: '1d',
+format: 'rg32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg32uint', 'rg32uint'],
+});
+try {
+computePassEncoder40.setBindGroup(4, bindGroup35, new Uint32Array(9164), 8095, 0);
+} catch {}
+let querySet87 = device12.createQuerySet({
+type: 'occlusion',
+count: 2467,
+});
+let textureView104 = texture116.createView({
+  label: '\u{1f72b}\ue75e\u04c2\u5421\u{1f941}\u9227',
+  aspect: 'all',
+  format: 'etc2-rgb8a1unorm-srgb',
+  mipLevelCount: 1
+});
+try {
+renderBundleEncoder88.setVertexBuffer(21, undefined, 2164622242, 420560858);
+} catch {}
+let bindGroup40 = device11.createBindGroup({
+label: '\u077a\u97df\u{1f93e}\u0ac3\u62ca\u0ec7\u04f7\uda84',
+layout: bindGroupLayout40,
+entries: [],
+});
+let commandEncoder85 = device11.createCommandEncoder({label: '\u{1fd03}\u{1ffcd}\u{1f77a}\u59c2\u{1f6bf}\u7d88\udfcf\ufa78\u01c3'});
+let commandBuffer17 = commandEncoder85.finish({
+label: '\u{1faad}\u0801\ue4fc',
+});
+let renderBundleEncoder93 = device11.createRenderBundleEncoder({
+  label: '\uc679\udbdc\u0671\ua3af',
+  colorFormats: ['rg16float', 'r8unorm', 'rgba8sint', 'rgba32float', 'rgba8unorm-srgb', 'rgba16uint'],
+  sampleCount: 1,
+  depthReadOnly: true
+});
+let sampler72 = device11.createSampler({
+label: '\u{1fafc}\u107e\u6e9a\u3a85\u2c29',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 38.431,
+lodMaxClamp: 82.260,
+});
+let video39 = await videoWithData();
+let bindGroupLayout42 = device13.createBindGroupLayout({
+entries: [{
+binding: 6692,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}, {
+binding: 6510,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+}],
+});
+let sampler73 = device13.createSampler({
+label: '\uafb4\uf9cb\u{1fdad}\u4500',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMinClamp: 99.500,
+lodMaxClamp: 99.519,
+});
+let imageBitmap25 = await createImageBitmap(video33);
+let renderBundle96 = renderBundleEncoder70.finish({label: '\u4159\u6ad9\u866f\ud080\u6ce9\u05ca\u74ea\u150d\u{1f68e}\u{1f9d6}\u7489'});
+try {
+gpuCanvasContext18.configure({
+device: device8,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['bgra8unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device8.queue.writeTexture({
+  texture: texture118,
+  mipLevel: 0,
+  origin: { x: 92, y: 1, z: 1 },
+  aspect: 'all',
+}, arrayBuffer11, /* required buffer size: 609 */
+{offset: 609}, {width: 242, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas32 = document.createElement('canvas');
+let img42 = await imageWithData(126, 102, '#c96f1c07', '#7fb50ae8');
+let imageBitmap26 = await createImageBitmap(video30);
+let imageData24 = new ImageData(48, 220);
+let querySet88 = device8.createQuerySet({
+label: '\u{1f9d0}\u14f8\u94f2\u4d4f\u348f\u18b9\u06f5\u0bf5\u03ab',
+type: 'occlusion',
+count: 1030,
+});
+let textureView105 = texture95.createView({
+  label: '\u0d0f\uef67\ued17\u{1f985}',
+  aspect: 'depth-only',
+  baseMipLevel: 5,
+  baseArrayLayer: 65,
+  arrayLayerCount: 35
+});
+let sampler74 = device8.createSampler({
+addressModeU: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 94.138,
+lodMaxClamp: 98.748,
+});
+try {
+computePassEncoder40.setBindGroup(1, bindGroup35, new Uint32Array(2655), 1597, 0);
+} catch {}
+let videoFrame29 = new VideoFrame(canvas3, {timestamp: 0});
+let commandEncoder86 = device8.createCommandEncoder({});
+let textureView106 = texture95.createView({
+  label: '\u031b\u097c\u5926\u2e10\ue07d\u7c61\uccd3',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+  baseArrayLayer: 48
+});
+try {
+commandEncoder86.copyBufferToBuffer(buffer35, 19500, buffer40, 15204, 1412);
+dissociateBuffer(device8, buffer35);
+dissociateBuffer(device8, buffer40);
+} catch {}
+try {
+commandEncoder86.copyTextureToTexture({
+  texture: texture108,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture110,
+  mipLevel: 0,
+  origin: { x: 16, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext33 = canvas32.getContext('webgpu');
+let imageBitmap27 = await createImageBitmap(imageData2);
+pseudoSubmit(device7, commandEncoder60);
+let texture123 = device7.createTexture({
+label: '\u{1fb43}\u{1f9cb}\u00ef\u{1fa7e}',
+size: [2280, 8, 1],
+dimension: '2d',
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['eac-r11snorm', 'eac-r11snorm', 'eac-r11snorm'],
+});
+let sampler75 = device7.createSampler({
+label: '\u{1ff14}\u0915',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 46.287,
+compare: 'equal',
+maxAnisotropy: 13,
+});
+try {
+device7.queue.submit([
+]);
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let renderBundleEncoder94 = device9.createRenderBundleEncoder({
+  label: '\u0e83\u06ac',
+  colorFormats: ['rgba16float', 'rg16sint', 'rgba8uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+let renderBundle97 = renderBundleEncoder78.finish({label: '\ud168\u102f\u0f53\ub39d\ua5b4\u{1fc66}\u{1fa6f}\u{1ff7e}\ue833\uccf2\u08da'});
+let sampler76 = device9.createSampler({
+label: '\u0221\u00c0\u{1f81b}\u{1fa39}\uccd6\u09b3\u0700',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 8.015,
+lodMaxClamp: 91.560,
+});
+try {
+renderBundleEncoder81.setIndexBuffer(buffer42, 'uint32', 12364, 6925);
+} catch {}
+try {
+renderBundleEncoder81.setVertexBuffer(4, buffer37, 24040);
+} catch {}
+let textureView107 = texture122.createView({label: '\u9d45\u1e9e\u604c\ucd50\u0932\u{1f775}'});
+let renderBundleEncoder95 = device8.createRenderBundleEncoder({
+  label: '\u4a8a\u7f64\u5fd8\u059f\u{1f84f}\u4c8f',
+  colorFormats: ['rgb10a2unorm', 'r32float', undefined, 'r8sint', 'r8uint', 'bgra8unorm'],
+  sampleCount: 1
+});
+let renderBundle98 = renderBundleEncoder95.finish();
+try {
+renderBundleEncoder77.setVertexBuffer(37, undefined, 951476406, 2286694537);
+} catch {}
+try {
+device8.addEventListener('uncapturederror', e => { log('device8.uncapturederror'); log(e); e.label = device8.label; });
+} catch {}
+try {
+commandEncoder86.clearBuffer(buffer40);
+dissociateBuffer(device8, buffer40);
+} catch {}
+try {
+renderBundleEncoder77.insertDebugMarker('\u0fcb');
+} catch {}
+try {
+device8.queue.writeTexture({
+  texture: texture122,
+  mipLevel: 0,
+  origin: { x: 15, y: 1, z: 1 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 537 */
+{offset: 537}, {width: 74, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas33 = document.createElement('canvas');
+let buffer51 = device9.createBuffer({
+  label: '\u2041\u6a76\u{1fda3}\ua221\u0629\u408a\u0149\u56f6\u1364\u{1fc61}\u16f7',
+  size: 4161,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: false
+});
+let texture124 = device9.createTexture({
+label: '\ua349\u0c3f\u46da\u1d50',
+size: [102, 3, 929],
+mipLevelCount: 9,
+dimension: '3d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8uint'],
+});
+let texture125 = gpuCanvasContext3.getCurrentTexture();
+let renderBundleEncoder96 = device9.createRenderBundleEncoder({
+  label: '\u{1fea1}\u2b11\ucc16',
+  colorFormats: ['rgba16float', 'rg16sint', 'rgba8uint'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+device9.queue.writeTexture({
+  texture: texture125,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 791 */
+{offset: 791, rowsPerImage: 279}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline83 = await device9.createComputePipelineAsync({
+label: '\ua56b\u{1fc90}',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule25,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let video40 = await videoWithData();
+let textureView108 = texture117.createView({
+  label: '\u6c21\u01f3\uc635\u{1f770}\u{1fea1}\u92e0\u1ff3\u{1fb46}\u179b\u{1ff79}',
+  dimension: '2d',
+  baseMipLevel: 4
+});
+try {
+renderBundleEncoder93.setVertexBuffer(51, undefined, 2896336763, 57719847);
+} catch {}
+let imageBitmap28 = await createImageBitmap(img37);
+try {
+renderBundleEncoder87.setVertexBuffer(0, buffer37, 7916);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+device: device9,
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba32float', 'rg16sint', 'rgba8unorm-srgb', 'rgba16float'],
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+device9.queue.writeBuffer(buffer48, 6140, new BigUint64Array(14101), 8296, 56);
+} catch {}
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline84 = await device9.createRenderPipelineAsync({
+layout: 'auto',
+fragment: {
+  module: shaderModule25,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rgba8uint'}]
+},
+vertex: {
+  module: shaderModule25,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 47048,
+attributes: [{
+format: 'sint32x2',
+offset: 33912,
+shaderLocation: 11,
+}, {
+format: 'snorm16x4',
+offset: 36380,
+shaderLocation: 23,
+}, {
+format: 'uint32',
+offset: 37908,
+shaderLocation: 19,
+}],
+},
+{
+arrayStride: 7496,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x4',
+offset: 4884,
+shaderLocation: 4,
+}, {
+format: 'float32',
+offset: 7124,
+shaderLocation: 16,
+}, {
+format: 'uint32x2',
+offset: 6824,
+shaderLocation: 17,
+}, {
+format: 'sint16x2',
+offset: 6452,
+shaderLocation: 9,
+}, {
+format: 'sint32x4',
+offset: 5060,
+shaderLocation: 18,
+}, {
+format: 'snorm16x4',
+offset: 3808,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 49092,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x4',
+offset: 32588,
+shaderLocation: 21,
+}, {
+format: 'float32x4',
+offset: 38636,
+shaderLocation: 5,
+}, {
+format: 'uint16x2',
+offset: 13140,
+shaderLocation: 0,
+}, {
+format: 'uint32x3',
+offset: 44376,
+shaderLocation: 10,
+}, {
+format: 'sint16x4',
+offset: 43756,
+shaderLocation: 14,
+}, {
+format: 'sint8x4',
+offset: 20096,
+shaderLocation: 12,
+}, {
+format: 'float16x4',
+offset: 11472,
+shaderLocation: 15,
+}, {
+format: 'snorm8x2',
+offset: 45320,
+shaderLocation: 6,
+}, {
+format: 'snorm8x2',
+offset: 35406,
+shaderLocation: 8,
+}, {
+format: 'unorm16x4',
+offset: 6868,
+shaderLocation: 22,
+}, {
+format: 'float32x2',
+offset: 7572,
+shaderLocation: 20,
+}],
+},
+{
+arrayStride: 1348,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 628,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 47332,
+attributes: [{
+format: 'uint16x2',
+offset: 1008,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 8580,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x4',
+offset: 2324,
+shaderLocation: 7,
+}, {
+format: 'uint8x4',
+offset: 832,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+let renderBundle99 = renderBundleEncoder43.finish({label: '\u0ee7\u8df2\u0843\u{1fd60}\uc152\u05df'});
+let sampler77 = device2.createSampler({
+label: '\u0be9\uc764\u9f99\u7b7e\ue1af\u0cd6\u{1f833}\u098e',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMaxClamp: 91.378,
+compare: 'equal',
+});
+try {
+computePassEncoder25.setPipeline(pipeline55);
+} catch {}
+let textureView109 = texture115.createView({label: '\u0189\u77b7\uaa7b\u005d'});
+let computePassEncoder46 = commandEncoder81.beginComputePass({label: '\u{1f723}\u5558\ucaef\u{1fe20}\u03fd\u{1f645}\u70d1\u6eb4\ue3ce\ubd0b'});
+document.body.prepend(img32);
+let bindGroup41 = device12.createBindGroup({
+layout: bindGroupLayout37,
+entries: [],
+});
+let pipelineLayout26 = device12.createPipelineLayout({
+  label: '\u{1f6e6}\uacf7\u{1fb0f}',
+  bindGroupLayouts: [bindGroupLayout37, bindGroupLayout37, bindGroupLayout37, bindGroupLayout37, bindGroupLayout37, bindGroupLayout37, bindGroupLayout37]
+});
+let commandEncoder87 = device12.createCommandEncoder({});
+let img43 = await imageWithData(165, 243, '#b27850e8', '#547606f6');
+let bindGroupLayout43 = device13.createBindGroupLayout({
+label: '\u{1fa02}\u0d8a\u0a58\ub718\u8430\u2e03',
+entries: [{
+binding: 7831,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}, {
+binding: 1927,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+}, {
+binding: 2226,
+visibility: 0,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+}],
+});
+let sampler78 = device13.createSampler({
+label: '\ud7b2\u3bcb\u72e6',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+lodMinClamp: 65.889,
+lodMaxClamp: 96.251,
+});
+try {
+gpuCanvasContext30.configure({
+device: device13,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+document.body.prepend(img10);
+let imageData25 = new ImageData(236, 64);
+let canvas34 = document.createElement('canvas');
+let texture126 = device9.createTexture({
+size: [1120, 1, 1],
+mipLevelCount: 4,
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg8sint'],
+});
+let textureView110 = texture124.createView({
+  label: '\u{1fe3f}\u6c84\u{1f79e}\ua9ca\u082a\u8811\u{1f7c4}\u13a0\u0e85',
+  format: 'rgba8uint',
+  baseMipLevel: 3
+});
+try {
+renderBundleEncoder96.setVertexBuffer(5, buffer37, 42140, 4606);
+} catch {}
+let commandEncoder88 = device8.createCommandEncoder({});
+let textureView111 = texture110.createView({label: '\u{1f60c}\u{1fc92}\u079f\ufce6\ua6b3', format: 'bgra8unorm'});
+let renderBundleEncoder97 = device8.createRenderBundleEncoder({
+  label: '\u0c25\u75ba\ub162\u6ca8\u{1f6c2}\u4ea9\u{1fa46}\u0e0f',
+  colorFormats: ['rgb10a2unorm', 'r32float', undefined, 'r8sint', 'r8uint', 'bgra8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler79 = device8.createSampler({
+label: '\u0938\u0f9b\u{1fbd5}\u{1fe90}\u09ee\u{1fc09}\u0c89\ud226',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 58.565,
+lodMaxClamp: 89.811,
+compare: 'less',
+});
+try {
+commandEncoder88.insertDebugMarker('\u5d50');
+} catch {}
+try {
+device8.queue.submit([
+commandBuffer13,
+]);
+} catch {}
+let pipelineLayout27 = device13.createPipelineLayout({label: '\u9bb4\u0df9\uc10a\u4745\u{1ffc0}\u{1fc3f}', bindGroupLayouts: [bindGroupLayout43]});
+let sampler80 = device13.createSampler({
+label: '\u06d8\u2a15\u0aa4\u5919',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 9.205,
+lodMaxClamp: 80.733,
+compare: 'always',
+});
+try {
+adapter3.label = '\uf952\u0c6d\u0cac\u{1ffb7}\ub396\u96f5\u0623\u899d';
+} catch {}
+try {
+window.someLabel = device9.queue.label;
+} catch {}
+let querySet89 = device9.createQuerySet({
+label: '\u65ef\u09ed\u01fd\u1744\u097c\u{1f6a1}\ubae8\u0dc7\u066b\u0740',
+type: 'occlusion',
+count: 2412,
+});
+let textureView112 = texture99.createView({label: '\ub3b7\u2f71\u{1fb95}\u{1fc05}\ue559\u2c59'});
+try {
+  await buffer51.mapAsync(GPUMapMode.READ, 0, 1640);
+} catch {}
+try {
+device9.queue.writeBuffer(buffer48, 192, new Float32Array(9373), 6501, 496);
+} catch {}
+let pipeline85 = device9.createComputePipeline({
+layout: pipelineLayout19,
+compute: {
+module: shaderModule25,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let gpuCanvasContext34 = canvas33.getContext('webgpu');
+let img44 = await imageWithData(280, 72, '#4373c16b', '#4235425d');
+let videoFrame30 = new VideoFrame(img34, {timestamp: 0});
+let textureView113 = texture119.createView({
+  label: '\ud87b\u0ec1\u04dd\u4881\u{1fc32}\u{1fe93}\u3927\ua0d4\u{1fc65}\u{1f6d9}',
+  dimension: '2d-array',
+  aspect: 'depth-only',
+  baseMipLevel: 2,
+  mipLevelCount: 1
+});
+let bindGroup42 = device7.createBindGroup({
+label: '\uc9b8\u631e\ubc20\u7dd5',
+layout: bindGroupLayout32,
+entries: [],
+});
+let sampler81 = device7.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 12.145,
+lodMaxClamp: 83.911,
+});
+try {
+  await promise64;
+} catch {}
+let canvas35 = document.createElement('canvas');
+let img45 = await imageWithData(300, 249, '#b2348219', '#90cf18f3');
+let shaderModule29 = device10.createShaderModule({
+label: '\u351f\u4f60\u{1f741}\u0795\u276b\u7596\u{1fb2d}',
+code: `@group(0) @binding(2862)
+var<storage, read_write> function11: array<u32>;
+@group(3) @binding(2862)
+var<storage, read_write> field22: array<u32>;
+@group(4) @binding(2862)
+var<storage, read_write> parameter14: array<u32>;
+@group(0) @binding(1367)
+var<storage, read_write> function12: array<u32>;
+@group(8) @binding(1500)
+var<storage, read_write> i11: array<u32>;
+@group(9) @binding(2862)
+var<storage, read_write> global15: array<u32>;
+@group(8) @binding(2862)
+var<storage, read_write> local15: array<u32>;
+@group(9) @binding(1367)
+var<storage, read_write> type17: array<u32>;
+@group(7) @binding(1367)
+var<storage, read_write> type18: array<u32>;
+@group(7) @binding(2862)
+var<storage, read_write> global16: array<u32>;
+@group(1) @binding(1500)
+var<storage, read_write> type19: array<u32>;
+@group(9) @binding(1500)
+var<storage, read_write> i12: array<u32>;
+@group(0) @binding(1500)
+var<storage, read_write> type20: array<u32>;
+@group(4) @binding(1367)
+var<storage, read_write> field23: array<u32>;
+@group(1) @binding(2862)
+var<storage, read_write> parameter15: array<u32>;
+@group(4) @binding(1500)
+var<storage, read_write> field24: array<u32>;
+@group(1) @binding(1367)
+var<storage, read_write> global17: array<u32>;
+@group(7) @binding(1500)
+var<storage, read_write> type21: array<u32>;
+@group(8) @binding(1367)
+var<storage, read_write> local16: array<u32>;
+
+@compute @workgroup_size(5, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S36 {
+  @location(35) f0: vec3<f32>,
+  @builtin(position) f1: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(3) f1: u32,
+  @location(1) f2: vec4<f32>,
+  @location(0) f3: vec2<f32>,
+  @builtin(frag_depth) f4: f32
+}
+
+@fragment
+fn fragment0(@location(21) a0: vec3<f32>, @location(44) a1: vec2<f32>, a2: S36) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S35 {
+  @location(25) f0: vec3<u32>,
+  @location(19) f1: vec2<u32>,
+  @location(10) f2: i32,
+  @builtin(vertex_index) f3: u32,
+  @location(1) f4: vec3<f32>,
+  @location(6) f5: f32,
+  @location(14) f6: f32,
+  @location(22) f7: u32,
+  @location(26) f8: vec4<f32>,
+  @location(3) f9: vec4<u32>,
+  @location(24) f10: vec4<u32>,
+  @location(4) f11: vec2<u32>,
+  @location(28) f12: vec3<u32>,
+  @location(2) f13: i32,
+  @location(12) f14: vec2<f16>,
+  @location(5) f15: f16,
+  @location(0) f16: vec3<i32>
+}
+struct VertexOutput0 {
+  @location(35) f423: vec3<f32>,
+  @location(44) f424: vec2<f32>,
+  @builtin(position) f425: vec4<f32>,
+  @location(21) f426: vec3<f32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, a1: S35, @location(27) a2: vec4<u32>, @location(21) a3: i32, @location(18) a4: i32, @location(11) a5: vec3<i32>, @location(23) a6: vec2<i32>, @location(17) a7: vec2<f16>, @location(8) a8: vec2<f32>, @location(15) a9: vec4<f16>, @location(16) a10: vec2<i32>, @location(20) a11: vec2<f16>, @location(13) a12: u32, @location(7) a13: vec3<f32>, @location(9) a14: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let pipelineLayout28 = device10.createPipelineLayout({label: '\u{1fd59}\u0ce7\u{1f8b6}', bindGroupLayouts: [bindGroupLayout41, bindGroupLayout39]});
+let computePassEncoder47 = commandEncoder83.beginComputePass({label: '\u2e6a\u0053\ueae3'});
+let sampler82 = device10.createSampler({
+label: '\u{1fcad}\u{1ff7f}\u{1fa5c}\u{1ffce}\u{1fac2}\uf764\u17bd\u0670\u7363\udaa9',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 74.130,
+lodMaxClamp: 82.870,
+});
+let pipeline86 = await device10.createRenderPipelineAsync({
+label: '\u0bba\u{1fed9}\u5e39\u3bd8\uac38\u1cde\u0c19\u37f2\u017d\u199e\uabdc',
+layout: pipelineLayout28,
+multisample: {
+mask: 0x80ba2406,
+},
+fragment: {
+  module: shaderModule29,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16float', writeMask: 0}, {format: 'rgba32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'equal',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'keep',
+},
+stencilWriteMask: 1825,
+depthBias: 48,
+depthBiasSlopeScale: 97,
+},
+vertex: {
+  module: shaderModule29,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1276,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 1248,
+shaderLocation: 18,
+}, {
+format: 'uint32x3',
+offset: 764,
+shaderLocation: 24,
+}, {
+format: 'float16x4',
+offset: 36,
+shaderLocation: 17,
+}, {
+format: 'uint32x2',
+offset: 756,
+shaderLocation: 28,
+}, {
+format: 'float16x4',
+offset: 948,
+shaderLocation: 7,
+}, {
+format: 'float16x2',
+offset: 104,
+shaderLocation: 14,
+}, {
+format: 'sint16x2',
+offset: 352,
+shaderLocation: 0,
+}, {
+format: 'uint32',
+offset: 72,
+shaderLocation: 25,
+}, {
+format: 'unorm16x4',
+offset: 636,
+shaderLocation: 5,
+}, {
+format: 'float32x3',
+offset: 564,
+shaderLocation: 12,
+}, {
+format: 'sint16x2',
+offset: 8,
+shaderLocation: 10,
+}, {
+format: 'uint32x2',
+offset: 412,
+shaderLocation: 3,
+}, {
+format: 'uint8x4',
+offset: 1236,
+shaderLocation: 4,
+}, {
+format: 'snorm16x4',
+offset: 976,
+shaderLocation: 15,
+}, {
+format: 'sint16x4',
+offset: 388,
+shaderLocation: 23,
+}, {
+format: 'snorm8x2',
+offset: 312,
+shaderLocation: 9,
+}, {
+format: 'unorm16x2',
+offset: 1232,
+shaderLocation: 1,
+}, {
+format: 'sint16x4',
+offset: 388,
+shaderLocation: 21,
+}, {
+format: 'float16x4',
+offset: 888,
+shaderLocation: 26,
+}, {
+format: 'unorm10-10-10-2',
+offset: 1064,
+shaderLocation: 8,
+}, {
+format: 'sint16x4',
+offset: 440,
+shaderLocation: 16,
+}, {
+format: 'sint32x2',
+offset: 128,
+shaderLocation: 11,
+}, {
+format: 'unorm16x4',
+offset: 912,
+shaderLocation: 20,
+}, {
+format: 'uint16x2',
+offset: 80,
+shaderLocation: 13,
+}, {
+format: 'uint8x2',
+offset: 166,
+shaderLocation: 27,
+}, {
+format: 'sint16x4',
+offset: 144,
+shaderLocation: 2,
+}, {
+format: 'uint16x4',
+offset: 392,
+shaderLocation: 19,
+}],
+},
+{
+arrayStride: 1744,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1400,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 2532,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x4',
+offset: 528,
+shaderLocation: 22,
+}],
+},
+{
+arrayStride: 0,
+attributes: [],
+},
+{
+arrayStride: 1660,
+attributes: [],
+},
+{
+arrayStride: 2516,
+attributes: [],
+},
+{
+arrayStride: 2908,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x4',
+offset: 448,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'front',
+},
+});
+let gpuCanvasContext35 = canvas34.getContext('webgpu');
+let buffer52 = device12.createBuffer({
+  label: '\u{1feb3}\u3921\u7d8f\u0cda\ubc6c\u3a6b\u08ae\u{1fc1e}\u5960',
+  size: 58142,
+  usage: GPUBufferUsage.STORAGE,
+  mappedAtCreation: false
+});
+let renderBundle100 = renderBundleEncoder82.finish({});
+try {
+computePassEncoder46.setBindGroup(3, bindGroup36, []);
+} catch {}
+let gpuCanvasContext36 = canvas35.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise57;
+} catch {}
+let renderBundleEncoder98 = device6.createRenderBundleEncoder({
+  label: '\u7f30\u5854\u0a48\u1ffc\ue98a',
+  colorFormats: ['rg8unorm', 'rg16sint', 'rgba8unorm-srgb', 'rg32float', undefined, 'r16float', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  stencilReadOnly: true
+});
+let renderBundle101 = renderBundleEncoder72.finish({label: '\u06ba\u0b82\u5877\u{1f609}\u0964\u{1fa37}\u6d5c\uce56\ufe80\u0b04\u02b7'});
+let pipeline87 = device6.createComputePipeline({
+layout: 'auto',
+compute: {
+module: shaderModule27,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let commandEncoder89 = device12.createCommandEncoder({label: '\u0891\uad66\u0c73\ud2b7\u1bbf\ud235\u65ef\ue3f7\u0c8c'});
+let textureView114 = texture116.createView({dimension: '2d-array', format: 'etc2-rgb8a1unorm-srgb', baseMipLevel: 1, baseArrayLayer: 0});
+gc();
+let canvas36 = document.createElement('canvas');
+let imageBitmap29 = await createImageBitmap(offscreenCanvas5);
+try {
+renderBundleEncoder93.setBindGroup(3, bindGroup38);
+} catch {}
+try {
+renderBundleEncoder93.setBindGroup(2, bindGroup38, new Uint32Array(4575), 4473, 0);
+} catch {}
+try {
+await device11.popErrorScope();
+} catch {}
+canvas29.width = 620;
+let texture127 = device9.createTexture({
+label: '\u2bbb\u62d5\u0787\u004b\ufc03\u{1fa64}\u{1f701}\u5a33',
+size: [356, 240, 450],
+sampleCount: 8,
+dimension: '3d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+gpuCanvasContext33.configure({
+device: device9,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16sint', 'bgra8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device9.queue.writeBuffer(buffer48, 1076, new DataView(new ArrayBuffer(6618)), 4225, 2248);
+} catch {}
+try {
+device9.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame23,
+  origin: { x: 34, y: 67 },
+  flipY: true,
+}, {
+  texture: texture125,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline88 = await device9.createRenderPipelineAsync({
+label: '\u05f1\u{1fac3}\ufefc\uca09\u{1fef6}\u{1fa10}\u0380\u9f3a\ud54b\u0c0f\u13fa',
+layout: pipelineLayout19,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule25,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float'}, {format: 'rg16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8uint', writeMask: 0}]
+},
+vertex: {
+  module: shaderModule25,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 29984,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x2',
+offset: 8284,
+shaderLocation: 15,
+}, {
+format: 'uint16x2',
+offset: 132,
+shaderLocation: 10,
+}, {
+format: 'float32x2',
+offset: 24712,
+shaderLocation: 16,
+}, {
+format: 'uint32x2',
+offset: 23652,
+shaderLocation: 17,
+}, {
+format: 'sint32',
+offset: 3260,
+shaderLocation: 13,
+}, {
+format: 'sint16x4',
+offset: 23640,
+shaderLocation: 12,
+}, {
+format: 'unorm16x4',
+offset: 10952,
+shaderLocation: 6,
+}, {
+format: 'sint32x4',
+offset: 2204,
+shaderLocation: 21,
+}, {
+format: 'uint32x2',
+offset: 25084,
+shaderLocation: 0,
+}, {
+format: 'unorm16x4',
+offset: 12672,
+shaderLocation: 22,
+}, {
+format: 'sint32x3',
+offset: 18096,
+shaderLocation: 14,
+}, {
+format: 'snorm8x2',
+offset: 18998,
+shaderLocation: 23,
+}, {
+format: 'float32x4',
+offset: 23100,
+shaderLocation: 5,
+}, {
+format: 'uint32',
+offset: 24640,
+shaderLocation: 3,
+}, {
+format: 'uint32x4',
+offset: 18368,
+shaderLocation: 19,
+}, {
+format: 'float32x3',
+offset: 27840,
+shaderLocation: 1,
+}, {
+format: 'uint8x4',
+offset: 14508,
+shaderLocation: 4,
+}, {
+format: 'uint16x2',
+offset: 10952,
+shaderLocation: 2,
+}, {
+format: 'sint32x4',
+offset: 11416,
+shaderLocation: 9,
+}, {
+format: 'sint8x4',
+offset: 23568,
+shaderLocation: 11,
+}, {
+format: 'float16x2',
+offset: 23188,
+shaderLocation: 20,
+}, {
+format: 'float32x3',
+offset: 1660,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 28108,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 13144,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 25428,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x4',
+offset: 9856,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 49480,
+attributes: [],
+},
+{
+arrayStride: 48004,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 32108,
+attributes: [],
+},
+{
+arrayStride: 13792,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x2',
+offset: 8940,
+shaderLocation: 18,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+unclippedDepth: true,
+},
+});
+pseudoSubmit(device12, commandEncoder78);
+let texture128 = device12.createTexture({
+label: '\u3e84\u{1f6c8}\u{1fe0f}\u5b2d\u07e0',
+size: [96, 5, 1],
+mipLevelCount: 7,
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-8x5-unorm-srgb', 'astc-8x5-unorm-srgb', 'astc-8x5-unorm'],
+});
+try {
+renderBundleEncoder88.setVertexBuffer(34, undefined, 3581896510);
+} catch {}
+try {
+device12.queue.writeTexture({
+  texture: texture128,
+  mipLevel: 0,
+  origin: { x: 80, y: 0, z: 0 },
+  aspect: 'all',
+}, new Float32Array(arrayBuffer5), /* required buffer size: 462 */
+{offset: 462}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+pseudoSubmit(device10, commandEncoder83);
+let texture129 = device10.createTexture({
+label: '\u{1fc08}\u094d\u0505\u64ef\u{1fba1}',
+size: {width: 1997},
+dimension: '1d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm'],
+});
+let textureView115 = texture105.createView({dimension: '2d', baseMipLevel: 2, mipLevelCount: 3, baseArrayLayer: 133});
+let renderBundle102 = renderBundleEncoder91.finish({});
+let pipeline89 = device10.createComputePipeline({
+label: '\u6d24\u2df8',
+layout: pipelineLayout28,
+compute: {
+module: shaderModule29,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline90 = await device10.createRenderPipelineAsync({
+label: '\u{1f8ae}\uf369\u{1fb08}',
+layout: pipelineLayout28,
+multisample: {
+mask: 0xdec2f676,
+},
+fragment: {
+  module: shaderModule29,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16float', writeMask: 0}, {format: 'rgba32float'}, {format: 'rgba32float'}, {format: 'r32uint', writeMask: 0}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'keep',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 746,
+stencilWriteMask: 142,
+depthBias: 61,
+depthBiasSlopeScale: 51,
+depthBiasClamp: 90,
+},
+vertex: {
+  module: shaderModule29,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 1668,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x4',
+offset: 372,
+shaderLocation: 6,
+}, {
+format: 'uint8x2',
+offset: 882,
+shaderLocation: 24,
+}, {
+format: 'float16x4',
+offset: 1612,
+shaderLocation: 8,
+}, {
+format: 'uint32x3',
+offset: 1288,
+shaderLocation: 27,
+}, {
+format: 'uint32x3',
+offset: 1296,
+shaderLocation: 3,
+}, {
+format: 'snorm8x4',
+offset: 1036,
+shaderLocation: 20,
+}, {
+format: 'uint16x4',
+offset: 1068,
+shaderLocation: 28,
+}, {
+format: 'uint8x4',
+offset: 416,
+shaderLocation: 19,
+}, {
+format: 'snorm16x2',
+offset: 1452,
+shaderLocation: 9,
+}, {
+format: 'unorm8x4',
+offset: 1516,
+shaderLocation: 12,
+}, {
+format: 'uint32x4',
+offset: 1224,
+shaderLocation: 4,
+}, {
+format: 'float32x2',
+offset: 664,
+shaderLocation: 1,
+}, {
+format: 'float32x3',
+offset: 1528,
+shaderLocation: 15,
+}, {
+format: 'uint32x3',
+offset: 1628,
+shaderLocation: 13,
+}, {
+format: 'sint32x2',
+offset: 1168,
+shaderLocation: 16,
+}, {
+format: 'sint16x2',
+offset: 624,
+shaderLocation: 0,
+}, {
+format: 'sint32',
+offset: 452,
+shaderLocation: 23,
+}, {
+format: 'sint16x4',
+offset: 1132,
+shaderLocation: 21,
+}, {
+format: 'uint8x2',
+offset: 1220,
+shaderLocation: 22,
+}, {
+format: 'float32x3',
+offset: 1088,
+shaderLocation: 17,
+}, {
+format: 'uint16x2',
+offset: 540,
+shaderLocation: 25,
+}, {
+format: 'float32x3',
+offset: 712,
+shaderLocation: 26,
+}, {
+format: 'sint8x2',
+offset: 274,
+shaderLocation: 18,
+}, {
+format: 'sint16x4',
+offset: 1420,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 3200,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 2496,
+shaderLocation: 14,
+}, {
+format: 'unorm16x4',
+offset: 2708,
+shaderLocation: 7,
+}, {
+format: 'sint16x4',
+offset: 1944,
+shaderLocation: 10,
+}, {
+format: 'float32',
+offset: 672,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 3508,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x3',
+offset: 1776,
+shaderLocation: 2,
+}],
+}
+]
+},
+primitive: {
+cullMode: 'back',
+},
+});
+let imageData26 = new ImageData(116, 184);
+let gpuCanvasContext37 = canvas36.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img46 = await imageWithData(51, 117, '#c067d21f', '#711a82fa');
+let imageData27 = new ImageData(176, 128);
+let textureView116 = texture117.createView({label: '\u{1f694}\ud65e\u6e64', dimension: '2d-array', baseMipLevel: 2, mipLevelCount: 2, arrayLayerCount: 1});
+let sampler83 = device11.createSampler({
+label: '\u014e\u8aaa\uacdf\u7ad0\u1b2a\u8e44\uda86\u081f',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 90.781,
+lodMaxClamp: 94.904,
+maxAnisotropy: 15,
+});
+let adapter19 = await navigator.gpu.requestAdapter();
+let imageBitmap30 = await createImageBitmap(offscreenCanvas5);
+let commandEncoder90 = device12.createCommandEncoder({label: '\u2b5e\u3d00\u{1fb60}\u056b\u{1fa5e}'});
+let textureView117 = texture115.createView({label: '\u0cf7\u09b8\u04a7\ud881\u{1fa91}\u0ac0\u{1fe86}\u{1fde4}\u0cab\u{1fe1b}\u0ba9'});
+let imageData28 = new ImageData(8, 188);
+pseudoSubmit(device9, commandEncoder76);
+let sampler84 = device9.createSampler({
+label: '\u061e\u39e1\u291d\u8891\u0142\u0fa9\u07fb',
+addressModeU: 'mirror-repeat',
+minFilter: 'nearest',
+lodMinClamp: 49.775,
+lodMaxClamp: 77.689,
+maxAnisotropy: 1,
+});
+try {
+device9.addEventListener('uncapturederror', e => { log('device9.uncapturederror'); log(e); e.label = device9.label; });
+} catch {}
+try {
+device9.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img42,
+  origin: { x: 30, y: 99 },
+  flipY: true,
+}, {
+  texture: texture125,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter13.label = '\u730a\ucb11\ubc8c';
+} catch {}
+let renderBundleEncoder99 = device12.createRenderBundleEncoder({colorFormats: ['r16uint'], depthStencilFormat: 'depth24plus-stencil8', sampleCount: 4});
+try {
+renderBundleEncoder88.setBindGroup(0, bindGroup36);
+} catch {}
+try {
+querySet82.destroy();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let adapter20 = await navigator.gpu.requestAdapter({
+});
+let commandEncoder91 = device11.createCommandEncoder({label: '\u{1fc6e}\u5e44\u7fb5\u7494\u{1fed5}\u3833\u69b2\u{1fc98}\uec42\u02c0'});
+let texture130 = device11.createTexture({
+label: '\ua2d1\u0deb\u056c\u15d7\u0747\u{1f7dd}\u5856\u0edb\u{1fa2b}\u{1fe8b}\uc9b8',
+size: [120, 10, 59],
+mipLevelCount: 6,
+dimension: '2d',
+format: 'astc-12x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView118 = texture119.createView({label: '\ud2e4\u{1ff05}\u0a3c\u{1f8d5}\ub863\u3e63\u6986', baseMipLevel: 3});
+let sampler85 = device11.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 64.010,
+lodMaxClamp: 80.188,
+maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder93.setBindGroup(3, bindGroup38, new Uint32Array(7251), 46, 0);
+} catch {}
+try {
+commandEncoder91.copyBufferToBuffer(buffer45, 2644, buffer50, 18332, 2540);
+dissociateBuffer(device11, buffer45);
+dissociateBuffer(device11, buffer50);
+} catch {}
+let video41 = await videoWithData();
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let device14 = await promise66;
+let bindGroupLayout44 = device6.createBindGroupLayout({
+label: '\u0f29\u{1fb95}\uaaa8\u0964\uf64f\u344b',
+entries: [{
+binding: 144,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+}],
+});
+let commandEncoder92 = device6.createCommandEncoder({});
+let computePassEncoder48 = commandEncoder92.beginComputePass({});
+let pipeline91 = device6.createComputePipeline({
+label: '\u678b\u{1f80f}\uf7f1\ua66c\u1e71\u4638\u0af3',
+layout: pipelineLayout25,
+compute: {
+module: shaderModule27,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let commandEncoder93 = device6.createCommandEncoder({label: '\u883d\uacaf\u2b35\u{1fa3e}\u3db4\u02ca\u{1f787}\u3519\uaeef'});
+let renderBundle103 = renderBundleEncoder71.finish({label: '\u0043\ufc69\u0991\u{1fdc3}\u0f79\u251c\u694e\u0eb9\u8284\u0305\u012e'});
+try {
+computePassEncoder45.setPipeline(pipeline87);
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+try {
+commandEncoder72.resolveQuerySet(querySet65, 24, 1052, buffer38, 0);
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture112,
+  mipLevel: 0,
+  origin: { x: 979, y: 0, z: 76 },
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 70019888 */
+{offset: 581, bytesPerRow: 7299, rowsPerImage: 181}, {width: 1797, height: 0, depthOrArrayLayers: 54});
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let shaderModule30 = device13.createShaderModule({
+code: `@group(0) @binding(7831)
+var<storage, read_write> local17: array<u32>;
+@group(0) @binding(1927)
+var<storage, read_write> local18: array<u32>;
+
+@compute @workgroup_size(7, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec3<f32>,
+  @location(0) f1: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(24) a0: vec2<f32>, @location(8) a1: vec3<i32>, @location(0) a2: vec4<u32>, @location(19) a3: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+let buffer53 = device13.createBuffer({
+  label: '\u0e14\u{1f94a}\u0f2d\uc45a\u46a6\u2667\u0fd9\u705f\ue8c7\ub2f6\u7fa1',
+  size: 14259,
+  usage: GPUBufferUsage.MAP_WRITE
+});
+let commandEncoder94 = device13.createCommandEncoder({label: '\ud9fa\u5c2d\u03c4\u0c56\u0a94\u0a3b\u0900\udf11\u{1fd8e}\u0004\u057f'});
+let querySet90 = device13.createQuerySet({
+type: 'occlusion',
+count: 3043,
+});
+let renderBundleEncoder100 = device13.createRenderBundleEncoder({
+  label: '\u{1fed7}\u{1f730}\ucd4b\u1a79\uf38f\u{1ffbc}\ub6aa\u0350\u{1fa4e}',
+  colorFormats: ['rg8sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  stencilReadOnly: true
+});
+let pipeline92 = await device13.createRenderPipelineAsync({
+label: '\u8ea1\ub059\u0317\ua305',
+layout: pipelineLayout27,
+multisample: {
+count: 4,
+mask: 0xcd512f5b,
+},
+fragment: {
+  module: shaderModule30,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8sint', writeMask: 0}]
+},
+vertex: {
+  module: shaderModule30,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 14080,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 8728,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x3',
+offset: 8340,
+shaderLocation: 8,
+}, {
+format: 'float32',
+offset: 8720,
+shaderLocation: 24,
+}, {
+format: 'snorm8x2',
+offset: 536,
+shaderLocation: 19,
+}, {
+format: 'uint32x2',
+offset: 724,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let renderBundleEncoder101 = device13.createRenderBundleEncoder({
+  colorFormats: ['rg8sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler86 = device13.createSampler({
+label: '\ubc38\u0923\u{1f7ad}\u{1fccd}\ud1a2\u08c4\u4df6\u{1fd96}\u{1fbb0}\u0b71',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 3.235,
+lodMaxClamp: 5.229,
+});
+try {
+renderBundleEncoder100.setVertexBuffer(36, undefined, 1163838028, 1261018949);
+} catch {}
+try {
+gpuCanvasContext36.configure({
+device: device13,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+video39.width = 293;
+let texture131 = device10.createTexture({
+label: '\u{1fe87}\u036c\u{1fbd7}\u{1ffe5}\ucb93',
+size: {width: 3995, height: 1, depthOrArrayLayers: 34},
+mipLevelCount: 9,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['stencil8', 'stencil8', 'stencil8'],
+});
+try {
+renderBundleEncoder90.pushDebugGroup('\u0298');
+} catch {}
+let pipeline93 = await device10.createRenderPipelineAsync({
+label: '\u4997\u{1f934}\u0a06\u{1fbb2}\ue084\u0e2b\u1ead',
+layout: pipelineLayout28,
+multisample: {
+mask: 0x5c0969cb,
+},
+fragment: {
+  module: shaderModule29,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16float', writeMask: 0}, {format: 'rgba32float', writeMask: GPUColorWrite.BLUE}, {
+  format: 'rgba32float',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+},
+stencilWriteMask: 1585,
+depthBias: 0,
+depthBiasSlopeScale: 65,
+depthBiasClamp: 86,
+},
+vertex: {
+  module: shaderModule29,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 3100,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 400,
+shaderLocation: 28,
+}, {
+format: 'float16x4',
+offset: 1876,
+shaderLocation: 26,
+}, {
+format: 'sint32x4',
+offset: 36,
+shaderLocation: 11,
+}, {
+format: 'sint16x2',
+offset: 1960,
+shaderLocation: 2,
+}, {
+format: 'uint32',
+offset: 3040,
+shaderLocation: 3,
+}, {
+format: 'uint16x4',
+offset: 1220,
+shaderLocation: 19,
+}, {
+format: 'uint32',
+offset: 3024,
+shaderLocation: 22,
+}, {
+format: 'unorm16x2',
+offset: 2104,
+shaderLocation: 14,
+}, {
+format: 'uint32x2',
+offset: 476,
+shaderLocation: 4,
+}, {
+format: 'snorm16x4',
+offset: 1248,
+shaderLocation: 6,
+}, {
+format: 'float32',
+offset: 644,
+shaderLocation: 20,
+}, {
+format: 'sint32x3',
+offset: 1716,
+shaderLocation: 23,
+}, {
+format: 'uint32x4',
+offset: 1060,
+shaderLocation: 27,
+}, {
+format: 'sint32x3',
+offset: 576,
+shaderLocation: 18,
+}, {
+format: 'sint16x2',
+offset: 812,
+shaderLocation: 10,
+}, {
+format: 'float16x4',
+offset: 2164,
+shaderLocation: 15,
+}, {
+format: 'unorm8x4',
+offset: 392,
+shaderLocation: 17,
+}, {
+format: 'uint8x2',
+offset: 2498,
+shaderLocation: 13,
+}, {
+format: 'unorm16x2',
+offset: 336,
+shaderLocation: 5,
+}, {
+format: 'unorm16x2',
+offset: 2488,
+shaderLocation: 7,
+}, {
+format: 'snorm8x4',
+offset: 2996,
+shaderLocation: 8,
+}, {
+format: 'float32x2',
+offset: 1664,
+shaderLocation: 1,
+}, {
+format: 'sint32x3',
+offset: 1496,
+shaderLocation: 21,
+}, {
+format: 'uint16x4',
+offset: 1720,
+shaderLocation: 25,
+}, {
+format: 'snorm16x4',
+offset: 1920,
+shaderLocation: 12,
+}, {
+format: 'sint32x2',
+offset: 2040,
+shaderLocation: 0,
+}, {
+format: 'sint32x2',
+offset: 1984,
+shaderLocation: 16,
+}, {
+format: 'uint32',
+offset: 680,
+shaderLocation: 24,
+}, {
+format: 'snorm8x2',
+offset: 1420,
+shaderLocation: 9,
+}],
+}
+]
+},
+});
+offscreenCanvas6.width = 123;
+try {
+gpuCanvasContext24.unconfigure();
+} catch {}
+try {
+  await promise61;
+} catch {}
+let video42 = await videoWithData();
+let bindGroup43 = device12.createBindGroup({
+label: '\u{1f759}\u{1f70d}\u078a\ua9c7\u05f3\u{1f790}\u022b\u094f',
+layout: bindGroupLayout37,
+entries: [],
+});
+let querySet91 = device12.createQuerySet({
+label: '\u{1fbb7}\u3165\udc95',
+type: 'occlusion',
+count: 1784,
+});
+let renderBundle104 = renderBundleEncoder88.finish({label: '\uee83\u23c4\ub6e5\ub422\u2425\u{1f7c5}\u166b'});
+try {
+device12.pushErrorScope('internal');
+} catch {}
+let imageData29 = new ImageData(172, 124);
+let bindGroupLayout45 = device3.createBindGroupLayout({
+label: '\u48b1\u{1fe71}',
+entries: [],
+});
+let bindGroup44 = device3.createBindGroup({
+label: '\u08cf\u6d0b\udb3f\u1b3c\u{1fcdb}\uce84\u{1ff61}\ua885\u1088',
+layout: bindGroupLayout45,
+entries: [],
+});
+let texture132 = device3.createTexture({
+label: '\u{1fdf8}\u20ad\u017f\u44e3\u{1fe28}\u41c9\u8d22\u0a65\u16d3\u{1f922}\u047f',
+size: {width: 72, height: 180, depthOrArrayLayers: 75},
+mipLevelCount: 7,
+dimension: '2d',
+format: 'astc-12x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-12x10-unorm-srgb', 'astc-12x10-unorm', 'astc-12x10-unorm-srgb'],
+});
+let textureView119 = texture42.createView({label: '\u0fa0\ufde6\u15f1\u93a4', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 174});
+try {
+renderBundleEncoder39.setBindGroup(0, bindGroup44);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(4, bindGroup44, new Uint32Array(8254), 1578, 0);
+} catch {}
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let img47 = await imageWithData(203, 208, '#1a0fd9cf', '#fda4f121');
+let bindGroup45 = device7.createBindGroup({
+label: '\ud91b\u4fa3\u0793\ufef6\u{1ff56}',
+layout: bindGroupLayout32,
+entries: [],
+});
+let commandEncoder95 = device7.createCommandEncoder({label: '\u3201\uf20e\u01cf\u9748\u54fb\u{1f69f}\u6cb3'});
+let querySet92 = device7.createQuerySet({
+label: '\u1343\u6dec',
+type: 'occlusion',
+count: 1133,
+});
+let renderBundle105 = renderBundleEncoder74.finish();
+let video43 = await videoWithData();
+let bindGroup46 = device11.createBindGroup({
+label: '\u5438\u79b4\u3ef5\uccd8\u0e39\uc1d9',
+layout: bindGroupLayout40,
+entries: [],
+});
+let texture133 = device11.createTexture({
+label: '\uf02b\u6afe\udc9a\u37a5\ue0df\u09c2\u{1fd56}\u{1fff5}\u0272',
+size: [120, 10, 1],
+mipLevelCount: 2,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-8x5-unorm', 'astc-8x5-unorm-srgb', 'astc-8x5-unorm'],
+});
+let textureView120 = texture130.createView({label: '\u{1f816}\uce26\u09d4', baseArrayLayer: 21, arrayLayerCount: 1});
+let computePassEncoder49 = commandEncoder91.beginComputePass({label: '\uc7cd\u6226\ue4d8'});
+try {
+computePassEncoder49.end();
+} catch {}
+try {
+renderBundleEncoder93.setBindGroup(2, bindGroup40);
+} catch {}
+try {
+renderBundleEncoder93.setVertexBuffer(28, undefined, 2289719867, 1011618910);
+} catch {}
+try {
+gpuCanvasContext31.configure({
+device: device11,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['bgra8unorm', 'depth32float-stencil8', 'bgra8unorm', 'bgra8unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let video44 = await videoWithData();
+let buffer54 = device7.createBuffer({size: 64809, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder96 = device7.createCommandEncoder();
+let texture134 = device7.createTexture({
+size: [560, 1, 245],
+mipLevelCount: 7,
+dimension: '3d',
+format: 'r32sint',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['r32sint'],
+});
+let textureView121 = texture120.createView({label: '\u{1fb84}\u07d3\u0eec\u9a6c\u205b\u2e27\ufb2b\u{1ff09}', dimension: '2d-array', mipLevelCount: 5});
+let arrayBuffer12 = buffer34.getMappedRange(25056, 88);
+document.body.prepend(video16);
+let buffer55 = device8.createBuffer({label: '\u0b82\u8b7b\u08ba', size: 26122, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let querySet93 = device8.createQuerySet({
+label: '\ub8dd\ue270\u{1fd47}\ue9f7\udd3e\uf3cd\u0cfd',
+type: 'occlusion',
+count: 3365,
+});
+let textureView122 = texture118.createView({label: '\ue534\uc15e\u099f\u5468', arrayLayerCount: 1});
+try {
+device8.queue.writeBuffer(buffer55, 7196, new BigUint64Array(4233), 1310, 1004);
+} catch {}
+try {
+  await promise60;
+} catch {}
+document.body.prepend(canvas32);
+let device15 = await adapter18.requestDevice({
+label: '\u0e16\u0819\u{1fbf0}\u0ce8\u77c0\uebf4',
+requiredLimits: {
+maxBindGroups: 9,
+maxColorAttachmentBytesPerSample: 42,
+maxVertexBufferArrayStride: 25367,
+maxStorageTexturesPerShaderStage: 20,
+maxStorageBuffersPerShaderStage: 16,
+maxDynamicStorageBuffersPerPipelineLayout: 21453,
+maxBindingsPerBindGroup: 7280,
+maxTextureDimension1D: 16245,
+maxTextureDimension2D: 12666,
+maxVertexBuffers: 9,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 26028135,
+maxUniformBuffersPerShaderStage: 26,
+maxInterStageShaderVariables: 118,
+maxInterStageShaderComponents: 68,
+},
+});
+let offscreenCanvas31 = new OffscreenCanvas(674, 767);
+let imageBitmap31 = await createImageBitmap(img29);
+let pipelineLayout29 = device9.createPipelineLayout({bindGroupLayouts: [bindGroupLayout34, bindGroupLayout30, bindGroupLayout34, bindGroupLayout34]});
+try {
+computePassEncoder44.setPipeline(pipeline85);
+} catch {}
+try {
+renderBundleEncoder96.setVertexBuffer(4, buffer37);
+} catch {}
+let buffer56 = device9.createBuffer({
+  label: '\u02c5\uec7f',
+  size: 64423,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM
+});
+let commandEncoder97 = device9.createCommandEncoder({label: '\ue6ad\u{1f6af}\u9924\u440b\u07a9\u{1fa74}\u0969\u0e0b'});
+let querySet94 = device9.createQuerySet({
+label: '\u300a\u0601\u{1f8c5}\u7a1f\u0932\ub2a7\u0faf\u3851\u8dc2',
+type: 'occlusion',
+count: 1444,
+});
+let device16 = await adapter20.requestDevice({
+label: '\uc98f\u0984\u0402\u31e7\u0805\u6b9d\u38c4\u00e7\uf603\u1df4',
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 40,
+maxVertexAttributes: 18,
+maxVertexBufferArrayStride: 19145,
+maxStorageTexturesPerShaderStage: 38,
+maxStorageBuffersPerShaderStage: 28,
+maxDynamicStorageBuffersPerPipelineLayout: 20194,
+maxBindingsPerBindGroup: 1598,
+maxTextureDimension1D: 8206,
+maxTextureDimension2D: 15637,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 176191717,
+maxUniformBuffersPerShaderStage: 36,
+maxInterStageShaderVariables: 101,
+maxInterStageShaderComponents: 98,
+maxSamplersPerShaderStage: 21,
+},
+});
+let img48 = await imageWithData(14, 158, '#b1c1c034', '#7031f192');
+try {
+offscreenCanvas31.getContext('webgl2');
+} catch {}
+let buffer57 = device12.createBuffer({
+  label: '\ue8ad\u03fa\u6647\u3e2e\u0f34\u{1f7bf}\u040d\uce83',
+  size: 54696,
+  usage: GPUBufferUsage.COPY_SRC,
+  mappedAtCreation: true
+});
+let renderBundleEncoder102 = device12.createRenderBundleEncoder({colorFormats: ['r16uint'], depthStencilFormat: 'depth24plus-stencil8', sampleCount: 4});
+let renderBundle106 = renderBundleEncoder86.finish({label: '\u{1fa10}\ucd60'});
+try {
+renderBundleEncoder102.setBindGroup(1, bindGroup41);
+} catch {}
+let pipelineLayout30 = device10.createPipelineLayout({
+  label: '\u017f\u08f1\ub5c4\u0ccc\u400d',
+  bindGroupLayouts: [bindGroupLayout38, bindGroupLayout38, bindGroupLayout39, bindGroupLayout38, bindGroupLayout39, bindGroupLayout39]
+});
+let texture135 = device10.createTexture({
+label: '\u0946\u122b\u0583\u0d34\u59ac\u25a3\u03f1\u554f\u4002\u0664\u59d5',
+size: [1997],
+dimension: '1d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler87 = device10.createSampler({
+label: '\u{1f680}\u{1fb9f}\u5dcd\u18f4',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 53.356,
+lodMaxClamp: 58.586,
+maxAnisotropy: 19,
+});
+let pipeline94 = device10.createComputePipeline({
+layout: 'auto',
+compute: {
+module: shaderModule29,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline95 = device10.createRenderPipeline({
+label: '\uef68\u3058',
+layout: pipelineLayout30,
+fragment: {
+  module: shaderModule29,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg16float',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'constant', dstFactor: 'one-minus-constant'},
+},
+  writeMask: 0
+}, {format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'never',
+depthFailOp: 'decrement-clamp',
+passOp: 'zero',
+},
+stencilBack: {
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 1517,
+depthBias: 28,
+depthBiasSlopeScale: 3,
+},
+vertex: {
+  module: shaderModule29,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+attributes: [{
+format: 'uint32x3',
+offset: 2112,
+shaderLocation: 19,
+}, {
+format: 'sint8x2',
+offset: 2006,
+shaderLocation: 16,
+}, {
+format: 'sint16x2',
+offset: 3436,
+shaderLocation: 0,
+}, {
+format: 'unorm16x2',
+offset: 2444,
+shaderLocation: 17,
+}, {
+format: 'snorm8x4',
+offset: 228,
+shaderLocation: 14,
+}, {
+format: 'snorm16x2',
+offset: 1980,
+shaderLocation: 5,
+}, {
+format: 'uint16x2',
+offset: 1792,
+shaderLocation: 24,
+}, {
+format: 'uint16x4',
+offset: 3100,
+shaderLocation: 13,
+}, {
+format: 'uint8x2',
+offset: 2172,
+shaderLocation: 25,
+}, {
+format: 'uint32x3',
+offset: 1796,
+shaderLocation: 22,
+}, {
+format: 'sint32x4',
+offset: 1636,
+shaderLocation: 2,
+}, {
+format: 'uint16x2',
+offset: 3048,
+shaderLocation: 4,
+}, {
+format: 'snorm16x4',
+offset: 3084,
+shaderLocation: 12,
+}, {
+format: 'unorm8x4',
+offset: 1528,
+shaderLocation: 1,
+}, {
+format: 'sint16x4',
+offset: 3052,
+shaderLocation: 23,
+}, {
+format: 'snorm16x2',
+offset: 2764,
+shaderLocation: 15,
+}, {
+format: 'float32x3',
+offset: 1944,
+shaderLocation: 6,
+}, {
+format: 'snorm8x4',
+offset: 932,
+shaderLocation: 26,
+}],
+},
+{
+arrayStride: 3288,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x2',
+offset: 376,
+shaderLocation: 20,
+}, {
+format: 'sint8x4',
+offset: 2408,
+shaderLocation: 11,
+}, {
+format: 'float32x3',
+offset: 1164,
+shaderLocation: 7,
+}, {
+format: 'sint16x2',
+offset: 772,
+shaderLocation: 18,
+}, {
+format: 'unorm8x4',
+offset: 1144,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 1452,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x4',
+offset: 1376,
+shaderLocation: 27,
+}],
+},
+{
+arrayStride: 2028,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1776,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 3700,
+attributes: [{
+format: 'sint32x4',
+offset: 2964,
+shaderLocation: 21,
+}, {
+format: 'uint8x4',
+offset: 1320,
+shaderLocation: 3,
+}, {
+format: 'uint8x2',
+offset: 3004,
+shaderLocation: 28,
+}],
+},
+{
+arrayStride: 3076,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x3',
+offset: 976,
+shaderLocation: 8,
+}, {
+format: 'sint32x3',
+offset: 896,
+shaderLocation: 10,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+frontFace: 'cw',
+cullMode: 'back',
+},
+});
+let querySet95 = device15.createQuerySet({
+label: '\u0a1e\ubfca\u96d7\u{1f697}\ua865\u0949\u089b\u{1feb6}\uaaa0',
+type: 'occlusion',
+count: 358,
+});
+let texture136 = device15.createTexture({
+size: [768],
+dimension: '1d',
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+});
+try {
+gpuCanvasContext34.unconfigure();
+} catch {}
+let offscreenCanvas32 = new OffscreenCanvas(406, 37);
+let buffer58 = device15.createBuffer({label: '\ue090\u{1fcfd}', size: 63665, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let sampler88 = device15.createSampler({
+label: '\u{1f618}\uf02f\u0bd7\uf339',
+addressModeU: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 71.002,
+lodMaxClamp: 78.394,
+maxAnisotropy: 18,
+});
+let gpuCanvasContext38 = offscreenCanvas32.getContext('webgpu');
+let canvas37 = document.createElement('canvas');
+try {
+canvas37.getContext('bitmaprenderer');
+} catch {}
+let querySet96 = device8.createQuerySet({
+label: '\u3022\ubb38\ud085\u0e66\ubc1a',
+type: 'occlusion',
+count: 1229,
+});
+try {
+renderBundleEncoder97.setBindGroup(0, bindGroup35);
+} catch {}
+try {
+device8.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder86.copyTextureToTexture({
+  texture: texture108,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture110,
+  mipLevel: 0,
+  origin: { x: 11, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device8.queue.writeTexture({
+  texture: texture122,
+  mipLevel: 0,
+  origin: { x: 45, y: 0, z: 0 },
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(24)), /* required buffer size: 465 */
+{offset: 465}, {width: 41, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device8.queue.onSubmittedWorkDone();
+} catch {}
+let canvas38 = document.createElement('canvas');
+let querySet97 = device10.createQuerySet({
+type: 'occlusion',
+count: 2628,
+});
+let sampler89 = device10.createSampler({
+label: '\u0767\u0aa0\ud545\u0dc7\u8e6d\u03ab\u036b\u{1ff65}\u0b82\u1849',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 42.447,
+lodMaxClamp: 55.062,
+maxAnisotropy: 14,
+});
+let imageBitmap32 = await createImageBitmap(img1);
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let imageBitmap33 = await createImageBitmap(imageData23);
+document.body.prepend(video9);
+let offscreenCanvas33 = new OffscreenCanvas(682, 979);
+let imageBitmap34 = await createImageBitmap(imageData29);
+let videoFrame31 = new VideoFrame(canvas10, {timestamp: 0});
+let commandEncoder98 = device11.createCommandEncoder({});
+try {
+commandEncoder91.copyBufferToBuffer(buffer45, 4692, buffer50, 16256, 948);
+dissociateBuffer(device11, buffer45);
+dissociateBuffer(device11, buffer50);
+} catch {}
+let canvas39 = document.createElement('canvas');
+let img49 = await imageWithData(245, 267, '#a2c522ed', '#3ebb8002');
+let commandEncoder99 = device16.createCommandEncoder({});
+let gpuCanvasContext39 = canvas38.getContext('webgpu');
+try {
+window.someLabel = device9.label;
+} catch {}
+let shaderModule31 = device9.createShaderModule({
+label: '\u{1f6c0}\ub137\u6d8b\u17ec\u41be\u074a\u05d5\u{1fa52}\ua254\ucc71\u{1f825}',
+code: `@group(2) @binding(1744)
+var<storage, read_write> local19: array<u32>;
+@group(1) @binding(1665)
+var<storage, read_write> type22: array<u32>;
+@group(1) @binding(1453)
+var<storage, read_write> parameter16: array<u32>;
+@group(0) @binding(1744)
+var<storage, read_write> i13: array<u32>;
+@group(3) @binding(1744)
+var<storage, read_write> global18: array<u32>;
+
+@compute @workgroup_size(7, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(1) f1: vec2<i32>,
+  @location(2) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(30) a0: vec3<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S37 {
+  @location(5) f0: f32,
+  @location(2) f1: f16,
+  @location(7) f2: f32,
+  @builtin(vertex_index) f3: u32,
+  @location(18) f4: i32,
+  @location(21) f5: vec4<i32>,
+  @location(12) f6: vec2<f16>,
+  @builtin(instance_index) f7: u32,
+  @location(19) f8: vec2<u32>,
+  @location(4) f9: vec4<f32>,
+  @location(10) f10: vec2<u32>,
+  @location(13) f11: vec3<f32>,
+  @location(0) f12: vec2<i32>,
+  @location(3) f13: vec2<f32>,
+  @location(17) f14: i32,
+  @location(9) f15: i32,
+  @location(14) f16: vec4<i32>,
+  @location(1) f17: vec3<f16>,
+  @location(8) f18: f32,
+  @location(6) f19: vec3<u32>,
+  @location(20) f20: vec2<i32>,
+  @location(22) f21: vec3<u32>,
+  @location(11) f22: vec4<f16>,
+  @location(16) f23: vec2<u32>,
+  @location(23) f24: vec2<i32>,
+  @location(15) f25: vec3<u32>
+}
+struct VertexOutput0 {
+  @location(21) f427: vec2<i32>,
+  @location(17) f428: vec3<i32>,
+  @location(49) f429: vec4<u32>,
+  @location(67) f430: i32,
+  @location(69) f431: vec2<f32>,
+  @location(19) f432: vec4<u32>,
+  @location(37) f433: i32,
+  @location(8) f434: vec3<i32>,
+  @location(55) f435: vec2<i32>,
+  @location(47) f436: vec2<f32>,
+  @location(45) f437: f32,
+  @builtin(position) f438: vec4<f32>,
+  @location(70) f439: vec3<f16>,
+  @location(64) f440: vec4<f16>,
+  @location(1) f441: vec3<f16>,
+  @location(71) f442: vec2<f16>,
+  @location(40) f443: vec3<u32>,
+  @location(51) f444: vec2<u32>,
+  @location(50) f445: vec2<f16>,
+  @location(10) f446: vec3<f16>,
+  @location(59) f447: vec3<u32>,
+  @location(13) f448: vec4<i32>,
+  @location(15) f449: vec3<f16>,
+  @location(30) f450: vec3<f16>,
+  @location(28) f451: vec2<f32>
+}
+
+@vertex
+fn vertex0(a0: S37) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let buffer59 = device9.createBuffer({
+  label: '\u{1f71d}\u01c5\u0439\ud1a6\u{1ffcc}\u03fe\u357d\u{1f9da}\u0642\u600d\uf1f1',
+  size: 31388,
+  usage: GPUBufferUsage.STORAGE
+});
+let commandEncoder100 = device9.createCommandEncoder({label: '\u{1f947}\ue93a\u16b4\u{1fa1d}\u01b1\u{1f949}\u0387\u5156\u{1fc22}\u0145\ufc18'});
+let sampler90 = device9.createSampler({
+label: '\u08c6\u{1fb1b}\u3be9\uc58e\u0f28\u{1fbe9}\ucc17\u0ea1\u63ef\ue8bf\u0e66',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 72.541,
+lodMaxClamp: 75.055,
+maxAnisotropy: 3,
+});
+let promise67 = device9.popErrorScope();
+try {
+commandEncoder100.copyBufferToBuffer(buffer56, 41060, buffer51, 2112, 1808);
+dissociateBuffer(device9, buffer56);
+dissociateBuffer(device9, buffer51);
+} catch {}
+try {
+commandEncoder100.clearBuffer(buffer51, 2652, 792);
+dissociateBuffer(device9, buffer51);
+} catch {}
+let promise68 = adapter9.requestAdapterInfo();
+pseudoSubmit(device9, commandEncoder100);
+let texture137 = device9.createTexture({
+label: '\ued91\u9454\u05e6\u{1fe22}\u8ea9\u0802\u6545',
+size: {width: 178, height: 120, depthOrArrayLayers: 105},
+mipLevelCount: 3,
+dimension: '2d',
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['depth16unorm', 'depth16unorm', 'depth16unorm'],
+});
+let renderBundleEncoder103 = device9.createRenderBundleEncoder({colorFormats: ['rgba16float', 'rg16sint', 'rgba8uint'], sampleCount: 4});
+try {
+renderBundleEncoder81.setPipeline(pipeline88);
+} catch {}
+try {
+device9.queue.writeBuffer(buffer48, 5400, new DataView(new ArrayBuffer(32356)), 7135, 1208);
+} catch {}
+try {
+  await promise68;
+} catch {}
+let renderBundleEncoder104 = device15.createRenderBundleEncoder({
+  label: '\u0993\u8979\u91bc\u1c9f',
+  colorFormats: ['rg32sint', 'rgba16sint', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let imageBitmap35 = await createImageBitmap(img49);
+let imageBitmap36 = await createImageBitmap(videoFrame28);
+offscreenCanvas20.height = 732;
+let bindGroupLayout46 = device9.createBindGroupLayout({
+label: '\ud604\u0325\u47f5\uadb2\ua741\ud3be\u{1fe52}\u{1fcfa}\ub6f2',
+entries: [{
+binding: 747,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+}],
+});
+let textureView123 = texture113.createView({label: '\u{1f89e}\u4c3c\u07df', dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 3});
+let computePassEncoder50 = commandEncoder97.beginComputePass({label: '\u0dbd\u{1f895}\u6a0c\u0e95\u{1fdb3}\u3cec\u{1fe32}\u2f60\u{1fb6c}\u{1fb81}'});
+try {
+renderBundleEncoder81.draw(56);
+} catch {}
+try {
+device9.queue.writeBuffer(buffer48, 6484, new DataView(new ArrayBuffer(56906)), 55223, 72);
+} catch {}
+try {
+device9.queue.writeTexture({
+  texture: texture137,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 11 },
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 3853870 */
+{offset: 347, bytesPerRow: 347, rowsPerImage: 213}, {width: 44, height: 30, depthOrArrayLayers: 53});
+} catch {}
+let promise69 = device9.queue.onSubmittedWorkDone();
+offscreenCanvas10.height = 166;
+try {
+adapter19.label = '\u64a6\u5cc2\u010f';
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+try {
+  await promise62;
+} catch {}
+try {
+  await promise59;
+} catch {}
+let querySet98 = device14.createQuerySet({
+label: '\u0bd4\u{1ff3a}\u020f\u0716\ud12d\u53d9\u0e8a\u{1f99a}\u0eeb',
+type: 'occlusion',
+count: 3685,
+});
+let img50 = await imageWithData(118, 170, '#7afcab67', '#8856f961');
+let promise70 = device13.queue.onSubmittedWorkDone();
+let pipeline96 = await device13.createRenderPipelineAsync({
+label: '\u1c7f\u0977\u0887\u042c\u1acf\u3672\u{1f8ee}\u{1fcfe}\u163b',
+layout: pipelineLayout27,
+multisample: {
+count: 4,
+mask: 0x4473c601,
+},
+fragment: {
+  module: shaderModule30,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8sint', writeMask: 0}]
+},
+vertex: {
+  module: shaderModule30,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 292,
+attributes: [],
+},
+{
+arrayStride: 22640,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 23120,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x2',
+offset: 19036,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 7496,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 6318,
+shaderLocation: 8,
+}, {
+format: 'snorm8x2',
+offset: 1370,
+shaderLocation: 19,
+}],
+},
+{
+arrayStride: 18620,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 6326,
+shaderLocation: 24,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let video45 = await videoWithData();
+let computePassEncoder51 = commandEncoder87.beginComputePass({label: '\u25c5\u01c9\ub257\u599e\u0989\u{1ffde}\u{1fca2}\u613e\uae48\u0bef\u{1fbac}'});
+try {
+renderBundleEncoder99.setBindGroup(5, bindGroup41);
+} catch {}
+let arrayBuffer13 = buffer57.getMappedRange();
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let offscreenCanvas34 = new OffscreenCanvas(960, 493);
+let img51 = await imageWithData(89, 40, '#66036c19', '#fb1131b7');
+let buffer60 = device10.createBuffer({label: '\u24f2\u09c4\u04cd\ue49a\u4265\u0032\u36c7', size: 60891, usage: GPUBufferUsage.MAP_READ});
+let renderBundle107 = renderBundleEncoder91.finish({label: '\u84d2\u2543\u5a98'});
+let sampler91 = device10.createSampler({
+label: '\u9b7f\u{1fff9}\ub880',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 93.701,
+lodMaxClamp: 94.552,
+});
+try {
+gpuCanvasContext20.configure({
+device: device10,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r32sint', 'rgba8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let pipeline97 = device10.createComputePipeline({
+label: '\u{1feda}\u8b39',
+layout: pipelineLayout30,
+compute: {
+module: shaderModule29,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let texture138 = gpuCanvasContext18.getCurrentTexture();
+try {
+commandEncoder96.insertDebugMarker('\u36a5');
+} catch {}
+canvas0.height = 249;
+let promise71 = adapter8.requestDevice({
+label: '\u{1f758}\u127d\u{1fb93}\ub7a0\u{1fda8}',
+});
+let img52 = await imageWithData(108, 174, '#db627a04', '#e10434f5');
+gc();
+let img53 = await imageWithData(65, 22, '#1f7c4aa4', '#cc0b7635');
+let imageData30 = new ImageData(116, 244);
+let texture139 = device16.createTexture({
+label: '\u0204\u2cc8\ua2bc\u7792',
+size: {width: 120, height: 320, depthOrArrayLayers: 58},
+mipLevelCount: 5,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device16.queue.writeTexture({
+  texture: texture139,
+  mipLevel: 4,
+  origin: { x: 0, y: 12, z: 7 },
+  aspect: 'stencil-only',
+}, arrayBuffer12, /* required buffer size: 1828362 */
+{offset: 874, bytesPerRow: 191, rowsPerImage: 299}, {width: 7, height: 0, depthOrArrayLayers: 33});
+} catch {}
+try {
+await device16.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderBundleEncoder98.setVertexBuffer(61, undefined, 372796726, 874179771);
+} catch {}
+try {
+commandEncoder50.copyTextureToTexture({
+  texture: texture112,
+  mipLevel: 1,
+  origin: { x: 1340, y: 0, z: 36 },
+  aspect: 'all',
+}, {
+  texture: texture112,
+  mipLevel: 0,
+  origin: { x: 1955, y: 1, z: 7 },
+  aspect: 'all',
+}, {width: 164, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder93.resolveQuerySet(querySet57, 726, 57, buffer38, 7424);
+} catch {}
+let renderBundleEncoder105 = device15.createRenderBundleEncoder({colorFormats: ['rg32sint', 'rgba16sint', 'r8uint'], depthReadOnly: true});
+try {
+renderBundleEncoder105.insertDebugMarker('\u0136');
+} catch {}
+try {
+device15.queue.writeBuffer(buffer58, 60944, new Float32Array(60523), 51014, 308);
+} catch {}
+let canvas40 = document.createElement('canvas');
+let videoFrame32 = new VideoFrame(imageBitmap36, {timestamp: 0});
+let querySet99 = device13.createQuerySet({
+type: 'occlusion',
+count: 3418,
+});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let img54 = await imageWithData(45, 14, '#1bc548a6', '#5fdad031');
+let commandEncoder101 = device11.createCommandEncoder({label: '\u7d1f\u2a5d\u1981'});
+pseudoSubmit(device11, commandEncoder91);
+let renderBundle108 = renderBundleEncoder79.finish({label: '\u{1fbcc}\u0b94\u789e\u0503\u65d3\u06e8'});
+try {
+renderBundleEncoder93.setBindGroup(1, bindGroup40, new Uint32Array(2226), 1039, 0);
+} catch {}
+let commandEncoder102 = device4.createCommandEncoder({label: '\u8acf\u{1fcf0}\u0f5d\u8edb\u6f94\uae2c\u089f\u{1fced}\u{1ff05}\ufd04'});
+let texture140 = device4.createTexture({
+label: '\u3bca\u6341\u{1fdf6}\u4380\u3a61\u0a1b\u{1f7d3}\ua18e\u421c\u020a\u{1fe4e}',
+size: [340, 120, 173],
+mipLevelCount: 8,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-5x5-unorm'],
+});
+let textureView124 = texture67.createView({
+  label: '\u0c97\u{1fe77}\ued9e\u6654\u{1fd98}\u6a94\ua8c6\udf38\udc05',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseArrayLayer: 62
+});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup25, new Uint32Array(4471), 359, 0);
+} catch {}
+try {
+renderBundleEncoder61.setBindGroup(2, bindGroup30, []);
+} catch {}
+try {
+adapter18.label = '\u08fa\u0343\u{1fc1c}';
+} catch {}
+let commandEncoder103 = device9.createCommandEncoder({label: '\u2fac\u9318\uc7c5\uf93c\u1c1a\uc5eb\u{1f9ce}\u9f13\u8c40\uae3c\ua7c8'});
+let renderBundleEncoder106 = device9.createRenderBundleEncoder({
+  label: '\u0a86\ud0ab\u976e\u091e\u01aa',
+  colorFormats: ['rgba16float', 'rg16sint', 'rgba8uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle109 = renderBundleEncoder94.finish({label: '\u05c3\u096a\u{1fd47}\ua88e\u0f37\ud847\uacea'});
+try {
+renderBundleEncoder81.draw(32);
+} catch {}
+try {
+renderBundleEncoder103.setIndexBuffer(buffer42, 'uint16', 5582, 1262);
+} catch {}
+try {
+renderBundleEncoder87.setPipeline(pipeline88);
+} catch {}
+try {
+renderBundleEncoder87.setVertexBuffer(3, buffer37, 13392, 7685);
+} catch {}
+try {
+commandEncoder103.copyBufferToBuffer(buffer46, 34192, buffer48, 2940, 784);
+dissociateBuffer(device9, buffer46);
+dissociateBuffer(device9, buffer48);
+} catch {}
+try {
+commandEncoder103.clearBuffer(buffer42);
+dissociateBuffer(device9, buffer42);
+} catch {}
+let pipeline98 = await device9.createComputePipelineAsync({
+label: '\u{1fa9b}\u0306\u{1f944}\u0e07\u882b\u{1f6b3}\u1e19\u641d\u02f2\u0ff6\u9ccd',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule31,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+document.body.prepend(img36);
+try {
+canvas39.getContext('2d');
+} catch {}
+let offscreenCanvas35 = new OffscreenCanvas(577, 818);
+let buffer61 = device16.createBuffer({
+  label: '\u2901\u{1fa80}\u7644\u063c\u{1fd40}\u0e60\u{1f811}\uc361\u0bb6\u0ecf',
+  size: 53076,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true
+});
+try {
+commandEncoder99.copyTextureToTexture({
+  texture: texture139,
+  mipLevel: 4,
+  origin: { x: 0, y: 13, z: 30 },
+  aspect: 'stencil-only',
+}, {
+  texture: texture139,
+  mipLevel: 3,
+  origin: { x: 5, y: 20, z: 24 },
+  aspect: 'stencil-only',
+}, {width: 7, height: 1, depthOrArrayLayers: 23});
+} catch {}
+let videoFrame33 = new VideoFrame(canvas31, {timestamp: 0});
+let commandEncoder104 = device10.createCommandEncoder({label: '\ub4b1\u{1f8b5}\uf575\u9882\u69bd\u{1fb9c}\u04f1\u{1ff16}\u0701\u0b78'});
+let texture141 = device10.createTexture({
+label: '\u{1ff04}\u{1fa58}\u256b\u{1ff38}\u{1f927}\uf77c',
+size: [1997, 1, 1],
+mipLevelCount: 9,
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder52 = commandEncoder104.beginComputePass();
+let renderBundle110 = renderBundleEncoder84.finish({label: '\ub8b8\u{1fcc0}\u0630\u{1faff}\u01a8\u05b4\u27fc\u{1fb62}\u01a4'});
+let gpuCanvasContext40 = offscreenCanvas35.getContext('webgpu');
+video18.height = 30;
+let imageData31 = new ImageData(204, 248);
+let img55 = await imageWithData(79, 25, '#2e960522', '#a71a8299');
+let textureView125 = texture104.createView({dimension: '2d-array', baseMipLevel: 7, mipLevelCount: 1, baseArrayLayer: 0});
+try {
+commandEncoder96.copyBufferToBuffer(buffer54, 24632, buffer34, 12060, 812);
+dissociateBuffer(device7, buffer54);
+dissociateBuffer(device7, buffer34);
+} catch {}
+let texture142 = device7.createTexture({
+size: [425],
+dimension: '1d',
+format: 'r32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['r32float'],
+});
+let renderBundle111 = renderBundleEncoder74.finish({label: '\u0c23\u{1fc08}\u0db6\u0b79\u0721\u953d\u7c53\u0e09\u{1f98c}\u{1f7eb}'});
+try {
+commandEncoder95.copyTextureToTexture({
+  texture: texture123,
+  mipLevel: 0,
+  origin: { x: 44, y: 4, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture123,
+  mipLevel: 0,
+  origin: { x: 188, y: 4, z: 1 },
+  aspect: 'all',
+}, {width: 1572, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder96.clearBuffer(buffer34, 17876, 4176);
+dissociateBuffer(device7, buffer34);
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture142,
+  mipLevel: 0,
+  origin: { x: 40, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer9), /* required buffer size: 205 */
+{offset: 205, bytesPerRow: 1753}, {width: 382, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+offscreenCanvas33.getContext('2d');
+} catch {}
+let pipelineLayout31 = device7.createPipelineLayout({bindGroupLayouts: [bindGroupLayout32, bindGroupLayout32, bindGroupLayout32]});
+let texture143 = device7.createTexture({
+label: '\u43fc\u{1fec1}\ua90f',
+size: {width: 4372},
+dimension: '1d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rg8snorm', 'rg8snorm', 'rg8snorm'],
+});
+let computePassEncoder53 = commandEncoder96.beginComputePass();
+try {
+computePassEncoder53.end();
+} catch {}
+let arrayBuffer14 = buffer34.getMappedRange(25144, 32);
+try {
+buffer54.destroy();
+} catch {}
+try {
+computePassEncoder37.insertDebugMarker('\uafa2');
+} catch {}
+let shaderModule32 = device10.createShaderModule({
+label: '\u0290\u4657\u65be\u29a7',
+code: `@group(0) @binding(2862)
+var<storage, read_write> global19: array<u32>;
+@group(3) @binding(1367)
+var<storage, read_write> global20: array<u32>;
+@group(0) @binding(1500)
+var<storage, read_write> field25: array<u32>;
+@group(3) @binding(1500)
+var<storage, read_write> i14: array<u32>;
+@group(1) @binding(1500)
+var<storage, read_write> function13: array<u32>;
+
+@compute @workgroup_size(3, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(3) f1: vec2<u32>,
+  @location(0) f2: vec2<f32>,
+  @location(1) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S38 {
+  @location(13) f0: vec4<i32>,
+  @location(27) f1: vec3<f16>,
+  @location(11) f2: vec4<f16>,
+  @location(22) f3: vec3<i32>,
+  @location(6) f4: vec3<u32>,
+  @location(20) f5: vec3<i32>,
+  @location(2) f6: vec3<u32>,
+  @location(19) f7: u32
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec2<u32>, @location(16) a1: vec4<f32>, @builtin(vertex_index) a2: u32, @location(0) a3: vec4<f16>, @location(4) a4: i32, @location(3) a5: f32, @builtin(instance_index) a6: u32, a7: S38, @location(26) a8: vec4<i32>, @location(24) a9: vec4<f32>, @location(17) a10: vec2<u32>, @location(15) a11: vec4<u32>, @location(28) a12: vec4<f16>, @location(21) a13: vec3<i32>, @location(1) a14: vec4<u32>, @location(7) a15: vec2<f16>, @location(8) a16: vec4<f32>, @location(5) a17: vec4<f16>, @location(23) a18: vec4<i32>, @location(18) a19: i32, @location(14) a20: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+pseudoSubmit(device10, commandEncoder104);
+let textureView126 = texture131.createView({dimension: '2d', aspect: 'stencil-only', mipLevelCount: 4, baseArrayLayer: 3});
+let renderBundle112 = renderBundleEncoder91.finish({label: '\u5abb\u894b\u{1fd6a}\u017a\u{1f89b}\uce36\u9433'});
+try {
+renderBundleEncoder90.popDebugGroup();
+} catch {}
+let offscreenCanvas36 = new OffscreenCanvas(167, 351);
+let textureView127 = texture131.createView({aspect: 'stencil-only', baseMipLevel: 3, mipLevelCount: 6, baseArrayLayer: 18, arrayLayerCount: 10});
+let renderBundle113 = renderBundleEncoder90.finish({label: '\u5db3\u2f76'});
+document.body.prepend(canvas22);
+let querySet100 = device10.createQuerySet({
+type: 'occlusion',
+count: 3595,
+});
+let texture144 = device10.createTexture({
+label: '\u74bd\ufc8c\u0654\ue057\u21d5\u10d9\ueb95\ubf96',
+size: [1997, 1, 138],
+mipLevelCount: 11,
+dimension: '3d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rg32sint', 'rg32sint'],
+});
+try {
+texture135.destroy();
+} catch {}
+try {
+device10.queue.writeTexture({
+  texture: texture144,
+  mipLevel: 4,
+  origin: { x: 14, y: 1, z: 4 },
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 285 */
+{offset: 285}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline99 = await device10.createComputePipelineAsync({
+label: '\ufad6\u35f8\ue252\u{1f64b}',
+layout: pipelineLayout22,
+compute: {
+module: shaderModule29,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let gpuCanvasContext41 = offscreenCanvas34.getContext('webgpu');
+try {
+canvas40.getContext('2d');
+} catch {}
+let texture145 = device14.createTexture({
+size: {width: 552, height: 1, depthOrArrayLayers: 211},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+});
+let textureView128 = texture145.createView({label: '\u{1fda0}\u0e05\u1ec8\u{1fc0b}\u0e1b\u46f3\ua957\u0c87\u{1fa4e}\ufeee', baseMipLevel: 1});
+let sampler92 = device14.createSampler({
+label: '\u85c1\u515e\u{1feec}',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 8.471,
+lodMaxClamp: 74.881,
+maxAnisotropy: 18,
+});
+try {
+computePassEncoder36.setPipeline(pipeline87);
+} catch {}
+let offscreenCanvas37 = new OffscreenCanvas(311, 741);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+  await promise67;
+} catch {}
+let querySet101 = device11.createQuerySet({
+label: '\u3cd9\ucd7e\u0fbe\u081c\u{1fcbc}',
+type: 'occlusion',
+count: 336,
+});
+let textureView129 = texture133.createView({dimension: '2d-array'});
+let computePassEncoder54 = commandEncoder101.beginComputePass({label: '\u{1fee7}\ucbbc\u32ba\ud2be\u1f75\ubffe'});
+try {
+computePassEncoder54.setBindGroup(2, bindGroup40, new Uint32Array(7758), 3823, 0);
+} catch {}
+try {
+renderBundleEncoder93.setBindGroup(3, bindGroup38);
+} catch {}
+try {
+  await promise70;
+} catch {}
+try {
+gpuCanvasContext30.configure({
+device: device14,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgba8unorm-srgb', 'astc-5x5-unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+await device14.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap37 = await createImageBitmap(offscreenCanvas36);
+try {
+offscreenCanvas36.getContext('bitmaprenderer');
+} catch {}
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+pseudoSubmit(device6, commandEncoder84);
+let textureView130 = texture93.createView({
+  label: '\u{1fe77}\u0157\uc291\u920d\u4b08\ucca9\ue30e\u{1fa8b}\u{1fab9}',
+  format: 'astc-12x12-unorm-srgb',
+  baseMipLevel: 1,
+  mipLevelCount: 2
+});
+let computePassEncoder55 = commandEncoder50.beginComputePass({label: '\uc15b\u{1fa0a}\u{1f7f8}'});
+try {
+device6.queue.writeTexture({
+  texture: texture112,
+  mipLevel: 1,
+  origin: { x: 715, y: 0, z: 77 },
+  aspect: 'all',
+}, new ArrayBuffer(72), /* required buffer size: 20335524 */
+{offset: 765, bytesPerRow: 3723, rowsPerImage: 127}, {width: 864, height: 1, depthOrArrayLayers: 44});
+} catch {}
+let pipeline100 = device6.createRenderPipeline({
+label: '\u3ec2\u0f5b\u{1fa6d}\u1a0a\u0054\u{1f86c}\u9b97\u1abd',
+layout: pipelineLayout25,
+fragment: {
+  module: shaderModule27,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rg16sint'}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'dst'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+}
+}, {
+  format: 'rg32float',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, undefined, {format: 'r16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}]
+},
+vertex: {
+  module: shaderModule27,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 31204,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x4',
+offset: 17748,
+shaderLocation: 19,
+}, {
+format: 'float16x4',
+offset: 4648,
+shaderLocation: 22,
+}, {
+format: 'uint32x4',
+offset: 6772,
+shaderLocation: 5,
+}, {
+format: 'sint32x4',
+offset: 30940,
+shaderLocation: 14,
+}, {
+format: 'sint32x3',
+offset: 15760,
+shaderLocation: 18,
+}, {
+format: 'uint32x2',
+offset: 13368,
+shaderLocation: 12,
+}, {
+format: 'snorm16x4',
+offset: 25724,
+shaderLocation: 8,
+}, {
+format: 'sint32',
+offset: 7128,
+shaderLocation: 23,
+}],
+},
+{
+arrayStride: 25996,
+attributes: [{
+format: 'sint8x2',
+offset: 25912,
+shaderLocation: 13,
+}, {
+format: 'float16x2',
+offset: 9820,
+shaderLocation: 20,
+}, {
+format: 'sint16x4',
+offset: 25048,
+shaderLocation: 0,
+}, {
+format: 'unorm8x2',
+offset: 3744,
+shaderLocation: 1,
+}, {
+format: 'unorm16x2',
+offset: 7032,
+shaderLocation: 6,
+}, {
+format: 'unorm8x4',
+offset: 10744,
+shaderLocation: 21,
+}],
+},
+{
+arrayStride: 24016,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x4',
+offset: 20692,
+shaderLocation: 17,
+}, {
+format: 'unorm10-10-10-2',
+offset: 20456,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 20860,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x2',
+offset: 9728,
+shaderLocation: 7,
+}, {
+format: 'float16x2',
+offset: 1000,
+shaderLocation: 15,
+}, {
+format: 'uint8x4',
+offset: 4684,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let querySet102 = device8.createQuerySet({
+label: '\u{1f954}\ub161\u7ef3\u{1fb01}\ua6e6\u{1fffe}\u9383',
+type: 'occlusion',
+count: 2091,
+});
+let computePassEncoder56 = commandEncoder86.beginComputePass({label: '\u{1fb3b}\u{1f710}\ua4a4\u7027\u72c3\uc516\uecd5\u0924\u9dc0\u8a5b\uc208'});
+try {
+computePassEncoder56.setBindGroup(1, bindGroup39);
+} catch {}
+try {
+commandEncoder88.copyTextureToTexture({
+  texture: texture108,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture110,
+  mipLevel: 0,
+  origin: { x: 5, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device8.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+let bindGroupLayout47 = device11.createBindGroupLayout({
+label: '\uf0a3\u09a3\u4faf\ueb68\u07f5\u{1f690}\ub8e6\u03e3\u8d7f',
+entries: [{
+binding: 4231,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '2d-array' },
+}, {
+binding: 5422,
+visibility: 0,
+externalTexture: {},
+}],
+});
+let querySet103 = device11.createQuerySet({
+label: '\u30e4\u0846',
+type: 'occlusion',
+count: 3947,
+});
+try {
+computePassEncoder54.setBindGroup(0, bindGroup40);
+} catch {}
+try {
+renderBundleEncoder93.setBindGroup(2, bindGroup38);
+} catch {}
+try {
+commandEncoder98.copyBufferToBuffer(buffer45, 5176, buffer50, 28608, 844);
+dissociateBuffer(device11, buffer45);
+dissociateBuffer(device11, buffer50);
+} catch {}
+let sampler93 = device13.createSampler({
+label: '\u{1fd7c}\u0f7e\u{1fc34}\u{1fa7c}\u070c\u8b61\u67ec\u{1fa1d}\ub6c2\u{1fc6a}\uf332',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 56.810,
+compare: 'less',
+maxAnisotropy: 4,
+});
+let pipeline101 = await device13.createComputePipelineAsync({
+label: '\u9dfa\u{1f601}\ud5dd\ud5b8\u0d7a\u0c46',
+layout: pipelineLayout27,
+compute: {
+module: shaderModule30,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let offscreenCanvas38 = new OffscreenCanvas(724, 257);
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let canvas41 = document.createElement('canvas');
+let commandEncoder105 = device15.createCommandEncoder({label: '\u6e40\u6b6f\u{1fe85}\u799e\u6528\u0e8d\u0f20\u1774\u0d3d\u098d\u{1f786}'});
+let renderBundleEncoder107 = device15.createRenderBundleEncoder({label: '\u4d99\u0e10\u8aff', colorFormats: ['rg32sint', 'rgba16sint', 'r8uint'], stencilReadOnly: true});
+let sampler94 = device15.createSampler({
+label: '\ubf6d\u0879\u{1fdfe}\u06c4\u12f4\u{1fbc5}\u{1fa45}\ucdf1\u{1f80e}\u54af',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 62.560,
+lodMaxClamp: 79.296,
+});
+document.body.prepend(canvas2);
+let querySet104 = device10.createQuerySet({
+type: 'occlusion',
+count: 3895,
+});
+let imageData32 = new ImageData(4, 36);
+let commandEncoder106 = device6.createCommandEncoder({label: '\u03b8\u{1fe57}\u07e7\u3f52\u{1feda}'});
+let querySet105 = device6.createQuerySet({
+label: '\u144f\u0880\u255f',
+type: 'occlusion',
+count: 2826,
+});
+try {
+commandEncoder72.copyTextureToTexture({
+  texture: texture112,
+  mipLevel: 0,
+  origin: { x: 787, y: 0, z: 4 },
+  aspect: 'all',
+}, {
+  texture: texture112,
+  mipLevel: 0,
+  origin: { x: 304, y: 0, z: 96 },
+  aspect: 'all',
+}, {width: 3088, height: 0, depthOrArrayLayers: 7});
+} catch {}
+try {
+gpuCanvasContext27.unconfigure();
+} catch {}
+let bindGroupLayout48 = device6.createBindGroupLayout({
+entries: [{
+binding: 4521,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '2d' },
+}, {
+binding: 1274,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '1d' },
+}],
+});
+let renderBundleEncoder108 = device6.createRenderBundleEncoder({
+  label: '\u{1f752}\u08af\u{1fec8}\u00b9\ub96f\u0dc1\u9412\uc659',
+  colorFormats: ['rg8unorm', 'rg16sint', 'rgba8unorm-srgb', 'rg32float', undefined, 'r16float', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+try {
+commandEncoder72.resolveQuerySet(querySet105, 906, 639, buffer38, 2048);
+} catch {}
+try {
+computePassEncoder36.insertDebugMarker('\u68e3');
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+let videoFrame34 = new VideoFrame(video36, {timestamp: 0});
+let promise72 = adapter2.requestAdapterInfo();
+let gpuCanvasContext42 = offscreenCanvas38.getContext('webgpu');
+let querySet106 = device13.createQuerySet({
+label: '\u8827\u1ff6\u{1f857}\u{1fc60}\u04cb\u{1f8ae}\u2406\uf01b\u1b50',
+type: 'occlusion',
+count: 651,
+});
+let texture146 = device13.createTexture({
+label: '\u48f8\u0c7b\u0cab',
+size: [60, 93, 138],
+sampleCount: 1,
+format: 'rgba8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let sampler95 = device13.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 47.680,
+lodMaxClamp: 52.633,
+maxAnisotropy: 8,
+});
+let promise73 = buffer53.mapAsync(GPUMapMode.WRITE, 3864, 4396);
+try {
+gpuCanvasContext8.configure({
+device: device13,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device13.queue.writeTexture({
+  texture: texture146,
+  mipLevel: 0,
+  origin: { x: 27, y: 22, z: 29 },
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 1699365 */
+{offset: 341, bytesPerRow: 372, rowsPerImage: 225}, {width: 25, height: 68, depthOrArrayLayers: 21});
+} catch {}
+let pipeline102 = device13.createRenderPipeline({
+label: '\u{1fb4a}\u273d\u{1ff56}\u4b7c\u{1fee0}\u22af\u0915\u{1ff1d}\u0c23\u0ec5',
+layout: pipelineLayout27,
+multisample: {
+count: 1,
+mask: 0xb2b2b5c5,
+},
+fragment: {
+  module: shaderModule30,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8sint', writeMask: 0}]
+},
+vertex: {
+  module: shaderModule30,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 16808,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x2',
+offset: 13924,
+shaderLocation: 24,
+}, {
+format: 'uint16x4',
+offset: 13820,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 24764,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 10776,
+shaderLocation: 19,
+}],
+},
+{
+arrayStride: 1844,
+attributes: [],
+},
+{
+arrayStride: 23652,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 11378,
+shaderLocation: 8,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let gpuCanvasContext43 = canvas41.getContext('webgpu');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let texture147 = device14.createTexture({
+label: '\u{1fd62}\u077d\u0781\u0868\u{1fbea}\u0cf2\u{1fd7f}\u7dea\u0888\udc9e\u0a53',
+size: {width: 420, height: 20, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'etc2-rgb8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8unorm-srgb', 'etc2-rgb8unorm-srgb'],
+});
+let sampler96 = device14.createSampler({
+label: '\u0760\u247e\u{1f6ad}\ucb49\uad07\u{1fe56}\u0b56\u{1fef8}\u9e0a',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 70.102,
+lodMaxClamp: 82.376,
+});
+try {
+gpuCanvasContext22.unconfigure();
+} catch {}
+let bindGroupLayout49 = device15.createBindGroupLayout({
+label: '\u9943\u8abd',
+entries: [{
+binding: 691,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+}, {
+binding: 853,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 695461, hasDynamicOffset: true },
+}, {
+binding: 4645,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}],
+});
+let pipelineLayout32 = device15.createPipelineLayout({
+  label: '\u0886\u0a2f\ud24b\u4ab7\u{1fa4e}',
+  bindGroupLayouts: [bindGroupLayout49, bindGroupLayout49, bindGroupLayout49]
+});
+let commandEncoder107 = device15.createCommandEncoder({label: '\ucaa7\u000b\u0879\u9544\u5aa2\uc046'});
+let texture148 = device15.createTexture({
+label: '\u6fdb\u{1fbf9}\u4d34\ub693\u{1fbf9}\u0505',
+size: {width: 80},
+dimension: '1d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture149 = gpuCanvasContext18.getCurrentTexture();
+let computePassEncoder57 = commandEncoder107.beginComputePass({label: '\u0c60\u08ec\u3d22\u00af\uecca\u03f6\u0de7\u04fb\u0fdc'});
+let renderBundleEncoder109 = device15.createRenderBundleEncoder({label: '\u5aa3\u01a7\u0005', colorFormats: ['rg32sint', 'rgba16sint', 'r8uint'], stencilReadOnly: true});
+let renderBundle114 = renderBundleEncoder107.finish({label: '\u{1fa8c}\u8af1\u0dd1\uc8e6\u{1fe4a}\u{1fe1a}\ue185'});
+try {
+device15.queue.writeTexture({
+  texture: texture136,
+  mipLevel: 0,
+  origin: { x: 131, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint32Array(new ArrayBuffer(16)), /* required buffer size: 44 */
+{offset: 44}, {width: 615, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let querySet107 = device16.createQuerySet({
+label: '\u{1fceb}\u{1fab4}\u8019\u{1fba2}\uaea3\u610c\u{1fa25}\u00bb',
+type: 'occlusion',
+count: 729,
+});
+let texture150 = device16.createTexture({
+label: '\uac41\u{1fcd8}',
+size: [3720],
+dimension: '1d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm'],
+});
+let computePassEncoder58 = commandEncoder99.beginComputePass({label: '\u04cf\u05c3\u8c13\u06d7\u{1faa9}\u2bf3\u02b5\uba08\ub107\u331b'});
+let renderBundleEncoder110 = device16.createRenderBundleEncoder({
+  colorFormats: [undefined, 'r16float', 'r32uint', 'r8sint', 'rgba8unorm-srgb'],
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let img56 = await imageWithData(42, 290, '#d38a9909', '#8268f0f4');
+let adapter21 = await promise65;
+let imageData33 = new ImageData(76, 96);
+let computePassEncoder59 = commandEncoder105.beginComputePass({label: '\uffb7\u0a27\u082b'});
+try {
+gpuCanvasContext37.configure({
+device: device15,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm', 'rgb10a2unorm'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+let texture151 = device7.createTexture({
+label: '\u{1fc07}\ub6af\u8f89',
+size: [5712],
+dimension: '1d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler97 = device7.createSampler({
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 95.792,
+compare: 'equal',
+});
+try {
+commandEncoder96.clearBuffer(buffer34, 824, 11684);
+dissociateBuffer(device7, buffer34);
+} catch {}
+let promise74 = device7.queue.onSubmittedWorkDone();
+document.body.prepend(video25);
+let img57 = await imageWithData(76, 283, '#5e3666bc', '#de703bb8');
+let shaderModule33 = device6.createShaderModule({
+label: '\u7883\u0c29',
+code: `@group(0) @binding(939)
+var<storage, read_write> field26: array<u32>;
+@group(1) @binding(2707)
+var<storage, read_write> parameter17: array<u32>;
+@group(3) @binding(939)
+var<storage, read_write> global21: array<u32>;
+@group(2) @binding(939)
+var<storage, read_write> type23: array<u32>;
+@group(1) @binding(939)
+var<storage, read_write> function14: array<u32>;
+@group(2) @binding(2707)
+var<storage, read_write> parameter18: array<u32>;
+@group(0) @binding(2707)
+var<storage, read_write> i15: array<u32>;
+
+@compute @workgroup_size(3, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S39 {
+  @builtin(sample_index) f0: u32,
+  @builtin(position) f1: vec4<f32>,
+  @builtin(front_facing) f2: bool
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(0) f1: vec4<f32>,
+  @builtin(frag_depth) f2: f32,
+  @location(5) f3: f32,
+  @location(3) f4: vec3<f32>,
+  @location(6) f5: vec4<f32>,
+  @location(1) f6: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, a1: S39) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let renderBundle115 = renderBundleEncoder72.finish({label: '\u1ec0\u{1f794}\u{1f6e8}\u0992\u{1f7ad}\ub363\u4f5e\u{1fe77}\u02c2\u0bba'});
+try {
+device6.pushErrorScope('internal');
+} catch {}
+let gpuCanvasContext44 = offscreenCanvas37.getContext('webgpu');
+gc();
+let texture152 = device11.createTexture({
+label: '\ubb52\u0a27\u0cf9\u06e3\u0a73\u8148',
+size: [240, 20, 1],
+mipLevelCount: 6,
+format: 'astc-10x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder60 = commandEncoder98.beginComputePass({label: '\u0031\u024c\u0e42\u5dd5\u0712\u9c33\u020f\u5d78'});
+try {
+renderBundleEncoder93.setBindGroup(1, bindGroup40, new Uint32Array(4475), 1142, 0);
+} catch {}
+let canvas42 = document.createElement('canvas');
+let imageData34 = new ImageData(232, 180);
+let bindGroup47 = device7.createBindGroup({
+layout: bindGroupLayout32,
+entries: [],
+});
+try {
+commandEncoder96.copyBufferToBuffer(buffer54, 5504, buffer34, 12996, 11440);
+dissociateBuffer(device7, buffer54);
+dissociateBuffer(device7, buffer34);
+} catch {}
+try {
+renderBundleEncoder104.setVertexBuffer(65, undefined);
+} catch {}
+try {
+device15.queue.writeTexture({
+  texture: texture136,
+  mipLevel: 0,
+  origin: { x: 14, y: 1, z: 0 },
+  aspect: 'all',
+}, arrayBuffer12, /* required buffer size: 274 */
+{offset: 274}, {width: 607, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let videoFrame35 = new VideoFrame(imageBitmap29, {timestamp: 0});
+let renderBundle116 = renderBundleEncoder101.finish();
+let pipeline103 = device13.createRenderPipeline({
+layout: pipelineLayout27,
+multisample: {
+count: 4,
+mask: 0x6de0e589,
+},
+fragment: {module: shaderModule30, entryPoint: 'fragment0', targets: [{format: 'rg8sint', writeMask: 0}]},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 3389,
+stencilWriteMask: 984,
+depthBias: 88,
+depthBiasSlopeScale: 88,
+depthBiasClamp: 20,
+},
+vertex: {
+  module: shaderModule30,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 10508,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x3',
+offset: 9828,
+shaderLocation: 8,
+}, {
+format: 'snorm16x4',
+offset: 1420,
+shaderLocation: 24,
+}, {
+format: 'uint32',
+offset: 1260,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 22388,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 24460,
+attributes: [],
+},
+{
+arrayStride: 4060,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 6948,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x4',
+offset: 3652,
+shaderLocation: 19,
+}],
+}
+]
+},
+});
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+let computePassEncoder61 = commandEncoder79.beginComputePass({label: '\u207d\u0fe2\u7892\u75a6\u0c4a\u49e7\u0e3b\ub897'});
+let renderBundle117 = renderBundleEncoder88.finish({label: '\uf735\u0ce3\u{1f7ac}\ubcd6\u09b6\u9506\u0d5c\u562f\u9792'});
+let sampler98 = device12.createSampler({
+label: '\u{1faaa}\u06e1',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 10.803,
+lodMaxClamp: 72.211,
+compare: 'greater-equal',
+});
+try {
+renderBundleEncoder99.setVertexBuffer(8, undefined, 3528953248, 238440347);
+} catch {}
+try {
+await adapter3.requestAdapterInfo();
+} catch {}
+try {
+gpuCanvasContext34.unconfigure();
+} catch {}
+let renderBundle118 = renderBundleEncoder98.finish({label: '\u0a6c\u06c6\ued6f\ub7e3\u7cb8\u2620\u0ca4'});
+offscreenCanvas7.height = 766;
+try {
+canvas42.getContext('2d');
+} catch {}
+try {
+renderBundleEncoder97.setVertexBuffer(31, undefined, 197640936, 512686991);
+} catch {}
+let arrayBuffer15 = buffer40.getMappedRange(552, 16044);
+let pipelineLayout33 = device6.createPipelineLayout({
+  label: '\u8527\u092b\ud3da\uc2a0\uf1db\u9778\ued99\u0060\uaa89',
+  bindGroupLayouts: [bindGroupLayout44, bindGroupLayout36, bindGroupLayout44, bindGroupLayout36]
+});
+let querySet108 = device6.createQuerySet({
+label: '\u441a\u09f0\u6414\u{1fc90}\u4ec4\u024b\u0400\u0dd5\ub1a4\ue6f5\u066e',
+type: 'occlusion',
+count: 3643,
+});
+let renderBundleEncoder111 = device6.createRenderBundleEncoder({
+  label: '\u9284\u{1fc34}\ua011',
+  colorFormats: ['rg8unorm', 'rg16sint', 'rgba8unorm-srgb', 'rg32float', undefined, 'r16float', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  stencilReadOnly: true
+});
+try {
+commandEncoder106.copyTextureToTexture({
+  texture: texture112,
+  mipLevel: 0,
+  origin: { x: 1219, y: 1, z: 14 },
+  aspect: 'all',
+}, {
+  texture: texture112,
+  mipLevel: 0,
+  origin: { x: 2056, y: 1, z: 64 },
+  aspect: 'all',
+}, {width: 2372, height: 0, depthOrArrayLayers: 21});
+} catch {}
+try {
+device6.queue.submit([
+]);
+} catch {}
+let commandEncoder108 = device16.createCommandEncoder({label: '\u{1fb44}\u0be4\ub499\u0984\u128f\u{1f73e}'});
+try {
+gpuCanvasContext30.configure({
+device: device16,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.prepend(video42);
+let imageData35 = new ImageData(176, 220);
+let shaderModule34 = device15.createShaderModule({
+label: '\u6d93\u656f\u041d\u07a7\u04a5\u0ce4\u0bb3\u02f4\u0335\uecef',
+code: `@group(2) @binding(691)
+var<storage, read_write> global22: array<u32>;
+@group(1) @binding(4645)
+var<storage, read_write> type24: array<u32>;
+@group(1) @binding(853)
+var<storage, read_write> field27: array<u32>;
+@group(2) @binding(853)
+var<storage, read_write> parameter19: array<u32>;
+@group(0) @binding(853)
+var<storage, read_write> function15: array<u32>;
+
+@compute @workgroup_size(8, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S41 {
+  @location(35) f0: f16,
+  @location(96) f1: i32,
+  @location(55) f2: vec2<i32>,
+  @location(0) f3: vec2<f32>,
+  @location(12) f4: vec3<f16>,
+  @location(74) f5: vec3<f16>,
+  @location(112) f6: f16,
+  @location(27) f7: vec4<f32>,
+  @location(111) f8: vec4<f32>,
+  @location(71) f9: i32
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<u32>,
+  @location(0) f1: vec2<i32>,
+  @location(1) f2: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(103) a0: vec2<f32>, @location(17) a1: vec2<i32>, @location(61) a2: i32, @location(47) a3: vec2<f32>, @location(66) a4: u32, @location(97) a5: vec4<f32>, @location(40) a6: vec2<i32>, @location(73) a7: f32, @builtin(position) a8: vec4<f32>, @location(84) a9: vec2<f32>, @location(31) a10: vec3<f16>, @location(106) a11: f16, @location(21) a12: vec3<u32>, @location(100) a13: vec4<f16>, @location(89) a14: f16, @location(9) a15: vec2<i32>, @location(92) a16: vec3<u32>, @location(64) a17: vec4<f32>, @location(5) a18: vec3<i32>, @location(36) a19: i32, @location(81) a20: vec2<f32>, @location(88) a21: i32, @location(53) a22: f16, a23: S41, @builtin(sample_mask) a24: u32, @builtin(sample_index) a25: u32, @builtin(front_facing) a26: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S40 {
+  @builtin(instance_index) f0: u32,
+  @location(8) f1: f16,
+  @location(9) f2: vec4<f16>,
+  @location(10) f3: f16,
+  @location(13) f4: f16,
+  @location(14) f5: u32,
+  @location(5) f6: vec3<f32>
+}
+struct VertexOutput0 {
+  @location(12) f452: vec3<f16>,
+  @location(17) f453: vec2<i32>,
+  @location(81) f454: vec2<f32>,
+  @location(9) f455: vec2<i32>,
+  @location(40) f456: vec2<i32>,
+  @location(92) f457: vec3<u32>,
+  @location(31) f458: vec3<f16>,
+  @location(55) f459: vec2<i32>,
+  @location(74) f460: vec3<f16>,
+  @location(73) f461: f32,
+  @location(61) f462: i32,
+  @location(64) f463: vec4<f32>,
+  @location(53) f464: f16,
+  @location(84) f465: vec2<f32>,
+  @location(0) f466: vec2<f32>,
+  @location(97) f467: vec4<f32>,
+  @location(88) f468: i32,
+  @builtin(position) f469: vec4<f32>,
+  @location(5) f470: vec3<i32>,
+  @location(89) f471: f16,
+  @location(100) f472: vec4<f16>,
+  @location(27) f473: vec4<f32>,
+  @location(106) f474: f16,
+  @location(111) f475: vec4<f32>,
+  @location(47) f476: vec2<f32>,
+  @location(103) f477: vec2<f32>,
+  @location(96) f478: i32,
+  @location(35) f479: f16,
+  @location(21) f480: vec3<u32>,
+  @location(66) f481: u32,
+  @location(112) f482: f16,
+  @location(71) f483: i32,
+  @location(36) f484: i32
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec3<f16>, @location(6) a1: vec3<f16>, @location(11) a2: vec3<f16>, @location(3) a3: vec3<u32>, @location(0) a4: vec4<i32>, @location(2) a5: vec2<f16>, @location(4) a6: f16, @location(1) a7: vec4<u32>, a8: S40, @location(7) a9: f16, @location(12) a10: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+try {
+await adapter19.requestAdapterInfo();
+} catch {}
+try {
+computePassEncoder44.setPipeline(pipeline83);
+} catch {}
+try {
+renderBundleEncoder81.draw(64, 40, 0, 40);
+} catch {}
+try {
+renderBundleEncoder81.drawIndexed(64, 48, 56, -8, 56);
+} catch {}
+try {
+renderBundleEncoder81.setIndexBuffer(buffer42, 'uint16', 17254, 2015);
+} catch {}
+try {
+renderBundleEncoder106.setPipeline(pipeline88);
+} catch {}
+try {
+commandEncoder103.copyBufferToBuffer(buffer56, 45868, buffer51, 1208, 1996);
+dissociateBuffer(device9, buffer56);
+dissociateBuffer(device9, buffer51);
+} catch {}
+try {
+device9.queue.writeBuffer(buffer48, 4524, new BigUint64Array(34768), 15997, 204);
+} catch {}
+try {
+device9.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas17,
+  origin: { x: 457, y: 497 },
+  flipY: false,
+}, {
+  texture: texture125,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline104 = device9.createRenderPipeline({
+layout: 'auto',
+multisample: {
+count: 4,
+},
+fragment: {
+  module: shaderModule25,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'src-alpha'},
+},
+  writeMask: 0
+}, {format: 'rg16sint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2413,
+stencilWriteMask: 640,
+depthBias: 51,
+depthBiasSlopeScale: 80,
+depthBiasClamp: 41,
+},
+vertex: {
+  module: shaderModule25,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 16388,
+attributes: [{
+format: 'uint8x4',
+offset: 12196,
+shaderLocation: 7,
+}, {
+format: 'unorm8x2',
+offset: 15036,
+shaderLocation: 1,
+}, {
+format: 'unorm10-10-10-2',
+offset: 3052,
+shaderLocation: 23,
+}, {
+format: 'uint16x2',
+offset: 12120,
+shaderLocation: 0,
+}, {
+format: 'sint16x4',
+offset: 9596,
+shaderLocation: 21,
+}, {
+format: 'unorm16x2',
+offset: 5124,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 33104,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 21820,
+shaderLocation: 22,
+}, {
+format: 'float16x4',
+offset: 29220,
+shaderLocation: 20,
+}, {
+format: 'sint32',
+offset: 12816,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 47928,
+attributes: [{
+format: 'uint16x4',
+offset: 20244,
+shaderLocation: 10,
+}, {
+format: 'sint8x2',
+offset: 32678,
+shaderLocation: 13,
+}, {
+format: 'sint32x4',
+offset: 20968,
+shaderLocation: 18,
+}, {
+format: 'uint8x2',
+offset: 9460,
+shaderLocation: 2,
+}, {
+format: 'uint16x2',
+offset: 3468,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 7836,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32',
+offset: 5672,
+shaderLocation: 17,
+}, {
+format: 'unorm8x2',
+offset: 138,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x2',
+offset: 46906,
+shaderLocation: 12,
+}, {
+format: 'float32x2',
+offset: 34860,
+shaderLocation: 6,
+}, {
+format: 'sint8x2',
+offset: 43746,
+shaderLocation: 9,
+}, {
+format: 'snorm16x2',
+offset: 18688,
+shaderLocation: 16,
+}, {
+format: 'uint32x3',
+offset: 19200,
+shaderLocation: 19,
+}, {
+format: 'unorm8x4',
+offset: 27776,
+shaderLocation: 5,
+}, {
+format: 'sint32x2',
+offset: 28924,
+shaderLocation: 14,
+}, {
+format: 'uint32x3',
+offset: 17952,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+try {
+gpuCanvasContext22.unconfigure();
+} catch {}
+let offscreenCanvas39 = new OffscreenCanvas(296, 772);
+let bindGroup48 = device8.createBindGroup({
+label: '\u420a\u0621\u04eb\uf05d',
+layout: bindGroupLayout35,
+entries: [],
+});
+let commandEncoder109 = device8.createCommandEncoder({label: '\u{1fa4f}\u7b89\u{1ffd3}\u5e0b'});
+let texture153 = device8.createTexture({
+label: '\u0b8c\u{1fec7}\u8b28\ua9a3\u{1fdff}\u8faf\u0c3d\ue9e3\ud4fb\u6e94',
+size: [320, 15, 1],
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth16unorm', 'depth16unorm', 'depth16unorm'],
+});
+let textureView131 = texture107.createView({
+  label: '\u857e\u{1fe24}\u6993\u1a47\ua80c\u{1f635}\u9de9',
+  dimension: '2d-array',
+  aspect: 'depth-only',
+  baseMipLevel: 2,
+  baseArrayLayer: 21,
+  arrayLayerCount: 65
+});
+try {
+computePassEncoder56.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+commandEncoder88.copyTextureToBuffer({
+  texture: texture153,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'depth-only',
+}, {
+/* bytesInLastRow: 640 widthInBlocks: 320 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 13828 */
+offset: 2436,
+bytesPerRow: 768,
+buffer: buffer55,
+}, {width: 320, height: 15, depthOrArrayLayers: 1});
+dissociateBuffer(device8, buffer55);
+} catch {}
+try {
+adapter5.label = '\u4295\u1d0e\u{1fe70}';
+} catch {}
+let commandEncoder110 = device2.createCommandEncoder({label: '\u0f65\ubb81\ud2fc'});
+let texture154 = device2.createTexture({
+label: '\ub7d6\u{1fc83}',
+size: {width: 96, height: 192, depthOrArrayLayers: 1},
+format: 'etc2-rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgba8unorm', 'etc2-rgba8unorm', 'etc2-rgba8unorm-srgb'],
+});
+let renderBundle119 = renderBundleEncoder59.finish({});
+try {
+  await promise72;
+} catch {}
+try {
+  await promise74;
+} catch {}
+let promise75 = adapter21.requestDevice({
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 62,
+maxVertexAttributes: 30,
+maxVertexBufferArrayStride: 54543,
+maxStorageTexturesPerShaderStage: 8,
+maxDynamicStorageBuffersPerPipelineLayout: 18702,
+maxBindingsPerBindGroup: 3039,
+maxTextureDimension1D: 15770,
+maxTextureDimension2D: 9360,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 230035102,
+maxUniformBuffersPerShaderStage: 33,
+maxInterStageShaderVariables: 123,
+maxInterStageShaderComponents: 102,
+maxSamplersPerShaderStage: 17,
+},
+});
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+let videoFrame36 = new VideoFrame(imageBitmap22, {timestamp: 0});
+let renderBundleEncoder112 = device9.createRenderBundleEncoder({
+  label: '\u0ed1\u08b0\uf2fd\uf948\u0ebf\u04d4\u4c4f\u6215',
+  colorFormats: ['rgba16float', 'rg16sint', 'rgba8uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+commandEncoder103.resolveQuerySet(querySet75, 406, 39, buffer56, 7424);
+} catch {}
+let pipeline105 = await device9.createComputePipelineAsync({
+label: '\u5271\u612e\u{1fd21}\ua186\u0d56\u5ccf\u021a\u2c5a\u8fb7\u060b\u1d9c',
+layout: pipelineLayout29,
+compute: {
+module: shaderModule25,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+try {
+  await promise69;
+} catch {}
+try {
+adapter6.label = '\ub26a\u9f49\u08f3\u42a0\u0115';
+} catch {}
+let textureView132 = texture144.createView({label: '\u{1fe64}\u7307\uae83', mipLevelCount: 8});
+let sampler99 = device10.createSampler({
+label: '\uf0f2\u52c0\u05df\u56c2\u031e\u66d3\ucf00',
+minFilter: 'nearest',
+lodMinClamp: 80.139,
+lodMaxClamp: 90.975,
+});
+try {
+device10.addEventListener('uncapturederror', e => { log('device10.uncapturederror'); log(e); e.label = device10.label; });
+} catch {}
+try {
+device10.queue.writeTexture({
+  texture: texture105,
+  mipLevel: 4,
+  origin: { x: 15, y: 0, z: 6 },
+  aspect: 'all',
+}, new ArrayBuffer(98003), /* required buffer size: 98003 */
+{offset: 104, bytesPerRow: 171, rowsPerImage: 22}, {width: 87, height: 1, depthOrArrayLayers: 27});
+} catch {}
+let promise76 = device10.queue.onSubmittedWorkDone();
+let promise77 = navigator.gpu.requestAdapter({
+});
+let canvas43 = document.createElement('canvas');
+let bindGroupLayout50 = device9.createBindGroupLayout({
+label: '\u{1fbd7}\u02dd\u0754\u50f2\u4a41\uf2aa\u0186\u0d14',
+entries: [{
+binding: 303,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 688,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+}, {
+binding: 1833,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}],
+});
+let querySet109 = device9.createQuerySet({
+label: '\udfbc\u19fe\u{1f928}\u0680\u{1f9a3}\uc03b\u0718\u04c1\u0298\u0b79',
+type: 'occlusion',
+count: 2061,
+});
+let renderBundleEncoder113 = device9.createRenderBundleEncoder({
+  label: '\u0d02\u004d\udb6b\uf4e4\u0d38\u{1f9a0}',
+  colorFormats: ['rgba16float', 'rg16sint', 'rgba8uint'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder96.setVertexBuffer(0, buffer37, 39536, 226);
+} catch {}
+let promise78 = buffer43.mapAsync(GPUMapMode.WRITE, 27000, 3864);
+try {
+commandEncoder103.insertDebugMarker('\u{1f6b6}');
+} catch {}
+let imageBitmap38 = await createImageBitmap(imageBitmap2);
+let renderBundleEncoder114 = device9.createRenderBundleEncoder({
+  colorFormats: ['rgba16float', 'rg16sint', 'rgba8uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+let sampler100 = device9.createSampler({
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 29.184,
+});
+try {
+renderBundleEncoder87.drawIndexed(24, 56, 48, 680, 64);
+} catch {}
+try {
+renderBundleEncoder106.setPipeline(pipeline88);
+} catch {}
+try {
+  await buffer48.mapAsync(GPUMapMode.READ, 5952, 404);
+} catch {}
+try {
+device9.queue.writeTexture({
+  texture: texture125,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer10), /* required buffer size: 193 */
+{offset: 193, rowsPerImage: 165}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+let adapter22 = await navigator.gpu.requestAdapter();
+let shaderModule35 = device13.createShaderModule({
+label: '\u4585\u{1ffbe}',
+code: `@group(0) @binding(2226)
+var<storage, read_write> local20: array<u32>;
+@group(0) @binding(1927)
+var<storage, read_write> field28: array<u32>;
+
+@compute @workgroup_size(7, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(frag_depth) f0: f32,
+  @location(0) f1: vec3<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(22) a0: vec3<i32>, @location(21) a1: vec4<u32>, @builtin(vertex_index) a2: u32, @location(7) a3: vec3<i32>, @location(0) a4: vec2<f32>, @location(8) a5: f32, @location(13) a6: vec3<i32>, @location(10) a7: u32, @location(16) a8: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let pipelineLayout34 = device13.createPipelineLayout({
+  label: '\u{1ff9c}\u926d\u05db\u0a3e\u{1faca}\u09ec',
+  bindGroupLayouts: [bindGroupLayout42, bindGroupLayout43, bindGroupLayout43, bindGroupLayout43]
+});
+let texture155 = device13.createTexture({
+label: '\u1f83\u19fd\u5eea\u308a\uf557',
+size: [96, 10, 129],
+mipLevelCount: 5,
+format: 'astc-12x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x10-unorm'],
+});
+let sampler101 = device13.createSampler({
+label: '\uaa19\u037c',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 92.637,
+lodMaxClamp: 98.321,
+compare: 'less',
+});
+try {
+gpuCanvasContext29.configure({
+device: device13,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm-srgb', 'astc-8x6-unorm', 'astc-4x4-unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let imageData36 = new ImageData(24, 248);
+let bindGroup49 = device7.createBindGroup({
+label: '\uc4dd\u5741\uf25b',
+layout: bindGroupLayout32,
+entries: [],
+});
+let querySet110 = device7.createQuerySet({
+label: '\u05ae\u{1f86c}\u5e52\u057f\u0875\u6ec2\ued62\u702a\u{1fc60}',
+type: 'occlusion',
+count: 3461,
+});
+let sampler102 = device7.createSampler({
+label: '\ue375\u6e5a\u0452\u855a\u23f9\u3581\u0a9c\u04c5\u0c1a\u{1f762}\u7303',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 72.044,
+lodMaxClamp: 99.554,
+});
+try {
+commandEncoder96.copyBufferToBuffer(buffer54, 7936, buffer34, 15752, 4964);
+dissociateBuffer(device7, buffer54);
+dissociateBuffer(device7, buffer34);
+} catch {}
+let bindGroup50 = device12.createBindGroup({
+label: '\u899f\u{1ff79}\ubd1c',
+layout: bindGroupLayout37,
+entries: [],
+});
+let querySet111 = device12.createQuerySet({
+label: '\u05cb\u047d',
+type: 'occlusion',
+count: 475,
+});
+let renderBundleEncoder115 = device12.createRenderBundleEncoder({
+  label: '\u2f4b\uf164\u{1ff4e}\u74bd\u02cc\u3f96\u0931\ue488\u072d\u0972',
+  colorFormats: ['r16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder99.setBindGroup(3, bindGroup41);
+} catch {}
+try {
+renderBundleEncoder99.setBindGroup(0, bindGroup36, new Uint32Array(7270), 1241, 0);
+} catch {}
+let promise79 = device12.queue.onSubmittedWorkDone();
+let gpuCanvasContext45 = canvas43.getContext('webgpu');
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas39.getContext('webgl2');
+} catch {}
+let querySet112 = device10.createQuerySet({
+label: '\u0891\u8ca9\u495d\u{1f8ff}\uc264\u0f4a\ub739\u0018\uebfc\u0185',
+type: 'occlusion',
+count: 3355,
+});
+try {
+device10.addEventListener('uncapturederror', e => { log('device10.uncapturederror'); log(e); e.label = device10.label; });
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let offscreenCanvas40 = new OffscreenCanvas(639, 794);
+let imageData37 = new ImageData(132, 220);
+let shaderModule36 = device6.createShaderModule({
+label: '\u{1fd5c}\ua465\u{1fe27}\uda9b\u0742\u{1fbd6}\u{1fa68}\u0936\u03cf\u{1f9aa}',
+code: `@group(2) @binding(2707)
+var<storage, read_write> i16: array<u32>;
+@group(0) @binding(939)
+var<storage, read_write> parameter20: array<u32>;
+@group(3) @binding(2707)
+var<storage, read_write> field29: array<u32>;
+@group(2) @binding(939)
+var<storage, read_write> global23: array<u32>;
+@group(0) @binding(2707)
+var<storage, read_write> type25: array<u32>;
+@group(1) @binding(2707)
+var<storage, read_write> type26: array<u32>;
+@group(1) @binding(939)
+var<storage, read_write> parameter21: array<u32>;
+
+@compute @workgroup_size(4, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(1) f1: vec2<i32>,
+  @location(0) f2: vec3<f32>,
+  @location(7) f3: vec4<i32>,
+  @builtin(frag_depth) f4: f32,
+  @location(3) f5: vec2<f32>,
+  @location(6) f6: vec4<f32>,
+  @location(5) f7: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S42 {
+  @location(3) f0: vec2<i32>,
+  @location(21) f1: vec3<f32>,
+  @location(8) f2: vec4<f32>,
+  @location(2) f3: u32,
+  @location(23) f4: vec4<f32>,
+  @location(18) f5: vec4<f32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(13) a1: i32, @location(1) a2: vec2<u32>, a3: S42, @location(10) a4: vec3<f32>, @location(6) a5: vec2<i32>, @builtin(vertex_index) a6: u32, @location(15) a7: vec2<i32>, @location(4) a8: vec2<f32>, @location(5) a9: vec4<i32>, @location(11) a10: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let computePassEncoder62 = commandEncoder72.beginComputePass({label: '\u226b\uc725\u042b\u289a\u{1fe9d}\u0d7a\u0500\ud826\u0fca\u424a\ud9cf'});
+let renderBundleEncoder116 = device6.createRenderBundleEncoder({
+  label: '\u{1f739}\u0301\u08ef\u{1f79f}',
+  colorFormats: ['rg8unorm', 'rg16sint', 'rgba8unorm-srgb', 'rg32float', undefined, 'r16float', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8'
+});
+try {
+device6.addEventListener('uncapturederror', e => { log('device6.uncapturederror'); log(e); e.label = device6.label; });
+} catch {}
+try {
+computePassEncoder48.insertDebugMarker('\u0772');
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture112,
+  mipLevel: 0,
+  origin: { x: 2041, y: 0, z: 72 },
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer4), /* required buffer size: 3513246 */
+{offset: 170, bytesPerRow: 9786, rowsPerImage: 179}, {width: 2422, height: 1, depthOrArrayLayers: 3});
+} catch {}
+let pipeline106 = device6.createComputePipeline({
+label: '\ue58e\u{1ffd2}\u8512\u{1fc97}\u61ee\u0c47\u{1fd13}\ua758',
+layout: pipelineLayout20,
+compute: {
+module: shaderModule27,
+entryPoint: 'compute0',
+},
+});
+let gpuCanvasContext46 = offscreenCanvas40.getContext('webgpu');
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+let texture156 = device12.createTexture({
+size: [30, 40, 1],
+mipLevelCount: 6,
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [],
+});
+let textureView133 = texture116.createView({
+  label: '\u{1f8cb}\u0030\u0478\u0d2e\u90c9\u0117',
+  dimension: '2d',
+  format: 'etc2-rgb8a1unorm-srgb',
+  baseMipLevel: 1
+});
+try {
+renderBundleEncoder115.setVertexBuffer(45, undefined);
+} catch {}
+try {
+computePassEncoder51.pushDebugGroup('\u{1fc22}');
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let renderBundle120 = renderBundleEncoder84.finish({label: '\u2d40\u03fa\u9bbe\ufee5\u018f\ufb62\u0ac3\u7a5b\u42b7'});
+let sampler103 = device10.createSampler({
+label: '\uf0bb\ub2b0\u6c08\u{1f949}\ufa8b\u{1fec5}\u4e12\uf900\u09c1',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMaxClamp: 50.837,
+compare: 'greater-equal',
+});
+try {
+device10.destroy();
+} catch {}
+let texture157 = device9.createTexture({
+label: '\u0133\u5bfb',
+size: [25, 1, 1],
+mipLevelCount: 2,
+dimension: '2d',
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['depth24plus', 'depth24plus', 'depth24plus'],
+});
+let renderBundleEncoder117 = device9.createRenderBundleEncoder({
+  label: '\u5caf\u0fcc',
+  colorFormats: ['rgba16float', 'rg16sint', 'rgba8uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+commandEncoder103.copyBufferToBuffer(buffer43, 3308, buffer48, 348, 6116);
+dissociateBuffer(device9, buffer43);
+dissociateBuffer(device9, buffer48);
+} catch {}
+try {
+  await promise73;
+} catch {}
+let textureView134 = texture155.createView({
+  label: '\uab37\u12be\u51cb\u{1fc27}\ub8d3',
+  format: 'astc-12x10-unorm',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 60,
+  arrayLayerCount: 42
+});
+let renderBundleEncoder118 = device13.createRenderBundleEncoder({
+  label: '\u{1fe11}\u2b0f\ufc6d\ud34d\ued79\u041e\u41d3',
+  colorFormats: ['rg8sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  stencilReadOnly: true
+});
+try {
+buffer53.unmap();
+} catch {}
+try {
+gpuCanvasContext45.unconfigure();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let img58 = await imageWithData(31, 3, '#826e84e5', '#504b0a11');
+let textureView135 = texture146.createView({label: '\u320f\u018a\u6558\uf392\u9e2d\u0498', baseArrayLayer: 15, arrayLayerCount: 97});
+let renderBundleEncoder119 = device13.createRenderBundleEncoder({
+  label: '\ue4d0\u{1f6f1}\u0306\u{1f945}\u042a\u0019\u{1fd4e}\u{1fd6c}\uf142',
+  colorFormats: ['rg8sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  stencilReadOnly: true
+});
+try {
+querySet106.destroy();
+} catch {}
+try {
+device13.queue.writeTexture({
+  texture: texture146,
+  mipLevel: 0,
+  origin: { x: 16, y: 21, z: 30 },
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 2354587 */
+{offset: 357, bytesPerRow: 441, rowsPerImage: 113}, {width: 43, height: 28, depthOrArrayLayers: 48});
+} catch {}
+let offscreenCanvas41 = new OffscreenCanvas(424, 288);
+let pipelineLayout35 = device9.createPipelineLayout({
+  label: '\u0d91\u0d1a\u0cf5\u01a3',
+  bindGroupLayouts: [bindGroupLayout30, bindGroupLayout34, bindGroupLayout46]
+});
+let querySet113 = device9.createQuerySet({
+label: '\u{1fd3c}\u{1fd76}\u83a0\u7d02',
+type: 'occlusion',
+count: 1632,
+});
+let texture158 = device9.createTexture({
+label: '\u8c17\u4c1e\uf21c\u{1f7fa}\u0033\u7323',
+size: [1424, 960, 176],
+mipLevelCount: 9,
+format: 'astc-4x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-4x4-unorm-srgb'],
+});
+let textureView136 = texture137.createView({label: '\u0ae5\u041b\u034f\uea28\u926c', dimension: '2d', baseArrayLayer: 67});
+try {
+computePassEncoder44.end();
+} catch {}
+try {
+renderBundleEncoder106.drawIndexed(80);
+} catch {}
+try {
+renderBundleEncoder96.setIndexBuffer(buffer42, 'uint16', 18770, 533);
+} catch {}
+try {
+renderBundleEncoder112.setPipeline(pipeline88);
+} catch {}
+try {
+renderBundleEncoder80.setVertexBuffer(4, buffer37);
+} catch {}
+try {
+buffer37.unmap();
+} catch {}
+try {
+commandEncoder103.copyBufferToBuffer(buffer46, 2540, buffer42, 11956, 10672);
+dissociateBuffer(device9, buffer46);
+dissociateBuffer(device9, buffer42);
+} catch {}
+try {
+commandEncoder82.clearBuffer(buffer48, 6380, 48);
+dissociateBuffer(device9, buffer48);
+} catch {}
+try {
+commandEncoder82.resolveQuerySet(querySet76, 528, 2833, buffer56, 16384);
+} catch {}
+try {
+device9.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame21,
+  origin: { x: 9, y: 5 },
+  flipY: false,
+}, {
+  texture: texture125,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline107 = device9.createComputePipeline({
+label: '\u4262\u{1f7b1}\u0db8\uef03\u{1f621}',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule31,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let img59 = await imageWithData(120, 49, '#b2ed5fd4', '#c6c7bc9b');
+let textureView137 = texture148.createView({});
+try {
+renderBundleEncoder109.setVertexBuffer(79, undefined, 3726420738, 226517284);
+} catch {}
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+let textureView138 = texture150.createView({label: '\ude4a\u086d\u0e3c\u6641\u0a12\u{1f84d}\u0209\u02aa\u78e9\u07c7'});
+let computePassEncoder63 = commandEncoder108.beginComputePass();
+let sampler104 = device16.createSampler({
+label: '\u86bd\u{1fe8b}\uf1be\u1ae5',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 18.547,
+lodMaxClamp: 49.244,
+maxAnisotropy: 10,
+});
+try {
+renderBundleEncoder110.setVertexBuffer(56, undefined, 162915540, 4011731437);
+} catch {}
+try {
+gpuCanvasContext29.configure({
+device: device16,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+alphaMode: 'opaque',
+});
+} catch {}
+let gpuCanvasContext47 = offscreenCanvas41.getContext('webgpu');
+gc();
+let offscreenCanvas42 = new OffscreenCanvas(757, 434);
+let videoFrame37 = new VideoFrame(imageBitmap14, {timestamp: 0});
+let bindGroup51 = device12.createBindGroup({
+label: '\u{1fb75}\u{1f8ba}\u68b8\u14cb\ubd14\u{1fce1}\u0f0d',
+layout: bindGroupLayout37,
+entries: [],
+});
+pseudoSubmit(device12, commandEncoder89);
+let sampler105 = device12.createSampler({
+label: '\u0398\u{1fd6c}\u4533\u0709\ua3cc\u6474',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 38.003,
+lodMaxClamp: 56.796,
+maxAnisotropy: 10,
+});
+try {
+renderBundleEncoder102.setVertexBuffer(44, undefined, 3373028763);
+} catch {}
+let bindGroupLayout51 = device12.createBindGroupLayout({
+label: '\u1053\u9759\u545b\u027f\u{1fc4b}\u2ba3\u{1fe4c}',
+entries: [{
+binding: 5964,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+}],
+});
+try {
+gpuCanvasContext8.configure({
+device: device12,
+format: 'astc-10x5-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x6-unorm'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device12.queue.writeTexture({
+  texture: texture128,
+  mipLevel: 3,
+  origin: { x: 8, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 934 */
+{offset: 934}, {width: 0, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder120 = device6.createRenderBundleEncoder({
+  label: '\u00fb\u{1f836}\u075a\ub92a\u088b\u9776\u0725\ubab7\u08eb',
+  colorFormats: ['rg8unorm', 'rg16sint', 'rgba8unorm-srgb', 'rg32float', undefined, 'r16float', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8'
+});
+let pipeline108 = device6.createComputePipeline({
+layout: pipelineLayout25,
+compute: {
+module: shaderModule36,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+gc();
+let canvas44 = document.createElement('canvas');
+let pipelineLayout36 = device13.createPipelineLayout({label: '\u85b6\u0199\u04b4\u26f0\u4a35\u0f18\u{1fb7a}\ub1f3', bindGroupLayouts: [bindGroupLayout42]});
+let sampler106 = device13.createSampler({
+label: '\u08b7\u{1fdf7}\u3365\u{1f736}\u{1fcc8}\u9473\u013b\uaefe\u5416\u0207\u30d8',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 41.322,
+lodMaxClamp: 76.043,
+});
+try {
+renderBundleEncoder100.setVertexBuffer(23, undefined);
+} catch {}
+try {
+buffer53.unmap();
+} catch {}
+try {
+  await promise76;
+} catch {}
+let adapter23 = await navigator.gpu.requestAdapter({
+});
+let bindGroupLayout52 = device15.createBindGroupLayout({
+label: '\u0549\ue575\ub748\uff39',
+entries: [{
+binding: 4929,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+}, {
+binding: 642,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+}, {
+binding: 1429,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+}],
+});
+let renderBundle121 = renderBundleEncoder109.finish({label: '\uf330\u0371\ud141\u6c34\u3695\u68cd\u957e\u0653\u3eaf\u0bc8\u2085'});
+let sampler107 = device15.createSampler({
+label: '\u070a\u9182\u08e0\u288f\ud813\u{1fd95}\uc301\ud7ee\u4894\u1532',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 17.798,
+lodMaxClamp: 61.741,
+});
+try {
+device15.pushErrorScope('internal');
+} catch {}
+let pipeline109 = await device15.createComputePipelineAsync({
+label: '\ud024\u3397\uc07f\ubf80\ucdba',
+layout: pipelineLayout32,
+compute: {
+module: shaderModule34,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let buffer62 = device14.createBuffer({
+  label: '\u{1f8db}\u0eeb\u0dcd\u{1fe23}\u0873\ue274\u8077',
+  size: 61884,
+  usage: GPUBufferUsage.STORAGE,
+  mappedAtCreation: false
+});
+let texture159 = device14.createTexture({
+label: '\u1ff0\u449b\u07dd\u9fce\u470e',
+size: [605, 1, 155],
+mipLevelCount: 9,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+device14.addEventListener('uncapturederror', e => { log('device14.uncapturederror'); log(e); e.label = device14.label; });
+} catch {}
+try {
+buffer62.unmap();
+} catch {}
+pseudoSubmit(device16, commandEncoder99);
+let gpuCanvasContext48 = canvas44.getContext('webgpu');
+let bindGroup52 = device7.createBindGroup({
+label: '\u{1fd15}\u0402\u{1f65c}\u{1feea}\u38d5\u021d\u{1fe53}\u47be\u{1ff53}\u2710\u8511',
+layout: bindGroupLayout32,
+entries: [],
+});
+let computePassEncoder64 = commandEncoder96.beginComputePass({label: '\u2ad8\u{1f8c4}\u5278'});
+try {
+commandEncoder95.copyBufferToBuffer(buffer54, 55792, buffer34, 11720, 7228);
+dissociateBuffer(device7, buffer54);
+dissociateBuffer(device7, buffer34);
+} catch {}
+try {
+commandEncoder95.copyBufferToTexture({
+/* bytesInLastRow: 8464 widthInBlocks: 4232 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 25988 */
+offset: 25988,
+buffer: buffer54,
+}, {
+  texture: texture143,
+  mipLevel: 0,
+  origin: { x: 42, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 4232, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device7, buffer54);
+} catch {}
+try {
+commandEncoder95.copyTextureToTexture({
+  texture: texture121,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture121,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder95.clearBuffer(buffer34, 15008, 904);
+dissociateBuffer(device7, buffer34);
+} catch {}
+try {
+gpuCanvasContext44.unconfigure();
+} catch {}
+try {
+offscreenCanvas42.getContext('bitmaprenderer');
+} catch {}
+let texture160 = device16.createTexture({
+label: '\u001a\u0ec7',
+size: [256, 480, 194],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView139 = texture160.createView({
+  label: '\ude89\u78bc\u084c\ub7c7\ub7aa\u6ce4\u0bd8\u2b24',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+  arrayLayerCount: 1
+});
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+try {
+  await promise79;
+} catch {}
+let commandEncoder111 = device12.createCommandEncoder({label: '\u8a22\u{1f7a5}\u079a\u0cb8\u7831\uebd5\u012b\u07b8'});
+let texture161 = device12.createTexture({
+label: '\u054b\u089b\u8365\ub626\u65c3\u6583',
+size: [8064, 12, 170],
+mipLevelCount: 4,
+dimension: '2d',
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x12-unorm'],
+});
+let textureView140 = texture156.createView({label: '\ucce2\u{1fe9a}', baseMipLevel: 2, mipLevelCount: 2, arrayLayerCount: 1});
+let renderBundleEncoder121 = device12.createRenderBundleEncoder({
+  label: '\u77cf\u3c74\u03a6\u660e\ue0a6',
+  colorFormats: ['r16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle122 = renderBundleEncoder102.finish({});
+let sampler108 = device12.createSampler({
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+lodMinClamp: 43.481,
+lodMaxClamp: 78.649,
+compare: 'greater-equal',
+});
+try {
+computePassEncoder61.end();
+} catch {}
+try {
+renderBundleEncoder99.setBindGroup(1, bindGroup51);
+} catch {}
+try {
+renderBundleEncoder99.setBindGroup(3, bindGroup43, new Uint32Array(5438), 3699, 0);
+} catch {}
+try {
+await device12.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let texture162 = device8.createTexture({
+size: {width: 60},
+dimension: '1d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg11b10ufloat', 'rg11b10ufloat'],
+});
+let computePassEncoder65 = commandEncoder109.beginComputePass({label: '\u{1f67f}\u0e75\u{1fd28}\u9aad\u{1f9e8}\u2ae6\ucaee\u6f30\u544d'});
+try {
+computePassEncoder41.setBindGroup(3, bindGroup39);
+} catch {}
+try {
+await device8.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup53 = device7.createBindGroup({
+label: '\u1718\u05d6\u4d87\u92ec\ucfa1\u{1f8e3}\u6fbd',
+layout: bindGroupLayout32,
+entries: [],
+});
+let computePassEncoder66 = commandEncoder95.beginComputePass({label: '\u{1f738}\u{1fe61}\u{1fff3}\u41dc\u{1ff43}\ue4d2\u0f08\u0159\u6c97\u04ad'});
+document.body.prepend(video25);
+let commandBuffer18 = commandEncoder88.finish({
+label: '\ub963\u8723\ua49c',
+});
+let texture163 = device8.createTexture({
+label: '\ufc20\u0aaa\u{1f96d}\u1594\u0072\u{1fc53}\u{1fa40}\ufb0c\u{1f8dd}\u{1fa7b}\ub83a',
+size: [30, 4, 647],
+mipLevelCount: 9,
+dimension: '3d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundleEncoder122 = device8.createRenderBundleEncoder({
+  label: '\uea94\ubcd6\ub7b0',
+  colorFormats: ['rgb10a2unorm', 'r32float', undefined, 'r8sint', 'r8uint', 'bgra8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler109 = device8.createSampler({
+label: '\u0435\u3668\u{1feda}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 26.981,
+maxAnisotropy: 7,
+});
+try {
+renderBundleEncoder122.setVertexBuffer(85, undefined, 2016905263, 801930873);
+} catch {}
+try {
+  await promise78;
+} catch {}
+let videoFrame38 = new VideoFrame(offscreenCanvas28, {timestamp: 0});
+gc();
+let bindGroupLayout53 = device13.createBindGroupLayout({
+entries: [{
+binding: 3514,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+}, {
+binding: 3530,
+visibility: 0,
+texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+}],
+});
+let commandEncoder112 = device13.createCommandEncoder({label: '\u046e\u67b3\u08a5\u3b04\u006c\u3568\u408f\u0a2c\u2fd8'});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let offscreenCanvas43 = new OffscreenCanvas(767, 407);
+try {
+computePassEncoder54.setBindGroup(3, bindGroup38);
+} catch {}
+try {
+device11.pushErrorScope('validation');
+} catch {}
+let promise80 = buffer45.mapAsync(GPUMapMode.WRITE, 0, 4816);
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+let imageData38 = new ImageData(108, 136);
+let adapter24 = await navigator.gpu.requestAdapter({
+});
+let sampler110 = device16.createSampler({
+label: '\u649e\u{1fd9f}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 74.924,
+maxAnisotropy: 6,
+});
+let offscreenCanvas44 = new OffscreenCanvas(120, 418);
+let buffer63 = device6.createBuffer({label: '\u0f59\u0bc1\u8a8b\uc697\u8b9d\u0057', size: 3717, usage: GPUBufferUsage.STORAGE});
+let texture164 = device6.createTexture({
+label: '\u0bd6\u0346\u{1feda}\u3ee0\u0e20\u06c6\uc706\u9d63',
+size: [7260, 12, 135],
+mipLevelCount: 3,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-12x12-unorm-srgb', 'astc-12x12-unorm-srgb', 'astc-12x12-unorm-srgb'],
+});
+let computePassEncoder67 = commandEncoder106.beginComputePass({});
+try {
+computePassEncoder48.end();
+} catch {}
+try {
+renderBundleEncoder116.setVertexBuffer(85, undefined, 1897653603, 390655332);
+} catch {}
+let device17 = await adapter24.requestDevice({
+label: '\u8662\u{1f85f}\u363c\u{1f7e7}\u025e\u{1fd3e}\u{1fdc0}',
+requiredFeatures: [
+'depth-clip-control',
+'texture-compression-etc2',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 49,
+maxVertexAttributes: 21,
+maxVertexBufferArrayStride: 36803,
+maxStorageTexturesPerShaderStage: 20,
+maxStorageBuffersPerShaderStage: 41,
+maxDynamicStorageBuffersPerPipelineLayout: 18290,
+maxBindingsPerBindGroup: 4222,
+maxTextureDimension1D: 11384,
+maxTextureDimension2D: 11287,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 165143862,
+maxUniformBuffersPerShaderStage: 37,
+maxInterStageShaderVariables: 73,
+maxInterStageShaderComponents: 117,
+maxSamplersPerShaderStage: 18,
+},
+});
+let video46 = await videoWithData();
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let imageData39 = new ImageData(184, 16);
+let texture165 = device11.createTexture({
+label: '\u0e9f\ue843\u034d',
+size: [542],
+dimension: '1d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+try {
+buffer49.unmap();
+} catch {}
+try {
+gpuCanvasContext47.configure({
+device: device11,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16float', 'astc-10x8-unorm-srgb', 'stencil8'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let gpuCanvasContext49 = offscreenCanvas43.getContext('webgpu');
+let commandEncoder113 = device8.createCommandEncoder({label: '\udbc9\u05df\uf0c2\u{1fa3e}\uea1b'});
+let commandBuffer19 = commandEncoder113.finish({
+label: '\u2c8e\u2194\u05ca\u5228\u8dee\uda17\u8d2b\u02a3\u99a3\u0a9c',
+});
+let texture166 = device8.createTexture({
+label: '\u9ff4\u04a9\u0a1f\ucdd3\ua281\ue9bd\u89ed',
+size: {width: 240, height: 32, depthOrArrayLayers: 125},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_SRC,
+});
+let renderBundle123 = renderBundleEncoder122.finish({});
+try {
+renderBundleEncoder89.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+computePassEncoder65.insertDebugMarker('\u0313');
+} catch {}
+let bindGroup54 = device8.createBindGroup({
+label: '\u9ead\u1ba7',
+layout: bindGroupLayout35,
+entries: [],
+});
+try {
+device8.queue.submit([
+commandBuffer19,
+]);
+} catch {}
+try {
+device8.queue.writeTexture({
+  texture: texture162,
+  mipLevel: 0,
+  origin: { x: 20, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 756 */
+{offset: 732, rowsPerImage: 296}, {width: 6, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext50 = offscreenCanvas44.getContext('webgpu');
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let imageBitmap39 = await createImageBitmap(imageData13);
+let querySet114 = device7.createQuerySet({
+label: '\u7c23\ue494\u06de\ubc3d\u6d6f\u{1f9b8}\u59d5',
+type: 'occlusion',
+count: 490,
+});
+let textureView141 = texture151.createView({label: '\u{1f83e}\u31dd\u069f\u8da5'});
+let renderBundle124 = renderBundleEncoder74.finish({label: '\uea7d\u5308\u04e4\u5ef0\u1dd3\udf94\u0646\u0582\u0472'});
+let arrayBuffer16 = buffer34.getMappedRange(24952, 84);
+let imageBitmap40 = await createImageBitmap(imageBitmap19);
+let querySet115 = device9.createQuerySet({
+type: 'occlusion',
+count: 1840,
+});
+let computePassEncoder68 = commandEncoder103.beginComputePass({});
+try {
+renderBundleEncoder114.setPipeline(pipeline88);
+} catch {}
+try {
+commandEncoder82.copyBufferToBuffer(buffer43, 37732, buffer51, 1032, 260);
+dissociateBuffer(device9, buffer43);
+dissociateBuffer(device9, buffer51);
+} catch {}
+try {
+commandEncoder82.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 5372 */
+offset: 5372,
+buffer: buffer46,
+}, {
+  texture: texture125,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device9, buffer46);
+} catch {}
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device9.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video37,
+  origin: { x: 2, y: 11 },
+  flipY: true,
+}, {
+  texture: texture125,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame39 = new VideoFrame(canvas2, {timestamp: 0});
+let bindGroupLayout54 = device7.createBindGroupLayout({
+label: '\u{1f600}\u6a99\u{1f6cd}\u{1f93b}\u{1f95a}\u0bf2\u43dd\u{1f83b}',
+entries: [{
+binding: 4331,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '1d' },
+}, {
+binding: 3028,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}, {
+binding: 2057,
+visibility: 0,
+externalTexture: {},
+}],
+});
+let texture167 = device7.createTexture({
+size: [248, 40, 100],
+mipLevelCount: 2,
+format: 'astc-8x5-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x5-unorm', 'astc-8x5-unorm'],
+});
+try {
+device7.queue.writeTexture({
+  texture: texture123,
+  mipLevel: 0,
+  origin: { x: 16, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 700 */
+{offset: 700}, {width: 2040, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let bindGroupLayout55 = device8.createBindGroupLayout({
+label: '\u{1f85e}\u9769\u9838\u65a2\u4d46',
+entries: [],
+});
+let bindGroup55 = device8.createBindGroup({
+layout: bindGroupLayout35,
+entries: [],
+});
+let querySet116 = device8.createQuerySet({
+label: '\uf8ff\u5b85\uf11f\u5421',
+type: 'occlusion',
+count: 1982,
+});
+try {
+device8.queue.writeBuffer(buffer55, 10140, new DataView(new ArrayBuffer(9532)), 5171, 3480);
+} catch {}
+let device18 = await adapter23.requestDevice({
+label: '\u4203\ubefe\u0c0f\u05b8\u{1f7ca}\u06b7\u051a\u{1f8b6}\u01b4\u05ba\ud0a9',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 9,
+maxColorAttachmentBytesPerSample: 34,
+maxVertexAttributes: 26,
+maxVertexBufferArrayStride: 44736,
+maxStorageTexturesPerShaderStage: 17,
+maxStorageBuffersPerShaderStage: 31,
+maxDynamicStorageBuffersPerPipelineLayout: 10284,
+maxBindingsPerBindGroup: 7473,
+maxTextureDimension1D: 16033,
+maxTextureDimension2D: 13989,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 55102677,
+maxUniformBuffersPerShaderStage: 44,
+maxInterStageShaderVariables: 115,
+maxInterStageShaderComponents: 123,
+maxSamplersPerShaderStage: 19,
+},
+});
+let img60 = await imageWithData(284, 198, '#d25fe1fe', '#6a8aaec8');
+let texture168 = device6.createTexture({
+size: {width: 1920, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['stencil8', 'stencil8'],
+});
+let textureView142 = texture112.createView({label: '\u{1fe49}\u{1fd4c}\u{1fd32}', dimension: '2d', aspect: 'all', baseMipLevel: 1, baseArrayLayer: 135});
+let sampler111 = device6.createSampler({
+label: '\u{1f837}\u0eb6\uff8b\u{1faaa}\u{1f7e4}\u08a4\u{1fd6a}\u9269',
+addressModeU: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 33.317,
+lodMaxClamp: 40.785,
+});
+try {
+computePassEncoder62.insertDebugMarker('\u3cd5');
+} catch {}
+try {
+gpuCanvasContext32.configure({
+device: device6,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let texture169 = device8.createTexture({
+label: '\uc498\u99ea\u071c',
+size: [134, 240, 283],
+mipLevelCount: 8,
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8uint', 'r8uint', 'r8uint'],
+});
+let renderBundleEncoder123 = device8.createRenderBundleEncoder({
+  colorFormats: ['rg8unorm', 'rgba8uint', 'rgba32sint', 'rgba32float', 'rg32uint', 'rg8sint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder76.setBindGroup(1, bindGroup54, []);
+} catch {}
+try {
+adapter11.label = '\u{1fa81}\u242b\uaecd\uafe3\u7f66\uf5a5\u2f15\u0c70\u096c';
+} catch {}
+let computePassEncoder69 = commandEncoder112.beginComputePass({});
+let sampler112 = device13.createSampler({
+label: '\u{1f82c}\u4712\u{1f80a}\u371b\u{1fa32}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 75.129,
+lodMaxClamp: 83.260,
+});
+try {
+renderBundleEncoder118.setVertexBuffer(13, undefined, 303177357);
+} catch {}
+try {
+await device13.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise80;
+} catch {}
+let device19 = await promise75;
+try {
+buffer61.unmap();
+} catch {}
+try {
+await device16.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundleEncoder124 = device15.createRenderBundleEncoder({label: '\u4313\ue04d', colorFormats: ['rg32sint', 'rgba16sint', 'r8uint'], stencilReadOnly: true});
+let renderBundle125 = renderBundleEncoder105.finish({});
+try {
+computePassEncoder59.setPipeline(pipeline109);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let offscreenCanvas45 = new OffscreenCanvas(608, 50);
+try {
+offscreenCanvas45.getContext('webgl2');
+} catch {}
+let commandEncoder114 = device11.createCommandEncoder({});
+let querySet117 = device11.createQuerySet({
+label: '\u2a4d\u0eb2\u{1ff32}\u450d\u92ee\u0441\ucbcf\u3d7b',
+type: 'occlusion',
+count: 3539,
+});
+let texture170 = device11.createTexture({
+size: [384, 60, 1],
+mipLevelCount: 6,
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture171 = gpuCanvasContext30.getCurrentTexture();
+let textureView143 = texture119.createView({dimension: '2d-array', aspect: 'depth-only', baseMipLevel: 1, mipLevelCount: 2});
+try {
+renderBundleEncoder93.setBindGroup(2, bindGroup40);
+} catch {}
+try {
+renderBundleEncoder93.setBindGroup(3, bindGroup46, new Uint32Array(378), 307, 0);
+} catch {}
+try {
+commandEncoder114.copyBufferToBuffer(buffer45, 3356, buffer50, 4800, 568);
+dissociateBuffer(device11, buffer45);
+dissociateBuffer(device11, buffer50);
+} catch {}
+try {
+device11.queue.writeTexture({
+  texture: texture170,
+  mipLevel: 4,
+  origin: { x: 8, y: 0, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 553 */
+{offset: 553, rowsPerImage: 226}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup56 = device7.createBindGroup({
+label: '\u{1fc8c}\u1c26\ua212\u76b4\u01c3\ua69a\udb1f\u505b\u2331\u{1f774}',
+layout: bindGroupLayout32,
+entries: [],
+});
+let buffer64 = device7.createBuffer({
+  label: '\u099f\u7e61\ud6e5\ud25d\u3d64\u8f73\u96fb\u{1fc48}\u052b\u8e97\u{1fe0b}',
+  size: 2556,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let querySet118 = device7.createQuerySet({
+label: '\u66ef\u0054\u{1f6c6}\u{1ffb3}\u53e4\u22cb\u58b5\uc9e3\u{1f86c}\u{1f79f}',
+type: 'occlusion',
+count: 461,
+});
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let bindGroupLayout56 = device13.createBindGroupLayout({
+label: '\u9967\u9c57\u0558\u0600\u0482\u98d6\u9e42\u4b28\u0bf9',
+entries: [],
+});
+let commandEncoder115 = device13.createCommandEncoder({label: '\u2520\u{1fa43}\ua03c\u{1fbdb}'});
+let commandEncoder116 = device6.createCommandEncoder();
+let computePassEncoder70 = commandEncoder93.beginComputePass({label: '\u55eb\u0427\u76d1\u6438\u{1f676}\u09fe\ubfd6\u7da5\u0376'});
+let sampler113 = device6.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 23.561,
+});
+let imageBitmap41 = await createImageBitmap(video27);
+try {
+window.someLabel = textureView128.label;
+} catch {}
+let bindGroupLayout57 = device14.createBindGroupLayout({
+entries: [],
+});
+let texture172 = device14.createTexture({
+label: '\u{1fc49}\u{1fdc6}\u0912\u{1fa08}\uc5ee\u{1f631}',
+size: {width: 840, height: 40, depthOrArrayLayers: 51},
+mipLevelCount: 2,
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler114 = device14.createSampler({
+label: '\u{1f882}\u049a',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 99.162,
+lodMaxClamp: 99.306,
+maxAnisotropy: 15,
+});
+document.body.prepend(img16);
+let videoFrame40 = new VideoFrame(video23, {timestamp: 0});
+let textureView144 = texture130.createView({
+  label: '\ueb04\ud3f3\u43df\u02e3',
+  baseMipLevel: 1,
+  mipLevelCount: 4,
+  baseArrayLayer: 27,
+  arrayLayerCount: 13
+});
+let computePassEncoder71 = commandEncoder114.beginComputePass({label: '\u8cb7\uc26e\u1e3a\u{1f617}\udd71\u8c84\ud08e\uc6cc'});
+let renderBundle126 = renderBundleEncoder83.finish({label: '\u0348\u862a\u746e\u06eb\u{1ff9b}\u05e7\u1bf2\u2706\u{1fc2b}\u4d42'});
+try {
+computePassEncoder60.setBindGroup(0, bindGroup38, new Uint32Array(4418), 578, 0);
+} catch {}
+canvas8.height = 1015;
+let img61 = await imageWithData(41, 208, '#f66c93aa', '#af9d9b40');
+let bindGroupLayout58 = device7.createBindGroupLayout({
+label: '\u{1fb46}\u1fb6\u{1f80e}\u80f3\u{1fe97}\u89f0\u22e3\u09fc\u{1f768}\u{1fffa}',
+entries: [{
+binding: 2119,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}, {
+binding: 1612,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+}],
+});
+let querySet119 = device7.createQuerySet({
+label: '\u45c5\uaca2',
+type: 'occlusion',
+count: 136,
+});
+try {
+computePassEncoder64.end();
+} catch {}
+try {
+commandEncoder96.clearBuffer(buffer34, 1576, 6204);
+dissociateBuffer(device7, buffer34);
+} catch {}
+let bindGroupLayout59 = device18.createBindGroupLayout({
+entries: [{
+binding: 2982,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'r32uint', access: 'write-only', viewDimension: '2d' },
+}, {
+binding: 6237,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+}, {
+binding: 6194,
+visibility: 0,
+buffer: { type: 'read-only-storage', minBindingSize: 283896, hasDynamicOffset: true },
+}],
+});
+let querySet120 = device18.createQuerySet({
+label: '\u17ca\u10aa\u06e7\u7945\u0dda\u1dac\u5bce\ubac3',
+type: 'occlusion',
+count: 4085,
+});
+let texture173 = device18.createTexture({
+label: '\u34c5\u49a4\udb7e\u{1fcc7}\u{1fe5b}',
+size: {width: 378, height: 1, depthOrArrayLayers: 41},
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgba32float', 'rgba32float'],
+});
+let textureView145 = texture173.createView({label: '\u0128\u0df8\u{1ff60}\u102c\u0b55\u0255\ua4ff\u0982\u0752\ub2d0\u0ff9'});
+let textureView146 = texture161.createView({
+  label: '\ub3a9\u9329\ueaee\u5c21\u{1f65a}\u7945\u0f29\ubae5\u483f',
+  dimension: '2d',
+  format: 'astc-12x12-unorm',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 55
+});
+try {
+renderBundleEncoder115.setVertexBuffer(59, undefined, 3327416312, 865621998);
+} catch {}
+video10.width = 61;
+gc();
+let shaderModule37 = device15.createShaderModule({
+label: '\ub424\u{1fb0e}',
+code: `@group(1) @binding(691)
+var<storage, read_write> local21: array<u32>;
+@group(0) @binding(4645)
+var<storage, read_write> parameter22: array<u32>;
+@group(1) @binding(4645)
+var<storage, read_write> global24: array<u32>;
+@group(2) @binding(853)
+var<storage, read_write> parameter23: array<u32>;
+@group(1) @binding(853)
+var<storage, read_write> type27: array<u32>;
+
+@compute @workgroup_size(3, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<u32>,
+  @location(0) f1: vec2<i32>,
+  @location(1) f2: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(48) a0: vec3<u32>, @location(91) a1: vec3<f16>, @location(44) a2: f32, @location(5) a3: vec4<f32>, @location(89) a4: vec3<u32>, @location(25) a5: vec3<f32>, @location(86) a6: vec3<i32>, @location(83) a7: vec3<i32>, @location(75) a8: vec2<u32>, @location(1) a9: vec3<u32>, @location(90) a10: vec3<u32>, @location(88) a11: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(23) f485: vec3<f16>,
+  @location(88) f486: u32,
+  @location(5) f487: vec4<f32>,
+  @location(24) f488: vec3<i32>,
+  @builtin(position) f489: vec4<f32>,
+  @location(83) f490: vec3<i32>,
+  @location(89) f491: vec3<u32>,
+  @location(53) f492: vec4<f16>,
+  @location(73) f493: vec2<f16>,
+  @location(34) f494: vec2<u32>,
+  @location(44) f495: f32,
+  @location(48) f496: vec3<u32>,
+  @location(10) f497: vec4<i32>,
+  @location(65) f498: vec3<i32>,
+  @location(7) f499: f32,
+  @location(110) f500: f16,
+  @location(75) f501: vec2<u32>,
+  @location(25) f502: vec3<f32>,
+  @location(66) f503: u32,
+  @location(105) f504: f32,
+  @location(90) f505: vec3<u32>,
+  @location(85) f506: vec2<i32>,
+  @location(91) f507: vec3<f16>,
+  @location(1) f508: vec3<u32>,
+  @location(86) f509: vec3<i32>,
+  @location(63) f510: vec4<i32>,
+  @location(19) f511: vec3<u32>,
+  @location(99) f512: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(3) a0: f16, @location(14) a1: vec4<i32>, @location(1) a2: vec2<u32>, @location(9) a3: f16, @location(5) a4: u32, @location(2) a5: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let renderBundleEncoder125 = device15.createRenderBundleEncoder({
+  label: '\u{1f863}\ub000\ue6cd\u{1f887}\u4013',
+  colorFormats: ['rg32sint', 'rgba16sint', 'r8uint'],
+  depthReadOnly: true
+});
+try {
+await device15.popErrorScope();
+} catch {}
+let promise81 = buffer58.mapAsync(GPUMapMode.READ, 37192, 21424);
+let img62 = await imageWithData(176, 21, '#51fcb479', '#ec3d7740');
+let promise82 = navigator.gpu.requestAdapter({
+});
+let imageData40 = new ImageData(116, 244);
+let pipelineLayout37 = device10.createPipelineLayout({
+  label: '\u{1f702}\u01a3\u70a4',
+  bindGroupLayouts: [bindGroupLayout38, bindGroupLayout41, bindGroupLayout39, bindGroupLayout41, bindGroupLayout39, bindGroupLayout39, bindGroupLayout39, bindGroupLayout41]
+});
+let videoFrame41 = videoFrame21.clone();
+let renderBundleEncoder126 = device16.createRenderBundleEncoder({
+  label: '\u90b4\u0293\u{1fa4b}\u02e2\u{1ff37}\u{1fee3}\u00ad\ud018\u0933\u{1fb2b}',
+  colorFormats: [undefined, 'r16float', 'r32uint', 'r8sint', 'rgba8unorm-srgb'],
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+device16.queue.writeTexture({
+  texture: texture139,
+  mipLevel: 1,
+  origin: { x: 0, y: 58, z: 16 },
+  aspect: 'stencil-only',
+}, new Int8Array(arrayBuffer16), /* required buffer size: 1701753 */
+{offset: 15, bytesPerRow: 177, rowsPerImage: 253}, {width: 60, height: 1, depthOrArrayLayers: 39});
+} catch {}
+let imageData41 = new ImageData(76, 4);
+try {
+commandEncoder96.copyBufferToTexture({
+/* bytesInLastRow: 1748 widthInBlocks: 874 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 1788 */
+offset: 1788,
+bytesPerRow: 1792,
+buffer: buffer54,
+}, {
+  texture: texture143,
+  mipLevel: 0,
+  origin: { x: 1885, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 874, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device7, buffer54);
+} catch {}
+try {
+gpuCanvasContext33.configure({
+device: device7,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let imageBitmap42 = await createImageBitmap(img50);
+let img63 = await imageWithData(106, 67, '#0c8c5d3d', '#1e38b078');
+let commandEncoder117 = device19.createCommandEncoder({label: '\u69d8\u6cec\uf2e8\u222f\u330c\u0651\u0d1f\u{1fdcd}\ub092\u{1f744}\u065e'});
+let querySet121 = device19.createQuerySet({
+label: '\u08e0\u{1fa6c}\u0749\u5c86\u0fdc\u60f5\u{1feca}',
+type: 'occlusion',
+count: 1412,
+});
+let texture174 = device19.createTexture({
+label: '\u2129\u77a9\u1546\uc6b0\u6a8b\ubb7b\u{1f9cb}\ubd23\u{1fe6c}\u{1feea}',
+size: [80, 20, 239],
+mipLevelCount: 2,
+format: 'rg32uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg32uint', 'rg32uint', 'rg32uint'],
+});
+let computePassEncoder72 = commandEncoder117.beginComputePass();
+try {
+gpuCanvasContext34.unconfigure();
+} catch {}
+let imageBitmap43 = await createImageBitmap(canvas20);
+let adapter25 = await navigator.gpu.requestAdapter({
+});
+let video47 = await videoWithData();
+try {
+gpuCanvasContext45.unconfigure();
+} catch {}
+let videoFrame42 = new VideoFrame(img31, {timestamp: 0});
+let textureView147 = texture146.createView({label: '\ue72b\u{1f6bb}\u{1f634}\ufc9e', baseArrayLayer: 126, arrayLayerCount: 1});
+let computePassEncoder73 = commandEncoder115.beginComputePass({label: '\u{1fd62}\uf44b\u7760\u0220\u{1f895}\u51e0\u6ba4\udb9b\ub2c1\u14a3\u08c6'});
+let imageBitmap44 = await createImageBitmap(img58);
+let pipelineLayout38 = device14.createPipelineLayout({bindGroupLayouts: [bindGroupLayout57, bindGroupLayout57, bindGroupLayout57]});
+let querySet122 = device14.createQuerySet({
+type: 'occlusion',
+count: 3785,
+});
+let renderBundleEncoder127 = device14.createRenderBundleEncoder({
+  label: '\u{1fcbe}\u608d\u3c43\u927a\ub1f6\u0a2e\u{1f91c}\u5a6a\uf22c\ubddb',
+  colorFormats: ['rgba8sint']
+});
+try {
+  await promise81;
+} catch {}
+let videoFrame43 = new VideoFrame(img20, {timestamp: 0});
+gc();
+let video48 = await videoWithData();
+let renderBundle127 = renderBundleEncoder126.finish({label: '\u347d\u{1f6d6}\u09dc\u{1f75a}\u1925\u5b2c\ua547\u8ef3'});
+let pipelineLayout39 = device18.createPipelineLayout({
+  label: '\uc2e6\u7c3d\udbad\u07cc\u2e26\u4599\u0d59\u0617\u{1ff1e}',
+  bindGroupLayouts: [bindGroupLayout59, bindGroupLayout59, bindGroupLayout59]
+});
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55) };
+} catch {}
+let promise83 = navigator.gpu.requestAdapter();
+let buffer65 = device19.createBuffer({size: 54321, usage: GPUBufferUsage.MAP_READ});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let videoFrame44 = new VideoFrame(imageBitmap33, {timestamp: 0});
+offscreenCanvas33.height = 564;
+let textureView148 = texture143.createView({label: '\u{1fc6b}\u9690\u0cc7\u{1f9c2}\u36ec\u692a\u53e1\u6c9f\u2826', baseMipLevel: 0});
+let renderBundle128 = renderBundleEncoder74.finish({label: '\ua65d\u{1fbea}\u0f68\u0ccc\ube9e\u{1f837}\u5b71\u0f80\u0a38\u8e37'});
+try {
+await device7.popErrorScope();
+} catch {}
+try {
+commandEncoder96.copyBufferToTexture({
+/* bytesInLastRow: 4280 widthInBlocks: 2140 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 35794 */
+offset: 35794,
+bytesPerRow: 4352,
+buffer: buffer54,
+}, {
+  texture: texture143,
+  mipLevel: 0,
+  origin: { x: 1728, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 2140, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device7, buffer54);
+} catch {}
+try {
+commandEncoder96.clearBuffer(buffer34, 20588, 3220);
+dissociateBuffer(device7, buffer34);
+} catch {}
+try {
+window.someLabel = device10.queue.label;
+} catch {}
+let querySet123 = device11.createQuerySet({
+type: 'occlusion',
+count: 3224,
+});
+let texture175 = device11.createTexture({
+label: '\u{1feda}\u{1f7d3}',
+size: {width: 60, height: 5, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rg16float', 'rg16float', 'rg16float'],
+});
+let textureView149 = texture133.createView({label: '\u0b97\u{1fa0c}\uea22\u5380\u049e\u96df\u8fad', baseMipLevel: 1, arrayLayerCount: 1});
+let sampler115 = device11.createSampler({
+label: '\u0048\u36da\u8379\u5f92\ub73f\u003c',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+lodMaxClamp: 81.701,
+});
+try {
+computePassEncoder54.setBindGroup(2, bindGroup38);
+} catch {}
+let offscreenCanvas46 = new OffscreenCanvas(906, 403);
+let bindGroup57 = device12.createBindGroup({
+label: '\ue987\ucd0d\u0338\ua80f\u0b57\ud806\uad8c\u{1fa0c}',
+layout: bindGroupLayout37,
+entries: [],
+});
+let texture176 = device12.createTexture({
+size: [2016, 1, 1],
+mipLevelCount: 3,
+format: 'depth24plus',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView150 = texture116.createView({
+  label: '\u0efb\u7d97\u{1ffb8}\u8714\u16eb\u0911\u068f\u624e\u0dca',
+  dimension: '2d-array',
+  format: 'etc2-rgb8a1unorm-srgb',
+  baseMipLevel: 1,
+  baseArrayLayer: 0
+});
+try {
+computePassEncoder46.setBindGroup(1, bindGroup36);
+} catch {}
+try {
+computePassEncoder46.setBindGroup(1, bindGroup37, new Uint32Array(422), 51, 0);
+} catch {}
+try {
+computePassEncoder46.end();
+} catch {}
+try {
+device12.queue.writeTexture({
+  texture: texture156,
+  mipLevel: 4,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(40), /* required buffer size: 674 */
+{offset: 674, bytesPerRow: 42}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let computePassEncoder74 = commandEncoder82.beginComputePass();
+let renderBundleEncoder128 = device9.createRenderBundleEncoder({
+  label: '\u0ab3\u9c60\uc5a3\u94dc\ub21b\ud99a\u4fa5',
+  colorFormats: ['rgba16float', 'rg16sint', 'rgba8uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder106.draw(0, 48, 40, 80);
+} catch {}
+try {
+device9.pushErrorScope('validation');
+} catch {}
+try {
+device9.queue.writeTexture({
+  texture: texture125,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, new DataView(arrayBuffer5), /* required buffer size: 176 */
+{offset: 176, bytesPerRow: 77}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture177 = device19.createTexture({
+label: '\ude9c\u3533\u509d\u6a4d\ua692\u7613\u{1fe05}\u{1fdb0}',
+size: [640],
+dimension: '1d',
+format: 'rgba8uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8uint'],
+});
+try {
+buffer65.destroy();
+} catch {}
+try {
+await device19.queue.onSubmittedWorkDone();
+} catch {}
+let canvas45 = document.createElement('canvas');
+let texture178 = device1.createTexture({
+label: '\ubd70\u0517\u7bb8\u6787\u20c3\u92d0\u09cf',
+size: [152, 1, 1859],
+mipLevelCount: 10,
+sampleCount: 1,
+dimension: '3d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg8snorm', 'rg8snorm'],
+});
+try {
+await device18.popErrorScope();
+} catch {}
+offscreenCanvas37.height = 165;
+let promise84 = adapter10.requestAdapterInfo();
+try {
+bindGroupLayout46.label = '\u0685\ud014\u0c33\uc75b\u{1f621}\u6e1b\u{1fd6b}\u07dd';
+} catch {}
+let bindGroupLayout60 = pipeline105.getBindGroupLayout(1);
+let commandEncoder118 = device9.createCommandEncoder({label: '\u{1fc8d}\uf949\u3958\u1cbf\u14ec\ufce2\ua93a\u07b8\u2aaf\u3b65\u{1f676}'});
+let texture179 = device9.createTexture({
+label: '\uc0f9\u{1fcf2}\u051d\u{1fd4f}\u0c23\u47f3\u0575\ucf80\uf07d\u2ca2',
+size: {width: 1424, height: 960, depthOrArrayLayers: 210},
+mipLevelCount: 9,
+format: 'depth16unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth16unorm'],
+});
+let computePassEncoder75 = commandEncoder118.beginComputePass({label: '\u{1f992}\u0af5\u665a'});
+let pipeline110 = await device9.createComputePipelineAsync({
+layout: pipelineLayout35,
+compute: {
+module: shaderModule31,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline111 = await device9.createRenderPipelineAsync({
+label: '\u{1fbe6}\u1611\u{1f658}\u{1f8b2}\u{1fead}\u{1fb7e}\ubc77\u29c9\u0740\u0949\uedef',
+layout: pipelineLayout29,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule25,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'keep',
+depthFailOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'invert',
+depthFailOp: 'increment-wrap',
+passOp: 'invert',
+},
+stencilReadMask: 524,
+stencilWriteMask: 982,
+depthBias: 99,
+depthBiasSlopeScale: 50,
+depthBiasClamp: 61,
+},
+vertex: {
+  module: shaderModule25,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 22512,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x2',
+offset: 17772,
+shaderLocation: 20,
+}, {
+format: 'sint32x3',
+offset: 16488,
+shaderLocation: 13,
+}, {
+format: 'uint32',
+offset: 5384,
+shaderLocation: 4,
+}, {
+format: 'snorm16x2',
+offset: 6684,
+shaderLocation: 8,
+}, {
+format: 'uint16x4',
+offset: 15696,
+shaderLocation: 0,
+}, {
+format: 'unorm8x4',
+offset: 15036,
+shaderLocation: 5,
+}, {
+format: 'uint16x4',
+offset: 10872,
+shaderLocation: 17,
+}, {
+format: 'uint8x4',
+offset: 18604,
+shaderLocation: 2,
+}, {
+format: 'uint16x4',
+offset: 4712,
+shaderLocation: 10,
+}, {
+format: 'sint16x4',
+offset: 14864,
+shaderLocation: 9,
+}, {
+format: 'float32x2',
+offset: 15864,
+shaderLocation: 6,
+}, {
+format: 'sint32x2',
+offset: 7472,
+shaderLocation: 11,
+}, {
+format: 'snorm16x4',
+offset: 1732,
+shaderLocation: 23,
+}, {
+format: 'snorm16x2',
+offset: 17012,
+shaderLocation: 22,
+}, {
+format: 'unorm16x2',
+offset: 14608,
+shaderLocation: 1,
+}, {
+format: 'uint16x4',
+offset: 7808,
+shaderLocation: 7,
+}, {
+format: 'uint32x3',
+offset: 12976,
+shaderLocation: 3,
+}, {
+format: 'sint32x3',
+offset: 1796,
+shaderLocation: 12,
+}, {
+format: 'sint32x4',
+offset: 5080,
+shaderLocation: 18,
+}, {
+format: 'sint32',
+offset: 4488,
+shaderLocation: 21,
+}, {
+format: 'snorm16x2',
+offset: 16652,
+shaderLocation: 15,
+}, {
+format: 'sint16x2',
+offset: 18600,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 4376,
+attributes: [{
+format: 'uint32',
+offset: 1924,
+shaderLocation: 19,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 31384,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x2',
+offset: 11996,
+shaderLocation: 16,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+  await promise84;
+} catch {}
+canvas32.height = 926;
+let promise85 = adapter20.requestAdapterInfo();
+let device20 = await adapter25.requestDevice({
+label: '\u{1fd38}\u{1f761}\ub2bf\u43d5\u8e7f\u9d74\ube57\u7894\u3e30\u209a',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 35,
+maxVertexBufferArrayStride: 63048,
+maxStorageTexturesPerShaderStage: 7,
+maxStorageBuffersPerShaderStage: 29,
+maxDynamicStorageBuffersPerPipelineLayout: 9088,
+maxBindingsPerBindGroup: 3934,
+maxTextureDimension1D: 16156,
+maxTextureDimension2D: 15673,
+minStorageBufferOffsetAlignment: 128,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 43118326,
+maxUniformBuffersPerShaderStage: 14,
+maxInterStageShaderVariables: 78,
+maxInterStageShaderComponents: 100,
+maxSamplersPerShaderStage: 20,
+},
+});
+let bindGroupLayout61 = device8.createBindGroupLayout({
+entries: [{
+binding: 1773,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}, {
+binding: 5509,
+visibility: GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+}, {
+binding: 5381,
+visibility: 0,
+externalTexture: {},
+}],
+});
+let commandEncoder119 = device8.createCommandEncoder({label: '\u{1fd9b}\u6340\ue99a\u2101\u6055\u0848\u066b\u0f6a\u600a'});
+let textureView151 = texture163.createView({
+  label: '\u{1f61f}\u{1f941}\u755c\uc3cf\u02a4\ud8c7\u0dec\u{1f973}',
+  dimension: '3d',
+  baseMipLevel: 2,
+  mipLevelCount: 5
+});
+let sampler116 = device8.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 25.802,
+lodMaxClamp: 81.179,
+maxAnisotropy: 11,
+});
+let externalTexture13 = device8.importExternalTexture({
+label: '\u{1ff72}\u183f\u23e3\u0293\u0e31\u50d2',
+source: video26,
+colorSpace: 'srgb',
+});
+try {
+commandEncoder119.copyBufferToBuffer(buffer35, 3288, buffer40, 6480, 10300);
+dissociateBuffer(device8, buffer35);
+dissociateBuffer(device8, buffer40);
+} catch {}
+let promise86 = adapter12.requestAdapterInfo();
+let texture180 = device16.createTexture({
+label: '\u{1ff95}\u99e1\u45a8\u{1fd62}\u0ede',
+size: {width: 1920, height: 1, depthOrArrayLayers: 215},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgba8sint',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8sint', 'rgba8sint'],
+});
+let renderBundle129 = renderBundleEncoder110.finish({label: '\u{1ffed}\u0327\u0e1d\u0ccc'});
+let sampler117 = device16.createSampler({
+label: '\u04a6\u07b8\ub008\u{1fc2e}\u381b\u{1fa86}\u{1f8fb}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 93.758,
+lodMaxClamp: 99.654,
+maxAnisotropy: 16,
+});
+try {
+texture180.destroy();
+} catch {}
+try {
+device16.queue.writeBuffer(buffer61, 52696, new Int16Array(5663), 2326, 20);
+} catch {}
+let promise87 = device16.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+document.body.prepend(canvas25);
+gc();
+let texture181 = device18.createTexture({
+label: '\uc2bd\u5e08\uef5e\ue6c2\u893d\ue1e4\u3098\u8500',
+size: [60, 60, 1],
+mipLevelCount: 3,
+dimension: '2d',
+format: 'astc-10x10-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let video49 = await videoWithData();
+let imageData42 = new ImageData(88, 144);
+let texture182 = device12.createTexture({
+label: '\u088d\u06ab\ue07c',
+size: [192, 10, 39],
+mipLevelCount: 4,
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x10-unorm', 'astc-12x10-unorm-srgb'],
+});
+try {
+device12.queue.writeTexture({
+  texture: texture156,
+  mipLevel: 1,
+  origin: { x: 1, y: 3, z: 0 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 2687 */
+{offset: 863, bytesPerRow: 148}, {width: 12, height: 13, depthOrArrayLayers: 1});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let shaderModule38 = device6.createShaderModule({
+label: '\u4976\u3adb\ufd29\u7e63\u{1f7d5}\u882d\u{1fc97}',
+code: `@group(0) @binding(939)
+var<storage, read_write> field30: array<u32>;
+@group(2) @binding(939)
+var<storage, read_write> field31: array<u32>;
+@group(2) @binding(2707)
+var<storage, read_write> field32: array<u32>;
+@group(1) @binding(939)
+var<storage, read_write> i17: array<u32>;
+@group(0) @binding(2707)
+var<storage, read_write> field33: array<u32>;
+@group(3) @binding(939)
+var<storage, read_write> i18: array<u32>;
+
+@compute @workgroup_size(7, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S43 {
+  @builtin(front_facing) f0: bool
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec3<f32>,
+  @location(1) f1: vec4<i32>,
+  @location(5) f2: f32,
+  @location(2) f3: vec4<f32>,
+  @builtin(sample_mask) f4: u32,
+  @location(3) f5: vec3<f32>,
+  @location(6) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(a0: S43, @builtin(sample_index) a1: u32, @builtin(sample_mask) a2: u32, @builtin(position) a3: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(21) a0: u32, @location(14) a1: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let querySet124 = device6.createQuerySet({
+label: '\u0e8e\u{1fce3}\u0918\u0ad8\ucb09',
+type: 'occlusion',
+count: 1091,
+});
+let renderBundleEncoder129 = device6.createRenderBundleEncoder({
+  label: '\u06a0\uf446\ud992\u{1fb74}\u{1f847}\u{1fe2e}\u0f73\u06cc\u9a28',
+  colorFormats: ['rg8unorm', 'rg16sint', 'rgba8unorm-srgb', 'rg32float', undefined, 'r16float', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+gpuCanvasContext32.configure({
+device: device6,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgba8unorm-srgb', 'r32sint', 'rgba8unorm', 'rgba8unorm-srgb'],
+alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup58 = device7.createBindGroup({
+label: '\u87eb\ubabe\u{1fa64}\u3502',
+layout: bindGroupLayout32,
+entries: [],
+});
+let sampler118 = device7.createSampler({
+label: '\u{1ff5b}\ufcfa\u0ff9\ue82c\u4cf3\u{1fa43}\u06b5\u33ce',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 54.561,
+lodMaxClamp: 82.985,
+});
+try {
+buffer54.unmap();
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture142,
+  mipLevel: 0,
+  origin: { x: 6, y: 0, z: 1 },
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer4), /* required buffer size: 301 */
+{offset: 301}, {width: 290, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+offscreenCanvas46.getContext('webgpu');
+} catch {}
+try {
+gpuCanvasContext50.unconfigure();
+} catch {}
+let canvas46 = document.createElement('canvas');
+try {
+canvas45.getContext('bitmaprenderer');
+} catch {}
+let texture183 = device13.createTexture({
+label: '\u{1f8ff}\u{1fc9e}\ua47b\u0769',
+size: [60],
+dimension: '1d',
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView152 = texture183.createView({label: '\u0865\u{1fd7a}\u45c9\u8530\ua4a7\u{1f9a8}', mipLevelCount: 1});
+let renderBundleEncoder130 = device13.createRenderBundleEncoder({
+  label: '\ud464\u8803\u0397\u{1f782}\u0b4a\u94a4\u8988',
+  colorFormats: ['rg8sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  stencilReadOnly: true
+});
+let sampler119 = device13.createSampler({
+label: '\ue8f8\u0552\u66ce\u05e0\u0273\u0eb3\uc8ba\u{1fc5e}\u{1faea}\u0207\u7035',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 9.968,
+lodMaxClamp: 15.831,
+maxAnisotropy: 3,
+});
+try {
+renderBundleEncoder119.setVertexBuffer(57, undefined, 3273222503);
+} catch {}
+try {
+await device13.queue.onSubmittedWorkDone();
+} catch {}
+canvas21.width = 859;
+try {
+adapter3.label = '\u012b\u{1fab1}\u{1ff66}\u2165\ud075\u0783\u{1ff3a}\u0ff1\u0092\u6336\u1fd1';
+} catch {}
+let img64 = await imageWithData(54, 154, '#946484f3', '#cac52b8b');
+pseudoSubmit(device11, commandEncoder101);
+let renderBundle130 = renderBundleEncoder79.finish();
+try {
+computePassEncoder71.setBindGroup(1, bindGroup46, new Uint32Array(9594), 8181, 0);
+} catch {}
+try {
+  await promise87;
+} catch {}
+let pipelineLayout40 = device14.createPipelineLayout({label: '\u653b\u{1f97b}\u0a1f\uefbd\u0971\u3670\uba62', bindGroupLayouts: []});
+let sampler120 = device14.createSampler({
+label: '\u6ee5\u{1fa76}\u035d\u{1fb53}\u4d69\u7d1c\u1d5c\u707e',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 99.293,
+lodMaxClamp: 99.608,
+maxAnisotropy: 4,
+});
+try {
+renderBundleEncoder127.setVertexBuffer(96, undefined, 2851353648, 1221473815);
+} catch {}
+let buffer66 = device13.createBuffer({size: 41382, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let renderBundle131 = renderBundleEncoder101.finish({label: '\u5e48\ud3b9\u2d23\uf2e6\u0e65\u{1ff06}\u4571\u091a\u0b5d'});
+gc();
+let img65 = await imageWithData(300, 102, '#0deb3f36', '#9052ed47');
+let querySet125 = device15.createQuerySet({
+label: '\u0488\udd7b',
+type: 'occlusion',
+count: 192,
+});
+let sampler121 = device15.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 49.090,
+lodMaxClamp: 65.882,
+compare: 'less',
+});
+try {
+renderBundleEncoder104.setVertexBuffer(18, undefined);
+} catch {}
+try {
+buffer58.unmap();
+} catch {}
+try {
+gpuCanvasContext7.configure({
+device: device15,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+offscreenCanvas16.height = 411;
+let canvas47 = document.createElement('canvas');
+try {
+device15.queue.writeTexture({
+  texture: texture136,
+  mipLevel: 0,
+  origin: { x: 183, y: 1, z: 0 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer4), /* required buffer size: 924 */
+{offset: 924}, {width: 530, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let imageBitmap45 = await createImageBitmap(img60);
+let texture184 = device15.createTexture({
+label: '\u058e\uea6d\u6579\u{1fb44}\u2767\u{1f7f4}\u4ae2\u0af9',
+size: {width: 24, height: 30, depthOrArrayLayers: 220},
+mipLevelCount: 2,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder57.setPipeline(pipeline109);
+} catch {}
+let renderBundle132 = renderBundleEncoder83.finish({label: '\u05f8\u27dd\u030f\u{1fd8e}'});
+try {
+computePassEncoder71.setBindGroup(3, bindGroup40, []);
+} catch {}
+gc();
+let video50 = await videoWithData();
+let videoFrame45 = new VideoFrame(canvas40, {timestamp: 0});
+let renderBundle133 = renderBundleEncoder74.finish({});
+try {
+querySet68.destroy();
+} catch {}
+try {
+  await buffer64.mapAsync(GPUMapMode.WRITE, 1880, 324);
+} catch {}
+try {
+commandEncoder96.copyTextureToTexture({
+  texture: texture123,
+  mipLevel: 0,
+  origin: { x: 616, y: 4, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture123,
+  mipLevel: 0,
+  origin: { x: 376, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 488, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer67 = device19.createBuffer({size: 9284, usage: GPUBufferUsage.INDIRECT});
+let querySet126 = device19.createQuerySet({
+label: '\u0ede\u{1fac4}\u0b70\u{1f977}\uc8d3\u78a7\u062c\u0d21\uf6da',
+type: 'occlusion',
+count: 2044,
+});
+try {
+buffer65.unmap();
+} catch {}
+let imageData43 = new ImageData(108, 136);
+try {
+canvas46.getContext('bitmaprenderer');
+} catch {}
+let texture185 = device13.createTexture({
+size: {width: 170, height: 105, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+device13.queue.writeTexture({
+  texture: texture146,
+  mipLevel: 0,
+  origin: { x: 20, y: 9, z: 91 },
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 807730 */
+{offset: 333, bytesPerRow: 269, rowsPerImage: 77}, {width: 32, height: 76, depthOrArrayLayers: 39});
+} catch {}
+let pipeline112 = device13.createRenderPipeline({
+label: '\uc5c7\u{1f78c}\u{1fe5b}\u624f\uf755\u45c1\u1236',
+layout: pipelineLayout27,
+fragment: {
+  module: shaderModule35,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8sint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'decrement-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2405,
+depthBias: 99,
+depthBiasSlopeScale: 32,
+depthBiasClamp: 5,
+},
+vertex: {
+  module: shaderModule35,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 3852,
+stepMode: 'instance',
+attributes: [{
+format: 'float32',
+offset: 2140,
+shaderLocation: 0,
+}, {
+format: 'uint8x4',
+offset: 1792,
+shaderLocation: 21,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x2',
+offset: 19580,
+shaderLocation: 16,
+}, {
+format: 'uint16x2',
+offset: 17184,
+shaderLocation: 10,
+}, {
+format: 'float16x2',
+offset: 808,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 26028,
+attributes: [],
+},
+{
+arrayStride: 20568,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x4',
+offset: 7368,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 23456,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x2',
+offset: 2844,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 296,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32',
+offset: 288,
+shaderLocation: 22,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+},
+});
+let imageBitmap46 = await createImageBitmap(video48);
+let bindGroupLayout62 = device12.createBindGroupLayout({
+entries: [],
+});
+let commandEncoder120 = device12.createCommandEncoder();
+let computePassEncoder76 = commandEncoder79.beginComputePass({label: '\u0a40\u41a6\u4967\u{1fef4}\u5dd5\u3ad1\u47f0\ua588\u0058\ub7af\u79e8'});
+let sampler122 = device12.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 23.702,
+lodMaxClamp: 35.387,
+});
+let textureView153 = texture136.createView({});
+let renderBundle134 = renderBundleEncoder109.finish({});
+try {
+computePassEncoder59.setPipeline(pipeline109);
+} catch {}
+try {
+renderBundleEncoder125.setVertexBuffer(93, undefined);
+} catch {}
+let pipeline113 = await device15.createComputePipelineAsync({
+label: '\u5b9e\u{1f802}\u{1fd5f}\u{1f667}\u98cd\u0749',
+layout: pipelineLayout32,
+compute: {
+module: shaderModule37,
+entryPoint: 'compute0',
+},
+});
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+let bindGroupLayout63 = device16.createBindGroupLayout({
+label: '\uc89e\u09ab\u0d2a',
+entries: [{
+binding: 471,
+visibility: 0,
+sampler: { type: 'non-filtering' },
+}, {
+binding: 579,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}],
+});
+let buffer68 = device16.createBuffer({label: '\u0b98\u04ae', size: 63899, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+device16.queue.writeTexture({
+  texture: texture160,
+  mipLevel: 3,
+  origin: { x: 10, y: 0, z: 2 },
+  aspect: 'all',
+}, new Int8Array(arrayBuffer6), /* required buffer size: 638178 */
+{offset: 405, bytesPerRow: 197, rowsPerImage: 159}, {width: 21, height: 58, depthOrArrayLayers: 21});
+} catch {}
+try {
+gpuCanvasContext43.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+offscreenCanvas46.height = 856;
+gc();
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+let gpuCanvasContext51 = canvas47.getContext('webgpu');
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise85;
+} catch {}
+let buffer69 = device17.createBuffer({size: 14108, usage: GPUBufferUsage.STORAGE, mappedAtCreation: true});
+let commandEncoder121 = device17.createCommandEncoder({label: '\u77f7\u00a4\u{1fd41}\ud222\u016e\u0d2d\u02fe\udfa3'});
+let querySet127 = device17.createQuerySet({
+label: '\u02e3\u0497\ub4f7\u0b0c\ua214\ue9a0\u0106\ufaf5',
+type: 'occlusion',
+count: 2826,
+});
+let texture186 = device17.createTexture({
+label: '\uc9c0\u0dd5\ueef0\u068f\ua84d\u0bed\u08eb\u0c99\u0430\u{1fc30}\uecc6',
+size: [1536, 480, 1],
+mipLevelCount: 11,
+format: 'etc2-rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgba8unorm', 'etc2-rgba8unorm-srgb', 'etc2-rgba8unorm'],
+});
+let computePassEncoder77 = commandEncoder121.beginComputePass();
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+try {
+videoFrame8.close();
+} catch {}
+let bindGroupLayout64 = device18.createBindGroupLayout({
+label: '\u{1fd5f}\u89fb\u{1f868}\u09cf\uf8cb\u737f',
+entries: [{
+binding: 5270,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}, {
+binding: 1530,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}],
+});
+let buffer70 = device18.createBuffer({
+  label: '\u86b9\ua6c5\u{1fec9}\u0869\u0828\u0722\u0775',
+  size: 52082,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let texture187 = device18.createTexture({
+size: {width: 6036, height: 105, depthOrArrayLayers: 1},
+mipLevelCount: 9,
+format: 'astc-6x5-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+try {
+buffer70.destroy();
+} catch {}
+let querySet128 = device8.createQuerySet({
+type: 'occlusion',
+count: 2505,
+});
+let commandBuffer20 = commandEncoder119.finish({
+label: '\u0cf1\ub4d9\uc125\u0d14\u9a25\u215e\u4e6f\u0df6\u{1fd18}\uf274',
+});
+let textureView154 = texture108.createView({
+  label: '\ubd28\u79e6\u0ff3\u{1fbda}\u4ad2\ua43e\u1f58\u6e1e',
+  dimension: '2d-array',
+  format: 'bgra8unorm-srgb',
+  arrayLayerCount: 1
+});
+try {
+renderBundleEncoder76.insertDebugMarker('\u0204');
+} catch {}
+try {
+device8.queue.writeBuffer(buffer55, 22764, new BigUint64Array(62258), 27259, 128);
+} catch {}
+try {
+device8.queue.writeTexture({
+  texture: texture162,
+  mipLevel: 0,
+  origin: { x: 5, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(956), /* required buffer size: 956 */
+{offset: 836, bytesPerRow: 136}, {width: 30, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipelineLayout41 = device9.createPipelineLayout({
+  label: '\u{1fd19}\u{1f893}\u1c04',
+  bindGroupLayouts: [bindGroupLayout34, bindGroupLayout30, bindGroupLayout30, bindGroupLayout50, bindGroupLayout50, bindGroupLayout50, bindGroupLayout30, bindGroupLayout30, bindGroupLayout50]
+});
+let texture188 = device9.createTexture({
+size: [1120],
+dimension: '1d',
+format: 'rg32uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rg32uint', 'rg32uint'],
+});
+let textureView155 = texture127.createView({
+  label: '\u{1f800}\ub13a\ud3fe\u027d\u5827\u991d\u246a',
+  dimension: '2d',
+  mipLevelCount: 1,
+  arrayLayerCount: 1
+});
+let renderBundle135 = renderBundleEncoder128.finish();
+try {
+renderBundleEncoder113.setVertexBuffer(7, buffer37);
+} catch {}
+try {
+computePassEncoder68.insertDebugMarker('\u2933');
+} catch {}
+try {
+device9.queue.submit([
+commandBuffer15,
+]);
+} catch {}
+try {
+device9.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 54, y: 179 },
+  flipY: false,
+}, {
+  texture: texture125,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let canvas48 = document.createElement('canvas');
+try {
+canvas48.getContext('webgl');
+} catch {}
+let buffer71 = device3.createBuffer({
+  label: '\u5ebb\u071f\ue5d4\u{1fb57}\ue6c6\u0141\uec9e\u778c',
+  size: 64889,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE
+});
+let querySet129 = device3.createQuerySet({
+label: '\u0261\uea3f',
+type: 'occlusion',
+count: 3671,
+});
+try {
+device3.queue.writeBuffer(buffer71, 59856, new DataView(new ArrayBuffer(17709)), 8839, 3968);
+} catch {}
+let texture189 = device18.createTexture({
+label: '\u089e\uf704\ue244\u06e0\ue605\u9ee4\ueea4\u0f0e\u{1f623}\u4114',
+size: {width: 10167, height: 2, depthOrArrayLayers: 1},
+mipLevelCount: 11,
+format: 'rgba16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float'],
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageData44 = new ImageData(40, 4);
+let querySet130 = device11.createQuerySet({
+label: '\u0e87\ud17f\u97f2\u0ff5',
+type: 'occlusion',
+count: 1626,
+});
+let promise88 = device11.queue.onSubmittedWorkDone();
+let video51 = await videoWithData();
+let buffer72 = device15.createBuffer({
+  label: '\u{1f6c4}\u026e\u09af\u08ea\ud7dc\u0e97\u{1faf4}\u{1fe03}',
+  size: 14705,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let renderBundle136 = renderBundleEncoder107.finish();
+try {
+renderBundleEncoder125.setVertexBuffer(36, undefined, 3288825405, 57877743);
+} catch {}
+try {
+device15.queue.writeBuffer(buffer58, 28192, new BigUint64Array(20249), 1125, 412);
+} catch {}
+try {
+  await promise88;
+} catch {}
+let img66 = await imageWithData(169, 118, '#26258471', '#d3419bc0');
+try {
+await adapter18.requestAdapterInfo();
+} catch {}
+let bindGroup59 = device12.createBindGroup({
+label: '\u0e11\u1b4e\u8f57\u{1f6c8}\u92f4\u{1f6e5}',
+layout: bindGroupLayout37,
+entries: [],
+});
+let commandEncoder122 = device12.createCommandEncoder();
+let texture190 = device12.createTexture({
+label: '\u0e3c\u{1f769}\u787f\u008d\u00d7\u0f57\u004e\u{1f9b4}\u{1fe04}\u05d8\u0869',
+size: [216, 234, 1],
+mipLevelCount: 5,
+format: 'astc-6x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-6x6-unorm-srgb', 'astc-6x6-unorm-srgb', 'astc-6x6-unorm'],
+});
+let renderBundle137 = renderBundleEncoder115.finish({label: '\uea31\ub36e\u1fda'});
+try {
+computePassEncoder51.setBindGroup(3, bindGroup43, new Uint32Array(953), 678, 0);
+} catch {}
+try {
+computePassEncoder76.end();
+} catch {}
+try {
+renderBundleEncoder121.setBindGroup(5, bindGroup59, new Uint32Array(5960), 1533, 0);
+} catch {}
+try {
+renderBundleEncoder121.insertDebugMarker('\u{1faf7}');
+} catch {}
+document.body.prepend(video32);
+try {
+window.someLabel = textureView60.label;
+} catch {}
+try {
+renderBundleEncoder106.setPipeline(pipeline88);
+} catch {}
+try {
+renderBundleEncoder85.setVertexBuffer(5, buffer37);
+} catch {}
+let imageBitmap47 = await createImageBitmap(canvas19);
+let commandEncoder123 = device14.createCommandEncoder({label: '\u0098\u4ceb\u22bd\u0762\u0af6\ud193\u{1f8ea}\u0d2b'});
+let querySet131 = device14.createQuerySet({
+type: 'occlusion',
+count: 1891,
+});
+let texture191 = device14.createTexture({
+label: '\u8f2a\uff81\u65d8\uf01e',
+size: {width: 420, height: 20, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'eac-rg11unorm',
+usage: GPUTextureUsage.COPY_SRC,
+});
+let sampler123 = device14.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 26.354,
+lodMaxClamp: 36.880,
+});
+try {
+computePassEncoder66.end();
+} catch {}
+try {
+device7.pushErrorScope('internal');
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture143,
+  mipLevel: 0,
+  origin: { x: 3035, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint16Array(new ArrayBuffer(72)), /* required buffer size: 2128 */
+{offset: 224}, {width: 952, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let img67 = await imageWithData(195, 241, '#611a09d8', '#ba6de332');
+let querySet132 = device8.createQuerySet({
+label: '\u7079\ue07a\u{1fdaa}',
+type: 'occlusion',
+count: 3651,
+});
+let texture192 = device8.createTexture({
+label: '\u99c8\ued85',
+size: {width: 60},
+dimension: '1d',
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['r8uint', 'r8uint', 'r8uint'],
+});
+let textureView156 = texture162.createView({
+  label: '\u21cd\ue253\u1cbf\u8046\u3a08\u02c0\ubcee\uf9fe\uc83e\u{1f7cd}',
+  format: 'rg11b10ufloat',
+  mipLevelCount: 1
+});
+let renderBundle138 = renderBundleEncoder97.finish();
+try {
+renderBundleEncoder123.setBindGroup(4, bindGroup39, new Uint32Array(4915), 4696, 0);
+} catch {}
+let img68 = await imageWithData(71, 37, '#59f9542b', '#b97fb5c4');
+let bindGroupLayout65 = device19.createBindGroupLayout({
+entries: [],
+});
+pseudoSubmit(device19, commandEncoder117);
+let sampler124 = device19.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+mipmapFilter: 'nearest',
+lodMaxClamp: 87.394,
+});
+let renderBundleEncoder131 = device13.createRenderBundleEncoder({
+  label: '\u9135\u799e\ua79c',
+  colorFormats: ['bgra8unorm', 'rgba32uint', undefined, 'rgba8unorm-srgb', 'r8unorm', 'rgba8uint', 'rgba8unorm-srgb', 'rgba8sint'],
+  stencilReadOnly: false
+});
+try {
+  await promise86;
+} catch {}
+gc();
+let buffer73 = device9.createBuffer({
+  label: '\uf5b4\u58e5\u09c7\u1feb\uc613',
+  size: 5801,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX
+});
+pseudoSubmit(device9, commandEncoder103);
+try {
+computePassEncoder50.setPipeline(pipeline83);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+device: device9,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device9.queue.writeTexture({
+  texture: texture137,
+  mipLevel: 2,
+  origin: { x: 0, y: 12, z: 10 },
+  aspect: 'depth-only',
+}, arrayBuffer16, /* required buffer size: 4711549 */
+{offset: 269, bytesPerRow: 358, rowsPerImage: 140}, {width: 44, height: 0, depthOrArrayLayers: 95});
+} catch {}
+let pipeline114 = await device9.createComputePipelineAsync({
+label: '\u7cbb\u{1fc4c}\u5487\u4692\uee52\u4886\u{1f9e2}\u0291\u2de1\u46f4',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule25,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline115 = device9.createRenderPipeline({
+label: '\u0301\u0b2d\u06ac',
+layout: pipelineLayout29,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule31,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'constant', dstFactor: 'one-minus-src-alpha'},
+}
+}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgba8uint'}]
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'decrement-clamp',
+},
+stencilWriteMask: 1365,
+depthBias: 59,
+depthBiasSlopeScale: 76,
+depthBiasClamp: 64,
+},
+vertex: {
+  module: shaderModule31,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 10700,
+attributes: [{
+format: 'sint32',
+offset: 1116,
+shaderLocation: 21,
+}, {
+format: 'uint32x2',
+offset: 5484,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 40220,
+attributes: [{
+format: 'sint16x4',
+offset: 26232,
+shaderLocation: 23,
+}, {
+format: 'sint32x4',
+offset: 2476,
+shaderLocation: 0,
+}, {
+format: 'sint16x4',
+offset: 3728,
+shaderLocation: 20,
+}, {
+format: 'sint8x4',
+offset: 33096,
+shaderLocation: 18,
+}, {
+format: 'sint32',
+offset: 11840,
+shaderLocation: 14,
+}, {
+format: 'float16x2',
+offset: 10068,
+shaderLocation: 12,
+}, {
+format: 'uint32x4',
+offset: 18804,
+shaderLocation: 6,
+}, {
+format: 'float16x2',
+offset: 19408,
+shaderLocation: 5,
+}, {
+format: 'float32x4',
+offset: 10560,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 39224,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 12756,
+shaderLocation: 8,
+}, {
+format: 'float32x2',
+offset: 22836,
+shaderLocation: 7,
+}, {
+format: 'snorm16x4',
+offset: 16496,
+shaderLocation: 13,
+}, {
+format: 'uint8x4',
+offset: 8344,
+shaderLocation: 16,
+}, {
+format: 'float32x3',
+offset: 16484,
+shaderLocation: 11,
+}, {
+format: 'unorm8x4',
+offset: 3540,
+shaderLocation: 2,
+}, {
+format: 'sint32x3',
+offset: 37140,
+shaderLocation: 17,
+}, {
+format: 'uint8x2',
+offset: 4906,
+shaderLocation: 22,
+}, {
+format: 'sint32x4',
+offset: 15092,
+shaderLocation: 9,
+}, {
+format: 'float32x4',
+offset: 22084,
+shaderLocation: 1,
+}, {
+format: 'uint32x3',
+offset: 15968,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 43456,
+attributes: [{
+format: 'uint32x2',
+offset: 32692,
+shaderLocation: 19,
+}],
+},
+{
+arrayStride: 8252,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+attributes: [{
+format: 'float16x2',
+offset: 49032,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+document.body.prepend(video20);
+let video52 = await videoWithData();
+let videoFrame46 = new VideoFrame(canvas45, {timestamp: 0});
+let sampler125 = device15.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 17.844,
+lodMaxClamp: 34.813,
+compare: 'greater-equal',
+});
+let externalTexture14 = device15.importExternalTexture({
+label: '\u{1f9ee}\u3cb0\u0beb\u08e0\u0780\u{1f661}\uc11c\u3102',
+source: video41,
+colorSpace: 'srgb',
+});
+try {
+buffer72.unmap();
+} catch {}
+try {
+device15.queue.writeTexture({
+  texture: texture184,
+  mipLevel: 0,
+  origin: { x: 0, y: 13, z: 62 },
+  aspect: 'all',
+}, arrayBuffer14, /* required buffer size: 1468626 */
+{offset: 345, bytesPerRow: 267, rowsPerImage: 39}, {width: 24, height: 1, depthOrArrayLayers: 142});
+} catch {}
+let videoFrame47 = new VideoFrame(imageBitmap34, {timestamp: 0});
+let buffer74 = device16.createBuffer({
+  label: '\u{1fcfe}\u3026\u44ca\u3dde\ufc02\ua9a4\u045b\u{1f730}\u0718\u0cf0',
+  size: 42788,
+  usage: GPUBufferUsage.INDIRECT,
+  mappedAtCreation: true
+});
+let texture193 = device16.createTexture({
+size: {width: 930, height: 1, depthOrArrayLayers: 916},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+});
+let textureView157 = texture150.createView({mipLevelCount: 1});
+let imageBitmap48 = await createImageBitmap(video33);
+let img69 = await imageWithData(300, 215, '#9bb75dce', '#a8322bfa');
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55) };
+} catch {}
+let bindGroupLayout66 = device7.createBindGroupLayout({
+label: '\u{1fbab}\u005b\u9d13',
+entries: [{
+binding: 1519,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}, {
+binding: 3215,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '2d' },
+}],
+});
+gc();
+let sampler126 = device17.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 54.746,
+lodMaxClamp: 59.964,
+});
+let videoFrame48 = new VideoFrame(video49, {timestamp: 0});
+let bindGroupLayout67 = device18.createBindGroupLayout({
+entries: [{
+binding: 2862,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+}],
+});
+let buffer75 = device18.createBuffer({
+  label: '\u0058\ub516\uded4\u0b74\u7a42\u066f\u7f42\u{1f79e}\u{1f66c}',
+  size: 23032,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+try {
+gpuCanvasContext11.configure({
+device: device18,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float'],
+alphaMode: 'opaque',
+});
+} catch {}
+let bindGroupLayout68 = pipeline36.getBindGroupLayout(1);
+let externalTexture15 = device2.importExternalTexture({
+label: '\uec7f\u0b3f\u2994\u011e\u{1f60e}\uc64c\uc941\u0d5c\u0849\u6bac',
+source: videoFrame1,
+colorSpace: 'srgb',
+});
+try {
+computePassEncoder18.setPipeline(pipeline55);
+} catch {}
+try {
+commandEncoder110.copyTextureToTexture({
+  texture: texture72,
+  mipLevel: 3,
+  origin: { x: 3, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture72,
+  mipLevel: 3,
+  origin: { x: 3, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 25, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img10);
+canvas1.height = 104;
+let shaderModule39 = device15.createShaderModule({
+label: '\ua9ab\u546b\uf290\u07d7\u09f6\u{1fff7}\u{1fec8}\u{1fb07}',
+code: `@group(1) @binding(4645)
+var<storage, read_write> i19: array<u32>;
+@group(1) @binding(691)
+var<storage, read_write> i20: array<u32>;
+@group(1) @binding(853)
+var<storage, read_write> type28: array<u32>;
+@group(0) @binding(853)
+var<storage, read_write> local22: array<u32>;
+@group(0) @binding(691)
+var<storage, read_write> type29: array<u32>;
+@group(2) @binding(691)
+var<storage, read_write> field34: array<u32>;
+@group(2) @binding(853)
+var<storage, read_write> local23: array<u32>;
+
+@compute @workgroup_size(7, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S45 {
+  @location(82) f0: vec4<f16>,
+  @builtin(front_facing) f1: bool,
+  @location(21) f2: f32,
+  @location(115) f3: vec4<f16>,
+  @location(46) f4: vec2<u32>,
+  @location(107) f5: vec2<f16>,
+  @builtin(sample_index) f6: u32
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<i32>,
+  @location(0) f1: vec4<i32>,
+  @location(2) f2: vec3<u32>
+}
+
+@fragment
+fn fragment0(@location(49) a0: vec3<f32>, @location(73) a1: vec3<f16>, @location(109) a2: vec3<u32>, @location(74) a3: vec2<u32>, @location(26) a4: vec3<f32>, @location(20) a5: vec2<i32>, @location(29) a6: vec2<u32>, @location(9) a7: vec3<i32>, @location(34) a8: vec4<f32>, a9: S45, @location(31) a10: f16, @location(55) a11: vec3<u32>, @location(18) a12: f32, @location(58) a13: u32, @location(85) a14: vec4<f32>, @location(25) a15: i32, @location(16) a16: u32, @location(96) a17: u32, @location(89) a18: vec2<f16>, @location(53) a19: vec3<f16>, @location(103) a20: vec4<f16>, @location(105) a21: vec2<f32>, @location(51) a22: vec2<u32>, @location(106) a23: vec4<i32>, @builtin(sample_mask) a24: u32, @builtin(position) a25: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S44 {
+  @location(5) f0: vec4<f16>,
+  @location(3) f1: f32,
+  @location(11) f2: vec3<f32>,
+  @location(15) f3: i32,
+  @location(10) f4: vec3<i32>,
+  @location(1) f5: vec2<f32>,
+  @location(6) f6: vec4<u32>,
+  @location(0) f7: vec3<f32>,
+  @location(14) f8: vec2<u32>,
+  @builtin(vertex_index) f9: u32,
+  @location(7) f10: vec4<i32>,
+  @location(4) f11: vec4<f16>,
+  @location(13) f12: vec4<i32>
+}
+struct VertexOutput0 {
+  @location(46) f513: vec2<u32>,
+  @location(49) f514: vec3<f32>,
+  @location(58) f515: u32,
+  @location(106) f516: vec4<i32>,
+  @location(18) f517: f32,
+  @location(9) f518: vec3<i32>,
+  @location(31) f519: f16,
+  @location(20) f520: vec2<i32>,
+  @location(109) f521: vec3<u32>,
+  @location(82) f522: vec4<f16>,
+  @location(105) f523: vec2<f32>,
+  @location(16) f524: u32,
+  @location(21) f525: f32,
+  @location(26) f526: vec3<f32>,
+  @location(96) f527: u32,
+  @location(115) f528: vec4<f16>,
+  @location(73) f529: vec3<f16>,
+  @location(103) f530: vec4<f16>,
+  @location(51) f531: vec2<u32>,
+  @location(89) f532: vec2<f16>,
+  @location(85) f533: vec4<f32>,
+  @location(74) f534: vec2<u32>,
+  @location(55) f535: vec3<u32>,
+  @location(53) f536: vec3<f16>,
+  @location(29) f537: vec2<u32>,
+  @location(34) f538: vec4<f32>,
+  @location(107) f539: vec2<f16>,
+  @builtin(position) f540: vec4<f32>,
+  @location(25) f541: i32
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec3<f16>, a1: S44, @location(9) a2: f16, @location(12) a3: vec4<u32>, @location(8) a4: vec3<f32>, @builtin(instance_index) a5: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let buffer76 = device15.createBuffer({size: 32096, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture194 = device15.createTexture({
+label: '\u91f1\u91ee\u{1fbd6}\ucaea\u{1fa9b}',
+size: [96],
+dimension: '1d',
+format: 'rgba16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16uint'],
+});
+let renderBundleEncoder132 = device15.createRenderBundleEncoder({colorFormats: ['rg32sint', 'rgba16sint', 'r8uint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle139 = renderBundleEncoder125.finish({label: '\uc811\u9668\u04a9\uba6c\u{1fe9a}\u99a8\u{1f810}'});
+try {
+computePassEncoder59.setPipeline(pipeline109);
+} catch {}
+try {
+buffer72.unmap();
+} catch {}
+let pipeline116 = device15.createComputePipeline({
+label: '\u599e\u03b6\u01eb',
+layout: pipelineLayout32,
+compute: {
+module: shaderModule39,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let video53 = await videoWithData();
+let texture195 = device19.createTexture({
+label: '\ubb5a\u172e\u067b\ucb4f',
+size: [936, 1, 76],
+mipLevelCount: 6,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let sampler127 = device19.createSampler({
+label: '\ubda9\u04fd\uc9d0\ue2bf\u{1fb91}\u7e55\u{1fed1}\u4364\u5259\ue41d\u0690',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 7.185,
+});
+let canvas49 = document.createElement('canvas');
+let imageData45 = new ImageData(24, 16);
+let querySet133 = device19.createQuerySet({
+label: '\u{1f9e2}\u0455\u8853\u{1fb80}\u273f\u0a9a',
+type: 'occlusion',
+count: 644,
+});
+let texture196 = device19.createTexture({
+label: '\u{1f8c1}\ub4b7\u3d38\u8734\u{1fa5d}',
+size: {width: 640, height: 160, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+sampleCount: 1,
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['eac-r11snorm', 'eac-r11snorm', 'eac-r11snorm'],
+});
+let querySet134 = device15.createQuerySet({
+label: '\u{1fc2e}\u011c\u1689\u4c28\u9744\u{1fe5e}\u7ff9\u0e3b',
+type: 'occlusion',
+count: 2033,
+});
+let texture197 = device15.createTexture({
+label: '\u01ee\u1380\u{1fb71}\u{1f6d5}\u{1ff85}\udb6d\u9999\u03b5\uc058\u0bea\u02e5',
+size: {width: 240, height: 60, depthOrArrayLayers: 456},
+mipLevelCount: 9,
+dimension: '3d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [],
+});
+let textureView158 = texture194.createView({label: '\ud08b\u0451\u4542\uf79b\u0fdd'});
+try {
+gpuCanvasContext27.configure({
+device: device15,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device15.queue.writeTexture({
+  texture: texture184,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 56 },
+  aspect: 'depth-only',
+}, arrayBuffer12, /* required buffer size: 3326719 */
+{offset: 790, bytesPerRow: 321, rowsPerImage: 287}, {width: 24, height: 30, depthOrArrayLayers: 37});
+} catch {}
+let gpuCanvasContext52 = canvas49.getContext('webgpu');
+try {
+gpuCanvasContext7.configure({
+device: device20,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb', 'rgba8unorm', 'astc-12x10-unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroupLayout69 = device13.createBindGroupLayout({
+entries: [{
+binding: 982,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+}, {
+binding: 2289,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '1d' },
+}],
+});
+let textureView159 = texture155.createView({label: '\u{1f7e4}\u070a\u04fa', format: 'astc-12x10-unorm', baseArrayLayer: 91, arrayLayerCount: 13});
+try {
+computePassEncoder69.end();
+} catch {}
+try {
+device13.pushErrorScope('validation');
+} catch {}
+document.body.prepend(video16);
+let bindGroupLayout70 = device19.createBindGroupLayout({
+label: '\u4a42\u00e6\u6f76\u07ac\u1204\u060e\u{1fd54}\u0c20\u0435\u388c\ud043',
+entries: [],
+});
+let pipelineLayout42 = device19.createPipelineLayout({
+  label: '\uf53b\u2b52\u045b\ucb54\ufb56\u5eb3\u1db3\u1849\u0bdd\u{1f7e2}\u{1fbf6}',
+  bindGroupLayouts: [bindGroupLayout70, bindGroupLayout70, bindGroupLayout65, bindGroupLayout70, bindGroupLayout65, bindGroupLayout65, bindGroupLayout65, bindGroupLayout70, bindGroupLayout70, bindGroupLayout70]
+});
+let querySet135 = device12.createQuerySet({
+label: '\u{1fc37}\u0476\u{1faa0}\ue202\u4237\u8ab7\u6d42\u08b1\u0b86\u060e',
+type: 'occlusion',
+count: 574,
+});
+let textureView160 = texture156.createView({label: '\u2b9b\u{1f8f3}\u{1f852}\u5ba5\u67cb\ub873', baseMipLevel: 3, mipLevelCount: 2});
+gc();
+try {
+window.someLabel = device5.queue.label;
+} catch {}
+try {
+gpuCanvasContext47.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+try {
+await adapter23.requestAdapterInfo();
+} catch {}
+let promise89 = adapter6.requestAdapterInfo();
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+document.body.prepend(video28);
+let computePassEncoder78 = commandEncoder123.beginComputePass({label: '\ua834\ubb76\uada1\uc0a2\u0823\u0e1d\u2391'});
+let renderBundle140 = renderBundleEncoder127.finish({label: '\uf032\ud820\u{1fc2b}\u{1fad9}\u0ff5\uec29\u{1f6ca}\u254b\u37ad\ua9b0'});
+try {
+device14.queue.writeTexture({
+  texture: texture159,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 75 },
+  aspect: 'stencil-only',
+}, arrayBuffer10, /* required buffer size: 878453 */
+{offset: 158, bytesPerRow: 287, rowsPerImage: 45}, {width: 75, height: 1, depthOrArrayLayers: 69});
+} catch {}
+gc();
+let offscreenCanvas47 = new OffscreenCanvas(109, 619);
+let imageBitmap49 = await createImageBitmap(video27);
+try {
+  await promise89;
+} catch {}
+let imageBitmap50 = await createImageBitmap(canvas11);
+let bindGroup60 = device19.createBindGroup({
+label: '\u0f91\u0af5',
+layout: bindGroupLayout65,
+entries: [],
+});
+let buffer77 = device19.createBuffer({label: '\u0e09\u5d49\u6d18\ud532\uebda\ue52e', size: 42243, usage: GPUBufferUsage.INDEX});
+let querySet136 = device19.createQuerySet({
+label: '\udd68\u{1fef5}\uca87',
+type: 'occlusion',
+count: 120,
+});
+let renderBundleEncoder133 = device19.createRenderBundleEncoder({
+  label: '\u{1fc83}\u1fdf\u{1fd43}\u717d\u3ec4\u{1f697}\uc750\u055e\u403b',
+  colorFormats: ['rg32uint', 'r8uint', 'r16sint', 'rgb10a2unorm', 'r8sint', 'rg16uint', 'rg8sint'],
+  sampleCount: 4
+});
+try {
+renderBundleEncoder133.setBindGroup(0, bindGroup60);
+} catch {}
+try {
+texture174.destroy();
+} catch {}
+try {
+computePassEncoder72.pushDebugGroup('\ud073');
+} catch {}
+let commandEncoder124 = device18.createCommandEncoder({});
+let textureView161 = texture173.createView({label: '\u43b0\u0190\u{1f6d8}\u0bed\u6b0a', format: 'rgba32float', arrayLayerCount: 1});
+try {
+commandEncoder124.copyBufferToBuffer(buffer70, 1684, buffer75, 1368, 3008);
+dissociateBuffer(device18, buffer70);
+dissociateBuffer(device18, buffer75);
+} catch {}
+try {
+commandEncoder124.copyTextureToTexture({
+  texture: texture181,
+  mipLevel: 0,
+  origin: { x: 20, y: 40, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture181,
+  mipLevel: 2,
+  origin: { x: 0, y: 10, z: 0 },
+  aspect: 'all',
+}, {width: 10, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext53 = offscreenCanvas47.getContext('webgpu');
+let offscreenCanvas48 = new OffscreenCanvas(528, 867);
+let img70 = await imageWithData(286, 28, '#8a4e621d', '#db668974');
+let pipelineLayout43 = device19.createPipelineLayout({
+  label: '\u{1fccb}\u92cd\u02ac\u0a2b\u0b33\u65d3\u4aaf\u1791\ub8b5\ua364\u525c',
+  bindGroupLayouts: [bindGroupLayout70, bindGroupLayout65, bindGroupLayout70, bindGroupLayout65, bindGroupLayout65, bindGroupLayout70, bindGroupLayout70]
+});
+let commandEncoder125 = device19.createCommandEncoder({label: '\u47d3\u{1f733}\u7981'});
+let textureView162 = texture177.createView({label: '\u{1faa2}\u{1fd00}\uae9e\u{1f617}\u0413\u0555\u0bb4\u820b\u851d\u4245', aspect: 'all'});
+let buffer78 = device14.createBuffer({
+  label: '\u54a3\u0be5',
+  size: 37689,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX
+});
+let textureView163 = texture159.createView({
+  label: '\u2079\u71d9\u0fa8\uab6e\u200a\uc7e0\u0e15\u8697\u7d8e',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  baseMipLevel: 2,
+  baseArrayLayer: 120,
+  arrayLayerCount: 1
+});
+let renderBundleEncoder134 = device14.createRenderBundleEncoder({label: '\u{1ff1d}\uf3ba\u1e7e\u{1fd45}\u01a2\u{1f686}\u8c34\u{1f858}', colorFormats: ['rgba8sint']});
+try {
+buffer62.unmap();
+} catch {}
+let texture198 = gpuCanvasContext7.getCurrentTexture();
+let renderBundle141 = renderBundleEncoder109.finish({label: '\u4d15\u089b\u4342\u0365\u4b26\u88c7\u04df'});
+try {
+buffer76.unmap();
+} catch {}
+let pipeline117 = device15.createRenderPipeline({
+label: '\u2b56\u{1fbf1}\u{1fa7e}\u9ebb\ue0f7\u288d\u0dbd\ubcc8\u{1fae1}\u032d\u0722',
+layout: pipelineLayout32,
+multisample: {
+mask: 0xf2079c67,
+},
+fragment: {
+  module: shaderModule37,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: 0}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}]
+},
+vertex: {
+  module: shaderModule37,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 18180,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x2',
+offset: 14812,
+shaderLocation: 3,
+}, {
+format: 'sint8x2',
+offset: 10566,
+shaderLocation: 14,
+}, {
+format: 'unorm8x4',
+offset: 9616,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 3512,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 23428,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32',
+offset: 7036,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 8800,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 19488,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x3',
+offset: 14620,
+shaderLocation: 1,
+}, {
+format: 'unorm16x2',
+offset: 7588,
+shaderLocation: 2,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+},
+});
+offscreenCanvas37.width = 24;
+let shaderModule40 = device18.createShaderModule({
+label: '\u{1fc22}\u76d2\ua8b2\u{1f8ef}\u0a39\u{1f7c0}\u{1f8d2}\u0121\u042d',
+code: `@group(2) @binding(6237)
+var<storage, read_write> field35: array<u32>;
+@group(2) @binding(6194)
+var<storage, read_write> field36: array<u32>;
+@group(0) @binding(2982)
+var<storage, read_write> field37: array<u32>;
+@group(0) @binding(6237)
+var<storage, read_write> field38: array<u32>;
+@group(1) @binding(6194)
+var<storage, read_write> function16: array<u32>;
+@group(1) @binding(2982)
+var<storage, read_write> local24: array<u32>;
+@group(0) @binding(6194)
+var<storage, read_write> global25: array<u32>;
+
+@compute @workgroup_size(3, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec2<u32>,
+  @location(0) f1: vec4<u32>,
+  @location(1) f2: u32,
+  @location(2) f3: vec4<f32>,
+  @location(6) f4: vec2<u32>,
+  @builtin(sample_mask) f5: u32,
+  @location(5) f6: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(position) a2: vec4<f32>, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S46 {
+  @location(10) f0: vec2<u32>,
+  @location(7) f1: vec4<f32>,
+  @location(18) f2: vec3<f16>,
+  @location(17) f3: vec2<f32>,
+  @location(15) f4: vec3<f16>,
+  @builtin(instance_index) f5: u32,
+  @location(23) f6: f16
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec2<f16>, @location(19) a1: vec2<i32>, @location(3) a2: vec2<i32>, @location(14) a3: f16, a4: S46, @location(25) a5: vec3<u32>, @location(20) a6: vec4<f16>, @location(13) a7: vec2<f32>, @location(12) a8: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let texture199 = device18.createTexture({
+label: '\u7df8\u0cc3\u5c0f\u4070\ud0dc\u8b99\u{1f8ca}',
+size: {width: 10020, height: 30, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView164 = texture178.createView({label: '\u{1fb1e}\u{1f9cb}\u1aa0\u4100\u44b0\u0c47\u0331\uc5d7\u{1f7e9}\u{1ff12}', baseMipLevel: 1});
+let computePassEncoder79 = commandEncoder124.beginComputePass({label: '\u2ac9\u{1fe9a}\u9741\ud30d\u4e99\ua757\u{1fbd4}\u8bed\uc31b'});
+try {
+gpuCanvasContext38.configure({
+device: device18,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg11b10ufloat', 'bgra8unorm', 'bgra8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+await device18.queue.onSubmittedWorkDone();
+} catch {}
+try {
+textureView5.label = '\u82b8\u{1f736}\u876d\u0bc4\u0ac1\u0cc7\u0641';
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+pseudoSubmit(device17, commandEncoder121);
+let texture200 = device17.createTexture({
+label: '\u{1fd46}\u0d22\u58bc\u4306\u0716\u087e\ua0a5\u6ce2\u1da4',
+size: {width: 192, height: 60, depthOrArrayLayers: 21},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+device17.addEventListener('uncapturederror', e => { log('device17.uncapturederror'); log(e); e.label = device17.label; });
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let imageBitmap51 = await createImageBitmap(offscreenCanvas2);
+try {
+offscreenCanvas48.getContext('2d');
+} catch {}
+let commandEncoder126 = device7.createCommandEncoder({label: '\u{1fb24}\uc693\u09c4\u5f08\u7012\ue22e\u0c0e\uf17a\u0a99'});
+let texture201 = device7.createTexture({
+label: '\u{1f841}\ue291\u821c\u{1fdfa}\u99b6\u{1fc38}\u9b03\u{1f7fd}',
+size: [6223, 1, 118],
+mipLevelCount: 9,
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba32uint', 'rgba32uint'],
+});
+let renderBundleEncoder135 = device7.createRenderBundleEncoder({
+  colorFormats: ['r32float', 'rgba16sint', 'r16uint', 'rg16sint', undefined, 'rg16float', 'r16float', 'rgba16sint'],
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder135.setVertexBuffer(4, undefined, 2333102350, 894818244);
+} catch {}
+try {
+commandEncoder95.copyTextureToTexture({
+  texture: texture201,
+  mipLevel: 4,
+  origin: { x: 243, y: 0, z: 18 },
+  aspect: 'all',
+}, {
+  texture: texture201,
+  mipLevel: 2,
+  origin: { x: 819, y: 0, z: 16 },
+  aspect: 'all',
+}, {width: 127, height: 0, depthOrArrayLayers: 98});
+} catch {}
+try {
+computePassEncoder37.insertDebugMarker('\u754c');
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend(canvas5);
+let img71 = await imageWithData(61, 286, '#0bf66a4b', '#f1709965');
+let videoFrame49 = new VideoFrame(offscreenCanvas4, {timestamp: 0});
+let texture202 = device9.createTexture({
+label: '\u{1f836}\u{1f780}\u00c4\ubd26\u9ad6',
+size: [2304, 1, 104],
+mipLevelCount: 2,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [],
+});
+let texture203 = gpuCanvasContext20.getCurrentTexture();
+let renderBundle142 = renderBundleEncoder106.finish({label: '\u8c84\u9c7a\u0865\u91bc\u{1fb45}\u0b60\uc843'});
+try {
+renderBundleEncoder81.draw(64, 32);
+} catch {}
+let pipeline118 = device9.createRenderPipeline({
+label: '\u0a6d\u0228\u0938\uc71b\u{1f8b4}\u6d76\u89d6\u03b3',
+layout: pipelineLayout19,
+multisample: {
+mask: 0xac58122e,
+},
+fragment: {
+  module: shaderModule31,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba16float', writeMask: 0}, {format: 'rg16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: 0}]
+},
+vertex: {
+  module: shaderModule31,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 3552,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x2',
+offset: 1340,
+shaderLocation: 19,
+}, {
+format: 'sint32x4',
+offset: 2228,
+shaderLocation: 21,
+}, {
+format: 'float32x2',
+offset: 3508,
+shaderLocation: 7,
+}, {
+format: 'sint32x4',
+offset: 668,
+shaderLocation: 17,
+}, {
+format: 'sint32',
+offset: 2172,
+shaderLocation: 9,
+}, {
+format: 'uint16x4',
+offset: 2364,
+shaderLocation: 6,
+}, {
+format: 'uint16x2',
+offset: 24,
+shaderLocation: 10,
+}, {
+format: 'uint32x4',
+offset: 1932,
+shaderLocation: 16,
+}, {
+format: 'snorm8x4',
+offset: 104,
+shaderLocation: 4,
+}, {
+format: 'snorm8x4',
+offset: 3232,
+shaderLocation: 3,
+}, {
+format: 'unorm8x2',
+offset: 2102,
+shaderLocation: 2,
+}, {
+format: 'sint16x2',
+offset: 724,
+shaderLocation: 20,
+}],
+},
+{
+arrayStride: 14628,
+attributes: [{
+format: 'float32x2',
+offset: 1664,
+shaderLocation: 5,
+}, {
+format: 'sint32',
+offset: 11992,
+shaderLocation: 14,
+}, {
+format: 'float32x2',
+offset: 8704,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 10688,
+attributes: [{
+format: 'sint16x2',
+offset: 4652,
+shaderLocation: 18,
+}, {
+format: 'unorm10-10-10-2',
+offset: 8268,
+shaderLocation: 12,
+}, {
+format: 'uint32x3',
+offset: 9572,
+shaderLocation: 15,
+}, {
+format: 'unorm16x4',
+offset: 1000,
+shaderLocation: 11,
+}, {
+format: 'sint32x3',
+offset: 3988,
+shaderLocation: 0,
+}, {
+format: 'uint16x2',
+offset: 4604,
+shaderLocation: 22,
+}, {
+format: 'sint8x2',
+offset: 8926,
+shaderLocation: 23,
+}, {
+format: 'unorm10-10-10-2',
+offset: 6044,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 4616,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 43632,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 28696,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 40760,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x2',
+offset: 37176,
+shaderLocation: 8,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let offscreenCanvas49 = new OffscreenCanvas(211, 873);
+try {
+offscreenCanvas49.getContext('webgpu');
+} catch {}
+let texture204 = device20.createTexture({
+label: '\u{1f943}\u08fa\ue059\u6ba0\u{1f632}',
+size: {width: 3631, height: 107, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder136 = device20.createRenderBundleEncoder({
+  label: '\u26c3\u0619\u8404\u7c41\u040f\u0b50\u8367\u0721\u046e\u{1f7c3}\u03b2',
+  colorFormats: ['r32uint', undefined, 'rgba32float', 'rgba16uint'],
+  sampleCount: 1,
+  stencilReadOnly: true
+});
+let renderBundle143 = renderBundleEncoder136.finish({label: '\u0334\u{1fb25}\u040d\u63f5\u19f8\u07eb\u{1f9df}\u3c6b\u{1fa3e}'});
+try {
+device20.addEventListener('uncapturederror', e => { log('device20.uncapturederror'); log(e); e.label = device20.label; });
+} catch {}
+try {
+device20.queue.writeTexture({
+  texture: texture204,
+  mipLevel: 0,
+  origin: { x: 341, y: 53, z: 1 },
+  aspect: 'all',
+}, new DataView(arrayBuffer10), /* required buffer size: 303 */
+{offset: 303, bytesPerRow: 11982}, {width: 2930, height: 26, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout71 = device18.createBindGroupLayout({
+label: '\u6e54\u3008\u3227\u073e\u6df1\u{1f851}\u4bd0\u4696\u{1fad6}',
+entries: [],
+});
+try {
+device18.pushErrorScope('internal');
+} catch {}
+try {
+  await buffer75.mapAsync(GPUMapMode.READ, 0, 8560);
+} catch {}
+try {
+await device18.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline119 = await device18.createComputePipelineAsync({
+label: '\u{1fb13}\uc4bf\u0634\u0850\ub537\u{1f85a}\u0f1f\u33eb',
+layout: pipelineLayout39,
+compute: {
+module: shaderModule40,
+entryPoint: 'compute0',
+},
+});
+let canvas50 = document.createElement('canvas');
+let querySet137 = device14.createQuerySet({
+type: 'occlusion',
+count: 2502,
+});
+let texture205 = device14.createTexture({
+label: '\u{1fbd0}\ub3dc\u{1f65a}\udd11\uf936\u0d18\u432d\u6154',
+size: [420, 20, 156],
+mipLevelCount: 6,
+format: 'astc-4x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-4x4-unorm'],
+});
+let sampler128 = device14.createSampler({
+label: '\u43ec\u0eba\u05a0\u020b\u{1f810}\u70ba\u{1fcd0}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 74.948,
+lodMaxClamp: 89.173,
+});
+try {
+buffer62.destroy();
+} catch {}
+try {
+gpuCanvasContext15.configure({
+device: device14,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+canvas50.getContext('webgpu');
+} catch {}
+let texture206 = device15.createTexture({
+label: '\u0b0c\u95ed\u{1f862}\u4963\u3ce5\u0a95\uabcf\ub45d\u6942\u00b4\u39ab',
+size: [2840, 1, 255],
+mipLevelCount: 10,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['bgra8unorm', 'bgra8unorm-srgb'],
+});
+try {
+gpuCanvasContext38.unconfigure();
+} catch {}
+let bindGroupLayout72 = device15.createBindGroupLayout({
+label: '\u04f5\uddd7\u087c\uf8e1\u{1ff46}',
+entries: [{
+binding: 1063,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+}, {
+binding: 7150,
+visibility: GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}, {
+binding: 412,
+visibility: 0,
+externalTexture: {},
+}],
+});
+let texture207 = device15.createTexture({
+size: {width: 320, height: 240, depthOrArrayLayers: 124},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgb9e5ufloat', 'rgb9e5ufloat'],
+});
+let textureView165 = texture197.createView({label: '\ubb9b\uef0c\u10fb', baseMipLevel: 5});
+let sampler129 = device15.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 3.503,
+});
+let pipeline120 = await device15.createComputePipelineAsync({
+label: '\ue341\u{1f787}\u82b6\u5baa\uc32c\u09b3\u073b\u1050\u8dc3',
+layout: pipelineLayout32,
+compute: {
+module: shaderModule39,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline121 = await device15.createRenderPipelineAsync({
+label: '\u{1fe7a}\u08d8\ud5b3\u{1fd11}',
+layout: pipelineLayout32,
+multisample: {
+count: 4,
+mask: 0x166aed2b,
+},
+fragment: {
+  module: shaderModule37,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: 0}, {format: 'rgba16sint', writeMask: GPUColorWrite.RED}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+vertex: {
+  module: shaderModule37,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 14976,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x4',
+offset: 5480,
+shaderLocation: 5,
+}, {
+format: 'float16x4',
+offset: 3336,
+shaderLocation: 9,
+}, {
+format: 'sint8x2',
+offset: 3838,
+shaderLocation: 14,
+}, {
+format: 'uint16x4',
+offset: 7844,
+shaderLocation: 1,
+}, {
+format: 'snorm16x2',
+offset: 9004,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 18276,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x2',
+offset: 2960,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+cullMode: 'back',
+},
+});
+try {
+window.someLabel = texture183.label;
+} catch {}
+let querySet138 = device13.createQuerySet({
+label: '\ua1bf\u8593\u{1f95e}\ufa1b',
+type: 'occlusion',
+count: 761,
+});
+let renderBundleEncoder137 = device13.createRenderBundleEncoder({
+  label: '\u5d6d\u227c',
+  colorFormats: ['rg8sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  stencilReadOnly: true
+});
+let renderBundle144 = renderBundleEncoder119.finish({label: '\ue237\u{1fa2e}\u7d57'});
+let renderBundleEncoder138 = device20.createRenderBundleEncoder({
+  label: '\u{1f69a}\u0737\u1d27\u{1fb61}\ufa20\u{1f8f6}\u3bdd\ubd7c\ud0dd\ub14f\u{1fd6f}',
+  colorFormats: ['rg8uint', 'rgb10a2unorm'],
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder138.setVertexBuffer(10, undefined, 2365584549, 495518058);
+} catch {}
+let imageData46 = new ImageData(156, 60);
+let buffer79 = device7.createBuffer({
+  label: '\u69df\u{1f976}\ue37c\u0d96\u0e42\u{1f7dc}\u{1f94b}\u7afe\u0162',
+  size: 50751,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false
+});
+let renderBundle145 = renderBundleEncoder74.finish({label: '\u0e09\u{1fc6a}\u0541\uea14\u4790'});
+try {
+renderBundleEncoder135.setBindGroup(3, bindGroup49);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+device: device7,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+alphaMode: 'premultiplied',
+});
+} catch {}
+let canvas51 = document.createElement('canvas');
+let gpuCanvasContext54 = canvas51.getContext('webgpu');
+let querySet139 = device17.createQuerySet({
+label: '\ud2a1\u0192\u6963',
+type: 'occlusion',
+count: 3932,
+});
+let texture208 = device17.createTexture({
+label: '\u6ea9\u{1fb7c}\u5e01\u60aa\u4626\u9af3\u34f0\u0f01\u0f82',
+size: [1536, 480, 168],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rg8sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg8sint', 'rg8sint'],
+});
+let sampler130 = device17.createSampler({
+label: '\u{1ff3b}\u0849\u03dd\u6ec2\u0b2d\u{1f879}\u06ff\u4ed8\uf72a\u{1f660}',
+addressModeW: 'clamp-to-edge',
+lodMinClamp: 93.967,
+lodMaxClamp: 97.277,
+});
+let texture209 = device20.createTexture({
+label: '\u4bc9\u3256\uaa97\u{1fccb}\u{1fe4d}\u36b4\u{1f9ca}\u97de\u{1f789}',
+size: {width: 8561, height: 27, depthOrArrayLayers: 1},
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r32sint', 'r32sint'],
+});
+let renderBundle146 = renderBundleEncoder138.finish({label: '\u4f7c\u0981\u00ab\u05d1'});
+let sampler131 = device20.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 46.707,
+lodMaxClamp: 93.759,
+});
+try {
+device20.queue.writeTexture({
+  texture: texture204,
+  mipLevel: 1,
+  origin: { x: 417, y: 2, z: 0 },
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer5), /* required buffer size: 19894 */
+{offset: 291, bytesPerRow: 3307}, {width: 767, height: 6, depthOrArrayLayers: 1});
+} catch {}
+let bindGroupLayout73 = device16.createBindGroupLayout({
+label: '\u{1fe1e}\u0fe5',
+entries: [],
+});
+let bindGroup61 = device16.createBindGroup({
+label: '\u72b9\uffa2\ue4bf\ue7bd\u296e\u{1fe66}\ue883\ub60e\u{1fda4}\ubd9b',
+layout: bindGroupLayout73,
+entries: [],
+});
+let textureView166 = texture193.createView({label: '\u4dcf\uab16\u0d0c\u006e', baseMipLevel: 1});
+try {
+computePassEncoder63.setBindGroup(6, bindGroup61, new Uint32Array(6889), 6497, 0);
+} catch {}
+let imageBitmap52 = await createImageBitmap(imageBitmap13);
+try {
+commandEncoder74.copyTextureToTexture({
+  texture: texture161,
+  mipLevel: 3,
+  origin: { x: 144, y: 12, z: 63 },
+  aspect: 'all',
+}, {
+  texture: texture161,
+  mipLevel: 3,
+  origin: { x: 228, y: 0, z: 5 },
+  aspect: 'all',
+}, {width: 732, height: 0, depthOrArrayLayers: 57});
+} catch {}
+let commandEncoder127 = device16.createCommandEncoder();
+let textureView167 = texture150.createView({
+  label: '\ub030\u{1f697}\u4321\ub549\u{1f7b4}\u60ad\u{1f6fa}\u{1f7fd}\u024a',
+  format: 'bgra8unorm',
+  mipLevelCount: 1
+});
+let sampler132 = device16.createSampler({
+label: '\u024b\ub26b\u6268',
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+lodMinClamp: 67.963,
+lodMaxClamp: 87.395,
+});
+try {
+commandEncoder127.copyBufferToBuffer(buffer68, 18388, buffer61, 31640, 2496);
+dissociateBuffer(device16, buffer68);
+dissociateBuffer(device16, buffer61);
+} catch {}
+try {
+gpuCanvasContext42.configure({
+device: device16,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let canvas52 = document.createElement('canvas');
+let pipelineLayout44 = device11.createPipelineLayout({
+  label: '\u0443\u2f94\u0872\ubd38\u{1f65b}\ufa63\u{1f716}\u09c7\u032c\u7290\u46cb',
+  bindGroupLayouts: [bindGroupLayout40]
+});
+let renderBundleEncoder139 = device11.createRenderBundleEncoder({colorFormats: ['rgba8sint'], sampleCount: 4, depthReadOnly: true, stencilReadOnly: true});
+let renderBundle147 = renderBundleEncoder139.finish({label: '\u1993\u{1f8f0}\ubf93\u03d2\u9d81\u05c3\u0875\u474d\u9ee8'});
+let sampler133 = device11.createSampler({
+label: '\u0db9\u0e31',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 29.082,
+lodMaxClamp: 54.154,
+maxAnisotropy: 14,
+});
+try {
+computePassEncoder60.setBindGroup(3, bindGroup40, new Uint32Array(7008), 3233, 0);
+} catch {}
+try {
+computePassEncoder71.end();
+} catch {}
+try {
+renderBundleEncoder93.setBindGroup(2, bindGroup40, new Uint32Array(5339), 3473, 0);
+} catch {}
+let arrayBuffer17 = buffer50.getMappedRange();
+try {
+commandEncoder114.copyBufferToBuffer(buffer45, 4040, buffer50, 23212, 968);
+dissociateBuffer(device11, buffer45);
+dissociateBuffer(device11, buffer50);
+} catch {}
+let video54 = await videoWithData();
+let bindGroup62 = device14.createBindGroup({
+layout: bindGroupLayout57,
+entries: [],
+});
+let pipelineLayout45 = device14.createPipelineLayout({label: '\u2b02\u03e0', bindGroupLayouts: [bindGroupLayout57, bindGroupLayout57, bindGroupLayout57]});
+pseudoSubmit(device14, commandEncoder123);
+let texture210 = device14.createTexture({
+label: '\ua97f\u0311\u{1fa8a}\u062d\u{1fda6}\udbe9',
+size: [1210, 1, 216],
+mipLevelCount: 10,
+format: 'rgba16uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16uint'],
+});
+let sampler134 = device14.createSampler({
+label: '\u0b7b\ue28f\ub33c\uce0a\ud4fd\u7bba\uf214\u26c2\u{1f8f8}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 99.280,
+lodMaxClamp: 99.953,
+compare: 'never',
+});
+try {
+renderBundleEncoder134.setVertexBuffer(5, buffer78, 29644);
+} catch {}
+let imageData47 = new ImageData(92, 60);
+try {
+device20.label = '\u067b\u{1fe78}\ub80b\ub45c\ub2ad\u1213\u0258\uc919\u16b1';
+} catch {}
+try {
+await device20.queue.onSubmittedWorkDone();
+} catch {}
+offscreenCanvas31.height = 861;
+let bindGroupLayout74 = device11.createBindGroupLayout({
+label: '\u0db1\u8efb\u02b6\u{1f678}\u9b0d\u024c\u854f',
+entries: [{
+binding: 5381,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 910558, hasDynamicOffset: true },
+}, {
+binding: 677,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+}, {
+binding: 861,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+}],
+});
+let texture211 = device11.createTexture({
+label: '\uead7\ue84f\ufd48\ub18c\u0233\ua87e\u0a78\u{1fb1e}\u8b94\ub00f',
+size: {width: 38, height: 96, depthOrArrayLayers: 28},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg11b10ufloat', 'rg11b10ufloat'],
+});
+let renderBundleEncoder140 = device11.createRenderBundleEncoder({
+  label: '\u{1fac7}\u5cb0\u{1f7a4}\ua01b\u3d02\u9afe\u{1ff34}\u{1feb0}',
+  colorFormats: ['rgba8sint'],
+  sampleCount: 4
+});
+try {
+buffer49.unmap();
+} catch {}
+try {
+commandEncoder114.copyBufferToBuffer(buffer45, 3640, buffer50, 26292, 2184);
+dissociateBuffer(device11, buffer45);
+dissociateBuffer(device11, buffer50);
+} catch {}
+try {
+computePassEncoder54.insertDebugMarker('\u{1fc62}');
+} catch {}
+try {
+device11.queue.writeTexture({
+  texture: texture170,
+  mipLevel: 1,
+  origin: { x: 40, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer14, /* required buffer size: 679 */
+{offset: 679, bytesPerRow: 380, rowsPerImage: 294}, {width: 144, height: 24, depthOrArrayLayers: 0});
+} catch {}
+let promise90 = device11.queue.onSubmittedWorkDone();
+let canvas53 = document.createElement('canvas');
+try {
+canvas52.getContext('webgl');
+} catch {}
+try {
+device13.queue.writeTexture({
+  texture: texture185,
+  mipLevel: 1,
+  origin: { x: 35, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer12, /* required buffer size: 3114 */
+{offset: 170, bytesPerRow: 288}, {width: 20, height: 55, depthOrArrayLayers: 1});
+} catch {}
+let imageData48 = new ImageData(208, 144);
+try {
+renderBundleEncoder134.setBindGroup(1, bindGroup62);
+} catch {}
+try {
+computePassEncoder78.pushDebugGroup('\u0788');
+} catch {}
+let commandEncoder128 = device8.createCommandEncoder({label: '\u1a58\u24aa\u0ede\u0e10\u9aae\u300f'});
+try {
+  await buffer55.mapAsync(GPUMapMode.READ, 0, 12576);
+} catch {}
+try {
+commandEncoder128.clearBuffer(buffer55, 24996, 572);
+dissociateBuffer(device8, buffer55);
+} catch {}
+try {
+device8.queue.submit([
+]);
+} catch {}
+let adapter26 = await navigator.gpu.requestAdapter({
+});
+try {
+canvas53.getContext('webgl2');
+} catch {}
+let computePassEncoder80 = commandEncoder116.beginComputePass({label: '\u{1fd23}\u569a\ua70f\u{1fcd9}\u0cd3'});
+let sampler135 = device6.createSampler({
+label: '\u0bba\u0fcb\uc422\u420e\ua21d\u8e78',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 87.348,
+lodMaxClamp: 87.397,
+compare: 'less-equal',
+maxAnisotropy: 19,
+});
+try {
+commandEncoder92.copyTextureToTexture({
+  texture: texture93,
+  mipLevel: 3,
+  origin: { x: 12, y: 12, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture93,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline122 = await device6.createComputePipelineAsync({
+label: '\u0a58\u1be8\u075a\u68ac\u2221\ubfa1\uee83\u0ceb',
+layout: pipelineLayout20,
+compute: {
+module: shaderModule38,
+entryPoint: 'compute0',
+},
+});
+let pipeline123 = await device6.createRenderPipelineAsync({
+label: '\u0217\u0651\u71ff\uad94\uaa33',
+layout: pipelineLayout24,
+multisample: {
+count: 4,
+mask: 0x9d867ec0,
+},
+fragment: {
+  module: shaderModule27,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'one-minus-dst-alpha'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {format: 'rg16sint'}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {
+  format: 'rg32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, undefined, {format: 'r16float', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'rgb10a2unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'one-minus-dst'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}]
+},
+vertex: {
+  module: shaderModule27,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 22760,
+shaderLocation: 20,
+}, {
+format: 'sint32x3',
+offset: 15236,
+shaderLocation: 23,
+}, {
+format: 'unorm10-10-10-2',
+offset: 15588,
+shaderLocation: 1,
+}, {
+format: 'unorm16x2',
+offset: 33268,
+shaderLocation: 7,
+}, {
+format: 'uint16x4',
+offset: 22796,
+shaderLocation: 12,
+}, {
+format: 'uint32x4',
+offset: 6160,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 0,
+attributes: [{
+format: 'sint32x4',
+offset: 20308,
+shaderLocation: 14,
+}, {
+format: 'unorm10-10-10-2',
+offset: 7828,
+shaderLocation: 22,
+}, {
+format: 'uint8x2',
+offset: 25448,
+shaderLocation: 19,
+}, {
+format: 'snorm16x4',
+offset: 2628,
+shaderLocation: 6,
+}, {
+format: 'sint32',
+offset: 26736,
+shaderLocation: 0,
+}, {
+format: 'uint16x2',
+offset: 19360,
+shaderLocation: 11,
+}, {
+format: 'float32x2',
+offset: 26956,
+shaderLocation: 21,
+}, {
+format: 'sint8x2',
+offset: 19248,
+shaderLocation: 17,
+}, {
+format: 'sint16x4',
+offset: 6652,
+shaderLocation: 18,
+}, {
+format: 'sint32x4',
+offset: 2096,
+shaderLocation: 13,
+}, {
+format: 'unorm10-10-10-2',
+offset: 4488,
+shaderLocation: 15,
+}, {
+format: 'snorm16x4',
+offset: 19888,
+shaderLocation: 16,
+}, {
+format: 'snorm8x4',
+offset: 29136,
+shaderLocation: 8,
+}],
+}
+]
+},
+});
+let video55 = await videoWithData();
+let pipelineLayout46 = device6.createPipelineLayout({
+  label: '\u0846\uec96\ue1a0\u9256\u1489\u0e2e\u7b36\ud5cb',
+  bindGroupLayouts: [bindGroupLayout44, bindGroupLayout48, bindGroupLayout48, bindGroupLayout36, bindGroupLayout48, bindGroupLayout48]
+});
+let querySet140 = device6.createQuerySet({
+label: '\ud94a\u4d21\u97b1\u00ea\u{1ff22}\ueb34\u0684',
+type: 'occlusion',
+count: 831,
+});
+try {
+renderBundleEncoder111.setVertexBuffer(28, undefined, 1287044521);
+} catch {}
+try {
+commandEncoder92.resolveQuerySet(querySet105, 652, 428, buffer38, 512);
+} catch {}
+canvas38.width = 181;
+gc();
+let texture212 = device7.createTexture({
+label: '\u0046\u0b92\u{1f9a0}\ue2ef\u06fb\u{1f6a3}\u071a',
+size: [96, 8, 218],
+mipLevelCount: 6,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView168 = texture151.createView({});
+try {
+device7.queue.submit([
+]);
+} catch {}
+let videoFrame50 = new VideoFrame(video1, {timestamp: 0});
+try {
+  await promise90;
+} catch {}
+let textureView169 = texture113.createView({
+  label: '\ue124\u0462\udcb8\u8650\ucfc0\uc5b1\u83e6\u08e7\u{1f90e}\u{1fb36}',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+  mipLevelCount: 2,
+  arrayLayerCount: 1
+});
+let renderBundle148 = renderBundleEncoder106.finish();
+try {
+buffer37.destroy();
+} catch {}
+video21.height = 231;
+let querySet141 = device12.createQuerySet({
+label: '\ufb2b\ub936\u{1f8e3}\ub4a8\u29a8\u0fa0\u05d8\ue28b',
+type: 'occlusion',
+count: 541,
+});
+let renderBundleEncoder141 = device12.createRenderBundleEncoder({
+  colorFormats: ['r16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle149 = renderBundleEncoder115.finish({label: '\u7f94\u{1f6a9}\u7130'});
+try {
+computePassEncoder51.insertDebugMarker('\u0d63');
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let sampler136 = device20.createSampler({
+label: '\u01b2\uedf7\ud87e\u09fa\u4dad\u8f1b\u{1f62d}\u2e0f\uabc7',
+addressModeU: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 6.472,
+lodMaxClamp: 79.916,
+maxAnisotropy: 20,
+});
+try {
+await device20.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderBundleEncoder116.setVertexBuffer(83, undefined);
+} catch {}
+try {
+commandEncoder92.resolveQuerySet(querySet124, 757, 276, buffer38, 4352);
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture112,
+  mipLevel: 0,
+  origin: { x: 1464, y: 0, z: 81 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 4632757 */
+{offset: 505, bytesPerRow: 10433, rowsPerImage: 12}, {width: 2591, height: 0, depthOrArrayLayers: 38});
+} catch {}
+let imageData49 = new ImageData(248, 60);
+let renderBundleEncoder142 = device20.createRenderBundleEncoder({
+  label: '\u0a2f\u24a2\u5877\u03ec\u5eb4\u062c\ua696\u{1fea4}\u0c17',
+  colorFormats: ['rg8uint', 'rgb10a2unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+device20.queue.writeTexture({
+  texture: texture204,
+  mipLevel: 0,
+  origin: { x: 584, y: 8, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(72), /* required buffer size: 111128 */
+{offset: 684, bytesPerRow: 12303}, {width: 3005, height: 9, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup63 = device8.createBindGroup({
+label: '\u4ef6\u{1fd77}\u8f3b\u08ec\u6997\u06b2',
+layout: bindGroupLayout35,
+entries: [],
+});
+let computePassEncoder81 = commandEncoder128.beginComputePass({});
+try {
+computePassEncoder56.setBindGroup(4, bindGroup55, new Uint32Array(4201), 3405, 0);
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+let texture213 = device12.createTexture({
+label: '\uf7e9\uee58',
+size: {width: 360, height: 1, depthOrArrayLayers: 164},
+mipLevelCount: 7,
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['rg32sint', 'rg32sint', 'rg32sint'],
+});
+let textureView170 = texture128.createView({label: '\u834a\ue4f3', baseMipLevel: 2, mipLevelCount: 2});
+try {
+device12.queue.writeTexture({
+  texture: texture128,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint16Array(new ArrayBuffer(80)), /* required buffer size: 253 */
+{offset: 253, rowsPerImage: 11}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img72 = await imageWithData(268, 23, '#2cef5250', '#a5003c6d');
+let device21 = await promise71;
+let querySet142 = device21.createQuerySet({
+label: '\u754a\u818e\uf3af',
+type: 'occlusion',
+count: 1788,
+});
+let renderBundleEncoder143 = device21.createRenderBundleEncoder({
+  label: '\u73bf\u38a6\u03bd\u0d53\u{1f8c0}\udc51\u00a2',
+  colorFormats: ['r32float', 'r16uint', 'rgba8unorm', 'rg8uint', 'r8uint', 'rg8unorm', 'rg8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle150 = renderBundleEncoder143.finish({label: '\uc35c\u{1f803}\u2572\u040c\u0f3e\u0638'});
+let imageData50 = new ImageData(152, 208);
+let commandBuffer21 = commandEncoder112.finish({
+});
+let renderBundle151 = renderBundleEncoder130.finish({label: '\u333e\u3dda\u0294\ufc22\u{1fb4c}\u5cce'});
+let sampler137 = device13.createSampler({
+label: '\u6902\u97c2\u{1fe34}\u0f1c',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 27.285,
+lodMaxClamp: 79.658,
+compare: 'never',
+maxAnisotropy: 7,
+});
+try {
+device13.pushErrorScope('internal');
+} catch {}
+try {
+buffer66.destroy();
+} catch {}
+try {
+device13.queue.submit([
+]);
+} catch {}
+let texture214 = device14.createTexture({
+label: '\ua35f\u0ecc\ufe45\u{1f9a6}\u4540\uf68b\u8623\ufc44\u{1fc14}\ue379\u{1fabc}',
+size: {width: 1680, height: 80, depthOrArrayLayers: 234},
+mipLevelCount: 5,
+sampleCount: 1,
+format: 'etc2-rgba8unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder144 = device14.createRenderBundleEncoder({label: '\u4a90\u0922\u2131\uecb2\u{1fcd6}\ub467\u{1f7dd}', colorFormats: ['rgba8sint']});
+let renderBundle152 = renderBundleEncoder144.finish({label: '\u0d8d\u{1febf}\u4d8a\u{1f8e9}\u0f65\ud439\u9bb2\u6cca'});
+try {
+renderBundleEncoder134.setBindGroup(3, bindGroup62);
+} catch {}
+let canvas54 = document.createElement('canvas');
+let buffer80 = device19.createBuffer({
+  label: '\u7dc6\u{1faf7}\u0957\udb07\u0473\uc0c7',
+  size: 30442,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let texture215 = device19.createTexture({
+label: '\u{1fa2b}\uba60\u9ca5\u9eaf\uad9f\u4363',
+size: [936, 1, 1],
+mipLevelCount: 7,
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgb9e5ufloat', 'rgb9e5ufloat'],
+});
+let texture216 = gpuCanvasContext3.getCurrentTexture();
+let textureView171 = texture177.createView({
+  label: '\u2574\u0b9c\u4407\u3b0a\u{1f743}\u0b16\u0672\u{1fc70}\u31f6\u5988\u{1fee9}',
+  baseArrayLayer: 0
+});
+try {
+commandEncoder125.copyTextureToBuffer({
+  texture: texture215,
+  mipLevel: 1,
+  origin: { x: 12, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 1820 widthInBlocks: 455 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 7328 */
+offset: 7328,
+buffer: buffer80,
+}, {width: 455, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device19, buffer80);
+} catch {}
+document.body.prepend(video30);
+let canvas55 = document.createElement('canvas');
+let img73 = await imageWithData(93, 114, '#57383fa7', '#f054bcb4');
+gc();
+let bindGroupLayout75 = device11.createBindGroupLayout({
+label: '\u{1f6f9}\ub9f5\u9e16\u72fc\u3d49',
+entries: [{
+binding: 4900,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+try {
+device11.pushErrorScope('validation');
+} catch {}
+let promise91 = buffer49.mapAsync(GPUMapMode.WRITE, 0, 23928);
+try {
+device11.queue.submit([
+commandBuffer17,
+]);
+} catch {}
+try {
+device11.queue.writeTexture({
+  texture: texture175,
+  mipLevel: 1,
+  origin: { x: 19, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer11, /* required buffer size: 196 */
+{offset: 184, rowsPerImage: 15}, {width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+offscreenCanvas27.width = 373;
+let canvas56 = document.createElement('canvas');
+try {
+renderBundleEncoder133.setBindGroup(3, bindGroup60, []);
+} catch {}
+try {
+device19.queue.writeTexture({
+  texture: texture215,
+  mipLevel: 0,
+  origin: { x: 192, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 652 */
+{offset: 652}, {width: 531, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet143 = device8.createQuerySet({
+label: '\u{1fb08}\u153a\u{1fd00}\u{1f900}\u{1f987}',
+type: 'occlusion',
+count: 3484,
+});
+try {
+renderBundleEncoder77.setVertexBuffer(99, undefined, 1384936263);
+} catch {}
+try {
+renderBundleEncoder77.pushDebugGroup('\u40f3');
+} catch {}
+try {
+renderBundleEncoder77.popDebugGroup();
+} catch {}
+let gpuCanvasContext55 = canvas55.getContext('webgpu');
+let canvas57 = document.createElement('canvas');
+try {
+canvas54.getContext('webgl2');
+} catch {}
+let video56 = await videoWithData();
+let imageData51 = new ImageData(156, 140);
+try {
+  await promise91;
+} catch {}
+try {
+computePassEncoder36.insertDebugMarker('\u0ba7');
+} catch {}
+let pipeline124 = device6.createRenderPipeline({
+label: '\u990e\u{1f659}\ueb50\u{1fcb9}\u3b98\u3307\u{1f8cf}\u{1fdec}\u8a85\udb62',
+layout: pipelineLayout33,
+fragment: {
+  module: shaderModule33,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN
+}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'one-minus-dst'},
+alpha: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-dst'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rg32float'}, undefined, {
+  format: 'r16float',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'src'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.BLUE
+}, {
+  format: 'rgb10a2unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'zero'},
+},
+  writeMask: 0
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater-equal',
+depthFailOp: 'decrement-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 357,
+stencilWriteMask: 3041,
+depthBiasSlopeScale: 46,
+depthBiasClamp: 31,
+},
+vertex: {module: shaderModule33, entryPoint: 'vertex0', buffers: [
+
+]},
+primitive: {
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let imageData52 = new ImageData(236, 52);
+let videoFrame51 = new VideoFrame(offscreenCanvas44, {timestamp: 0});
+try {
+canvas56.getContext('2d');
+} catch {}
+try {
+canvas57.getContext('bitmaprenderer');
+} catch {}
+let renderBundle153 = renderBundleEncoder74.finish({label: '\u{1fa23}\ub8de\u0693\u0573\u0c63\u6b79\u0597\u9d57\u058e\u{1ffe1}\u{1f8ef}'});
+try {
+renderBundleEncoder135.setVertexBuffer(6, buffer79, 26012, 13484);
+} catch {}
+try {
+commandEncoder95.copyBufferToBuffer(buffer54, 45044, buffer34, 18144, 6288);
+dissociateBuffer(device7, buffer54);
+dissociateBuffer(device7, buffer34);
+} catch {}
+try {
+commandEncoder126.clearBuffer(buffer34, 4540, 9184);
+dissociateBuffer(device7, buffer34);
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture151,
+  mipLevel: 0,
+  origin: { x: 3927, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer11), /* required buffer size: 11242 */
+{offset: 762, bytesPerRow: 10758}, {width: 1310, height: 1, depthOrArrayLayers: 1});
+} catch {}
+offscreenCanvas1.height = 618;
+let img74 = await imageWithData(149, 226, '#58eea68f', '#8b5ad992');
+let textureView172 = texture208.createView({label: '\u{1ff89}\u31d1\u931c\u1ac4\u6eb9', baseMipLevel: 3});
+try {
+buffer69.unmap();
+} catch {}
+try {
+gpuCanvasContext27.configure({
+device: device17,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+window.someLabel = device16.label;
+} catch {}
+let textureView173 = texture139.createView({
+  label: '\u{1fb7c}\u{1fdea}\u6591\uad40\u48f0\u{1fe41}\u{1fa71}\ub240\u027d',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  mipLevelCount: 4,
+  baseArrayLayer: 2
+});
+let computePassEncoder82 = commandEncoder127.beginComputePass({label: '\u{1f844}\u07ef\ub4d3\u{1fd8e}\u{1fd21}\u0576'});
+let sampler138 = device16.createSampler({
+label: '\u526f\u855a\u0dbe\u5eea\u193e\ucb57\u047d\u00e0\u{1fb58}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 43.883,
+lodMaxClamp: 53.801,
+});
+try {
+device16.queue.writeTexture({
+  texture: texture150,
+  mipLevel: 0,
+  origin: { x: 906, y: 0, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(571), /* required buffer size: 571 */
+{offset: 571}, {width: 1604, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle154 = renderBundleEncoder82.finish({});
+try {
+renderBundleEncoder141.setBindGroup(3, bindGroup43);
+} catch {}
+try {
+device12.queue.writeTexture({
+  texture: texture190,
+  mipLevel: 1,
+  origin: { x: 78, y: 24, z: 0 },
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(72)), /* required buffer size: 802 */
+{offset: 802, bytesPerRow: 379}, {width: 30, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let sampler139 = device13.createSampler({
+addressModeV: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 48.940,
+lodMaxClamp: 93.120,
+});
+try {
+computePassEncoder73.setPipeline(pipeline101);
+} catch {}
+let promise92 = device13.createRenderPipelineAsync({
+label: '\u5e9c\u{1fa50}\u{1fd63}\u7bfe\u6d48\u{1f73d}\u7e23\u{1f8bb}\u2756',
+layout: pipelineLayout34,
+multisample: {
+count: 4,
+},
+vertex: {
+  module: shaderModule30,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 12656,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32',
+offset: 2104,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 10900,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 10516,
+shaderLocation: 0,
+}, {
+format: 'float16x4',
+offset: 6692,
+shaderLocation: 19,
+}, {
+format: 'unorm8x2',
+offset: 8738,
+shaderLocation: 24,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let canvas58 = document.createElement('canvas');
+let imageBitmap53 = await createImageBitmap(imageBitmap19);
+let querySet144 = device13.createQuerySet({
+label: '\u0955\u0aad\u0360\u{1f6aa}\u04f0',
+type: 'occlusion',
+count: 2993,
+});
+try {
+renderBundleEncoder118.setVertexBuffer(56, undefined, 4081049771, 187847934);
+} catch {}
+try {
+commandEncoder94.copyTextureToTexture({
+  texture: texture155,
+  mipLevel: 2,
+  origin: { x: 0, y: 10, z: 66 },
+  aspect: 'all',
+}, {
+  texture: texture155,
+  mipLevel: 1,
+  origin: { x: 12, y: 0, z: 72 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 25});
+} catch {}
+let gpuCanvasContext56 = canvas58.getContext('webgpu');
+canvas29.width = 384;
+let canvas59 = document.createElement('canvas');
+let bindGroup64 = device19.createBindGroup({
+layout: bindGroupLayout70,
+entries: [],
+});
+let querySet145 = device19.createQuerySet({
+label: '\u01cb\u0eaa\u4b37\u4a41',
+type: 'occlusion',
+count: 3439,
+});
+let textureView174 = texture215.createView({
+  label: '\u{1f9e3}\ubdee\u05df\u3102\u82e7\ua35f\u3be8\u071a\u06e0\uc9d6\u0762',
+  baseMipLevel: 2,
+  mipLevelCount: 2
+});
+let promise93 = device19.popErrorScope();
+try {
+  await promise93;
+} catch {}
+let offscreenCanvas50 = new OffscreenCanvas(101, 305);
+let imageBitmap54 = await createImageBitmap(imageBitmap5);
+try {
+canvas59.getContext('bitmaprenderer');
+} catch {}
+let imageBitmap55 = await createImageBitmap(img71);
+let gpuCanvasContext57 = offscreenCanvas50.getContext('webgpu');
+gc();
+let img75 = await imageWithData(294, 215, '#452b72a8', '#0fdad053');
+try {
+buffer80.unmap();
+} catch {}
+try {
+device19.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img67,
+  origin: { x: 157, y: 57 },
+  flipY: true,
+}, {
+  texture: texture216,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder145 = device18.createRenderBundleEncoder({
+  label: '\u6fa2\u0d72\u0564\ua00e',
+  colorFormats: ['rgba8uint', 'r16uint', 'rgba16float', 'rg32uint', undefined, 'rg8uint', 'rg8uint', undefined],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler140 = device18.createSampler({
+label: '\u00ab\u7092\u{1fd4c}\u7786\u06cc\u048c\u0438\u90a4\u{1f88d}\u{1fa8c}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 16.679,
+compare: 'greater',
+});
+try {
+renderBundleEncoder145.setVertexBuffer(7, undefined, 978217864);
+} catch {}
+let textureView175 = texture93.createView({dimension: '2d-array', baseMipLevel: 6});
+try {
+renderBundleEncoder108.setPipeline(pipeline124);
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture112,
+  mipLevel: 1,
+  origin: { x: 528, y: 0, z: 10 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer17), /* required buffer size: 52223249 */
+{offset: 1, bytesPerRow: 2024, rowsPerImage: 194}, {width: 493, height: 0, depthOrArrayLayers: 134});
+} catch {}
+let promise94 = navigator.gpu.requestAdapter({
+powerPreference: 'high-performance',
+});
+try {
+renderBundleEncoder145.setVertexBuffer(82, undefined, 4182001986, 34133342);
+} catch {}
+try {
+gpuCanvasContext55.configure({
+device: device18,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device18.queue.writeTexture({
+  texture: texture178,
+  mipLevel: 3,
+  origin: { x: 7, y: 1, z: 6 },
+  aspect: 'all',
+}, arrayBuffer16, /* required buffer size: 95807 */
+{offset: 503, bytesPerRow: 12, rowsPerImage: 38}, {width: 2, height: 0, depthOrArrayLayers: 210});
+} catch {}
+let pipeline125 = await device18.createComputePipelineAsync({
+label: '\u5b37\u00da\u0c13\u{1fb78}\u16b9\ua537\ua7db\ub88d',
+layout: pipelineLayout39,
+compute: {
+module: shaderModule40,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let texture217 = device14.createTexture({
+label: '\u{1fd58}\ubcdc\uef37\uceb0\ua642',
+size: {width: 1680},
+dimension: '1d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let renderBundle155 = renderBundleEncoder127.finish({label: '\u0347\u506c\ue098'});
+try {
+buffer78.unmap();
+} catch {}
+try {
+computePassEncoder78.popDebugGroup();
+} catch {}
+try {
+device14.queue.writeTexture({
+  texture: texture145,
+  mipLevel: 1,
+  origin: { x: 103, y: 0, z: 15 },
+  aspect: 'all',
+}, new Float32Array(arrayBuffer14), /* required buffer size: 5848033 */
+{offset: 439, bytesPerRow: 597, rowsPerImage: 118}, {width: 144, height: 1, depthOrArrayLayers: 84});
+} catch {}
+let adapter27 = await promise58;
+let commandEncoder129 = device11.createCommandEncoder({});
+let texture218 = device11.createTexture({
+size: [384, 60, 1],
+mipLevelCount: 2,
+format: 'astc-12x12-unorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-12x12-unorm-srgb', 'astc-12x12-unorm-srgb', 'astc-12x12-unorm'],
+});
+let renderBundle156 = renderBundleEncoder79.finish();
+let bindGroup65 = device14.createBindGroup({
+label: '\ue42d\u0eb0\u06de',
+layout: bindGroupLayout57,
+entries: [],
+});
+let commandEncoder130 = device14.createCommandEncoder({});
+let querySet146 = device14.createQuerySet({
+label: '\u{1f95d}\u576a\u07ad\u{1fd92}',
+type: 'occlusion',
+count: 1593,
+});
+pseudoSubmit(device14, commandEncoder130);
+let video57 = await videoWithData();
+let bindGroupLayout76 = device6.createBindGroupLayout({
+label: '\u6491\u0309',
+entries: [],
+});
+let buffer81 = device6.createBuffer({
+  label: '\u{1f92e}\u{1f6a1}\u7c17\u1627\u{1fb45}\u549e\ub86b\u3e7d\u{1f7ed}',
+  size: 10943,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM
+});
+let commandEncoder131 = device6.createCommandEncoder({label: '\u1c2d\u17e0\u1b98\u3d6a\u0601\u5d31\u{1f9b1}\u66c9\u042a'});
+let renderBundleEncoder146 = device6.createRenderBundleEncoder({
+  label: '\u0af7\u0ded\u7321\u1113\uf538\uc83b\u0400\u2ac5\uc459\u33b1',
+  colorFormats: ['rg8unorm', 'rg16sint', 'rgba8unorm-srgb', 'rg32float', undefined, 'r16float', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder146.insertDebugMarker('\u49b2');
+} catch {}
+let renderBundle157 = renderBundleEncoder133.finish();
+try {
+buffer65.destroy();
+} catch {}
+try {
+commandEncoder125.copyTextureToBuffer({
+  texture: texture215,
+  mipLevel: 0,
+  origin: { x: 3, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 3696 widthInBlocks: 924 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 8552 */
+offset: 4856,
+rowsPerImage: 205,
+buffer: buffer80,
+}, {width: 924, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device19, buffer80);
+} catch {}
+try {
+device19.queue.writeBuffer(buffer80, 18100, new Int16Array(14827), 5615, 4044);
+} catch {}
+try {
+device19.queue.writeTexture({
+  texture: texture216,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 63 */
+{offset: 63}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageData53 = new ImageData(164, 84);
+let commandEncoder132 = device12.createCommandEncoder({label: '\ub4eb\uee21\u05c8\ud906\u4182'});
+let commandBuffer22 = commandEncoder90.finish({
+label: '\u7cd3\u64fe\u9f94\u{1fa16}',
+});
+pseudoSubmit(device12, commandEncoder74);
+try {
+renderBundleEncoder99.setBindGroup(2, bindGroup57);
+} catch {}
+try {
+device12.queue.submit([
+]);
+} catch {}
+let video58 = await videoWithData();
+let querySet147 = device21.createQuerySet({
+label: '\u008d\u3646\u4449\u02fb\u{1fe48}\uf000\u052e',
+type: 'occlusion',
+count: 2661,
+});
+let renderBundleEncoder147 = device21.createRenderBundleEncoder({
+  label: '\u067c\u8cb2\u95e5\u03dd\u5693\u{1faab}\u0b88\u02f5\u2cd1\u9d8d',
+  colorFormats: ['r32float', 'r16uint', 'rgba8unorm', 'rg8uint', 'r8uint', 'rg8unorm', 'rg8uint'],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+try {
+gpuCanvasContext32.configure({
+device: device21,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+alphaMode: 'opaque',
+});
+} catch {}
+let adapter28 = await navigator.gpu.requestAdapter({
+});
+let bindGroupLayout77 = device15.createBindGroupLayout({
+label: '\ub659\u63f8\u9e58',
+entries: [{
+binding: 4261,
+visibility: 0,
+storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '3d' },
+}, {
+binding: 998,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}],
+});
+let commandEncoder133 = device15.createCommandEncoder({});
+let texture219 = device15.createTexture({
+label: '\u{1ff46}\u5d71\u04aa\ud5d4',
+size: {width: 80, height: 60, depthOrArrayLayers: 138},
+dimension: '3d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView176 = texture149.createView({
+  label: '\u072e\u{1fc56}\u2d39\u{1ffbd}\u1aa7\u{1fd7f}\u0b8b\u0a21\u024e\ubae9\u08d5',
+  dimension: '2d-array',
+  format: 'bgra8unorm-srgb'
+});
+let computePassEncoder83 = commandEncoder133.beginComputePass({});
+try {
+computePassEncoder83.setPipeline(pipeline113);
+} catch {}
+try {
+renderBundleEncoder124.setPipeline(pipeline117);
+} catch {}
+try {
+buffer76.unmap();
+} catch {}
+let imageData54 = new ImageData(116, 228);
+let renderBundleEncoder148 = device17.createRenderBundleEncoder({
+  label: '\ua8b3\u801d\u2a77\u{1fe03}\ud19f\u0f94\uf80e\u{1fb6d}\u7cd1\u69d8',
+  colorFormats: ['r8uint', 'r32sint'],
+  depthReadOnly: true
+});
+let imageBitmap56 = await createImageBitmap(imageData53);
+let promise95 = adapter8.requestAdapterInfo();
+try {
+device17.label = '\u6563\u{1fb41}\ubd15\u{1f855}\u724c\ubd56\u0989\u8c67\u0106';
+} catch {}
+let sampler141 = device17.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 70.670,
+lodMaxClamp: 81.762,
+maxAnisotropy: 1,
+});
+let renderBundle158 = renderBundleEncoder110.finish();
+let sampler142 = device16.createSampler({
+label: '\u37bb\u64dc\u3efb\uf1b5\ufac4',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 21.647,
+lodMaxClamp: 96.874,
+maxAnisotropy: 18,
+});
+let arrayBuffer18 = buffer74.getMappedRange(18384);
+try {
+  await promise95;
+} catch {}
+document.body.prepend(canvas5);
+let commandEncoder134 = device18.createCommandEncoder({label: '\uef0c\u2a22\u01c2\ub850\ucc1c\ua774\uf544\u3f70\u56fc\u0732\uc17e'});
+let computePassEncoder84 = commandEncoder134.beginComputePass();
+try {
+computePassEncoder84.end();
+} catch {}
+try {
+renderBundleEncoder145.insertDebugMarker('\u09ea');
+} catch {}
+let pipeline126 = await device18.createComputePipelineAsync({
+label: '\u{1ff39}\u{1fae1}\u09af\u6957\ua1b2\u0308',
+layout: pipelineLayout39,
+compute: {
+module: shaderModule40,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+gc();
+let imageBitmap57 = await createImageBitmap(canvas7);
+try {
+gpuCanvasContext42.unconfigure();
+} catch {}
+gc();
+let bindGroup66 = device11.createBindGroup({
+layout: bindGroupLayout40,
+entries: [],
+});
+let buffer82 = device11.createBuffer({
+  label: '\u3d73\u0430\u0ba5\ud8b5\u4cb6\u0a04',
+  size: 40313,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM
+});
+try {
+renderBundleEncoder140.setBindGroup(3, bindGroup40);
+} catch {}
+try {
+commandEncoder114.clearBuffer(buffer50);
+dissociateBuffer(device11, buffer50);
+} catch {}
+let commandEncoder135 = device7.createCommandEncoder({label: '\u3a3b\u{1f777}\u04ee\uc4b3\u8a73'});
+let video59 = await videoWithData();
+try {
+adapter12.label = '\u{1fdf9}\u01bd';
+} catch {}
+let bindGroupLayout78 = device17.createBindGroupLayout({
+label: '\u9f83\u68a9\u7fc1',
+entries: [{
+binding: 1038,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+}],
+});
+let commandEncoder136 = device16.createCommandEncoder({});
+let textureView177 = texture150.createView({
+  label: '\u{1f7f1}\u0e2d\u0d0b\u0445\u0f91\u2c8e\u0e05\uad66\u{1fb66}\u{1ff32}\u07c2',
+  format: 'bgra8unorm',
+  mipLevelCount: 1
+});
+let sampler143 = device16.createSampler({
+label: '\uaf26\ue681\u6dca\u0284\ue9c1\u8a20\u0b42\uc382\u{1f978}',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 99.131,
+lodMaxClamp: 99.693,
+maxAnisotropy: 9,
+});
+let arrayBuffer19 = buffer74.getMappedRange(0, 3988);
+try {
+buffer68.destroy();
+} catch {}
+try {
+commandEncoder136.clearBuffer(buffer61);
+dissociateBuffer(device16, buffer61);
+} catch {}
+try {
+await device16.queue.onSubmittedWorkDone();
+} catch {}
+let canvas60 = document.createElement('canvas');
+let commandEncoder137 = device11.createCommandEncoder({label: '\u0a59\u0408\u9d85\u{1fdda}\udcb6\u0aba\u5351\u0fc6'});
+let sampler144 = device11.createSampler({
+label: '\u076e\u{1f744}\ucc24\u02cb\ud498\u{1f94c}',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 37.316,
+lodMaxClamp: 79.727,
+maxAnisotropy: 6,
+});
+try {
+buffer47.destroy();
+} catch {}
+let imageData55 = new ImageData(32, 16);
+let querySet148 = device7.createQuerySet({
+label: '\u0091\u068f\u0d68\uef3a\u0f91\u1a2c\u{1ffc2}\ua66c\u0582\u{1f91e}',
+type: 'occlusion',
+count: 162,
+});
+let computePassEncoder85 = commandEncoder126.beginComputePass({label: '\ua6e4\ud916\u{1fa84}\u9170\u1ef3\u164a\u046b\u17e3\u{1fedc}\u49b1'});
+let sampler145 = device7.createSampler({
+label: '\u920f\u9f75\ua39d\u2943\ufe5a\u{1f7f1}\u64d7\ucb1c\u57c9',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 62.673,
+lodMaxClamp: 85.785,
+maxAnisotropy: 3,
+});
+try {
+renderBundleEncoder135.setVertexBuffer(8, buffer79, 50348, 379);
+} catch {}
+try {
+commandEncoder96.clearBuffer(buffer34, 4564, 7128);
+dissociateBuffer(device7, buffer34);
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture201,
+  mipLevel: 4,
+  origin: { x: 65, y: 0, z: 35 },
+  aspect: 'all',
+}, new ArrayBuffer(3993779), /* required buffer size: 3993779 */
+{offset: 971, bytesPerRow: 1367, rowsPerImage: 73}, {width: 73, height: 1, depthOrArrayLayers: 41});
+} catch {}
+try {
+await device7.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext58 = canvas60.getContext('webgpu');
+let commandEncoder138 = device21.createCommandEncoder({label: '\u01ee\u{1fa50}\uaf1b\u0c89\u{1fd82}\u7f38\u91c9\u{1fcbc}\u{1f867}'});
+let querySet149 = device21.createQuerySet({
+label: '\ud850\u{1f7ce}\u0748\u064f\u68e0\u{1fea3}\udbbe',
+type: 'occlusion',
+count: 4056,
+});
+let computePassEncoder86 = commandEncoder138.beginComputePass({label: '\u998f\u5d1a'});
+let promise96 = device21.queue.onSubmittedWorkDone();
+let commandEncoder139 = device13.createCommandEncoder();
+let renderBundle159 = renderBundleEncoder137.finish({label: '\udc59\u7dc6\u6559\u9c49\u17f9\u0a1d\u4de4'});
+try {
+renderBundleEncoder118.setVertexBuffer(34, undefined, 2730165003);
+} catch {}
+try {
+device13.queue.submit([
+]);
+} catch {}
+let pipeline127 = device13.createComputePipeline({
+label: '\u0ef2\uf2f2\u4384\u{1faaa}\ue781',
+layout: pipelineLayout27,
+compute: {
+module: shaderModule30,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let textureView178 = texture197.createView({label: '\u52fa\u1330\u0e18', baseMipLevel: 1, mipLevelCount: 3});
+try {
+computePassEncoder57.setPipeline(pipeline113);
+} catch {}
+try {
+renderBundleEncoder124.drawIndexed(0, 0, 72, 688, 0);
+} catch {}
+try {
+renderBundleEncoder104.setPipeline(pipeline117);
+} catch {}
+try {
+computePassEncoder57.insertDebugMarker('\u{1f68b}');
+} catch {}
+try {
+device15.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame18,
+  origin: { x: 8, y: 6 },
+  flipY: false,
+}, {
+  texture: texture198,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture220 = device11.createTexture({
+label: '\u94e3\u01a2\u05d4\u6a03\u2dc4\u08ca\u{1fbdc}\u8cb1\ub3c4',
+size: [542, 1, 18],
+mipLevelCount: 1,
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba32uint', 'rgba32uint', 'rgba32uint'],
+});
+let renderBundle160 = renderBundleEncoder140.finish();
+let sampler146 = device11.createSampler({
+label: '\u{1f6f7}\u{1f75f}\u084a\u{1f758}\ufae0\ua5d0\u{1fe02}\u0b28\u00db\u7cbe\u38c7',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMinClamp: 4.932,
+lodMaxClamp: 40.690,
+});
+try {
+renderBundleEncoder93.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+commandEncoder114.pushDebugGroup('\uf020');
+} catch {}
+try {
+gpuCanvasContext42.unconfigure();
+} catch {}
+let imageData56 = new ImageData(168, 48);
+try {
+device11.queue.writeTexture({
+  texture: texture220,
+  mipLevel: 0,
+  origin: { x: 16, y: 0, z: 5 },
+  aspect: 'all',
+}, arrayBuffer19, /* required buffer size: 25633767 */
+{offset: 463, bytesPerRow: 7978, rowsPerImage: 292}, {width: 498, height: 1, depthOrArrayLayers: 12});
+} catch {}
+gc();
+let offscreenCanvas51 = new OffscreenCanvas(462, 463);
+let imageData57 = new ImageData(164, 88);
+let videoFrame52 = new VideoFrame(video55, {timestamp: 0});
+let commandEncoder140 = device15.createCommandEncoder({label: '\u061a\u{1f720}\u36c5\udcf8\u0bc5\u9de2\u6cdd'});
+let textureView179 = texture149.createView({label: '\ubea8\u4ff6\u0e8b\u01fa\u16a7\u033d', format: 'bgra8unorm-srgb', mipLevelCount: 1});
+try {
+computePassEncoder83.setPipeline(pipeline120);
+} catch {}
+try {
+renderBundleEncoder104.drawIndexed(8, 48, 0, -312, 8);
+} catch {}
+try {
+commandEncoder140.copyBufferToBuffer(buffer72, 9616, buffer76, 31248, 844);
+dissociateBuffer(device15, buffer72);
+dissociateBuffer(device15, buffer76);
+} catch {}
+try {
+device15.queue.writeTexture({
+  texture: texture219,
+  mipLevel: 0,
+  origin: { x: 40, y: 7, z: 19 },
+  aspect: 'all',
+}, arrayBuffer15, /* required buffer size: 503756 */
+{offset: 148, bytesPerRow: 76, rowsPerImage: 220}, {width: 32, height: 27, depthOrArrayLayers: 31});
+} catch {}
+let gpuCanvasContext59 = offscreenCanvas51.getContext('webgpu');
+let videoFrame53 = new VideoFrame(imageBitmap1, {timestamp: 0});
+let commandEncoder141 = device6.createCommandEncoder({label: '\u043a\u{1f638}\u2b56\u3467\ueb48\u00fe\ub4ba'});
+try {
+renderBundleEncoder108.drawIndexed(8, 56);
+} catch {}
+try {
+device6.pushErrorScope('validation');
+} catch {}
+try {
+device6.queue.submit([
+commandBuffer14,
+]);
+} catch {}
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline128 = await device6.createRenderPipelineAsync({
+label: '\u5f8c\u41a1\u0bfe',
+layout: pipelineLayout20,
+fragment: {
+  module: shaderModule36,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one', dstFactor: 'zero'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE
+}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'one-minus-dst-alpha'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rg32float', writeMask: 0}, undefined, {format: 'r16float', writeMask: GPUColorWrite.RED}, {
+  format: 'rgb10a2unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'less',
+failOp: 'zero',
+depthFailOp: 'replace',
+},
+stencilBack: {
+compare: 'greater',
+depthFailOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilReadMask: 2813,
+stencilWriteMask: 2860,
+depthBiasSlopeScale: 88,
+depthBiasClamp: 0,
+},
+vertex: {
+  module: shaderModule36,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 11392,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x2',
+offset: 10432,
+shaderLocation: 8,
+}, {
+format: 'float32',
+offset: 9728,
+shaderLocation: 21,
+}, {
+format: 'snorm16x2',
+offset: 964,
+shaderLocation: 18,
+}, {
+format: 'unorm8x2',
+offset: 10070,
+shaderLocation: 10,
+}, {
+format: 'sint8x2',
+offset: 7264,
+shaderLocation: 15,
+}, {
+format: 'sint8x4',
+offset: 1636,
+shaderLocation: 13,
+}, {
+format: 'sint32',
+offset: 10700,
+shaderLocation: 6,
+}, {
+format: 'snorm16x4',
+offset: 2780,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 15420,
+shaderLocation: 23,
+}, {
+format: 'uint16x2',
+offset: 29456,
+shaderLocation: 2,
+}, {
+format: 'uint16x2',
+offset: 18156,
+shaderLocation: 1,
+}, {
+format: 'sint16x4',
+offset: 13352,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 3800,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x4',
+offset: 308,
+shaderLocation: 11,
+}, {
+format: 'sint8x4',
+offset: 2260,
+shaderLocation: 3,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+},
+});
+try {
+  await promise96;
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame40.close();
+videoFrame41.close();
+videoFrame42.close();
+videoFrame43.close();
+videoFrame44.close();
+videoFrame45.close();
+videoFrame46.close();
+videoFrame47.close();
+videoFrame48.close();
+videoFrame49.close();
+videoFrame50.close();
+videoFrame51.close();
+videoFrame52.close();
+videoFrame53.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -977,6 +977,11 @@ void RenderBundleEncoder::setPipeline(const RenderPipeline& pipeline)
         m_sampleMask = pipeline.sampleMask();
 
         if (m_renderPassEncoder) {
+            if (NSString* error = m_renderPassEncoder->errorValidatingPipeline(pipeline)) {
+                makeInvalid(error);
+                return;
+            }
+
             id<MTLRenderCommandEncoder> commandEncoder = m_renderPassEncoder->renderCommandEncoder();
             id<MTLRenderPipelineState> renderPipeline = m_currentPipelineState;
             if (renderPipeline && previousRenderPipelineState != m_currentPipelineState)

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -100,6 +100,7 @@ public:
     void setCommandEncoder(const BindGroupEntryUsageData::Resource&);
     void addResourceToActiveResources(const BindGroupEntryUsageData::Resource&, id<MTLResource>, OptionSet<BindGroupEntryUsage>);
     static double quantizedDepthValue(double, WGPUTextureFormat);
+    NSString* errorValidatingPipeline(const RenderPipeline&) const;
 
 private:
     RenderPassEncoder(id<MTLRenderCommandEncoder>, const WGPURenderPassDescriptor&, NSUInteger, bool depthReadOnly, bool stencilReadOnly, CommandEncoder&, id<MTLBuffer>, uint64_t maxDrawCount, Device&);


### PR DESCRIPTION
#### 25b857296fadedbda2bfc9d957537b46338149e4
<pre>
[WebGPU] RenderBundleEncoder::setPipeline replay command should call into RenderPassEncoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=273578">https://bugs.webkit.org/show_bug.cgi?id=273578</a>
&lt;radar://127229686&gt;

Reviewed by Dan Glastonbury.

We were not validating setPipeline calls in ICBs leading
to metal validation errors in invalid usage scenarios.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-273578-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-273578.html: Added.
Add regression tests.

* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::setPipeline):
Class helper.

* Source/WebGPU/WebGPU/RenderPassEncoder.h:
Introduce helper.

* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::errorValidatingPipeline const):
(WebGPU::RenderPassEncoder::setPipeline):
Call helper.

Canonical link: <a href="https://commits.webkit.org/278357@main">https://commits.webkit.org/278357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84db48f8257c622ef75ca5f96a60c48803b3f95d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50292 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53551 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/982 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/629 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41029 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22132 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/24658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/540 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8670 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55137 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25388 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48434 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/26651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43470 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47462 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11030 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27513 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/26381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->