### PR TITLE
Synchronizing iOS and macOS text boundary codepaths

### DIFF
--- a/Source/WebCore/platform/text/mac/TextBoundaries.mm
+++ b/Source/WebCore/platform/text/mac/TextBoundaries.mm
@@ -38,188 +38,20 @@
 #import <wtf/text/TextBreakIteratorInternalICU.h>
 #import <wtf/unicode/CharacterNames.h>
 
+@interface NSAttributedString (WebKit)
+- (NSRange)doubleClickAtIndex:(NSUInteger)location;
+- (NSUInteger)nextWordFromIndex:(NSUInteger)position forward:(BOOL)forward;
+@end
+
 namespace WebCore {
-
-#if !USE(APPKIT)
-
-static bool isSkipCharacter(char32_t c)
-{
-    return c == 0xA0 || c == '\n' || c == '.' || c == ',' || c == '!'  || c == '?' || c == ';' || c == ':' || u_isspace(c);
-}
-
-static bool isWhitespaceCharacter(char32_t c)
-{
-    return c == 0xA0 || c == '\n' || u_isspace(c);
-}
-
-static bool isWordDelimitingCharacter(char32_t c)
-{
-    // Ampersand is an exception added to treat AT&T as a single word (see <rdar://problem/5022264>).
-    return !CFCharacterSetIsLongCharacterMember(CFCharacterSetGetPredefined(kCFCharacterSetAlphaNumeric), c) && c != '&';
-}
-
-static bool isSymbolCharacter(char32_t c)
-{
-    return CFCharacterSetIsLongCharacterMember(CFCharacterSetGetPredefined(kCFCharacterSetSymbol), c);
-}
-
-static bool isAmbiguousBoundaryCharacter(char32_t character)
-{
-    // These are characters that can behave as word boundaries, but can appear within words.
-    return character == '\'' || character == rightSingleQuotationMark || character == hebrewPunctuationGershayim;
-}
-
-static CFStringTokenizerRef tokenizerForString(CFStringRef str)
-{
-    static const NeverDestroyed locale = [] {
-        const char* localID = currentTextBreakLocaleID();
-        auto currentLocaleID = adoptCF(CFStringCreateWithBytesNoCopy(kCFAllocatorDefault, reinterpret_cast<const UInt8*>(localID), strlen(localID), kCFStringEncodingASCII, false, kCFAllocatorNull));
-        return adoptCF(CFLocaleCreate(kCFAllocatorDefault, currentLocaleID.get()));
-    }();
-
-    if (!locale.get())
-        return nullptr;
-
-    CFRange entireRange = CFRangeMake(0, CFStringGetLength(str));    
-
-    static NeverDestroyed<RetainPtr<CFStringTokenizerRef>> tokenizer;
-    if (!tokenizer.get())
-        tokenizer.get() = adoptCF(CFStringTokenizerCreate(kCFAllocatorDefault, str, entireRange, kCFStringTokenizerUnitWordBoundary, locale.get().get()));
-    else
-        CFStringTokenizerSetString(tokenizer.get().get(), str, entireRange);
-    return tokenizer.get().get();
-}
-
-// Simple case: A word is a stream of characters delimited by a special set of word-delimiting characters.
-static void findSimpleWordBoundary(StringView text, int position, int* start, int* end)
-{
-    ASSERT(position >= 0);
-    ASSERT(static_cast<unsigned>(position) < text.length());
-
-    unsigned startPos = position;
-    while (startPos > 0) {
-        int i = startPos;
-        char32_t characterBeforeStartPos;
-        U16_PREV(text, 0, i, characterBeforeStartPos);
-        if (isWordDelimitingCharacter(characterBeforeStartPos)) {
-            ASSERT(i >= 0);
-            if (!i)
-                break;
-
-            if (!isAmbiguousBoundaryCharacter(characterBeforeStartPos))
-                break;
-
-            char32_t characterBeforeBeforeStartPos;
-            U16_PREV(text, 0, i, characterBeforeBeforeStartPos);
-            if (isWordDelimitingCharacter(characterBeforeBeforeStartPos))
-                break;
-        }
-        U16_BACK_1(text, 0, startPos);
-    }
-    
-    unsigned endPos = position;
-    while (endPos < text.length()) {
-        char32_t character;
-        U16_GET(text, 0, endPos, text.length(), character);
-        if (isWordDelimitingCharacter(character)) {
-            unsigned i = endPos;
-            U16_FWD_1(text, i, text.length());
-            ASSERT(i <= text.length());
-            if (i == text.length())
-                break;
-            char32_t characterAfterEndPos;
-            U16_NEXT(text, i, text.length(), characterAfterEndPos);
-            if (!isAmbiguousBoundaryCharacter(character))
-                break;
-            if (isWordDelimitingCharacter(characterAfterEndPos))
-                break;
-        }
-        U16_FWD_1(text, endPos, text.length());
-    }
-
-    // The text may consist of all delimiter characters (e.g. "++++++++" or a series of emoji), and returning an empty range
-    // makes no sense (and doesn't match findComplexWordBoundary() behavior).
-    if (startPos == endPos && endPos < text.length()) {
-        char32_t character;
-        U16_GET(text, 0, endPos, text.length(), character);
-        if (isSymbolCharacter(character))
-            U16_FWD_1(text, endPos, text.length());
-    }
-
-    *start = startPos;
-    *end = endPos;
-}
-
-// Complex case: use CFStringTokenizer to find word boundary.
-static void findComplexWordBoundary(StringView text, int position, int* start, int* end)
-{
-    RetainPtr<CFStringRef> charString = text.createCFStringWithoutCopying();
-
-    CFStringTokenizerRef tokenizer = tokenizerForString(charString.get());
-    if (!tokenizer) {
-        // Error creating tokenizer, so just use simple function.
-        findSimpleWordBoundary(text, position, start, end);
-        return;
-    }
-
-    CFStringTokenizerTokenType  token = CFStringTokenizerGoToTokenAtIndex(tokenizer, position);
-    if (token == kCFStringTokenizerTokenNone) {
-        // No token found: select entire block.
-        // NB: I never hit this section in all my testing.
-        *start = 0;
-        *end = text.length();
-        return;
-    }
-
-    CFRange result = CFStringTokenizerGetCurrentTokenRange(tokenizer);
-    *start = result.location;
-    *end = result.location + result.length;
-}
-
-#endif
 
 void findWordBoundary(StringView text, int position, int* start, int* end)
 {
-#if USE(APPKIT)
+
     auto attributedString = adoptNS([[NSAttributedString alloc] initWithString:text.createNSStringWithoutCopying().get()]);
     NSRange range = [attributedString doubleClickAtIndex:std::min<unsigned>(position, text.length() - 1)];
     *start = range.location;
     *end = range.location + range.length;
-#else
-    unsigned pos = position;
-    if (pos == text.length() && pos)
-        --pos;
-
-    // For complex text (Thai, Japanese, Chinese), visible_units will pass the text in as a 
-    // single contiguous run of characters, providing as much context as is possible.
-    // We only need one character to determine if the text is complex.
-    char32_t ch;
-    unsigned i = pos;
-    U16_NEXT(text, i, text.length(), ch);
-    bool isComplex = requiresContextForWordBoundary(ch);
-
-    // FIXME: This check improves our word boundary behavior, but doesn't actually go far enough.
-    // See <rdar://problem/8853951> Take complex word boundary finding path when necessary
-    if (!isComplex) {
-        // Check again for complex text, at the start of the run.
-        i = 0;
-        U16_NEXT(text, i, text.length(), ch);
-        isComplex = requiresContextForWordBoundary(ch);
-    }
-
-    if (isComplex)
-        findComplexWordBoundary(text, position, start, end);
-    else
-        findSimpleWordBoundary(text, position, start, end);
-
-#define LOG_WORD_BREAK 0
-#if LOG_WORD_BREAK
-    auto uniString = text.createCFStringWithoutCopying();
-    auto foundWord = text.substring(*start, *end - *start).createCFStringWithoutCopying();
-    NSLog(@"%s_BREAK '%@' (%d,%d) in '%@' (%p) at %d, length=%d", isComplex ? "COMPLEX" : "SIMPLE", foundWord.get(), *start, *end, uniString.get(), uniString.get(), position, text.length());
-#endif
-    
-#endif
 }
 
 void findEndWordBoundary(StringView text, int position, int* end)
@@ -230,7 +62,7 @@ void findEndWordBoundary(StringView text, int position, int* end)
 
 int findNextWordFromIndex(StringView text, int position, bool forward)
 {   
-#if USE(APPKIT)
+
     String textWithoutUnpairedSurrogates;
     if (hasUnpairedSurrogate(text)) {
         textWithoutUnpairedSurrogates = replaceUnpairedSurrogatesWithReplacementCharacter(text.toStringWithoutCopying());
@@ -238,30 +70,6 @@ int findNextWordFromIndex(StringView text, int position, bool forward)
     }
     auto attributedString = adoptNS([[NSAttributedString alloc] initWithString:text.createNSStringWithoutCopying().get()]);
     return [attributedString nextWordFromIndex:position forward:forward];
-#else
-    // This very likely won't behave exactly like the non-iPhone version, but it works
-    // for the contexts in which it is used on iPhone, and in the future will be
-    // tuned to improve the iPhone-specific behavior for the keyboard and text editing.
-    int pos = position;
-    UBreakIterator* boundary = wordBreakIterator(text);
-    if (boundary) {
-        if (forward) {
-            do {
-                pos = ubrk_following(boundary, pos);
-                if (pos == UBRK_DONE)
-                    pos = text.length();
-            } while (static_cast<unsigned>(pos) < text.length() && (pos == 0 || !isSkipCharacter(text[pos - 1])) && isSkipCharacter(text[pos]));
-        }
-        else {
-            do {
-                pos = ubrk_preceding(boundary, pos);
-                if (pos == UBRK_DONE)
-                    pos = 0;
-            } while (pos > 0 && isSkipCharacter(text[pos]) && !isWhitespaceCharacter(text[pos - 1]));
-        }
-    }
-    return pos;
-#endif
 }
 
 }


