### PR TITLE
Crash in CheckedPtr::decrementPtrCount via SplitTextNodeContainingElementCommand::doApply

### DIFF
--- a/LayoutTests/editing/style/apply-style-split-text-element-at-end-crash-expected.txt
+++ b/LayoutTests/editing/style/apply-style-split-text-element-at-end-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if WebKit does not crash.
+
+PASS

--- a/LayoutTests/editing/style/apply-style-split-text-element-at-end-crash.html
+++ b/LayoutTests/editing/style/apply-style-split-text-element-at-end-crash.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function runTest() {
+    summary.addEventListener("DOMNodeRemoved", () => {
+        hr.appendChild(div);
+        div.appendChild(summary);
+        d.focus();
+        document.execCommand("selectAll", false);
+        document.execCommand("subscript", false);
+    }, {once: true});
+    try {
+        summary.remove();
+    } catch(e) { }
+    document.execCommand("indent", false);
+    document.execCommand("removeFormat", false);
+    document.body.innerHTML = '<p>This test passes if WebKit does not crash.</p>PASS';
+}
+
+</script>
+<body onload="runTest()">
+<summary id="summary">abc</summary>
+<div id="div">def<div>x</div></div>
+<details id="d" open="true" contenteditable><hr id="hr"><hr></details>
+</body>
+</html>

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -618,10 +618,6 @@ void CompositeEditCommand::insertNodeAt(Ref<Node>&& insertChild, const Position&
 
 void CompositeEditCommand::appendNode(Ref<Node>&& node, Ref<ContainerNode>&& parent)
 {
-    // When cloneParagraphUnderNewElement() clones the fallback content of an OBJECT element,
-    // the ASSERT below may fire since the return value of canHaveChildrenForEditing is not reliable
-    // until the render object of the OBJECT is created. Hence we ignore this check for OBJECTs.
-    ASSERT(canHaveChildrenForEditing(parent) || parent->hasTagName(objectTag));
     applyCommandToComposite(AppendNodeCommand::create(WTFMove(parent), WTFMove(node), editingAction()));
 }
 

--- a/Source/WebCore/editing/SplitTextNodeContainingElementCommand.cpp
+++ b/Source/WebCore/editing/SplitTextNodeContainingElementCommand.cpp
@@ -52,13 +52,15 @@ void SplitTextNodeContainingElementCommand::doApply()
     if (!parent || !parent->parentElement() || !parent->parentElement()->hasEditableStyle())
         return;
 
-    CheckedPtr parentRenderer = parent->renderer();
-    if (!parentRenderer || !parentRenderer->isInline()) {
-        wrapContentsInDummySpan(*parent);
-        RefPtr firstChild = dynamicDowncast<Element>(parent->firstChild());
-        if (!firstChild)
-            return;
-        parent = WTFMove(firstChild);
+    {
+        CheckedPtr parentRenderer = parent->renderer();
+        if (!parentRenderer || !parentRenderer->isInline()) {
+            wrapContentsInDummySpan(*parent);
+            RefPtr firstChild = dynamicDowncast<Element>(parent->firstChild());
+            if (!firstChild)
+                return;
+            parent = WTFMove(firstChild);
+        }
     }
 
     splitElement(*parent, m_text);


### PR DESCRIPTION
#### 6de0a6e596b6b251fe46c8b12b05a62aea4afb64
<pre>
Crash in CheckedPtr::decrementPtrCount via SplitTextNodeContainingElementCommand::doApply
<a href="https://bugs.webkit.org/show_bug.cgi?id=273581">https://bugs.webkit.org/show_bug.cgi?id=273581</a>
&lt;<a href="https://rdar.apple.com/127116949">rdar://127116949</a>&gt;

Reviewed by Wenson Hsieh.

The crash was caused by SplitTextNodeContainingElementCommand::doApply holding onto a CheckedPtr
of RenderObject until across a call to splitElement, which could trigger a layout and delete
the render object. Fixed the crash by reducing the scope of CheckedPtr.

Also remove the debug assertion in CompositeEditCommand::appendNode which gets hit with the
newly added test case.

* LayoutTests/editing/style/apply-style-split-text-element-at-end-crash-expected.txt: Added.
* LayoutTests/editing/style/apply-style-split-text-element-at-end-crash.html: Added.
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::appendNode):
* Source/WebCore/editing/SplitTextNodeContainingElementCommand.cpp:
(WebCore::SplitTextNodeContainingElementCommand::doApply):

Canonical link: <a href="https://commits.webkit.org/278242@main">https://commits.webkit.org/278242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c241a58233b2a079518819ceb8ad1c8230cc47c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53182 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/616 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52240 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/185 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40739 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26795 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42962 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21867 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24231 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/191 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8309 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/237 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54763 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/25033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48127 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26291 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43156 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27152 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7204 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26020 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->