### PR TITLE
REGRESSION (273393@main): Elevated CPU use in UIProcess and NetworkProcess due to always sending resource load messages to UIProcess.

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
@@ -70,7 +70,7 @@ NetworkResourceLoadParameters::NetworkResourceLoadParameters(
     , std::optional<UserContentControllerIdentifier> userContentControllerIdentifier
 #endif
 #if ENABLE(WK_WEB_EXTENSIONS)
-    , bool pageHasExtensionController
+    , bool pageHasLoadedWebExtensions
 #endif
     , bool linkPreconnectEarlyHintsEnabled
     , bool shouldRecordFrameLoadForStorageAccess
@@ -109,7 +109,7 @@ NetworkResourceLoadParameters::NetworkResourceLoadParameters(
         , userContentControllerIdentifier(userContentControllerIdentifier)
 #endif
 #if ENABLE(WK_WEB_EXTENSIONS)
-        , pageHasExtensionController(pageHasExtensionController)
+        , pageHasLoadedWebExtensions(pageHasLoadedWebExtensions)
 #endif
         , linkPreconnectEarlyHintsEnabled(linkPreconnectEarlyHintsEnabled)
         , shouldRecordFrameLoadForStorageAccess(shouldRecordFrameLoadForStorageAccess)

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
@@ -87,7 +87,7 @@ public:
         , std::optional<UserContentControllerIdentifier>
 #endif
 #if ENABLE(WK_WEB_EXTENSIONS)
-        , bool pageHasExtensionController
+        , bool pageHasLoadedWebExtensions
 #endif
         , bool linkPreconnectEarlyHintsEnabled
         , bool shouldRecordFrameLoadForStorageAccess
@@ -138,7 +138,7 @@ public:
 #endif
 
 #if ENABLE(WK_WEB_EXTENSIONS)
-    bool pageHasExtensionController { false };
+    bool pageHasLoadedWebExtensions { false };
 #endif
 
     bool linkPreconnectEarlyHintsEnabled { false };

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
@@ -108,7 +108,7 @@ class WebKit::NetworkResourceLoadParameters : WebKit::NetworkLoadParameters {
 #endif
 
 #if ENABLE(WK_WEB_EXTENSIONS)
-    bool pageHasExtensionController;
+    bool pageHasLoadedWebExtensions;
 #endif
 
     bool linkPreconnectEarlyHintsEnabled;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -355,7 +355,7 @@ bool NetworkResourceLoader::shouldSendResourceLoadMessages() const
         return true;
 
 #if ENABLE(WK_WEB_EXTENSIONS)
-    if (m_parameters.pageHasExtensionController)
+    if (m_parameters.pageHasLoadedWebExtensions)
         return true;
 #endif
 

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
@@ -73,6 +73,11 @@ public:
     void didFailLoadForFrame(WebPage&, WebFrame&, const URL&);
 
     RefPtr<WebExtensionContextProxy> extensionContext(const String& uniqueIdentifier) const;
+    RefPtr<WebExtensionContextProxy> extensionContext(const URL&) const;
+    RefPtr<WebExtensionContextProxy> extensionContext(WebFrame&, WebCore::DOMWrapperWorld&) const;
+
+    bool hasLoadedContexts() const { return !m_extensionContexts.isEmpty(); }
+    const WebExtensionContextProxySet& extensionContexts() const { return m_extensionContexts; }
 #endif
 
 private:
@@ -84,12 +89,6 @@ private:
 #if PLATFORM(COCOA)
     void load(const WebExtensionContextParameters&);
     void unload(WebExtensionContextIdentifier);
-
-    RefPtr<WebExtensionContextProxy> extensionContext(const URL&) const;
-    RefPtr<WebExtensionContextProxy> extensionContext(WebFrame&, WebCore::DOMWrapperWorld&) const;
-
-    bool hasLoadedContexts() const { return !m_extensionContexts.isEmpty(); }
-    const WebExtensionContextProxySet& extensionContexts() const { return m_extensionContexts; }
 #endif
 
     WebExtensionControllerIdentifier m_identifier;

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -80,6 +80,10 @@
 #include <WebCore/QuickLook.h>
 #endif
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+#include "WebExtensionControllerProxy.h"
+#endif
+
 #define WEBLOADERSTRATEGY_RELEASE_LOG_BASIC(fmt, ...) RELEASE_LOG(Network, "%p - WebLoaderStrategy::" fmt, this, ##__VA_ARGS__)
 #define WEBLOADERSTRATEGY_RELEASE_LOG_ERROR_BASIC(fmt, ...) RELEASE_LOG_ERROR(Network, "%p - WebLoaderStrategy::" fmt, this, ##__VA_ARGS__)
 
@@ -340,8 +344,10 @@ static void addParametersShared(const LocalFrame* frame, NetworkResourceLoadPara
         page->logMediaDiagnosticMessage(parameters.request.httpBody());
 
 #if ENABLE(WK_WEB_EXTENSIONS)
-        if (auto* webPage = WebPage::fromCorePage(*page))
-            parameters.pageHasExtensionController = webPage->webExtensionControllerProxy();
+        if (RefPtr webPage = WebPage::fromCorePage(*page)) {
+            if (RefPtr extensionControllerProxy = webPage->webExtensionControllerProxy())
+                parameters.pageHasLoadedWebExtensions = extensionControllerProxy->hasLoadedContexts();
+        }
 #endif
     }
 


### PR DESCRIPTION
#### 75ca8019625a49f6806846f69f7c6e028dfef6e4
<pre>
REGRESSION (273393@main): Elevated CPU use in UIProcess and NetworkProcess due to always sending resource load messages to UIProcess.
<a href="https://webkit.org/b/273582">https://webkit.org/b/273582</a>
<a href="https://rdar.apple.com/127380142">rdar://127380142</a>

Reviewed by Brian Weinstein.

Only send the resource messages if the page has loaded extensions, not just an extension controller.
The NetworkResourceLoadParameters are sent over for each scheduled load, so it is always accurate.
Renamed the struct field from pageHasExtensionController to pageHasLoadedWebExtensions.

* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp:
(WebKit::NetworkResourceLoadParameters::NetworkResourceLoadParameters):
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::shouldSendResourceLoadMessages const):
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::addParametersShared):

Canonical link: <a href="https://commits.webkit.org/278248@main">https://commits.webkit.org/278248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fa5fa43866d7c12c8cee31751c15dc19d938359

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53178 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/612 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40735 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52033 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42960 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21862 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24228 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8305 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46327 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54759 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25029 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/174 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/query.tentative.https.any.worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48124 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26286 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43154 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47170 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27148 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7207 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26016 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->