### PR DESCRIPTION
#### e887ec9373c01dbaed316b47d7e8113e3c2323e6
<pre>
Synchronizing iOS and macOS text boundary codepaths
<a href="https://bugs.webkit.org/show_bug.cgi?id=273583">https://bugs.webkit.org/show_bug.cgi?id=273583</a>
<a href="https://rdar.apple.com/122491165">rdar://122491165</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/platform/text/mac/TextBoundaries.mm:
(WebCore::findWordBoundary):
(WebCore::findNextWordFromIndex):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e887ec9373c01dbaed316b47d7e8113e3c2323e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3024 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53966 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1398 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41321 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52806 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27729 "Found 29 new test failures: editing/deleting/list-item-1.html, editing/deleting/non-smart-delete.html, editing/deleting/smart-delete-002.html, editing/execCommand/indent-pre.html, editing/execCommand/remove-formatting-2-live-range.html, editing/inserting/4960120-2.html, editing/inserting/insert-paragraph-03.html, editing/inserting/insert-paragraph-04.html, editing/inserting/paragraph-separator-01.html, editing/inserting/paragraph-separator-02.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22443 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25080 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/935 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9148 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47060 "Found 15 new API test failures: TestWebKitAPI.DocumentEditingContext.RequestTwoWordsAroundSelection, TestWebKitAPI.DocumentEditingContext.RequestThreeWordsAroundSelection, TestWebKitAPI.DocumentEditingContext.RequestRectsInTextAreaAcrossWordWrappedLine, TestWebKitAPI.DocumentEditingContext.SpatialAndCurrentSelectionRequest_RectBeforeRangeSelection, TestWebKitAPI.DocumentEditingContext.RequestFirstWordUsingCharacterGranularity, TestWebKitAPI.DocumentEditingContext.RequestLastWord, TestWebKitAPI.DocumentEditingContext.RequestRectsInTextAreaInsideIFrame, TestWebKitAPI.DocumentEditingContext.Simple, TestWebKitAPI.DocumentEditingContext.SpatialAndCurrentSelectionRequest_RectAroundCaretSelection, TestWebKitAPI.iOSMouseSupport.ContextClickAtEndOfSelection ... (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55556 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/892 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48736 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27066 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43800 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47798 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27934 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26798 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->