### PR TITLE
[WebGPU] Queue should not allow command buffer to be committed twice

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2116,6 +2116,8 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Release ] fast/webgpu/fuzz-273503.html [ Pass Failure Timeout ]
 [ Debug ] fast/webgpu/fuzz-273578.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-273578.html [ Pass Failure Timeout ]
+[ Debug ] fast/webgpu/fuzz-273585.html [ Skip ]
+[ Release ] fast/webgpu/fuzz-273585.html [ Pass Failure Timeout ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/fuzz-273585-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-273585-expected.txt
@@ -1,0 +1,675 @@
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: popErrorScope failed
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: There are too many active WebGL contexts on this page, the oldest context will be lost.
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+layer at (0,0) size 982x5202
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x5202
+  RenderBlock {HTML} at (0,0) size 785x5202 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x5186
+      RenderText {#text} at (32,137) size 26x17
+        text run at (32,137) width 26: "\x{C1AA}\x{C94}"
+      RenderText {#text} at (57,137) size 87x17
+        text run at (57,137) width 87: "\x{4F78}\x{D83F}\x{DE8B}\x{D83F}\x{DDDC}\x{9E7}\x{C52}\x{63A9}\x{77E1}"
+      RenderText {#text} at (443,137) size 62x17
+        text run at (443,137) width 62: "\x{910F}\x{742A}\x{B92}\x{D83D}\x{DE81}"
+      RenderText {#text} at (504,137) size 65x17
+        text run at (504,137) width 65: "\x{D75}\x{BE26}\x{D83E}\x{DED9}\x{2ABB}"
+      RenderText {#text} at (568,137) size 98x17
+        text run at (568,137) width 98: "\x{A76}\x{44CD}\x{DF6}\x{4F0}\x{1C62}\x{FD8}\x{235A}\x{173E}\x{D83F}\x{DED7}"
+      RenderText {#text} at (665,137) size 72x17
+        text run at (665,137) width 72: "\x{D83E}\x{DD5B}\x{200B}\x{D83D}\x{DFEA}\x{1A46}\x{AB6F}\x{D83F}\x{DF12}"
+      RenderText {#text} at (300,296) size 63x17
+        text run at (300,296) width 15: "\x{34E5}"
+        text run at (315,296) width 11 RTL: "\x{85D}"
+        text run at (325,296) width 38: "\x{F632}\x{B956}\x{FFC}"
+      RenderText {#text} at (362,296) size 123x17
+        text run at (362,296) width 123: "\x{4E06}\x{CECA}\x{D83F}\x{DED1}\x{E430}\x{96AB}\x{85DD}\x{575E}\x{1D9}\x{879E}"
+      RenderText {#text} at (484,296) size 79x17
+        text run at (484,296) width 79: "\x{D83E}\x{DCE2}\x{AD5}\x{8870}\x{20C7}\x{B348}\x{AD31}"
+      RenderText {#text} at (562,296) size 45x17
+        text run at (562,296) width 35: "\x{C6E8}\x{D83E}\x{DC2A}\x{A026}"
+        text run at (596,296) width 11 RTL: "\x{7DA}"
+      RenderText {#text} at (606,296) size 82x17
+        text run at (606,296) width 16: "\x{3FBE}"
+        text run at (621,296) width 10 RTL: "\x{72F}\x{82B}"
+        text run at (630,296) width 58: "\x{91B1}\x{1F7}\x{D83F}\x{DC56}\x{ED0}\x{77B4}"
+      RenderText {#text} at (600,454) size 70x17
+        text run at (600,454) width 70: "\x{9AA}\x{4946}\x{4B32}\x{D83E}\x{DCA5}\x{908}\x{D83F}\x{DF1A}"
+      RenderImage {IMG} at (284,592) size 21x165
+      RenderText {#text} at (305,744) size 80x17
+        text run at (305,744) width 80: "\x{3091}\x{9AD}\x{ABA2}\x{CFD}\x{D83D}\x{DF95}\x{B13}\x{4B0E}"
+      RenderText {#text} at (384,744) size 154x17
+        text run at (384,744) width 63: "\x{C22}\x{4C66}\x{A99C}\x{D83E}\x{DEB0}"
+        text run at (446,744) width 15 RTL: "\x{6FA}"
+        text run at (460,744) width 78: "\x{F675}\x{5712}\x{E343}\x{A88A}\x{4B4}\x{608C}"
+      RenderText {#text} at (553,744) size 36x17
+        text run at (553,744) width 36: "\x{55A7}\x{D83F}\x{DF2E}\x{2DD8}"
+      RenderText {#text} at (588,744) size 107x17
+        text run at (588,744) width 60: "\x{D83E}\x{DC95}\x{16CF}\x{C63A}\x{82D}\x{A2F8}\x{D83D}\x{DFD8}"
+        text run at (647,744) width 12 RTL: "\x{86B}"
+        text run at (658,744) width 37: "\x{A737}\x{D83F}\x{DF22}\x{D83F}\x{DFBF}"
+      RenderText {#text} at (0,744) size 762x181
+        text run at (694,744) width 68: "\x{1401}\x{CD2}\x{B6E4}\x{8940}\x{AF27}"
+        text run at (0,908) width 57: "\x{CAE4}\x{90}\x{8DB9}\x{1EC8}\x{FF00}"
+      RenderText {#text} at (72,908) size 37x17
+        text run at (72,908) width 27: "\x{B66D}\x{592}\x{D83F}\x{DEDD}"
+        text run at (98,908) width 11 RTL: "\x{64A}"
+      RenderText {#text} at (457,908) size 94x17
+        text run at (457,908) width 94: "\x{5D93}\x{D7F}\x{5957}\x{D83E}\x{DE78}\x{51B}\x{E8D}\x{D7C}"
+      RenderText {#text} at (550,908) size 120x17
+        text run at (550,908) width 120: "\x{7195}\x{556F}\x{D83E}\x{DCAE}\x{ED7}\x{D83F}\x{DC74}\x{D83F}\x{DC9A}\x{D83F}\x{DF3F}\x{D83E}\x{DE67}\x{C08D}\x{2E51}"
+      RenderText {#text} at (0,908) size 755x175
+        text run at (669,908) width 86: "\x{D83E}\x{DF48}\x{25CA}\x{5554}\x{4281}\x{D83F}\x{DF60}\x{E4EE}\x{434E}"
+        text run at (0,1066) width 20 RTL: "\x{FD79}"
+        text run at (19,1066) width 26: "\x{CAA}\x{C890}"
+      RenderText {#text} at (44,1066) size 42x17
+        text run at (44,1066) width 42: "\x{C93}\x{D83D}\x{DE93}\x{995}"
+      RenderText {#text} at (385,1066) size 99x17
+        text run at (385,1066) width 99: "\x{140}\x{30B}\x{D83F}\x{DD8B}\x{E03E}\x{D83E}\x{DF2B}\x{75AD}\x{D83E}\x{DCE1}\x{E7C2}\x{CF21}\x{420}"
+      RenderText {#text} at (483,1066) size 22x17
+        text run at (483,1066) width 22: "\x{D83E}\x{DF49}\x{6}"
+      RenderText {#text} at (504,1066) size 108x17
+        text run at (504,1066) width 108: "\x{C24}\x{4EF}\x{D83F}\x{DED8}\x{30C9}\x{6D71}\x{40B1}\x{D83E}\x{DEF4}\x{F888}"
+      RenderText {#text} at (611,1066) size 115x17
+        text run at (611,1066) width 115: "\x{6EDD}\x{D83E}\x{DD93}\x{929}\x{6982}\x{C1A}\x{E97}\x{4E1}\x{2813}\x{3ED}\x{585}"
+      RenderText {#text} at (0,1066) size 751x42
+        text run at (725,1066) width 26: "\x{EFCC}\x{4DA1}"
+        text run at (0,1091) width 44: "\x{13B}\x{D83E}\x{DC1C}\x{55D6}\x{A35}"
+      RenderText {#text} at (0,1501) size 86x17
+        text run at (0,1501) width 8: "\x{663}"
+        text run at (7,1501) width 79: "\x{73A6}\x{D83D}\x{DF18}\x{F3F}\x{B3C}\x{38BB}\x{B45}\x{823}\x{D83F}\x{DC95}"
+      RenderText {#text} at (85,1501) size 63x17
+        text run at (85,1501) width 63: "\x{4592}\x{21E7}\x{8DB}\x{B90B}\x{499}"
+      RenderText {#text} at (147,1501) size 107x17
+        text run at (147,1501) width 22: "\x{D83F}\x{DD08}\x{D840}"
+        text run at (168,1501) width 15 RTL: "\x{8BE}"
+        text run at (182,1501) width 72: "\x{6A31}\x{407}\x{975}\x{D83F}\x{DFC9}\x{8716}\x{D83F}\x{DE6D}"
+      RenderText {#text} at (253,1501) size 32x17
+        text run at (253,1501) width 32: "\x{2D8F}\x{F772}"
+      RenderText {#text} at (284,1501) size 11x17
+        text run at (284,1501) width 11: "\x{517}\x{343}"
+      RenderText {#text} at (294,1501) size 42x17
+        text run at (294,1501) width 42: "\x{DDBE}\x{5A81}\x{8744}"
+      RenderText {#text} at (335,1501) size 29x17
+        text run at (335,1501) width 29: "\x{A2C5}\x{B79D}\x{B9}"
+      RenderText {#text} at (363,1501) size 72x17
+        text run at (363,1501) width 72: "\x{B3A7}\x{E810}\x{AFF5}\x{B583}\x{46FD}"
+      RenderText {#text} at (434,1501) size 81x17
+        text run at (434,1501) width 81: "\x{1A23}\x{991C}\x{FD7}\x{D83F}\x{DEE9}\x{D83E}\x{DC87}\x{BEF1}\x{D83E}\x{DF30}"
+      RenderText {#text} at (514,1501) size 72x17
+        text run at (514,1501) width 72: "\x{BC91}\x{AD3}\x{D4C}\x{95A}\x{C81E}\x{90A}"
+      RenderText {#text} at (585,1501) size 108x17
+        text run at (585,1501) width 37: "\x{648D}\x{D83E}\x{DCFE}\x{EED5}"
+        text run at (621,1501) width 9 RTL: "\x{7D6}"
+        text run at (629,1501) width 64: "\x{FE45}\x{1A75}\x{EBF6}\x{5997}\x{1B95}\x{C3C}"
+      RenderText {#text} at (213,2180) size 110x17
+        text run at (213,2180) width 15: "\x{730E}"
+        text run at (228,2180) width 22 RTL: "\x{893}\x{63B}"
+        text run at (249,2180) width 74: "\x{37B0}\x{D83D}\x{DF13}\x{7144}\x{A748}\x{D83D}\x{DEA3}\x{654}"
+      RenderHTMLCanvas {CANVAS} at (322,1523) size 301x670
+      RenderText {#text} at (622,2180) size 53x17
+        text run at (622,2180) width 23: "\x{EAD5}\x{D5A}"
+        text run at (644,2180) width 24 RTL: "\x{8B8}\x{FBA}"
+        text run at (667,2180) width 8: "\x{FF}"
+      RenderText {#text} at (674,2180) size 46x17
+        text run at (674,2180) width 46: "\x{4E04}\x{4715}\x{2ED7}"
+      RenderText {#text} at (0,2180) size 739x45
+        text run at (719,2180) width 20: "\x{EDB}\x{A016}"
+        text run at (0,2208) width 51: "\x{4EE}\x{D83D}\x{DF66}\x{E14F}\x{25B}\x{F27C}"
+      RenderText {#text} at (50,2208) size 123x17
+        text run at (50,2208) width 12 RTL: "\x{88F}"
+        text run at (61,2208) width 66: "\x{56DE}\x{75E3}\x{8FF1}\x{D83E}\x{DDF9}"
+        text run at (126,2208) width 11 RTL: "\x{803}"
+        text run at (136,2208) width 37: "\x{185E}\x{4350}\x{295}\x{D83D}\x{DF2A}"
+      RenderText {#text} at (172,2208) size 70x17
+        text run at (172,2208) width 51: "\x{2AF}\x{34CD}\x{725A}\x{D83D}\x{DE76}"
+        text run at (222,2208) width 20 RTL: "\x{FD02}"
+      RenderText {#text} at (241,2208) size 126x17
+        text run at (241,2208) width 38: "\x{D665}\x{9AD8}\x{296}"
+        text run at (278,2208) width 12 RTL: "\x{FB37}"
+        text run at (289,2208) width 67: "\x{BEE8}\x{D83F}\x{DE77}\x{D359}\x{9A67}\x{D83F}\x{DE37}"
+        text run at (355,2208) width 12 RTL: "\x{5FC}"
+      RenderText {#text} at (366,2208) size 57x17
+        text run at (366,2208) width 57: "\x{A5ED}\x{C406}\x{162E}\x{9661}"
+      RenderText {#text} at (422,2208) size 64x17
+        text run at (422,2208) width 64: "\x{FFE}\x{3ACD}\x{4A37}\x{EEAE}\x{D83E}\x{DC79}"
+      RenderText {#text} at (485,2208) size 124x17
+        text run at (485,2208) width 124: "\x{A1}\x{55C}\x{F41D}\x{AA95}\x{3A64}\x{F68F}\x{D83D}\x{DF3B}\x{DA00}\x{855B}\x{C24D}\x{447D}"
+      RenderText {#text} at (608,2208) size 122x17
+        text run at (608,2208) width 122: "\x{F315}\x{41E}\x{DD54}\x{D83E}\x{DDE2}\x{D83D}\x{DEE9}\x{5B24}\x{BBB7}\x{A8A2}\x{24F}"
+      RenderText {#text} at (0,2208) size 760x224
+        text run at (729,2208) width 31: "\x{9C9D}\x{BB35}"
+        text run at (0,2415) width 52: "\x{431F}\x{D83E}\x{DFBF}\x{9FE}\x{4545}"
+      RenderText {#text} at (51,2415) size 138x17
+        text run at (51,2415) width 71: "\x{B606}\x{C420}\x{C27D}\x{308}\x{886E}\x{563}"
+        text run at (121,2415) width 14 RTL: "\x{77D}"
+        text run at (134,2415) width 55: "\x{3948}\x{5EF4}\x{A28E}\x{BAB6}"
+      RenderText {#text} at (204,2415) size 114x17
+        text run at (204,2415) width 114: "\x{CFC9}\x{AB02}\x{BFB0}\x{D83F}\x{DE32}\x{3CC0}\x{8AD8}\x{2711}\x{4D25}"
+      RenderText {#text} at (317,2415) size 104x17
+        text run at (317,2415) width 104: "\x{19EE}\x{9E44}\x{E64A}\x{D83E}\x{DC17}\x{D83E}\x{DE59}\x{62A1}\x{1F7}\x{7F8F}"
+      RenderText {#text} at (420,2415) size 46x17
+        text run at (420,2415) width 46: "\x{2458}\x{D83E}\x{DDEF}\x{27C8}"
+      RenderText {#text} at (465,2415) size 28x17
+        text run at (465,2415) width 28: "\x{C985}\x{1645}"
+      RenderImage {IMG} at (492,2227) size 182x201
+      RenderText {#text} at (673,2415) size 61x17
+        text run at (673,2415) width 61: "\x{D83F}\x{DE63}\x{D83D}\x{DEC6}\x{3355}\x{D83E}\x{DF0E}\x{17A6}"
+      RenderText {#text} at (290,2554) size 67x17
+        text run at (290,2554) width 67: "\x{89}\x{4AC3}\x{9A87}\x{E4F1}\x{8154}"
+      RenderText {#text} at (356,2554) size 120x17
+        text run at (356,2554) width 72: "\x{D83E}\x{DE82}\x{1D98}\x{629D}\x{AE61}\x{7BCB}"
+        text run at (427,2554) width 14 RTL: "\x{852}"
+        text run at (440,2554) width 36: "\x{B2BB}\x{28EC}\x{29B1}"
+      RenderText {#text} at (475,2554) size 51x17
+        text run at (475,2554) width 51: "\x{D83D}\x{DF4E}\x{D83F}\x{DC12}\x{634B}\x{6008}"
+      RenderText {#text} at (525,2554) size 118x17
+        text run at (525,2554) width 118: "\x{278}\x{4C70}\x{905}\x{D83E}\x{DD64}\x{D83E}\x{DED5}\x{A441}\x{D83F}\x{DE86}\x{D83E}\x{DFDA}\x{D83F}\x{DFAB}"
+      RenderText {#text} at (0,2554) size 767x175
+        text run at (642,2554) width 71: "\x{2F6C}\x{9192}\x{586B}\x{291}\x{4D45}"
+        text run at (712,2554) width 25 RTL: "\x{FD21}"
+        text run at (736,2554) width 31: "\x{CF1C}\x{8A0B}"
+        text run at (0,2712) width 11: "\x{E4C8}"
+      RenderImage {IMG} at (10,2573) size 295x152
+      RenderText {#text} at (304,2712) size 88x17
+        text run at (304,2712) width 40: "\x{A78E}\x{63A3}\x{C4AF}"
+        text run at (343,2712) width 10 RTL: "\x{843}"
+        text run at (352,2712) width 40: "\x{30B2}\x{AE1B}\x{A810}"
+      RenderText {#text} at (391,2712) size 26x17
+        text run at (391,2712) width 26: "\x{D83D}\x{DEED}\x{98D1}"
+      RenderText {#text} at (416,2712) size 103x17
+        text run at (416,2712) width 103: "\x{C934}\x{C655}\x{1CA}\x{ACA}\x{D83E}\x{DC1C}'\x{D83E}\x{DD9D}\x{D83F}\x{DC62}"
+      RenderText {#text} at (518,2712) size 81x17
+        text run at (518,2712) width 27: "\x{BCE}\x{3CEB}"
+        text run at (544,2712) width 9 RTL: "\x{5E8}"
+        text run at (552,2712) width 47: "\x{397B}\x{F98}\x{A58}\x{2104}"
+      RenderImage {IMG} at (300,2765) size 26x233
+      RenderText {#text} at (626,2985) size 70x17
+        text run at (626,2985) width 55: "\x{D83D}\x{DEF7}\x{83C5}\x{D83E}\x{DDE1}"
+        text run at (681,2985) width 15 RTL: "\x{5D4}\x{846}"
+      RenderText {#text} at (0,2985) size 756x252
+        text run at (695,2985) width 61: "\x{D8E}\x{9EB9}\x{9FD5}\x{D83F}\x{DE5F}"
+        text run at (0,3220) width 53: "\x{88DA}\x{655}\x{D83F}\x{DF38}\x{B757}\x{3D8}\x{FE2A}"
+      RenderText {#text} at (52,3220) size 48x17
+        text run at (52,3220) width 48: "\x{2602}\x{5A15}\x{1797}\x{A38}"
+      RenderText {#text} at (99,3220) size 52x17
+        text run at (99,3220) width 52: "\x{DA07}\x{547E}\x{D83D}\x{DF3C}\x{8CAF}"
+      RenderImage {IMG} at (150,3004) size 247x229
+      RenderText {#text} at (396,3220) size 47x17
+        text run at (396,3220) width 47: "\x{D83F}\x{DC3E}\x{262}\x{3E0D}\x{E7E9}"
+      RenderText {#text} at (442,3220) size 103x17
+        text run at (442,3220) width 27: "\x{D851}\x{5F41}"
+        text run at (468,3220) width 20 RTL: "\x{837}"
+        text run at (487,3220) width 58: "\x{B48}\x{D83E}\x{DCB0}\x{BDCB}\x{B8EC}"
+      RenderText {#text} at (544,3220) size 46x17
+        text run at (544,3220) width 46: "\x{7A6}\x{90EE}\x{548D}\x{B538}"
+      RenderText {#text} at (589,3220) size 60x17
+        text run at (589,3220) width 8: "\x{31F}"
+        text run at (596,3220) width 8 RTL: "\x{676}"
+        text run at (603,3220) width 46: "\x{7053}\x{2F9B}\x{305}\x{657A}"
+      RenderText {#text} at (648,3220) size 105x17
+        text run at (648,3220) width 63: "\x{A6B}\x{AA0}\x{4013}\x{8F6E}\x{A9D1}\x{6DB}"
+        text run at (710,3220) width 6 RTL: "\x{FE97}"
+        text run at (715,3220) width 38: "\x{7754}\x{2FAF}\x{D83D}\x{DF4C}"
+      RenderText {#text} at (0,3220) size 764x47
+        text run at (752,3220) width 12: "\x{2EF8}"
+        text run at (0,3250) width 15: "\x{37A9}"
+      RenderText {#text} at (0,3421) size 56x17
+        text run at (0,3421) width 56: "\x{D83F}\x{DC0D}\x{67DC}\x{6EA3}\x{3A79}"
+      RenderText {#text} at (55,3421) size 67x17
+        text run at (55,3421) width 67: "\x{1}\x{CA89}\x{7852}\x{BDBC}\x{BED}"
+      RenderText {#text} at (0,3834) size 55x17
+        text run at (0,3834) width 55: "\x{3EA}\x{5659}\x{B224}\x{5A3A}"
+      RenderImage {IMG} at (54,3788) size 47x59
+      RenderText {#text} at (100,3834) size 93x17
+        text run at (100,3834) width 93: "\x{7D65}\x{4D20}\x{898}\x{D83F}\x{DE70}\x{B767}\x{90C}\x{4CCF}"
+      RenderText {#text} at (527,3834) size 122x17
+        text run at (527,3834) width 122: "\x{8AA4}\x{A3E}\x{B9F}\x{1F10}\x{E49}\x{D83F}\x{DF44}\x{B78}\x{CE88}\x{19F5}\x{D83D}\x{DEC0}"
+      RenderText {#text} at (648,3834) size 93x17
+        text run at (648,3834) width 67: "\x{DAB}\x{B758}\x{E82}\x{339}\x{D754}\x{98B}"
+        text run at (714,3834) width 12 RTL: "\x{895}"
+        text run at (725,3834) width 16: "\x{B544}"
+      RenderText {#text} at (0,3973) size 117x17
+        text run at (0,3973) width 117: "\x{5DE9}\x{BAC7}\x{615A}\x{443}\x{D83E}\x{DC0B}\x{5AE9}\x{FB8}\x{3E2D}\x{45A8}"
+      RenderImage {IMG} at (116,3920) size 156x66
+      RenderText {#text} at (271,3973) size 111x17
+        text run at (271,3973) width 111: "\x{4456}\x{763D}\x{6858}\x{3197}\x{7B4A}\x{A6C5}\x{13D1}\x{AE2C}"
+      RenderText {#text} at (381,3973) size 82x17
+        text run at (381,3973) width 82: "\x{4907}\x{B652}\x{D83E}\x{DE43}\x{CBD5}\x{C520}\x{459}"
+      RenderImage {IMG} at (462,3859) size 288x127
+      RenderText {#text} at (0,4001) size 120x17
+        text run at (0,4001) width 120: "\x{D83F}\x{DDA7}\x{363}\x{D83E}\x{DC47}\x{5E75}\x{D83F}\x{DE23}\x{1AE}\x{A8E5}\x{D83F}\x{DEF3}\x{48DF}\x{5107}"
+      RenderText {#text} at (119,4001) size 27x17
+        text run at (119,4001) width 27: "\x{E95D}\x{BA46}"
+      RenderText {#text} at (145,4001) size 110x17
+        text run at (145,4001) width 99: "\x{6D9B}\x{D83D}\x{DE24}\x{8BA2}\x{6CE6}\x{E9B}\x{D83E}\x{DFA8}\x{1361}\x{22DE}"
+        text run at (243,4001) width 12 RTL: "\x{621}\x{709}"
+      RenderText {#text} at (254,4001) size 35x17
+        text run at (254,4001) width 35: "\x{D83F}\x{DD69}\x{5660}\x{A0E6}"
+      RenderText {#text} at (288,4001) size 84x17
+        text run at (288,4001) width 84: "\x{6B8D}\x{CD3F}{\x{BA63}\x{D83F}\x{DC58}\x{D83E}\x{DE79}"
+      RenderText {#text} at (371,4001) size 79x17
+        text run at (371,4001) width 79: "\x{6BB9}\x{D83F}\x{DEA4}\x{2C97}\x{2972}\x{1BF}\x{DE85}\x{CFE7}"
+      RenderText {#text} at (449,4001) size 67x17
+        text run at (449,4001) width 67: "\x{EF1}\x{B007}\x{3F51}\x{261D}\x{D83F}\x{DC63}"
+      RenderText {#text} at (515,4001) size 76x17
+        text run at (515,4001) width 44: "\x{98B8}\x{29B}\x{9DD}\x{D83E}\x{DF77}"
+        text run at (558,4001) width 12 RTL: "\x{812}"
+        text run at (569,4001) width 22: "\x{970}\x{4E6C}"
+      RenderText {#text} at (590,4001) size 140x17
+        text run at (590,4001) width 140: "\x{D83D}\x{DFE5}\x{D83E}\x{DC26}\x{61CA}\x{D83E}\x{DE1C}\x{D83E}\x{DC4B}\x{8674}\x{3056}\x{1992}\x{37B8}\x{8F24}"
+      RenderImage {IMG} at (0,4272) size 76x41
+      RenderText {#text} at (76,4300) size 26x17
+        text run at (76,4300) width 26: "\x{E444}\x{8A50}"
+      RenderText {#text} at (101,4300) size 123x17
+        text run at (101,4300) width 123: "\x{6E4}\x{312}\x{D83E}\x{DDBF}\x{D3EF}\x{2A01}\x{8F1B}\x{24D5}\x{D83F}\x{DD89}\x{CE5}\x{4551}"
+      RenderImage {IMG} at (223,4251) size 56x62
+      RenderText {#text} at (278,4300) size 31x17
+        text run at (278,4300) width 31: "\x{D70}\x{3846}"
+      RenderText {#text} at (308,4300) size 81x17
+        text run at (308,4300) width 81: "\x{9AA4}\x{116F}\x{D83F}\x{DCB4}\x{2376}\x{D945}\x{F70C}\x{907}"
+      RenderText {#text} at (388,4300) size 69x17
+        text run at (388,4300) width 7 RTL: "\x{692}"
+        text run at (394,4300) width 63: "\x{D83E}\x{DF0B}\x{996}\x{4A8}\x{D7}\x{EABE}\x{AAB0}"
+      RenderImage {IMG} at (0,4363) size 298x170
+      RenderText {#text} at (298,4520) size 103x17
+        text run at (298,4520) width 103: "\x{CAD}\x{D94}\x{4B88}\x{816}\x{394D}\x{F0ED}\x{36A2}\x{A98}\x{3A3E}"
+      RenderText {#text} at (438,4520) size 100x17
+        text run at (438,4520) width 100: "\x{D83F}\x{DEC6}\x{D55E}\x{402}\x{D83F}\x{DF7B}\x{8A4E}\x{CADE}\x{B7B1}\x{1E61}"
+      RenderText {#text} at (537,4520) size 117x17
+        text run at (537,4520) width 32: "\x{B25}\x{D83F}\x{DC03}\x{D83F}\x{DD50}"
+        text run at (568,4520) width 10 RTL: "\x{79B}"
+        text run at (577,4520) width 77: "\x{D83E}\x{DDC3}\x{576}\x{E20F}\x{280}\x{4DEE}\x{13A}\x{F0F9}"
+      RenderImage {IMG} at (0,4540) size 292x253
+      RenderText {#text} at (292,4780) size 103x17
+        text run at (292,4780) width 103: "\x{24DD}\x{1788}\x{D83E}\x{DE55}\x{6EB}\x{103}\x{D83E}\x{DE5C}\x{D83E}\x{DDEB}\x{DB9}"
+      RenderText {#text} at (394,4780) size 105x17
+        text run at (394,4780) width 105: "\x{10D}\x{BA96}\x{12FD}\x{D83E}\x{DE2D}\x{965}\x{9671}\x{1C5}\x{4E8F}"
+      RenderText {#text} at (498,4780) size 102x17
+        text run at (498,4780) width 102: "\x{52B}\x{D83E}\x{DEB4}\x{6B33}\x{6575}\x{2DB}\x{F261}\x{9F9}\x{7167}"
+      RenderText {#text} at (599,4780) size 116x17
+        text run at (599,4780) width 116: "\x{1FA5}\x{D272}\x{923B}\x{658}\x{65F1}\x{BE17}\x{2CD9}\x{C06}\x{E310}\x{D83F}\x{DCED}"
+      RenderText {#text} at (0,4811) size 34x17
+        text run at (0,4811) width 34: "\x{123E}\x{D83E}\x{DCAA}\x{D83E}\x{DF0C}"
+      RenderText {#text} at (33,4811) size 120x17
+        text run at (33,4811) width 26: "\x{24BF}\x{B00}"
+        text run at (58,4811) width 12 RTL: "\x{5FF}"
+        text run at (69,4811) width 14: "\x{2FA}\x{B13}"
+        text run at (82,4811) width 11 RTL: "\x{8BC}"
+        text run at (92,4811) width 61: "\x{B7B}\x{FD1}\x{D83F}\x{DF3C}\x{CEF8}\x{9508}"
+      RenderText {#text} at (152,4811) size 88x17
+        text run at (152,4811) width 88: "\x{7A2A}\x{F372}\x{8321}\x{EC39}\x{9A92}\x{F10}\x{BD6D}"
+      RenderText {#text} at (239,4811) size 88x17
+        text run at (239,4811) width 88: "\x{115}\x{6749}\x{D83D}\x{DEAA}\x{BB6A}\x{C0F2}\x{52EF}"
+      RenderText {#text} at (326,4811) size 22x17
+        text run at (326,4811) width 22: "\x{D83E}\x{DF52}\x{D83E}\x{DE24}"
+      RenderText {#text} at (347,4811) size 111x17
+        text run at (347,4811) width 111: "\x{C403}\x{ED76}\x{F09D}\x{D83E}\x{DCC4}\x{DE85}\x{356}\x{96C6}\x{E0BE}\x{BF7}"
+      RenderText {#text} at (457,4811) size 79x17
+        text run at (457,4811) width 79: "\x{ECB8}\x{68FB}\x{7337}\x{C07}\x{FE0}\x{8A1C}"
+      RenderText {#text} at (535,4811) size 85x17
+        text run at (535,4811) width 85: "\x{B050}\x{7756}\x{372}\x{D83D}\x{DFF3}\x{D22}\x{12C}\x{29B8}"
+      RenderText {#text} at (619,4811) size 100x17
+        text run at (619,4811) width 80: "\x{D83F}\x{DD83}\x{D83F}\x{DD58}\x{6EE2}\x{47A3}\x{10B}\x{2CC7}\x{BC62}"
+        text run at (698,4811) width 10 RTL: "\x{67F}"
+        text run at (707,4811) width 12: "\x{D83F}\x{DC12}"
+      RenderText {#text} at (0,4811) size 752x45
+        text run at (718,4811) width 34: "\x{F24}\x{A756}\x{4864}"
+        text run at (0,4839) width 116: "\x{D83D}\x{DF2C}\x{D83E}\x{DD04}\x{D83D}\x{DFF9}\x{D83E}\x{DD6D}\x{D83D}\x{DF33}\x{9AA9}\x{FF4C}\x{D83E}\x{DEAD}"
+      RenderText {#text} at (115,4839) size 52x17
+        text run at (115,4839) width 27: "\x{84E2}\x{D83E}\x{DCB2}"
+        text run at (141,4839) width 11 RTL: "\x{793}"
+        text run at (151,4839) width 16: "\x{812B}"
+      RenderText {#text} at (166,4839) size 119x17
+        text run at (166,4839) width 119: "\x{CD98}\x{D83E}\x{DEF8}\x{D83E}\x{DDA7}\x{AF08}\x{4EB8}\x{1243}\x{B2E}\x{FF7}"
+      RenderText {#text} at (284,4839) size 96x17
+        text run at (284,4839) width 96: "\x{1E56}\x{DB7F}\x{3BE0}\x{9F86}\x{4C4D}\x{D83F}\x{DCB1}\x{D83E}\x{DD9F}"
+      RenderText {#text} at (379,4839) size 60x17
+        text run at (379,4839) width 16: "\x{AC6C}"
+        text run at (394,4839) width 15 RTL: "\x{84C}"
+        text run at (408,4839) width 31: "\x{3CFB}\x{C01}"
+      RenderText {#text} at (438,4839) size 84x17
+        text run at (438,4839) width 84: "\x{C96F}\x{CFE}\x{D83E}\x{DD4C}\x{2EB1}\x{BFB}\x{D83F}\x{DFDA}"
+      RenderText {#text} at (521,4839) size 74x17
+        text run at (521,4839) width 74: "\x{966}\x{D83D}\x{DE44}\x{F51D}\x{D83E}\x{DF45}\x{F91}\x{2772}\x{D83F}\x{DF3B}"
+      RenderText {#text} at (594,4839) size 89x17
+        text run at (594,4839) width 67: "\x{94A5}\x{8A96}\x{6D75}\x{D83F}\x{DC81}\x{180}"
+        text run at (660,4839) width 12 RTL: "\x{6A6}"
+        text run at (671,4839) width 12: "\x{D83F}\x{DC37}"
+      RenderText {#text} at (682,4839) size 78x17
+        text run at (682,4839) width 58: "\x{EA1}\x{FB1}\x{A34}\x{5543}\x{D83F}\x{DF64}"
+        text run at (739,4839) width 13 RTL: "\x{801}"
+        text run at (751,4839) width 9: "\x{2EE1}"
+      RenderText {#text} at (0,4865) size 34x17
+        text run at (0,4865) width 34: "\x{1498}\x{D83F}\x{DE40}\x{D83E}\x{DC29}"
+      RenderText {#text} at (33,4865) size 23x17
+        text run at (33,4865) width 23: "\x{3040}\x{D83E}\x{DE44}"
+      RenderText {#text} at (55,4865) size 74x17
+        text run at (55,4865) width 74: "\x{D83F}\x{DF07}\x{DE60}\x{958}\x{D83F}\x{DD30}\x{4AC5}\x{3F37}"
+      RenderText {#text} at (128,4865) size 133x17
+        text run at (128,4865) width 133: "\x{7F0}\x{9CF}\x{C47A}\x{D74}\x{161C}\x{1F13}\x{97BB}\x{4FF7}\x{3AEF}\x{D83E}\x{DC98}\x{DDA}"
+      RenderText {#text} at (260,4865) size 111x17
+        text run at (260,4865) width 111: "\x{E60A}\x{5E72}\x{FAFC}\x{A318}\x{960}\x{9825}\x{265E}\x{6633}\x{6C91}"
+      RenderText {#text} at (370,4865) size 109x17
+        text run at (370,4865) width 61: "\x{739A}\x{2679}\x{24C2}\x{4019}"
+        text run at (430,4865) width 12 RTL: "\x{5C9}"
+        text run at (441,4865) width 38: "\x{CEE6}\x{D83E}\x{DF11}\x{A44}"
+      RenderText {#text} at (478,4865) size 32x17
+        text run at (478,4865) width 32: "\x{A89}\x{D83E}\x{DE59}\x{D83E}\x{DE6F}"
+      RenderText {#text} at (509,4865) size 83x17
+        text run at (509,4865) width 68: "\x{C1D6}\x{DC6A}\x{6930}\x{9921}\x{432}\x{ED}"
+        text run at (576,4865) width 5 RTL: "\x{701}"
+        text run at (580,4865) width 12: "\x{C84}"
+      RenderText {#text} at (591,4865) size 98x17
+        text run at (591,4865) width 98: "\x{D83D}\x{DE53}\x{D83F}\x{DC79}\x{C460}\x{BEF2}\x{4C04}\x{156}\x{372}\x{47A}"
+      RenderText {#text} at (688,4865) size 23x17
+        text run at (688,4865) width 23: "\x{D83E}\x{DC7C}\x{D83F}\x{DC5B}"
+      RenderText {#text} at (0,4865) size 756x43
+        text run at (710,4865) width 46: "\x{37FE}\x{9416}\x{9668}"
+        text run at (0,4891) width 54: "\x{E6B0}\x{F1F}\x{E27B}\x{B1B}\x{6F8B}"
+      RenderText {#text} at (53,4891) size 89x17
+        text run at (53,4891) width 89: "\x{533}\x{D83F}\x{DDD9}\x{C481}\x{C5EC}\x{A889}\x{49D9}\x{D83F}\x{DEBB}"
+      RenderText {#text} at (141,4891) size 120x17
+        text run at (141,4891) width 16: "\x{589C}"
+        text run at (156,4891) width 12 RTL: "\x{5CC}"
+        text run at (167,4891) width 49: "\x{1FF}\x{8296}\x{D83F}\x{DD87}\x{C9CD}"
+        text run at (215,4891) width 11 RTL: "\x{5E1}"
+        text run at (225,4891) width 12: "\x{EB97}"
+        text run at (236,4891) width 14 RTL: "\x{8B6}"
+        text run at (249,4891) width 12: "\x{D83E}\x{DE33}"
+      RenderText {#text} at (260,4891) size 70x17
+        text run at (260,4891) width 70: "\x{29E}\x{3AD8}\x{911F}\x{4170}\x{89AC}"
+      RenderText {#text} at (329,4891) size 127x17
+        text run at (329,4891) width 127: "\x{DAE}\x{D83E}\x{DFD0}\x{D676}\x{7A82}\x{D83F}\x{DC92}\x{D33}\x{99C8}\x{D83E}\x{DD52}\x{8FDE}\x{140}"
+      RenderText {#text} at (455,4891) size 145x17
+        text run at (455,4891) width 128: "\x{D83E}\x{DCB1}\x{D83E}\x{DCB7}\x{D83F}\x{DDE3}\x{B97C}\x{C855}\x{CD5B}\x{CF1}\x{C54C}\x{4043}\x{1535}"
+        text run at (587,4891) width 13 RTL: "\x{83D}"
+      RenderText {#text} at (582,4891) size 84x17
+        text run at (582,4891) width 6 RTL: "\x{5D5}"
+        text run at (599,4891) width 67: "\x{5E92}\x{1E8A}\x{9A39}\x{D29}\x{D83F}\x{DEBA}"
+      RenderText {#text} at (665,4891) size 31x17
+        text run at (665,4891) width 31: "\x{47B5}\x{8C8D}"
+      RenderText {#text} at (0,4891) size 764x45
+        text run at (695,4891) width 69: "\x{275C}\x{145}\x{C5C7}\x{F654}\x{DAD7}\x{BDD7}"
+        text run at (0,4919) width 19: "n\x{F047}"
+      RenderText {#text} at (18,4919) size 120x17
+        text run at (18,4919) width 28: "\x{ABB4}\x{AACB}\x{A19}"
+        text run at (45,4919) width 15 RTL: "\x{717}"
+        text run at (59,4919) width 79: "\x{E620}\x{D83E}\x{DC2C}\x{D83D}\x{DE54}\x{2C3}\x{BD07}\x{536}\x{4AFF}"
+      RenderText {#text} at (137,4919) size 63x17
+        text run at (137,4919) width 32: "\x{D83E}\x{DDCC}\x{D83E}\x{DC21}"
+        text run at (168,4919) width 17 RTL: "\x{6BE}\x{769}"
+        text run at (184,4919) width 16: "\x{41BE}"
+      RenderText {#text} at (199,4919) size 41x17
+        text run at (199,4919) width 15 RTL: "\x{808}"
+        text run at (213,4919) width 27: "\x{D83E}\x{DE4B}\x{4961}"
+      RenderText {#text} at (239,4919) size 48x17
+        text run at (239,4919) width 48: "\x{2CE9}\x{E5A6}\x{7C86}\x{10}"
+      RenderText {#text} at (286,4919) size 140x17
+        text run at (286,4919) width 140: "\x{D83F}\x{DE92}\x{E10B}\x{E644}\x{346D}\x{DD9}\x{EC1}\x{1D39}\x{BAE0}\x{CCC}\x{D0A}\x{272D}"
+      RenderText {#text} at (425,4919) size 144x17
+        text run at (425,4919) width 144: "\x{8E33}\x{F5F6}\x{D83E}\x{DD52}\x{542C}\x{AE0C}\x{33F}\x{B49F}\x{D83E}\x{DCA8}\x{DA4}\x{D83F}\x{DC82}\x{6138}"
+      RenderText {#text} at (568,4919) size 102x17
+        text run at (568,4919) width 33: "\x{D83F}\x{DF2D}\x{F4A7}\x{E7C6}"
+        text run at (600,4919) width 10 RTL: "\x{639}"
+        text run at (609,4919) width 27: "\x{FDD}\x{8C02}"
+        text run at (635,4919) width 5 RTL: "\x{627}"
+        text run at (639,4919) width 31: "\x{64C5}\x{3878}"
+      RenderText {#text} at (0,4919) size 768x44
+        text run at (669,4919) width 99: "\x{911D}\x{B0A}\x{D83E}\x{DF5D}\x{530D}\x{D6F0}\x{302}\x{9DF7}\x{D18}"
+        text run at (0,4946) width 15: "\x{B088}\x{EC9}"
+      RenderText {#text} at (14,4946) size 27x17
+        text run at (14,4946) width 12: "\x{D83F}\x{DDBE}"
+        text run at (35,4946) width 6 RTL: "\x{6C0}"
+      RenderText {#text} at (25,4946) size 76x17
+        text run at (25,4946) width 11 RTL: "\x{6D1}"
+        text run at (40,4946) width 61: "\x{B7EC}\x{DC39}\x{73EF}\x{1F90}\x{D83E}\x{DFE6}"
+      RenderText {#text} at (100,4946) size 132x17
+        text run at (100,4946) width 111: "\x{326D}\x{F53}\x{D83E}\x{DCAB}\x{482}\x{D83E}\x{DFFE}\x{B32F}\x{D83F}\x{DD03}\x{5C3E}\x{3D9C}"
+        text run at (210,4946) width 22 RTL: "\x{FCFC}"
+      RenderText {#text} at (231,4946) size 102x17
+        text run at (231,4946) width 77: "\x{8950}\x{4E2A}\x{EDC}\x{D83E}\x{DCD7}\x{D83F}\x{DD84}\x{44E}"
+        text run at (307,4946) width 11 RTL: "\x{848}"
+        text run at (317,4946) width 16: "\x{AF80}"
+      RenderText {#text} at (332,4946) size 129x17
+        text run at (332,4946) width 129: "\x{54D7}\x{E79C}\x{8C16}\x{63C6}\x{F54D}\x{8CEB}\x{8E6}\x{D83E}\x{DD1E}\x{F5BB}\x{AD09}"
+      RenderText {#text} at (460,4946) size 95x17
+        text run at (460,4946) width 95: "\x{D07B}\x{D83D}\x{DEBF}\x{C5}\x{D83E}\x{DCF7}\x{F8}\x{4AC9}\x{6E8E}"
+      RenderText {#text} at (554,4946) size 112x17
+        text run at (554,4946) width 112: "\x{C7FE}\x{AE4D}\x{4827}\x{BA55}\x{62AD}\x{FBA}\x{6065}\x{4EFC}"
+      RenderText {#text} at (0,4946) size 755x45
+        text run at (665,4946) width 90: "\x{10C6}\x{4BF}\x{BBE4}\x{D3B}\x{A0A}\x{B8E}\x{1487}\x{D83F}\x{DC7C}"
+        text run at (0,4974) width 32: "\x{23D}\x{1AA}\x{8F3F}"
+      RenderText {#text} at (31,4974) size 36x17
+        text run at (31,4974) width 36: "\x{328}\x{E96}\x{D83F}\x{DF71}\x{F10F}"
+      RenderText {#text} at (66,4974) size 88x17
+        text run at (66,4974) width 88: "\x{614A}\x{C870}\x{E997}\x{D83F}\x{DE46}\x{2D8B}\x{B80}\x{EFC4}"
+      RenderText {#text} at (153,4974) size 140x17
+        text run at (153,4974) width 140: "\x{496B}\x{D83F}\x{DE84}\x{D3D8}\x{D83D}\x{DF44}\x{1244}\x{D83E}\x{DD7C}\x{3C8A}\x{D73F}\x{E6DF}\x{D83F}\x{DD5E}"
+      RenderText {#text} at (292,4974) size 11x17
+        text run at (292,4974) width 11: "\x{2995}\x{F7D}"
+      RenderText {#text} at (302,4974) size 60x17
+        text run at (302,4974) width 60: "\x{515D}\x{DEA}k\x{D83F}\x{DDE9}\x{D099}"
+      RenderText {#text} at (361,4974) size 83x17
+        text run at (361,4974) width 83: "\x{4936}\x{A04}\x{D83D}\x{DE68}\x{7F8E}\x{5145}\x{3B80}"
+      RenderText {#text} at (443,4974) size 42x17
+        text run at (443,4974) width 42: "\x{B92B}\x{B663}\x{D83F}\x{DF52}"
+      RenderText {#text} at (484,4974) size 32x17
+        text run at (484,4974) width 32: "\x{D83F}\x{DD45}\x{4C8}\x{1500}"
+      RenderText {#text} at (515,4974) size 103x17
+        text run at (515,4974) width 11 RTL: "\x{649}"
+        text run at (525,4974) width 93: "Y\x{E2}\x{D83D}\x{DFCF}\x{BE7}\x{E856}\x{D83D}\x{DF5D}\x{96CF}\x{76BA}"
+      RenderText {#text} at (617,4974) size 71x17
+        text run at (617,4974) width 71: "\x{3190}\x{B978}\x{898}\x{AD2C}\x{CF05}"
+      RenderText {#text} at (687,4974) size 49x17
+        text run at (687,4974) width 49: "\x{D83F}\x{DC2C}\x{DDE0}\x{2E3F}\x{3B9A}"
+      RenderText {#text} at (0,5002) size 78x17
+        text run at (0,5002) width 31: "\x{D83E}\x{DE42}\x{A6E}\x{D9FC}"
+        text run at (30,5002) width 18 RTL: "\x{FC17}"
+        text run at (47,5002) width 31: "\x{24A9}\x{5434}"
+      RenderText {#text} at (77,5002) size 138x17
+        text run at (77,5002) width 138: "\x{8EB0}\x{D83F}\x{DCBB}\x{8B92}\x{4961}\x{D83F}\x{DE5F}\x{815F}\x{1496}\x{75DF}\x{F135}\x{D83E}\x{DCAE}\x{AB94}"
+      RenderText {#text} at (214,5002) size 119x17
+        text run at (214,5002) width 119: "\x{7}\x{F4E}\x{E9C5}\x{D83E}\x{DD16}\x{FF4}\x{C8B2}\x{8885}\x{1181}\x{D83F}\x{DDD6}"
+      RenderText {#text} at (332,5002) size 138x17
+        text run at (332,5002) width 138: "\x{F40D}\x{D83E}\x{DE7B}\x{D83F}\x{DE68}\x{481}\x{1242}\x{BA41}\x{8A50}\x{D83F}\x{DD54}\x{2F2A}\x{D83D}\x{DE49}"
+      RenderText {#text} at (469,5002) size 137x17
+        text run at (469,5002) width 137: "\x{884F}\x{146B}\x{D9C5}\x{D83E}\x{DF3C}\x{40EA}\x{BCD5}\x{5E1B}\x{A59}\x{D83E}\x{DCDD}\x{D83F}\x{DDF0}\x{7C60}"
+      RenderText {#text} at (605,5002) size 119x17
+        text run at (605,5002) width 119: "\x{5BB}\x{D83D}\x{DF58}\x{994}\x{D6F}\x{D83F}\x{DCBF}\x{1E35}\x{DD08}\x{90FE}\x{16AD}\x{B0D1}\x{5E87}"
+      RenderText {#text} at (0,5002) size 758x45
+        text run at (723,5002) width 35: "\x{78F9}\x{D83F}\x{DC10}\x{A0E3}"
+        text run at (0,5030) width 15: "\x{5AFC}"
+      RenderText {#text} at (15,5030) size 130x17
+        text run at (15,5030) width 130: "\x{5084}\x{BECB}\x{6B64}\x{D83E}\x{DC65}\x{D72B}\x{7CD8}\x{D83F}\x{DC17}\x{9C6}\x{D83F}\x{DEF6}\x{7A6}"
+      RenderText {#text} at (144,5030) size 67x17
+        text run at (144,5030) width 67: "\x{21AA}\x{C3A9}\x{32C1}\x{1E22}\x{D00}"
+      RenderText {#text} at (210,5030) size 111x17
+        text run at (210,5030) width 10 RTL: "\x{682}"
+        text run at (219,5030) width 102: "\x{78A3}\x{E49}\x{B61}\x{C2}\x{E55}\x{555}\x{3F5}\x{A4E9}\x{34EC}\x{D83E}\x{DE4D}"
+      RenderText {#text} at (320,5030) size 96x17
+        text run at (320,5030) width 42: "\x{5699}\x{8FFA}\x{F786}"
+        text run at (361,5030) width 9 RTL: "\x{685}"
+        text run at (369,5030) width 47: "\x{1D3F}\x{DB6B}\x{BF05}\x{4083}"
+      RenderText {#text} at (415,5030) size 35x17
+        text run at (415,5030) width 31: "\x{7F14}\x{9D87}"
+        text run at (445,5030) width 5 RTL: "\x{627}"
+      RenderText {#text} at (449,5030) size 53x17
+        text run at (449,5030) width 53: "\x{D83F}\x{DD01}\x{4ED3}\x{60F4}\x{2C4D}"
+      RenderText {#text} at (501,5030) size 52x17
+        text run at (501,5030) width 52: "\x{D404}\x{ADEF}\x{558}\x{D83F}\x{DC9A}"
+      RenderText {#text} at (552,5030) size 73x17
+        text run at (552,5030) width 12: "\x{D83E}\x{DF0D}"
+        text run at (563,5030) width 12 RTL: "\x{5EA}"
+        text run at (574,5030) width 51: "\x{1211}\x{EE55}\x{1C8A}\x{D83F}\x{DEAD}"
+      RenderText {#text} at (0,5030) size 744x42
+        text run at (624,5030) width 120: "\x{D83E}\x{DE97}\x{AFC9}\x{D83F}\x{DC32}\x{D83F}\x{DD2F}\x{20A}\x{F3F1}\x{D83E}\x{DD8F}\x{2E70}\x{3838}"
+        text run at (0,5055) width 11: "\x{D83E}\x{DF9C}"
+      RenderText {#text} at (10,5055) size 121x17
+        text run at (10,5055) width 121: "\x{D83E}\x{DC74}\x{D83D}\x{DF80}\x{FAE}\x{EA64}\x{525}\x{D83F}\x{DF92}\x{D83E}\x{DE4A}\x{4F6}\x{D83F}\x{DE5D}\x{D83E}\x{DF5C}\x{88DC}"
+      RenderText {#text} at (130,5055) size 38x17
+        text run at (130,5055) width 38: "\x{6B58}\x{CF96}\x{168B}"
+      RenderText {#text} at (167,5055) size 108x17
+        text run at (167,5055) width 50: "\x{B850}\x{D83D}\x{DF15}\x{850E}\x{C90}"
+        text run at (216,5055) width 8 RTL: "\x{6C1}"
+        text run at (223,5055) width 52: "\x{D83F}\x{DF5B}\x{6949}\x{4E7E}\x{9BA}"
+      RenderText {#text} at (274,5055) size 110x17
+        text run at (274,5055) width 12: "\x{D83E}\x{DC0E}"
+        text run at (285,5055) width 10 RTL: "\x{7D5}"
+        text run at (294,5055) width 90: "\x{3ADE}\x{D83D}\x{DFBF}\x{55B}\x{D83E}\x{DFD0}\x{F3C9}\x{AFC}\x{D83F}\x{DEA7}\x{FD5}\x{B6C}"
+      RenderText {#text} at (383,5055) size 57x17
+        text run at (383,5055) width 57: "\x{945}\x{5DA4}\x{D83E}\x{DDEE}\x{53A}"
+      RenderText {#text} at (439,5055) size 107x17
+        text run at (439,5055) width 107: "\x{81F7}\x{48AB}\x{2610}\x{6F92}\x{D83E}\x{DC73}\x{8881}\x{45F}\x{F920}"
+      RenderText {#text} at (545,5055) size 128x17
+        text run at (545,5055) width 128: "\x{E4B}\x{DD7}\x{736}\x{F5A}\x{7373}\x{532}\x{D83E}\x{DC9E}\x{D83E}\x{DE64}\x{274A}\x{CBF1}\x{6AA5}"
+      RenderText {#text} at (0,5055) size 751x45
+        text run at (672,5055) width 79: "\x{DEDD}\x{DC4D}\x{D83F}\x{DEBA}\x{D83F}\x{DE46}\x{F56F}\x{141D}\x{BA38}"
+        text run at (0,5083) width 48: "\x{E100}\x{E5A4}\x{E4D8}\x{6679}"
+      RenderText {#text} at (47,5083) size 51x17
+        text run at (47,5083) width 51: "\x{8AC3}\x{5294}\x{E15}\x{F006}"
+      RenderText {#text} at (97,5083) size 123x17
+        text run at (97,5083) width 123: "\x{F769}\x{D83E}\x{DCA1}\x{D83E}\x{DDF9}\x{25AE}\x{72E5}\x{D83E}\x{DCCF}\x{4A8C}\x{D1F0}\x{D83E}\x{DC81}\x{1C7A}"
+      RenderText {#text} at (219,5083) size 118x17
+        text run at (219,5083) width 22: "\x{D83F}\x{DEF5}\x{F8EC}"
+        text run at (240,5083) width 11 RTL: "\x{6D0}"
+        text run at (250,5083) width 16: "\x{487A}"
+        text run at (265,5083) width 7 RTL: "\x{693}"
+        text run at (271,5083) width 66: "\x{F3C}\x{9485}\x{673D}\x{D83E}\x{DCAB}\x{81DF}"
+      RenderText {#text} at (336,5083) size 130x17
+        text run at (336,5083) width 109: "\x{4A16}\x{82C6}\x{643C}\x{D83D}\x{DEB5}\x{135B}\x{DB59}\x{D83F}\x{DF91}\x{EA82}"
+        text run at (444,5083) width 11 RTL: "\x{752}"
+        text run at (454,5083) width 12: "\x{D83E}\x{DC78}"
+      RenderText {#text} at (465,5083) size 22x17
+        text run at (465,5083) width 22: "\x{94EA}\x{227}"
+      RenderText {#text} at (486,5083) size 124x17
+        text run at (486,5083) width 66: "\x{BA4}\x{1557}\x{E7B2}\x{E3DF}\x{D83D}\x{DE1A}"
+        text run at (551,5083) width 18 RTL: "\x{FCFA}"
+        text run at (568,5083) width 42: "\x{82F5}\x{A7BB}\x{C572}"
+      RenderText {#text} at (609,5083) size 105x17
+        text run at (609,5083) width 105: "\x{EDFC}\x{EFEA}\x{99D}\x{BD3D}\x{A907}\x{CBD}\x{D83F}\x{DF12}\x{918}\x{53F}\x{F1}"
+      RenderText {#text} at (713,5083) size 30x17
+        text run at (713,5083) width 23: "\x{AF5}\x{DCE}"
+        text run at (735,5083) width 8 RTL: "\x{84B}"
+      RenderText {#text} at (0,5083) size 758x45
+        text run at (742,5083) width 16: "\x{D83D}\x{DF05}"
+        text run at (0,5111) width 102: "\x{6B6B}\x{A57}\x{D83F}\x{DE71}\x{A8A}\x{FAB9}\x{2E87}\x{E26D}\x{9DC0}"
+      RenderText {#text} at (101,5111) size 127x17
+        text run at (101,5111) width 127: "\x{C1F9}\x{D83F}\x{DE33}\x{F143}\x{815B}\x{D83E}\x{DCFB}\x{AE3E}\x{4D6}\x{246}\x{D83D}\x{DF03}\x{B53D}"
+      RenderText {#text} at (227,5111) size 128x17
+        text run at (227,5111) width 128: "\x{D83E}\x{DCCB}\x{A4F7}\x{3F2}\x{4A5}\x{F49}\x{6D02}\x{2BE1}\x{1DAF}\x{D83E}\x{DE79}\x{3F1D}\x{B2D}"
+      RenderText {#text} at (354,5111) size 44x17
+        text run at (354,5111) width 44: "\x{E6FD}\x{D83E}\x{DCEA}\x{C86}\x{D83D}\x{DFB6}"
+      RenderText {#text} at (397,5111) size 94x17
+        text run at (397,5111) width 94: "\x{8550}\x{315}\x{D83F}\x{DEBE}\x{9D59}\x{A8E0}\x{D29}\x{DD57}\x{3736}"
+      RenderText {#text} at (490,5111) size 40x17
+        text run at (490,5111) width 40: "\x{978}\x{16F}\x{A1C}\x{9FCF}"
+      RenderText {#text} at (529,5111) size 121x17
+        text run at (529,5111) width 121: "\x{445}\x{C7E}\x{49B4}\x{F256}\x{9EB}\x{E2B3}\x{7D5D}\x{D83D}\x{DF3A}\x{D83F}\x{DDB5}\x{F993}"
+      RenderText {#text} at (649,5111) size 90x17
+        text run at (649,5111) width 90: "\x{203}\x{799B}\x{D83F}\x{DF95}\x{6834}\x{4A6E}\x{D83F}\x{DEEA}\x{634E}"
+      RenderText {#text} at (0,5111) size 754x45
+        text run at (738,5111) width 16: "\x{B821}"
+        text run at (0,5139) width 48: "\x{A615}\x{1D6}\x{4E7}\x{E06C}q"
+      RenderText {#text} at (47,5139) size 57x17
+        text run at (47,5139) width 57: "\x{D83E}\x{DEC0}\x{FAA}\x{D83D}\x{DED3}\x{474A}"
+      RenderText {#text} at (103,5139) size 117x17
+        text run at (103,5139) width 117: "\x{F198}\x{27BB}\x{5D7A}\x{AA7}\x{AF9C}\x{1EE4}\x{23C2}\x{35DA}\x{E551}"
+      RenderText {#text} at (219,5139) size 27x17
+        text run at (219,5139) width 27: "\x{5A8F}\x{D67}"
+      RenderText {#text} at (245,5139) size 25x17
+        text run at (245,5139) width 25: "\x{422F}\x{F34}"
+      RenderText {#text} at (269,5139) size 113x17
+        text run at (269,5139) width 113: "\x{4E0B}\x{AD32}\x{9EF}\x{92F2}\x{6147}\x{A0D8}\x{D83E}\x{DDCE}\x{D63F}"
+      RenderText {#text} at (381,5139) size 97x17
+        text run at (381,5139) width 16: "\x{D83E}\x{DF77}\x{2D42}"
+        text run at (396,5139) width 15 RTL: "\x{FC9D}"
+        text run at (410,5139) width 68: "\x{56AB}\x{38D3}\x{32E0}\x{1EF}\x{D6B}"
+      RenderText {#text} at (477,5139) size 20x17
+        text run at (477,5139) width 20: "\x{10}\x{E8A}"
+      RenderText {#text} at (496,5139) size 122x17
+        text run at (496,5139) width 23: "\x{D83E}\x{DC7F}\x{E324}"
+        text run at (518,5139) width 12 RTL: "\x{88A}"
+        text run at (529,5139) width 89: "\x{F2E}\x{9192}\x{B089}\x{E52B}\x{D83E}\x{DE89}\x{D83D}\x{DFBF}\x{8FA8}"
+      RenderText {#text} at (617,5139) size 77x17
+        text run at (617,5139) width 77: "\x{BAB5}\x{D028}\x{E7E}\x{D83F}\x{DC2F}\x{E14}\x{38B9}"
+      RenderText {#text} at (693,5139) size 50x17
+        text run at (693,5139) width 50: "\x{34E}\x{A22F}\x{24F}\x{D83E}\x{DC0E}\x{7F63}"
+      RenderText {#text} at (0,5139) size 758x42
+        text run at (742,5139) width 16: "\x{725E}"
+        text run at (0,5164) width 52: "\x{3512}\x{89F2}\x{E971}\x{F91}"
+        text run at (51,5164) width 10 RTL: "\x{5E4}"
+      RenderText {#text} at (60,5164) size 46x17
+        text run at (60,5164) width 46: "\x{F2C1}\x{570}\x{178}\x{91C7}"
+layer at (8,142) size 16x16
+  RenderVideo {VIDEO} at (0,134) size 16x16
+layer at (24,142) size 16x16
+  RenderVideo {VIDEO} at (16,134) size 16x16
+layer at (151,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (143,0) size 300x150
+layer at (8,167) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,159) size 300x150
+layer at (8,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,317) size 300x150
+layer at (308,325) size 300x150
+  RenderHTMLCanvas {CANVAS} at (300,317) size 300x150
+layer at (8,481) size 284x284
+  RenderVideo {VIDEO} at (0,473) size 284x284
+layer at (546,749) size 16x16
+  RenderVideo {VIDEO} at (537,741) size 17x16
+layer at (65,913) size 16x16
+  RenderVideo {VIDEO} at (56,905) size 17x16
+layer at (116,779) size 349x150
+  RenderHTMLCanvas {CANVAS} at (108,771) size 350x150
+layer at (93,937) size 300x150
+  RenderHTMLCanvas {CANVAS} at (85,929) size 301x150
+layer at (8,1120) size 885x385
+  RenderHTMLCanvas {CANVAS} at (0,1112) size 885x385
+layer at (8,1988) size 213x213
+  RenderVideo {VIDEO} at (0,1980) size 213x213
+layer at (196,2420) size 16x16
+  RenderVideo {VIDEO} at (188,2412) size 17x16
+layer at (8,2448) size 290x127
+  RenderHTMLCanvas {CANVAS} at (0,2440) size 290x127
+layer at (8,2856) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,2848) size 300x150
+layer at (334,2739) size 300x267
+  RenderHTMLCanvas {CANVAS} at (326,2731) size 300x267
+layer at (8,3276) size 974x150
+  RenderHTMLCanvas {CANVAS} at (0,3268) size 974x150
+layer at (8,3447) size 905x349
+  RenderHTMLCanvas {CANVAS} at (0,3439) size 905x349
+layer at (200,3832) size 335x23
+  RenderHTMLCanvas {CANVAS} at (192,3824) size 336x23
+layer at (748,3839) size 16x16
+  RenderVideo {VIDEO} at (740,3831) size 17x16
+layer at (465,4030) size 291x291
+  RenderVideo {VIDEO} at (456,4022) size 292x291
+layer at (408,4328) size 38x213
+  RenderVideo {VIDEO} at (400,4320) size 39x213

--- a/LayoutTests/fast/webgpu/fuzz-273585.html
+++ b/LayoutTests/fast/webgpu/fuzz-273585.html
@@ -1,0 +1,20956 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUCommandEncoder} commandEncoder
+ */
+function pseudoSubmit(device, commandEncoder) {
+  device.pushErrorScope('validation');
+  commandEncoder.clearBuffer(device.createBuffer({size: 0, usage: 0}), 0, 0);
+  device.popErrorScope().then(() => {});
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let promise0 = navigator.gpu.requestAdapter({
+});
+let promise1 = navigator.gpu.requestAdapter({
+});
+let adapter0 = await navigator.gpu.requestAdapter();
+let promise2 = adapter0.requestDevice({
+label: '\ue183\u0dbc\ud3d3\ub238\u{1fe0a}\u0e99\u01f7',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 55,
+maxVertexBufferArrayStride: 17024,
+maxStorageTexturesPerShaderStage: 43,
+maxStorageBuffersPerShaderStage: 10,
+maxDynamicStorageBuffersPerPipelineLayout: 8762,
+maxBindingsPerBindGroup: 5530,
+maxTextureDimension1D: 12687,
+maxTextureDimension2D: 11464,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 211056528,
+maxUniformBuffersPerShaderStage: 35,
+maxInterStageShaderVariables: 111,
+maxInterStageShaderComponents: 63,
+maxSamplersPerShaderStage: 19,
+},
+});
+let adapter1 = await navigator.gpu.requestAdapter({
+});
+let device0 = await promise2;
+let querySet0 = device0.createQuerySet({
+label: '\u8735\u{1f69a}\u94af\u{1fca3}\u03fc\u8db0\u62de\u0a8d\uaa23\u0844\u0310',
+type: 'occlusion',
+count: 3183,
+});
+let texture0 = device0.createTexture({
+label: '\u989e\u9d22\u05b3\u{1fdbb}\u1e2e\u3448\u{1ff41}\u4ab0\u{1f7f7}\u8fe2',
+size: {width: 4704, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler0 = device0.createSampler({
+label: '\uf806\u04e9\uf354',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 40.036,
+lodMaxClamp: 53.113,
+maxAnisotropy: 10,
+});
+let sampler1 = device0.createSampler({
+label: '\u671e\u00eb\u{1f9f2}\u0c0e\u6658\u9906\ue37c\u64fe\u8fdf\u01a0\u061d',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 49.134,
+lodMaxClamp: 74.836,
+maxAnisotropy: 4,
+});
+let sampler2 = device0.createSampler({
+label: '\u0011\ubfeb\uf8c0\u{1fddb}\u0851\u1ac3\ud4ca\u8c70\ubc96',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+lodMinClamp: 38.058,
+lodMaxClamp: 66.042,
+});
+let querySet1 = device0.createQuerySet({
+type: 'occlusion',
+count: 1276,
+});
+let sampler3 = device0.createSampler({
+label: '\u8328\u06e8',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 25.027,
+lodMaxClamp: 60.615,
+});
+let commandEncoder0 = device0.createCommandEncoder({label: '\u0b3b\u5247\u{1fdf8}\u78d0\u42bc\u{1fef1}\u{1ff01}\ub0d4'});
+let commandBuffer0 = commandEncoder0.finish({
+label: '\ufd3c\uf439\u0537\u072a\u548e\u0266\ude19\u0aaf\u0f40\u048e',
+});
+let promise3 = device0.queue.onSubmittedWorkDone();
+let textureView0 = texture0.createView({label: '\u{1f9b5}\u0e99\uf0b0\u0330\u07ae\u534c\u0c3c\ub207\u733b', mipLevelCount: 2});
+try {
+  await promise3;
+} catch {}
+let canvas0 = document.createElement('canvas');
+let imageData0 = new ImageData(80, 56);
+let commandEncoder1 = device0.createCommandEncoder({});
+try {
+commandEncoder1.insertDebugMarker('\ue180');
+} catch {}
+let imageBitmap0 = await createImageBitmap(imageData0);
+let querySet2 = device0.createQuerySet({
+type: 'occlusion',
+count: 2279,
+});
+let imageBitmap1 = await createImageBitmap(imageData0);
+let textureView1 = texture0.createView({});
+try {
+commandEncoder1.pushDebugGroup('\u1a5f');
+} catch {}
+let imageBitmap2 = await createImageBitmap(imageBitmap0);
+try {
+window.someLabel = sampler0.label;
+} catch {}
+let texture1 = device0.createTexture({
+label: '\u031d\u09b0\u1dae\uc8f0\ud583\uf9cf\u25a7\u1477',
+size: {width: 4544},
+sampleCount: 1,
+dimension: '1d',
+format: 'rg32uint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rg32uint'],
+});
+let computePassEncoder0 = commandEncoder1.beginComputePass({label: '\u7ccd\uc531\u9440\u7420\u{1f762}\u19ee'});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 3141, y: 0, z: 0 },
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(72)), /* required buffer size: 9776 */
+{offset: 520}, {width: 1157, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+let bindGroupLayout0 = device0.createBindGroupLayout({
+label: '\u{1f968}\ud6dc\u{1ff1f}\u706a',
+entries: [{
+binding: 1160,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}],
+});
+let querySet3 = device0.createQuerySet({
+label: '\u0eb5\u9194',
+type: 'occlusion',
+count: 2753,
+});
+let texture2 = device0.createTexture({
+size: {width: 4704},
+sampleCount: 1,
+dimension: '1d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let textureView2 = texture1.createView({label: '\uace2\u0fec', aspect: 'all', mipLevelCount: 1});
+document.body.prepend(canvas0);
+let textureView3 = texture1.createView({format: 'rg32uint', baseMipLevel: 0});
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 400, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(33302), /* required buffer size: 33302 */
+{offset: 630, rowsPerImage: 86}, {width: 4084, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView4 = texture0.createView({baseMipLevel: 1, mipLevelCount: 3, baseArrayLayer: 0});
+let promise4 = adapter0.requestAdapterInfo();
+let pipelineLayout0 = device0.createPipelineLayout({
+  label: '\u0b58\uef0e\u0b24\u31e0\u0028\u5efc\u{1f90f}\u26f8\u{1fe40}\u{1fa33}',
+  bindGroupLayouts: [bindGroupLayout0]
+});
+let commandEncoder2 = device0.createCommandEncoder({label: '\u0d88\u{1fa54}\ub2df\u0976\ufa1e\u720f\u6df5\u7c9b'});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 194, y: 1, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 7 */
+{offset: 7}, {width: 482, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame0 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let canvas1 = document.createElement('canvas');
+let img0 = await imageWithData(98, 98, '#64999d6f', '#0f01d74f');
+let commandEncoder3 = device0.createCommandEncoder({label: '\u{1ff33}\u0ac6\uf3f9\uc09c\u099d\u6f32\uf68b\u3e43\u{1fe18}\u{1fd85}'});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 57, y: 0, z: 0 },
+  aspect: 'all',
+}, new Float64Array(new ArrayBuffer(0)), /* required buffer size: 413 */
+{offset: 413, rowsPerImage: 48}, {width: 3935, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+let imageData1 = new ImageData(216, 256);
+let bindGroupLayout1 = device0.createBindGroupLayout({
+label: '\u2cc2\u9444\u{1f7cd}',
+entries: [{
+binding: 1646,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'comparison' },
+}, {
+binding: 3641,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+}, {
+binding: 2862,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+}],
+});
+let querySet4 = device0.createQuerySet({
+label: '\u0a75\u0a4e\ua26f\u0b39\u{1fbcc}\u0bba\u519e\u0b30',
+type: 'occlusion',
+count: 2819,
+});
+let commandBuffer1 = commandEncoder3.finish({
+});
+pseudoSubmit(device0, commandEncoder2);
+let promise6 = device0.popErrorScope();
+let gpuCanvasContext1 = canvas1.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend(img0);
+let textureView5 = texture1.createView({});
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(392, 15);
+let texture3 = device0.createTexture({
+label: '\u33d7\ueab9\uea25\u0f1f\u044d\u{1fdb1}\u02bd\u091f',
+size: [66, 372, 1],
+mipLevelCount: 9,
+sampleCount: 1,
+format: 'astc-6x6-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler4 = device0.createSampler({
+label: '\u07d2\u57c6\u8ae7\u{1f9c6}\u0645\uba5e\u07b6\u{1ff37}\uaec4\u006a\ub6c7',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 74.916,
+lodMaxClamp: 84.406,
+maxAnisotropy: 11,
+});
+try {
+  await promise6;
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(674, 115);
+let commandEncoder4 = device0.createCommandEncoder({label: '\u{1fd1f}\u{1fe53}\u0a2e\u1ab3\u0dc0\u64a3\ued95\u{1fb78}\u51ca\u07e8'});
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: { x: 35, y: 1, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(835), /* required buffer size: 835 */
+{offset: 835}, {width: 1721, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder({label: '\u{1f8b3}\u09e6\u963a\u1274\ubc11\u292f\u2cec'});
+let querySet5 = device0.createQuerySet({
+label: '\u0d4d\uc4a5\ud0d3\u{1fc1b}\u{1faa4}\u{1f779}\u{1fb9d}\u0e78\u021e\u0d19\u{1f986}',
+type: 'occlusion',
+count: 312,
+});
+let textureView6 = texture1.createView({label: '\u2d21\u9005\u03cc\u295b\u1dca\ubfa3\u{1f683}\u07cf\u0bc4\u9475'});
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: { x: 1496, y: 0, z: 1 },
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(40)), /* required buffer size: 772 */
+{offset: 772}, {width: 1815, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+label: '\uf419\u0040\uff5b\u7cd3',
+code: `@group(0) @binding(1160)
+var<storage, read_write> function0: array<u32>;
+
+@compute @workgroup_size(4, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S1 {
+  @location(110) f0: vec4<f16>
+}
+struct FragmentOutput0 {
+  @builtin(frag_depth) f0: f32,
+  @location(0) f1: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(30) a0: vec3<i32>, @location(24) a1: vec4<f32>, @location(65) a2: u32, @location(26) a3: i32, @location(64) a4: vec4<u32>, @location(6) a5: vec3<f16>, @location(25) a6: vec2<i32>, @builtin(sample_index) a7: u32, @location(48) a8: u32, @location(67) a9: vec4<f32>, @location(33) a10: i32, @location(69) a11: vec2<u32>, @location(23) a12: i32, @location(87) a13: f32, @location(66) a14: vec3<u32>, @location(40) a15: i32, @builtin(front_facing) a16: bool, @location(8) a17: vec4<i32>, @location(42) a18: vec3<u32>, a19: S1, @location(68) a20: f16, @builtin(sample_mask) a21: u32, @location(102) a22: f16, @location(11) a23: vec4<i32>, @location(105) a24: vec3<u32>, @location(16) a25: vec3<f32>, @location(35) a26: vec3<f16>, @location(51) a27: vec4<f16>, @location(61) a28: i32, @builtin(position) a29: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S0 {
+  @location(6) f0: vec4<u32>
+}
+struct VertexOutput0 {
+  @location(16) f0: vec3<f32>,
+  @location(40) f1: i32,
+  @location(68) f2: f16,
+  @location(51) f3: vec4<f16>,
+  @location(25) f4: vec2<i32>,
+  @location(30) f5: vec3<i32>,
+  @location(33) f6: i32,
+  @location(69) f7: vec2<u32>,
+  @location(11) f8: vec4<i32>,
+  @builtin(position) f9: vec4<f32>,
+  @location(6) f10: vec3<f16>,
+  @location(35) f11: vec3<f16>,
+  @location(23) f12: i32,
+  @location(105) f13: vec3<u32>,
+  @location(67) f14: vec4<f32>,
+  @location(26) f15: i32,
+  @location(42) f16: vec3<u32>,
+  @location(65) f17: u32,
+  @location(102) f18: f16,
+  @location(24) f19: vec4<f32>,
+  @location(61) f20: i32,
+  @location(64) f21: vec4<u32>,
+  @location(110) f22: vec4<f16>,
+  @location(87) f23: f32,
+  @location(48) f24: u32,
+  @location(8) f25: vec4<i32>,
+  @location(66) f26: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(13) a0: u32, @location(8) a1: vec4<f16>, a2: S0, @location(2) a3: u32, @location(0) a4: vec3<f32>, @location(5) a5: vec3<u32>, @location(11) a6: u32, @location(9) a7: vec4<u32>, @location(1) a8: vec3<f16>, @location(12) a9: vec4<i32>, @location(7) a10: vec3<i32>, @builtin(instance_index) a11: u32, @location(10) a12: vec4<u32>, @location(14) a13: vec2<f32>, @location(4) a14: vec3<i32>, @location(15) a15: f16, @location(3) a16: vec2<f32>, @builtin(vertex_index) a17: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let buffer0 = device0.createBuffer({
+  label: '\u0d8c\u0253\ucbb9\u97c1',
+  size: 16860,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true
+});
+let textureView7 = texture2.createView({label: '\u21b3\u0d27\ue146'});
+document.body.prepend(canvas0);
+let imageData2 = new ImageData(116, 52);
+let bindGroupLayout2 = device0.createBindGroupLayout({
+label: '\u{1f6c9}\u{1f88c}\u283d\u657e',
+entries: [],
+});
+let textureView8 = texture1.createView({label: '\u46d9\u0203\ueb59\ubfd5\u37e6\u6b4b\u957f'});
+let computePassEncoder1 = commandEncoder5.beginComputePass({label: '\u9fdc\u{1fdde}\u{1fa7e}\u8ad5'});
+let pipeline0 = await device0.createComputePipelineAsync({
+label: '\u08ca\u26a6\uf4d4\u7f13\u0dab\u0f50\u0b12\u0884\ub9f3\uc457\u0e1c',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({
+label: '\u5c73\u1007\u7e14\u{1fc79}',
+entries: [{
+binding: 2495,
+visibility: 0,
+storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '3d' },
+}],
+});
+let bindGroup0 = device0.createBindGroup({
+label: '\uca49\u4c1b\u052f\u7f48\u{1ff6b}\u6665\u09d3\u0247\u{1fd29}\u5bd8\u0d3e',
+layout: bindGroupLayout2,
+entries: [],
+});
+let texture4 = device0.createTexture({
+label: '\u0816\u{1fe3c}\ucbc3\u{1ffbc}\u951e\u0708\u2d9b\u{1faed}\ufdd8\u{1f77c}',
+size: {width: 588},
+dimension: '1d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let sampler5 = device0.createSampler({
+label: '\u0ae1\uc5db\u0c13\u7453\u774e\ue3fd',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+mipmapFilter: 'nearest',
+lodMinClamp: 59.307,
+lodMaxClamp: 60.473,
+});
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+commandEncoder1.popDebugGroup();
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let pipeline1 = device0.createRenderPipeline({
+label: '\uecc8\u0535\u0fc6\ufdb8\u440a\u133e\u{1fb7a}\u3581\u3cac\u03b7',
+layout: pipelineLayout0,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED
+}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'always',
+failOp: 'increment-clamp',
+depthFailOp: 'keep',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 1635,
+stencilWriteMask: 2821,
+depthBias: 84,
+depthBiasSlopeScale: 20,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 4052,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x2',
+offset: 1408,
+shaderLocation: 15,
+}, {
+format: 'uint16x2',
+offset: 2836,
+shaderLocation: 2,
+}, {
+format: 'uint8x2',
+offset: 3732,
+shaderLocation: 10,
+}, {
+format: 'sint32x3',
+offset: 2460,
+shaderLocation: 4,
+}, {
+format: 'unorm8x4',
+offset: 2248,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 10944,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x2',
+offset: 6688,
+shaderLocation: 13,
+}, {
+format: 'sint8x2',
+offset: 3514,
+shaderLocation: 12,
+}, {
+format: 'float32',
+offset: 6712,
+shaderLocation: 3,
+}, {
+format: 'sint8x2',
+offset: 6272,
+shaderLocation: 7,
+}, {
+format: 'snorm16x2',
+offset: 5632,
+shaderLocation: 1,
+}, {
+format: 'snorm8x4',
+offset: 9152,
+shaderLocation: 8,
+}, {
+format: 'uint8x4',
+offset: 6196,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 5260,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x2',
+offset: 302,
+shaderLocation: 6,
+}, {
+format: 'uint8x4',
+offset: 5076,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 16468,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x3',
+offset: 416,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 8512,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 5900,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 9616,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 15012,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x4',
+offset: 1532,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+},
+});
+let imageData3 = new ImageData(204, 208);
+try {
+window.someLabel = commandEncoder0.label;
+} catch {}
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\u515d\u{1f94b}\u{1fec1}',
+  colorFormats: ['rg8unorm', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle0 = renderBundleEncoder0.finish({label: '\u99e1\u08d5\uf3c9\uaa12\u6637\ub38e\u04d0\u7404\u{1ff4d}'});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(1, bindGroup0, new Uint32Array(4766), 558, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-10x6-unorm-srgb', 'rgba16float', 'rg16sint', 'rgb10a2unorm'],
+colorSpace: 'display-p3',
+});
+} catch {}
+let texture5 = device0.createTexture({
+label: '\u{1f9ab}\u5d1b\u0434\ua338\u169c\u84fa\u06c6\u65c2\u0c2a\u5ab8\u0139',
+size: {width: 1136, height: 9, depthOrArrayLayers: 143},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+});
+let texture6 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder1.setPipeline(pipeline0);
+} catch {}
+let promise8 = device0.createComputePipelineAsync({
+label: '\u5f3c\u0a39\u0cd4\u{1f94b}\uc183\u08b0\u{1fdb4}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let commandEncoder6 = device0.createCommandEncoder({});
+let promise9 = device0.createRenderPipelineAsync({
+label: '\uc235\u{1f6f8}\u2939\ub1e6',
+layout: pipelineLayout0,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'less',
+depthFailOp: 'replace',
+},
+stencilBack: {
+failOp: 'decrement-clamp',
+passOp: 'zero',
+},
+stencilReadMask: 1678,
+depthBias: 6,
+depthBiasSlopeScale: 32,
+depthBiasClamp: 73,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 5320,
+attributes: [{
+format: 'sint16x2',
+offset: 2108,
+shaderLocation: 7,
+}, {
+format: 'unorm16x4',
+offset: 3284,
+shaderLocation: 3,
+}, {
+format: 'uint8x2',
+offset: 730,
+shaderLocation: 11,
+}, {
+format: 'snorm16x4',
+offset: 2888,
+shaderLocation: 8,
+}, {
+format: 'float32x3',
+offset: 1368,
+shaderLocation: 14,
+}, {
+format: 'uint32',
+offset: 3156,
+shaderLocation: 6,
+}, {
+format: 'unorm8x2',
+offset: 2314,
+shaderLocation: 1,
+}, {
+format: 'uint32x3',
+offset: 4312,
+shaderLocation: 2,
+}, {
+format: 'unorm8x4',
+offset: 992,
+shaderLocation: 0,
+}, {
+format: 'uint16x2',
+offset: 1908,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 12252,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 11698,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 15000,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x2',
+offset: 7880,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 12464,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 1080,
+shaderLocation: 15,
+}, {
+format: 'uint32x3',
+offset: 2320,
+shaderLocation: 13,
+}, {
+format: 'sint16x4',
+offset: 6808,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 752,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x4',
+offset: 52,
+shaderLocation: 9,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let video0 = await videoWithData();
+try {
+window.someLabel = device0.label;
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout({
+label: '\u2838\u974a\ud8a5',
+entries: [],
+});
+let renderBundle1 = renderBundleEncoder0.finish({label: '\u5224\u233f\u0ea2\u1ccf\ue91a\u030f\u0ea7\u1644\u6545\u{1ff86}\u5986'});
+let sampler6 = device0.createSampler({
+label: '\u0eeb\u88cf',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 7.024,
+lodMaxClamp: 75.140,
+maxAnisotropy: 5,
+});
+let promise10 = adapter1.requestAdapterInfo();
+pseudoSubmit(device0, commandEncoder4);
+let texture7 = device0.createTexture({
+label: '\u058f\udf82\uf61f\u0ab8',
+size: [20, 240, 1],
+mipLevelCount: 2,
+dimension: '2d',
+format: 'astc-5x4-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-5x4-unorm', 'astc-5x4-unorm-srgb'],
+});
+let pipeline2 = await promise9;
+let bindGroup1 = device0.createBindGroup({
+label: '\u6581\u010b\u{1f879}',
+layout: bindGroupLayout2,
+entries: [],
+});
+let commandEncoder7 = device0.createCommandEncoder({label: '\u00dc\u{1f850}\udebd\ue5dd\u0d0c\u{1fd90}\u0c7e\ud124'});
+let texture8 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder1.setBindGroup(6, bindGroup1, new Uint32Array(212), 161, 0);
+} catch {}
+try {
+computePassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder1.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture5,
+  mipLevel: 3,
+  origin: { x: 94, y: 0, z: 4 },
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder1.insertDebugMarker('\u{1f9f3}');
+} catch {}
+let pipeline3 = await promise8;
+let offscreenCanvas2 = new OffscreenCanvas(597, 767);
+let texture9 = device0.createTexture({
+label: '\u0778\u8824\u854b\u0730\u{1f656}\u0285\u749b\u924b',
+size: {width: 2064, height: 156, depthOrArrayLayers: 109},
+mipLevelCount: 9,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x12-unorm'],
+});
+let renderBundle2 = renderBundleEncoder0.finish({});
+let sampler7 = device0.createSampler({
+label: '\u21e5\u0b20\ua8aa\ub52e\u007c',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 90.964,
+lodMaxClamp: 97.764,
+maxAnisotropy: 13,
+});
+try {
+computePassEncoder1.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder1.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: { x: 1101, y: 1, z: 105 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+let buffer1 = device0.createBuffer({
+  label: '\u6f4e\u006e\u{1f74b}\u6136\ua71e\u8cb6',
+  size: 18035,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX
+});
+let texture10 = device0.createTexture({
+size: [721, 48, 72],
+mipLevelCount: 5,
+sampleCount: 1,
+dimension: '3d',
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['r32sint'],
+});
+let sampler8 = device0.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 20.911,
+});
+try {
+computePassEncoder1.setBindGroup(4, bindGroup1, new Uint32Array(5269), 5212, 0);
+} catch {}
+let arrayBuffer0 = buffer0.getMappedRange(0, 14348);
+try {
+offscreenCanvas1.getContext('webgpu');
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({label: '\ud697\u{1f9ab}\u{1fd05}\u0b50\u{1fef0}\u891c\ube1b\ue352'});
+let querySet6 = device0.createQuerySet({
+label: '\u05fe\u{1fdb2}\u0bf6\u{1f9ec}\u970e\u0359\u1566\u4ff1\u{1faaa}',
+type: 'occlusion',
+count: 2525,
+});
+let commandBuffer2 = commandEncoder6.finish({
+});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  label: '\u1a73\u021f\u{1fe39}\u04bf\u485d\uf164\ucf53\u{1fbc7}',
+  colorFormats: ['rg8unorm', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle3 = renderBundleEncoder1.finish({label: '\uc13d\ud5c9\ua14c\u08f5'});
+let externalTexture0 = device0.importExternalTexture({
+label: '\u{1fdb9}\u1a42\u{1fbb2}\u9890',
+source: video0,
+});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup0, new Uint32Array(8832), 4818, 0);
+} catch {}
+let pipeline4 = await device0.createComputePipelineAsync({
+label: '\ubc2f\u{1fd25}\u0e50\u09c7\u{1fdb0}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+  await promise4;
+} catch {}
+try {
+offscreenCanvas0.getContext('webgpu');
+} catch {}
+let texture11 = device0.createTexture({
+label: '\u04d1\u0a8b\ue30b\u5f83\u7a89\u09df\u{1feff}\u7169\uf3c5\uea69',
+size: {width: 80, height: 960, depthOrArrayLayers: 1115},
+mipLevelCount: 11,
+dimension: '3d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST,
+});
+try {
+device0.queue.submit([
+commandBuffer2,
+commandBuffer0,
+]);
+} catch {}
+let videoFrame1 = new VideoFrame(canvas1, {timestamp: 0});
+let bindGroupLayout5 = device0.createBindGroupLayout({
+label: '\u9ed3\u{1fb28}\ubd04\u{1f70f}',
+entries: [{
+binding: 4774,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+}, {
+binding: 1145,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}, {
+binding: 4529,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}],
+});
+let bindGroupLayout6 = pipeline4.getBindGroupLayout(0);
+let buffer2 = device0.createBuffer({label: '\ueda6\ueac7', size: 62669, usage: GPUBufferUsage.UNIFORM, mappedAtCreation: false});
+let texture12 = device0.createTexture({
+size: [2796, 108, 250],
+mipLevelCount: 4,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-12x12-unorm-srgb', 'astc-12x12-unorm', 'astc-12x12-unorm-srgb'],
+});
+try {
+computePassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+offscreenCanvas2.getContext('webgl');
+} catch {}
+let texture13 = device0.createTexture({
+label: '\u{1f820}\uf68a\u70e6\u7c48\u0f5f\u{1fea2}',
+size: {width: 80, height: 960, depthOrArrayLayers: 1},
+mipLevelCount: 6,
+format: 'astc-5x5-unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-5x5-unorm'],
+});
+let computePassEncoder2 = commandEncoder8.beginComputePass({label: '\u3483\u{1f9d8}\ud454\u04c6\uea9d'});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  label: '\ue89b\u{1f738}\u1914\u6da3\u6532',
+  colorFormats: ['rg8unorm', undefined],
+  depthStencilFormat: 'depth32float-stencil8'
+});
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 8,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 15436 */
+{offset: 632, bytesPerRow: 40, rowsPerImage: 185}, {width: 1, height: 1, depthOrArrayLayers: 3});
+} catch {}
+let commandBuffer3 = commandEncoder7.finish({
+});
+let texture14 = device0.createTexture({
+label: '\u0d19\u{1fb4b}\u8cd3\u{1fa14}\u13eb',
+size: [4704, 1, 2],
+mipLevelCount: 8,
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+try {
+renderBundleEncoder2.setBindGroup(0, bindGroup1, []);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(5, bindGroup0, new Uint32Array(1367), 833, 0);
+} catch {}
+try {
+commandEncoder1.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture5,
+  mipLevel: 3,
+  origin: { x: 94, y: 0, z: 6 },
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder1.pushDebugGroup('\u0165');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 396, y: 24, z: 228 },
+  aspect: 'all',
+}, new Float32Array(arrayBuffer0), /* required buffer size: 396824 */
+{offset: 172, bytesPerRow: 2854, rowsPerImage: 69}, {width: 2100, height: 12, depthOrArrayLayers: 3});
+} catch {}
+document.body.prepend(img0);
+let imageData4 = new ImageData(156, 124);
+let querySet7 = device0.createQuerySet({
+type: 'occlusion',
+count: 1302,
+});
+let renderBundle4 = renderBundleEncoder2.finish({label: '\u0472\u{1f6d1}\u{1f847}\ua252\u4f5e\u0053\u814c\u{1fd0c}'});
+try {
+computePassEncoder2.setBindGroup(5, bindGroup1);
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(47, 353);
+let pipelineLayout1 = device0.createPipelineLayout({label: '\u4345\u{1f9a3}', bindGroupLayouts: []});
+let buffer3 = device0.createBuffer({
+  label: '\u524e\u0cb9\u09c1\uf8c2\u65a3\u614f',
+  size: 44052,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT
+});
+let textureView9 = texture10.createView({label: '\u765d\u0341\u2cfe\u7e9a', baseMipLevel: 1});
+let computePassEncoder3 = commandEncoder1.beginComputePass({});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm', undefined], depthStencilFormat: 'depth32float-stencil8', depthReadOnly: true});
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x12-unorm-srgb', 'rgba8unorm'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer1,
+commandBuffer3,
+]);
+} catch {}
+let pipeline5 = device0.createRenderPipeline({
+label: '\u05b5\u9f65\u1ab3\u0d72\u24d7\u0050\ud53f\uc7e3',
+layout: pipelineLayout0,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, undefined]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'equal',
+failOp: 'invert',
+depthFailOp: 'zero',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'replace',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 2418,
+stencilWriteMask: 2007,
+depthBias: 31,
+depthBiasClamp: 45,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 5316,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x4',
+offset: 3204,
+shaderLocation: 9,
+}, {
+format: 'float16x2',
+offset: 1892,
+shaderLocation: 0,
+}, {
+format: 'uint8x4',
+offset: 2428,
+shaderLocation: 6,
+}, {
+format: 'uint16x4',
+offset: 1348,
+shaderLocation: 10,
+}, {
+format: 'sint8x4',
+offset: 4404,
+shaderLocation: 7,
+}, {
+format: 'sint32x3',
+offset: 4596,
+shaderLocation: 4,
+}, {
+format: 'uint32x3',
+offset: 1144,
+shaderLocation: 2,
+}, {
+format: 'uint32x4',
+offset: 2856,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x2',
+offset: 7700,
+shaderLocation: 13,
+}, {
+format: 'unorm8x4',
+offset: 11268,
+shaderLocation: 14,
+}, {
+format: 'uint8x4',
+offset: 13912,
+shaderLocation: 5,
+}, {
+format: 'float32x4',
+offset: 5080,
+shaderLocation: 3,
+}, {
+format: 'sint32',
+offset: 10340,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 3724,
+attributes: [],
+},
+{
+arrayStride: 6532,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x4',
+offset: 4716,
+shaderLocation: 8,
+}, {
+format: 'float32',
+offset: 5048,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 6308,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 8,
+shaderLocation: 15,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-list',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+externalTexture0.label = '\ufea2\u0af9';
+} catch {}
+let bindGroupLayout7 = pipeline3.getBindGroupLayout(0);
+try {
+computePassEncoder3.setPipeline(pipeline3);
+} catch {}
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+let textureView10 = texture8.createView({
+  label: '\u{1f63c}\ub01b\u0d92\u19a1\u{1fbca}\u0491\u0525\u226c\ucf63\u8341',
+  dimension: '2d-array',
+  format: 'rgb10a2unorm'
+});
+let renderBundle5 = renderBundleEncoder2.finish({label: '\u39bc\u{1fde7}'});
+try {
+renderBundleEncoder3.setVertexBuffer(3, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 6,
+  origin: { x: 0, y: 4, z: 8 },
+  aspect: 'all',
+}, new Float32Array(arrayBuffer0), /* required buffer size: 392062 */
+{offset: 744, bytesPerRow: 294, rowsPerImage: 166}, {width: 1, height: 4, depthOrArrayLayers: 9});
+} catch {}
+let buffer4 = device0.createBuffer({size: 37307, usage: GPUBufferUsage.COPY_SRC});
+let sampler9 = device0.createSampler({
+label: '\u5105\u0a58\uf411',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 62.680,
+lodMaxClamp: 68.434,
+maxAnisotropy: 7,
+});
+try {
+renderBundleEncoder3.setVertexBuffer(5, buffer1, 6260, 3625);
+} catch {}
+let promise12 = device0.popErrorScope();
+try {
+renderBundleEncoder3.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(2, buffer1, 16808, 664);
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+let pipeline6 = await device0.createComputePipelineAsync({
+label: '\u0f29\uddd7\u94e0\uc7d0\u05c1\u0561',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipelineLayout2 = device0.createPipelineLayout({label: '\ud4a8\u08d7', bindGroupLayouts: [bindGroupLayout4, bindGroupLayout4]});
+let texture15 = gpuCanvasContext1.getCurrentTexture();
+let renderBundle6 = renderBundleEncoder0.finish();
+try {
+renderBundleEncoder3.setVertexBuffer(6, buffer1, 11708, 2039);
+} catch {}
+let canvas2 = document.createElement('canvas');
+let video1 = await videoWithData();
+let promise14 = adapter1.requestAdapterInfo();
+let texture16 = device0.createTexture({
+label: '\u9f44\u{1ffd3}\u67bc\ud1b1\u{1fba6}\u7c81\u{1f6de}\u9167',
+size: {width: 3520},
+dimension: '1d',
+format: 'r32float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler10 = device0.createSampler({
+label: '\uba32\u048f\u05a5\u31fd\u8d01\u0670\u524f\u9cc2\u{1f736}',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 97.817,
+lodMaxClamp: 98.810,
+});
+try {
+  await promise13;
+} catch {}
+let commandEncoder9 = device0.createCommandEncoder();
+let querySet8 = device0.createQuerySet({
+label: '\u03bd\u0db8\u6b37\u4aaf',
+type: 'occlusion',
+count: 355,
+});
+let sampler11 = device0.createSampler({
+label: '\u0316\u02c6\u08d6\u{1fed7}\udcb8\u{1f765}',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 96.219,
+lodMaxClamp: 98.010,
+compare: 'not-equal',
+maxAnisotropy: 8,
+});
+try {
+computePassEncoder2.setBindGroup(5, bindGroup0);
+} catch {}
+try {
+commandEncoder9.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 3,
+  origin: { x: 84, y: 0, z: 183 },
+  aspect: 'all',
+}, {
+  texture: texture12,
+  mipLevel: 3,
+  origin: { x: 72, y: 0, z: 30 },
+  aspect: 'all',
+}, {width: 180, height: 24, depthOrArrayLayers: 11});
+} catch {}
+gc();
+let video2 = await videoWithData();
+let querySet9 = device0.createQuerySet({
+label: '\u328d\u{1f781}',
+type: 'occlusion',
+count: 3508,
+});
+let sampler12 = device0.createSampler({
+label: '\u0367\u722d\ua4b1\uc4fb',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 48.806,
+lodMaxClamp: 80.249,
+compare: 'not-equal',
+});
+try {
+buffer4.unmap();
+} catch {}
+try {
+commandEncoder9.clearBuffer(buffer3);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline7 = await device0.createComputePipelineAsync({
+label: '\u{1fad1}\u51ec\u0370\u0bb1\u018b',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline8 = device0.createRenderPipeline({
+label: '\ud7a8\ue710\u55e8\ud7e7\uae10\u{1ff9c}\u5622\udc9c\u1e81\u{1f6cd}',
+layout: pipelineLayout1,
+multisample: {
+mask: 0x1cdd375a,
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, undefined]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+failOp: 'replace',
+depthFailOp: 'increment-clamp',
+},
+stencilReadMask: 3819,
+stencilWriteMask: 2376,
+depthBias: 9,
+depthBiasSlopeScale: 58,
+depthBiasClamp: 88,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 16860,
+attributes: [{
+format: 'sint32x3',
+offset: 3564,
+shaderLocation: 7,
+}, {
+format: 'uint16x2',
+offset: 10644,
+shaderLocation: 9,
+}, {
+format: 'sint32x2',
+offset: 11212,
+shaderLocation: 12,
+}, {
+format: 'uint32x4',
+offset: 16572,
+shaderLocation: 11,
+}, {
+format: 'snorm16x2',
+offset: 6796,
+shaderLocation: 3,
+}, {
+format: 'snorm16x4',
+offset: 16372,
+shaderLocation: 15,
+}, {
+format: 'uint16x4',
+offset: 6640,
+shaderLocation: 6,
+}, {
+format: 'snorm8x2',
+offset: 7904,
+shaderLocation: 0,
+}, {
+format: 'snorm16x4',
+offset: 13228,
+shaderLocation: 14,
+}, {
+format: 'uint8x2',
+offset: 128,
+shaderLocation: 2,
+}, {
+format: 'float32x3',
+offset: 6840,
+shaderLocation: 8,
+}, {
+format: 'uint32x4',
+offset: 4664,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 896,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 708,
+shaderLocation: 5,
+}, {
+format: 'float32x2',
+offset: 352,
+shaderLocation: 1,
+}, {
+format: 'sint8x2',
+offset: 886,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 12700,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 2856,
+shaderLocation: 13,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'ccw',
+},
+});
+let videoFrame2 = new VideoFrame(canvas2, {timestamp: 0});
+let bindGroupLayout8 = pipeline0.getBindGroupLayout(0);
+let texture17 = device0.createTexture({
+label: '\u77ea\u056c\u0440\u{1f7b8}\ubaef\u09be\u0403\u{1f8d7}\u0e3d',
+size: [9088, 72, 1],
+mipLevelCount: 3,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-8x6-unorm-srgb', 'astc-8x6-unorm', 'astc-8x6-unorm'],
+});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\u{1f621}\u{1f8fc}\u0024\u6035\u09b6\u5b9c\uee5a',
+  colorFormats: ['r16sint', 'r8uint', 'rg16uint', 'r8uint', 'rg32sint', 'r8unorm'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup1, new Uint32Array(796), 217, 0);
+} catch {}
+try {
+texture1.destroy();
+} catch {}
+try {
+commandEncoder9.copyBufferToTexture({
+/* bytesInLastRow: 7840 widthInBlocks: 3920 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 12018 */
+offset: 4178,
+buffer: buffer1,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: { x: 200, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 3920, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder9.copyTextureToTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture5,
+  mipLevel: 2,
+  origin: { x: 167, y: 0, z: 11 },
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba8unorm-srgb'],
+alphaMode: 'opaque',
+});
+} catch {}
+let videoFrame3 = new VideoFrame(img0, {timestamp: 0});
+let buffer5 = device0.createBuffer({
+  label: '\u1da2\uf507\u2a57\udca2\u019a\u76ea\u{1ffae}\u0c0c\u083f\udef0',
+  size: 24921,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let renderBundle7 = renderBundleEncoder0.finish({label: '\u0572\uf151\u07eb\ucedc'});
+try {
+computePassEncoder2.setBindGroup(5, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup1, new Uint32Array(8871), 967, 0);
+} catch {}
+let promise15 = device0.createRenderPipelineAsync({
+label: '\u0a74\u{1fdaa}\u0066\u{1fb2f}\u{1f7f7}\u0953\u0078\u9cff\u36c9\ufb6d\u{1fda2}',
+layout: pipelineLayout2,
+multisample: {
+count: 4,
+mask: 0xcff79e3d,
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'subtract', srcFactor: 'src', dstFactor: 'src'},
+}
+}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 1798,
+stencilWriteMask: 82,
+depthBias: 37,
+depthBiasSlopeScale: 67,
+depthBiasClamp: 45,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 16528,
+attributes: [{
+format: 'uint16x4',
+offset: 5944,
+shaderLocation: 13,
+}, {
+format: 'uint16x4',
+offset: 14788,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 364,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32',
+offset: 252,
+shaderLocation: 6,
+}, {
+format: 'sint8x2',
+offset: 214,
+shaderLocation: 7,
+}, {
+format: 'sint32x2',
+offset: 224,
+shaderLocation: 12,
+}, {
+format: 'float16x4',
+offset: 32,
+shaderLocation: 0,
+}, {
+format: 'float32x2',
+offset: 268,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 1136,
+attributes: [{
+format: 'uint32x3',
+offset: 548,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 9336,
+attributes: [],
+},
+{
+arrayStride: 12048,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x3',
+offset: 940,
+shaderLocation: 9,
+}, {
+format: 'uint32x4',
+offset: 2324,
+shaderLocation: 10,
+}, {
+format: 'snorm8x4',
+offset: 3636,
+shaderLocation: 15,
+}, {
+format: 'sint8x4',
+offset: 9180,
+shaderLocation: 4,
+}, {
+format: 'unorm8x4',
+offset: 7260,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 7408,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 5640,
+shaderLocation: 8,
+}, {
+format: 'uint32x2',
+offset: 2364,
+shaderLocation: 11,
+}, {
+format: 'unorm8x2',
+offset: 396,
+shaderLocation: 14,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let video3 = await videoWithData();
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+let texture18 = device0.createTexture({
+label: '\u5cab\u{1f71a}\u053d\u060f\u079a\u06c6\u5043\u{1fbe9}\u545c',
+size: [880, 1, 1],
+mipLevelCount: 7,
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['r16float', 'r16float', 'r16float'],
+});
+try {
+renderBundleEncoder3.setVertexBuffer(1, buffer1);
+} catch {}
+let pipeline9 = device0.createComputePipeline({
+label: '\uf4d9\u3775\u85ce\u0017\u37ba',
+layout: 'auto',
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let textureView11 = texture1.createView({});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16sint', 'r8uint', 'rg16uint', 'r8uint', 'rg32sint', 'r8unorm'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle8 = renderBundleEncoder5.finish({label: '\ue00d\u0a06\u0d90\uda36\ub8df\ucd17\u{1fd3f}\u{1fc87}\u01c4\u{1f9fa}'});
+try {
+renderBundleEncoder3.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(5, buffer1, 3352, 1710);
+} catch {}
+try {
+commandEncoder9.copyBufferToBuffer(buffer0, 11364, buffer3, 21572, 2284);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder9.clearBuffer(buffer3);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let computePassEncoder4 = commandEncoder9.beginComputePass({label: '\u5b0a\ua89d'});
+try {
+renderBundleEncoder3.draw(24, 16, 8, 16);
+} catch {}
+try {
+renderBundleEncoder3.drawIndexedIndirect(buffer3, 20796);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(6, buffer1);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+gc();
+let querySet10 = device0.createQuerySet({
+label: '\u5c03\u{1fec2}\u0ca9\u207a',
+type: 'occlusion',
+count: 2443,
+});
+let texture19 = device0.createTexture({
+size: [721, 48, 755],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgba8unorm', 'rgba8unorm', 'rgba8unorm-srgb'],
+});
+try {
+computePassEncoder4.setBindGroup(6, bindGroup0);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(0, bindGroup0, new Uint32Array(8983), 3323, 0);
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder3.draw(40, 0);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline8);
+} catch {}
+try {
+  await promise7;
+} catch {}
+let commandEncoder10 = device0.createCommandEncoder({label: '\uaddd\u03b3\u0f36\udcc3\u03f8\u944b\u8056'});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  label: '\u0b78\u6000\u5b3a\u{1fd12}\ud700',
+  colorFormats: ['r16sint', 'r8uint', 'rg16uint', 'r8uint', 'rg32sint', 'r8unorm'],
+  sampleCount: 4
+});
+let renderBundle9 = renderBundleEncoder5.finish({label: '\u{1f676}\u{1fd69}'});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup1, []);
+} catch {}
+try {
+renderBundleEncoder3.draw(72);
+} catch {}
+try {
+await device0.popErrorScope();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x8-unorm-srgb', 'bgra8unorm', 'stencil8', 'bgra8unorm-srgb'],
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 16844, new BigUint64Array(28576), 7192, 2480);
+} catch {}
+let pipeline10 = device0.createComputePipeline({
+label: '\uaaa9\u3c7e\u{1fcd6}\u0371\ud97c\u0a63\u047c',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let commandEncoder11 = device0.createCommandEncoder({label: '\ud7e2\u60af\u00e2\u{1fb77}\u0747\ue6b8\u597e\u{1f78c}\u6771'});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder3.drawIndexed(72, 56, 40, 688, 48);
+} catch {}
+try {
+renderBundleEncoder3.drawIndexedIndirect(buffer3, 14524);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 19580, new Int16Array(9535), 3955);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 6,
+  origin: { x: 0, y: 3, z: 2 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 744364 */
+{offset: 142, bytesPerRow: 226, rowsPerImage: 235}, {width: 1, height: 4, depthOrArrayLayers: 15});
+} catch {}
+let pipeline11 = device0.createRenderPipeline({
+layout: pipelineLayout1,
+multisample: {
+count: 4,
+mask: 0xc74e8b91,
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, undefined]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'not-equal',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'keep',
+},
+stencilReadMask: 40,
+stencilWriteMask: 3494,
+depthBias: 35,
+depthBiasSlopeScale: 94,
+depthBiasClamp: 29,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 6516,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 15948,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x4',
+offset: 336,
+shaderLocation: 1,
+}, {
+format: 'snorm8x2',
+offset: 1762,
+shaderLocation: 8,
+}, {
+format: 'uint8x4',
+offset: 16488,
+shaderLocation: 10,
+}, {
+format: 'snorm8x4',
+offset: 11864,
+shaderLocation: 3,
+}, {
+format: 'uint32',
+offset: 13852,
+shaderLocation: 2,
+}, {
+format: 'sint8x4',
+offset: 15536,
+shaderLocation: 4,
+}, {
+format: 'uint32x4',
+offset: 15756,
+shaderLocation: 5,
+}, {
+format: 'float32x2',
+offset: 9236,
+shaderLocation: 15,
+}, {
+format: 'uint32x4',
+offset: 7888,
+shaderLocation: 9,
+}, {
+format: 'unorm16x2',
+offset: 24,
+shaderLocation: 14,
+}, {
+format: 'uint32x4',
+offset: 1280,
+shaderLocation: 6,
+}, {
+format: 'sint8x2',
+offset: 2620,
+shaderLocation: 12,
+}, {
+format: 'sint8x2',
+offset: 11014,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 6728,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x2',
+offset: 1020,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 1492,
+attributes: [],
+},
+{
+arrayStride: 12836,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 11568,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 9084,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 2612,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 132,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+gc();
+let renderBundle10 = renderBundleEncoder6.finish();
+try {
+renderBundleEncoder3.drawIndexed(24, 56, 80, -664, 32);
+} catch {}
+try {
+renderBundleEncoder3.drawIndirect(buffer3, 4748);
+} catch {}
+try {
+commandEncoder10.clearBuffer(buffer3, 1640, 13204);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 5 },
+  aspect: 'all',
+}, new ArrayBuffer(80150), /* required buffer size: 80150 */
+{offset: 370, bytesPerRow: 72, rowsPerImage: 121}, {width: 1, height: 20, depthOrArrayLayers: 10});
+} catch {}
+let pipeline12 = await device0.createRenderPipelineAsync({
+label: '\ue040\u9015\u0b99\u07d1\ua9f8\u2372\u{1fa55}',
+layout: pipelineLayout2,
+multisample: {
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'dst', dstFactor: 'one-minus-dst'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.RED
+}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'greater',
+depthFailOp: 'replace',
+},
+stencilWriteMask: 3345,
+depthBias: 87,
+depthBiasSlopeScale: 37,
+depthBiasClamp: 52,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 11452,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm16x4',
+offset: 8796,
+shaderLocation: 14,
+}, {
+format: 'uint32',
+offset: 2516,
+shaderLocation: 11,
+}, {
+format: 'sint32x4',
+offset: 4400,
+shaderLocation: 4,
+}, {
+format: 'uint8x4',
+offset: 432,
+shaderLocation: 5,
+}, {
+format: 'snorm16x2',
+offset: 8692,
+shaderLocation: 0,
+}, {
+format: 'snorm8x4',
+offset: 5972,
+shaderLocation: 1,
+}, {
+format: 'uint32x4',
+offset: 3156,
+shaderLocation: 2,
+}, {
+format: 'uint16x2',
+offset: 3736,
+shaderLocation: 10,
+}, {
+format: 'uint8x2',
+offset: 9902,
+shaderLocation: 6,
+}, {
+format: 'uint8x4',
+offset: 10800,
+shaderLocation: 13,
+}, {
+format: 'uint32x3',
+offset: 9160,
+shaderLocation: 9,
+}, {
+format: 'unorm16x2',
+offset: 11152,
+shaderLocation: 8,
+}, {
+format: 'sint32x4',
+offset: 5160,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 12944,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 12156,
+shaderLocation: 3,
+}, {
+format: 'sint32',
+offset: 3060,
+shaderLocation: 12,
+}, {
+format: 'snorm8x2',
+offset: 2584,
+shaderLocation: 15,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let querySet11 = device0.createQuerySet({
+type: 'occlusion',
+count: 2297,
+});
+let sampler13 = device0.createSampler({
+label: '\uf008\u0150\u980f\u8874\u016e',
+addressModeU: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 84.045,
+lodMaxClamp: 87.558,
+});
+try {
+computePassEncoder2.setBindGroup(6, bindGroup0, new Uint32Array(6045), 4824, 0);
+} catch {}
+try {
+renderBundleEncoder3.drawIndexed(80);
+} catch {}
+try {
+renderBundleEncoder3.drawIndexedIndirect(buffer3, 29252);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder11.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture5,
+  mipLevel: 1,
+  origin: { x: 387, y: 3, z: 14 },
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+let video4 = await videoWithData();
+let bindGroup2 = device0.createBindGroup({
+layout: bindGroupLayout8,
+entries: [{
+binding: 1160,
+resource: externalTexture0
+}],
+});
+try {
+computePassEncoder3.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder3.drawIndexed(16, 24);
+} catch {}
+let commandBuffer4 = commandEncoder11.finish({
+label: '\ub88e\u79cc\ude88\ud987\u48c9\u{1f6ce}\u0a11\u0a50\u{1f93a}',
+});
+let renderBundle11 = renderBundleEncoder0.finish({});
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder3.draw(16);
+} catch {}
+try {
+commandEncoder10.copyBufferToBuffer(buffer1, 9280, buffer3, 5036, 5120);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer3);
+} catch {}
+video2.height = 48;
+let commandBuffer5 = commandEncoder10.finish({
+label: '\u0520\ud63a\u{1fdb5}\u0f7c\u566b\u04cf\u7626\u0cf3',
+});
+let textureView12 = texture12.createView({
+  label: '\u4bd5\u01c7',
+  format: 'astc-12x12-unorm-srgb',
+  mipLevelCount: 1,
+  baseArrayLayer: 56,
+  arrayLayerCount: 51
+});
+let renderBundle12 = renderBundleEncoder1.finish();
+try {
+renderBundleEncoder3.drawIndexedIndirect(buffer3, 23456);
+} catch {}
+try {
+commandEncoder1.copyBufferToBuffer(buffer1, 17448, buffer3, 6196, 164);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 2,
+  origin: { x: 44, y: 0, z: 58 },
+  aspect: 'all',
+}, new DataView(arrayBuffer0), /* required buffer size: 1624242 */
+{offset: 630, bytesPerRow: 676, rowsPerImage: 52}, {width: 134, height: 10, depthOrArrayLayers: 47});
+} catch {}
+let bindGroup3 = device0.createBindGroup({
+label: '\ub83f\u0ecf',
+layout: bindGroupLayout6,
+entries: [{
+binding: 1160,
+resource: externalTexture0
+}],
+});
+let texture20 = device0.createTexture({
+label: '\ubc95\u{1f7c7}\u533c\u0e54\u9d8a\u2f59\ue62d\u7367\u014a',
+size: [20, 240, 1],
+mipLevelCount: 8,
+dimension: '2d',
+format: 'astc-10x8-unorm-srgb',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x8-unorm'],
+});
+let computePassEncoder5 = commandEncoder1.beginComputePass({label: '\u{1ff4e}\u5692\u0370\u0e28\u0556'});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u0080\u4d73\u3a71\u533a\u1075\u04c9\ufaae\u0064',
+  colorFormats: ['rg8unorm', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 1,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder3.drawIndexed(56, 8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 1,
+  origin: { x: 5, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 924 */
+{offset: 924, bytesPerRow: 176}, {width: 5, height: 92, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise14;
+} catch {}
+let commandEncoder12 = device0.createCommandEncoder({label: '\u{1fb0f}\u0871\udbf7\ub13a\ubae8'});
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+commandEncoder8.copyTextureToBuffer({
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 22352 */
+offset: 22344,
+buffer: buffer3,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let texture21 = gpuCanvasContext0.getCurrentTexture();
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm', undefined], depthStencilFormat: 'depth32float-stencil8', depthReadOnly: true});
+try {
+renderBundleEncoder3.drawIndexed(72);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(0, buffer1, 4140, 4744);
+} catch {}
+let arrayBuffer1 = buffer0.getMappedRange(14352, 208);
+try {
+device0.queue.writeBuffer(buffer3, 15380, new BigUint64Array(43312), 33893, 2428);
+} catch {}
+canvas2.width = 742;
+let sampler14 = device0.createSampler({
+label: '\u0158\u4c88',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 76.709,
+lodMaxClamp: 81.515,
+});
+try {
+renderBundleEncoder7.setBindGroup(6, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder3.drawIndirect(buffer3, 31236);
+} catch {}
+try {
+commandEncoder12.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 2,
+  origin: { x: 5, y: 5, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 13392 */
+offset: 3104,
+bytesPerRow: 256,
+buffer: buffer3,
+}, {width: 15, height: 205, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder8.clearBuffer(buffer3, 30344);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['astc-10x10-unorm-srgb', 'rg16uint'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline13 = await device0.createComputePipelineAsync({
+label: '\u{1fbfa}\uf877\u0a48\u0eb4\u090b\u4114\u{1f975}\u{1fccf}\u{1f958}\u0d6d\u384e',
+layout: pipelineLayout1,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+});
+canvas2.height = 71;
+let querySet12 = device0.createQuerySet({
+label: '\ucd76\u0039\u{1fd59}\ufc78\u{1ffe7}\u57f2\u06d0\u0d72\u047f\u6975\u{1ff3b}',
+type: 'occlusion',
+count: 2712,
+});
+let texture22 = device0.createTexture({
+label: '\uf116\u{1fed0}\u7ff0\u0ae3\u0942\u4c2e\u{1ff87}\u76da\u{1ffa1}\u4812\u8878',
+size: {width: 40},
+dimension: '1d',
+format: 'r32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['r32float', 'r32float'],
+});
+let texture23 = gpuCanvasContext0.getCurrentTexture();
+let textureView13 = texture3.createView({
+  label: '\u{1f882}\u7109\u01a1\u7ada\u9dae\u05d9\u{1fba0}\u04a9\ua977\u07fd\uf0bf',
+  dimension: '2d-array',
+  aspect: 'all',
+  format: 'astc-6x6-unorm',
+  baseMipLevel: 7,
+  mipLevelCount: 1
+});
+let computePassEncoder6 = commandEncoder12.beginComputePass({label: '\u339d\u08c2\u0fc3\u3326\u02bd\uabf3\u798e\u838c\u3479'});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u099a\ufa67\u19a4',
+  colorFormats: ['r16sint', 'r8uint', 'rg16uint', 'r8uint', 'rg32sint', 'r8unorm'],
+  sampleCount: 4
+});
+try {
+computePassEncoder4.dispatchWorkgroups(4, 5, 4);
+} catch {}
+try {
+renderBundleEncoder3.draw(8, 56, 8, 56);
+} catch {}
+try {
+renderBundleEncoder3.drawIndexedIndirect(buffer3, 25248);
+} catch {}
+try {
+commandEncoder8.copyBufferToBuffer(buffer4, 15800, buffer3, 19516, 9532);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 1,
+  origin: { x: 36, y: 1, z: 51 },
+  aspect: 'all',
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: { x: 423, y: 3, z: 54 },
+  aspect: 'all',
+}, {width: 296, height: 0, depthOrArrayLayers: 232});
+} catch {}
+let commandEncoder13 = device0.createCommandEncoder({label: '\uf266\udada\u6112\u0e90\uf0bd\u0e5c\u017f\ub664'});
+let sampler15 = device0.createSampler({
+label: '\u008f\udb6f\u0362',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+maxAnisotropy: 16,
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder1.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(0, buffer1, 6204, 9229);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer4,
+]);
+} catch {}
+let pipeline14 = device0.createComputePipeline({
+label: '\u{1ffa6}\u032e\u291e\u3d62\u5c58\u0645\u3fb3\u7e7e\uad53\uf1a1\u7a35',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+});
+let commandEncoder14 = device0.createCommandEncoder({label: '\u5294\u{1f832}\uae68'});
+let computePassEncoder7 = commandEncoder14.beginComputePass({});
+try {
+renderBundleEncoder3.draw(24, 80, 8, 80);
+} catch {}
+try {
+commandEncoder13.clearBuffer(buffer3, 34568);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+computePassEncoder1.insertDebugMarker('\u96c8');
+} catch {}
+let imageBitmap3 = await createImageBitmap(video3);
+try {
+canvas2.getContext('webgl2');
+} catch {}
+let commandEncoder15 = device0.createCommandEncoder({label: '\u0350\u{1fd71}\u16aa\u7dfe\u08b9\u991f'});
+let querySet13 = device0.createQuerySet({
+label: '\u0273\u0057\u575a\u6fc0\u0001\u{1f947}\u{1fe4d}\u07c7',
+type: 'occlusion',
+count: 3891,
+});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  colorFormats: ['rg8unorm', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder7.setBindGroup(5, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder3.draw(48);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 5448, new BigUint64Array(43672), 19804, 2764);
+} catch {}
+let pipeline15 = device0.createComputePipeline({
+label: '\u6497\ud46c\u{1f64b}\u426a',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let canvas3 = document.createElement('canvas');
+let textureView14 = texture1.createView({label: '\ubabd\u0900\u{1f8e6}\u114c\u03be\u3405\u944f\u57a2', baseMipLevel: 0, arrayLayerCount: 1});
+let computePassEncoder8 = commandEncoder15.beginComputePass({label: '\u{1ff11}\u40af\u{1f6e8}\u17ac\uc35c\u12be\u{1f63d}\u6361\ue4da'});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({
+  colorFormats: ['rg8unorm', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 1,
+  depthReadOnly: true
+});
+try {
+computePassEncoder4.dispatchWorkgroupsIndirect(buffer3, 42980);
+} catch {}
+try {
+renderBundleEncoder3.drawIndexed(48);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(2, buffer1, 15912);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 27088, new BigUint64Array(10375), 6673, 1088);
+} catch {}
+let pipeline16 = await promise15;
+let imageData5 = new ImageData(40, 132);
+let textureView15 = texture8.createView({label: '\u{1fcd9}\u406c\u{1f6bd}\u0e83', dimension: '2d', arrayLayerCount: 1});
+let computePassEncoder9 = commandEncoder8.beginComputePass();
+try {
+computePassEncoder4.setBindGroup(6, bindGroup2);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(1, bindGroup3, new Uint32Array(1468), 1282, 0);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(buffer4, 18880, buffer3, 28800, 9300);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 37708, new Float32Array(53906), 31207, 536);
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+let pipeline17 = await device0.createComputePipelineAsync({
+label: '\uc816\u072e\u{1f652}\u0f72\u21a8\u{1f8de}\ub316',
+layout: 'auto',
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+canvas3.getContext('webgl');
+} catch {}
+let texture24 = device0.createTexture({
+label: '\u{1f835}\u9fe9\uf111\u{1fe40}\uf1e2\u{1ffa7}\u8977\u09e5',
+size: [2272, 18, 1],
+mipLevelCount: 10,
+format: 'rg16sint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  label: '\u0161\u07ff\u{1fda3}\u{1f6e0}\u03f0\u{1f72d}\u52af',
+  colorFormats: ['rg8unorm', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder12.setBindGroup(5, bindGroup1, new Uint32Array(1111), 714, 0);
+} catch {}
+try {
+renderBundleEncoder3.drawIndexed(8, 24, 48, -504, 48);
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture3,
+  mipLevel: 5,
+  origin: { x: 6, y: 6, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 35280, new DataView(new ArrayBuffer(64442)), 59702);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 0, y: 6, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(2006), /* required buffer size: 2006 */
+{offset: 511, bytesPerRow: 133}, {width: 12, height: 72, depthOrArrayLayers: 1});
+} catch {}
+let pipeline18 = await device0.createRenderPipelineAsync({
+label: '\u64f2\u{1f66b}\u73e2\u289d',
+layout: pipelineLayout0,
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-dst-alpha'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'zero'},
+},
+  writeMask: GPUColorWrite.RED
+}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'zero',
+},
+stencilWriteMask: 4050,
+depthBiasSlopeScale: 13,
+depthBiasClamp: 65,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 2940,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x2',
+offset: 1932,
+shaderLocation: 1,
+}, {
+format: 'sint8x2',
+offset: 72,
+shaderLocation: 4,
+}, {
+format: 'sint8x4',
+offset: 1568,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 988,
+shaderLocation: 2,
+}, {
+format: 'uint32x2',
+offset: 2660,
+shaderLocation: 10,
+}, {
+format: 'uint16x4',
+offset: 72,
+shaderLocation: 5,
+}, {
+format: 'unorm8x2',
+offset: 1272,
+shaderLocation: 0,
+}, {
+format: 'uint8x2',
+offset: 2530,
+shaderLocation: 11,
+}, {
+format: 'sint16x2',
+offset: 2772,
+shaderLocation: 7,
+}, {
+format: 'uint16x4',
+offset: 584,
+shaderLocation: 9,
+}, {
+format: 'float32x2',
+offset: 176,
+shaderLocation: 15,
+}, {
+format: 'uint32x2',
+offset: 2896,
+shaderLocation: 13,
+}, {
+format: 'snorm16x2',
+offset: 2316,
+shaderLocation: 3,
+}, {
+format: 'uint32x4',
+offset: 2516,
+shaderLocation: 6,
+}, {
+format: 'float32x4',
+offset: 884,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 11232,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x2',
+offset: 5336,
+shaderLocation: 8,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+adapter1.label = '\u032d\u{1f8ce}\u032d\u0fd4\ue4c3\u126d\u024d';
+} catch {}
+let texture25 = device0.createTexture({
+label: '\u{1f8f7}\u2275\u683d\u0878',
+size: [10],
+sampleCount: 1,
+dimension: '1d',
+format: 'r8sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8sint'],
+});
+let textureView16 = texture17.createView({label: '\u{1fa58}\u0658\u6c42', dimension: '2d-array', format: 'astc-8x6-unorm', mipLevelCount: 2});
+let sampler16 = device0.createSampler({
+label: '\u0309\ua8c6',
+addressModeW: 'repeat',
+lodMinClamp: 78.827,
+lodMaxClamp: 93.666,
+});
+try {
+renderBundleEncoder11.setVertexBuffer(4, buffer1, 8648);
+} catch {}
+try {
+  await buffer5.mapAsync(GPUMapMode.WRITE, 0, 24216);
+} catch {}
+try {
+  await promise11;
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout({
+label: '\u296a\u4dfb\u7393\uf1c0\u9e05',
+entries: [{
+binding: 791,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}, {
+binding: 4085,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 4664,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+}],
+});
+let bindGroup4 = device0.createBindGroup({
+label: '\u87b0\u{1fc12}\u7752',
+layout: bindGroupLayout6,
+entries: [{
+binding: 1160,
+resource: externalTexture0
+}],
+});
+let querySet14 = device0.createQuerySet({
+label: '\u0bbf\uda98\u0aed\u016a\u{1ff8d}\u000d\u00f2\u97fc',
+type: 'occlusion',
+count: 2373,
+});
+let textureView17 = texture5.createView({
+  label: '\u{1f724}\u0dbb\uc98b\uda7b\u8af4\u8955\u0840\u0f52\u52d9\ub34e\uf990',
+  dimension: '3d',
+  baseMipLevel: 3,
+  baseArrayLayer: 0
+});
+let computePassEncoder10 = commandEncoder13.beginComputePass();
+try {
+computePassEncoder8.setBindGroup(4, bindGroup3, new Uint32Array(4953), 434, 0);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder3.drawIndexedIndirect(buffer3, 36928);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 9108, new Int16Array(2778));
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(957, 199);
+let querySet15 = device0.createQuerySet({
+type: 'occlusion',
+count: 3460,
+});
+let texture26 = device0.createTexture({
+label: '\u0149\ua851\u2e2f\u{1f62f}\u0b2a\u{1f956}',
+size: {width: 3520},
+dimension: '1d',
+format: 'rg16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rg16uint', 'rg16uint'],
+});
+try {
+renderBundleEncoder3.setBindGroup(4, bindGroup4, []);
+} catch {}
+try {
+renderBundleEncoder3.drawIndexed(80, 24, 80);
+} catch {}
+try {
+renderBundleEncoder3.drawIndexedIndirect(buffer3, 40872);
+} catch {}
+try {
+renderBundleEncoder3.drawIndirect(buffer3, 30992);
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(316, 383);
+let texture27 = device0.createTexture({
+label: '\u64af\u{1f629}\u95bb\u0ebd',
+size: [2884, 192, 1],
+mipLevelCount: 2,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth32float-stencil8', 'depth32float-stencil8'],
+});
+try {
+renderBundleEncoder3.draw(24, 56, 32, 40);
+} catch {}
+try {
+renderBundleEncoder3.drawIndirect(buffer3, 34680);
+} catch {}
+try {
+querySet1.destroy();
+} catch {}
+let pipeline19 = await device0.createComputePipelineAsync({
+label: '\u6d11\uc8e2\ue5bd\ud43c\u3395\u6bb0\u038c\u017f\u0a10\u0490\u{1ff97}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+offscreenCanvas3.getContext('webgl');
+} catch {}
+let bindGroup5 = device0.createBindGroup({
+label: '\u50e7\u0d7e\u0ccb\u{1fa6f}\u087e\ue542\u00d9\u4564\u{1f8ff}',
+layout: bindGroupLayout4,
+entries: [],
+});
+let querySet16 = device0.createQuerySet({
+label: '\u6947\ueb33\u3cca\u{1fe0b}\u2394\u0fc2\u1bf1\u008b\u8b63',
+type: 'occlusion',
+count: 3902,
+});
+let texture28 = device0.createTexture({
+label: '\u5b2c\uab5e\u0bbc\u5a7b\ue292\u0e29\ueba3',
+size: {width: 80, height: 960, depthOrArrayLayers: 1},
+mipLevelCount: 10,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x8-unorm-srgb', 'astc-8x8-unorm', 'astc-8x8-unorm-srgb'],
+});
+try {
+renderBundleEncoder4.setBindGroup(6, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(3, bindGroup3, new Uint32Array(3700), 1963, 0);
+} catch {}
+try {
+renderBundleEncoder3.drawIndexed(80, 72);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 34200, new Float32Array(3258), 1933);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline20 = device0.createRenderPipeline({
+label: '\u04a5\uda1d\u{1f860}\u{1fbc1}',
+layout: pipelineLayout0,
+multisample: {
+mask: 0x59685ccd,
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALL}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'zero',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 744,
+stencilWriteMask: 666,
+depthBiasSlopeScale: 50,
+depthBiasClamp: 11,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 5428,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x2',
+offset: 3788,
+shaderLocation: 15,
+}, {
+format: 'unorm8x2',
+offset: 4736,
+shaderLocation: 8,
+}, {
+format: 'sint32x3',
+offset: 204,
+shaderLocation: 12,
+}, {
+format: 'uint16x2',
+offset: 2796,
+shaderLocation: 2,
+}, {
+format: 'uint16x4',
+offset: 2532,
+shaderLocation: 13,
+}, {
+format: 'unorm16x4',
+offset: 5352,
+shaderLocation: 14,
+}, {
+format: 'uint16x4',
+offset: 2008,
+shaderLocation: 9,
+}, {
+format: 'uint8x4',
+offset: 4800,
+shaderLocation: 5,
+}, {
+format: 'uint32x4',
+offset: 2220,
+shaderLocation: 6,
+}, {
+format: 'snorm16x2',
+offset: 3132,
+shaderLocation: 3,
+}, {
+format: 'uint16x2',
+offset: 1104,
+shaderLocation: 11,
+}, {
+format: 'float32x4',
+offset: 2972,
+shaderLocation: 1,
+}, {
+format: 'sint32x4',
+offset: 5088,
+shaderLocation: 7,
+}, {
+format: 'sint16x2',
+offset: 4028,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 7336,
+attributes: [{
+format: 'unorm16x4',
+offset: 3924,
+shaderLocation: 0,
+}, {
+format: 'uint32x2',
+offset: 4816,
+shaderLocation: 10,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+},
+});
+try {
+offscreenCanvas4.getContext('webgl');
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+label: '\u{1f72d}\u5b3c\ufb8c\u348c',
+layout: bindGroupLayout7,
+entries: [{
+binding: 1160,
+resource: externalTexture0
+}],
+});
+try {
+computePassEncoder4.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline8);
+} catch {}
+let bindGroup7 = device0.createBindGroup({
+label: '\u6887\u{1fe85}\u{1fe29}\u{1ff06}\u0b9b',
+layout: bindGroupLayout6,
+entries: [{
+binding: 1160,
+resource: externalTexture0
+}],
+});
+let textureView18 = texture4.createView({label: '\u4d57\u7642\u{1fad4}\u{1ff8d}\u{1fbc1}\u{1f90d}\uc83e', mipLevelCount: 1});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup4, new Uint32Array(6109), 5689, 0);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder3.drawIndexedIndirect(buffer3, 10432);
+} catch {}
+try {
+renderBundleEncoder3.drawIndirect(buffer3, 14836);
+} catch {}
+let arrayBuffer2 = buffer0.getMappedRange(15680, 720);
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas5.getContext('webgpu');
+let bindGroup8 = device0.createBindGroup({
+label: '\u9acb\uc0bc\u{1ffde}\u0c76\u3178\u{1fb49}\u0e69',
+layout: bindGroupLayout6,
+entries: [{
+binding: 1160,
+resource: externalTexture0
+}],
+});
+let sampler17 = device0.createSampler({
+label: '\ubb08\u3583\u3dc0\u01a4\udb2f\uc977',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+lodMaxClamp: 91.521,
+});
+try {
+renderBundleEncoder3.drawIndexed(24, 80);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 29496, new Int16Array(63324), 22784, 452);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let canvas4 = document.createElement('canvas');
+let textureView19 = texture2.createView({label: '\u0e8a\u5945\u{1fa81}\u5514\u{1f6af}\u0673\ueef3\u0497', format: 'rg32sint'});
+try {
+renderBundleEncoder8.setVertexBuffer(4, buffer1, 3520, 43);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let pipeline21 = device0.createComputePipeline({
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+  await promise5;
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(412, 410);
+let img1 = await imageWithData(166, 100, '#bb957b22', '#1de26573');
+let textureView20 = texture15.createView({label: '\u0a6f\u109e\u{1fdbf}\u095f', format: 'rgb10a2unorm'});
+try {
+computePassEncoder4.dispatchWorkgroups(2, 5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 2,
+  origin: { x: 0, y: 42, z: 0 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer0), /* required buffer size: 743 */
+{offset: 563, bytesPerRow: 41, rowsPerImage: 275}, {width: 6, height: 30, depthOrArrayLayers: 1});
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext3 = canvas4.getContext('webgpu');
+let canvas5 = document.createElement('canvas');
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  label: '\u{1fc30}\uf0c6\u2159\u83b3\u7b52',
+  colorFormats: ['rg8unorm', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true
+});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup2, new Uint32Array(8817), 5857, 0);
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder3.drawIndirect(buffer3, 16544);
+} catch {}
+let pipeline22 = device0.createComputePipeline({
+label: '\uc4db\u0593\u0e98\u08a1\u74c3\ua2b7\ub04e',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.prepend(canvas4);
+gc();
+let bindGroupLayout10 = pipeline7.getBindGroupLayout(0);
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout0, bindGroupLayout3, bindGroupLayout7, bindGroupLayout1]});
+let commandEncoder16 = device0.createCommandEncoder();
+let renderBundle13 = renderBundleEncoder3.finish({label: '\u29cb\ud96f\u{1fbe0}\u4c72\u{1f7c4}\u3320\u8dff\ubb3d'});
+let sampler18 = device0.createSampler({
+label: '\u0f3f\uc769\u0a1d\u003c\u0795',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+lodMinClamp: 17.112,
+lodMaxClamp: 44.378,
+});
+try {
+renderBundleEncoder13.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer1, 9720, buffer3, 2588, 2812);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline23 = device0.createComputePipeline({
+label: '\uaded\u132a',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+  await promise12;
+} catch {}
+video4.width = 52;
+try {
+canvas5.getContext('webgl2');
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+label: '\uf1f2\u9c64\u{1fd36}\u0230\u{1fd4c}\u782c\u{1fd04}\u0450',
+code: `@group(3) @binding(1646)
+var<storage, read_write> field0: array<u32>;
+@group(3) @binding(3641)
+var<storage, read_write> local0: array<u32>;
+@group(2) @binding(1160)
+var<storage, read_write> type0: array<u32>;
+
+@compute @workgroup_size(2, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S3 {
+  @location(33) f0: vec3<i32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<u32>,
+  @location(5) f1: vec3<f32>,
+  @location(3) f2: vec4<u32>,
+  @location(0) f3: vec4<i32>,
+  @location(1) f4: vec4<u32>,
+  @location(4) f5: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(12) a0: vec2<f32>, @location(70) a1: f32, @location(41) a2: vec2<u32>, @location(35) a3: u32, @location(25) a4: vec2<f16>, @location(43) a5: vec2<f32>, @location(32) a6: vec3<f16>, a7: S3, @location(15) a8: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S2 {
+  @location(7) f0: vec4<f16>,
+  @location(2) f1: f32,
+  @location(8) f2: vec4<u32>,
+  @location(4) f3: i32,
+  @location(3) f4: u32
+}
+struct VertexOutput0 {
+  @location(84) f27: vec2<f32>,
+  @location(64) f28: vec4<u32>,
+  @location(96) f29: vec2<f32>,
+  @builtin(position) f30: vec4<f32>,
+  @location(85) f31: f16,
+  @location(48) f32: vec2<i32>,
+  @location(12) f33: vec2<f32>,
+  @location(41) f34: vec2<u32>,
+  @location(52) f35: vec3<f32>,
+  @location(50) f36: f16,
+  @location(67) f37: vec3<i32>,
+  @location(51) f38: vec4<u32>,
+  @location(32) f39: vec3<f16>,
+  @location(35) f40: u32,
+  @location(109) f41: vec2<f32>,
+  @location(33) f42: vec3<i32>,
+  @location(86) f43: vec2<i32>,
+  @location(10) f44: f16,
+  @location(70) f45: f32,
+  @location(77) f46: vec4<f32>,
+  @location(25) f47: vec2<f16>,
+  @location(55) f48: vec3<f32>,
+  @location(43) f49: vec2<f32>,
+  @location(15) f50: vec4<f32>,
+  @location(105) f51: vec3<f32>,
+  @location(68) f52: f16,
+  @location(24) f53: f16,
+  @location(83) f54: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec2<i32>, a1: S2, @location(1) a2: f32, @location(9) a3: i32, @location(0) a4: vec2<i32>, @location(11) a5: vec4<f32>, @location(14) a6: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let pipelineLayout4 = device0.createPipelineLayout({
+  label: '\u8a07\u01e4\u{1f986}\u{1f630}',
+  bindGroupLayouts: [bindGroupLayout6, bindGroupLayout4, bindGroupLayout7]
+});
+let commandEncoder17 = device0.createCommandEncoder({label: '\u028e\u568b\u2521\u6187\uc279\u{1f996}'});
+let texture29 = device0.createTexture({
+size: [40, 480, 1],
+mipLevelCount: 9,
+format: 'astc-8x6-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView21 = texture20.createView({
+  label: '\u{1f738}\u{1f8eb}\u0f9c\u{1fd59}\u06c0\ua66a\u0967\u{1fa1e}',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 6
+});
+let renderBundle14 = renderBundleEncoder5.finish({label: '\u07bf\u0909\ud930\u{1f899}\ud48f\u886b'});
+try {
+renderBundleEncoder8.setBindGroup(5, bindGroup1);
+} catch {}
+try {
+commandEncoder16.copyTextureToBuffer({
+  texture: texture25,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 8 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 35285 */
+offset: 35285,
+buffer: buffer3,
+}, {width: 8, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let promise19 = device0.createRenderPipelineAsync({
+label: '\u{1fad2}\u0ccf\u0b0c\u4d32\u7f86\u03dd\u2ef9\u{1fb2f}\ue8da',
+layout: pipelineLayout0,
+multisample: {
+mask: 0x93dec81f,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'r8uint', writeMask: GPUColorWrite.ALL}, {format: 'rg16uint'}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'zero',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'increment-wrap',
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+stencilReadMask: 1384,
+stencilWriteMask: 993,
+depthBiasSlopeScale: 27,
+depthBiasClamp: 39,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 12792,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32',
+offset: 6096,
+shaderLocation: 8,
+}, {
+format: 'sint32x4',
+offset: 504,
+shaderLocation: 9,
+}, {
+format: 'float32',
+offset: 8572,
+shaderLocation: 11,
+}, {
+format: 'snorm8x4',
+offset: 6668,
+shaderLocation: 2,
+}, {
+format: 'sint32x4',
+offset: 4320,
+shaderLocation: 6,
+}, {
+format: 'sint32x3',
+offset: 9804,
+shaderLocation: 14,
+}, {
+format: 'sint8x2',
+offset: 3404,
+shaderLocation: 0,
+}, {
+format: 'unorm10-10-10-2',
+offset: 3436,
+shaderLocation: 7,
+}, {
+format: 'uint32x4',
+offset: 428,
+shaderLocation: 3,
+}, {
+format: 'float32x4',
+offset: 2932,
+shaderLocation: 1,
+}, {
+format: 'sint16x4',
+offset: 4652,
+shaderLocation: 4,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'cw',
+cullMode: 'back',
+},
+});
+gc();
+let textureView22 = texture10.createView({baseMipLevel: 2, mipLevelCount: 2});
+let computePassEncoder11 = commandEncoder17.beginComputePass({label: '\u09b8\u{1fe04}\u062f\u0987\u7b5f\u{1fb18}\u071f\ua687'});
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 23808);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer3, 29732);
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer3);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline24 = device0.createComputePipeline({
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+},
+});
+gc();
+let videoFrame4 = new VideoFrame(offscreenCanvas5, {timestamp: 0});
+let pipelineLayout5 = device0.createPipelineLayout({
+  label: '\u{1ff40}\uc427\u{1fcef}\u{1fa53}\u{1fdd1}\u0a2f\u575f\ub2b6\u{1f717}\u0794\uafed',
+  bindGroupLayouts: [bindGroupLayout7, bindGroupLayout2]
+});
+let buffer6 = device0.createBuffer({
+  label: '\u05d1\udbb0\u0766\u{1f860}\u{1ffaf}',
+  size: 65440,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true
+});
+try {
+renderBundleEncoder13.drawIndexed(32, 48, 80, 56, 24);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 504);
+} catch {}
+let arrayBuffer3 = buffer6.getMappedRange(62256, 164);
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 1512, y: 72, z: 223 },
+  aspect: 'all',
+}, {
+  texture: texture12,
+  mipLevel: 3,
+  origin: { x: 72, y: 0, z: 115 },
+  aspect: 'all',
+}, {width: 276, height: 12, depthOrArrayLayers: 24});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba32uint', 'rgba16float', 'rgba16float', 'rgba16float'],
+colorSpace: 'srgb',
+});
+} catch {}
+let pipeline25 = device0.createComputePipeline({
+layout: pipelineLayout0,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+},
+});
+let adapter2 = await promise1;
+let img2 = await imageWithData(148, 33, '#794715f9', '#300f6f4b');
+try {
+querySet14.label = '\ubebb\ub0cf\uda69';
+} catch {}
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({
+  label: '\ud45d\u{1f7a2}\ucc48\u{1f60e}\u{1f862}\u{1f8b1}\u{1f811}\uf3c0\u7357\u02ad',
+  colorFormats: ['r16sint', 'r8uint', 'rg16uint', 'r8uint', 'rg32sint', 'r8unorm'],
+  sampleCount: 4
+});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder7.dispatchWorkgroups(4, 4);
+} catch {}
+try {
+renderBundleEncoder13.draw(80, 64);
+} catch {}
+try {
+computePassEncoder1.pushDebugGroup('\uca5f');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 11036, new BigUint64Array(63781), 29020, 120);
+} catch {}
+let pipeline26 = await device0.createRenderPipelineAsync({
+label: '\ub7c8\u{1f92d}\u9d44\u033c\u09ba\u8507\u85a7\u{1fe0d}\u{1f7d3}\ua666\u6fc0',
+layout: pipelineLayout5,
+multisample: {
+mask: 0xc2cc0429,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8uint'}, {
+  format: 'rg16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r8uint', writeMask: 0}, {format: 'rg32sint', writeMask: 0}, {
+  format: 'r8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'dst-alpha'},
+alpha: {operation: 'add', srcFactor: 'one-minus-src-alpha', dstFactor: 'src-alpha-saturated'},
+}
+}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-wrap',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+depthFailOp: 'increment-wrap',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 4064,
+stencilWriteMask: 3196,
+depthBias: 92,
+depthBiasSlopeScale: 87,
+depthBiasClamp: 80,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 15240,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 12212,
+shaderLocation: 7,
+}, {
+format: 'sint8x2',
+offset: 12550,
+shaderLocation: 0,
+}, {
+format: 'snorm16x2',
+offset: 11044,
+shaderLocation: 1,
+}, {
+format: 'float16x2',
+offset: 476,
+shaderLocation: 11,
+}, {
+format: 'sint16x2',
+offset: 10872,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 10052,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x2',
+offset: 1972,
+shaderLocation: 2,
+}, {
+format: 'uint8x2',
+offset: 382,
+shaderLocation: 8,
+}, {
+format: 'sint8x2',
+offset: 3060,
+shaderLocation: 6,
+}, {
+format: 'sint16x4',
+offset: 9404,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 3720,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x4',
+offset: 10560,
+shaderLocation: 3,
+}, {
+format: 'sint16x2',
+offset: 4428,
+shaderLocation: 14,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+  await promise16;
+} catch {}
+let adapter3 = await promise0;
+let textureView23 = texture5.createView({baseMipLevel: 0, mipLevelCount: 3});
+try {
+computePassEncoder9.setBindGroup(6, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder13.draw(48, 48);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(8);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer3, 16460);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(5, buffer1, 15276, 439);
+} catch {}
+let promise20 = device0.popErrorScope();
+let gpuCanvasContext4 = offscreenCanvas6.getContext('webgpu');
+let promise21 = navigator.gpu.requestAdapter({
+});
+let canvas6 = document.createElement('canvas');
+let bindGroupLayout11 = device0.createBindGroupLayout({
+label: '\u0e38\u055e\uc42e\ua7b5\u0792',
+entries: [{
+binding: 1548,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+}],
+});
+let bindGroup9 = device0.createBindGroup({
+label: '\u{1fcea}\u0044\u{1fc21}\u061d',
+layout: bindGroupLayout7,
+entries: [{
+binding: 1160,
+resource: externalTexture0
+}],
+});
+let buffer7 = device0.createBuffer({size: 40176, usage: GPUBufferUsage.MAP_READ});
+let commandEncoder18 = device0.createCommandEncoder({});
+let texture30 = device0.createTexture({
+label: '\u245d\u62f6\ubb21\u9f18\u1321\u{1fbdb}',
+size: {width: 10},
+dimension: '1d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['r16float'],
+});
+let renderBundle15 = renderBundleEncoder13.finish({label: '\u0b39\u353d\u069a\u{1fd35}\u{1f8e5}\u{1fa99}\u09b8\u0614'});
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup4);
+} catch {}
+let arrayBuffer4 = buffer6.getMappedRange(62424, 2660);
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 1,
+  origin: { x: 288, y: 12, z: 198 },
+  aspect: 'all',
+}, {
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 12, y: 0, z: 91 },
+  aspect: 'all',
+}, {width: 684, height: 24, depthOrArrayLayers: 5});
+} catch {}
+try {
+computePassEncoder1.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let textureView24 = texture12.createView({label: '\uc17e\u9190', baseMipLevel: 1, mipLevelCount: 2, baseArrayLayer: 100, arrayLayerCount: 20});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({
+  label: '\u5855\u{1ff81}',
+  colorFormats: ['rg8unorm', undefined],
+  depthStencilFormat: 'depth32float-stencil8'
+});
+try {
+computePassEncoder6.setPipeline(pipeline10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 5,
+  origin: { x: 4, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 467 */
+{offset: 467, rowsPerImage: 90}, {width: 13, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline27 = device0.createRenderPipeline({
+label: '\u9dce\u{1fddc}\ue712\ub69b\u929b\u{1fe66}\u{1f6ff}\u28b9\u{1fd1f}\uf474',
+layout: pipelineLayout5,
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'r16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'r8uint', writeMask: 0}, {format: 'rg16uint', writeMask: 0}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg32sint', writeMask: 0}, {format: 'r8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'never',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'always',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 1589,
+stencilWriteMask: 881,
+depthBias: 47,
+depthBiasSlopeScale: 71,
+depthBiasClamp: 33,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x2',
+offset: 7392,
+shaderLocation: 9,
+}, {
+format: 'snorm8x4',
+offset: 2264,
+shaderLocation: 11,
+}, {
+format: 'float32x4',
+offset: 16360,
+shaderLocation: 7,
+}, {
+format: 'unorm8x2',
+offset: 12070,
+shaderLocation: 1,
+}, {
+format: 'sint32x3',
+offset: 4588,
+shaderLocation: 6,
+}, {
+format: 'sint16x2',
+offset: 4644,
+shaderLocation: 4,
+}, {
+format: 'uint8x2',
+offset: 9782,
+shaderLocation: 3,
+}, {
+format: 'unorm16x2',
+offset: 7512,
+shaderLocation: 2,
+}, {
+format: 'sint32x2',
+offset: 10796,
+shaderLocation: 0,
+}, {
+format: 'uint32',
+offset: 732,
+shaderLocation: 8,
+}, {
+format: 'sint16x2',
+offset: 2220,
+shaderLocation: 14,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let textureView25 = texture19.createView({label: '\u0e65\u0ec6\ubd5b', format: 'rgba8unorm', baseMipLevel: 2});
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(7, buffer1, 16304);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder18.copyBufferToTexture({
+/* bytesInLastRow: 992 widthInBlocks: 62 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 34096 */
+offset: 34096,
+bytesPerRow: 1024,
+buffer: buffer4,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 1524, y: 12, z: 5 },
+  aspect: 'all',
+}, {width: 744, height: 72, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer4);
+} catch {}
+let pipeline28 = await device0.createRenderPipelineAsync({
+label: '\uc123\u{1fb96}\u0405\ub350\u09c1\u075a\uf4be',
+layout: pipelineLayout3,
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x2',
+offset: 1978,
+shaderLocation: 2,
+}, {
+format: 'float32x3',
+offset: 15768,
+shaderLocation: 11,
+}, {
+format: 'uint32x2',
+offset: 14108,
+shaderLocation: 8,
+}, {
+format: 'sint8x4',
+offset: 8052,
+shaderLocation: 0,
+}, {
+format: 'sint32x4',
+offset: 10940,
+shaderLocation: 14,
+}, {
+format: 'unorm16x4',
+offset: 10288,
+shaderLocation: 1,
+}, {
+format: 'unorm16x4',
+offset: 1968,
+shaderLocation: 7,
+}, {
+format: 'sint16x4',
+offset: 3752,
+shaderLocation: 4,
+}, {
+format: 'uint32x3',
+offset: 1372,
+shaderLocation: 3,
+}, {
+format: 'sint8x4',
+offset: 6704,
+shaderLocation: 9,
+}, {
+format: 'sint16x2',
+offset: 7572,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(video1);
+let device1 = await adapter2.requestDevice({
+label: '\u{1fa95}\u089e\u032d',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 10,
+maxColorAttachmentBytesPerSample: 33,
+maxVertexAttributes: 29,
+maxVertexBufferArrayStride: 27338,
+maxStorageTexturesPerShaderStage: 28,
+maxStorageBuffersPerShaderStage: 36,
+maxDynamicStorageBuffersPerPipelineLayout: 2114,
+maxBindingsPerBindGroup: 9050,
+maxTextureDimension1D: 11529,
+maxTextureDimension2D: 15797,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 223220592,
+maxUniformBuffersPerShaderStage: 37,
+maxInterStageShaderVariables: 55,
+maxInterStageShaderComponents: 64,
+},
+});
+let commandEncoder19 = device1.createCommandEncoder({label: '\u96f9\u7405\uf568\u0165\ud279\uda99\u0344\u0dad\u{1f972}'});
+let computePassEncoder12 = commandEncoder19.beginComputePass();
+try {
+adapter2.label = '\u08d5\ua7cf\u0538\ub460\ue6df\u0b60\u8b69';
+} catch {}
+let buffer8 = device1.createBuffer({label: '\uea26\u0d52\uab59', size: 37626, usage: GPUBufferUsage.STORAGE});
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+canvas3.height = 777;
+let commandEncoder20 = device0.createCommandEncoder({label: '\uf0ec\u2d63\uf994'});
+try {
+renderBundleEncoder12.setBindGroup(0, bindGroup1, new Uint32Array(3368), 2942, 0);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexed(40, 24);
+} catch {}
+try {
+renderBundleEncoder8.drawIndexedIndirect(buffer3, 30856);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+device: device0,
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['r16sint'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+renderBundleEncoder8.drawIndirect(buffer3, 35444);
+} catch {}
+try {
+  await promise20;
+} catch {}
+document.body.prepend(canvas2);
+let gpuCanvasContext5 = canvas6.getContext('webgpu');
+let commandBuffer6 = commandEncoder18.finish({
+label: '\u4a94\ufae1',
+});
+let texture31 = device0.createTexture({
+label: '\u2e76\u236b\ua60a\u72a5\u{1ff3d}\u5c98\u07d1\u{1ff03}',
+size: {width: 1136, height: 9, depthOrArrayLayers: 1},
+mipLevelCount: 11,
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgb10a2unorm', 'rgb10a2unorm', 'rgb10a2unorm'],
+});
+let renderBundle16 = renderBundleEncoder8.finish({label: '\u1567\u7c1d\u99a0\u5fe0\ub37f'});
+try {
+commandEncoder20.copyBufferToTexture({
+/* bytesInLastRow: 13904 widthInBlocks: 1738 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 16984 */
+offset: 16984,
+buffer: buffer4,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: { x: 775, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 1738, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder16.pushDebugGroup('\u81f1');
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'astc-10x5-unorm-srgb', 'rgba8unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 30096, new DataView(new ArrayBuffer(24397)), 22309);
+} catch {}
+let pipeline29 = device0.createRenderPipeline({
+label: '\uc039\u22d2\u0108\u0e4b\u648f\u{1f629}\uf965\u2827\u0b98',
+layout: pipelineLayout5,
+multisample: {
+mask: 0x8f896934,
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r8uint'}, {format: 'rg16uint', writeMask: 0}, {format: 'r8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rg32sint'}, {format: 'r8unorm', writeMask: GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'keep',
+depthFailOp: 'increment-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2883,
+depthBias: 92,
+depthBiasClamp: 76,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 9348,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x4',
+offset: 6372,
+shaderLocation: 6,
+}, {
+format: 'uint8x4',
+offset: 9248,
+shaderLocation: 8,
+}, {
+format: 'snorm16x2',
+offset: 5120,
+shaderLocation: 2,
+}, {
+format: 'unorm16x2',
+offset: 5756,
+shaderLocation: 1,
+}, {
+format: 'sint32x4',
+offset: 7560,
+shaderLocation: 9,
+}, {
+format: 'unorm8x4',
+offset: 7488,
+shaderLocation: 11,
+}, {
+format: 'uint16x4',
+offset: 3564,
+shaderLocation: 3,
+}, {
+format: 'sint8x4',
+offset: 8068,
+shaderLocation: 0,
+}, {
+format: 'float16x4',
+offset: 1620,
+shaderLocation: 7,
+}, {
+format: 'sint32x4',
+offset: 132,
+shaderLocation: 4,
+}, {
+format: 'sint8x4',
+offset: 2140,
+shaderLocation: 14,
+}],
+}
+]
+},
+});
+let texture32 = device1.createTexture({
+label: '\u{1fc1d}\u{1f63c}\u0fa6\u808a',
+size: [320],
+dimension: '1d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb'],
+});
+let renderBundleEncoder16 = device1.createRenderBundleEncoder({
+  label: '\u464d\u0a9e\u0fef\u17d5\u063e\u3428\u831d\u3144\ue531\u0f46',
+  colorFormats: ['rgb10a2uint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+try {
+renderBundleEncoder16.setVertexBuffer(27, undefined, 819379979, 2973899079);
+} catch {}
+try {
+computePassEncoder12.insertDebugMarker('\u61f7');
+} catch {}
+try {
+  await promise18;
+} catch {}
+let canvas7 = document.createElement('canvas');
+let imageBitmap4 = await createImageBitmap(canvas4);
+let commandEncoder21 = device1.createCommandEncoder();
+let imageData6 = new ImageData(200, 216);
+let bindGroup10 = device0.createBindGroup({
+layout: bindGroupLayout4,
+entries: [],
+});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16sint', 'r8uint', 'rg16uint', 'r8uint', 'rg32sint', 'r8unorm'],
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let renderBundle17 = renderBundleEncoder7.finish({label: '\u2c96\u3faa\u527f\u7ce6\u1445\u5479\ud2e7\u0415\u4262\u0f0c\u0e36'});
+try {
+renderBundleEncoder11.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer5, 1276, buffer3, 13420, 7340);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: { x: 1511, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 5499 */
+{offset: 41, rowsPerImage: 153}, {width: 2729, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext6 = canvas7.getContext('webgpu');
+let bindGroupLayout12 = device0.createBindGroupLayout({
+label: '\u0d33\u04e9\u0287\uca18\uf42c\ub2ee\u4610\u3ddd\u5ccb',
+entries: [{
+binding: 5062,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+}, {
+binding: 1161,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '1d' },
+}, {
+binding: 4533,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+let textureView26 = texture12.createView({
+  label: '\ubdc9\u0887',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+  baseArrayLayer: 35,
+  arrayLayerCount: 149
+});
+try {
+renderBundleEncoder11.drawIndexedIndirect(buffer3, 42464);
+} catch {}
+try {
+renderBundleEncoder11.drawIndirect(buffer3, 36560);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer3);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let texture33 = device1.createTexture({
+label: '\ud45f\u{1f72d}\u03e9\u{1f8a1}\u05de\u7b45\u0dda\u09b0\u0f7f\uc05c',
+size: [4160, 205, 1],
+mipLevelCount: 8,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [],
+});
+let renderBundle18 = renderBundleEncoder16.finish({label: '\u329d\u{1f6b6}\u{1ff4e}\u{1fa7e}\u091f\uf934'});
+let sampler19 = device1.createSampler({
+label: '\u9640\u26fa\u4bbc\u{1fab1}\u76ea\u3285\u2578\u{1f6d8}\ua1c4\uaed9',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 60.045,
+lodMaxClamp: 80.732,
+compare: 'less-equal',
+});
+let promise22 = device1.popErrorScope();
+let videoFrame5 = new VideoFrame(canvas3, {timestamp: 0});
+let bindGroupLayout13 = device0.createBindGroupLayout({
+entries: [{
+binding: 2371,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 2457,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+}],
+});
+let bindGroup11 = device0.createBindGroup({
+label: '\ua9c4\ue4b9\uf277\ua07f\u03d3\u{1f904}',
+layout: bindGroupLayout0,
+entries: [{
+binding: 1160,
+resource: externalTexture0
+}],
+});
+let sampler20 = device0.createSampler({
+label: '\u{1fdaf}\ud8c7\ue8d9\u{1f7ef}\u{1fe74}\u6976',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 85.839,
+lodMaxClamp: 94.276,
+maxAnisotropy: 16,
+});
+try {
+computePassEncoder11.setBindGroup(4, bindGroup8, new Uint32Array(3961), 1722, 0);
+} catch {}
+try {
+renderBundleEncoder11.draw(40, 72, 32, 56);
+} catch {}
+try {
+renderBundleEncoder11.drawIndirect(buffer3, 17928);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(6, buffer1, 6100, 6254);
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(buffer0, 1844, buffer3, 9088, 12156);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 3632, new BigUint64Array(8792), 4499);
+} catch {}
+let pipeline30 = device0.createComputePipeline({
+layout: 'auto',
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+},
+});
+let imageData7 = new ImageData(176, 60);
+try {
+device1.queue.label = '\u40f3\u5326\ua993\u833a\uc51a\u04b5';
+} catch {}
+let texture34 = device1.createTexture({
+label: '\u68d9\u5047\u8b66\ub8e0\ua66c\u559a\u{1f867}\uefcf\u{1fb16}\ub3cd\u589d',
+size: [160, 17, 131],
+sampleCount: 1,
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+let textureView27 = texture32.createView({label: '\u0296\u0ae0\u83bb', format: 'bgra8unorm-srgb'});
+let renderBundleEncoder18 = device1.createRenderBundleEncoder({
+  label: '\u865f\u{1fe29}\u0fb7\u6fa8\u0263\udb3b\ue765\u{1ff25}\u{1f857}\u1e95',
+  colorFormats: ['rgb10a2uint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let sampler21 = device1.createSampler({
+label: '\ua871\uf0b3\uc69c',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 72.806,
+});
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+let imageBitmap5 = await createImageBitmap(videoFrame4);
+let commandEncoder22 = device0.createCommandEncoder({label: '\u{1ffe5}\uf672\ud275\u08a7\u0031\uaaff\u0275\uc480'});
+try {
+buffer6.unmap();
+} catch {}
+try {
+commandEncoder20.copyBufferToTexture({
+/* bytesInLastRow: 342 widthInBlocks: 171 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 53712 */
+offset: 53712,
+buffer: buffer6,
+}, {
+  texture: texture14,
+  mipLevel: 4,
+  origin: { x: 6, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 171, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer3);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 4,
+  origin: { x: 12, y: 3, z: 2 },
+  aspect: 'all',
+}, new ArrayBuffer(11155), /* required buffer size: 11155 */
+{offset: 100, bytesPerRow: 67, rowsPerImage: 165}, {width: 13, height: 0, depthOrArrayLayers: 2});
+} catch {}
+gc();
+let canvas8 = document.createElement('canvas');
+try {
+canvas8.getContext('webgl2');
+} catch {}
+let textureView28 = texture34.createView({dimension: '2d-array', format: 'r16uint', mipLevelCount: 1, baseArrayLayer: 16, arrayLayerCount: 16});
+let computePassEncoder13 = commandEncoder21.beginComputePass({label: '\u531b\ubc95\ub58a\u0b80'});
+let sampler22 = device1.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 92.661,
+});
+let promise23 = device1.popErrorScope();
+offscreenCanvas0.height = 32;
+let renderBundle19 = renderBundleEncoder18.finish({});
+canvas0.height = 798;
+let commandEncoder23 = device0.createCommandEncoder({label: '\u{1fbc6}\u9860'});
+let querySet17 = device0.createQuerySet({
+label: '\u{1ffb1}\u9fc9',
+type: 'occlusion',
+count: 3813,
+});
+let texture35 = device0.createTexture({
+label: '\uef06\u547d\u21c8\ud639\u0824\u092c\ufa4f\u{1fb04}\uc63d',
+size: [40, 480, 1],
+mipLevelCount: 2,
+sampleCount: 1,
+format: 'astc-8x8-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x8-unorm', 'astc-8x8-unorm'],
+});
+let renderBundle20 = renderBundleEncoder10.finish({label: '\u0978\u4a7a\ub668\u0d90\u{1f77a}\u0366'});
+let sampler23 = device0.createSampler({
+label: '\u87b6\ud891\uf78b\u{1fef1}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 54.348,
+lodMaxClamp: 82.649,
+});
+try {
+computePassEncoder10.setPipeline(pipeline24);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(6, bindGroup4, new Uint32Array(5296), 4593, 0);
+} catch {}
+try {
+renderBundleEncoder11.draw(0, 72, 48, 80);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexedIndirect(buffer3, 22408);
+} catch {}
+try {
+renderBundleEncoder11.drawIndirect(buffer3, 43736);
+} catch {}
+try {
+commandEncoder16.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba8unorm-srgb'],
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer6,
+]);
+} catch {}
+let texture36 = device1.createTexture({
+label: '\u37f2\ucb6b\u{1fc22}\u795c\u0332\u{1fba3}\uc547\u869a\u025c\ube4a\ud46c',
+size: [80, 8, 131],
+mipLevelCount: 6,
+sampleCount: 1,
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-10x8-unorm', 'astc-10x8-unorm-srgb', 'astc-10x8-unorm-srgb'],
+});
+let renderBundleEncoder19 = device1.createRenderBundleEncoder({
+  label: '\u8d40\u{1ff4e}\u7beb\u9ce1\u{1fc78}\u08f0\u2b87\u7c84\u5513\u02a7\ud68d',
+  colorFormats: ['r16uint', 'bgra8unorm', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle21 = renderBundleEncoder19.finish({label: '\u870c\u6767\u{1fbdd}\u0466\u0bef'});
+let querySet18 = device1.createQuerySet({
+label: '\uf95e\u0849\u{1fd79}\u047d\u840a\u0b0a\u100d\u391a\u018e\ubcc9\u{1fdcf}',
+type: 'occlusion',
+count: 3691,
+});
+offscreenCanvas0.width = 99;
+let commandEncoder24 = device1.createCommandEncoder({label: '\u{1f99b}\u{1fdc2}'});
+let sampler24 = device1.createSampler({
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 52.333,
+lodMaxClamp: 83.615,
+});
+try {
+device1.pushErrorScope('validation');
+} catch {}
+let promise24 = device1.popErrorScope();
+try {
+device1.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 57 },
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(32)), /* required buffer size: 1367300 */
+{offset: 760, bytesPerRow: 140, rowsPerImage: 227}, {width: 0, height: 0, depthOrArrayLayers: 44});
+} catch {}
+gc();
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+let video5 = await videoWithData();
+let imageData8 = new ImageData(32, 72);
+let videoFrame6 = new VideoFrame(canvas3, {timestamp: 0});
+let commandEncoder25 = device0.createCommandEncoder({label: '\ue943\u0846\ude95\u7805'});
+let textureView29 = texture16.createView({label: '\u0693\u0df4\u3a2e\u02fb\u08cf\u{1fd53}'});
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+renderBundleEncoder11.drawIndexed(72, 56, 32, 8);
+} catch {}
+try {
+  await promise24;
+} catch {}
+let querySet19 = device0.createQuerySet({
+label: '\uc19a\ubc0c\u5fa6\u96cc\u02c0\u0e96',
+type: 'occlusion',
+count: 2884,
+});
+try {
+renderBundleEncoder11.drawIndexedIndirect(buffer3, 42444);
+} catch {}
+try {
+renderBundleEncoder11.drawIndirect(buffer3, 8856);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(6, buffer1);
+} catch {}
+try {
+commandEncoder9.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 0,
+  origin: { x: 128, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 1492 widthInBlocks: 746 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 23074 */
+offset: 23074,
+buffer: buffer3,
+}, {width: 746, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 71, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video5,
+  origin: { x: 0, y: 10 },
+  flipY: true,
+}, {
+  texture: texture31,
+  mipLevel: 4,
+  origin: { x: 2, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 14, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 4,
+  origin: { x: 10, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 4985255 */
+{offset: 695, bytesPerRow: 280, rowsPerImage: 138}, {width: 0, height: 0, depthOrArrayLayers: 130});
+} catch {}
+try {
+  await promise23;
+} catch {}
+let video6 = await videoWithData();
+let querySet20 = device1.createQuerySet({
+label: '\u0725\u0061\ude7c\u29a4\u02d9',
+type: 'occlusion',
+count: 57,
+});
+let renderBundle22 = renderBundleEncoder19.finish();
+let imageData9 = new ImageData(56, 152);
+let buffer9 = device1.createBuffer({
+  label: '\u8869\u093d\u0307\u9608\u0daf\u0795\u{1fdbc}\u{1f720}\u5201',
+  size: 21524,
+  usage: GPUBufferUsage.COPY_DST
+});
+let textureView30 = texture36.createView({
+  label: '\u0ad4\u0e5d\u{1f91b}\u707d\u7d66\ueb79',
+  dimension: '2d',
+  format: 'astc-10x8-unorm-srgb',
+  baseMipLevel: 5,
+  baseArrayLayer: 43
+});
+let renderBundleEncoder20 = device1.createRenderBundleEncoder({colorFormats: ['r16uint', 'bgra8unorm', 'rgb10a2unorm'], depthStencilFormat: 'depth24plus-stencil8'});
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+commandEncoder21.clearBuffer(buffer9);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 1,
+  origin: { x: 20, y: 0, z: 39 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 1808205 */
+{offset: 693, bytesPerRow: 232, rowsPerImage: 147}, {width: 10, height: 0, depthOrArrayLayers: 54});
+} catch {}
+try {
+await device1.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img0);
+let renderBundleEncoder21 = device1.createRenderBundleEncoder({
+  colorFormats: ['r16uint', 'bgra8unorm', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true
+});
+try {
+buffer9.unmap();
+} catch {}
+try {
+commandEncoder24.clearBuffer(buffer9);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+commandEncoder24.insertDebugMarker('\u{1fade}');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer9, 540, new BigUint64Array(50812), 13171, 2436);
+} catch {}
+let img3 = await imageWithData(60, 248, '#bc7ab89a', '#f66a2e8a');
+try {
+renderBundleEncoder11.draw(56, 40, 16, 64);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(5, buffer1, 2560, 13611);
+} catch {}
+let promise25 = buffer7.mapAsync(GPUMapMode.READ);
+try {
+commandEncoder20.clearBuffer(buffer3);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipelineLayout6 = device0.createPipelineLayout({label: '\u{1f959}\u{1ff39}\u9cb5\u92ee\u4f40\u{1f909}\ubca3', bindGroupLayouts: [bindGroupLayout11]});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({
+  label: '\u{1faeb}\u0ad3\u{1fa12}\u6018\u{1f76c}\uec9c\u018b',
+  colorFormats: ['rg16uint', 'r16sint', 'r16float', 'rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder15.setBindGroup(6, bindGroup1, new Uint32Array(2140), 312, 0);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 296, y: 0, z: 0 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer3), /* required buffer size: 663 */
+{offset: 663}, {width: 2646, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline31 = device0.createRenderPipeline({
+label: '\u{1f962}\u0274\u9e69\u{1fc23}\u{1f6ef}\u{1fb86}\u03fd\u4d89\u6b48',
+layout: pipelineLayout6,
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16sint', writeMask: 0}, {format: 'r8uint', writeMask: GPUColorWrite.BLUE}, {format: 'rg16uint'}, {format: 'r8uint'}, {format: 'rg32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r8unorm', writeMask: GPUColorWrite.ALL}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'replace',
+depthFailOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilWriteMask: 3948,
+depthBias: 26,
+depthBiasClamp: 91,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 4236,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x4',
+offset: 3704,
+shaderLocation: 3,
+}, {
+format: 'float32x2',
+offset: 2892,
+shaderLocation: 1,
+}, {
+format: 'sint32x3',
+offset: 2616,
+shaderLocation: 9,
+}],
+},
+{
+arrayStride: 3264,
+attributes: [{
+format: 'sint8x2',
+offset: 762,
+shaderLocation: 0,
+}, {
+format: 'sint8x2',
+offset: 2508,
+shaderLocation: 14,
+}, {
+format: 'sint32x2',
+offset: 232,
+shaderLocation: 4,
+}, {
+format: 'snorm16x2',
+offset: 200,
+shaderLocation: 7,
+}, {
+format: 'float32x4',
+offset: 668,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 7884,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x2',
+offset: 2920,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 1260,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 1164,
+shaderLocation: 11,
+}, {
+format: 'sint32',
+offset: 1120,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+canvas6.height = 88;
+let videoFrame7 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let shaderModule2 = device0.createShaderModule({
+label: '\u76cc\u8c97\u4fef\u2622\u{1f8dc}\u{1f7ec}\udd11',
+code: `@group(0) @binding(1548)
+var<storage, read_write> i0: array<u32>;
+
+@compute @workgroup_size(7, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S4 {
+  @builtin(sample_index) f0: u32,
+  @location(76) f1: vec2<u32>,
+  @location(61) f2: vec4<f32>,
+  @location(30) f3: u32,
+  @location(39) f4: vec2<f16>,
+  @location(86) f5: vec2<f32>,
+  @location(104) f6: vec2<i32>,
+  @location(99) f7: f32,
+  @location(91) f8: u32,
+  @location(20) f9: f16,
+  @location(74) f10: vec3<i32>,
+  @location(57) f11: vec4<i32>,
+  @location(4) f12: vec4<f16>,
+  @location(69) f13: vec4<f16>,
+  @location(37) f14: f32,
+  @location(43) f15: vec4<f32>,
+  @location(73) f16: vec4<i32>,
+  @location(56) f17: vec3<f32>,
+  @builtin(position) f18: vec4<f32>,
+  @location(63) f19: vec2<f16>,
+  @location(15) f20: vec2<u32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(0) f1: vec4<f32>,
+  @location(1) f2: vec4<f32>,
+  @location(4) f3: vec2<f32>,
+  @location(3) f4: vec2<i32>,
+  @location(5) f5: vec2<i32>
+}
+
+@fragment
+fn fragment0(@location(34) a0: vec2<u32>, @location(100) a1: vec4<u32>, a2: S4, @location(9) a3: vec4<f32>, @location(36) a4: vec2<f16>, @location(16) a5: vec4<f32>, @builtin(front_facing) a6: bool, @builtin(sample_mask) a7: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(20) f55: f16,
+  @location(61) f56: vec4<f32>,
+  @location(37) f57: f32,
+  @location(34) f58: vec2<u32>,
+  @location(36) f59: vec2<f16>,
+  @location(9) f60: vec4<f32>,
+  @location(91) f61: u32,
+  @location(57) f62: vec4<i32>,
+  @location(56) f63: vec3<f32>,
+  @location(99) f64: f32,
+  @location(15) f65: vec2<u32>,
+  @location(76) f66: vec2<u32>,
+  @location(43) f67: vec4<f32>,
+  @location(39) f68: vec2<f16>,
+  @location(4) f69: vec4<f16>,
+  @builtin(position) f70: vec4<f32>,
+  @location(69) f71: vec4<f16>,
+  @location(74) f72: vec3<i32>,
+  @location(104) f73: vec2<i32>,
+  @location(16) f74: vec4<f32>,
+  @location(100) f75: vec4<u32>,
+  @location(30) f76: u32,
+  @location(63) f77: vec2<f16>,
+  @location(73) f78: vec4<i32>,
+  @location(86) f79: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(13) a0: vec3<f16>, @location(0) a1: u32, @location(5) a2: vec3<f16>, @builtin(instance_index) a3: u32, @location(15) a4: i32, @location(10) a5: u32, @location(14) a6: vec4<u32>, @builtin(vertex_index) a7: u32, @location(8) a8: vec2<i32>, @location(3) a9: vec4<u32>, @location(7) a10: vec2<f16>, @location(6) a11: vec2<i32>, @location(1) a12: i32, @location(12) a13: vec3<f32>, @location(4) a14: f16, @location(11) a15: vec3<u32>, @location(2) a16: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let querySet21 = device0.createQuerySet({
+label: '\uc5e4\u17d5\u3b19\u{1f673}\u0c07\u0ac7\uec7f\u8e76\u355e',
+type: 'occlusion',
+count: 1055,
+});
+let texture37 = device0.createTexture({
+size: {width: 1136, height: 9, depthOrArrayLayers: 615},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'r8uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundle23 = renderBundleEncoder11.finish({label: '\ufa02\uda77\u{1f77e}\u{1fe43}\u0846'});
+try {
+renderBundleEncoder22.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer1, 3692, buffer3, 2676, 328);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 21244, new Float32Array(27257), 11835, 1528);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1136, height: 9, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas8,
+  origin: { x: 38, y: 31 },
+  flipY: true,
+}, {
+  texture: texture31,
+  mipLevel: 0,
+  origin: { x: 737, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 167, height: 9, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise25;
+} catch {}
+let imageData10 = new ImageData(32, 244);
+let texture38 = device0.createTexture({
+size: {width: 9088},
+dimension: '1d',
+format: 'r32float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r32float', 'r32float'],
+});
+let renderBundle24 = renderBundleEncoder0.finish({label: '\u0ea0\u095e\uea18\u{1fdb0}'});
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(5, bindGroup7);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 10, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer1), /* required buffer size: 614 */
+{offset: 562}, {width: 13, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline32 = await device0.createComputePipelineAsync({
+label: '\u981f\u2c1e',
+layout: 'auto',
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline33 = await promise19;
+let texture39 = device1.createTexture({
+label: '\u018b\u5426\u{1f83c}\ua66c\u{1f80d}\ubac5\u{1f89e}\u0818\u0276\u1868\ucf0f',
+size: {width: 720},
+dimension: '1d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb'],
+});
+let promise26 = device1.queue.onSubmittedWorkDone();
+document.body.prepend(canvas3);
+let img4 = await imageWithData(166, 292, '#f35dab1f', '#2edf7408');
+let bindGroup12 = device0.createBindGroup({
+layout: bindGroupLayout7,
+entries: [{
+binding: 1160,
+resource: externalTexture0
+}],
+});
+let pipelineLayout7 = device0.createPipelineLayout({
+  label: '\u35ae\u7daa\ufd45\u0099\u082a\u090d',
+  bindGroupLayouts: [bindGroupLayout10, bindGroupLayout11, bindGroupLayout7, bindGroupLayout9]
+});
+let commandEncoder26 = device0.createCommandEncoder({label: '\uf913\u804c\u8a10'});
+let querySet22 = device0.createQuerySet({
+label: '\u0acc\u7e1d\ue0df',
+type: 'occlusion',
+count: 3645,
+});
+let texture40 = device0.createTexture({
+label: '\u652d\u20ee\u{1f975}\u{1f9f8}\u5231\u{1ff59}\u7b36\u{1f89f}\u027b\u074a',
+size: [96, 96, 1],
+mipLevelCount: 4,
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({
+  label: '\u73cf\u074d\u{1fd6f}\u{1fc7d}\u9a3b\u9aff\u096e\u{1fb34}\u2b69\u0949\uad1e',
+  colorFormats: ['rgba8unorm', 'r8sint', undefined],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle25 = renderBundleEncoder11.finish({label: '\u9713\u{1f908}\u09da\u0b63\ubb61\u1048\u0950\u9a00\ub259\u26eb\u0aa6'});
+let sampler25 = device0.createSampler({
+label: '\u92f9\u{1fa22}\u7a6f\u{1fcd1}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 93.418,
+lodMaxClamp: 95.969,
+});
+try {
+computePassEncoder7.insertDebugMarker('\u5d4b');
+} catch {}
+let pipeline34 = device0.createRenderPipeline({
+label: '\u44c4\u012c\u{1f619}\ubc0c\u{1fb07}\u3b83\u0925',
+layout: pipelineLayout2,
+multisample: {
+count: 1,
+mask: 0x17301aab,
+},
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgb10a2unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'dst-alpha'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: 0
+}, {format: 'bgra8unorm-srgb'}, {
+  format: 'rgba16float',
+  blend: {
+color: {operation: 'add', srcFactor: 'dst-alpha', dstFactor: 'dst'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'rg32sint', writeMask: GPUColorWrite.GREEN}, {format: 'rg16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r8sint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'greater',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+depthFailOp: 'keep',
+passOp: 'decrement-clamp',
+},
+stencilWriteMask: 3517,
+depthBiasSlopeScale: 11,
+depthBiasClamp: 60,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 10680,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint16x4',
+offset: 4072,
+shaderLocation: 15,
+}, {
+format: 'float32',
+offset: 1612,
+shaderLocation: 4,
+}, {
+format: 'uint32x3',
+offset: 8704,
+shaderLocation: 3,
+}, {
+format: 'uint16x2',
+offset: 6804,
+shaderLocation: 11,
+}, {
+format: 'snorm8x2',
+offset: 9680,
+shaderLocation: 13,
+}, {
+format: 'unorm8x4',
+offset: 7404,
+shaderLocation: 7,
+}, {
+format: 'uint32x3',
+offset: 9900,
+shaderLocation: 10,
+}, {
+format: 'uint16x2',
+offset: 1384,
+shaderLocation: 2,
+}, {
+format: 'uint32x4',
+offset: 1992,
+shaderLocation: 0,
+}, {
+format: 'sint32',
+offset: 3216,
+shaderLocation: 6,
+}, {
+format: 'sint16x4',
+offset: 2160,
+shaderLocation: 8,
+}, {
+format: 'float16x2',
+offset: 3852,
+shaderLocation: 5,
+}, {
+format: 'snorm16x2',
+offset: 7992,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 10220,
+attributes: [{
+format: 'sint32',
+offset: 6152,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 7412,
+attributes: [{
+format: 'uint16x4',
+offset: 4200,
+shaderLocation: 14,
+}],
+}
+]
+},
+});
+try {
+  await promise22;
+} catch {}
+let bindGroup13 = device0.createBindGroup({
+label: '\u{1fc82}\u8cdd\u845e\ucda0\u0a0c\u{1fb47}\ubd3d',
+layout: bindGroupLayout7,
+entries: [{
+binding: 1160,
+resource: externalTexture0
+}],
+});
+let texture41 = device0.createTexture({
+label: '\u023c\u9506\u93e2\u4a44\u0e79\u4634\uf1b7\ua4e5',
+size: {width: 20, height: 240, depthOrArrayLayers: 1},
+mipLevelCount: 5,
+format: 'astc-10x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView31 = texture38.createView({label: '\u46c2\u0ca8\u0156\ue85a\u0f19'});
+try {
+renderBundleEncoder12.setBindGroup(5, bindGroup6);
+} catch {}
+let pipeline35 = device0.createComputePipeline({
+label: '\u2071\u0875\u2602\u1601\u8861',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let querySet23 = device0.createQuerySet({
+label: '\u5240\u0966',
+type: 'occlusion',
+count: 3610,
+});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({
+  label: '\u0d26\u085f',
+  colorFormats: ['r16sint', 'r8uint', 'rg16uint', 'r8uint', 'rg32sint', 'r8unorm'],
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let renderBundle26 = renderBundleEncoder23.finish({label: '\uc383\u{1fc74}\u062e\u67d9\u{1feca}'});
+try {
+commandEncoder9.copyBufferToBuffer(buffer0, 14760, buffer3, 3724, 112);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let imageData11 = new ImageData(184, 72);
+let computePassEncoder14 = commandEncoder24.beginComputePass({label: '\u0c0d\ua542\u04d5\u{1f731}\u22d1\u{1fc55}\u0420\u7f36\u0a64\u{1fa0d}'});
+let renderBundle27 = renderBundleEncoder18.finish({});
+try {
+commandEncoder21.clearBuffer(buffer9);
+dissociateBuffer(device1, buffer9);
+} catch {}
+let querySet24 = device1.createQuerySet({
+type: 'occlusion',
+count: 517,
+});
+try {
+commandEncoder21.clearBuffer(buffer9);
+dissociateBuffer(device1, buffer9);
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+label: '\u072e\u6973\u0499\u3df8\u{1fb88}\u0aa5\u0721\ud8d1\u3f9f\u{1fa1b}',
+code: `@group(0) @binding(1160)
+var<storage, read_write> field1: array<u32>;
+
+@compute @workgroup_size(6, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S6 {
+  @builtin(position) f0: vec4<f32>,
+  @location(68) f1: vec4<u32>,
+  @location(10) f2: u32,
+  @location(85) f3: f16,
+  @location(84) f4: vec2<f16>,
+  @location(49) f5: u32,
+  @location(101) f6: u32,
+  @location(3) f7: vec2<f16>,
+  @location(34) f8: vec3<f16>,
+  @location(58) f9: vec4<f32>,
+  @location(52) f10: vec2<u32>,
+  @location(87) f11: vec4<f32>,
+  @location(29) f12: i32,
+  @location(97) f13: vec3<f32>,
+  @location(67) f14: u32,
+  @location(61) f15: vec3<i32>,
+  @location(56) f16: vec4<f32>,
+  @location(12) f17: vec4<f32>,
+  @location(8) f18: vec2<u32>,
+  @location(32) f19: vec2<f16>,
+  @location(83) f20: vec2<f32>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(0) f1: vec4<f32>,
+  @location(5) f2: vec4<f32>,
+  @location(3) f3: vec4<f32>,
+  @location(2) f4: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(17) a0: vec3<u32>, a1: S6) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S5 {
+  @location(2) f0: vec2<f16>,
+  @location(9) f1: vec2<f16>,
+  @location(6) f2: vec2<i32>,
+  @location(10) f3: vec2<f16>,
+  @location(15) f4: vec2<i32>,
+  @location(13) f5: vec4<u32>
+}
+struct VertexOutput0 {
+  @location(65) f80: f16,
+  @location(45) f81: vec2<i32>,
+  @location(29) f82: i32,
+  @location(97) f83: vec3<f32>,
+  @location(34) f84: vec3<f16>,
+  @location(84) f85: vec2<f16>,
+  @location(3) f86: vec2<f16>,
+  @location(85) f87: f16,
+  @location(19) f88: vec3<f16>,
+  @location(15) f89: f32,
+  @location(61) f90: vec3<i32>,
+  @location(79) f91: vec2<u32>,
+  @location(2) f92: u32,
+  @location(17) f93: vec3<u32>,
+  @location(56) f94: vec4<f32>,
+  @location(101) f95: u32,
+  @location(10) f96: u32,
+  @location(52) f97: vec2<u32>,
+  @location(83) f98: vec2<f32>,
+  @location(8) f99: vec2<u32>,
+  @location(12) f100: vec4<f32>,
+  @location(67) f101: u32,
+  @location(49) f102: u32,
+  @location(87) f103: vec4<f32>,
+  @location(40) f104: vec2<u32>,
+  @location(68) f105: vec4<u32>,
+  @builtin(position) f106: vec4<f32>,
+  @location(80) f107: u32,
+  @location(32) f108: vec2<f16>,
+  @location(58) f109: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(3) a0: f16, @location(14) a1: vec4<f16>, @location(12) a2: vec3<i32>, a3: S5, @location(7) a4: vec3<f16>, @location(5) a5: vec3<u32>, @location(11) a6: vec4<u32>, @location(8) a7: vec2<i32>, @location(0) a8: vec2<f16>, @location(1) a9: vec2<f32>, @builtin(vertex_index) a10: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+try {
+commandEncoder16.copyBufferToBuffer(buffer0, 4056, buffer3, 20428, 4428);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let commandEncoder27 = device1.createCommandEncoder({label: '\u043a\u2b9e\u3a12\uc639\u046b\u{1fb0d}\uc1cb\u080f'});
+let renderBundleEncoder25 = device1.createRenderBundleEncoder({
+  colorFormats: ['r16uint', 'bgra8unorm', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true
+});
+let renderBundle28 = renderBundleEncoder16.finish();
+try {
+device1.queue.writeBuffer(buffer9, 19632, new DataView(new ArrayBuffer(22416)), 18410, 412);
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+code: `@group(0) @binding(1160)
+var<storage, read_write> function1: array<u32>;
+
+@compute @workgroup_size(6, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(4) f1: u32,
+  @location(2) f2: vec4<u32>,
+  @location(0) f3: vec2<f32>,
+  @location(3) f4: vec4<f32>,
+  @location(5) f5: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(5) a0: vec2<f32>, @location(2) a1: u32, @location(12) a2: vec3<f16>, @location(0) a3: vec2<u32>, @location(8) a4: vec3<u32>, @location(13) a5: vec2<u32>, @location(11) a6: f16, @location(14) a7: vec3<i32>, @location(7) a8: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroupLayout14 = device0.createBindGroupLayout({
+label: '\u78ee\ud1ba\u{1f84e}\u02c6\ufea1\u984b',
+entries: [{
+binding: 4535,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}, {
+binding: 1395,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '1d' },
+}, {
+binding: 3040,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'non-filtering' },
+}],
+});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16sint', 'r8uint', 'rg16uint', 'r8uint', 'rg32sint', 'r8unorm'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle29 = renderBundleEncoder9.finish({label: '\u0eb9\u0a67'});
+try {
+computePassEncoder10.setPipeline(pipeline32);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba32float'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+adapter1.label = '\u72c8\u086a\u0a92\u153a';
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+label: '\u46c5\u51bc\u0fa0\u032c\u4e5f\u04a5\u{1fb34}',
+code: `@group(1) @binding(2495)
+var<storage, read_write> field2: array<u32>;
+@group(3) @binding(3641)
+var<storage, read_write> type1: array<u32>;
+@group(3) @binding(1646)
+var<storage, read_write> i1: array<u32>;
+@group(0) @binding(1160)
+var<storage, read_write> function2: array<u32>;
+
+@compute @workgroup_size(7, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec3<f32>,
+  @location(1) f1: vec2<i32>,
+  @location(3) f2: vec4<i32>,
+  @builtin(frag_depth) f3: f32,
+  @location(0) f4: vec4<u32>,
+  @location(5) f5: vec2<i32>
+}
+
+@fragment
+fn fragment0(@location(99) a0: vec3<f16>, @location(97) a1: vec4<f32>, @location(19) a2: f32, @location(43) a3: vec2<f16>, @location(30) a4: vec4<u32>, @location(81) a5: vec3<i32>, @location(110) a6: vec3<f16>, @location(69) a7: vec4<u32>, @location(105) a8: vec3<f32>, @location(16) a9: vec4<i32>, @location(36) a10: vec3<f32>, @location(47) a11: i32, @location(11) a12: vec4<f16>, @location(31) a13: vec2<f16>, @location(9) a14: u32, @location(7) a15: vec3<f16>, @location(68) a16: vec4<i32>, @location(3) a17: vec4<f16>, @builtin(position) a18: vec4<f32>, @location(18) a19: vec4<i32>, @location(35) a20: vec2<f16>, @location(73) a21: f16, @builtin(sample_index) a22: u32, @location(48) a23: i32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(43) f110: vec2<f16>,
+  @location(19) f111: f32,
+  @location(11) f112: vec4<f16>,
+  @location(7) f113: vec3<f16>,
+  @location(81) f114: vec3<i32>,
+  @builtin(position) f115: vec4<f32>,
+  @location(97) f116: vec4<f32>,
+  @location(68) f117: vec4<i32>,
+  @location(16) f118: vec4<i32>,
+  @location(31) f119: vec2<f16>,
+  @location(47) f120: i32,
+  @location(110) f121: vec3<f16>,
+  @location(35) f122: vec2<f16>,
+  @location(30) f123: vec4<u32>,
+  @location(69) f124: vec4<u32>,
+  @location(9) f125: u32,
+  @location(44) f126: vec2<i32>,
+  @location(36) f127: vec3<f32>,
+  @location(3) f128: vec4<f16>,
+  @location(73) f129: f16,
+  @location(48) f130: i32,
+  @location(99) f131: vec3<f16>,
+  @location(18) f132: vec4<i32>,
+  @location(105) f133: vec3<f32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let renderBundle30 = renderBundleEncoder4.finish({label: '\u2ac4\u0312\uc2cc\uebbb\u7b55\u0710\uaba7'});
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup1, new Uint32Array(7420), 490, 0);
+} catch {}
+let pipeline36 = await device0.createRenderPipelineAsync({
+label: '\ud9d4\ub430\uf011',
+layout: pipelineLayout3,
+multisample: {
+mask: 0x98490d2e,
+},
+fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'one-minus-src'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'dst'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'never',
+failOp: 'decrement-wrap',
+depthFailOp: 'invert',
+passOp: 'replace',
+},
+stencilReadMask: 2735,
+stencilWriteMask: 4078,
+depthBias: 73,
+depthBiasSlopeScale: 98,
+},
+vertex: {
+  module: shaderModule0,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 14260,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x3',
+offset: 2456,
+shaderLocation: 10,
+}, {
+format: 'float16x4',
+offset: 9308,
+shaderLocation: 8,
+}, {
+format: 'float32x3',
+offset: 11808,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 7368,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32',
+offset: 2172,
+shaderLocation: 2,
+}, {
+format: 'unorm16x2',
+offset: 1908,
+shaderLocation: 14,
+}, {
+format: 'sint32',
+offset: 6816,
+shaderLocation: 4,
+}, {
+format: 'float32x4',
+offset: 2368,
+shaderLocation: 1,
+}, {
+format: 'float16x4',
+offset: 3008,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 10780,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x3',
+offset: 952,
+shaderLocation: 11,
+}, {
+format: 'uint16x4',
+offset: 6256,
+shaderLocation: 9,
+}, {
+format: 'sint8x2',
+offset: 6188,
+shaderLocation: 7,
+}],
+},
+{
+arrayStride: 12848,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 15596,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x3',
+offset: 48,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 14308,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x3',
+offset: 5676,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 13372,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x4',
+offset: 8148,
+shaderLocation: 0,
+}, {
+format: 'uint32',
+offset: 220,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 12992,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x2',
+offset: 2020,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'ccw',
+cullMode: 'none',
+unclippedDepth: true,
+},
+});
+let img5 = await imageWithData(52, 216, '#0eac75b6', '#bb4d8b47');
+let textureView32 = texture36.createView({label: '\ubc5b\uee05\u{1f921}', mipLevelCount: 1, baseArrayLayer: 11, arrayLayerCount: 106});
+try {
+renderBundleEncoder20.setVertexBuffer(17, undefined, 3597416463);
+} catch {}
+try {
+computePassEncoder14.insertDebugMarker('\u7b1a');
+} catch {}
+let textureView33 = texture34.createView({
+  label: '\u{1f64c}\u{1f912}\u{1f821}\u0dc7\u32ee\u0d22\u0558\ua29f',
+  baseArrayLayer: 68,
+  arrayLayerCount: 50
+});
+try {
+commandEncoder27.clearBuffer(buffer9);
+dissociateBuffer(device1, buffer9);
+} catch {}
+let promise27 = adapter3.requestAdapterInfo();
+let commandEncoder28 = device0.createCommandEncoder({});
+let querySet25 = device0.createQuerySet({
+label: '\u08a5\u{1fcd0}\u05ca\u2f18\u{1fb66}\u23bb\u0ed8\u6e4d\u0592\u{1ffc2}',
+type: 'occlusion',
+count: 1941,
+});
+let textureView34 = texture37.createView({label: '\u05f6\u3c2b\uc348\u91c9\u{1fde8}\u0b22\u{1f7ab}\u56be\u{1f7de}\u16eb', baseMipLevel: 4});
+try {
+commandEncoder28.copyBufferToBuffer(buffer5, 2640, buffer3, 21728, 20208);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder22.clearBuffer(buffer3);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+renderBundleEncoder26.pushDebugGroup('\uc427');
+} catch {}
+try {
+gpuCanvasContext4.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba16float', 'rgba16uint', 'rgba16float', 'rgba16float'],
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: { x: 627, y: 1, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(370), /* required buffer size: 370 */
+{offset: 370}, {width: 4058, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline37 = device0.createRenderPipeline({
+label: '\u0bdb\u{1f824}\u{1ffd2}\u{1fc24}\ub477\uce9f\ua817\u0d77\u0bf9\u9e31',
+layout: pipelineLayout3,
+fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16float', writeMask: 0}, {format: 'rgba32float'}, {format: 'rgba32uint'}, {
+  format: 'rgba8unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+}
+}, undefined, {format: 'rgba16float'}]
+},
+vertex: {
+  module: shaderModule3,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 15404,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32',
+offset: 12316,
+shaderLocation: 5,
+}, {
+format: 'sint32x4',
+offset: 6612,
+shaderLocation: 15,
+}, {
+format: 'sint8x4',
+offset: 14164,
+shaderLocation: 12,
+}, {
+format: 'uint16x4',
+offset: 3416,
+shaderLocation: 13,
+}, {
+format: 'float32x2',
+offset: 3472,
+shaderLocation: 9,
+}, {
+format: 'float16x4',
+offset: 14832,
+shaderLocation: 7,
+}, {
+format: 'unorm16x2',
+offset: 13000,
+shaderLocation: 0,
+}, {
+format: 'unorm16x2',
+offset: 14888,
+shaderLocation: 10,
+}, {
+format: 'unorm16x2',
+offset: 7964,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 1744,
+shaderLocation: 8,
+}, {
+format: 'uint32',
+offset: 2388,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 7688,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm8x4',
+offset: 1856,
+shaderLocation: 1,
+}, {
+format: 'unorm16x4',
+offset: 5164,
+shaderLocation: 2,
+}, {
+format: 'float32x4',
+offset: 1412,
+shaderLocation: 3,
+}, {
+format: 'sint32x2',
+offset: 7260,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+try {
+  await promise26;
+} catch {}
+let imageBitmap6 = await createImageBitmap(imageBitmap4);
+let bindGroupLayout15 = device0.createBindGroupLayout({
+entries: [{
+binding: 1495,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+}, {
+binding: 5491,
+visibility: 0,
+externalTexture: {},
+}, {
+binding: 5397,
+visibility: GPUShaderStage.COMPUTE,
+externalTexture: {},
+}],
+});
+let bindGroup14 = device0.createBindGroup({
+label: '\ucd7b\u0ce2\u0997\u3560\u05f8\ufa28\u9ee2\u0de7',
+layout: bindGroupLayout15,
+entries: [{
+binding: 1495,
+resource: sampler20
+}, {
+binding: 5491,
+resource: externalTexture0
+}, {
+binding: 5397,
+resource: externalTexture0
+}],
+});
+let sampler26 = device0.createSampler({
+label: '\u{1fc83}\u069a\u0e85\ue132\u0f3a\u4690\uab47\uef8c\uefd6\uf01c\u9164',
+addressModeU: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 56.173,
+lodMaxClamp: 81.575,
+compare: 'less',
+maxAnisotropy: 10,
+});
+try {
+commandEncoder28.clearBuffer(buffer3);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+renderBundleEncoder26.popDebugGroup();
+} catch {}
+let videoFrame8 = new VideoFrame(video0, {timestamp: 0});
+let bindGroupLayout16 = device1.createBindGroupLayout({
+label: '\u035b\u{1f694}\u0a5a\u092b\ua481',
+entries: [{
+binding: 7932,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '1d' },
+}, {
+binding: 6112,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '2d' },
+}],
+});
+let pipelineLayout8 = device1.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder29 = device1.createCommandEncoder({label: '\u{1f6c2}\u715d'});
+let textureView35 = texture33.createView({aspect: 'stencil-only', baseMipLevel: 6, mipLevelCount: 2});
+let renderBundleEncoder27 = device1.createRenderBundleEncoder({
+  label: '\u0c31\u2ddf\u8168\u{1f7e6}\u0a88\u039a\ucbb9',
+  colorFormats: ['rgb10a2uint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle31 = renderBundleEncoder20.finish({label: '\u4c1d\u8ee9\u0cc9\ubc6b\u{1f6ab}\u6d1b\u634f\u9edc\u4203\u0ef0'});
+try {
+renderBundleEncoder27.setVertexBuffer(57, undefined, 2664305010);
+} catch {}
+try {
+commandEncoder27.clearBuffer(buffer9);
+dissociateBuffer(device1, buffer9);
+} catch {}
+let renderBundle32 = renderBundleEncoder2.finish({label: '\u2a01\u6836\u3da8\u0e7e\u08c3\u1280\u9204\u078d\u4479\u0b2a\u1839'});
+try {
+renderBundleEncoder12.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+/* bytesInLastRow: 36 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 15756 */
+offset: 15720,
+buffer: buffer6,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 23, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 9, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+label: '\u0eeb\u{1fb1d}\uce9a',
+code: `@group(0) @binding(1548)
+var<storage, read_write> type2: array<u32>;
+
+@compute @workgroup_size(3, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<f32>,
+  @location(6) f1: vec4<u32>,
+  @location(5) f2: vec4<f32>,
+  @location(0) f3: vec2<f32>,
+  @location(2) f4: vec4<u32>,
+  @location(1) f5: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(sample_index) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(14) a0: vec2<u32>, @location(13) a1: f32, @location(6) a2: vec2<f16>, @location(0) a3: vec2<f16>, @location(12) a4: u32, @builtin(vertex_index) a5: u32, @location(10) a6: f32, @location(2) a7: vec2<u32>, @location(3) a8: vec3<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let buffer10 = device0.createBuffer({label: '\u0646\u0818\u0429', size: 62069, usage: GPUBufferUsage.INDEX});
+let renderBundle33 = renderBundleEncoder9.finish({label: '\u06de\u20df\ufcb9\u0134\u9ae2\u1b2a\u06e7\u0fa7\u{1fea8}\u{1f820}'});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup2, new Uint32Array(7970), 1292, 0);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(1, bindGroup9);
+} catch {}
+let pipeline38 = await device0.createComputePipelineAsync({
+label: '\u{1f808}\ua4f0\uaea5\u{1f9da}\u{1fbd2}\uf284\u5d89\u0a26\ub318\u{1fa26}\u0f89',
+layout: 'auto',
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let video7 = await videoWithData();
+let commandBuffer7 = commandEncoder21.finish({
+label: '\u{1fc2a}\u008e\u1a22\u{1f61f}\u964c',
+});
+try {
+computePassEncoder12.pushDebugGroup('\u477c');
+} catch {}
+try {
+  await promise17;
+} catch {}
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({
+  label: '\ue7e3\uc3e5\u9278\u45f8\udb24\uf171',
+  colorFormats: ['r16sint', 'r8uint', 'rg16uint', 'r8uint', 'rg32sint', 'r8unorm'],
+  sampleCount: 4,
+  depthReadOnly: false
+});
+let renderBundle34 = renderBundleEncoder3.finish({label: '\uf1e9\u558d\u65db\u795a\u{1fb36}\u0022'});
+try {
+renderBundleEncoder28.setVertexBuffer(6, buffer1, 5080, 2840);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+commandEncoder17.copyBufferToBuffer(buffer6, 46664, buffer3, 37776, 4176);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer3);
+} catch {}
+document.body.prepend(video2);
+let imageBitmap7 = await createImageBitmap(canvas1);
+let commandEncoder30 = device0.createCommandEncoder({label: '\udc15\ufb6a\u3467\u{1fb3b}\u0627\u63c3\ud2e7\u4f3d'});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({
+  label: '\uf41f\u0424\u25f4\u{1fec8}\u4757\uedd6\u0a5c\u009b',
+  colorFormats: ['rg8unorm', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder7.setBindGroup(6, bindGroup4, []);
+} catch {}
+try {
+computePassEncoder7.dispatchWorkgroups(5, 3, 2);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(6, buffer1, 16492, 669);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 3,
+  origin: { x: 1, y: 13, z: 21 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer3), /* required buffer size: 1424450 */
+{offset: 51, bytesPerRow: 103, rowsPerImage: 145}, {width: 3, height: 55, depthOrArrayLayers: 96});
+} catch {}
+let canvas9 = document.createElement('canvas');
+let buffer11 = device1.createBuffer({size: 5078, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder31 = device1.createCommandEncoder({label: '\u{1f6fd}\u0af0\u01c4\u{1f738}\u0df2\u02aa\ue133\u1f50'});
+let renderBundleEncoder30 = device1.createRenderBundleEncoder({
+  label: '\u049f\u052f\u{1fa32}\u04eb\uc0e5\u{1f7e4}\ube24',
+  colorFormats: ['r16uint', 'bgra8unorm', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true
+});
+try {
+  await buffer11.mapAsync(GPUMapMode.WRITE, 944, 2028);
+} catch {}
+try {
+commandEncoder31.copyTextureToTexture({
+  texture: texture36,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 39 },
+  aspect: 'all',
+}, {
+  texture: texture36,
+  mipLevel: 5,
+  origin: { x: 0, y: 0, z: 94 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 3});
+} catch {}
+try {
+device1.queue.submit([
+commandBuffer7,
+]);
+} catch {}
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(98, undefined, 2644774804);
+} catch {}
+try {
+commandEncoder24.clearBuffer(buffer9);
+dissociateBuffer(device1, buffer9);
+} catch {}
+document.body.prepend(canvas6);
+let video8 = await videoWithData();
+let videoFrame9 = videoFrame7.clone();
+let texture42 = device1.createTexture({
+label: '\u0c93\u{1ff1a}\u0afc',
+size: [1040, 51, 48],
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16sint'],
+});
+let sampler27 = device1.createSampler({
+label: '\u{1f9a1}\u0cd6\u29f6\u{1fd52}\ue95f\ub847\u{1f940}\u7b26\u{1fcb0}\ua5c3\u{1fd2c}',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMinClamp: 52.341,
+lodMaxClamp: 53.535,
+});
+try {
+commandEncoder29.copyTextureToTexture({
+  texture: texture36,
+  mipLevel: 0,
+  origin: { x: 30, y: 0, z: 45 },
+  aspect: 'all',
+}, {
+  texture: texture36,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 105 },
+  aspect: 'all',
+}, {width: 30, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer9, 2940, new Float32Array(62700), 18463, 1592);
+} catch {}
+let gpuCanvasContext7 = canvas9.getContext('webgpu');
+let adapter4 = await navigator.gpu.requestAdapter({
+});
+let imageData12 = new ImageData(88, 152);
+let bindGroupLayout17 = pipeline31.getBindGroupLayout(0);
+let pipelineLayout9 = device0.createPipelineLayout({
+  label: '\ubd7c\u0198\u1234\u78a2\u053a\ub6a3\u0672\ud0a2\u0c5e\u{1fd1a}\u0512',
+  bindGroupLayouts: [bindGroupLayout6, bindGroupLayout2, bindGroupLayout15]
+});
+let commandBuffer8 = commandEncoder26.finish({
+});
+let texture43 = device0.createTexture({
+label: '\u2da0\u1e48\u6889\u0a0d\u0295\u66b5\u3032\u281d\u{1fcc1}',
+size: [20, 240, 1],
+mipLevelCount: 6,
+format: 'astc-5x4-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView36 = texture3.createView({label: '\u0ee9\u{1f855}', dimension: '2d-array', baseMipLevel: 8});
+try {
+renderBundleEncoder17.setBindGroup(4, bindGroup10);
+} catch {}
+try {
+commandEncoder22.clearBuffer(buffer3);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline39 = await device0.createComputePipelineAsync({
+label: '\u0236\u{1fd3f}\u830b\u0080\u4a42\u{1f72f}\u583d\ucf68\u8af0\u25ce\u6e0d',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+  await promise27;
+} catch {}
+try {
+window.someLabel = device0.queue.label;
+} catch {}
+let buffer12 = device0.createBuffer({
+  label: '\u{1fe16}\ufed3\u{1fd7d}\u0598\u{1fd5e}\u508f',
+  size: 35978,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE
+});
+let querySet26 = device0.createQuerySet({
+label: '\u{1ffb3}\u{1fd87}\u0d69\u{1fd20}\u0763\ucf88\u0d3e',
+type: 'occlusion',
+count: 2273,
+});
+let renderBundle35 = renderBundleEncoder12.finish({label: '\u01d2\uc1eb\u8f64\u0c78'});
+let sampler28 = device0.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 3.820,
+});
+try {
+computePassEncoder7.dispatchWorkgroups(3, 4, 5);
+} catch {}
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(5, buffer1);
+} catch {}
+try {
+texture11.destroy();
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer12, 32996, 1980);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 30820, new Float32Array(41040), 23336, 420);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 187, y: 0, z: 0 },
+  aspect: 'all',
+}, new Int16Array(arrayBuffer0), /* required buffer size: 12177 */
+{offset: 649, bytesPerRow: 11604, rowsPerImage: 52}, {width: 2882, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 284, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: video6,
+  origin: { x: 1, y: 1 },
+  flipY: true,
+}, {
+  texture: texture31,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 9, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise10;
+} catch {}
+document.body.prepend(video0);
+let computePassEncoder15 = commandEncoder31.beginComputePass({label: '\u0deb\u07e6\uc77f\u233a\u95e2\u{1ff51}\u6c83\u0c1d\u8c9e'});
+let renderBundleEncoder31 = device1.createRenderBundleEncoder({
+  label: '\u{1f81c}\u{1fea4}\u5738\u3d14\u038e\u0646\u4edd\ufc46\u3370\u{1fc1c}',
+  colorFormats: ['rgba16uint', 'rg32float', 'rgb10a2uint', 'rg8uint', 'r8sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+try {
+device1.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: { x: 25, y: 7, z: 76 },
+  aspect: 'all',
+}, new Int16Array(arrayBuffer0), /* required buffer size: 434576 */
+{offset: 359, bytesPerRow: 431, rowsPerImage: 100}, {width: 100, height: 8, depthOrArrayLayers: 11});
+} catch {}
+document.body.prepend(img3);
+let canvas10 = document.createElement('canvas');
+let renderBundle36 = renderBundleEncoder14.finish({label: '\ua770\uc692\u{1fdee}\u3566'});
+let sampler29 = device0.createSampler({
+label: '\u6062\u{1fb67}\u{1f9ee}\u46a3\u0092\u0af0\u{1ffe1}\uce12\u0ddb\u{1fe5b}',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 94.589,
+maxAnisotropy: 15,
+});
+try {
+computePassEncoder7.dispatchWorkgroups(5);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(1, bindGroup7, []);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+/* bytesInLastRow: 12 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 57214 */
+offset: 57214,
+buffer: buffer6,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: { x: 4, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder9.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture5,
+  mipLevel: 2,
+  origin: { x: 168, y: 1, z: 15 },
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer8,
+]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 3,
+  origin: { x: 2, y: 2, z: 1 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 578738 */
+{offset: 153, bytesPerRow: 305, rowsPerImage: 271}, {width: 57, height: 0, depthOrArrayLayers: 8});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 1, y: 1 },
+  flipY: true,
+}, {
+  texture: texture31,
+  mipLevel: 9,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture44 = device0.createTexture({
+size: {width: 880},
+dimension: '1d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgb10a2uint', 'rgb10a2uint', 'rgb10a2uint'],
+});
+let textureView37 = texture0.createView({label: '\u01c9\u2b60\u1eb0\u{1ff17}\u28ba', dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 1});
+try {
+computePassEncoder5.setPipeline(pipeline38);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(6, bindGroup7);
+} catch {}
+try {
+commandEncoder30.copyTextureToBuffer({
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 10216 */
+offset: 10208,
+buffer: buffer12,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer12);
+} catch {}
+let bindGroup15 = device0.createBindGroup({
+label: '\u{1fe4d}\u385d\u0739\ubed0\u070f',
+layout: bindGroupLayout4,
+entries: [],
+});
+let texture45 = device0.createTexture({
+label: '\uf05f\uf40b\u0a84\u0ad8\ue4d2\u0770',
+size: [588, 1, 235],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder22.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder26.insertDebugMarker('\u0bb0');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 22248, new DataView(new ArrayBuffer(55358)), 31426, 21004);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 63 },
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 27525954 */
+{offset: 426, bytesPerRow: 706, rowsPerImage: 228}, {width: 480, height: 0, depthOrArrayLayers: 172});
+} catch {}
+let commandEncoder32 = device1.createCommandEncoder();
+let textureView38 = texture42.createView({
+  label: '\u{1fc8f}\ub962\u0d92\ua674\u0f03\u1db7\u{1f8bf}\u5c09\u4d7d',
+  format: 'rgba16sint',
+  baseMipLevel: 0
+});
+let computePassEncoder16 = commandEncoder29.beginComputePass({label: '\ua06b\u000d\u6764\u{1f6a6}\u03b4\u58d4\u{1fb83}'});
+try {
+gpuCanvasContext3.configure({
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm-srgb', 'stencil8', 'bgra8unorm-srgb', 'astc-8x8-unorm-srgb'],
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: { x: 34, y: 3, z: 43 },
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 6683849 */
+{offset: 650, bytesPerRow: 495, rowsPerImage: 173}, {width: 102, height: 8, depthOrArrayLayers: 79});
+} catch {}
+let pipelineLayout10 = device0.createPipelineLayout({
+  label: '\u913b\u0937',
+  bindGroupLayouts: [bindGroupLayout2, bindGroupLayout15, bindGroupLayout15, bindGroupLayout8, bindGroupLayout0, bindGroupLayout6, bindGroupLayout7]
+});
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(4, bindGroup14, []);
+} catch {}
+let arrayBuffer5 = buffer0.getMappedRange(14560, 976);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 74, y: 60 },
+  flipY: true,
+}, {
+  texture: texture31,
+  mipLevel: 10,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageData13 = new ImageData(180, 152);
+try {
+canvas10.getContext('webgl2');
+} catch {}
+let bindGroupLayout18 = device1.createBindGroupLayout({
+label: '\uc67c\u0f44\u443e\u{1f840}\u{1fa16}',
+entries: [],
+});
+let textureView39 = texture33.createView({dimension: '2d-array', aspect: 'all', baseMipLevel: 2, mipLevelCount: 3});
+try {
+computePassEncoder12.popDebugGroup();
+} catch {}
+try {
+device1.destroy();
+} catch {}
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({
+  label: '\u39c7\u0418\u{1ff5b}\u03ba\u8224\u{1fb63}\u4ef6',
+  colorFormats: ['rgb10a2unorm', 'bgra8unorm-srgb', 'rgba16float', 'rg32sint', 'rg16float', 'r8sint'],
+  depthReadOnly: true
+});
+try {
+computePassEncoder1.setPipeline(pipeline21);
+} catch {}
+try {
+commandEncoder23.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 41640 */
+offset: 41640,
+bytesPerRow: 0,
+rowsPerImage: 375,
+buffer: buffer6,
+}, {
+  texture: texture11,
+  mipLevel: 2,
+  origin: { x: 18, y: 56, z: 22 },
+  aspect: 'all',
+}, {width: 0, height: 137, depthOrArrayLayers: 197});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder15.resolveQuerySet(querySet1, 746, 362, buffer12, 17408);
+} catch {}
+let offscreenCanvas7 = new OffscreenCanvas(752, 691);
+let computePassEncoder17 = commandEncoder30.beginComputePass({});
+let renderBundle37 = renderBundleEncoder12.finish({label: '\ua81d\u5ddd\ud4ba\u0779'});
+try {
+computePassEncoder7.dispatchWorkgroups(5, 2);
+} catch {}
+try {
+computePassEncoder7.dispatchWorkgroupsIndirect(buffer3, 16732);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(5, buffer1);
+} catch {}
+try {
+buffer0.destroy();
+} catch {}
+try {
+commandEncoder28.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 4,
+  origin: { x: 17, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 32 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 42418 */
+offset: 42386,
+buffer: buffer3,
+}, {width: 16, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder15.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 5,
+  origin: { x: 21, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let gpuCanvasContext8 = offscreenCanvas7.getContext('webgpu');
+let textureView40 = texture3.createView({
+  label: '\u{1ffb2}\u0cb3\u{1f6eb}\u08b4\u01ce\u491e\u{1fcf9}\u{1fd19}\u6b54\u4540',
+  dimension: '2d-array',
+  baseMipLevel: 8
+});
+try {
+renderBundleEncoder17.setBindGroup(6, bindGroup6, new Uint32Array(6540), 6364, 0);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(4, buffer1, 40, 3090);
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer0, 7460, buffer3, 33004, 6032);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder13.clearBuffer(buffer3);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 22624, new Float32Array(32256), 10915, 1340);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 3,
+  origin: { x: 38, y: 0, z: 10 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 250395 */
+{offset: 351, bytesPerRow: 216, rowsPerImage: 15}, {width: 33, height: 3, depthOrArrayLayers: 78});
+} catch {}
+video6.height = 139;
+offscreenCanvas3.width = 891;
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let device2 = await adapter4.requestDevice({
+requiredLimits: {
+maxBindGroups: 9,
+maxColorAttachmentBytesPerSample: 38,
+maxVertexAttributes: 27,
+maxVertexBufferArrayStride: 56471,
+maxStorageBuffersPerShaderStage: 27,
+maxDynamicStorageBuffersPerPipelineLayout: 57215,
+maxBindingsPerBindGroup: 3849,
+maxTextureDimension1D: 15592,
+maxTextureDimension2D: 10351,
+maxUniformBufferBindingSize: 135140657,
+maxUniformBuffersPerShaderStage: 30,
+maxInterStageShaderVariables: 33,
+maxSamplersPerShaderStage: 20,
+},
+});
+let texture46 = device0.createTexture({
+label: '\u088b\ue4d3\uc0ed\u2a44\u006f',
+size: [1442, 96, 125],
+mipLevelCount: 11,
+dimension: '3d',
+format: 'rgba32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler30 = device0.createSampler({
+label: '\u05b7\u91ca\ue5cd\u{1fc4c}\u605e\u0276\u0195',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 66.061,
+lodMaxClamp: 75.046,
+});
+try {
+computePassEncoder1.setPipeline(pipeline22);
+} catch {}
+let pipeline40 = device0.createComputePipeline({
+label: '\u5ff0\u08ff\u0ece\u2986\u{1f98a}\u{1f62d}\u0a84\u0f29',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let imageData14 = new ImageData(248, 192);
+let computePassEncoder18 = commandEncoder12.beginComputePass({label: '\uad40\u{1ff81}\u0f4b\u1a50\u288c'});
+try {
+commandEncoder9.copyBufferToBuffer(buffer5, 10376, buffer3, 10700, 5072);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline41 = device0.createComputePipeline({
+label: '\ua763\u7603\uced1\u{1f9b9}\u{1f99e}\u2ac4\u0e90\u{1f86f}',
+layout: pipelineLayout7,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let img6 = await imageWithData(107, 216, '#8c3493d1', '#71cf28d0');
+let device3 = await adapter3.requestDevice({
+label: '\u3f8f\u03e1\u01c8\u0a28',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+});
+let commandEncoder33 = device3.createCommandEncoder({label: '\u0025\u{1f652}\u{1fec9}\u{1fe1e}\ufd8b\u93dc\uce6a\u{1feaf}\u{1fa70}'});
+try {
+await device3.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(418, 95);
+try {
+adapter2.label = '\u5907\u{1fb30}\u2e57\u51d6\u8f41\udc12';
+} catch {}
+let img7 = await imageWithData(292, 190, '#41126ea9', '#98c96499');
+let textureView41 = texture15.createView({
+  label: '\ud6cf\u025c\u{1f8cf}\u7cb4\uad80\ua5fc',
+  dimension: '2d-array',
+  format: 'astc-10x6-unorm-srgb',
+  baseArrayLayer: 0
+});
+try {
+computePassEncoder7.dispatchWorkgroupsIndirect(buffer3, 39240);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(5, bindGroup13, []);
+} catch {}
+let imageData15 = new ImageData(208, 168);
+let texture47 = device2.createTexture({
+label: '\u04ec\u{1ff0d}\u002f\u0e9b\ubcf4\u985a\u082c\uc28f\ucbd9\u44e1',
+size: [207, 15, 37],
+mipLevelCount: 2,
+format: 'rgba32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba32sint', 'rgba32sint'],
+});
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+try {
+await adapter2.requestAdapterInfo();
+} catch {}
+try {
+offscreenCanvas8.getContext('webgpu');
+} catch {}
+try {
+device3.queue.label = '\u5858\uf2b2\u{1febd}\u9cd4\ufc5d\ub16b';
+} catch {}
+let commandEncoder34 = device3.createCommandEncoder({label: '\u521e\u0b7e\u{1fbf8}\u8db9\u5670\u08e7\u06c3\u0298\ud8b6'});
+let offscreenCanvas9 = new OffscreenCanvas(675, 206);
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let renderBundle38 = renderBundleEncoder15.finish({label: '\u4699\u{1f635}\u3829\u3655'});
+try {
+renderBundleEncoder24.setBindGroup(5, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer10, 'uint32', 7176, 36683);
+} catch {}
+try {
+texture40.destroy();
+} catch {}
+try {
+commandEncoder23.copyBufferToBuffer(buffer0, 2520, buffer3, 41604, 1160);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder13.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 0,
+  origin: { x: 9, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 80 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 41556 */
+offset: 41556,
+buffer: buffer3,
+}, {width: 20, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder25.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: { x: 406, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture18,
+  mipLevel: 6,
+  origin: { x: 3, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 9, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let querySet27 = device1.createQuerySet({
+type: 'occlusion',
+count: 237,
+});
+let renderBundleEncoder33 = device1.createRenderBundleEncoder({
+  label: '\u9489\ue429\u940e\u{1fcf7}\u04b9\u0a00\ua4fe\u0d85\u0fde\u4f7e\u08de',
+  colorFormats: ['r16uint', 'bgra8unorm', 'rgb10a2unorm'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true
+});
+try {
+commandEncoder32.copyBufferToBuffer(buffer11, 2608, buffer9, 17272, 1544);
+dissociateBuffer(device1, buffer11);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+device: device1,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x6-unorm', 'bgra8unorm-srgb', 'bgra8unorm', 'astc-5x4-unorm'],
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: { x: 8, y: 6, z: 15 },
+  aspect: 'all',
+}, new ArrayBuffer(13164529), /* required buffer size: 13164529 */
+{offset: 199, bytesPerRow: 448, rowsPerImage: 260}, {width: 149, height: 5, depthOrArrayLayers: 114});
+} catch {}
+document.body.prepend(img3);
+let imageBitmap8 = await createImageBitmap(imageData3);
+let imageData16 = new ImageData(48, 80);
+let querySet28 = device2.createQuerySet({
+label: '\u{1f895}\ua3ec\ue2a2\u8b88\u91e1\u0d6e\u0dab',
+type: 'occlusion',
+count: 1258,
+});
+let renderBundleEncoder34 = device2.createRenderBundleEncoder({
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+let renderBundle39 = renderBundleEncoder34.finish({label: '\u44d5\u{1f76b}\u0ea6\u5a90\ua3fb'});
+let img8 = await imageWithData(177, 161, '#e1c736ca', '#9a5ed6c8');
+let video9 = await videoWithData();
+let sampler31 = device0.createSampler({
+label: '\u{1f64e}\u56db\ue5b1\u{1f877}\u76a8\u08f4\u1d28\u0aaf',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 67.825,
+lodMaxClamp: 79.611,
+});
+try {
+computePassEncoder7.setPipeline(pipeline41);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(6, bindGroup6);
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(buffer4, 7204, buffer12, 21780, 2648);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+offscreenCanvas9.getContext('webgl');
+} catch {}
+let textureView42 = texture13.createView({label: '\u{1f98a}\u0d7b\u5f24\u21da\uda29', mipLevelCount: 2, arrayLayerCount: 1});
+let computePassEncoder19 = commandEncoder20.beginComputePass({});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup7, new Uint32Array(3195), 480, 0);
+} catch {}
+try {
+commandEncoder25.copyBufferToBuffer(buffer5, 8556, buffer3, 18072, 7984);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let img9 = await imageWithData(178, 33, '#174453fe', '#1fbc4cca');
+let canvas11 = document.createElement('canvas');
+let gpuCanvasContext9 = canvas11.getContext('webgpu');
+let offscreenCanvas10 = new OffscreenCanvas(791, 955);
+let offscreenCanvas11 = new OffscreenCanvas(305, 52);
+let texture48 = device2.createTexture({
+label: '\uf584\u{1ff6a}\u4f40\u45a6\u7007\u{1fdad}',
+size: [1656, 120, 82],
+mipLevelCount: 9,
+sampleCount: 1,
+dimension: '3d',
+format: 'rgba8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8sint'],
+});
+let renderBundleEncoder35 = device2.createRenderBundleEncoder({
+  label: '\u0e06\u89ee\u8c5d\u49c0\u52b6\u0f6d\u045a\u{1fe30}\u730b',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+device2.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 7,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(670), /* required buffer size: 670 */
+{offset: 670}, {width: 9, height: 1, depthOrArrayLayers: 0});
+} catch {}
+gc();
+try {
+await adapter4.requestAdapterInfo();
+} catch {}
+canvas0.height = 907;
+video4.height = 96;
+let offscreenCanvas12 = new OffscreenCanvas(964, 754);
+let commandEncoder35 = device3.createCommandEncoder({label: '\u1797\ua2e5'});
+offscreenCanvas11.width = 207;
+let offscreenCanvas13 = new OffscreenCanvas(835, 869);
+let imageBitmap9 = await createImageBitmap(offscreenCanvas8);
+let videoFrame10 = new VideoFrame(imageBitmap6, {timestamp: 0});
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({
+  label: '\u86df\ucdce',
+  colorFormats: ['rgba8unorm', 'r8sint', undefined],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+try {
+renderBundleEncoder17.setBindGroup(6, bindGroup3);
+} catch {}
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 5,
+  origin: { x: 20, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture18,
+  mipLevel: 3,
+  origin: { x: 81, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(querySet8, 77, 105, buffer12, 25344);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 32412, new BigUint64Array(30794), 4910, 384);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let img10 = await imageWithData(281, 34, '#877ed0db', '#b2c34080');
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let adapter5 = await promise21;
+try {
+await adapter5.requestAdapterInfo();
+} catch {}
+try {
+device2.label = '\ub234\u{1f87b}\u046e\u691a\u6929\u0ee9\u07c8';
+} catch {}
+let texture49 = device2.createTexture({
+label: '\u{1fa1d}\u{1fcb0}\uf02e\u{1f918}',
+size: [207],
+dimension: '1d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let renderBundleEncoder37 = device2.createRenderBundleEncoder({
+  label: '\uc340\u0dce\u0a59\u{1fc33}\u709d\u8008\uba61\uc169\u1691\ub0e7',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle40 = renderBundleEncoder34.finish({label: '\u0103\u1717\uf111\u0ef4\u04a4\u4ae7\u0956'});
+try {
+device2.pushErrorScope('internal');
+} catch {}
+let adapter6 = await navigator.gpu.requestAdapter({
+});
+let texture50 = device3.createTexture({
+size: {width: 860, height: 1, depthOrArrayLayers: 190},
+mipLevelCount: 4,
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+let sampler32 = device3.createSampler({
+label: '\u{1fb38}\uddd8\uee54',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMaxClamp: 90.564,
+});
+try {
+gpuCanvasContext1.configure({
+device: device3,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r16float', 'r32float', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+});
+} catch {}
+document.body.prepend(img0);
+let querySet29 = device3.createQuerySet({
+label: '\u7966\u{1f708}\u4d7e\u881f',
+type: 'occlusion',
+count: 390,
+});
+pseudoSubmit(device3, commandEncoder33);
+let texture51 = device3.createTexture({
+label: '\u95d3\u0a8d\u0be6\u{1fd48}\u0260\u0629\u0e81',
+size: [6880, 1, 1],
+mipLevelCount: 7,
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let sampler33 = device3.createSampler({
+label: '\ud89f\u6ee3\uec70\u8efb',
+addressModeU: 'mirror-repeat',
+magFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 54.255,
+lodMaxClamp: 58.137,
+compare: 'not-equal',
+});
+let gpuCanvasContext10 = offscreenCanvas10.getContext('webgpu');
+let bindGroupLayout19 = device3.createBindGroupLayout({
+label: '\uac3b\u{1fb0c}\u{1fbb8}\u{1fb97}\u{1fb2b}\u90a1',
+entries: [],
+});
+let querySet30 = device3.createQuerySet({
+type: 'occlusion',
+count: 3435,
+});
+let texture52 = device3.createTexture({
+label: '\u05f7\u014c',
+size: [1776, 20, 32],
+mipLevelCount: 5,
+format: 'etc2-rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC,
+});
+let sampler34 = device3.createSampler({
+label: '\u38b8\u007d\u0ee5\u0e9c\u0443\u{1fd1c}\u08e2',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 56.452,
+lodMaxClamp: 85.476,
+compare: 'equal',
+maxAnisotropy: 6,
+});
+try {
+device3.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 5,
+  origin: { x: 64, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 997 */
+{offset: 777}, {width: 55, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let bindGroupLayout20 = device2.createBindGroupLayout({
+label: '\u86fc\u8b39\u0505\u{1f6d3}\u{1fc55}\u{1fe51}\u5a16\u{1f84f}\u{1f871}\u85ed',
+entries: [{
+binding: 3183,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}, {
+binding: 2585,
+visibility: 0,
+externalTexture: {},
+}],
+});
+let commandEncoder36 = device2.createCommandEncoder({label: '\ud083\u03e0\u5ddc'});
+try {
+renderBundleEncoder37.setVertexBuffer(50, undefined);
+} catch {}
+try {
+querySet28.destroy();
+} catch {}
+let gpuCanvasContext11 = offscreenCanvas13.getContext('webgpu');
+let video10 = await videoWithData();
+let sampler35 = device0.createSampler({
+label: '\u{1f603}\u5a06\u4518\u6087\u0cb9\u8ac7\u426d\u0cf9\u5f71',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 22.798,
+lodMaxClamp: 50.141,
+maxAnisotropy: 3,
+});
+try {
+commandEncoder15.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture5,
+  mipLevel: 3,
+  origin: { x: 24, y: 1, z: 11 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder25.clearBuffer(buffer12, 19224, 5104);
+dissociateBuffer(device0, buffer12);
+} catch {}
+let imageBitmap10 = await createImageBitmap(video7);
+pseudoSubmit(device0, commandEncoder13);
+let texture53 = device0.createTexture({
+label: '\ua067\u0567\u577e\u511a\u{1f6bd}\u042b\ucf82\ufa2f\u{1f8f0}\u0787',
+size: {width: 9088, height: 72, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [],
+});
+let renderBundleEncoder38 = device0.createRenderBundleEncoder({
+  label: '\u{1fe7e}\u0cf6\ufe81\u{1fcb9}\u0ebb\u{1f7dd}\u4cf1\ue96d\u0569\u{1f770}',
+  colorFormats: ['r16float', 'rgba32float', 'rgba32uint', 'rgba8unorm', undefined, 'rgba16float'],
+  stencilReadOnly: true
+});
+try {
+computePassEncoder19.setBindGroup(5, bindGroup9, new Uint32Array(6527), 1368, 0);
+} catch {}
+try {
+querySet11.destroy();
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(querySet26, 607, 347, buffer12, 7680);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 1,
+  origin: { x: 5, y: 28, z: 0 },
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer2), /* required buffer size: 350 */
+{offset: 332, bytesPerRow: 2}, {width: 0, height: 40, depthOrArrayLayers: 1});
+} catch {}
+let pipeline42 = device0.createRenderPipeline({
+label: '\u0b9a\u9a48',
+layout: pipelineLayout5,
+fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgba32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgba8unorm'}, undefined, {format: 'rgba16float'}]
+},
+vertex: {
+  module: shaderModule4,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 2172,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32',
+offset: 1840,
+shaderLocation: 8,
+}, {
+format: 'uint32',
+offset: 72,
+shaderLocation: 2,
+}, {
+format: 'snorm16x2',
+offset: 940,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 644,
+shaderLocation: 13,
+}, {
+format: 'uint32x2',
+offset: 948,
+shaderLocation: 0,
+}, {
+format: 'unorm10-10-10-2',
+offset: 2048,
+shaderLocation: 11,
+}, {
+format: 'snorm16x2',
+offset: 1860,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 9936,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 14420,
+attributes: [{
+format: 'sint32x2',
+offset: 2852,
+shaderLocation: 14,
+}, {
+format: 'snorm16x2',
+offset: 12232,
+shaderLocation: 7,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+},
+});
+gc();
+let texture54 = device0.createTexture({
+size: {width: 10, height: 120, depthOrArrayLayers: 187},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rg8uint', 'rg8uint'],
+});
+let computePassEncoder20 = commandEncoder22.beginComputePass({label: '\u53cf\ub0d3\ud604\u{1f9c2}'});
+let renderBundleEncoder39 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2unorm', 'bgra8unorm-srgb', 'rgba16float', 'rg32sint', 'rg16float', 'r8sint'],
+  depthReadOnly: true
+});
+let sampler36 = device0.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+lodMinClamp: 60.675,
+lodMaxClamp: 72.322,
+});
+try {
+computePassEncoder18.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder39.setVertexBuffer(3, buffer1);
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(querySet14, 447, 1555, buffer12, 3584);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 10184, new Int16Array(7011), 3556, 3216);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+try {
+commandEncoder34.label = '\u{1ff21}\ud49a\u{1fd4b}\u0b1e\ua1d5\u010b\u0590\u021f\ubc6c';
+} catch {}
+let bindGroupLayout21 = device3.createBindGroupLayout({
+entries: [{
+binding: 188,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'non-filtering' },
+}, {
+binding: 636,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}],
+});
+let querySet31 = device3.createQuerySet({
+label: '\udeba\u3399\ucb37\u1ffd\u0c89\u9a72\u03d3\u03fe',
+type: 'occlusion',
+count: 1993,
+});
+let texture55 = device3.createTexture({
+label: '\ud7ae\u{1f8b0}\u0415\uf20b\u{1f7c7}\u3512\u0b62\u531e',
+size: [1986],
+dimension: '1d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder21 = commandEncoder34.beginComputePass({label: '\u5bda\u031e\u6ed1\u541a\u1ea7\uecfe\u4ff6\u180c\ufa86\uaedb\u2b4a'});
+try {
+gpuCanvasContext11.configure({
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['eac-r11snorm', 'bgra8unorm', 'rgba8snorm', 'bgra8unorm-srgb'],
+alphaMode: 'premultiplied',
+});
+} catch {}
+let gpuCanvasContext12 = offscreenCanvas12.getContext('webgpu');
+let offscreenCanvas14 = new OffscreenCanvas(479, 476);
+document.body.prepend(canvas11);
+let imageData17 = new ImageData(100, 52);
+let computePassEncoder22 = commandEncoder17.beginComputePass({label: '\u035a\ue328\udf25\u0973\u{1f6f0}\u0ad7\udaa3\u0d8a'});
+let renderBundleEncoder40 = device0.createRenderBundleEncoder({
+  label: '\u77ca\u5943\u31dc\u8a26\u{1fc1e}',
+  colorFormats: ['rgb10a2unorm', 'bgra8unorm-srgb', 'rgba16float', 'rg32sint', 'rg16float', 'r8sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+commandEncoder23.copyBufferToTexture({
+/* bytesInLastRow: 64 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 51216 */
+offset: 51216,
+bytesPerRow: 256,
+rowsPerImage: 43,
+buffer: buffer6,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: { x: 0, y: 192, z: 1 },
+  aspect: 'all',
+}, {width: 32, height: 192, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder23.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 4,
+  origin: { x: 0, y: 6, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 18192 */
+offset: 18192,
+buffer: buffer3,
+}, {width: 0, height: 6, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder15.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 2,
+  origin: { x: 202, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+let pipeline43 = device0.createComputePipeline({
+label: '\u0771\u0e34\u5458\u3762\ua14b\u4240\u{1fdcb}\u{1fad3}\u0d09',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipelineLayout11 = device2.createPipelineLayout({
+  label: '\u6afd\u96cc',
+  bindGroupLayouts: [bindGroupLayout20, bindGroupLayout20, bindGroupLayout20, bindGroupLayout20, bindGroupLayout20, bindGroupLayout20, bindGroupLayout20, bindGroupLayout20, bindGroupLayout20]
+});
+let computePassEncoder23 = commandEncoder36.beginComputePass({label: '\u0358\u8ce8\u958c\uc6cd\u{1fb8c}\u173f'});
+let sampler37 = device2.createSampler({
+label: '\u7f23\u0dee\uec46\u{1f863}\uea48\u{1f90f}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 55.877,
+lodMaxClamp: 61.744,
+});
+try {
+device2.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 5,
+  origin: { x: 12, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 1467 */
+{offset: 803, bytesPerRow: 260}, {width: 36, height: 3, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext13 = offscreenCanvas14.getContext('webgpu');
+let shaderModule7 = device2.createShaderModule({
+label: '\u027e\u{1fc56}\u000c\u{1f6c1}\uf0ca\ue802\u6acf\u02e9\u69cc',
+code: `@group(0) @binding(2585)
+var<storage, read_write> i2: array<u32>;
+@group(3) @binding(2585)
+var<storage, read_write> i3: array<u32>;
+@group(2) @binding(2585)
+var<storage, read_write> local1: array<u32>;
+@group(5) @binding(2585)
+var<storage, read_write> i4: array<u32>;
+@group(7) @binding(2585)
+var<storage, read_write> function3: array<u32>;
+@group(7) @binding(3183)
+var<storage, read_write> parameter0: array<u32>;
+@group(3) @binding(3183)
+var<storage, read_write> field3: array<u32>;
+@group(1) @binding(2585)
+var<storage, read_write> function4: array<u32>;
+@group(6) @binding(2585)
+var<storage, read_write> global0: array<u32>;
+@group(1) @binding(3183)
+var<storage, read_write> parameter1: array<u32>;
+@group(4) @binding(3183)
+var<storage, read_write> parameter2: array<u32>;
+@group(4) @binding(2585)
+var<storage, read_write> parameter3: array<u32>;
+@group(6) @binding(3183)
+var<storage, read_write> global1: array<u32>;
+@group(8) @binding(3183)
+var<storage, read_write> global2: array<u32>;
+
+@compute @workgroup_size(4, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) {
+
+}
+
+struct S7 {
+  @location(23) f0: vec2<i32>,
+  @location(22) f1: vec3<f16>,
+  @location(24) f2: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec2<f32>, @builtin(vertex_index) a1: u32, @location(25) a2: u32, @location(20) a3: vec2<u32>, @builtin(instance_index) a4: u32, @location(8) a5: vec3<u32>, @location(15) a6: f32, @location(13) a7: i32, @location(21) a8: vec4<u32>, @location(19) a9: i32, @location(16) a10: f32, @location(5) a11: vec4<f16>, @location(1) a12: u32, @location(2) a13: vec4<u32>, a14: S7) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+});
+try {
+computePassEncoder23.insertDebugMarker('\u5359');
+} catch {}
+try {
+gpuCanvasContext6.configure({
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb', 'r8sint', 'rgb9e5ufloat'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let texture56 = device3.createTexture({
+label: '\u0374\u0a2e\u01d8',
+size: [222, 2, 72],
+sampleCount: 1,
+dimension: '3d',
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg8uint', 'rg8uint', 'rg8uint'],
+});
+let computePassEncoder24 = commandEncoder35.beginComputePass();
+let sampler38 = device3.createSampler({
+label: '\u0a91\u3831\u058e\ue5b1',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 33.015,
+lodMaxClamp: 48.667,
+maxAnisotropy: 16,
+});
+try {
+device3.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: { x: 11, y: 0, z: 25 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 4015433 */
+{offset: 799, bytesPerRow: 413, rowsPerImage: 243}, {width: 137, height: 1, depthOrArrayLayers: 41});
+} catch {}
+let gpuCanvasContext14 = offscreenCanvas11.getContext('webgpu');
+let textureView43 = texture8.createView({label: '\u07ec\u4597', dimension: '2d-array', format: 'rg16sint'});
+try {
+renderBundleEncoder32.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(5, bindGroup7, new Uint32Array(5437), 3443, 0);
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(7, buffer1, 9688);
+} catch {}
+try {
+commandEncoder9.copyBufferToBuffer(buffer4, 34132, buffer3, 34464, 1128);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 9156, new Float32Array(60734), 59008);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 29}
+*/
+{
+  source: img0,
+  origin: { x: 48, y: 43 },
+  flipY: true,
+}, {
+  texture: texture45,
+  mipLevel: 3,
+  origin: { x: 18, y: 0, z: 8 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 42, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline44 = await device0.createComputePipelineAsync({
+label: '\ua8bf\u2ff3\u{1fda8}\u3a17\u06f9\u030b',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+adapter5.label = '\u13cb\u9a8e\u0a37\u78d7\ub89e';
+} catch {}
+let querySet32 = device0.createQuerySet({
+label: '\ub091\u380b\u{1fd54}\u0971\u02ca\u{1f617}',
+type: 'occlusion',
+count: 1164,
+});
+let computePassEncoder25 = commandEncoder23.beginComputePass({});
+let renderBundle41 = renderBundleEncoder2.finish({});
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder39.setVertexBuffer(4, buffer1, 4244, 7701);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: { x: 176, y: 8, z: 56 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 9005044 */
+{offset: 590, bytesPerRow: 3209, rowsPerImage: 122}, {width: 393, height: 0, depthOrArrayLayers: 24});
+} catch {}
+let pipeline45 = await device0.createRenderPipelineAsync({
+label: '\u4010\u2b51\u82bb\ufe1f\u05fc\u4c1c\uc9be\u0f96\u18de\u2224',
+layout: pipelineLayout5,
+multisample: {
+},
+fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16sint', writeMask: 0}, {format: 'r8uint', writeMask: GPUColorWrite.ALL}, {format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r8uint', writeMask: GPUColorWrite.BLUE}, {format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r8unorm', writeMask: GPUColorWrite.ALL}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'less',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'zero',
+passOp: 'zero',
+},
+stencilReadMask: 3200,
+stencilWriteMask: 3519,
+depthBias: 85,
+depthBiasSlopeScale: 10,
+depthBiasClamp: 15,
+},
+vertex: {
+  module: shaderModule1,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 16808,
+attributes: [{
+format: 'uint32x4',
+offset: 4680,
+shaderLocation: 3,
+}, {
+format: 'sint8x2',
+offset: 3582,
+shaderLocation: 4,
+}, {
+format: 'sint32x2',
+offset: 15072,
+shaderLocation: 6,
+}, {
+format: 'sint16x4',
+offset: 1828,
+shaderLocation: 9,
+}, {
+format: 'float16x2',
+offset: 2908,
+shaderLocation: 7,
+}, {
+format: 'unorm8x4',
+offset: 15136,
+shaderLocation: 1,
+}, {
+format: 'sint32x4',
+offset: 16568,
+shaderLocation: 0,
+}, {
+format: 'float32x3',
+offset: 11040,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 10236,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x2',
+offset: 8820,
+shaderLocation: 2,
+}, {
+format: 'sint16x2',
+offset: 4172,
+shaderLocation: 14,
+}, {
+format: 'uint32x4',
+offset: 8180,
+shaderLocation: 8,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+cullMode: 'front',
+},
+});
+let buffer13 = device2.createBuffer({label: '\u81c6\ud658', size: 2374, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let renderBundle42 = renderBundleEncoder35.finish();
+let sampler39 = device2.createSampler({
+label: '\u86f1\uc7e9\u0b24\u0190\u4b7c\u{1f69c}\u{1fac7}\u0ba5\u0122\u764d\uc499',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 7.914,
+lodMaxClamp: 68.090,
+});
+let pipeline46 = device2.createRenderPipeline({
+label: '\u0f36\ueff8\ubfff\uf3de\ud038\u{1f991}\u70e5\u0578\u{1fcb3}\u{1fde3}\u{1fc1e}',
+layout: pipelineLayout11,
+multisample: {
+mask: 0xa821af0e,
+},
+fragment: {module: shaderModule7, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'replace',
+depthFailOp: 'decrement-clamp',
+passOp: 'keep',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-wrap',
+depthFailOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 2552,
+stencilWriteMask: 2311,
+depthBias: 38,
+depthBiasSlopeScale: 98,
+depthBiasClamp: 100,
+},
+vertex: {
+  module: shaderModule7,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 49960,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x2',
+offset: 24372,
+shaderLocation: 25,
+}, {
+format: 'uint8x4',
+offset: 36620,
+shaderLocation: 1,
+}, {
+format: 'unorm8x4',
+offset: 19176,
+shaderLocation: 22,
+}, {
+format: 'unorm8x2',
+offset: 7550,
+shaderLocation: 5,
+}, {
+format: 'unorm10-10-10-2',
+offset: 27064,
+shaderLocation: 14,
+}, {
+format: 'uint32x4',
+offset: 6100,
+shaderLocation: 20,
+}, {
+format: 'snorm16x2',
+offset: 33512,
+shaderLocation: 15,
+}, {
+format: 'uint16x2',
+offset: 29764,
+shaderLocation: 24,
+}, {
+format: 'sint32x4',
+offset: 15908,
+shaderLocation: 23,
+}, {
+format: 'sint32x2',
+offset: 46784,
+shaderLocation: 19,
+}],
+},
+{
+arrayStride: 22688,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x2',
+offset: 5696,
+shaderLocation: 16,
+}, {
+format: 'uint32',
+offset: 51312,
+shaderLocation: 21,
+}, {
+format: 'uint16x2',
+offset: 21076,
+shaderLocation: 2,
+}, {
+format: 'uint8x2',
+offset: 4236,
+shaderLocation: 8,
+}, {
+format: 'sint32x3',
+offset: 18596,
+shaderLocation: 13,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+cullMode: 'back',
+},
+});
+gc();
+try {
+computePassEncoder20.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer10, 'uint32', 6720, 48150);
+} catch {}
+try {
+computePassEncoder1.pushDebugGroup('\ubf78');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 9,
+  origin: { x: 2, y: 1, z: 1 },
+  aspect: 'all',
+}, new Float64Array(arrayBuffer0), /* required buffer size: 122 */
+{offset: 122}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup16 = device3.createBindGroup({
+label: '\uc017\u0dbc\ucde1\u0d27\u5632\u6a57\u07ea\u031f\u{1fa21}',
+layout: bindGroupLayout19,
+entries: [],
+});
+let texture57 = device3.createTexture({
+label: '\ue69b\u{1feae}\uedf6\u0c09\ufc17',
+size: [860, 1, 110],
+mipLevelCount: 9,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['stencil8', 'stencil8', 'stencil8'],
+});
+let sampler40 = device3.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+lodMaxClamp: 97.252,
+maxAnisotropy: 1,
+});
+try {
+device3.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 0,
+  origin: { x: 89, y: 1, z: 1 },
+  aspect: 'all',
+}, new Int32Array(arrayBuffer4), /* required buffer size: 199 */
+{offset: 199}, {width: 1823, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video8.width = 182;
+let buffer14 = device2.createBuffer({label: '\u7880\u04bb\u{1f8d8}\u30b4\u5b82', size: 34523, usage: GPUBufferUsage.MAP_READ});
+let commandEncoder37 = device2.createCommandEncoder();
+let sampler41 = device2.createSampler({
+label: '\u{1f69c}\u{1fed0}\u03a5\u03c0\u{1ffc0}\uab57\u0fd5\ubf1c',
+addressModeU: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 49.865,
+lodMaxClamp: 84.916,
+compare: 'always',
+});
+let pipeline47 = device2.createRenderPipeline({
+label: '\u3dc8\ubca4\u09d2\u{1fc8d}\u{1faa8}\u2248\ub07d\u{1fd49}\u{1f951}\u{1fd95}',
+layout: pipelineLayout11,
+fragment: {module: shaderModule7, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'not-equal',
+failOp: 'zero',
+depthFailOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+depthFailOp: 'increment-clamp',
+passOp: 'invert',
+},
+stencilReadMask: 841,
+depthBias: 45,
+depthBiasSlopeScale: 23,
+depthBiasClamp: 60,
+},
+vertex: {
+  module: shaderModule7,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 49780,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 33704,
+shaderLocation: 8,
+}, {
+format: 'float16x4',
+offset: 8860,
+shaderLocation: 15,
+}, {
+format: 'uint32x3',
+offset: 29524,
+shaderLocation: 25,
+}, {
+format: 'sint32x4',
+offset: 42624,
+shaderLocation: 13,
+}, {
+format: 'uint16x4',
+offset: 22404,
+shaderLocation: 20,
+}, {
+format: 'uint32x3',
+offset: 8188,
+shaderLocation: 24,
+}, {
+format: 'snorm8x2',
+offset: 45682,
+shaderLocation: 5,
+}, {
+format: 'snorm8x2',
+offset: 43622,
+shaderLocation: 16,
+}, {
+format: 'sint8x2',
+offset: 2110,
+shaderLocation: 23,
+}, {
+format: 'uint32x4',
+offset: 29712,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 53088,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x3',
+offset: 40216,
+shaderLocation: 21,
+}],
+},
+{
+arrayStride: 23368,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x2',
+offset: 6520,
+shaderLocation: 14,
+}, {
+format: 'sint32x3',
+offset: 22956,
+shaderLocation: 19,
+}, {
+format: 'uint32x4',
+offset: 11784,
+shaderLocation: 1,
+}, {
+format: 'float16x2',
+offset: 376,
+shaderLocation: 22,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+},
+});
+let device4 = await adapter6.requestDevice({
+label: '\u0b08\u04f3\u0a86\ud08b\uc5f3\u43e9\udf44\u{1fb62}\u56fa\u{1ff50}',
+});
+let texture58 = device0.createTexture({
+size: {width: 4544, height: 36, depthOrArrayLayers: 1},
+mipLevelCount: 2,
+format: 'astc-8x6-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x6-unorm-srgb', 'astc-8x6-unorm-srgb'],
+});
+let textureView44 = texture26.createView({label: '\ub476\u44e2\u{1fc96}\u16e7', dimension: '1d', baseMipLevel: 0, arrayLayerCount: 1});
+try {
+renderBundleEncoder36.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+commandEncoder9.copyBufferToBuffer(buffer6, 5032, buffer3, 13736, 24816);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+computePassEncoder1.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 34364, new Float32Array(33041), 12029, 288);
+} catch {}
+let promise28 = device0.queue.onSubmittedWorkDone();
+let texture59 = gpuCanvasContext3.getCurrentTexture();
+try {
+renderBundleEncoder32.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+commandEncoder30.copyBufferToBuffer(buffer6, 30524, buffer3, 25092, 7248);
+dissociateBuffer(device0, buffer6);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder25.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: { x: 112, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 3432, new BigUint64Array(3173), 963, 1260);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 284, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 220, y: 82 },
+  flipY: false,
+}, {
+  texture: texture31,
+  mipLevel: 2,
+  origin: { x: 47, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 52, height: 2, depthOrArrayLayers: 1});
+} catch {}
+let pipeline48 = await device0.createComputePipelineAsync({
+label: '\u09aa\ud15f\ube72\u{1fa8b}',
+layout: pipelineLayout2,
+compute: {
+module: shaderModule4,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+offscreenCanvas3.width = 563;
+try {
+device0.label = '\ucbf9\u9356\u89ad\u0674\u{1fde9}\uf8f0\u67ae\u35f3\u0b74\u07af\u1c10';
+} catch {}
+let querySet33 = device0.createQuerySet({
+label: '\u09cf\u4227\u0734\uf891\u088b',
+type: 'occlusion',
+count: 2742,
+});
+let texture60 = device0.createTexture({
+label: '\u07a4\u693e\u4661\u{1fd5d}\u{1f8cf}\u12ff\ua588\u04ce',
+size: [7040, 1, 1],
+mipLevelCount: 7,
+format: 'rg16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: [],
+});
+try {
+renderBundleEncoder40.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-6x6-unorm-srgb', 'depth24plus', 'rgba8unorm', 'rgba8unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 4,
+  origin: { x: 40, y: 5, z: 0 },
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer3), /* required buffer size: 177844 */
+{offset: 506, bytesPerRow: 202, rowsPerImage: 219}, {width: 46, height: 2, depthOrArrayLayers: 5});
+} catch {}
+let canvas12 = document.createElement('canvas');
+let texture61 = device0.createTexture({
+label: '\ube74\u308c\ufaed\u8148\uc2a2\u{1f8a7}\u3b6b\u7f8c',
+size: {width: 2352, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'rg8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg8sint'],
+});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder20.setBindGroup(2, bindGroup8, new Uint32Array(4409), 2230, 0);
+} catch {}
+try {
+renderBundleEncoder38.setPipeline(pipeline42);
+} catch {}
+let gpuCanvasContext15 = canvas12.getContext('webgpu');
+try {
+  await promise28;
+} catch {}
+video8.width = 284;
+let bindGroupLayout22 = device3.createBindGroupLayout({
+entries: [{
+binding: 624,
+visibility: GPUShaderStage.COMPUTE,
+storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '3d' },
+}, {
+binding: 644,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+}],
+});
+let buffer15 = device3.createBuffer({
+  label: '\u9fc5\ud977\u55a1\u0107\u07a9\u841c\uc313\ue11d\uddfe',
+  size: 22773,
+  usage: GPUBufferUsage.MAP_WRITE
+});
+let externalTexture1 = device3.importExternalTexture({
+source: videoFrame1,
+colorSpace: 'display-p3',
+});
+let commandEncoder38 = device2.createCommandEncoder({label: '\u0644\u{1f840}\u9407\u6495\u0325\u50c9'});
+let texture62 = device2.createTexture({
+label: '\u{1fbdd}\u09f3\u{1f87d}\u0065\u{1fe21}\u{1fb99}\u03ec',
+size: {width: 1520, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 4,
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+});
+let renderBundle43 = renderBundleEncoder35.finish();
+let sampler42 = device2.createSampler({
+label: '\u0158\ubf04\u6cf1\u26d9',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 91.156,
+lodMaxClamp: 98.261,
+compare: 'less-equal',
+});
+let promise29 = device2.queue.onSubmittedWorkDone();
+let texture63 = device4.createTexture({
+label: '\u{1ff4a}\u561e\u0659',
+size: [1200, 1, 1],
+mipLevelCount: 11,
+sampleCount: 1,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler43 = device4.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 61.761,
+lodMaxClamp: 72.549,
+maxAnisotropy: 16,
+});
+try {
+device4.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 7,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'stencil-only',
+}, new ArrayBuffer(48), /* required buffer size: 679 */
+{offset: 670}, {width: 9, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let device5 = await adapter5.requestDevice({
+label: '\u4a66\u4f6c\u0de8\u087e\ud7cb\u{1f628}\u0a36\u0ae4',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 6,
+maxColorAttachmentBytesPerSample: 46,
+maxVertexAttributes: 24,
+maxVertexBufferArrayStride: 11604,
+maxStorageTexturesPerShaderStage: 30,
+maxStorageBuffersPerShaderStage: 24,
+maxDynamicStorageBuffersPerPipelineLayout: 9781,
+maxBindingsPerBindGroup: 8408,
+maxTextureDimension1D: 11662,
+maxTextureDimension2D: 15462,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 196159058,
+maxUniformBuffersPerShaderStage: 20,
+maxInterStageShaderVariables: 113,
+maxInterStageShaderComponents: 109,
+maxSamplersPerShaderStage: 20,
+},
+});
+let videoFrame11 = new VideoFrame(img8, {timestamp: 0});
+try {
+device4.queue.label = '\u039c\u2ecb\u{1f8c0}\u5a05\u{1f8f3}\u{1fc7b}\u7d6f\ua365\u0c85';
+} catch {}
+let renderBundleEncoder41 = device4.createRenderBundleEncoder({
+  label: '\u4b73\u60d7\u5f47\u0998\u5095\u05d1\u1237\u38bc\u6660',
+  colorFormats: ['rg32float', 'rgba32sint'],
+  sampleCount: 1,
+  stencilReadOnly: true
+});
+let sampler44 = device4.createSampler({
+label: '\u{1f6aa}\u96e4\u0184\u0a3b\u1fe5\u{1f663}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 47.469,
+lodMaxClamp: 94.064,
+compare: 'not-equal',
+});
+let img11 = await imageWithData(101, 283, '#5d570e15', '#b51411c0');
+try {
+renderBundleEncoder32.setBindGroup(6, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder38.drawIndirect(buffer3, 36028);
+} catch {}
+try {
+commandEncoder30.copyBufferToTexture({
+/* bytesInLastRow: 7956 widthInBlocks: 1989 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 17716 */
+offset: 17716,
+buffer: buffer5,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 414, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 1989, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+adapter6.label = '\u06d1\uf94e';
+} catch {}
+let commandEncoder39 = device3.createCommandEncoder({label: '\u9485\uc062'});
+try {
+commandEncoder39.copyTextureToTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: { x: 103, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: { x: 572, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 1662, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let canvas13 = document.createElement('canvas');
+let querySet34 = device4.createQuerySet({
+label: '\u427e\u{1f852}\u0f4a\u7185\u03b0\ud6fe\u1578',
+type: 'occlusion',
+count: 2091,
+});
+let texture64 = gpuCanvasContext6.getCurrentTexture();
+try {
+gpuCanvasContext7.configure({
+device: device4,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+pseudoSubmit(device0, commandEncoder5);
+let computePassEncoder26 = commandEncoder15.beginComputePass({label: '\u2c95\u0954\u9273\u3fea\u7965\u3328\u5fd8\u503d\u2b5c\u7d77\ubb1f'});
+let sampler45 = device0.createSampler({
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 22.302,
+maxAnisotropy: 3,
+});
+try {
+renderBundleEncoder39.setBindGroup(4, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder38.draw(16, 8, 0, 56);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexedIndirect(buffer3, 3604);
+} catch {}
+try {
+renderBundleEncoder38.drawIndirect(buffer3, 41896);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(7, buffer1, 4440, 5988);
+} catch {}
+try {
+texture60.destroy();
+} catch {}
+try {
+commandEncoder30.clearBuffer(buffer3);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline49 = device0.createRenderPipeline({
+label: '\u65d4\ue59a\u7384\ua276\u{1fa48}',
+layout: pipelineLayout5,
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16float', writeMask: 0}, {format: 'rgba32float', writeMask: 0}, {format: 'rgba32uint'}, {
+  format: 'rgba8unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'dst'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, undefined, {
+  format: 'rgba16float',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'dst-alpha'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+}
+}]
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 12996,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 820,
+shaderLocation: 0,
+}, {
+format: 'unorm10-10-10-2',
+offset: 10172,
+shaderLocation: 10,
+}, {
+format: 'float16x2',
+offset: 12884,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 7404,
+attributes: [{
+format: 'snorm16x4',
+offset: 6388,
+shaderLocation: 3,
+}, {
+format: 'uint32x3',
+offset: 916,
+shaderLocation: 14,
+}, {
+format: 'unorm8x4',
+offset: 3152,
+shaderLocation: 6,
+}],
+},
+{
+arrayStride: 180,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x4',
+offset: 12,
+shaderLocation: 12,
+}, {
+format: 'uint32x3',
+offset: 168,
+shaderLocation: 2,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+cullMode: 'front',
+},
+});
+gc();
+try {
+canvas13.getContext('webgl');
+} catch {}
+let shaderModule8 = device2.createShaderModule({
+code: `@group(0) @binding(2585)
+var<storage, read_write> global3: array<u32>;
+@group(3) @binding(2585)
+var<storage, read_write> i5: array<u32>;
+@group(5) @binding(3183)
+var<storage, read_write> field4: array<u32>;
+@group(7) @binding(2585)
+var<storage, read_write> i6: array<u32>;
+@group(1) @binding(3183)
+var<storage, read_write> global4: array<u32>;
+@group(6) @binding(3183)
+var<storage, read_write> function5: array<u32>;
+@group(8) @binding(2585)
+var<storage, read_write> i7: array<u32>;
+@group(2) @binding(2585)
+var<storage, read_write> field5: array<u32>;
+@group(5) @binding(2585)
+var<storage, read_write> i8: array<u32>;
+@group(7) @binding(3183)
+var<storage, read_write> function6: array<u32>;
+@group(2) @binding(3183)
+var<storage, read_write> parameter4: array<u32>;
+@group(4) @binding(2585)
+var<storage, read_write> global5: array<u32>;
+@group(3) @binding(3183)
+var<storage, read_write> parameter5: array<u32>;
+@group(1) @binding(2585)
+var<storage, read_write> function7: array<u32>;
+@group(0) @binding(3183)
+var<storage, read_write> type3: array<u32>;
+@group(4) @binding(3183)
+var<storage, read_write> field6: array<u32>;
+@group(8) @binding(3183)
+var<storage, read_write> global6: array<u32>;
+
+@compute @workgroup_size(7, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4<f32>, @builtin(sample_mask) a2: u32) -> @builtin(sample_mask) u32 {
+return u32();
+}
+
+struct S8 {
+  @location(20) f0: vec2<f16>,
+  @location(17) f1: vec4<i32>,
+  @location(24) f2: vec4<f16>,
+  @location(11) f3: vec3<f32>,
+  @location(26) f4: vec4<f32>,
+  @location(22) f5: vec4<f32>,
+  @location(25) f6: u32,
+  @location(19) f7: vec2<f32>,
+  @location(18) f8: vec3<i32>,
+  @location(21) f9: vec3<f32>,
+  @location(7) f10: vec4<u32>,
+  @location(8) f11: vec2<u32>,
+  @location(3) f12: vec2<f16>,
+  @location(12) f13: vec3<f16>,
+  @location(13) f14: vec2<u32>
+}
+
+@vertex
+fn vertex0(a0: S8, @builtin(vertex_index) a1: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let commandEncoder40 = device2.createCommandEncoder({label: '\u{1fd6d}\u09b1\u0da5\u08d8\u0d6f\u{1f937}\uce2f'});
+try {
+renderBundleEncoder37.setVertexBuffer(37, undefined, 3389912282, 87108669);
+} catch {}
+let pipeline50 = await device2.createComputePipelineAsync({
+label: '\uaafd\u08e8\u{1f652}\u3850\uadab',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+},
+});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let imageData18 = new ImageData(184, 76);
+let bindGroup17 = device0.createBindGroup({
+layout: bindGroupLayout7,
+entries: [{
+binding: 1160,
+resource: externalTexture0
+}],
+});
+let buffer16 = device0.createBuffer({size: 4616, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let computePassEncoder27 = commandEncoder16.beginComputePass();
+try {
+computePassEncoder9.setBindGroup(1, bindGroup10, new Uint32Array(7185), 379, 0);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(0, bindGroup6, new Uint32Array(845), 615, 0);
+} catch {}
+try {
+renderBundleEncoder38.draw(0, 32, 0, 40);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexedIndirect(buffer3, 29700);
+} catch {}
+try {
+renderBundleEncoder38.drawIndirect(buffer3, 30352);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(3, buffer1);
+} catch {}
+try {
+commandEncoder9.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 31938 */
+offset: 31938,
+bytesPerRow: 0,
+rowsPerImage: 260,
+buffer: buffer6,
+}, {
+  texture: texture54,
+  mipLevel: 3,
+  origin: { x: 0, y: 4, z: 7 },
+  aspect: 'all',
+}, {width: 0, height: 10, depthOrArrayLayers: 10});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder30.clearBuffer(buffer12, 32760, 2216);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder30.resolveQuerySet(querySet5, 264, 20, buffer12, 4096);
+} catch {}
+let pipeline51 = device0.createComputePipeline({
+label: '\ue81e\u7b40\u{1fadc}\u4b33\u056f\u53c6\u{1fa51}\u0233\u{1fd39}\u0ea5\u0594',
+layout: pipelineLayout10,
+compute: {
+module: shaderModule1,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let bindGroupLayout23 = device2.createBindGroupLayout({
+label: '\u62a4\u515f\u{1f684}\u751a\u6b96',
+entries: [{
+binding: 1590,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+}, {
+binding: 1487,
+visibility: GPUShaderStage.COMPUTE,
+sampler: { type: 'comparison' },
+}],
+});
+let commandBuffer9 = commandEncoder38.finish({
+label: '\u0f04\u370e\u5528',
+});
+let computePassEncoder28 = commandEncoder37.beginComputePass({label: '\u8333\u2856\u5f73\u9464\u0080\u0fbf\u0444'});
+try {
+computePassEncoder28.setPipeline(pipeline50);
+} catch {}
+let promise30 = device2.queue.onSubmittedWorkDone();
+let canvas14 = document.createElement('canvas');
+let querySet35 = device3.createQuerySet({
+label: '\u0297\u{1fea0}',
+type: 'occlusion',
+count: 3984,
+});
+let textureView45 = texture57.createView({
+  label: '\u004b\u0421\u0087\uaec5\u02f7',
+  aspect: 'stencil-only',
+  baseMipLevel: 2,
+  mipLevelCount: 3,
+  baseArrayLayer: 39,
+  arrayLayerCount: 40
+});
+let externalTexture2 = device3.importExternalTexture({
+source: video1,
+});
+try {
+device3.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 1,
+  origin: { x: 78, y: 0, z: 0 },
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer2), /* required buffer size: 221 */
+{offset: 221, bytesPerRow: 6215}, {width: 1517, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder41 = device4.createCommandEncoder({label: '\u3470\uf79c\u8c3c\u8bfc\u{1f948}\u215d\u3068\u38aa\u0b4f\u089e'});
+let gpuCanvasContext16 = canvas14.getContext('webgpu');
+let bindGroup18 = device0.createBindGroup({
+label: '\u7d80\u{1f90a}\uf94c\u1d4d',
+layout: bindGroupLayout4,
+entries: [],
+});
+let texture65 = device0.createTexture({
+label: '\u442f\u{1fe33}\u0630\u5625\u3330\uec1f',
+size: [12, 100, 89],
+format: 'astc-12x10-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-12x10-unorm', 'astc-12x10-unorm'],
+});
+let computePassEncoder29 = commandEncoder9.beginComputePass({});
+let renderBundleEncoder42 = device0.createRenderBundleEncoder({
+  label: '\u70e8\ue5a0\u74f0\uf96f\u1692\ue09f',
+  colorFormats: ['rgba8unorm', 'r8sint', undefined],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+commandEncoder25.clearBuffer(buffer12, 1588, 27036);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 12464, new DataView(new ArrayBuffer(1158)), 549, 292);
+} catch {}
+let offscreenCanvas15 = new OffscreenCanvas(692, 556);
+let imageBitmap11 = await createImageBitmap(video6);
+let renderBundle44 = renderBundleEncoder41.finish();
+let canvas15 = document.createElement('canvas');
+let commandEncoder42 = device5.createCommandEncoder({});
+try {
+await device5.queue.onSubmittedWorkDone();
+} catch {}
+let video11 = await videoWithData();
+let videoFrame12 = new VideoFrame(canvas10, {timestamp: 0});
+let sampler46 = device2.createSampler({
+label: '\u6ce3\ua3e2\u{1f8f3}\u2a87\u03a4\u4696\ub87f\u2a56\udc71\uc412\uabd0',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 41.032,
+lodMaxClamp: 97.966,
+compare: 'greater-equal',
+});
+try {
+computePassEncoder23.setPipeline(pipeline50);
+} catch {}
+try {
+commandEncoder40.copyTextureToTexture({
+  texture: texture48,
+  mipLevel: 0,
+  origin: { x: 1071, y: 21, z: 47 },
+  aspect: 'all',
+}, {
+  texture: texture48,
+  mipLevel: 1,
+  origin: { x: 137, y: 5, z: 10 },
+  aspect: 'all',
+}, {width: 402, height: 44, depthOrArrayLayers: 5});
+} catch {}
+try {
+computePassEncoder28.pushDebugGroup('\u{1fa36}');
+} catch {}
+let commandEncoder43 = device5.createCommandEncoder({label: '\uee53\uccd5\ua874\u4b23\u0a6a\uae8e\u{1f648}\u07e8\ud528\uf5f5'});
+let querySet36 = device5.createQuerySet({
+label: '\u0c75\u96bd\u0f22\u{1ff0a}\u8e19\u1b07\u789f\uad86',
+type: 'occlusion',
+count: 647,
+});
+let imageBitmap12 = await createImageBitmap(offscreenCanvas9);
+let sampler47 = device3.createSampler({
+label: '\u{1facb}\u092c\u0a05\u2ffa\ucd80\u1b83',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 95.015,
+lodMaxClamp: 97.187,
+});
+let imageData19 = new ImageData(248, 212);
+let commandEncoder44 = device4.createCommandEncoder();
+let texture66 = device4.createTexture({
+size: {width: 600},
+dimension: '1d',
+format: 'bgra8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder30 = commandEncoder44.beginComputePass({label: '\u038e\uc9ad\u0ff9\u5a93\u1e46\u37ce\u083a'});
+let renderBundle45 = renderBundleEncoder41.finish({label: '\u08be\u36e7\u0714\uf58f\u0fd6\u{1fc77}\u{1fdb1}\u{1fb6e}\u5c12\u291c'});
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture63,
+  mipLevel: 9,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture63,
+  mipLevel: 6,
+  origin: { x: 8, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise30;
+} catch {}
+try {
+renderBundleEncoder38.drawIndexedIndirect(buffer3, 13284);
+} catch {}
+try {
+querySet7.destroy();
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(buffer16, 2328, buffer12, 1104, 1628);
+dissociateBuffer(device0, buffer16);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder30.clearBuffer(buffer3);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+computePassEncoder22.pushDebugGroup('\u1e0b');
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let adapter7 = await navigator.gpu.requestAdapter({
+});
+let bindGroupLayout24 = device5.createBindGroupLayout({
+label: '\u0858\u3384\u{1ff2f}\u0b6b\u00c1\uaf1b',
+entries: [],
+});
+let bindGroup19 = device5.createBindGroup({
+label: '\u070c\ued06\u6344\ud1b4\u{1fdd7}\ue4f6\u058a\u4627\u035f\u{1fc95}\uf48c',
+layout: bindGroupLayout24,
+entries: [],
+});
+let commandEncoder45 = device5.createCommandEncoder();
+offscreenCanvas9.width = 323;
+let bindGroup20 = device5.createBindGroup({
+label: '\u96fc\u02ab\u0d64\u0d56\u1d59\u018d\ufaa5\u0333\u1e4f',
+layout: bindGroupLayout24,
+entries: [],
+});
+let texture67 = device5.createTexture({
+label: '\u5c51\u236e\u09c5\u17a6\u07dd\u5925\ub42e\u{1fa54}\uea9b\udbaf',
+size: {width: 30, height: 32, depthOrArrayLayers: 224},
+mipLevelCount: 5,
+format: 'r16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['r16sint'],
+});
+let textureView46 = texture67.createView({
+  label: '\u11a0\uc066\u{1f632}\u0695\ufea8\u{1f746}\u{1f956}',
+  dimension: '2d',
+  baseMipLevel: 2,
+  baseArrayLayer: 9
+});
+let computePassEncoder31 = commandEncoder42.beginComputePass({label: '\ua20a\ue824\uc960\u6c5b'});
+try {
+gpuCanvasContext16.configure({
+device: device5,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let pipelineLayout12 = device3.createPipelineLayout({
+  label: '\u{1f9d1}\u226e\u0a69\u0c51\u{1f65a}\u032e\u0d33\ufd85',
+  bindGroupLayouts: [bindGroupLayout21, bindGroupLayout21, bindGroupLayout21]
+});
+try {
+buffer15.unmap();
+} catch {}
+try {
+  await buffer15.mapAsync(GPUMapMode.WRITE, 0, 18588);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 6,
+  origin: { x: 12, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 1049 */
+{offset: 677, rowsPerImage: 255}, {width: 93, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let video12 = await videoWithData();
+try {
+computePassEncoder28.popDebugGroup();
+} catch {}
+let pipeline52 = await device2.createRenderPipelineAsync({
+label: '\u45b7\u{1fe33}\u02c8\ufe83\u005f\u{1fcbf}\u{1fb57}\u0c3b\u7220\udde9',
+layout: pipelineLayout11,
+multisample: {
+mask: 0x9cff90d1,
+},
+fragment: {module: shaderModule8, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'equal',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'decrement-wrap',
+depthFailOp: 'invert',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 3543,
+depthBias: 46,
+depthBiasSlopeScale: 15,
+depthBiasClamp: 80,
+},
+vertex: {
+  module: shaderModule8,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 14116,
+stepMode: 'instance',
+attributes: [{
+format: 'sint8x4',
+offset: 11912,
+shaderLocation: 17,
+}],
+},
+{
+arrayStride: 53404,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x2',
+offset: 33680,
+shaderLocation: 26,
+}, {
+format: 'uint8x4',
+offset: 25608,
+shaderLocation: 25,
+}, {
+format: 'snorm16x2',
+offset: 45972,
+shaderLocation: 3,
+}, {
+format: 'float16x4',
+offset: 36540,
+shaderLocation: 22,
+}, {
+format: 'unorm16x4',
+offset: 2524,
+shaderLocation: 20,
+}, {
+format: 'uint8x2',
+offset: 9966,
+shaderLocation: 7,
+}, {
+format: 'float32x2',
+offset: 41288,
+shaderLocation: 12,
+}, {
+format: 'uint16x2',
+offset: 28116,
+shaderLocation: 13,
+}, {
+format: 'float32x3',
+offset: 21376,
+shaderLocation: 24,
+}, {
+format: 'unorm16x4',
+offset: 35332,
+shaderLocation: 21,
+}, {
+format: 'uint32x3',
+offset: 1076,
+shaderLocation: 8,
+}, {
+format: 'float32x2',
+offset: 14440,
+shaderLocation: 19,
+}],
+},
+{
+arrayStride: 14448,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 25352,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 4916,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 42964,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 55480,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x2',
+offset: 31340,
+shaderLocation: 18,
+}],
+},
+{
+arrayStride: 45608,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm16x2',
+offset: 23724,
+shaderLocation: 11,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+cullMode: 'back',
+},
+});
+let commandEncoder46 = device5.createCommandEncoder({label: '\u18d9\ufa3b\u026e\u{1f731}\u0ce5\uc8a6\uefd4'});
+let computePassEncoder32 = commandEncoder46.beginComputePass({label: '\u505a\u00d2\u0f1d\u{1fca2}\u{1f776}\u0433\u{1fef1}\u326f'});
+let texture68 = device2.createTexture({
+label: '\u082f\u04a9\u{1fa11}\u1985\u0fea\u0b92\uf6a8\u96e9\uafae\u0a22',
+size: [4890, 1, 144],
+mipLevelCount: 12,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth24plus-stencil8'],
+});
+try {
+renderBundleEncoder37.setVertexBuffer(34, undefined, 1971821671);
+} catch {}
+let gpuCanvasContext17 = canvas15.getContext('webgpu');
+try {
+offscreenCanvas15.getContext('webgpu');
+} catch {}
+let commandEncoder47 = device5.createCommandEncoder({label: '\ub2bd\u0a69'});
+let querySet37 = device5.createQuerySet({
+label: '\u446d\u0b20\u5253\u9904\u0804\u01ba\uce62\u0f27\u{1ff30}',
+type: 'occlusion',
+count: 2650,
+});
+try {
+computePassEncoder32.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+computePassEncoder32.insertDebugMarker('\u{1fd62}');
+} catch {}
+try {
+gpuCanvasContext8.configure({
+device: device5,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['astc-8x5-unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let imageData20 = new ImageData(184, 120);
+let buffer17 = device2.createBuffer({size: 46132, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: true});
+let querySet38 = device2.createQuerySet({
+label: '\u0bde\u55fc\u{1fe95}\u6266\ucaa9\u03ce\u{1ffa5}\ubf16\u{1ff36}\ub4dd',
+type: 'occlusion',
+count: 1319,
+});
+let texture69 = device2.createTexture({
+label: '\u836b\u5560\uea6d\u{1f7b4}\udc33\u056d\u9e1a',
+size: [237],
+dimension: '1d',
+format: 'r16uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+let textureView47 = texture48.createView({baseMipLevel: 6, arrayLayerCount: 1});
+try {
+renderBundleEncoder37.setVertexBuffer(49, undefined, 2015521719);
+} catch {}
+try {
+commandEncoder40.copyTextureToTexture({
+  texture: texture48,
+  mipLevel: 6,
+  origin: { x: 11, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture48,
+  mipLevel: 7,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let canvas16 = document.createElement('canvas');
+let commandEncoder48 = device2.createCommandEncoder({label: '\u{1fa30}\u99af\u6fa2\u4f01'});
+let querySet39 = device2.createQuerySet({
+label: '\ue4ba\u5fc6\u0f46\u{1f7c1}\u00e1\u1d11\ua1e6\u5500',
+type: 'occlusion',
+count: 357,
+});
+let textureView48 = texture47.createView({aspect: 'all', mipLevelCount: 1, baseArrayLayer: 17, arrayLayerCount: 12});
+let renderBundle46 = renderBundleEncoder35.finish({label: '\u7ba9\u4c34\uad22\ufb1b\u{1f6ce}\u7990'});
+try {
+computePassEncoder28.end();
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+let pipeline53 = await device2.createComputePipelineAsync({
+label: '\u0c01\u5ea4\u6571\u{1f916}\u1b47\u50c4\u845e',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let texture70 = device2.createTexture({
+label: '\uabb4\u0a75\u{1faae}\u{1f681}\u099b\u{1fcc4}\u2512\ub3fd\u0d07',
+size: {width: 80, height: 27, depthOrArrayLayers: 137},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgb10a2unorm', 'rgb10a2unorm'],
+});
+let renderBundle47 = renderBundleEncoder34.finish();
+try {
+renderBundleEncoder37.setVertexBuffer(5, undefined);
+} catch {}
+let promise31 = device2.queue.onSubmittedWorkDone();
+let offscreenCanvas16 = new OffscreenCanvas(767, 989);
+pseudoSubmit(device3, commandEncoder39);
+try {
+computePassEncoder24.setBindGroup(2, bindGroup16, new Uint32Array(7942), 4593, 0);
+} catch {}
+try {
+gpuCanvasContext17.configure({
+device: device3,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device3.destroy();
+} catch {}
+let bindGroupLayout25 = pipeline33.getBindGroupLayout(0);
+let computePassEncoder33 = commandEncoder30.beginComputePass({label: '\u2314\ub688\ub38e\u72a5\u39b7\u6379\u09ef'});
+let renderBundle48 = renderBundleEncoder23.finish({label: '\uc60b\u8e39\u{1f779}\u900b\u38c0\u{1f845}'});
+let sampler48 = device0.createSampler({
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 90.046,
+lodMaxClamp: 99.751,
+maxAnisotropy: 12,
+});
+try {
+renderBundleEncoder38.drawIndexed(24, 8, 64);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline54 = device0.createRenderPipeline({
+layout: pipelineLayout3,
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgb10a2unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'one-minus-dst'},
+alpha: {operation: 'add', srcFactor: 'src', dstFactor: 'dst-alpha'},
+},
+  writeMask: 0
+}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'one-minus-dst-alpha'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {
+  format: 'rgba16float',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'src-alpha'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.RED
+}, {format: 'rg32sint'}, {
+  format: 'rg16float',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'src-alpha-saturated'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-wrap',
+passOp: 'zero',
+},
+stencilWriteMask: 2941,
+depthBias: 37,
+depthBiasSlopeScale: 53,
+depthBiasClamp: 63,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 13244,
+attributes: [],
+},
+{
+arrayStride: 14496,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 1552,
+shaderLocation: 15,
+}, {
+format: 'snorm16x2',
+offset: 1660,
+shaderLocation: 4,
+}, {
+format: 'snorm16x4',
+offset: 1144,
+shaderLocation: 12,
+}, {
+format: 'float32x3',
+offset: 12600,
+shaderLocation: 5,
+}, {
+format: 'sint32x4',
+offset: 10616,
+shaderLocation: 8,
+}, {
+format: 'uint8x4',
+offset: 12164,
+shaderLocation: 3,
+}, {
+format: 'uint32x2',
+offset: 4688,
+shaderLocation: 10,
+}, {
+format: 'uint16x4',
+offset: 3564,
+shaderLocation: 11,
+}, {
+format: 'float16x2',
+offset: 13124,
+shaderLocation: 13,
+}, {
+format: 'uint16x2',
+offset: 12332,
+shaderLocation: 0,
+}, {
+format: 'uint32x2',
+offset: 6400,
+shaderLocation: 2,
+}, {
+format: 'sint32x2',
+offset: 3668,
+shaderLocation: 6,
+}, {
+format: 'sint8x4',
+offset: 11836,
+shaderLocation: 1,
+}, {
+format: 'snorm16x2',
+offset: 12928,
+shaderLocation: 7,
+}, {
+format: 'uint32x2',
+offset: 9900,
+shaderLocation: 14,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+cullMode: 'none',
+unclippedDepth: true,
+},
+});
+let promise32 = adapter7.requestDevice({
+label: '\u{1fc9e}\u0418\u0409\u002f\u{1f780}\uc2ae\u080d\u76c6\uc7e0\u{1f9b3}\u8db7',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxColorAttachmentBytesPerSample: 41,
+maxVertexAttributes: 24,
+maxVertexBufferArrayStride: 16250,
+maxStorageTexturesPerShaderStage: 29,
+maxStorageBuffersPerShaderStage: 36,
+maxDynamicStorageBuffersPerPipelineLayout: 52727,
+maxBindingsPerBindGroup: 5819,
+maxTextureDimension1D: 9652,
+maxTextureDimension2D: 11612,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 196423672,
+maxUniformBuffersPerShaderStage: 32,
+maxInterStageShaderVariables: 45,
+maxInterStageShaderComponents: 72,
+maxSamplersPerShaderStage: 18,
+},
+});
+let bindGroup21 = device5.createBindGroup({
+layout: bindGroupLayout24,
+entries: [],
+});
+let pipelineLayout13 = device5.createPipelineLayout({
+  label: '\ua470\u0fa5\u{1f98b}\u2e4e\u0656\u072e',
+  bindGroupLayouts: [bindGroupLayout24, bindGroupLayout24, bindGroupLayout24, bindGroupLayout24, bindGroupLayout24]
+});
+let buffer18 = device2.createBuffer({
+  label: '\u059a\u8306\u04b0\u0f41\ufb5c\u02a3\u90bf',
+  size: 26171,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let commandBuffer10 = commandEncoder37.finish();
+let textureView49 = texture48.createView({dimension: '3d', baseMipLevel: 2});
+let computePassEncoder34 = commandEncoder40.beginComputePass();
+let renderBundleEncoder43 = device2.createRenderBundleEncoder({
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle49 = renderBundleEncoder34.finish({label: '\udab9\u1630\uabb9\u5420\u1298\ued7f\u08b8\u1c98'});
+try {
+computePassEncoder23.setPipeline(pipeline50);
+} catch {}
+let video13 = await videoWithData();
+let imageData21 = new ImageData(136, 136);
+try {
+offscreenCanvas16.getContext('bitmaprenderer');
+} catch {}
+pseudoSubmit(device5, commandEncoder42);
+let textureView50 = texture67.createView({
+  label: '\u61dd\u{1fc30}\u0a2a\u7eb3\u0b99\u100b\ub812\uf5b3\u{1ffe2}\u88e2',
+  aspect: 'all',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 125,
+  arrayLayerCount: 35
+});
+let renderBundleEncoder44 = device5.createRenderBundleEncoder({
+  label: '\u0fcc\ud2a6\u0f9e\u0679\u0588\u{1fa48}\ue43f\u0df5\u005a\ub9e5\ub8ec',
+  colorFormats: ['rgba8sint', 'rg8sint', undefined, 'r8uint', undefined, 'rgba16sint', 'rgb10a2uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle50 = renderBundleEncoder44.finish({});
+let querySet40 = device0.createQuerySet({
+label: '\u{1f9ec}\u{1f6ea}',
+type: 'occlusion',
+count: 2614,
+});
+let renderBundle51 = renderBundleEncoder22.finish({label: '\u{1fffe}\u5662'});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+computePassEncoder26.setBindGroup(2, bindGroup8, new Uint32Array(8541), 2653, 0);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(4, bindGroup3, new Uint32Array(9401), 7982, 0);
+} catch {}
+try {
+renderBundleEncoder38.draw(56, 72, 16);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(5, buffer1, 13860);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer5,
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 25492, new DataView(new ArrayBuffer(37429)), 5540, 5232);
+} catch {}
+let gpuCanvasContext18 = canvas16.getContext('webgpu');
+try {
+  await promise31;
+} catch {}
+let canvas17 = document.createElement('canvas');
+let bindGroup22 = device0.createBindGroup({
+layout: bindGroupLayout8,
+entries: [{
+binding: 1160,
+resource: externalTexture0
+}],
+});
+let pipelineLayout14 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout15, bindGroupLayout25, bindGroupLayout3, bindGroupLayout4, bindGroupLayout3, bindGroupLayout7, bindGroupLayout8]
+});
+let renderBundle52 = renderBundleEncoder10.finish();
+try {
+renderBundleEncoder26.setIndexBuffer(buffer10, 'uint32', 45336, 8752);
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(buffer1, 2224, buffer3, 26044, 13312);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder25.copyTextureToBuffer({
+  texture: texture40,
+  mipLevel: 1,
+  origin: { x: 0, y: 12, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 30528 */
+offset: 30528,
+bytesPerRow: 256,
+buffer: buffer12,
+}, {width: 24, height: 24, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 1125, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture60,
+  mipLevel: 4,
+  origin: { x: 87, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 74, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder25.resolveQuerySet(querySet5, 54, 51, buffer12, 2304);
+} catch {}
+let pipeline55 = await device0.createComputePipelineAsync({
+label: '\u61de\u{1fd8f}\ua94e\u0ede\u3e47\u0a8c\u007f\ucd86\u{1f83a}',
+layout: pipelineLayout9,
+compute: {
+module: shaderModule0,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let buffer19 = device2.createBuffer({size: 62780, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let commandEncoder49 = device2.createCommandEncoder({});
+let texture71 = device2.createTexture({
+size: [320, 110, 1],
+mipLevelCount: 6,
+sampleCount: 1,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['stencil8', 'stencil8'],
+});
+let renderBundle53 = renderBundleEncoder43.finish({label: '\u{1fcbd}\u{1fe79}\ub40b\u0f98'});
+let promise33 = buffer13.mapAsync(GPUMapMode.WRITE, 0, 1468);
+try {
+commandEncoder49.clearBuffer(buffer19);
+dissociateBuffer(device2, buffer19);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+device: device2,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+alphaMode: 'opaque',
+});
+} catch {}
+canvas15.height = 175;
+let commandEncoder50 = device0.createCommandEncoder();
+let renderBundle54 = renderBundleEncoder11.finish({});
+try {
+renderBundleEncoder38.drawIndexedIndirect(buffer3, 15200);
+} catch {}
+let arrayBuffer6 = buffer7.getMappedRange(0, 2380);
+try {
+  await buffer6.mapAsync(GPUMapMode.WRITE, 8440);
+} catch {}
+try {
+commandEncoder25.copyBufferToBuffer(buffer16, 2524, buffer12, 22000, 696);
+dissociateBuffer(device0, buffer16);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder25.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 11180 */
+offset: 11180,
+rowsPerImage: 21,
+buffer: buffer4,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder25.copyTextureToTexture({
+  texture: texture40,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture40,
+  mipLevel: 1,
+  origin: { x: 24, y: 12, z: 0 },
+  aspect: 'all',
+}, {width: 12, height: 36, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder50.resolveQuerySet(querySet1, 1157, 23, buffer12, 32000);
+} catch {}
+try {
+renderBundleEncoder40.pushDebugGroup('\u0cdb');
+} catch {}
+try {
+canvas17.getContext('webgl2');
+} catch {}
+let commandBuffer11 = commandEncoder41.finish({
+label: '\u0f5f\ua303',
+});
+let texture72 = device4.createTexture({
+size: {width: 600},
+dimension: '1d',
+format: 'rgba8sint',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['rgba8sint', 'rgba8sint'],
+});
+let renderBundleEncoder45 = device4.createRenderBundleEncoder({
+  label: '\u0ecd\u413b\u{1f8f9}\u{1f641}\u{1fc0d}\u2029\uc15e\u{1f7d1}\ud7c8\ue4bc\u084d',
+  colorFormats: ['rg32float', 'rgba32sint'],
+  depthReadOnly: true,
+  stencilReadOnly: false
+});
+try {
+  await promise29;
+} catch {}
+let offscreenCanvas17 = new OffscreenCanvas(844, 40);
+let bindGroupLayout26 = device4.createBindGroupLayout({
+label: '\u{1ffe5}\u08bf\u0961\u1607\uc3fd\u{1fd6a}\u94c9\u03f3\u{1ff86}\u0eda',
+entries: [{
+binding: 754,
+visibility: 0,
+sampler: { type: 'filtering' },
+}, {
+binding: 366,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '2d-array' },
+}, {
+binding: 879,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+}],
+});
+let pipelineLayout15 = device4.createPipelineLayout({
+  label: '\u{1fd47}\u1fc6\u8b75\u0318',
+  bindGroupLayouts: [bindGroupLayout26, bindGroupLayout26, bindGroupLayout26, bindGroupLayout26]
+});
+pseudoSubmit(device4, commandEncoder44);
+let textureView51 = texture66.createView({label: '\u8f24\u{1fcee}\u5127\u{1f7bf}'});
+let renderBundleEncoder46 = device4.createRenderBundleEncoder({
+  label: '\u82f0\u0221\ua810\u0512\u{1f8db}\u4321\uded7\u02f8\u0fa4',
+  colorFormats: ['rg32float', 'rgba32sint'],
+  stencilReadOnly: false
+});
+let renderBundle55 = renderBundleEncoder45.finish({label: '\u2d76\ud4da\u077d\u8d82\uf1b2\ua7dc\u723c'});
+try {
+renderBundleEncoder46.setVertexBuffer(98, undefined, 3729226227, 520930243);
+} catch {}
+let gpuCanvasContext19 = offscreenCanvas17.getContext('webgpu');
+let bindGroupLayout27 = device5.createBindGroupLayout({
+label: '\u9f09\u096e\u{1ff08}\ubb66\u0f88\u05a6\ub490',
+entries: [{
+binding: 3496,
+visibility: GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}, {
+binding: 2772,
+visibility: GPUShaderStage.FRAGMENT,
+externalTexture: {},
+}, {
+binding: 6385,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+let buffer20 = device5.createBuffer({
+  label: '\u0101\u{1f6a9}\u{1f791}\u{1f824}\u5d2a\u09d2\ub0fc\u{1f64f}\u5b24\uf74e',
+  size: 32432,
+  usage: GPUBufferUsage.INDEX
+});
+let sampler49 = device5.createSampler({
+label: '\ua1f0\u1b79\u0ebf\u{1fb22}',
+addressModeV: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 30.808,
+lodMaxClamp: 43.812,
+compare: 'less',
+});
+try {
+await device5.popErrorScope();
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+try {
+device4.queue.submit([
+]);
+} catch {}
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+let buffer21 = device5.createBuffer({
+  label: '\ucd7c\u0b81\u0288\u{1fb62}\ua3f9\u{1fdfb}',
+  size: 30320,
+  usage: GPUBufferUsage.COPY_SRC,
+  mappedAtCreation: true
+});
+let texture73 = device5.createTexture({
+label: '\u36f9\u040e\ub7cf\u{1fd63}\u{1fb6a}\ubbdd\u85da\u{1f62b}\ufa77\u86dd\u222f',
+size: [30, 32, 342],
+mipLevelCount: 4,
+dimension: '3d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler50 = device5.createSampler({
+label: '\u0a90\u608e\u09f5\u224f\uccb5\u0a99\u5fb9\u{1fba5}\u00eb\u0f2e',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 35.381,
+lodMaxClamp: 43.961,
+});
+try {
+computePassEncoder32.setBindGroup(2, bindGroup19, new Uint32Array(2094), 273, 0);
+} catch {}
+try {
+  await promise33;
+} catch {}
+let img12 = await imageWithData(200, 109, '#5473a1d8', '#2f622f52');
+let commandEncoder51 = device5.createCommandEncoder({label: '\u00e3\u{1f825}\u061a\ucb76\u{1f9a4}'});
+let texture74 = device5.createTexture({
+label: '\u8e53\ueadd\u0d0b\u0301\u56d2\u{1f8c8}\u{1fbbf}\u69cd\udcb1\uc2d2\ud267',
+size: [120, 128, 224],
+mipLevelCount: 2,
+format: 'etc2-rgb8a1unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8a1unorm-srgb', 'etc2-rgb8a1unorm-srgb'],
+});
+let textureView52 = texture73.createView({format: 'bgra8unorm', mipLevelCount: 3});
+try {
+commandEncoder43.copyTextureToTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: { x: 80, y: 44, z: 122 },
+  aspect: 'all',
+}, {
+  texture: texture74,
+  mipLevel: 1,
+  origin: { x: 20, y: 24, z: 93 },
+  aspect: 'all',
+}, {width: 28, height: 36, depthOrArrayLayers: 94});
+} catch {}
+let buffer22 = device4.createBuffer({size: 18020, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture75 = device4.createTexture({
+label: '\u{1ff9c}\u075e\u0115\u8162\u{1faf4}\ubeee\u63c7\u097f',
+size: {width: 600, height: 1, depthOrArrayLayers: 74},
+mipLevelCount: 4,
+sampleCount: 1,
+dimension: '3d',
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16sint', 'rg16sint', 'rg16sint'],
+});
+let textureView53 = texture66.createView({label: '\u{1f688}\u64f9\u0203\u{1fdf1}\u8a2e', dimension: '1d', aspect: 'all'});
+let renderBundle56 = renderBundleEncoder45.finish({});
+try {
+renderBundleEncoder46.setVertexBuffer(62, undefined, 2032357105, 1403290832);
+} catch {}
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+gpuCanvasContext7.configure({
+device: device4,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['rg16uint', 'bgra8unorm-srgb'],
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+await device4.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let textureView54 = texture7.createView({baseArrayLayer: 0});
+let sampler51 = device0.createSampler({
+label: '\uf17b\u6ff2\u4972\uacb3\u64a1',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+minFilter: 'linear',
+lodMinClamp: 54.740,
+lodMaxClamp: 85.747,
+});
+try {
+renderBundleEncoder38.drawIndirect(buffer3, 37916);
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(buffer5, 16820, buffer3, 12688, 324);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer12, 25996, 3328);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder50.resolveQuerySet(querySet11, 1085, 685, buffer12, 29440);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: { x: 410, y: 27, z: 543 },
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(0)), /* required buffer size: 13663411 */
+{offset: 563, bytesPerRow: 1234, rowsPerImage: 173}, {width: 271, height: 0, depthOrArrayLayers: 65});
+} catch {}
+let canvas18 = document.createElement('canvas');
+let video14 = await videoWithData();
+let renderBundleEncoder47 = device5.createRenderBundleEncoder({
+  label: '\u{1f61e}\u33de\u0d1d\u737e\u{1fe5a}\ua5c6\u07e4\u0990\u38f6\u2fbe\u0135',
+  colorFormats: ['r32sint', 'rgba8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+try {
+commandEncoder43.copyTextureToTexture({
+  texture: texture74,
+  mipLevel: 1,
+  origin: { x: 0, y: 8, z: 115 },
+  aspect: 'all',
+}, {
+  texture: texture74,
+  mipLevel: 1,
+  origin: { x: 20, y: 12, z: 62 },
+  aspect: 'all',
+}, {width: 36, height: 28, depthOrArrayLayers: 7});
+} catch {}
+try {
+device5.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 1,
+  origin: { x: 20, y: 8, z: 110 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 1735357 */
+{offset: 221, bytesPerRow: 214, rowsPerImage: 180}, {width: 12, height: 36, depthOrArrayLayers: 46});
+} catch {}
+let video15 = await videoWithData();
+try {
+computePassEncoder34.end();
+} catch {}
+try {
+commandEncoder40.copyTextureToBuffer({
+  texture: texture62,
+  mipLevel: 0,
+  origin: { x: 4, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 6000 widthInBlocks: 1500 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 25960 */
+offset: 25960,
+bytesPerRow: 6400,
+buffer: buffer19,
+}, {width: 1500, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer19);
+} catch {}
+let canvas19 = document.createElement('canvas');
+let videoFrame13 = new VideoFrame(offscreenCanvas4, {timestamp: 0});
+let video16 = await videoWithData();
+let imageBitmap13 = await createImageBitmap(canvas7);
+try {
+canvas18.getContext('webgl2');
+} catch {}
+let bindGroupLayout28 = device2.createBindGroupLayout({
+label: '\u{1f93e}\uba0d\u02d8\ud339\u7c42\u74ea',
+entries: [],
+});
+let commandEncoder52 = device2.createCommandEncoder({label: '\u{1fad5}\ua3db\u0149\ufa49\u72a9\u0eda\u494c\u1c31\ubedb\u{1fef0}\u{1fab0}'});
+let texture76 = device2.createTexture({
+label: '\u0edc\uce81',
+size: {width: 475},
+dimension: '1d',
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r16uint'],
+});
+let texture77 = device2.createTexture({
+label: '\u{1fb24}\u{1f88c}\u8131',
+size: {width: 475, height: 1, depthOrArrayLayers: 278},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgb10a2uint', 'rgb10a2uint'],
+});
+let textureView55 = texture68.createView({
+  dimension: '2d',
+  aspect: 'stencil-only',
+  baseMipLevel: 4,
+  mipLevelCount: 3,
+  baseArrayLayer: 58,
+  arrayLayerCount: 1
+});
+let renderBundle57 = renderBundleEncoder43.finish({});
+try {
+commandEncoder48.copyBufferToBuffer(buffer13, 2288, buffer19, 6580, 80);
+dissociateBuffer(device2, buffer13);
+dissociateBuffer(device2, buffer19);
+} catch {}
+try {
+commandEncoder49.insertDebugMarker('\ue06a');
+} catch {}
+try {
+device2.queue.writeBuffer(buffer19, 29824, new BigUint64Array(36550), 4761, 0);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 4,
+  origin: { x: 9, y: 2, z: 2 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 106097 */
+{offset: 874, bytesPerRow: 549, rowsPerImage: 187}, {width: 91, height: 5, depthOrArrayLayers: 2});
+} catch {}
+gc();
+let querySet41 = device4.createQuerySet({
+label: '\u25b3\ua386',
+type: 'occlusion',
+count: 1356,
+});
+let texture78 = device4.createTexture({
+label: '\u0c32\ue4ae\ua1cd\u7c03\uf1a9\u9e57\u4cf6',
+size: {width: 600, height: 1, depthOrArrayLayers: 134},
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['depth24plus-stencil8', 'depth24plus-stencil8', 'depth24plus-stencil8'],
+});
+let renderBundle58 = renderBundleEncoder41.finish({label: '\ub576\u0758\uece4\uc4d3'});
+document.body.prepend(canvas3);
+let imageData22 = new ImageData(20, 192);
+let commandEncoder53 = device5.createCommandEncoder({});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup19, new Uint32Array(5358), 4142, 0);
+} catch {}
+try {
+computePassEncoder32.end();
+} catch {}
+try {
+computePassEncoder31.insertDebugMarker('\u{1f812}');
+} catch {}
+let canvas20 = document.createElement('canvas');
+video4.height = 138;
+let img13 = await imageWithData(35, 39, '#bd345cab', '#8ac10889');
+document.body.prepend(canvas3);
+try {
+canvas19.getContext('webgpu');
+} catch {}
+let adapter8 = await navigator.gpu.requestAdapter({
+});
+let commandEncoder54 = device4.createCommandEncoder({label: '\u52b5\u0e69\u2d85\ub155'});
+let querySet42 = device4.createQuerySet({
+label: '\u03f7\u0780\u0c30\u034e\ue57a\u036a\u6a4a\u08e8\u281d',
+type: 'occlusion',
+count: 2153,
+});
+let renderBundleEncoder48 = device4.createRenderBundleEncoder({
+  label: '\u08d8\u{1fb21}\u{1f857}\u3ad1\u{1fd1c}\u6d1b\u0fb3\u{1f9bb}\uc77c',
+  colorFormats: ['rg32float', 'rgba32sint'],
+  sampleCount: 1,
+  depthReadOnly: true
+});
+let sampler52 = device4.createSampler({
+label: '\ua1e7\u12b1\u{1fc07}\u6196\u088e\ue1b0\u0570\u010a',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 99.665,
+maxAnisotropy: 2,
+});
+try {
+texture64.destroy();
+} catch {}
+try {
+commandEncoder54.insertDebugMarker('\u3628');
+} catch {}
+try {
+device4.destroy();
+} catch {}
+let offscreenCanvas18 = new OffscreenCanvas(742, 45);
+let bindGroup23 = device5.createBindGroup({
+label: '\uc504\uadd5\u1054\u9f8f\uee4b\u0f6b\u09e8\u1931\u0d30\ua2c1',
+layout: bindGroupLayout24,
+entries: [],
+});
+let texture79 = gpuCanvasContext16.getCurrentTexture();
+try {
+renderBundleEncoder47.setBindGroup(5, bindGroup19);
+} catch {}
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+let offscreenCanvas19 = new OffscreenCanvas(35, 591);
+document.body.prepend(video1);
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let videoFrame14 = new VideoFrame(offscreenCanvas9, {timestamp: 0});
+let renderBundleEncoder49 = device5.createRenderBundleEncoder({
+  label: '\u581b\u263b\u{1ffbc}\u0af1\u0f19\u{1f7d9}\u2b8c\u0b22\ue824\u{1f8af}\u0dda',
+  colorFormats: ['rgba8sint', 'rg8sint', undefined, 'r8uint', undefined, 'rgba16sint', 'rgb10a2uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler53 = device5.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 90.415,
+lodMaxClamp: 95.544,
+maxAnisotropy: 18,
+});
+let video17 = await videoWithData();
+try {
+window.someLabel = device1.queue.label;
+} catch {}
+let offscreenCanvas20 = new OffscreenCanvas(584, 405);
+let computePassEncoder35 = commandEncoder43.beginComputePass();
+let renderBundleEncoder50 = device5.createRenderBundleEncoder({
+  colorFormats: ['r32sint', 'rgba8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+computePassEncoder35.setBindGroup(4, bindGroup21);
+} catch {}
+let promise34 = device5.queue.onSubmittedWorkDone();
+gc();
+let videoFrame15 = new VideoFrame(img6, {timestamp: 0});
+let commandEncoder55 = device0.createCommandEncoder({label: '\udb73\ud336\u8cf5\ud23b\u{1f873}\u0d93'});
+let computePassEncoder36 = commandEncoder28.beginComputePass({});
+let renderBundleEncoder51 = device0.createRenderBundleEncoder({
+  label: '\u2274\u5f6a\u0401',
+  colorFormats: ['rg16uint', 'r16sint', 'r16float', 'rgba16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: false
+});
+try {
+renderBundleEncoder28.setBindGroup(5, bindGroup10, new Uint32Array(7942), 2106, 0);
+} catch {}
+try {
+renderBundleEncoder38.draw(40, 48, 72, 72);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexedIndirect(buffer3, 15588);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder55.copyBufferToBuffer(buffer16, 3040, buffer12, 19100, 332);
+dissociateBuffer(device0, buffer16);
+dissociateBuffer(device0, buffer12);
+} catch {}
+let pipeline56 = device0.createComputePipeline({
+label: '\u{1f9bc}\uafc6\u989a\u2ae1\ue3c7\ubce0\u40fe',
+layout: pipelineLayout14,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+gc();
+let videoFrame16 = new VideoFrame(video0, {timestamp: 0});
+try {
+renderBundleEncoder47.setBindGroup(2, bindGroup20);
+} catch {}
+let bindGroupLayout29 = device0.createBindGroupLayout({
+label: '\u367d\u4b7e\u2d0e\ub1c7\u{1f7e5}\u{1f8aa}\u{1f9f2}\ud975\ufd99\u0650',
+entries: [{
+binding: 4823,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+let texture80 = device0.createTexture({
+label: '\u{1ff77}\u{1f8ef}\u0d9c\u{1fd06}\u2091\u{1f7a8}\u4956\u0e50\uc4ea\u11be',
+size: [228, 12, 95],
+format: 'astc-12x12-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['astc-12x12-unorm-srgb', 'astc-12x12-unorm'],
+});
+let computePassEncoder37 = commandEncoder50.beginComputePass({label: '\u9aaf\u{1ff59}\u02dc\u238e\u0578\u03f0\u3c3d\u{1ff31}'});
+let renderBundleEncoder52 = device0.createRenderBundleEncoder({
+  label: '\u7277\u1679\u3536\uec97\u03f3\u{1fe08}\u04d8\u0ec0\u00cf',
+  colorFormats: ['r16sint', 'r8uint', 'rg16uint', 'r8uint', 'rg32sint', 'r8unorm'],
+  sampleCount: 4
+});
+try {
+computePassEncoder22.setPipeline(pipeline32);
+} catch {}
+try {
+renderBundleEncoder38.drawIndirect(buffer3, 28316);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(5, buffer1, 5224, 12733);
+} catch {}
+let promise35 = buffer16.mapAsync(GPUMapMode.WRITE, 2312, 1716);
+try {
+device0.queue.writeBuffer(buffer12, 29136, new Float32Array(17921), 8269, 1148);
+} catch {}
+try {
+buffer6.label = '\uc980\u110d';
+} catch {}
+let buffer23 = device0.createBuffer({
+  label: '\u{1febc}\u2b7f\u311a\ud3bf\u0dff\u{1f74a}\u632b\u{1fa64}',
+  size: 51197,
+  usage: GPUBufferUsage.COPY_DST
+});
+let computePassEncoder38 = commandEncoder55.beginComputePass();
+let renderBundle59 = renderBundleEncoder52.finish({label: '\u0084\u4926'});
+try {
+computePassEncoder18.end();
+} catch {}
+try {
+renderBundleEncoder38.drawIndexed(56);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexedIndirect(buffer3, 37332);
+} catch {}
+try {
+renderBundleEncoder38.drawIndirect(buffer3, 30860);
+} catch {}
+try {
+commandEncoder25.copyBufferToBuffer(buffer1, 8344, buffer3, 6432, 8904);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder25.copyTextureToBuffer({
+  texture: texture15,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 19736 */
+offset: 19736,
+rowsPerImage: 171,
+buffer: buffer23,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer23);
+} catch {}
+try {
+commandEncoder25.clearBuffer(buffer12, 13992, 3644);
+dissociateBuffer(device0, buffer12);
+} catch {}
+let img14 = await imageWithData(251, 229, '#ad41cfbf', '#82f6382e');
+let bindGroupLayout30 = device0.createBindGroupLayout({
+label: '\u08c6\ubd53\u5931\u47e8\u0e5c\uc4ac\u{1fb72}\u7f07\u68c8\u5430\u0536',
+entries: [{
+binding: 694,
+visibility: 0,
+storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '3d' },
+}, {
+binding: 566,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'filtering' },
+}],
+});
+let bindGroup24 = device0.createBindGroup({
+label: '\u907b\u48bb\ud803\u{1fe23}\u{1f757}\uaa9d\u0783',
+layout: bindGroupLayout15,
+entries: [{
+binding: 5491,
+resource: externalTexture0
+}, {
+binding: 1495,
+resource: sampler36
+}, {
+binding: 5397,
+resource: externalTexture0
+}],
+});
+let buffer24 = device0.createBuffer({size: 283, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let querySet43 = device0.createQuerySet({
+label: '\u156b\uda6c\u65a8\u59cf\u6a2d\u0b79\u0f4f\u2479\u0171',
+type: 'occlusion',
+count: 1080,
+});
+let texture81 = device0.createTexture({
+label: '\u5ff0\u881a\u9654\u8eb5\ua964\u{1f8dc}\u084c\u9a38',
+size: [1176, 1, 1025],
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8snorm'],
+});
+let computePassEncoder39 = commandEncoder25.beginComputePass({});
+let renderBundleEncoder53 = device0.createRenderBundleEncoder({
+  label: '\u07f0\u53c6\u45bb\u2694\u097c\u{1f70c}\ua1e5\u{1fb73}\u07e5\udf17\ue6ac',
+  colorFormats: ['rg8unorm', undefined],
+  depthStencilFormat: 'depth32float-stencil8'
+});
+let renderBundle60 = renderBundleEncoder0.finish({label: '\u0cb7\u08c4\ud6a1\u26c6\ufb92'});
+let sampler54 = device0.createSampler({
+label: '\u{1f8b7}\u0e65\ub013\uf5cd\ud4b7\u0609\u08bc\u07f9\u03a2\u{1f897}\udfa7',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+lodMinClamp: 68.425,
+lodMaxClamp: 99.684,
+compare: 'greater',
+});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup10, []);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(5, bindGroup6, new Uint32Array(805), 42, 0);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexedIndirect(buffer3, 19680);
+} catch {}
+try {
+commandEncoder12.copyTextureToBuffer({
+  texture: texture17,
+  mipLevel: 0,
+  origin: { x: 2352, y: 12, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 5472 widthInBlocks: 342 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 19296 */
+offset: 19296,
+buffer: buffer12,
+}, {width: 2736, height: 6, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder12.clearBuffer(buffer12, 26736, 4416);
+dissociateBuffer(device0, buffer12);
+} catch {}
+let bindGroup25 = device2.createBindGroup({
+layout: bindGroupLayout28,
+entries: [],
+});
+let commandEncoder56 = device2.createCommandEncoder({label: '\ue5d3\u{1f9e0}\u0b8a\u6c4a\u0309\u701b'});
+let computePassEncoder40 = commandEncoder52.beginComputePass({label: '\u0103\u077a\u005d'});
+let sampler55 = device2.createSampler({
+label: '\ub81c\u{1f63c}\ua678\u7d3c\u{1fe05}',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 97.241,
+maxAnisotropy: 11,
+});
+try {
+commandEncoder40.copyTextureToTexture({
+  texture: texture77,
+  mipLevel: 3,
+  origin: { x: 8, y: 1, z: 18 },
+  aspect: 'all',
+}, {
+  texture: texture77,
+  mipLevel: 2,
+  origin: { x: 57, y: 1, z: 31 },
+  aspect: 'all',
+}, {width: 48, height: 0, depthOrArrayLayers: 3});
+} catch {}
+let texture82 = gpuCanvasContext7.getCurrentTexture();
+let textureView56 = texture73.createView({label: '\u0a67\u{1fe86}\u0f12', format: 'bgra8unorm', baseMipLevel: 2, mipLevelCount: 1});
+let renderBundle61 = renderBundleEncoder50.finish({});
+try {
+device5.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new Int8Array(arrayBuffer6), /* required buffer size: 587 */
+{offset: 583}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let device6 = await adapter8.requestDevice({
+requiredLimits: {
+maxColorAttachmentBytesPerSample: 59,
+maxVertexAttributes: 24,
+maxVertexBufferArrayStride: 53215,
+maxStorageTexturesPerShaderStage: 5,
+maxDynamicStorageBuffersPerPipelineLayout: 53746,
+maxBindingsPerBindGroup: 9036,
+maxTextureDimension1D: 13090,
+maxTextureDimension2D: 13725,
+maxVertexBuffers: 9,
+minUniformBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 255511045,
+maxUniformBuffersPerShaderStage: 40,
+maxInterStageShaderVariables: 26,
+maxInterStageShaderComponents: 104,
+maxSamplersPerShaderStage: 18,
+},
+});
+let offscreenCanvas21 = new OffscreenCanvas(545, 281);
+try {
+adapter8.label = '\u909c\u40f2';
+} catch {}
+let texture83 = device3.createTexture({
+label: '\u06c9\u{1f6cf}\u{1f85e}\u18b7\u28ee',
+size: {width: 1776, height: 20, depthOrArrayLayers: 32},
+mipLevelCount: 3,
+format: 'etc2-rgb8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8unorm-srgb', 'etc2-rgb8unorm', 'etc2-rgb8unorm'],
+});
+let textureView57 = texture50.createView({label: '\u6677\u68f4\ud9dd\u1fcc', dimension: '2d', baseMipLevel: 2, mipLevelCount: 2, baseArrayLayer: 166});
+let promise36 = device3.popErrorScope();
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: { x: 5, y: 0, z: 15 },
+  aspect: 'all',
+}, new Uint16Array(new ArrayBuffer(56)), /* required buffer size: 3795015 */
+{offset: 959, bytesPerRow: 656, rowsPerImage: 118}, {width: 204, height: 2, depthOrArrayLayers: 50});
+} catch {}
+let promise37 = device3.queue.onSubmittedWorkDone();
+let texture84 = device5.createTexture({
+label: '\ub9c5\u83d4\ucb12\u0f7d\uee8f\u40c0\u41d2\u9bea',
+size: {width: 705, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 9,
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle62 = renderBundleEncoder44.finish({label: '\u{1f76a}\u8cf6\uc62c\u{1f769}'});
+let sampler56 = device5.createSampler({
+label: '\u20f3\ub47b\ub8d2\u0a10\u0652\u{1fe8a}\u9140\u0625\u4b86\u0de9',
+addressModeU: 'mirror-repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 19.565,
+});
+try {
+renderBundleEncoder49.setVertexBuffer(41, undefined);
+} catch {}
+try {
+device5.queue.writeTexture({
+  texture: texture84,
+  mipLevel: 6,
+  origin: { x: 6, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 335 */
+{offset: 335}, {width: 4, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext20 = offscreenCanvas18.getContext('webgpu');
+try {
+  await promise36;
+} catch {}
+let videoFrame17 = new VideoFrame(videoFrame6, {timestamp: 0});
+try {
+canvas20.getContext('webgl');
+} catch {}
+try {
+offscreenCanvas19.getContext('bitmaprenderer');
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas21.getContext('2d');
+} catch {}
+try {
+textureView38.label = '\u{1fa94}\u0562\u20f7\u62ab\u{1ffb0}\u8d95\u4c3c\u5b3a\udc57';
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let externalTexture3 = device0.importExternalTexture({
+label: '\u340c\uce31\u{1f681}\u{1f9db}\uae76\u28f0\u82d5\u80fc\u{1fcd8}\u2108\u24c6',
+source: videoFrame6,
+colorSpace: 'srgb',
+});
+try {
+commandEncoder12.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 468, y: 24, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: { x: 24, y: 0, z: 30 },
+  aspect: 'all',
+}, {width: 168, height: 0, depthOrArrayLayers: 36});
+} catch {}
+try {
+commandEncoder12.clearBuffer(buffer23, 9552, 14848);
+dissociateBuffer(device0, buffer23);
+} catch {}
+try {
+computePassEncoder22.popDebugGroup();
+} catch {}
+let imageData23 = new ImageData(136, 168);
+let commandEncoder57 = device6.createCommandEncoder({label: '\u3279\u{1ffd9}\u1a45'});
+pseudoSubmit(device6, commandEncoder57);
+let texture85 = device6.createTexture({
+label: '\u33b3\ue0d1\u0560\u{1f6ce}\u{1f99d}',
+size: [160, 960, 1],
+mipLevelCount: 3,
+format: 'rg8uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg8uint'],
+});
+document.body.prepend(canvas3);
+let bindGroupLayout31 = device2.createBindGroupLayout({
+label: '\u{1fea8}\u86bd\u{1f919}\u0d3b\uf931\u95a5\u{1fb06}',
+entries: [{
+binding: 2479,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+sampler: { type: 'filtering' },
+}, {
+binding: 3615,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+}],
+});
+let computePassEncoder41 = commandEncoder40.beginComputePass({label: '\u8893\u4bff\u1f7e\u{1fe2d}\u3d10\u{1fa48}\u03f4\u074b\u01dd\u011a\uca7e'});
+let renderBundle63 = renderBundleEncoder43.finish({label: '\u052d\uf167\u01c1\u2b4f\u{1f85a}\u0a77\u0593\u{1f605}\u675c\u{1fe54}\uabd1'});
+try {
+computePassEncoder41.setBindGroup(4, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(9, undefined, 1201707677, 631816372);
+} catch {}
+try {
+commandEncoder49.pushDebugGroup('\u{1fa32}');
+} catch {}
+let sampler57 = device0.createSampler({
+label: '\uf6fa\ua9d4\ufcd2\ub3e2\uae96\u0280\u{1f795}\u1cfb\u079a\u0bc6',
+addressModeU: 'repeat',
+addressModeW: 'repeat',
+lodMaxClamp: 70.565,
+});
+try {
+renderBundleEncoder38.drawIndexed(72);
+} catch {}
+try {
+buffer24.destroy();
+} catch {}
+try {
+commandEncoder12.copyBufferToBuffer(buffer5, 19944, buffer12, 15792, 3424);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder12.copyTextureToBuffer({
+  texture: texture60,
+  mipLevel: 5,
+  origin: { x: 45, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 620 widthInBlocks: 155 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 22920 */
+offset: 22920,
+buffer: buffer12,
+}, {width: 155, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+gpuCanvasContext17.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['astc-10x5-unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb', 'astc-6x6-unorm'],
+alphaMode: 'premultiplied',
+});
+} catch {}
+let promise38 = device0.queue.onSubmittedWorkDone();
+let offscreenCanvas22 = new OffscreenCanvas(556, 371);
+let textureView58 = texture85.createView({label: '\u0736\u2ca2\u0153\uf205\uf970\ua994', dimension: '2d', mipLevelCount: 2});
+let renderBundleEncoder54 = device6.createRenderBundleEncoder({
+  label: '\u7be0\u0017\u6fb0\u{1f604}\u7bce\uc2b8\u{1fcdb}',
+  colorFormats: ['rg16uint', 'rgba8sint', 'rgb10a2uint', 'rg8sint', 'rgba32sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+  await promise34;
+} catch {}
+let imageData24 = new ImageData(136, 152);
+try {
+offscreenCanvas20.getContext('webgpu');
+} catch {}
+let buffer25 = device6.createBuffer({
+  label: '\u2cb3\u{1ffc0}\u{1f82f}\ubd77\u04ee\u{1f6aa}',
+  size: 4300,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let texture86 = device6.createTexture({
+label: '\u9490\u{1fd92}\u082e\u0631\ua6f6\udf71',
+size: {width: 1590},
+dimension: '1d',
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['r16uint'],
+});
+let renderBundle64 = renderBundleEncoder54.finish({});
+let imageBitmap14 = await createImageBitmap(canvas1);
+let commandEncoder58 = device6.createCommandEncoder({label: '\ub198\u97f3\u0d18'});
+let computePassEncoder42 = commandEncoder58.beginComputePass({});
+let sampler58 = device6.createSampler({
+label: '\u{1f64f}\u1ae2\u06d9\u{1f820}\u{1feff}\u69bf\u01c2\u07bc\u{1f946}',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 96.514,
+lodMaxClamp: 99.695,
+});
+let video18 = await videoWithData();
+try {
+computePassEncoder35.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(71, undefined, 3360772369, 785381293);
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(/*
+{width: 22, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData10,
+  origin: { x: 3, y: 33 },
+  flipY: true,
+}, {
+  texture: texture84,
+  mipLevel: 5,
+  origin: { x: 4, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 11, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandBuffer12 = commandEncoder45.finish();
+let texture87 = gpuCanvasContext3.getCurrentTexture();
+let renderBundleEncoder55 = device5.createRenderBundleEncoder({
+  colorFormats: ['bgra8unorm', 'rg32sint', 'rgb10a2uint', 'rg16sint', 'r16float'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+buffer21.unmap();
+} catch {}
+try {
+commandEncoder51.copyTextureToTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture82,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device5.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 197 */
+{offset: 197}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let adapter9 = await navigator.gpu.requestAdapter({
+powerPreference: 'low-power',
+});
+let device7 = await promise32;
+let img15 = await imageWithData(42, 142, '#e159e3b3', '#400e57a5');
+let renderBundleEncoder56 = device0.createRenderBundleEncoder({
+  label: '\u26c2\u8d98\u{1ff5b}\u5aa4\u0bfe\u0b74\uc453\u05bd\u965a\u07ef',
+  colorFormats: ['r16sint', 'r8uint', 'rg16uint', 'r8uint', 'rg32sint', 'r8unorm'],
+  sampleCount: 4
+});
+let sampler59 = device0.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 54.233,
+lodMaxClamp: 82.396,
+maxAnisotropy: 13,
+});
+try {
+commandEncoder12.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 2,
+  origin: { x: 564, y: 0, z: 67 },
+  aspect: 'all',
+}, {
+  texture: texture40,
+  mipLevel: 1,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 36, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise35;
+} catch {}
+let textureView59 = texture79.createView({label: '\u0ce4\u9c50\ufb35', dimension: '2d-array', format: 'bgra8unorm-srgb'});
+let computePassEncoder43 = commandEncoder51.beginComputePass();
+let renderBundleEncoder57 = device5.createRenderBundleEncoder({
+  label: '\u9006\u7395',
+  colorFormats: ['r32sint', 'rgba8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder49.setVertexBuffer(89, undefined, 1796533354, 703946550);
+} catch {}
+try {
+buffer21.unmap();
+} catch {}
+try {
+await device5.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let bindGroupLayout32 = device2.createBindGroupLayout({
+label: '\ud062\u2527\u799c',
+entries: [{
+binding: 3338,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+}, {
+binding: 1520,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+}, {
+binding: 2084,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+let texture88 = device2.createTexture({
+size: {width: 761},
+dimension: '1d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rg16float'],
+});
+let sampler60 = device2.createSampler({
+label: '\ud609\u6111\u34a2\u0674\u457a\u0c83\u{1fa48}\ub8ef\u0f73\u9da2',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+minFilter: 'nearest',
+lodMinClamp: 85.344,
+lodMaxClamp: 99.692,
+});
+try {
+computePassEncoder23.setPipeline(pipeline53);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(5, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(74, undefined, 1638112670);
+} catch {}
+try {
+commandEncoder56.copyBufferToBuffer(buffer17, 25184, buffer19, 52508, 9928);
+dissociateBuffer(device2, buffer17);
+dissociateBuffer(device2, buffer19);
+} catch {}
+try {
+commandEncoder49.copyTextureToTexture({
+  texture: texture62,
+  mipLevel: 0,
+  origin: { x: 28, y: 1, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture62,
+  mipLevel: 0,
+  origin: { x: 263, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 193, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder49.clearBuffer(buffer19);
+dissociateBuffer(device2, buffer19);
+} catch {}
+gc();
+let promise39 = navigator.gpu.requestAdapter({
+});
+let bindGroup26 = device5.createBindGroup({
+label: '\u035f\u0174\u2d0b\u611f\u{1fb16}\ud790\u7100\u{1fc88}\u{1fbae}',
+layout: bindGroupLayout24,
+entries: [],
+});
+let commandBuffer13 = commandEncoder46.finish({
+});
+let textureView60 = texture67.createView({dimension: '2d', baseMipLevel: 4, baseArrayLayer: 15});
+let renderBundleEncoder58 = device5.createRenderBundleEncoder({
+  label: '\u{1f9c5}\u{1ff59}\uff9a\u4785',
+  colorFormats: ['r32sint', 'rgba8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder57.setIndexBuffer(buffer20, 'uint32', 9804);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+device: device5,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rg16uint', 'rg16float', 'rgba16float', 'depth24plus'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device5.queue.submit([
+]);
+} catch {}
+try {
+device5.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 271 */
+{offset: 271}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+offscreenCanvas22.getContext('bitmaprenderer');
+} catch {}
+try {
+computePassEncoder38.setBindGroup(0, bindGroup17, new Uint32Array(8519), 2286, 0);
+} catch {}
+try {
+renderBundleEncoder38.draw(64, 72);
+} catch {}
+let pipeline57 = await device0.createComputePipelineAsync({
+label: '\u8ab1\u099d',
+layout: pipelineLayout3,
+compute: {
+module: shaderModule2,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let img16 = await imageWithData(7, 195, '#d7d14b73', '#28b2c4de');
+let canvas21 = document.createElement('canvas');
+try {
+device1.queue.label = '\uf2d0\u2922\u{1f87d}\u{1fe1b}';
+} catch {}
+video16.width = 10;
+canvas11.width = 881;
+let canvas22 = document.createElement('canvas');
+pseudoSubmit(device6, commandEncoder58);
+let texture89 = device6.createTexture({
+label: '\u403d\u{1f97b}\u49d6\u02f8\u{1fea0}\u812f\u{1fb84}\u5fb9\u{1fef0}\u0ab0',
+size: {width: 247},
+dimension: '1d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let textureView61 = texture89.createView({label: '\u{1f85e}\u07d6\uc833', dimension: '1d'});
+let renderBundle65 = renderBundleEncoder54.finish({label: '\u91e5\u0856\u08bb\u{1fd20}\uea2e\u0f37'});
+let sampler61 = device6.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 61.764,
+lodMaxClamp: 63.758,
+maxAnisotropy: 16,
+});
+try {
+device6.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: { x: 4, y: 1, z: 0 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 932 */
+{offset: 932, rowsPerImage: 252}, {width: 1576, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise37;
+} catch {}
+let renderBundleEncoder59 = device2.createRenderBundleEncoder({
+  label: '\uc517\u{1fcc2}\u9675\uee87\ub44e\u0b52\ue54c\u0969',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+let sampler62 = device2.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+lodMaxClamp: 82.144,
+});
+try {
+computePassEncoder23.setBindGroup(5, bindGroup25, new Uint32Array(9558), 5431, 0);
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline50);
+} catch {}
+let arrayBuffer7 = buffer13.getMappedRange(1384, 48);
+try {
+commandEncoder49.resolveQuerySet(querySet39, 188, 109, buffer19, 54528);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer19, 20896, new Float32Array(7801));
+} catch {}
+canvas16.width = 482;
+let textureView62 = texture76.createView({baseArrayLayer: 0});
+try {
+computePassEncoder41.setPipeline(pipeline53);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(52, undefined, 2766876596, 1194567158);
+} catch {}
+let arrayBuffer8 = buffer13.getMappedRange(1432, 28);
+try {
+commandEncoder48.clearBuffer(buffer19);
+dissociateBuffer(device2, buffer19);
+} catch {}
+try {
+gpuCanvasContext17.configure({
+device: device2,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer19, 34388, new Float32Array(7341), 7221, 112);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture88,
+  mipLevel: 0,
+  origin: { x: 88, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(2153), /* required buffer size: 2153 */
+{offset: 53, bytesPerRow: 2394}, {width: 525, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let buffer26 = device7.createBuffer({size: 33187, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let commandEncoder59 = device7.createCommandEncoder({label: '\u{1fae3}\u51bf\u0ae3\u76c4\u91b7\u9907\uaeab\u4425\u2f9a'});
+let imageData25 = new ImageData(140, 208);
+let commandEncoder60 = device5.createCommandEncoder({});
+try {
+renderBundleEncoder57.insertDebugMarker('\u018f');
+} catch {}
+try {
+device5.queue.submit([
+commandBuffer12,
+]);
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 101, y: 9 },
+  flipY: true,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img17 = await imageWithData(156, 162, '#62a1649e', '#e28b4148');
+let buffer27 = device0.createBuffer({
+  label: '\u002b\ue5ca\u{1fb39}\u4748\u0384\u{1f98a}',
+  size: 44988,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true
+});
+try {
+renderBundleEncoder38.draw(8, 16, 32, 48);
+} catch {}
+offscreenCanvas16.height = 417;
+let offscreenCanvas23 = new OffscreenCanvas(509, 974);
+try {
+device6.queue.label = '\u0799\u{1f7e8}\uc5f1\u1166\u0d2e\u4c5a\u0d12\u1d0f';
+} catch {}
+let commandEncoder61 = device6.createCommandEncoder();
+let textureView63 = texture85.createView({dimension: '2d-array', baseMipLevel: 2});
+let querySet44 = device6.createQuerySet({
+label: '\u{1ff1e}\u3dc1\u{1fe12}\u17a4\u{1fc18}\u030f\u{1f8aa}',
+type: 'occlusion',
+count: 624,
+});
+let textureView64 = texture89.createView({label: '\u0add\u546b\u40ee\u0cdb\ua358\uc428', arrayLayerCount: 1});
+let renderBundleEncoder60 = device6.createRenderBundleEncoder({
+  label: '\u1ca8\u03c5\u2d50\uedba\u{1fb00}\u{1fb39}\u3c05\u7d5a\u461e\ud729\u{1fb39}',
+  colorFormats: ['rg16uint', 'rgba8sint', 'rgb10a2uint', 'rg8sint', 'rgba32sint'],
+  stencilReadOnly: false
+});
+let renderBundle66 = renderBundleEncoder60.finish({label: '\u5a4d\u{1fd79}\ucb8e\u021b\u{1fbea}'});
+try {
+externalTexture1.label = '\u689d\u{1fb11}\u03ab\ucf76\u3b6e\u091b\u{1f618}\u{1fcd3}\u0dd0';
+} catch {}
+let bindGroup27 = device5.createBindGroup({
+label: '\u6ac6\ucf30\u{1f7d8}\uba1f\u670b\u7447\u7ea4\u0cec\u6518',
+layout: bindGroupLayout24,
+entries: [],
+});
+let textureView65 = texture87.createView({
+  label: '\u04ce\u02c6\uc12f\u{1f68f}\u07a7\uc94f\u{1fc4d}\u06c7\u{1fcae}',
+  format: 'bgra8unorm-srgb',
+  mipLevelCount: 1
+});
+try {
+device5.queue.writeTexture({
+  texture: texture84,
+  mipLevel: 7,
+  origin: { x: 0, y: 1, z: 1 },
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 712 */
+{offset: 712}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas24 = new OffscreenCanvas(816, 554);
+let bindGroupLayout33 = device0.createBindGroupLayout({
+label: '\u0371\ub283\u{1fe5d}\u8061\uf828\u9c5c\uaa7a\u3b64',
+entries: [{
+binding: 4754,
+visibility: GPUShaderStage.COMPUTE,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+}, {
+binding: 4503,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}],
+});
+let renderBundleEncoder61 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm', undefined], depthStencilFormat: 'depth32float-stencil8', sampleCount: 1});
+try {
+computePassEncoder25.setBindGroup(4, bindGroup18, new Uint32Array(9934), 147, 0);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder38.draw(8, 48, 32, 0);
+} catch {}
+try {
+commandEncoder12.clearBuffer(buffer12, 1440, 3056);
+dissociateBuffer(device0, buffer12);
+} catch {}
+offscreenCanvas7.height = 57;
+let video19 = await videoWithData();
+let imageBitmap15 = await createImageBitmap(canvas9);
+let adapter10 = await promise39;
+let img18 = await imageWithData(105, 291, '#e957ecb1', '#acbfc79d');
+let imageBitmap16 = await createImageBitmap(imageBitmap1);
+let promise40 = adapter0.requestAdapterInfo();
+let buffer28 = device5.createBuffer({
+  label: '\ua8f1\u00d1\u09ba\u0c56',
+  size: 38346,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let querySet45 = device5.createQuerySet({
+label: '\u34e4\u{1fc3b}\u{1f647}',
+type: 'occlusion',
+count: 3874,
+});
+let texture90 = device5.createTexture({
+label: '\u0768\u614d\u0888\ueca7\u0447\u{1fda3}',
+size: [2821, 1, 176],
+mipLevelCount: 8,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth32float-stencil8', 'depth32float-stencil8', 'depth32float-stencil8'],
+});
+let computePassEncoder44 = commandEncoder47.beginComputePass({});
+let renderBundleEncoder62 = device5.createRenderBundleEncoder({
+  label: '\u06f1\u0e2c\u0cf0\u0826\u52eb\u0afb\u03c7\u0ac5\u053e',
+  colorFormats: ['rgba8sint', 'rg8sint', undefined, 'r8uint', undefined, 'rgba16sint', 'rgb10a2uint'],
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder58.setVertexBuffer(85, undefined, 79672398, 809660989);
+} catch {}
+let videoFrame18 = new VideoFrame(videoFrame10, {timestamp: 0});
+let textureView66 = texture71.createView({
+  label: '\u52d4\u5ddd\u35b6\u4fe5\u032e\u0460',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  baseMipLevel: 2,
+  mipLevelCount: 1
+});
+try {
+computePassEncoder23.setPipeline(pipeline53);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(85, undefined, 3084872849, 958365805);
+} catch {}
+try {
+commandEncoder49.copyTextureToBuffer({
+  texture: texture62,
+  mipLevel: 3,
+  origin: { x: 115, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 10592 */
+offset: 10592,
+buffer: buffer19,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer19);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer19, 3612, new Int16Array(10023), 9409, 392);
+} catch {}
+let video20 = await videoWithData();
+let textureView67 = texture79.createView({label: '\u5925\u51e2\u1ea2\ubcd3\u3d19'});
+let renderBundle67 = renderBundleEncoder47.finish({});
+try {
+renderBundleEncoder57.setVertexBuffer(51, undefined);
+} catch {}
+let promise41 = buffer28.mapAsync(GPUMapMode.WRITE, 22152, 13012);
+try {
+computePassEncoder31.pushDebugGroup('\u7f73');
+} catch {}
+try {
+device5.queue.writeTexture({
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, new Float32Array(arrayBuffer0), /* required buffer size: 386 */
+{offset: 386, bytesPerRow: 39, rowsPerImage: 105}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video9);
+try {
+offscreenCanvas24.getContext('webgl2');
+} catch {}
+let texture91 = device2.createTexture({
+size: [160, 1, 14],
+mipLevelCount: 3,
+dimension: '3d',
+format: 'r8sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let pipeline58 = device2.createComputePipeline({
+label: '\u05c3\u9677\ua362\u0eb9\u0f73\u98e2\u{1ff26}\u4553\u417d\u3e1b',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+document.body.prepend(video15);
+let shaderModule9 = device0.createShaderModule({
+label: '\u{1fb15}\u036e\u{1fa20}\u07c7',
+code: `@group(2) @binding(5397)
+var<storage, read_write> i9: array<u32>;
+@group(0) @binding(1160)
+var<storage, read_write> local2: array<u32>;
+@group(2) @binding(1495)
+var<storage, read_write> function8: array<u32>;
+
+@compute @workgroup_size(6, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<i32>,
+  @location(4) f1: vec4<u32>,
+  @location(2) f2: vec4<i32>,
+  @builtin(frag_depth) f3: f32,
+  @builtin(sample_mask) f4: u32,
+  @location(0) f5: vec2<i32>,
+  @location(5) f6: vec4<i32>,
+  @location(3) f7: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32, @builtin(front_facing) a2: bool, @builtin(position) a3: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(3) a1: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+hints: {},
+});
+let texture92 = device0.createTexture({
+label: '\ufa1b\uc87f',
+size: {width: 2272, height: 18, depthOrArrayLayers: 1},
+mipLevelCount: 12,
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let computePassEncoder45 = commandEncoder12.beginComputePass();
+let renderBundle68 = renderBundleEncoder51.finish({label: '\ufdc7\ub823\u{1fc4e}\uedb4\ue1a3\u0dbe\uc73e'});
+try {
+renderBundleEncoder38.drawIndexed(8, 24, 64, 208, 0);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(6, buffer1, 13064, 4205);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer23, 8216, new DataView(new ArrayBuffer(36841)), 27593, 7244);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture44,
+  mipLevel: 0,
+  origin: { x: 22, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 577 */
+{offset: 577}, {width: 855, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let canvas23 = document.createElement('canvas');
+try {
+adapter0.label = '\uf4ba\u4238\u01bc\uf20c\u113f\u{1f702}\uab6a\u7ec6\u878d\u25ec';
+} catch {}
+let bindGroupLayout34 = device7.createBindGroupLayout({
+label: '\uceba\u031e\u0550\u411d\u7e1b\u3eea',
+entries: [{
+binding: 783,
+visibility: GPUShaderStage.FRAGMENT,
+buffer: { type: 'uniform', minBindingSize: 614493, hasDynamicOffset: true },
+}],
+});
+let commandEncoder62 = device7.createCommandEncoder();
+let texture93 = device7.createTexture({
+label: '\u02a9\u{1f683}\u3ac3',
+size: [840, 40, 1],
+dimension: '3d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8snorm'],
+});
+let computePassEncoder46 = commandEncoder59.beginComputePass({});
+try {
+canvas23.getContext('webgpu');
+} catch {}
+let img19 = await imageWithData(56, 163, '#5c0deb8b', '#863116aa');
+let texture94 = device5.createTexture({
+label: '\u05f0\u0528\u049a\u889e',
+size: [1410, 1, 1],
+mipLevelCount: 11,
+dimension: '2d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['bgra8unorm-srgb'],
+});
+let renderBundle69 = renderBundleEncoder50.finish({label: '\uc927\u520d\u902e\ucc27\u6c44'});
+try {
+renderBundleEncoder62.setIndexBuffer(buffer20, 'uint16', 1894, 12816);
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture93,
+  mipLevel: 0,
+  origin: { x: 291, y: 3, z: 0 },
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 5790 */
+{offset: 745, bytesPerRow: 140}, {width: 5, height: 37, depthOrArrayLayers: 1});
+} catch {}
+let querySet46 = device2.createQuerySet({
+label: '\uff9e\u96ef\ua333\u{1f897}\u588b\u0b79',
+type: 'occlusion',
+count: 692,
+});
+let texture95 = device2.createTexture({
+label: '\u{1fbbb}\u046c\u0bb2\u{1fa09}\uf6fa\u7f2d',
+size: {width: 1380, height: 1, depthOrArrayLayers: 114},
+mipLevelCount: 9,
+dimension: '3d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rg8snorm', 'rg8snorm'],
+});
+try {
+renderBundleEncoder37.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+commandEncoder49.popDebugGroup();
+} catch {}
+let pipeline59 = device2.createComputePipeline({
+layout: pipelineLayout11,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+device6.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: { x: 481, y: 0, z: 0 },
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(80)), /* required buffer size: 450 */
+{offset: 450}, {width: 581, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle70 = renderBundleEncoder9.finish({label: '\uf44a\u9654\u2117\u{1fe0d}\u46a8'});
+let sampler63 = device0.createSampler({
+label: '\ub0db\udd73\u05d8\ufab7\uc8a7\ufa5c\u58a6\u0991\u0d58\u8b71\ua5d4',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 37.925,
+lodMaxClamp: 78.248,
+});
+try {
+renderBundleEncoder17.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexed(80, 64, 72, 344, 48);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexedIndirect(buffer3, 4396);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 1776, new DataView(new ArrayBuffer(34157)), 29805);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img5,
+  origin: { x: 33, y: 209 },
+  flipY: false,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline60 = device0.createComputePipeline({
+label: '\ude11\u{1fed2}',
+layout: pipelineLayout0,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+},
+});
+let pipeline61 = device0.createRenderPipeline({
+label: '\u85ff\ue2bc\u{1f739}\u2f3f\u867e',
+layout: pipelineLayout2,
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'src-alpha', dstFactor: 'dst'},
+},
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {
+  format: 'rgba16float',
+  blend: {
+color: {operation: 'add', srcFactor: 'src', dstFactor: 'dst-alpha'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'rg32sint', writeMask: 0}, {format: 'rg16float', writeMask: GPUColorWrite.ALL}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'keep',
+passOp: 'increment-clamp',
+},
+depthBias: 65,
+depthBiasClamp: 48,
+},
+vertex: {
+  module: shaderModule2,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 9536,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x4',
+offset: 8424,
+shaderLocation: 1,
+}, {
+format: 'uint16x2',
+offset: 9312,
+shaderLocation: 14,
+}, {
+format: 'sint32x3',
+offset: 6132,
+shaderLocation: 8,
+}, {
+format: 'snorm8x2',
+offset: 1024,
+shaderLocation: 12,
+}, {
+format: 'sint8x2',
+offset: 4282,
+shaderLocation: 15,
+}, {
+format: 'sint8x4',
+offset: 1140,
+shaderLocation: 6,
+}, {
+format: 'unorm8x4',
+offset: 5872,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 1908,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x4',
+offset: 108,
+shaderLocation: 11,
+}, {
+format: 'uint16x4',
+offset: 1844,
+shaderLocation: 0,
+}, {
+format: 'float32x3',
+offset: 144,
+shaderLocation: 4,
+}, {
+format: 'uint32x2',
+offset: 1464,
+shaderLocation: 3,
+}, {
+format: 'uint32',
+offset: 920,
+shaderLocation: 10,
+}, {
+format: 'uint16x2',
+offset: 1244,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 6968,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 2836,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 5272,
+attributes: [{
+format: 'unorm16x2',
+offset: 3096,
+shaderLocation: 5,
+}, {
+format: 'float16x2',
+offset: 2148,
+shaderLocation: 7,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+let querySet47 = device7.createQuerySet({
+label: '\u2eff\u8e31\u0819\u40d6\u42d6',
+type: 'occlusion',
+count: 1505,
+});
+let textureView68 = texture93.createView({label: '\u{1fdff}\u0c64\u0bd1\u23f5'});
+let computePassEncoder47 = commandEncoder62.beginComputePass({label: '\ua995\u1d77\u{1f95c}\u1f1a\u{1fdc7}'});
+try {
+await device7.popErrorScope();
+} catch {}
+offscreenCanvas17.width = 618;
+let texture96 = device7.createTexture({
+label: '\u375c\ude1b\u07f2\u0208\u{1fe3f}\u9b03\u02d8\u0650\u7094\ubdcc\u0939',
+size: {width: 1248, height: 1, depthOrArrayLayers: 223},
+mipLevelCount: 6,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [],
+});
+let renderBundleEncoder63 = device7.createRenderBundleEncoder({
+  label: '\uf4d4\u6436\ub004\u0f6d\ufac6\u{1fc8b}\u{1f613}\u{1fe95}\u04bf',
+  colorFormats: [],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder46.end();
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(querySet47, 278, 945, buffer26, 11264);
+} catch {}
+let gpuCanvasContext21 = canvas21.getContext('webgpu');
+try {
+  await promise41;
+} catch {}
+let bindGroupLayout35 = device7.createBindGroupLayout({
+label: '\u93f2\u{1ff78}\u{1f80f}\u7923\ub6ba\u{1f76d}\u06d7\uad0c',
+entries: [{
+binding: 4885,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d' },
+}, {
+binding: 2560,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}],
+});
+let querySet48 = device7.createQuerySet({
+label: '\u9e93\u0cba\u79ed\u6872',
+type: 'occlusion',
+count: 1332,
+});
+let renderBundleEncoder64 = device7.createRenderBundleEncoder({
+  label: '\u51e5\u{1ff4e}',
+  colorFormats: [],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true
+});
+try {
+commandEncoder59.resolveQuerySet(querySet48, 712, 430, buffer26, 12032);
+} catch {}
+try {
+canvas22.getContext('bitmaprenderer');
+} catch {}
+let buffer29 = device2.createBuffer({
+  label: '\u{1fb4d}\uddc7\ubb0c\u9483\ub376\u{1f6f6}\ud339\u44b4',
+  size: 21556,
+  usage: GPUBufferUsage.STORAGE
+});
+let video21 = await videoWithData();
+let pipelineLayout16 = device7.createPipelineLayout({bindGroupLayouts: []});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let offscreenCanvas25 = new OffscreenCanvas(269, 551);
+let gpuCanvasContext22 = offscreenCanvas25.getContext('webgpu');
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let videoFrame19 = new VideoFrame(img3, {timestamp: 0});
+let commandEncoder63 = device5.createCommandEncoder({label: '\u0666\u{1fbbc}\u1fd5'});
+let textureView69 = texture94.createView({
+  label: '\u{1f9b6}\u1a17\u{1fb4d}\u4c56\u0504\u2a58\ued22\u01a8\u7366',
+  format: 'bgra8unorm-srgb',
+  baseMipLevel: 9,
+  mipLevelCount: 1
+});
+let renderBundleEncoder65 = device5.createRenderBundleEncoder({
+  label: '\u{1f62e}\u1747\ua9ba\u{1f798}\u04d3',
+  colorFormats: ['rgba8sint', 'rg8sint', undefined, 'r8uint', undefined, 'rgba16sint', 'rgb10a2uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let promise42 = adapter7.requestAdapterInfo();
+let commandEncoder64 = device2.createCommandEncoder({label: '\u08fa\u8fe7\u046c'});
+let texture97 = device2.createTexture({
+label: '\u27e9\udf65\u3f0c\u{1f7b9}\u15e4',
+size: {width: 2760, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'r32float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['r32float'],
+});
+try {
+commandEncoder48.clearBuffer(buffer19);
+dissociateBuffer(device2, buffer19);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer19, 16972, new DataView(new ArrayBuffer(22991)), 15970, 2036);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline62 = await device2.createRenderPipelineAsync({
+label: '\u1ea4\uebd6\u4f43\u0624',
+layout: pipelineLayout11,
+multisample: {
+count: 4,
+mask: 0xdf01786c,
+},
+fragment: {module: shaderModule8, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'greater',
+failOp: 'invert',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-clamp',
+depthFailOp: 'replace',
+passOp: 'keep',
+},
+stencilReadMask: 4029,
+stencilWriteMask: 3022,
+depthBias: 46,
+depthBiasSlopeScale: 51,
+depthBiasClamp: 57,
+},
+vertex: {
+  module: shaderModule8,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 40580,
+attributes: [{
+format: 'sint32',
+offset: 11980,
+shaderLocation: 17,
+}, {
+format: 'uint8x2',
+offset: 39716,
+shaderLocation: 25,
+}],
+},
+{
+arrayStride: 24284,
+attributes: [],
+},
+{
+arrayStride: 30440,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x3',
+offset: 11676,
+shaderLocation: 24,
+}, {
+format: 'unorm16x2',
+offset: 5512,
+shaderLocation: 26,
+}, {
+format: 'unorm10-10-10-2',
+offset: 27848,
+shaderLocation: 20,
+}, {
+format: 'snorm8x2',
+offset: 11088,
+shaderLocation: 11,
+}, {
+format: 'unorm16x4',
+offset: 11308,
+shaderLocation: 3,
+}, {
+format: 'uint16x2',
+offset: 17388,
+shaderLocation: 7,
+}, {
+format: 'uint32x4',
+offset: 23280,
+shaderLocation: 13,
+}, {
+format: 'sint8x2',
+offset: 742,
+shaderLocation: 18,
+}, {
+format: 'uint8x4',
+offset: 29404,
+shaderLocation: 8,
+}, {
+format: 'float16x2',
+offset: 17184,
+shaderLocation: 19,
+}, {
+format: 'float16x4',
+offset: 28264,
+shaderLocation: 21,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 44544,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 3072,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 1840,
+shaderLocation: 22,
+}],
+},
+{
+arrayStride: 12332,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x4',
+offset: 6640,
+shaderLocation: 12,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'none',
+},
+});
+let video22 = await videoWithData();
+let bindGroup28 = device0.createBindGroup({
+label: '\u0779\ue552\uf280\u14f4\u{1fc34}\u8c2f\u95eb\u{1f67c}\uf05f\ua491',
+layout: bindGroupLayout10,
+entries: [{
+binding: 1160,
+resource: externalTexture3
+}],
+});
+try {
+renderBundleEncoder38.drawIndexed(80);
+} catch {}
+let gpuCanvasContext23 = offscreenCanvas23.getContext('webgpu');
+let canvas24 = document.createElement('canvas');
+let shaderModule10 = device2.createShaderModule({
+code: `@group(6) @binding(3183)
+var<storage, read_write> parameter6: array<u32>;
+@group(4) @binding(2585)
+var<storage, read_write> local3: array<u32>;
+@group(8) @binding(3183)
+var<storage, read_write> function9: array<u32>;
+@group(5) @binding(2585)
+var<storage, read_write> local4: array<u32>;
+@group(8) @binding(2585)
+var<storage, read_write> global7: array<u32>;
+@group(3) @binding(3183)
+var<storage, read_write> parameter7: array<u32>;
+@group(0) @binding(2585)
+var<storage, read_write> parameter8: array<u32>;
+@group(7) @binding(3183)
+var<storage, read_write> i10: array<u32>;
+@group(4) @binding(3183)
+var<storage, read_write> global8: array<u32>;
+@group(1) @binding(2585)
+var<storage, read_write> field7: array<u32>;
+@group(2) @binding(2585)
+var<storage, read_write> global9: array<u32>;
+
+@compute @workgroup_size(7, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@location(15) a0: f32, @location(10) a1: f16, @builtin(front_facing) a2: bool, @location(6) a3: vec4<i32>, @builtin(position) a4: vec4<f32>, @location(19) a5: f32, @location(5) a6: vec2<f32>, @location(29) a7: vec4<u32>, @location(13) a8: vec2<i32>, @location(28) a9: u32, @location(21) a10: vec2<u32>) -> @builtin(frag_depth) f32 {
+return f32();
+}
+
+struct S9 {
+  @location(1) f0: vec2<u32>,
+  @location(13) f1: vec2<f16>,
+  @location(8) f2: vec2<f32>,
+  @location(3) f3: vec2<f32>
+}
+struct VertexOutput0 {
+  @location(8) f134: f32,
+  @location(16) f135: vec2<f16>,
+  @location(1) f136: f16,
+  @location(12) f137: vec2<u32>,
+  @location(7) f138: vec3<i32>,
+  @location(0) f139: vec2<f32>,
+  @location(19) f140: f32,
+  @location(24) f141: f32,
+  @location(21) f142: vec2<u32>,
+  @location(23) f143: vec2<u32>,
+  @location(3) f144: vec2<f32>,
+  @location(9) f145: vec4<u32>,
+  @location(29) f146: vec4<u32>,
+  @location(4) f147: vec4<f32>,
+  @location(5) f148: vec2<f32>,
+  @location(2) f149: vec2<u32>,
+  @location(22) f150: u32,
+  @location(18) f151: f32,
+  @location(13) f152: vec2<i32>,
+  @location(27) f153: vec3<u32>,
+  @location(10) f154: f16,
+  @builtin(position) f155: vec4<f32>,
+  @location(31) f156: u32,
+  @location(15) f157: f32,
+  @location(20) f158: vec2<u32>,
+  @location(28) f159: u32,
+  @location(6) f160: vec4<i32>,
+  @location(32) f161: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(18) a0: vec2<i32>, @location(9) a1: u32, @location(7) a2: vec4<i32>, @location(16) a3: vec4<f16>, @location(25) a4: i32, @builtin(instance_index) a5: u32, @location(20) a6: i32, @location(19) a7: f16, @location(5) a8: vec4<f16>, @location(23) a9: i32, @location(22) a10: vec3<f16>, @location(10) a11: u32, @location(6) a12: vec2<f32>, @location(2) a13: vec4<f32>, @location(14) a14: vec3<u32>, @location(4) a15: vec4<f32>, @location(26) a16: vec2<f32>, a17: S9, @location(17) a18: vec4<u32>, @location(12) a19: u32, @location(11) a20: vec4<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroupLayout36 = device2.createBindGroupLayout({
+label: '\ucf81\u{1ffde}\u8a05\u0018\u469d\u0308',
+entries: [{
+binding: 3191,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+}],
+});
+let sampler64 = device2.createSampler({
+label: '\uf70d\ua014\ub38c\u0079\u002d\u7574',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 27.697,
+lodMaxClamp: 50.805,
+});
+try {
+computePassEncoder40.setBindGroup(7, bindGroup25, new Uint32Array(7313), 4292, 0);
+} catch {}
+try {
+renderBundleEncoder59.setPipeline(pipeline62);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+try {
+commandEncoder48.copyTextureToBuffer({
+  texture: texture49,
+  mipLevel: 0,
+  origin: { x: 17, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 1496 widthInBlocks: 187 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 28304 */
+offset: 26808,
+buffer: buffer19,
+}, {width: 187, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer19);
+} catch {}
+let renderBundle71 = renderBundleEncoder49.finish();
+let sampler65 = device5.createSampler({
+label: '\uddc5\u{1f90f}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 14.636,
+lodMaxClamp: 20.518,
+maxAnisotropy: 5,
+});
+try {
+renderBundleEncoder65.setBindGroup(0, bindGroup19);
+} catch {}
+let bindGroupLayout37 = device7.createBindGroupLayout({
+label: '\u0166\u06e0\u{1f616}',
+entries: [{
+binding: 3038,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 3660,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 4730,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '3d' },
+}],
+});
+let textureView70 = texture93.createView({label: '\u0e6c\u{1fdc2}'});
+try {
+device7.queue.writeTexture({
+  texture: texture93,
+  mipLevel: 0,
+  origin: { x: 16, y: 19, z: 0 },
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer1), /* required buffer size: 6392 */
+{offset: 712, bytesPerRow: 813}, {width: 802, height: 7, depthOrArrayLayers: 1});
+} catch {}
+let renderBundleEncoder66 = device6.createRenderBundleEncoder({
+  label: '\u{1fddf}\u076a\u4281\ue464\ua89d\u6e49\u02dc',
+  colorFormats: ['rg16uint', 'rgba8sint', 'rgb10a2uint', 'rg8sint', 'rgba32sint'],
+  depthReadOnly: true
+});
+let canvas25 = document.createElement('canvas');
+try {
+canvas24.getContext('bitmaprenderer');
+} catch {}
+let texture98 = device5.createTexture({
+label: '\u8903\ufb56\u0eac\u0e53',
+size: {width: 120, height: 128, depthOrArrayLayers: 224},
+mipLevelCount: 8,
+format: 'etc2-rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let promise43 = device5.popErrorScope();
+let imageBitmap17 = await createImageBitmap(imageBitmap13);
+try {
+canvas25.getContext('webgl');
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let buffer30 = device6.createBuffer({
+  label: '\u378b\uf8fe\u368d\u033b\uaeed\u6704\u{1fe4e}\ua3f7',
+  size: 607,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX
+});
+let renderBundleEncoder67 = device6.createRenderBundleEncoder({
+  label: '\u{1f95b}\ua534\u8c23\u{1f9e8}\u0016\ue081\u0341\u01fe',
+  colorFormats: ['rg16uint', 'rgba8sint', 'rgb10a2uint', 'rg8sint', 'rgba32sint'],
+  stencilReadOnly: true
+});
+let renderBundle72 = renderBundleEncoder54.finish({label: '\uece1\ueccb\u0ece\u{1ff0e}\u{1ff4b}\u56b0'});
+try {
+commandEncoder61.copyBufferToTexture({
+/* bytesInLastRow: 54 widthInBlocks: 27 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 2940 */
+offset: 2886,
+buffer: buffer25,
+}, {
+  texture: texture86,
+  mipLevel: 0,
+  origin: { x: 1151, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 27, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device6, buffer25);
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: { x: 478, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 1413 */
+{offset: 201, rowsPerImage: 112}, {width: 606, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device6.queue.writeBuffer(buffer30, 604, new Int16Array(31699), 28288, 0);
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: { x: 1226, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 208 */
+{offset: 208, bytesPerRow: 997, rowsPerImage: 29}, {width: 364, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture99 = device5.createTexture({
+label: '\u{1f8f0}\u1cf0\u040d\u86c7',
+size: {width: 60, height: 64, depthOrArrayLayers: 1858},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rgb9e5ufloat',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgb9e5ufloat', 'rgb9e5ufloat', 'rgb9e5ufloat'],
+});
+let textureView71 = texture82.createView({label: '\u{1f8b2}\u87c6\u2b80\u46fa\u{1f7e6}', dimension: '2d'});
+let computePassEncoder48 = commandEncoder60.beginComputePass({});
+try {
+renderBundleEncoder62.setIndexBuffer(buffer20, 'uint32', 29824, 2398);
+} catch {}
+try {
+computePassEncoder31.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let imageData26 = new ImageData(196, 164);
+document.body.prepend(img7);
+try {
+  await promise42;
+} catch {}
+let buffer31 = device6.createBuffer({
+  label: '\u{1f82e}\u{1f73e}\uf195\u1fd9\u0553\u0853\u436b\u843d\u{1f778}',
+  size: 35072,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let sampler66 = device6.createSampler({
+label: '\u7ab3\u0384\u9832\u{1f923}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 33.340,
+lodMaxClamp: 90.123,
+});
+try {
+device6.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: { x: 171, y: 1, z: 0 },
+  aspect: 'all',
+}, new Int16Array(arrayBuffer0), /* required buffer size: 483 */
+{offset: 483}, {width: 1037, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder65 = device0.createCommandEncoder({});
+let renderBundle73 = renderBundleEncoder3.finish({label: '\u{1f86d}\u0355\u4e94\u02c3\u5cd8'});
+try {
+renderBundleEncoder24.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder38.draw(56, 64);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+commandEncoder65.clearBuffer(buffer23, 48056, 1696);
+dissociateBuffer(device0, buffer23);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 32160, new BigUint64Array(60933), 23380, 1180);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 311 */
+{offset: 311}, {width: 10, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise40;
+} catch {}
+let shaderModule11 = device0.createShaderModule({
+code: `@group(2) @binding(1160)
+var<storage, read_write> i11: array<u32>;
+@group(0) @binding(1160)
+var<storage, read_write> local5: array<u32>;
+
+@compute @workgroup_size(2, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<f32>,
+  @builtin(frag_depth) f1: f32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S10 {
+  @location(9) f0: vec4<u32>,
+  @location(4) f1: u32,
+  @location(8) f2: vec4<i32>,
+  @location(15) f3: vec4<f32>,
+  @location(1) f4: i32
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec4<f16>, a1: S10, @location(12) a2: vec2<u32>, @location(2) a3: vec2<f16>, @builtin(instance_index) a4: u32, @location(11) a5: vec4<i32>, @location(7) a6: vec2<f32>, @location(5) a7: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+pseudoSubmit(device0, commandEncoder17);
+let renderBundleEncoder68 = device0.createRenderBundleEncoder({
+  label: '\u293f\u8b17\ue090\u872f\u2dfe\u2ed8\uab56\u05a4\u0926\u729a',
+  colorFormats: ['r16sint', 'r8uint', 'rg16uint', 'r8uint', 'rg32sint', 'r8unorm'],
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder5.setPipeline(pipeline38);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup3, new Uint32Array(7536), 2723, 0);
+} catch {}
+try {
+renderBundleEncoder38.draw(80, 16, 32, 16);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexedIndirect(buffer3, 37020);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(7, buffer1);
+} catch {}
+try {
+gpuCanvasContext21.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData20,
+  origin: { x: 77, y: 118 },
+  flipY: true,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline63 = device0.createRenderPipeline({
+label: '\u34e5\u08ab\uc659\u960f\u87be\uc0a2\ud4fe\ub3bf\u08ec\u0ba7\u{1f9e5}',
+layout: pipelineLayout2,
+multisample: {
+count: 4,
+mask: 0x91891456,
+},
+fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'one-minus-src'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, undefined]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'not-equal',
+depthFailOp: 'keep',
+},
+stencilReadMask: 1637,
+depthBiasSlopeScale: 72,
+depthBiasClamp: 94,
+},
+vertex: {
+  module: shaderModule11,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 12736,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 10904,
+shaderLocation: 2,
+}, {
+format: 'unorm8x4',
+offset: 9796,
+shaderLocation: 7,
+}, {
+format: 'uint8x4',
+offset: 9652,
+shaderLocation: 12,
+}, {
+format: 'uint32x3',
+offset: 1288,
+shaderLocation: 4,
+}, {
+format: 'snorm8x2',
+offset: 11102,
+shaderLocation: 15,
+}, {
+format: 'sint16x2',
+offset: 10776,
+shaderLocation: 5,
+}, {
+format: 'sint16x4',
+offset: 1036,
+shaderLocation: 11,
+}, {
+format: 'uint8x4',
+offset: 12112,
+shaderLocation: 9,
+}, {
+format: 'sint32x4',
+offset: 3272,
+shaderLocation: 1,
+}, {
+format: 'unorm10-10-10-2',
+offset: 6256,
+shaderLocation: 10,
+}, {
+format: 'sint32',
+offset: 6940,
+shaderLocation: 8,
+}],
+}
+]
+},
+});
+let promise44 = adapter8.requestAdapterInfo();
+let sampler67 = device5.createSampler({
+label: '\u3756\u1c14\u092e\uec1c',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+lodMinClamp: 68.196,
+lodMaxClamp: 71.694,
+});
+try {
+renderBundleEncoder65.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+device5.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video7,
+  origin: { x: 10, y: 4 },
+  flipY: false,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let offscreenCanvas26 = new OffscreenCanvas(706, 510);
+try {
+renderBundleEncoder38.drawIndexedIndirect(buffer3, 43872);
+} catch {}
+try {
+renderBundleEncoder38.drawIndirect(buffer3, 25984);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device0,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer23, 36644, new DataView(new ArrayBuffer(14897)), 1454, 8100);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame20 = new VideoFrame(videoFrame1, {timestamp: 0});
+try {
+  await promise38;
+} catch {}
+video10.height = 139;
+let commandEncoder66 = device7.createCommandEncoder({label: '\uc083\u5d91\uf5e3\u08dd\uf9dd'});
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+try {
+  await promise44;
+} catch {}
+document.body.prepend(video1);
+video10.height = 50;
+let offscreenCanvas27 = new OffscreenCanvas(653, 301);
+let offscreenCanvas28 = new OffscreenCanvas(830, 934);
+try {
+  await promise43;
+} catch {}
+let bindGroup29 = device5.createBindGroup({
+label: '\u0463\u0488\u0371\ua22d\ucc33\u{1f9b8}\u7dab\u{1fa5d}\u4487',
+layout: bindGroupLayout24,
+entries: [],
+});
+let querySet49 = device5.createQuerySet({
+type: 'occlusion',
+count: 3037,
+});
+let renderBundleEncoder69 = device5.createRenderBundleEncoder({
+  label: '\u0d80\ubec1\ua148\u03b1\u06dc\u{1fd01}',
+  colorFormats: ['bgra8unorm', 'rg32sint', 'rgb10a2uint', 'rg16sint', 'r16float'],
+  stencilReadOnly: false
+});
+try {
+renderBundleEncoder69.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+gpuCanvasContext15.configure({
+device: device5,
+format: 'rgba16float',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['rgba16float', 'rgba16float', 'astc-4x4-unorm'],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+video8.height = 76;
+let renderBundleEncoder70 = device6.createRenderBundleEncoder({
+  label: '\u2b7b\u5941\u599a',
+  colorFormats: ['rg16uint', 'rgba8sint', 'rgb10a2uint', 'rg8sint', 'rgba32sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+buffer25.unmap();
+} catch {}
+try {
+commandEncoder61.clearBuffer(buffer30, 572, 4);
+dissociateBuffer(device6, buffer30);
+} catch {}
+let gpuCanvasContext24 = offscreenCanvas28.getContext('webgpu');
+let shaderModule12 = device0.createShaderModule({
+label: '\u{1fc71}\u44d0\u951b\u06c7\ua4f7',
+code: `@group(0) @binding(1160)
+var<storage, read_write> field8: array<u32>;
+
+@compute @workgroup_size(2, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S12 {
+  @location(28) f0: f16
+}
+struct FragmentOutput0 {
+  @location(5) f0: vec4<i32>,
+  @location(1) f1: vec4<i32>,
+  @location(4) f2: vec4<u32>,
+  @location(2) f3: vec2<i32>,
+  @location(3) f4: vec4<f32>,
+  @location(0) f5: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @location(71) a1: u32, @location(106) a2: vec2<u32>, @location(110) a3: vec2<f32>, @builtin(position) a4: vec4<f32>, @location(37) a5: vec2<f32>, @location(42) a6: vec2<i32>, @location(33) a7: vec3<f32>, @location(93) a8: vec3<f32>, @location(102) a9: vec3<i32>, @location(29) a10: vec2<i32>, @builtin(sample_index) a11: u32, @location(77) a12: u32, @location(39) a13: vec2<u32>, @location(101) a14: vec3<f32>, @location(48) a15: vec3<u32>, @location(50) a16: vec4<f32>, @location(10) a17: f16, @location(84) a18: f32, @location(66) a19: vec3<u32>, @location(100) a20: vec3<f32>, @location(109) a21: vec2<f32>, a22: S12, @builtin(sample_mask) a23: u32, @location(85) a24: vec2<i32>, @location(91) a25: vec2<f32>, @location(55) a26: vec2<u32>, @location(103) a27: vec3<u32>, @location(18) a28: vec4<u32>, @location(58) a29: f32, @location(87) a30: vec2<f32>, @location(89) a31: f16) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S11 {
+  @location(12) f0: vec3<i32>,
+  @location(3) f1: vec3<f32>,
+  @location(5) f2: vec3<i32>,
+  @location(9) f3: vec3<i32>,
+  @builtin(vertex_index) f4: u32,
+  @location(15) f5: vec4<i32>,
+  @location(6) f6: vec4<f16>,
+  @location(8) f7: vec3<f16>,
+  @location(0) f8: i32,
+  @location(10) f9: vec3<u32>,
+  @location(14) f10: vec2<u32>,
+  @location(2) f11: vec2<f32>,
+  @location(4) f12: vec2<i32>,
+  @location(1) f13: f16,
+  @location(11) f14: vec2<f16>
+}
+struct VertexOutput0 {
+  @location(103) f162: vec3<u32>,
+  @location(101) f163: vec3<f32>,
+  @location(29) f164: vec2<i32>,
+  @location(39) f165: vec2<u32>,
+  @location(93) f166: vec3<f32>,
+  @builtin(position) f167: vec4<f32>,
+  @location(37) f168: vec2<f32>,
+  @location(109) f169: vec2<f32>,
+  @location(48) f170: vec3<u32>,
+  @location(100) f171: vec3<f32>,
+  @location(85) f172: vec2<i32>,
+  @location(18) f173: vec4<u32>,
+  @location(42) f174: vec2<i32>,
+  @location(66) f175: vec3<u32>,
+  @location(84) f176: f32,
+  @location(55) f177: vec2<u32>,
+  @location(102) f178: vec3<i32>,
+  @location(3) f179: vec2<f32>,
+  @location(106) f180: vec2<u32>,
+  @location(110) f181: vec2<f32>,
+  @location(89) f182: f16,
+  @location(91) f183: vec2<f32>,
+  @location(33) f184: vec3<f32>,
+  @location(87) f185: vec2<f32>,
+  @location(58) f186: f32,
+  @location(71) f187: u32,
+  @location(28) f188: f16,
+  @location(77) f189: u32,
+  @location(10) f190: f16,
+  @location(50) f191: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec2<f16>, @location(13) a1: vec2<f16>, a2: S11, @builtin(instance_index) a3: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+try {
+renderBundleEncoder38.draw(72, 64, 8, 0);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexedIndirect(buffer3, 19200);
+} catch {}
+try {
+renderBundleEncoder38.drawIndirect(buffer3, 33500);
+} catch {}
+try {
+commandEncoder65.resolveQuerySet(querySet13, 3097, 32, buffer24, 0);
+} catch {}
+let buffer32 = device0.createBuffer({
+  label: '\u{1f868}\u7e37\u{1fbda}\ua21d\ubd7f\u04df\u{1fc1b}\u0f43\u{1fea6}\u0b69\u0ee9',
+  size: 2993,
+  usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX
+});
+let textureView72 = texture23.createView({
+  label: '\u0745\u63ba\ue5dd\u8387\u{1f9f8}\u638e\u0be9\ucdbe\u0883',
+  dimension: '2d-array',
+  arrayLayerCount: 1
+});
+let renderBundleEncoder71 = device0.createRenderBundleEncoder({
+  label: '\u64e4\u0f03',
+  colorFormats: ['r16float', 'rgba32float', 'rgba32uint', 'rgba8unorm', undefined, 'rgba16float'],
+  sampleCount: 1,
+  stencilReadOnly: false
+});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder20.setBindGroup(1, bindGroup28, new Uint32Array(7181), 1126, 0);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline43);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexed(8, 40, 48, 752, 64);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexedIndirect(buffer3, 31720);
+} catch {}
+try {
+renderBundleEncoder61.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder65.copyTextureToTexture({
+  texture: texture60,
+  mipLevel: 3,
+  origin: { x: 308, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 736, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 427, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap5,
+  origin: { x: 306, y: 185 },
+  flipY: true,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: { x: 1, y: 1, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline64 = await device0.createComputePipelineAsync({
+layout: pipelineLayout3,
+compute: {
+module: shaderModule5,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+document.body.prepend(canvas4);
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+let device8 = await adapter10.requestDevice({
+label: '\ue87b\u024b\uda31',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+});
+let texture100 = device6.createTexture({
+label: '\u{1febf}\u8d6f\u4aec\u{1fb8e}\u5b1a',
+size: {width: 230, height: 1, depthOrArrayLayers: 35},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'rg11b10ufloat',
+usage: GPUTextureUsage.COPY_DST,
+});
+try {
+commandEncoder61.clearBuffer(buffer30, 60, 220);
+dissociateBuffer(device6, buffer30);
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: { x: 837, y: 0, z: 1 },
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer1), /* required buffer size: 570 */
+{offset: 570}, {width: 305, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame21 = new VideoFrame(offscreenCanvas6, {timestamp: 0});
+let commandBuffer14 = commandEncoder59.finish({
+label: '\u273b\u096c\u7838\u0c42\u09e8\u{1f6fc}\u{1fbd8}\u8da1\u3046',
+});
+let renderBundle74 = renderBundleEncoder63.finish({label: '\u316e\u39e1\u8e61\u{1fb8d}\u6ba6\u3ca9'});
+try {
+renderBundleEncoder64.setVertexBuffer(78, undefined, 1825097912, 2152477113);
+} catch {}
+let querySet50 = device2.createQuerySet({
+label: '\ua6a4\u95d1\u92d7\u{1f6c3}',
+type: 'occlusion',
+count: 2735,
+});
+let texture101 = gpuCanvasContext15.getCurrentTexture();
+let textureView73 = texture95.createView({label: '\uaa00\u55fd\u{1f85e}', baseMipLevel: 0, mipLevelCount: 8});
+try {
+renderBundleEncoder59.draw(72, 64, 48, 80);
+} catch {}
+try {
+renderBundleEncoder59.setPipeline(pipeline62);
+} catch {}
+try {
+commandEncoder48.copyBufferToBuffer(buffer18, 25404, buffer19, 38628, 16);
+dissociateBuffer(device2, buffer18);
+dissociateBuffer(device2, buffer19);
+} catch {}
+try {
+commandEncoder48.resolveQuerySet(querySet39, 111, 105, buffer19, 6912);
+} catch {}
+try {
+commandEncoder48.insertDebugMarker('\u0b16');
+} catch {}
+let canvas26 = document.createElement('canvas');
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+try {
+device3.label = '\u881b\u{1fc19}\u9817\u653a';
+} catch {}
+let gpuCanvasContext25 = offscreenCanvas27.getContext('webgpu');
+pseudoSubmit(device5, commandEncoder51);
+let texture102 = device5.createTexture({
+size: {width: 1410, height: 1, depthOrArrayLayers: 256},
+mipLevelCount: 10,
+format: 'depth32float-stencil8',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth32float-stencil8'],
+});
+let computePassEncoder49 = commandEncoder63.beginComputePass({label: '\u0d00\u{1feaf}\u0571\ua8b0\u6b0b\u5817\u779e'});
+try {
+renderBundleEncoder55.setBindGroup(5, bindGroup23);
+} catch {}
+let gpuCanvasContext26 = offscreenCanvas26.getContext('webgpu');
+let buffer33 = device7.createBuffer({
+  label: '\u0b49\u085a\u1d03\u02a0\u05b2\u3d09',
+  size: 10874,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let commandEncoder67 = device7.createCommandEncoder({label: '\uef53\ud8b7\u06f6\u44e8\u0c1d\u9b41\u0c9b\uf66a\u0288'});
+let promise45 = buffer33.mapAsync(GPUMapMode.READ, 10640, 196);
+try {
+commandEncoder66.resolveQuerySet(querySet48, 966, 268, buffer26, 8448);
+} catch {}
+let commandEncoder68 = device5.createCommandEncoder({});
+let textureView74 = texture90.createView({
+  label: '\u0666\uffd1\u{1f7cc}\u{1f969}\u0b58',
+  aspect: 'depth-only',
+  baseMipLevel: 7,
+  baseArrayLayer: 35,
+  arrayLayerCount: 3
+});
+let computePassEncoder50 = commandEncoder53.beginComputePass();
+try {
+renderBundleEncoder55.setBindGroup(1, bindGroup26, new Uint32Array(5103), 3355, 0);
+} catch {}
+let arrayBuffer9 = buffer28.getMappedRange(22152, 5608);
+try {
+commandEncoder68.copyTextureToTexture({
+  texture: texture84,
+  mipLevel: 4,
+  origin: { x: 43, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture84,
+  mipLevel: 7,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let textureView75 = texture34.createView({label: '\u{1f69c}\u0d8d', mipLevelCount: 1, baseArrayLayer: 59, arrayLayerCount: 67});
+try {
+commandEncoder32.copyBufferToBuffer(buffer11, 4292, buffer9, 12196, 296);
+dissociateBuffer(device1, buffer11);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+  await promise45;
+} catch {}
+try {
+canvas26.getContext('webgl2');
+} catch {}
+let querySet51 = device0.createQuerySet({
+label: '\u{1fcab}\u{1f879}\u03de\ufed3\u0d0c\uf5f2\u0af1',
+type: 'occlusion',
+count: 2954,
+});
+let sampler68 = device0.createSampler({
+label: '\u09e5\u04fc\ud673\uce86',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 15.293,
+lodMaxClamp: 84.635,
+maxAnisotropy: 19,
+});
+try {
+renderBundleEncoder61.drawIndexed(56, 40, 48, 40, 8);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(1, buffer1, 17820, 171);
+} catch {}
+try {
+commandEncoder65.copyBufferToBuffer(buffer16, 888, buffer12, 15856, 1796);
+dissociateBuffer(device0, buffer16);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder65.resolveQuerySet(querySet6, 2113, 333, buffer12, 4608);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 35060, new Float32Array(50280), 49822, 188);
+} catch {}
+let texture103 = device5.createTexture({
+label: '\u5bbc\u{1feb9}\uaa98\u0357\u0204\u{1fafc}\ud383\u06f9\ue2e5\u{1f87d}\u047f',
+size: {width: 120, height: 128, depthOrArrayLayers: 122},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'r16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['r16float', 'r16float'],
+});
+let computePassEncoder51 = commandEncoder68.beginComputePass({label: '\ufc53\u{1fb70}\ua70a'});
+let arrayBuffer10 = buffer28.getMappedRange(34688, 284);
+try {
+device5.destroy();
+} catch {}
+let video23 = await videoWithData();
+let commandEncoder69 = device3.createCommandEncoder({label: '\u{1f7dd}\ufcbd\u0841'});
+let commandBuffer15 = commandEncoder69.finish({
+label: '\uf74b\ue5f7\u0a38\u0b28\uc884\u49f6\u78d5',
+});
+let textureView76 = texture52.createView({
+  label: '\u{1fcb1}\u05b1\u989e\u2ad8\u10d1\ub827\u01d2\u2059',
+  baseMipLevel: 2,
+  mipLevelCount: 2,
+  baseArrayLayer: 17,
+  arrayLayerCount: 14
+});
+let sampler69 = device3.createSampler({
+label: '\u{1faa4}\u1bdf',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+lodMaxClamp: 97.454,
+});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let canvas27 = document.createElement('canvas');
+let videoFrame22 = new VideoFrame(img17, {timestamp: 0});
+let texture104 = device8.createTexture({
+label: '\u050e\u{1fb53}',
+size: [110, 230, 210],
+mipLevelCount: 2,
+format: 'astc-10x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let pipelineLayout17 = device0.createPipelineLayout({label: '\ue73b\u061d\u7d72\u7a42\u1e3e', bindGroupLayouts: [bindGroupLayout2]});
+try {
+renderBundleEncoder61.drawIndexedIndirect(buffer3, 13972);
+} catch {}
+let arrayBuffer11 = buffer27.getMappedRange(8424, 9068);
+try {
+commandEncoder65.copyBufferToTexture({
+/* bytesInLastRow: 96 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 12272 */
+offset: 12272,
+buffer: buffer1,
+}, {
+  texture: texture40,
+  mipLevel: 0,
+  origin: { x: 0, y: 72, z: 0 },
+  aspect: 'all',
+}, {width: 72, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder65.clearBuffer(buffer24, 264, 8);
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+renderBundleEncoder40.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 588, height: 1, depthOrArrayLayers: 235}
+*/
+{
+  source: img4,
+  origin: { x: 4, y: 167 },
+  flipY: true,
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: { x: 328, y: 0, z: 182 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 154, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let imageData27 = new ImageData(100, 232);
+let textureView77 = texture100.createView({label: '\u0fb3\u8747\uce8b\u{1f9c2}\u7c3a', aspect: 'all', mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder52 = commandEncoder61.beginComputePass({label: '\u9f6e\u635b\u08de\u{1f8ec}\u6f1f\uae20\u9cad'});
+let sampler70 = device6.createSampler({
+label: '\u017e\ud1f0\uef6b\u0e7d\ue799\u03e0\uf020\u0d12\u0ff3\u{1fa4a}\u{1fce9}',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 19.636,
+lodMaxClamp: 57.288,
+});
+try {
+renderBundleEncoder70.setVertexBuffer(0, buffer30, 516, 89);
+} catch {}
+try {
+device6.queue.writeBuffer(buffer30, 432, new Int16Array(33539), 1348, 24);
+} catch {}
+let querySet52 = device0.createQuerySet({
+label: '\ufdd3\ue191\u4a5e\uc2db\u{1fec2}',
+type: 'occlusion',
+count: 2111,
+});
+let renderBundle75 = renderBundleEncoder13.finish({label: '\u{1f9a8}\u1ab3\u03fd\u{1fa85}\u89b7\u{1fc3c}\u{1fea0}'});
+try {
+renderBundleEncoder61.drawIndirect(buffer3, 26900);
+} catch {}
+let imageBitmap18 = await createImageBitmap(imageData15);
+let querySet53 = device8.createQuerySet({
+label: '\u7dac\u40cb\u0006\u{1f9b5}\u{1fc76}\u251c\u{1ff2d}',
+type: 'occlusion',
+count: 3623,
+});
+let renderBundleEncoder72 = device8.createRenderBundleEncoder({
+  label: '\u{1f6eb}\u0900\u6520\u95c9\ub550\u4c3c\uaa07\u28d6\ua32d\u64d8\u{1fd97}',
+  colorFormats: ['rg8sint', 'bgra8unorm-srgb', 'r16sint', 'r8uint', 'rgb10a2unorm', 'rg32uint'],
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder72.setVertexBuffer(99, undefined, 2175118546, 576717748);
+} catch {}
+try {
+gpuCanvasContext22.configure({
+device: device8,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['eac-r11unorm', 'rgba8unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let promise46 = device8.queue.onSubmittedWorkDone();
+let gpuCanvasContext27 = canvas27.getContext('webgpu');
+try {
+  await promise46;
+} catch {}
+let bindGroupLayout38 = device8.createBindGroupLayout({
+label: '\u64bb\u{1fe79}\u{1fdfd}\uc8ed\u0d4a\u{1f8a3}\u02dd\u09d6\u{1faae}\u058d\u{1ff28}',
+entries: [{
+binding: 442,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+}, {
+binding: 232,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+}],
+});
+try {
+device8.queue.writeTexture({
+  texture: texture104,
+  mipLevel: 0,
+  origin: { x: 50, y: 40, z: 122 },
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer5), /* required buffer size: 44441 */
+{offset: 313, bytesPerRow: 232, rowsPerImage: 22}, {width: 30, height: 150, depthOrArrayLayers: 9});
+} catch {}
+let querySet54 = device2.createQuerySet({
+label: '\u01a1\u5a11\ufdbd',
+type: 'occlusion',
+count: 2501,
+});
+let commandBuffer16 = commandEncoder49.finish({
+label: '\u0259\u0931\u6e3c\u0dbf\u00ce',
+});
+let texture105 = device2.createTexture({
+size: {width: 1520, height: 1, depthOrArrayLayers: 118},
+mipLevelCount: 11,
+dimension: '3d',
+format: 'rg32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder53 = commandEncoder56.beginComputePass({label: '\u0ab0\u{1f913}\u{1f7c6}\u{1ffc1}\u04c8\u02bc\u{1ff1f}\ub040\u941c\ubdd5'});
+let renderBundleEncoder73 = device2.createRenderBundleEncoder({
+  label: '\u{1fdbe}\u686e\u5cdc',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder59.draw(40, 40, 0, 32);
+} catch {}
+try {
+renderBundleEncoder59.drawIndexed(48);
+} catch {}
+try {
+commandEncoder48.resolveQuerySet(querySet50, 1482, 1193, buffer19, 41984);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture77,
+  mipLevel: 2,
+  origin: { x: 4, y: 0, z: 15 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 2415357 */
+{offset: 841, bytesPerRow: 656, rowsPerImage: 184}, {width: 109, height: 1, depthOrArrayLayers: 21});
+} catch {}
+let textureView78 = texture85.createView({dimension: '2d-array', mipLevelCount: 1});
+let renderBundleEncoder74 = device6.createRenderBundleEncoder({
+  label: '\u{1fd6e}\ua9f7\u152e\u48ae\u973a\u056d\u{1f828}\u{1f83e}',
+  colorFormats: ['rg16uint', 'rgba8sint', 'rgb10a2uint', 'rg8sint', 'rgba32sint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder66.setVertexBuffer(5, buffer30, 348, 176);
+} catch {}
+try {
+gpuCanvasContext12.configure({
+device: device6,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8unorm', 'r16uint', 'rg16float'],
+alphaMode: 'premultiplied',
+});
+} catch {}
+let renderBundleEncoder75 = device0.createRenderBundleEncoder({
+  label: '\u0e17\u0703',
+  colorFormats: ['r8uint', undefined, 'rg16sint', 'r8uint', 'rg8sint', 'rgba8unorm', 'r8sint', 'r16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle76 = renderBundleEncoder3.finish({label: '\u0853\u53ce\u{1f984}'});
+try {
+renderBundleEncoder61.draw(72);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexed(0, 80);
+} catch {}
+document.body.prepend(img13);
+let pipelineLayout18 = device7.createPipelineLayout({
+  label: '\u05ad\u452e\u{1ff27}\u{1f627}\ud1fa\u3eb9',
+  bindGroupLayouts: [bindGroupLayout37, bindGroupLayout37]
+});
+try {
+commandEncoder67.resolveQuerySet(querySet47, 79, 217, buffer26, 9984);
+} catch {}
+let querySet55 = device6.createQuerySet({
+label: '\ued1a\u27c3\u072f',
+type: 'occlusion',
+count: 2105,
+});
+try {
+renderBundleEncoder74.setVertexBuffer(2, buffer30, 452, 108);
+} catch {}
+gc();
+let img20 = await imageWithData(190, 17, '#0e3aa195', '#10e55785');
+let imageData28 = new ImageData(88, 256);
+let computePassEncoder54 = commandEncoder65.beginComputePass();
+let renderBundle77 = renderBundleEncoder68.finish({});
+try {
+computePassEncoder54.setBindGroup(3, bindGroup2, new Uint32Array(9402), 1612, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let pipeline65 = await device0.createRenderPipelineAsync({
+label: '\u03e8\u0a44',
+layout: pipelineLayout2,
+fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgba32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rgba8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, undefined, {format: 'rgba16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less',
+stencilFront: {
+compare: 'less',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilWriteMask: 467,
+depthBias: 60,
+depthBiasSlopeScale: 3,
+depthBiasClamp: 59,
+},
+vertex: {
+  module: shaderModule4,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 7188,
+attributes: [{
+format: 'snorm16x4',
+offset: 5320,
+shaderLocation: 11,
+}, {
+format: 'float32x4',
+offset: 5440,
+shaderLocation: 7,
+}, {
+format: 'uint16x4',
+offset: 1656,
+shaderLocation: 8,
+}, {
+format: 'uint32',
+offset: 3180,
+shaderLocation: 13,
+}, {
+format: 'snorm8x2',
+offset: 3696,
+shaderLocation: 12,
+}, {
+format: 'uint8x4',
+offset: 632,
+shaderLocation: 0,
+}, {
+format: 'sint32x4',
+offset: 608,
+shaderLocation: 14,
+}, {
+format: 'uint32x4',
+offset: 4756,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 2132,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 12944,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 11632,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 656,
+attributes: [],
+},
+{
+arrayStride: 14348,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 12584,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 13812,
+attributes: [{
+format: 'snorm8x2',
+offset: 2100,
+shaderLocation: 5,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+video3.height = 127;
+offscreenCanvas15.height = 276;
+let texture106 = device6.createTexture({
+label: '\u4550\uc3c7\u{1fe9c}\u6ca2\u{1fda6}\ubf85',
+size: {width: 1455, height: 1, depthOrArrayLayers: 37},
+mipLevelCount: 10,
+dimension: '3d',
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder76 = device6.createRenderBundleEncoder({
+  label: '\u{1f6e7}\u{1f9af}\u01a4\uf607\u78f1\uaa07\ua907\u06a7',
+  colorFormats: ['rg16uint', 'rgba8sint', 'rgb10a2uint', 'rg8sint', 'rgba32sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle78 = renderBundleEncoder67.finish({label: '\u{1fe55}\u{1f700}\u{1f98b}\u{1f732}\u{1fdc5}\u{1ffb7}\uaa99\uaab0\u55f4\u5bbf'});
+try {
+await adapter2.requestAdapterInfo();
+} catch {}
+let texture107 = device2.createTexture({
+label: '\u07da\u37ca\u8b5f\u37be\ud3ce\u63f1\uc2bb\u13d2\ueccf',
+size: {width: 3040, height: 1, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'rgba8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView79 = texture48.createView({baseMipLevel: 2, mipLevelCount: 6});
+let computePassEncoder55 = commandEncoder48.beginComputePass({});
+let renderBundleEncoder77 = device2.createRenderBundleEncoder({
+  label: '\u0225\u{1f89c}\u02e4\uf836\ubae4\u599f\ud9bc\u{1fd0d}\u0d8d\u{1fa59}\uf128',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+commandEncoder64.resolveQuerySet(querySet50, 773, 1667, buffer19, 3072);
+} catch {}
+let pipeline66 = device2.createComputePipeline({
+label: '\ub9f6\u{1fa91}\uc73b\u2d98\ua58a\u{1f84c}\u8601\u{1fb91}',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule8,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+gc();
+let canvas28 = document.createElement('canvas');
+let imageBitmap19 = await createImageBitmap(videoFrame0);
+let buffer34 = device6.createBuffer({
+  label: '\ua2ae\u{1fc35}\u2925\u{1fdb7}',
+  size: 29433,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE
+});
+let texture108 = device6.createTexture({
+label: '\u3de5\u{1ff92}\u090c\u3627\u1ea4\u197c\u01be\u0102',
+size: [790, 1, 75],
+format: 'r8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8sint', 'r8sint'],
+});
+let promise47 = device6.popErrorScope();
+try {
+device6.addEventListener('uncapturederror', e => { log('device6.uncapturederror'); log(e); e.label = device6.label; });
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+try {
+  await promise47;
+} catch {}
+let querySet56 = device6.createQuerySet({
+type: 'occlusion',
+count: 2110,
+});
+let textureView80 = texture100.createView({label: '\u7e71\u2701\u{1f898}\uc456\u0f03\u0ff6', mipLevelCount: 1});
+try {
+renderBundleEncoder76.setVertexBuffer(50, undefined, 2913971006, 922986669);
+} catch {}
+let img21 = await imageWithData(109, 143, '#a36aa600', '#e75f0297');
+let video24 = await videoWithData();
+let querySet57 = device6.createQuerySet({
+label: '\u1516\u57b5\u{1fbf8}\ub26f',
+type: 'occlusion',
+count: 3281,
+});
+let sampler71 = device6.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 89.795,
+});
+try {
+  await buffer31.mapAsync(GPUMapMode.WRITE, 0, 23384);
+} catch {}
+let promise48 = device6.queue.onSubmittedWorkDone();
+let img22 = await imageWithData(152, 181, '#ec2ea400', '#36419cda');
+let commandEncoder70 = device7.createCommandEncoder({label: '\ua126\u0eac\u6580\uaa33\u{1f6ee}\ub7ca\u0794\u9062\u8767\u{1fdcf}'});
+let querySet58 = device7.createQuerySet({
+label: '\u{1f69d}\u{1f80d}\u9b80\u0596\u060e\u{1fb16}\u30db\u0756\uc700\u70c8',
+type: 'occlusion',
+count: 1762,
+});
+let sampler72 = device7.createSampler({
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+lodMinClamp: 58.358,
+lodMaxClamp: 62.559,
+compare: 'greater-equal',
+});
+try {
+commandEncoder66.clearBuffer(buffer33, 6272, 4592);
+dissociateBuffer(device7, buffer33);
+} catch {}
+let querySet59 = device2.createQuerySet({
+type: 'occlusion',
+count: 2311,
+});
+let textureView81 = texture95.createView({label: '\u19f0\u3db3\uaf8e\u{1feae}\u60ce\u0cbe', baseMipLevel: 6, mipLevelCount: 1});
+let computePassEncoder56 = commandEncoder64.beginComputePass({label: '\u088e\u7f02\ufbba\u003f\u{1ffb1}\u0d50\u2e11\u5150\u7f98\u129e\u07fb'});
+let renderBundle79 = renderBundleEncoder59.finish({label: '\uaa01\u7c1f\u54ba\uf1b2\u3018\u2da9\uefff\u{1ff80}\u087c\u{1f798}\u{1f89f}'});
+try {
+renderBundleEncoder73.setBindGroup(6, bindGroup25, new Uint32Array(3493), 880, 0);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let offscreenCanvas29 = new OffscreenCanvas(1, 557);
+let promise49 = adapter3.requestAdapterInfo();
+let texture109 = device8.createTexture({
+label: '\uf105\u41c4\u{1f970}\u{1f9ae}\ue2ea\u66a6\u0b1d\u{1f74f}\ua07b',
+size: {width: 48, height: 640, depthOrArrayLayers: 1},
+mipLevelCount: 10,
+dimension: '2d',
+format: 'etc2-rgba8unorm-srgb',
+usage: 0,
+viewFormats: ['etc2-rgba8unorm-srgb', 'etc2-rgba8unorm', 'etc2-rgba8unorm-srgb'],
+});
+let textureView82 = texture109.createView({mipLevelCount: 9});
+try {
+texture109.destroy();
+} catch {}
+try {
+device8.queue.writeTexture({
+  texture: texture104,
+  mipLevel: 0,
+  origin: { x: 10, y: 140, z: 31 },
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(80)), /* required buffer size: 3222 */
+{offset: 962, bytesPerRow: 358}, {width: 70, height: 70, depthOrArrayLayers: 1});
+} catch {}
+let textureView83 = texture93.createView({label: '\u0f43\u0a6f\u{1fc79}\uf109\uef16\u1af6\u152b\u{1fbd5}\u2600\ue51e\u{1f9c8}'});
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+offscreenCanvas21.height = 214;
+let canvas29 = document.createElement('canvas');
+let bindGroupLayout39 = device7.createBindGroupLayout({
+label: '\ue4c0\u704a\u083a\u8039',
+entries: [{
+binding: 1190,
+visibility: 0,
+sampler: { type: 'filtering' },
+}, {
+binding: 146,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '3d' },
+}],
+});
+let externalTexture4 = device7.importExternalTexture({
+source: videoFrame14,
+colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder64.setVertexBuffer(7, undefined, 2360499197, 274000500);
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture96,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 147 },
+  aspect: 'stencil-only',
+}, new BigUint64Array(arrayBuffer1), /* required buffer size: 1179243 */
+{offset: 170, bytesPerRow: 173, rowsPerImage: 235}, {width: 78, height: 1, depthOrArrayLayers: 30});
+} catch {}
+try {
+adapter1.label = '\uf993\uaec8\u005b\u02e9\u05ef\ub12b\u{1fac6}\u08a7';
+} catch {}
+let renderBundleEncoder78 = device6.createRenderBundleEncoder({colorFormats: ['rg16uint', 'rgba8sint', 'rgb10a2uint', 'rg8sint', 'rgba32sint'], stencilReadOnly: true});
+try {
+renderBundleEncoder76.setVertexBuffer(5, buffer30, 396);
+} catch {}
+offscreenCanvas12.height = 746;
+try {
+renderBundleEncoder61.drawIndexed(24, 48, 32, 112, 40);
+} catch {}
+try {
+renderBundleEncoder61.drawIndexedIndirect(buffer3, 30436);
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(7, buffer1);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let pipeline67 = await device0.createComputePipelineAsync({
+layout: pipelineLayout3,
+compute: {
+module: shaderModule12,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let renderBundleEncoder79 = device8.createRenderBundleEncoder({
+  label: '\u{1fd18}\u{1f8fe}\u0363\u{1fce5}\u0c7e',
+  colorFormats: ['rg8sint', 'bgra8unorm-srgb', 'r16sint', 'r8uint', 'rgb10a2unorm', 'rg32uint'],
+  depthReadOnly: true
+});
+try {
+gpuCanvasContext19.configure({
+device: device8,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8unorm', 'rgba16float', 'rgba16float'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device8.queue.writeTexture({
+  texture: texture104,
+  mipLevel: 1,
+  origin: { x: 30, y: 10, z: 92 },
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 126115 */
+{offset: 517, bytesPerRow: 310, rowsPerImage: 66}, {width: 30, height: 100, depthOrArrayLayers: 7});
+} catch {}
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+video23.width = 184;
+let shaderModule13 = device4.createShaderModule({
+code: `@group(2) @binding(366)
+var<storage, read_write> i12: array<u32>;
+@group(2) @binding(879)
+var<storage, read_write> parameter9: array<u32>;
+@group(0) @binding(366)
+var<storage, read_write> function10: array<u32>;
+@group(1) @binding(754)
+var<storage, read_write> i13: array<u32>;
+@group(2) @binding(754)
+var<storage, read_write> function11: array<u32>;
+@group(3) @binding(879)
+var<storage, read_write> parameter10: array<u32>;
+@group(3) @binding(366)
+var<storage, read_write> field9: array<u32>;
+@group(3) @binding(754)
+var<storage, read_write> function12: array<u32>;
+@group(0) @binding(754)
+var<storage, read_write> type4: array<u32>;
+@group(1) @binding(366)
+var<storage, read_write> global10: array<u32>;
+@group(1) @binding(879)
+var<storage, read_write> i14: array<u32>;
+@group(0) @binding(879)
+var<storage, read_write> field10: array<u32>;
+
+@compute @workgroup_size(1, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S13 {
+  @builtin(sample_index) f0: u32,
+  @builtin(front_facing) f1: bool
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<i32>,
+  @location(0) f1: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, a1: S13, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(15) a0: f16, @location(14) a1: vec4<f32>, @location(6) a2: vec3<u32>, @location(2) a3: vec2<f16>, @builtin(vertex_index) a4: u32, @location(1) a5: vec4<i32>, @location(4) a6: vec2<u32>, @location(7) a7: vec2<f32>, @location(0) a8: vec2<f32>, @location(8) a9: vec3<f32>, @location(11) a10: vec2<f32>, @location(10) a11: vec2<i32>, @location(13) a12: vec4<u32>, @location(9) a13: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let texture110 = device4.createTexture({
+label: '\u{1f76e}\u86c9\ufafc\u323a\u{1fed9}\u01bc\u4ce7\ua623',
+size: [600, 1, 148],
+mipLevelCount: 3,
+dimension: '3d',
+format: 'rg16uint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let sampler73 = device4.createSampler({
+label: '\u0e47\uc8e0\u089f\u0e58\u0905\ued18',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'linear',
+lodMaxClamp: 61.627,
+});
+try {
+device4.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 9,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'stencil-only',
+}, new Float32Array(new ArrayBuffer(0)), /* required buffer size: 664 */
+{offset: 662, rowsPerImage: 247}, {width: 2, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device4.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas13,
+  origin: { x: 166, y: 18 },
+  flipY: false,
+}, {
+  texture: texture64,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let sampler74 = device8.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMinClamp: 64.370,
+lodMaxClamp: 72.847,
+});
+let promise50 = device8.queue.onSubmittedWorkDone();
+let shaderModule14 = device0.createShaderModule({
+label: '\u0779\u91d5\u{1fc02}\u221c\ud1bf\u0cbd\ua682\u{1feb6}\uc554\u9b63\ud302',
+code: `@group(2) @binding(5397)
+var<storage, read_write> field11: array<u32>;
+@group(2) @binding(5491)
+var<storage, read_write> function13: array<u32>;
+@group(2) @binding(1495)
+var<storage, read_write> i15: array<u32>;
+@group(0) @binding(1160)
+var<storage, read_write> parameter11: array<u32>;
+
+@compute @workgroup_size(8, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S15 {
+  @builtin(position) f0: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(3) f0: vec4<i32>,
+  @location(1) f1: vec4<i32>,
+  @location(0) f2: vec2<u32>,
+  @location(2) f3: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32, a2: S15) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S14 {
+  @location(8) f0: vec2<f16>,
+  @location(14) f1: i32,
+  @location(10) f2: f32,
+  @location(7) f3: f32
+}
+
+@vertex
+fn vertex0(@location(4) a0: vec2<f32>, a1: S14, @location(12) a2: i32, @location(11) a3: vec3<i32>, @location(13) a4: vec2<f16>, @location(9) a5: vec3<i32>, @location(3) a6: i32, @location(6) a7: vec4<i32>, @location(0) a8: vec3<f32>, @builtin(instance_index) a9: u32, @location(1) a10: f16, @location(5) a11: vec2<f16>, @location(15) a12: vec4<f16>, @location(2) a13: vec2<f16>, @builtin(vertex_index) a14: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder71 = device0.createCommandEncoder({label: '\u052f\u8289\u8c86\u0ae8'});
+let commandBuffer17 = commandEncoder71.finish({
+label: '\u{1fc5d}\u{1fd4c}\u{1fbb1}\u{1fb4d}\u{1fcc4}\u2c4b\u9d9d\ud6b5\u2c17',
+});
+let renderBundleEncoder80 = device0.createRenderBundleEncoder({
+  label: '\u48d1\u08d5',
+  colorFormats: ['r16float', 'rgba32float', 'rgba32uint', 'rgba8unorm', undefined, 'rgba16float'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+commandEncoder14.resolveQuerySet(querySet19, 2758, 48, buffer27, 16896);
+} catch {}
+try {
+gpuCanvasContext19.configure({
+device: device0,
+format: 'r16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r16float'],
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.submit([
+]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 294, height: 1, depthOrArrayLayers: 117}
+*/
+{
+  source: video6,
+  origin: { x: 4, y: 0 },
+  flipY: false,
+}, {
+  texture: texture45,
+  mipLevel: 1,
+  origin: { x: 259, y: 0, z: 5 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 11, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise49;
+} catch {}
+try {
+adapter9.label = '\u{1f9d7}\u7cb0\u0527';
+} catch {}
+let buffer35 = device2.createBuffer({
+  label: '\u{1f83c}\ua1a1\u80c3\u{1faf9}\u7609\u326d\ue3ab\ubb22\u{1f886}',
+  size: 32910,
+  usage: GPUBufferUsage.VERTEX
+});
+try {
+computePassEncoder56.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder77.setBindGroup(5, bindGroup25);
+} catch {}
+let promise51 = buffer18.mapAsync(GPUMapMode.WRITE, 11000, 9560);
+try {
+device2.queue.writeTexture({
+  texture: texture48,
+  mipLevel: 2,
+  origin: { x: 66, y: 4, z: 5 },
+  aspect: 'all',
+}, arrayBuffer11, /* required buffer size: 2079731 */
+{offset: 15, bytesPerRow: 1664, rowsPerImage: 96}, {width: 345, height: 2, depthOrArrayLayers: 14});
+} catch {}
+let querySet60 = device6.createQuerySet({
+label: '\u086a\u{1ffc7}\u3e37',
+type: 'occlusion',
+count: 1183,
+});
+let texture111 = device6.createTexture({
+size: [400],
+dimension: '1d',
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView84 = texture86.createView({baseMipLevel: 0});
+let querySet61 = device0.createQuerySet({
+label: '\u037e\u08ca\ud29a\u{1fa5e}\u4752\u{1f829}\u02d3\uef2e\ub1a9',
+type: 'occlusion',
+count: 1182,
+});
+pseudoSubmit(device0, commandEncoder9);
+let renderBundle80 = renderBundleEncoder39.finish({label: '\ua60e\u0759\u17d1\u3b50'});
+try {
+renderBundleEncoder38.drawIndexed(8);
+} catch {}
+let arrayBuffer12 = buffer16.getMappedRange(2312, 1636);
+try {
+commandEncoder14.copyBufferToTexture({
+/* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 25276 */
+offset: 25276,
+buffer: buffer4,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder14.clearBuffer(buffer24, 252, 0);
+dissociateBuffer(device0, buffer24);
+} catch {}
+canvas13.height = 405;
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+window.someLabel = device8.queue.label;
+} catch {}
+let querySet62 = device8.createQuerySet({
+type: 'occlusion',
+count: 3296,
+});
+try {
+gpuCanvasContext24.configure({
+device: device8,
+format: 'rgba16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg32float', 'rgba16float', 'rgba16float', 'etc2-rgb8unorm-srgb'],
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device8.queue.writeTexture({
+  texture: texture104,
+  mipLevel: 0,
+  origin: { x: 10, y: 80, z: 45 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 108872 */
+{offset: 736, bytesPerRow: 146, rowsPerImage: 10}, {width: 60, height: 10, depthOrArrayLayers: 75});
+} catch {}
+document.body.prepend(video13);
+let offscreenCanvas30 = new OffscreenCanvas(163, 866);
+let computePassEncoder57 = commandEncoder14.beginComputePass({label: '\u6c34\u{1fc64}\u{1f791}\u0157\ucae4\u3ab4'});
+try {
+renderBundleEncoder32.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(1, buffer1, 15516, 1221);
+} catch {}
+try {
+texture35.destroy();
+} catch {}
+let textureView85 = texture108.createView({
+  label: '\u6362\ue067\ue3b1\u048d\u{1fb41}\ua26a\u8a9e\u{1ff72}\u71f6\uf805\ud2aa',
+  dimension: '2d',
+  baseArrayLayer: 41
+});
+document.body.prepend(canvas17);
+let img23 = await imageWithData(25, 79, '#7e116d13', '#6e369ad2');
+try {
+window.someLabel = renderBundle56.label;
+} catch {}
+document.body.prepend(canvas5);
+let renderBundleEncoder81 = device2.createRenderBundleEncoder({
+  label: '\u0efc\uf235\u0401\u8e2f\u01c0\u0475\u2338',
+  colorFormats: ['bgra8unorm', 'rgba8unorm-srgb', 'rg32uint', 'bgra8unorm-srgb', undefined, 'rg16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+device2.queue.submit([
+commandBuffer9,
+commandBuffer10,
+commandBuffer16,
+]);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline50);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(8, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder77.setVertexBuffer(0, buffer35, 19980, 8423);
+} catch {}
+let arrayBuffer13 = buffer17.getMappedRange(29840, 4968);
+try {
+gpuCanvasContext27.configure({
+device: device2,
+format: 'depth16unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'srgb',
+});
+} catch {}
+let buffer36 = device0.createBuffer({size: 53512, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let texture112 = device0.createTexture({
+label: '\u2eda\u0c99\u0f35\u148b\ua966\ufbb9\u88f1\u44ec\u21f1\u6e70',
+size: [80],
+dimension: '1d',
+format: 'rg16uint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [],
+});
+let sampler75 = device0.createSampler({
+label: '\ud78a\u{1ff79}\u2546\u2a41\u2cad\u{1fc09}',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMinClamp: 1.451,
+lodMaxClamp: 50.693,
+});
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+renderBundleEncoder61.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder61.draw(40, 16, 64, 24);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexed(56, 8, 8, -776, 56);
+} catch {}
+try {
+renderBundleEncoder80.setPipeline(pipeline49);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer17,
+]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 4616, new DataView(new ArrayBuffer(26542)), 11645, 5544);
+} catch {}
+let bindGroup30 = device0.createBindGroup({
+label: '\u{1fb50}\u3851\u{1f925}\u{1f698}',
+layout: bindGroupLayout2,
+entries: [],
+});
+let buffer37 = device0.createBuffer({label: '\u1f6a\u97c5\u0592\u002c\u2b02\u3322', size: 34545, usage: GPUBufferUsage.COPY_SRC});
+pseudoSubmit(device0, commandEncoder15);
+let computePassEncoder58 = commandEncoder23.beginComputePass({label: '\uc174\u0021\u9614\u{1fd38}\u4ac6'});
+try {
+renderBundleEncoder80.drawIndexedIndirect(buffer36, 11788);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer27, 'uint16', 33262, 4169);
+} catch {}
+let promise52 = buffer5.mapAsync(GPUMapMode.WRITE, 14176, 3640);
+try {
+device0.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 5,
+  origin: { x: 2, y: 2, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(11981), /* required buffer size: 11981 */
+{offset: 133, bytesPerRow: 516, rowsPerImage: 22}, {width: 31, height: 1, depthOrArrayLayers: 2});
+} catch {}
+let promise53 = device0.createRenderPipelineAsync({
+label: '\u{1fd0d}\u8f3f\u{1ff40}\u8175\u343c\uc128\ue163\uebae\u7aef\u4e41\u{1fc3b}',
+layout: pipelineLayout17,
+fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.RED
+}, {format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'rgba8unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'one-minus-src-alpha', dstFactor: 'one-minus-dst'},
+}
+}, undefined, {
+  format: 'rgba16float',
+  blend: {
+color: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'src-alpha'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'one-minus-src-alpha'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN
+}]
+},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'zero',
+depthFailOp: 'zero',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'keep',
+},
+stencilReadMask: 4064,
+stencilWriteMask: 3622,
+depthBias: 19,
+depthBiasSlopeScale: 34,
+depthBiasClamp: 67,
+},
+vertex: {
+  module: shaderModule6,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 15832,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x2',
+offset: 14360,
+shaderLocation: 0,
+}, {
+format: 'float32x4',
+offset: 8052,
+shaderLocation: 13,
+}, {
+format: 'float32',
+offset: 2840,
+shaderLocation: 10,
+}, {
+format: 'snorm16x2',
+offset: 7720,
+shaderLocation: 3,
+}, {
+format: 'uint16x2',
+offset: 6388,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 5652,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 10320,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 10408,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x3',
+offset: 1820,
+shaderLocation: 12,
+}, {
+format: 'uint32',
+offset: 3560,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 3452,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 4848,
+attributes: [],
+},
+{
+arrayStride: 14660,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 1824,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 328,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+let img24 = await imageWithData(172, 149, '#ff5bc1a0', '#5e682adc');
+let videoFrame23 = new VideoFrame(video7, {timestamp: 0});
+try {
+adapter8.label = '\u86ee\u908a\u768f\u716c';
+} catch {}
+let querySet63 = device6.createQuerySet({
+label: '\u06b2\u7422\u7791\uc8f2\u1ed6\u7da7',
+type: 'occlusion',
+count: 4060,
+});
+try {
+computePassEncoder52.end();
+} catch {}
+try {
+commandEncoder61.copyTextureToTexture({
+  texture: texture106,
+  mipLevel: 7,
+  origin: { x: 1, y: 0, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: { x: 302, y: 0, z: 17 },
+  aspect: 'all',
+}, {width: 10, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder61.resolveQuerySet(querySet57, 1716, 1564, buffer34, 12288);
+} catch {}
+try {
+device6.queue.writeBuffer(buffer30, 380, new Int16Array(57198), 36251, 52);
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: { x: 651, y: 1, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(125), /* required buffer size: 125 */
+{offset: 125}, {width: 845, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let imageBitmap20 = await createImageBitmap(video9);
+try {
+offscreenCanvas30.getContext('webgl2');
+} catch {}
+let renderBundleEncoder82 = device2.createRenderBundleEncoder({
+  label: '\u0d9d\u3c2b\u797e\u0638',
+  colorFormats: ['bgra8unorm', 'rgba8unorm-srgb', 'rg32uint', 'bgra8unorm-srgb', undefined, 'rg16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: false
+});
+try {
+renderBundleEncoder81.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture76,
+  mipLevel: 0,
+  origin: { x: 227, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 1317 */
+{offset: 885}, {width: 216, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let promise54 = device2.createComputePipelineAsync({
+layout: pipelineLayout11,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let canvas30 = document.createElement('canvas');
+let video25 = await videoWithData();
+try {
+canvas30.getContext('webgl');
+} catch {}
+let shaderModule15 = device7.createShaderModule({
+label: '\u466b\u0870\ubc76\u{1fbf7}\u27ed\u4d5c\u0c1d\u0d98\u7e1c\u35fe\u02f9',
+code: `@group(1) @binding(3038)
+var<storage, read_write> parameter12: array<u32>;
+@group(0) @binding(3038)
+var<storage, read_write> function14: array<u32>;
+@group(0) @binding(4730)
+var<storage, read_write> type5: array<u32>;
+@group(1) @binding(4730)
+var<storage, read_write> type6: array<u32>;
+@group(1) @binding(3660)
+var<storage, read_write> local6: array<u32>;
+
+@compute @workgroup_size(7, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S17 {
+  @builtin(position) f0: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec3<f32>,
+  @builtin(sample_mask) f1: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, a1: S17, @builtin(front_facing) a2: bool, @builtin(sample_mask) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S16 {
+  @location(16) f0: vec4<f32>,
+  @builtin(instance_index) f1: u32,
+  @location(17) f2: vec2<u32>,
+  @location(20) f3: i32,
+  @location(4) f4: i32
+}
+
+@vertex
+fn vertex0(a0: S16, @location(6) a1: vec3<i32>, @location(11) a2: vec2<i32>, @location(23) a3: vec2<f32>, @location(19) a4: vec3<f16>, @builtin(vertex_index) a5: u32, @location(14) a6: vec3<f32>, @location(21) a7: i32, @location(2) a8: f16, @location(0) a9: f32, @location(12) a10: vec3<i32>, @location(22) a11: vec2<f16>, @location(13) a12: u32, @location(9) a13: vec3<u32>, @location(8) a14: vec3<u32>, @location(5) a15: vec3<u32>, @location(10) a16: vec2<f16>, @location(1) a17: f32, @location(3) a18: vec4<u32>, @location(7) a19: vec3<u32>, @location(15) a20: vec2<i32>, @location(18) a21: vec2<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+try {
+renderBundleEncoder64.setVertexBuffer(9, undefined, 3850192367, 297040102);
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture93,
+  mipLevel: 0,
+  origin: { x: 415, y: 4, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(19489), /* required buffer size: 19489 */
+{offset: 753, bytesPerRow: 656}, {width: 368, height: 29, depthOrArrayLayers: 1});
+} catch {}
+let imageData29 = new ImageData(188, 216);
+let shaderModule16 = device2.createShaderModule({
+label: '\u{1ff73}\ua2ea\u3e47\u4fc3\u{1fa50}',
+code: `@group(2) @binding(3183)
+var<storage, read_write> function15: array<u32>;
+@group(8) @binding(2585)
+var<storage, read_write> parameter13: array<u32>;
+@group(7) @binding(3183)
+var<storage, read_write> local7: array<u32>;
+@group(0) @binding(3183)
+var<storage, read_write> field12: array<u32>;
+@group(1) @binding(3183)
+var<storage, read_write> field13: array<u32>;
+@group(8) @binding(3183)
+var<storage, read_write> local8: array<u32>;
+@group(4) @binding(2585)
+var<storage, read_write> i16: array<u32>;
+@group(6) @binding(3183)
+var<storage, read_write> field14: array<u32>;
+@group(5) @binding(3183)
+var<storage, read_write> function16: array<u32>;
+@group(1) @binding(2585)
+var<storage, read_write> field15: array<u32>;
+@group(6) @binding(2585)
+var<storage, read_write> field16: array<u32>;
+@group(0) @binding(2585)
+var<storage, read_write> type7: array<u32>;
+@group(7) @binding(2585)
+var<storage, read_write> function17: array<u32>;
+@group(4) @binding(3183)
+var<storage, read_write> i17: array<u32>;
+@group(2) @binding(2585)
+var<storage, read_write> field17: array<u32>;
+@group(3) @binding(3183)
+var<storage, read_write> function18: array<u32>;
+
+@compute @workgroup_size(8, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(5) f0: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S18 {
+  @location(20) f0: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec3<i32>, @location(0) a1: i32, @builtin(vertex_index) a2: u32, @location(17) a3: vec3<f16>, @location(3) a4: vec3<f16>, @location(15) a5: vec3<i32>, @location(26) a6: u32, @location(24) a7: vec3<f16>, @location(19) a8: vec4<u32>, @location(7) a9: vec3<u32>, @location(21) a10: vec4<i32>, @location(18) a11: vec3<i32>, @location(14) a12: u32, @builtin(instance_index) a13: u32, @location(12) a14: vec3<i32>, @location(23) a15: vec3<i32>, @location(10) a16: vec3<f16>, @location(5) a17: vec4<i32>, @location(25) a18: vec4<i32>, @location(16) a19: vec3<i32>, @location(9) a20: vec2<f32>, @location(2) a21: u32, @location(6) a22: f16, @location(11) a23: f16, @location(1) a24: f16, @location(13) a25: vec2<f32>, a26: S18, @location(22) a27: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+});
+let buffer38 = device2.createBuffer({
+  label: '\ude64\u{1fb80}\u{1fd3f}\u0dfd\ua197\u0536\u0c15\ud74f\u57e4\u59d9\ub231',
+  size: 28858,
+  usage: GPUBufferUsage.INDIRECT,
+  mappedAtCreation: false
+});
+let renderBundle81 = renderBundleEncoder34.finish({label: '\uaf12\u{1fdf6}\u702a\u{1f60a}\ud586'});
+let promise55 = device2.createComputePipelineAsync({
+label: '\ud092\u0e43\u3ff5\u0904\u0efb\u02b8',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let promise56 = navigator.gpu.requestAdapter();
+let offscreenCanvas31 = new OffscreenCanvas(221, 645);
+document.body.prepend(video10);
+let buffer39 = device7.createBuffer({
+  label: '\u0f56\u55ff\ub4cf\u0a40',
+  size: 13434,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+pseudoSubmit(device7, commandEncoder70);
+let renderBundle82 = renderBundleEncoder63.finish({label: '\u48bb\u0069\u410a\u0fcd\ua4fb\ub3a4\uf09c\ue718\u0f83\u{1f692}\uc3b8'});
+try {
+device7.queue.writeTexture({
+  texture: texture93,
+  mipLevel: 0,
+  origin: { x: 123, y: 11, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 35 */
+{offset: 35, bytesPerRow: 458}, {width: 435, height: 18, depthOrArrayLayers: 0});
+} catch {}
+let pipeline68 = device7.createComputePipeline({
+layout: pipelineLayout18,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let textureView86 = texture93.createView({label: '\u6bad\u3116\u{1f8f0}\u0b6d\u{1fc1c}\u{1fc28}\u078d\u0f44'});
+let computePassEncoder59 = commandEncoder67.beginComputePass({label: '\u0986\u{1faaa}\u06df\u1aab\u0470\u{1fa8e}\u0c36\u5ee6\u7854'});
+try {
+computePassEncoder47.setPipeline(pipeline68);
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture96,
+  mipLevel: 5,
+  origin: { x: 0, y: 1, z: 7 },
+  aspect: 'stencil-only',
+}, new ArrayBuffer(16), /* required buffer size: 268491 */
+{offset: 894, bytesPerRow: 153, rowsPerImage: 159}, {width: 39, height: 0, depthOrArrayLayers: 12});
+} catch {}
+let offscreenCanvas32 = new OffscreenCanvas(419, 284);
+let imageBitmap21 = await createImageBitmap(offscreenCanvas15);
+let bindGroupLayout40 = device7.createBindGroupLayout({
+label: '\u8b86\u950e\u4351\u8776',
+entries: [{
+binding: 1134,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '2d-array' },
+}, {
+binding: 3448,
+visibility: GPUShaderStage.FRAGMENT,
+sampler: { type: 'non-filtering' },
+}],
+});
+try {
+renderBundleEncoder64.setVertexBuffer(10, undefined);
+} catch {}
+try {
+gpuCanvasContext18.configure({
+device: device7,
+format: 'rgba16float',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'rgba16float'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+adapter7.label = '\u0ae9\ua46d';
+} catch {}
+let gpuCanvasContext28 = canvas28.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend(video23);
+let imageData30 = new ImageData(124, 232);
+try {
+offscreenCanvas31.getContext('webgl');
+} catch {}
+let imageBitmap22 = await createImageBitmap(video20);
+try {
+renderBundleEncoder81.setBindGroup(4, bindGroup25);
+} catch {}
+let canvas31 = document.createElement('canvas');
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+let shaderModule17 = device0.createShaderModule({
+code: `@group(0) @binding(1160)
+var<storage, read_write> global11: array<u32>;
+
+@compute @workgroup_size(5, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec3<i32>,
+  @location(6) f1: i32,
+  @location(7) f2: vec2<i32>,
+  @location(2) f3: vec2<i32>,
+  @location(3) f4: vec2<u32>,
+  @builtin(sample_mask) f5: u32,
+  @location(5) f6: vec4<f32>,
+  @location(0) f7: vec3<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(9) a0: vec3<f16>, @builtin(vertex_index) a1: u32, @location(15) a2: vec3<f32>, @location(11) a3: vec3<f16>, @location(8) a4: vec3<f32>, @location(5) a5: vec2<u32>, @location(10) a6: vec3<i32>, @location(6) a7: vec4<f16>, @location(0) a8: vec4<f32>, @location(13) a9: f32, @location(7) a10: vec2<i32>, @location(2) a11: vec2<f16>, @location(4) a12: vec3<i32>, @location(12) a13: vec2<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroup31 = device0.createBindGroup({
+layout: bindGroupLayout7,
+entries: [{
+binding: 1160,
+resource: externalTexture0
+}],
+});
+try {
+renderBundleEncoder38.setVertexBuffer(4, buffer32);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let promise57 = buffer7.mapAsync(GPUMapMode.READ, 0, 28620);
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: { x: 368, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(721309), /* required buffer size: 721309 */
+{offset: 171, bytesPerRow: 7594, rowsPerImage: 94}, {width: 3651, height: 1, depthOrArrayLayers: 2});
+} catch {}
+let gpuCanvasContext29 = offscreenCanvas29.getContext('webgpu');
+try {
+offscreenCanvas32.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder72 = device7.createCommandEncoder({});
+let textureView87 = texture93.createView({label: '\uc871\ufadf\u8ee3\u{1fe19}\u8eed\u2d59', aspect: 'all', baseArrayLayer: 0});
+let renderBundleEncoder83 = device7.createRenderBundleEncoder({
+  colorFormats: ['rg8unorm', 'rg16float', undefined, undefined, undefined, 'r16uint', 'rgba16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: false
+});
+try {
+device7.queue.writeTexture({
+  texture: texture93,
+  mipLevel: 0,
+  origin: { x: 61, y: 18, z: 0 },
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer7), /* required buffer size: 3528 */
+{offset: 642, bytesPerRow: 727}, {width: 705, height: 4, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let imageData31 = new ImageData(88, 168);
+let imageData32 = new ImageData(60, 168);
+let img25 = await imageWithData(192, 37, '#c7a7fc14', '#8b7348fc');
+let commandEncoder73 = device2.createCommandEncoder({});
+let sampler76 = device2.createSampler({
+label: '\u2ada\u0c5e\u8db1\u0471\u{1f815}\u9bc8\u43ff\u2aa9\u08cb\u{1f8bf}\u98e4',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'nearest',
+lodMinClamp: 39.031,
+lodMaxClamp: 42.647,
+compare: 'greater',
+});
+try {
+renderBundleEncoder81.setVertexBuffer(2, buffer35, 31836, 243);
+} catch {}
+try {
+commandEncoder73.resolveQuerySet(querySet39, 100, 145, buffer19, 12544);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture76,
+  mipLevel: 0,
+  origin: { x: 173, y: 1, z: 0 },
+  aspect: 'all',
+}, new Int16Array(arrayBuffer5), /* required buffer size: 40 */
+{offset: 40}, {width: 192, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline69 = await promise55;
+document.body.prepend(img4);
+let querySet64 = device2.createQuerySet({
+label: '\u2bf3\u0afa\u{1f870}\uf204',
+type: 'occlusion',
+count: 3486,
+});
+let renderBundle83 = renderBundleEncoder59.finish({label: '\ud4f8\u5a73\u02c4\u{1f65c}\u0714\u449e\u8f5e\u086c\u9592'});
+try {
+computePassEncoder55.end();
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline66);
+} catch {}
+try {
+commandEncoder73.clearBuffer(buffer19);
+dissociateBuffer(device2, buffer19);
+} catch {}
+let pipeline70 = await device2.createComputePipelineAsync({
+label: '\ue0cd\u{1f7bb}\u0db5\u080d\uadda',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let gpuCanvasContext30 = canvas31.getContext('webgpu');
+gc();
+let shaderModule18 = device2.createShaderModule({
+label: '\u0b22\u05fd\u0869\u22e7\uab70\u075d\u6d35\u6639',
+code: `@group(1) @binding(2585)
+var<storage, read_write> parameter14: array<u32>;
+@group(3) @binding(2585)
+var<storage, read_write> parameter15: array<u32>;
+@group(8) @binding(3183)
+var<storage, read_write> parameter16: array<u32>;
+@group(4) @binding(2585)
+var<storage, read_write> type8: array<u32>;
+@group(5) @binding(3183)
+var<storage, read_write> function19: array<u32>;
+@group(7) @binding(2585)
+var<storage, read_write> local9: array<u32>;
+@group(2) @binding(2585)
+var<storage, read_write> field18: array<u32>;
+@group(5) @binding(2585)
+var<storage, read_write> field19: array<u32>;
+@group(8) @binding(2585)
+var<storage, read_write> parameter17: array<u32>;
+@group(6) @binding(3183)
+var<storage, read_write> parameter18: array<u32>;
+@group(1) @binding(3183)
+var<storage, read_write> local10: array<u32>;
+
+@compute @workgroup_size(4, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S20 {
+  @builtin(sample_index) f0: u32,
+  @location(10) f1: f16,
+  @location(16) f2: vec3<i32>,
+  @location(19) f3: u32,
+  @location(5) f4: vec2<u32>,
+  @location(30) f5: f32,
+  @builtin(front_facing) f6: bool,
+  @location(17) f7: vec2<f32>,
+  @location(25) f8: vec3<u32>,
+  @location(31) f9: f16,
+  @location(12) f10: vec2<f32>,
+  @location(2) f11: vec2<i32>,
+  @builtin(sample_mask) f12: u32,
+  @location(23) f13: vec4<f32>,
+  @location(11) f14: f16,
+  @location(4) f15: vec4<i32>,
+  @location(13) f16: f32,
+  @location(21) f17: vec3<f32>,
+  @location(29) f18: f16
+}
+struct FragmentOutput0 {
+  @location(5) f0: vec4<u32>,
+  @location(3) f1: vec4<f32>,
+  @location(0) f2: vec4<f32>,
+  @location(1) f3: vec4<f32>,
+  @builtin(frag_depth) f4: f32,
+  @location(2) f5: vec2<u32>
+}
+
+@fragment
+fn fragment0(@location(14) a0: vec4<f32>, @location(22) a1: vec2<i32>, @location(20) a2: f32, @location(26) a3: vec2<u32>, @location(9) a4: vec3<f32>, @builtin(position) a5: vec4<f32>, @location(15) a6: vec2<f32>, a7: S20, @location(1) a8: vec2<i32>, @location(18) a9: vec4<f16>, @location(3) a10: vec3<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S19 {
+  @location(24) f0: f32,
+  @location(18) f1: vec2<u32>,
+  @location(21) f2: vec2<f32>,
+  @location(14) f3: vec3<i32>,
+  @location(15) f4: vec3<u32>,
+  @builtin(instance_index) f5: u32,
+  @location(25) f6: vec3<f32>,
+  @location(13) f7: vec2<i32>,
+  @location(26) f8: i32,
+  @location(12) f9: u32,
+  @location(0) f10: f32,
+  @location(6) f11: vec2<i32>,
+  @location(7) f12: i32
+}
+struct VertexOutput0 {
+  @location(9) f192: vec3<f32>,
+  @location(11) f193: f16,
+  @location(26) f194: vec2<u32>,
+  @builtin(position) f195: vec4<f32>,
+  @location(17) f196: vec2<f32>,
+  @location(18) f197: vec4<f16>,
+  @location(16) f198: vec3<i32>,
+  @location(2) f199: vec2<i32>,
+  @location(3) f200: vec3<i32>,
+  @location(22) f201: vec2<i32>,
+  @location(15) f202: vec2<f32>,
+  @location(19) f203: u32,
+  @location(20) f204: f32,
+  @location(1) f205: vec2<i32>,
+  @location(4) f206: vec4<i32>,
+  @location(29) f207: f16,
+  @location(25) f208: vec3<u32>,
+  @location(10) f209: f16,
+  @location(21) f210: vec3<f32>,
+  @location(12) f211: vec2<f32>,
+  @location(31) f212: f16,
+  @location(13) f213: f32,
+  @location(14) f214: vec4<f32>,
+  @location(23) f215: vec4<f32>,
+  @location(30) f216: f32,
+  @location(5) f217: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(19) a0: f16, @location(20) a1: vec3<f16>, @location(4) a2: vec2<f16>, @location(9) a3: vec4<i32>, @location(10) a4: vec3<f16>, a5: S19, @builtin(vertex_index) a6: u32, @location(1) a7: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let texture113 = device2.createTexture({
+label: '\u0342\u2817\u0cb6\u904a\u{1fcf5}',
+size: [5520, 1, 1],
+mipLevelCount: 3,
+format: 'r32sint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let sampler77 = device2.createSampler({
+label: '\u648f\u9bbb\u{1feee}\u8c6d\u18db',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 43.939,
+lodMaxClamp: 58.502,
+maxAnisotropy: 7,
+});
+let pipeline71 = device2.createRenderPipeline({
+label: '\ub9e8\u0175\ufda9',
+layout: 'auto',
+multisample: {
+count: 4,
+alphaToCoverageEnabled: true,
+},
+fragment: {
+  module: shaderModule18,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm'}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'dst-alpha'},
+}
+}, {format: 'rg32uint'}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'add', srcFactor: 'dst', dstFactor: 'one'},
+alpha: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'dst'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.RED
+}, undefined, {format: 'rg16uint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'increment-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-clamp',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'decrement-wrap',
+depthFailOp: 'decrement-wrap',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2722,
+stencilWriteMask: 3938,
+depthBias: 79,
+depthBiasSlopeScale: 95,
+depthBiasClamp: 84,
+},
+vertex: {
+  module: shaderModule18,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 30136,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x2',
+offset: 1948,
+shaderLocation: 18,
+}, {
+format: 'snorm8x4',
+offset: 25004,
+shaderLocation: 20,
+}, {
+format: 'sint8x4',
+offset: 10048,
+shaderLocation: 7,
+}, {
+format: 'uint32x3',
+offset: 21540,
+shaderLocation: 15,
+}, {
+format: 'sint16x2',
+offset: 27956,
+shaderLocation: 13,
+}, {
+format: 'float16x2',
+offset: 20640,
+shaderLocation: 25,
+}, {
+format: 'sint32x4',
+offset: 1260,
+shaderLocation: 6,
+}, {
+format: 'snorm8x4',
+offset: 17424,
+shaderLocation: 24,
+}, {
+format: 'uint16x2',
+offset: 4096,
+shaderLocation: 12,
+}, {
+format: 'sint32x3',
+offset: 616,
+shaderLocation: 1,
+}, {
+format: 'sint8x2',
+offset: 6364,
+shaderLocation: 9,
+}, {
+format: 'float16x2',
+offset: 23080,
+shaderLocation: 19,
+}, {
+format: 'float32x3',
+offset: 15648,
+shaderLocation: 4,
+}, {
+format: 'float32x4',
+offset: 25388,
+shaderLocation: 0,
+}, {
+format: 'sint32x4',
+offset: 21196,
+shaderLocation: 14,
+}],
+},
+{
+arrayStride: 41524,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32',
+offset: 41380,
+shaderLocation: 26,
+}, {
+format: 'snorm8x4',
+offset: 12648,
+shaderLocation: 21,
+}],
+},
+{
+arrayStride: 31252,
+attributes: [{
+format: 'float32',
+offset: 11208,
+shaderLocation: 10,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+cullMode: 'front',
+},
+});
+pseudoSubmit(device2, commandEncoder36);
+let renderBundleEncoder84 = device2.createRenderBundleEncoder({
+  label: '\u068d\u0d21\ub6da\ua924\u20be\u00c6\u86de\ue6fa\ue115',
+  colorFormats: ['bgra8unorm', 'rgba8unorm-srgb', 'rg32uint', 'bgra8unorm-srgb', undefined, 'rg16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+try {
+renderBundleEncoder77.setBindGroup(4, bindGroup25);
+} catch {}
+let adapter11 = await navigator.gpu.requestAdapter({
+});
+offscreenCanvas1.width = 290;
+let video26 = await videoWithData();
+let commandEncoder74 = device7.createCommandEncoder();
+let texture114 = device7.createTexture({
+size: {width: 4992},
+dimension: '1d',
+format: 'r8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8unorm', 'r8unorm', 'r8unorm'],
+});
+let textureView88 = texture93.createView({});
+let computePassEncoder60 = commandEncoder72.beginComputePass({label: '\u{1fb00}\u0f35\u0d63\u{1f7bf}\u3851\u{1fef2}\u0de3\u0e91'});
+try {
+commandEncoder74.copyBufferToBuffer(buffer39, 7696, buffer33, 6812, 1616);
+dissociateBuffer(device7, buffer39);
+dissociateBuffer(device7, buffer33);
+} catch {}
+let adapter12 = await navigator.gpu.requestAdapter();
+try {
+canvas29.getContext('webgpu');
+} catch {}
+let querySet65 = device6.createQuerySet({
+label: '\u{1faca}\u0e35\u857a\u{1f842}\u02b1\u00d8\uc323\u754a',
+type: 'occlusion',
+count: 778,
+});
+let sampler78 = device6.createSampler({
+label: '\ua1d1\u0e71\ued0f\u{1f629}\u5327\u003e\u44dc\u6e5f\u0199',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'nearest',
+lodMinClamp: 58.397,
+lodMaxClamp: 91.303,
+});
+try {
+renderBundleEncoder78.setVertexBuffer(3, buffer30, 456, 89);
+} catch {}
+try {
+commandEncoder61.copyBufferToBuffer(buffer25, 1912, buffer30, 412, 172);
+dissociateBuffer(device6, buffer25);
+dissociateBuffer(device6, buffer30);
+} catch {}
+let img26 = await imageWithData(73, 66, '#26ef3c4b', '#83b7d2fc');
+let video27 = await videoWithData();
+let buffer40 = device7.createBuffer({size: 25243, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT});
+let texture115 = device7.createTexture({
+label: '\u9796\u6823\ud9f8\u{1fb66}\u1196',
+size: [1680],
+dimension: '1d',
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgb10a2unorm', 'rgb10a2unorm'],
+});
+let sampler79 = device7.createSampler({
+label: '\u9e92\u{1f671}\u71af\u847e\u5c3e\u{1f9e2}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 60.028,
+lodMaxClamp: 78.340,
+maxAnisotropy: 17,
+});
+try {
+renderBundleEncoder64.setVertexBuffer(87, undefined, 2467832355, 491926512);
+} catch {}
+let pipeline72 = device7.createRenderPipeline({
+label: '\u0fc5\u084e\u3bec\u3305\u{1f85a}',
+layout: pipelineLayout18,
+multisample: {
+count: 4,
+},
+fragment: {module: shaderModule15, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'stencil8',
+stencilFront: {
+compare: 'equal',
+failOp: 'replace',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'not-equal',
+depthFailOp: 'increment-clamp',
+passOp: 'zero',
+},
+stencilReadMask: 1991,
+stencilWriteMask: 2204,
+depthBias: 91,
+depthBiasSlopeScale: 7,
+depthBiasClamp: 72,
+},
+vertex: {
+  module: shaderModule15,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 6080,
+attributes: [{
+format: 'sint32x3',
+offset: 404,
+shaderLocation: 4,
+}, {
+format: 'uint16x4',
+offset: 5600,
+shaderLocation: 3,
+}, {
+format: 'sint32x3',
+offset: 956,
+shaderLocation: 6,
+}, {
+format: 'sint16x4',
+offset: 5964,
+shaderLocation: 21,
+}, {
+format: 'unorm16x4',
+offset: 2872,
+shaderLocation: 14,
+}, {
+format: 'uint32x4',
+offset: 4512,
+shaderLocation: 5,
+}, {
+format: 'uint16x2',
+offset: 1136,
+shaderLocation: 7,
+}, {
+format: 'uint32',
+offset: 344,
+shaderLocation: 9,
+}, {
+format: 'float32x4',
+offset: 4860,
+shaderLocation: 10,
+}, {
+format: 'float32x4',
+offset: 1740,
+shaderLocation: 1,
+}, {
+format: 'snorm8x2',
+offset: 4806,
+shaderLocation: 23,
+}, {
+format: 'sint16x2',
+offset: 116,
+shaderLocation: 15,
+}, {
+format: 'float32x3',
+offset: 644,
+shaderLocation: 22,
+}, {
+format: 'sint32',
+offset: 2788,
+shaderLocation: 18,
+}, {
+format: 'uint8x4',
+offset: 1168,
+shaderLocation: 8,
+}, {
+format: 'uint32x2',
+offset: 2528,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 11776,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 3452,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm8x2',
+offset: 1040,
+shaderLocation: 0,
+}, {
+format: 'sint32',
+offset: 516,
+shaderLocation: 20,
+}, {
+format: 'uint16x4',
+offset: 340,
+shaderLocation: 17,
+}, {
+format: 'sint16x4',
+offset: 616,
+shaderLocation: 11,
+}, {
+format: 'unorm8x4',
+offset: 932,
+shaderLocation: 2,
+}, {
+format: 'float32',
+offset: 1276,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 16104,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 1440,
+attributes: [{
+format: 'snorm16x2',
+offset: 856,
+shaderLocation: 19,
+}, {
+format: 'sint8x2',
+offset: 332,
+shaderLocation: 12,
+}],
+}
+]
+},
+primitive: {
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let img27 = await imageWithData(160, 181, '#96f4acb0', '#4d4f2967');
+try {
+gpuCanvasContext5.configure({
+device: device8,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm-srgb', 'astc-4x4-unorm-srgb', 'astc-12x10-unorm'],
+alphaMode: 'premultiplied',
+});
+} catch {}
+let sampler80 = device6.createSampler({
+label: '\u1362\u1236\ua265\u{1ff73}\u{1f821}\u44d1\u{1f71e}\u004e\uee41\u0c98\u0b50',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 50.487,
+maxAnisotropy: 7,
+});
+let promise58 = device6.popErrorScope();
+let imageBitmap23 = await createImageBitmap(imageBitmap17);
+let commandEncoder75 = device0.createCommandEncoder({label: '\ud42c\u{1f69e}\u9c57\u07c0\u7017\u2a6c'});
+let textureView89 = texture18.createView({label: '\u72c5\uc228\u95bc\u00aa\uf1e9\u0ae7\u7b89', dimension: '2d-array', mipLevelCount: 2});
+let renderBundleEncoder85 = device0.createRenderBundleEncoder({
+  label: '\ud706\u8a7f\u0086\ue32b\u{1fbe4}\u682a\ua3d5\u{1fbae}\u{1fbbb}\u00fa',
+  colorFormats: ['r8uint', undefined, 'rg16sint', 'r8uint', 'rg8sint', 'rgba8unorm', 'r8sint', 'r16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+try {
+renderBundleEncoder61.setBindGroup(0, bindGroup4, new Uint32Array(8505), 7060, 0);
+} catch {}
+let arrayBuffer14 = buffer6.getMappedRange(14120, 3256);
+try {
+commandEncoder75.copyBufferToBuffer(buffer16, 836, buffer3, 29888, 1304);
+dissociateBuffer(device0, buffer16);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder75.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 0,
+  origin: { x: 336, y: 0, z: 1 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 4152 widthInBlocks: 519 aspectSpecificFormat.texelBlockSize: 8 */
+/* end: 26592 */
+offset: 26592,
+bytesPerRow: 4352,
+buffer: buffer12,
+}, {width: 519, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let canvas32 = document.createElement('canvas');
+let commandEncoder76 = device8.createCommandEncoder({label: '\u{1f9fd}\u0760\u45a5\uae1c\u97b8\u0655\u08fc\u7d14\u{1ff58}\uca15\u{1fe1b}'});
+let renderBundle84 = renderBundleEncoder79.finish({label: '\u{1fec9}\u9cda\ue445\u17c9'});
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+let video28 = await videoWithData();
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let sampler81 = device7.createSampler({
+label: '\u72ad\u1314\uab90\u5608',
+addressModeU: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 54.662,
+lodMaxClamp: 68.184,
+maxAnisotropy: 11,
+});
+try {
+commandEncoder74.copyBufferToBuffer(buffer40, 9212, buffer33, 5372, 5492);
+dissociateBuffer(device7, buffer40);
+dissociateBuffer(device7, buffer33);
+} catch {}
+let querySet66 = device2.createQuerySet({
+label: '\u0398\u9d7f',
+type: 'occlusion',
+count: 2179,
+});
+let sampler82 = device2.createSampler({
+label: '\u{1f7d2}\ud521\u08ee\u162b\u531e\u{1f796}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+lodMinClamp: 6.024,
+lodMaxClamp: 74.045,
+});
+try {
+renderBundleEncoder81.setBindGroup(0, bindGroup25);
+} catch {}
+let pipeline73 = device2.createRenderPipeline({
+layout: pipelineLayout11,
+multisample: {
+count: 4,
+mask: 0x892db6c6,
+},
+fragment: {module: shaderModule8, entryPoint: 'fragment0', targets: []},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+stencilFront: {
+compare: 'never',
+failOp: 'replace',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilWriteMask: 1028,
+depthBiasSlopeScale: 41,
+depthBiasClamp: 32,
+},
+vertex: {
+  module: shaderModule8,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 24816,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x2',
+offset: 5304,
+shaderLocation: 22,
+}, {
+format: 'uint32x4',
+offset: 14624,
+shaderLocation: 13,
+}, {
+format: 'float32',
+offset: 11112,
+shaderLocation: 12,
+}, {
+format: 'sint8x4',
+offset: 748,
+shaderLocation: 17,
+}, {
+format: 'sint32x2',
+offset: 6756,
+shaderLocation: 18,
+}, {
+format: 'uint32',
+offset: 11708,
+shaderLocation: 25,
+}, {
+format: 'uint8x2',
+offset: 1080,
+shaderLocation: 8,
+}, {
+format: 'uint32x3',
+offset: 15612,
+shaderLocation: 7,
+}, {
+format: 'snorm16x2',
+offset: 20252,
+shaderLocation: 21,
+}, {
+format: 'unorm10-10-10-2',
+offset: 4960,
+shaderLocation: 24,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 14924,
+shaderLocation: 19,
+}],
+},
+{
+arrayStride: 49292,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 4260,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 224,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 32080,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 8048,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 47612,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 37136,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm16x4',
+offset: 32956,
+shaderLocation: 20,
+}, {
+format: 'snorm8x2',
+offset: 8000,
+shaderLocation: 26,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+cullMode: 'back',
+},
+});
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+try {
+  await promise58;
+} catch {}
+let sampler83 = device7.createSampler({
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 20.642,
+lodMaxClamp: 89.857,
+});
+try {
+renderBundleEncoder64.setVertexBuffer(13, undefined, 3637008638);
+} catch {}
+let arrayBuffer15 = buffer33.getMappedRange(10744, 56);
+try {
+commandEncoder74.copyBufferToBuffer(buffer40, 2684, buffer33, 7708, 2372);
+dissociateBuffer(device7, buffer40);
+dissociateBuffer(device7, buffer33);
+} catch {}
+try {
+commandEncoder74.resolveQuerySet(querySet47, 1048, 20, buffer26, 15616);
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture96,
+  mipLevel: 2,
+  origin: { x: 0, y: 1, z: 21 },
+  aspect: 'stencil-only',
+}, new Float32Array(arrayBuffer7), /* required buffer size: 13952487 */
+{offset: 549, bytesPerRow: 598, rowsPerImage: 231}, {width: 312, height: 0, depthOrArrayLayers: 102});
+} catch {}
+let pipeline74 = device7.createComputePipeline({
+label: '\ufee1\uaf8e\u680f\uc11c\ue483',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+  await promise57;
+} catch {}
+gc();
+let querySet67 = device0.createQuerySet({
+label: '\u{1fcd5}\u0224\ued35\u3603',
+type: 'occlusion',
+count: 81,
+});
+let texture116 = device0.createTexture({
+label: '\u8344\u684f\u4831\uf5c8\ub405\u25e7\ud533\u{1f760}\uc573\u0d91\u02d5',
+size: {width: 1442, height: 96, depthOrArrayLayers: 1014},
+mipLevelCount: 5,
+dimension: '3d',
+format: 'rg16sint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16sint'],
+});
+let textureView90 = texture60.createView({
+  label: '\u{1fc84}\u0669\u05a5\u0eed\u{1f83b}\uf071\u{1fb87}',
+  dimension: '2d-array',
+  baseMipLevel: 5,
+  mipLevelCount: 1
+});
+try {
+computePassEncoder39.setBindGroup(3, bindGroup5, new Uint32Array(4208), 1896, 0);
+} catch {}
+try {
+renderBundleEncoder80.draw(72);
+} catch {}
+try {
+renderBundleEncoder61.drawIndexedIndirect(buffer3, 18576);
+} catch {}
+try {
+renderBundleEncoder80.setVertexBuffer(1, buffer32, 1064, 875);
+} catch {}
+try {
+commandEncoder75.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 2,
+  origin: { x: 57, y: 6, z: 26 },
+  aspect: 'all',
+}, {
+  texture: texture19,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, {width: 90, height: 6, depthOrArrayLayers: 79});
+} catch {}
+try {
+gpuCanvasContext3.configure({
+device: device0,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba16float', 'astc-6x5-unorm-srgb', 'rgba16float', 'astc-10x5-unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 40852, new Int16Array(39586), 13678, 1024);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 73, height: 1, depthOrArrayLayers: 29}
+*/
+{
+  source: canvas15,
+  origin: { x: 43, y: 26 },
+  flipY: true,
+}, {
+  texture: texture45,
+  mipLevel: 3,
+  origin: { x: 0, y: 0, z: 26 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 45, height: 0, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(video1);
+let offscreenCanvas33 = new OffscreenCanvas(462, 351);
+let renderBundle85 = renderBundleEncoder83.finish();
+let promise59 = device7.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+document.body.prepend(canvas11);
+let img28 = await imageWithData(31, 75, '#b3e0427d', '#1fad1885');
+let imageBitmap24 = await createImageBitmap(canvas27);
+let commandBuffer18 = commandEncoder73.finish({
+label: '\uc526\u{1ffa5}\u7ee6\u{1f96e}\u7d3b',
+});
+try {
+computePassEncoder53.setBindGroup(5, bindGroup25, new Uint32Array(3159), 2284, 0);
+} catch {}
+try {
+commandEncoder48.resolveQuerySet(querySet39, 149, 52, buffer19, 56576);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture107,
+  mipLevel: 1,
+  origin: { x: 236, y: 1, z: 0 },
+  aspect: 'all',
+}, arrayBuffer11, /* required buffer size: 934 */
+{offset: 934}, {width: 190, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise60 = device2.createComputePipelineAsync({
+label: '\ua44e\u{1fab9}\u{1f7e6}\u0674\u1a88',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let videoFrame24 = new VideoFrame(video12, {timestamp: 0});
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+let device9 = await adapter11.requestDevice({
+label: '\u74e2\u034f\ua786\u931e',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 11,
+maxColorAttachmentBytesPerSample: 41,
+maxVertexAttributes: 29,
+maxVertexBufferArrayStride: 47203,
+maxStorageTexturesPerShaderStage: 11,
+maxStorageBuffersPerShaderStage: 10,
+maxDynamicStorageBuffersPerPipelineLayout: 52650,
+maxBindingsPerBindGroup: 5558,
+maxTextureDimension1D: 12656,
+maxTextureDimension2D: 14700,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 57633682,
+maxUniformBuffersPerShaderStage: 19,
+maxInterStageShaderVariables: 34,
+maxInterStageShaderComponents: 80,
+maxSamplersPerShaderStage: 21,
+},
+});
+let offscreenCanvas34 = new OffscreenCanvas(560, 459);
+try {
+offscreenCanvas33.getContext('webgl');
+} catch {}
+let computePassEncoder61 = commandEncoder66.beginComputePass({});
+let renderBundle86 = renderBundleEncoder83.finish({});
+let sampler84 = device7.createSampler({
+label: '\u{1f6ba}\u039f\uc642\u066a\u{1fb4e}\ua926\uf4a0',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 83.378,
+lodMaxClamp: 91.441,
+});
+try {
+computePassEncoder61.insertDebugMarker('\u1c44');
+} catch {}
+try {
+  await promise59;
+} catch {}
+let video29 = await videoWithData();
+try {
+canvas32.getContext('webgpu');
+} catch {}
+let querySet68 = device6.createQuerySet({
+label: '\u60f7\uc3eb',
+type: 'occlusion',
+count: 1195,
+});
+let textureView91 = texture100.createView({label: '\u779f\u0768\u6935\u1de1\u{1fa76}\u252d\u838a\u9578', baseMipLevel: 1});
+try {
+commandEncoder61.clearBuffer(buffer30, 472, 36);
+dissociateBuffer(device6, buffer30);
+} catch {}
+let promise61 = device6.queue.onSubmittedWorkDone();
+let texture117 = device6.createTexture({
+label: '\u0f0b\u0334\ud112\u{1f92e}\u079a\u022e\u0a3e\u09a8\u6271',
+size: {width: 1980, height: 60, depthOrArrayLayers: 238},
+mipLevelCount: 10,
+dimension: '3d',
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg16float', 'rg16float', 'rg16float'],
+});
+let renderBundle87 = renderBundleEncoder60.finish({label: '\u{1fb9c}\u5125'});
+try {
+commandEncoder61.clearBuffer(buffer30, 72, 136);
+dissociateBuffer(device6, buffer30);
+} catch {}
+try {
+  await promise48;
+} catch {}
+let promise62 = adapter12.requestDevice({
+label: '\u03b7\ub8d5\u13aa\ub9be\u0b70\u{1f99d}\ua8e0\u028c\u0d70\u0a4a\u9435',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+});
+let texture118 = device9.createTexture({
+size: [40, 15, 47],
+mipLevelCount: 4,
+format: 'r8uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r8uint'],
+});
+try {
+  await promise50;
+} catch {}
+document.body.prepend(canvas3);
+let textureView92 = texture107.createView({
+  label: '\u0e83\ue912\u886f\ua075\u{1f9be}\u0aa9\udc7a\ue77d\u002f',
+  dimension: '2d-array',
+  baseMipLevel: 4
+});
+try {
+computePassEncoder56.setPipeline(pipeline53);
+} catch {}
+try {
+commandEncoder48.copyBufferToBuffer(buffer17, 3488, buffer19, 7124, 17876);
+dissociateBuffer(device2, buffer17);
+dissociateBuffer(device2, buffer19);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture71,
+  mipLevel: 3,
+  origin: { x: 0, y: 10, z: 0 },
+  aspect: 'stencil-only',
+}, arrayBuffer10, /* required buffer size: 371 */
+{offset: 371}, {width: 40, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let renderBundleEncoder86 = device7.createRenderBundleEncoder({
+  label: '\u9923\u{1fe2d}\uffc4\ua435\u857b\u0692\ub2e6',
+  colorFormats: ['rg8unorm', 'rg16float', undefined, undefined, undefined, 'r16uint', 'rgba16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4
+});
+let renderBundle88 = renderBundleEncoder83.finish({label: '\u0bc8\ua7d5\ua695\u{1f99a}\u{1fd48}\ue1d8\u524e\ua56b\u9231\u08f7\u04a7'});
+try {
+commandEncoder74.copyBufferToBuffer(buffer39, 412, buffer33, 9376, 816);
+dissociateBuffer(device7, buffer39);
+dissociateBuffer(device7, buffer33);
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture114,
+  mipLevel: 0,
+  origin: { x: 1021, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 4016 */
+{offset: 134}, {width: 3882, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline75 = device7.createComputePipeline({
+label: '\u0b97\u054c\u84de',
+layout: pipelineLayout18,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+},
+});
+try {
+  await promise61;
+} catch {}
+let buffer41 = device6.createBuffer({size: 60202, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView93 = texture85.createView({label: '\u43a0\u{1f649}\u814e\u02ef\u{1ff4c}\ud0ac', dimension: '2d-array', baseMipLevel: 2});
+try {
+device6.queue.writeTexture({
+  texture: texture108,
+  mipLevel: 0,
+  origin: { x: 179, y: 1, z: 1 },
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(48)), /* required buffer size: 2913747 */
+{offset: 907, bytesPerRow: 404, rowsPerImage: 103}, {width: 192, height: 0, depthOrArrayLayers: 71});
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let bindGroupLayout41 = device7.createBindGroupLayout({
+entries: [{
+binding: 932,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}, {
+binding: 5657,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+sampler: { type: 'comparison' },
+}, {
+binding: 930,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+}],
+});
+let buffer42 = device7.createBuffer({
+  label: '\u17cc\uba4c\u0ad2',
+  size: 41170,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX
+});
+let renderBundle89 = renderBundleEncoder83.finish({label: '\u9b28\ufbf2\u662b\u7868\u8bc1\uc923\u170e\u51f0\u0c02'});
+let pipeline76 = device7.createRenderPipeline({
+label: '\u508a\u{1ff74}\u088c\u{1fe32}\ub67a\u0d57\u{1ff1e}\u{1f7cb}\u{1f90a}\u0816\u{1f603}',
+layout: pipelineLayout16,
+vertex: {
+  module: shaderModule15,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 3884,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x2',
+offset: 3870,
+shaderLocation: 0,
+}, {
+format: 'float16x4',
+offset: 3600,
+shaderLocation: 14,
+}, {
+format: 'snorm8x2',
+offset: 1246,
+shaderLocation: 16,
+}, {
+format: 'snorm16x2',
+offset: 1172,
+shaderLocation: 10,
+}, {
+format: 'unorm8x2',
+offset: 3588,
+shaderLocation: 23,
+}, {
+format: 'uint32x2',
+offset: 1836,
+shaderLocation: 17,
+}, {
+format: 'snorm8x4',
+offset: 760,
+shaderLocation: 22,
+}, {
+format: 'uint32',
+offset: 1576,
+shaderLocation: 3,
+}],
+},
+{
+arrayStride: 10188,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x2',
+offset: 264,
+shaderLocation: 19,
+}, {
+format: 'sint8x4',
+offset: 4064,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 13268,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x3',
+offset: 5380,
+shaderLocation: 1,
+}, {
+format: 'sint32',
+offset: 3328,
+shaderLocation: 4,
+}, {
+format: 'sint16x4',
+offset: 664,
+shaderLocation: 18,
+}, {
+format: 'sint32',
+offset: 10336,
+shaderLocation: 20,
+}, {
+format: 'uint16x4',
+offset: 9816,
+shaderLocation: 7,
+}, {
+format: 'snorm8x2',
+offset: 3928,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 14744,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32',
+offset: 7952,
+shaderLocation: 6,
+}, {
+format: 'sint32',
+offset: 6900,
+shaderLocation: 21,
+}, {
+format: 'sint32x3',
+offset: 9500,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 5092,
+attributes: [{
+format: 'uint8x2',
+offset: 3518,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 1232,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 3360,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x3',
+offset: 2660,
+shaderLocation: 11,
+}, {
+format: 'uint8x2',
+offset: 566,
+shaderLocation: 5,
+}, {
+format: 'uint16x2',
+offset: 1480,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 11904,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x2',
+offset: 7448,
+shaderLocation: 9,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+window.someLabel = device2.label;
+} catch {}
+try {
+window.someLabel = pipeline62.label;
+} catch {}
+let shaderModule19 = device2.createShaderModule({
+code: `@group(4) @binding(3183)
+var<storage, read_write> type9: array<u32>;
+@group(8) @binding(2585)
+var<storage, read_write> i18: array<u32>;
+@group(5) @binding(3183)
+var<storage, read_write> global12: array<u32>;
+@group(3) @binding(3183)
+var<storage, read_write> field20: array<u32>;
+@group(5) @binding(2585)
+var<storage, read_write> local11: array<u32>;
+@group(0) @binding(2585)
+var<storage, read_write> i19: array<u32>;
+@group(6) @binding(2585)
+var<storage, read_write> i20: array<u32>;
+@group(8) @binding(3183)
+var<storage, read_write> type10: array<u32>;
+@group(6) @binding(3183)
+var<storage, read_write> parameter19: array<u32>;
+@group(3) @binding(2585)
+var<storage, read_write> global13: array<u32>;
+@group(1) @binding(2585)
+var<storage, read_write> type11: array<u32>;
+@group(4) @binding(2585)
+var<storage, read_write> function20: array<u32>;
+@group(2) @binding(2585)
+var<storage, read_write> i21: array<u32>;
+@group(7) @binding(3183)
+var<storage, read_write> i22: array<u32>;
+@group(1) @binding(3183)
+var<storage, read_write> parameter20: array<u32>;
+
+@compute @workgroup_size(5, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(3) f1: vec4<f32>,
+  @location(2) f2: vec4<u32>,
+  @location(1) f3: vec4<f32>,
+  @location(5) f4: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f218: vec4<f32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+});
+let buffer43 = device2.createBuffer({
+  label: '\u0d6e\uccb9\udcc3\u07e4\ud822',
+  size: 19740,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let commandEncoder77 = device2.createCommandEncoder();
+let texture119 = device2.createTexture({
+label: '\ufa1a\u{1fd41}\u{1f772}\u990e\u{1fb95}',
+size: [761],
+dimension: '1d',
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let computePassEncoder62 = commandEncoder77.beginComputePass({label: '\u00aa\ud464\u00f6\u{1fe1b}\u5f91\u66df\u0e94\u5eec\u1324\u{1f9d2}'});
+try {
+renderBundleEncoder77.setVertexBuffer(83, undefined);
+} catch {}
+let promise63 = device2.createRenderPipelineAsync({
+label: '\u6f59\ufcf9\u0bfd\u0402',
+layout: pipelineLayout11,
+fragment: {
+  module: shaderModule18,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'src-alpha'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.RED
+}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+color: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'src'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+}
+}, {format: 'rg32uint'}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'dst', dstFactor: 'src-alpha'},
+},
+  writeMask: 0
+}, undefined, {format: 'rg16uint', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'less-equal',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-wrap',
+depthFailOp: 'decrement-clamp',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilReadMask: 3893,
+depthBiasSlopeScale: 24,
+depthBiasClamp: 30,
+},
+vertex: {
+  module: shaderModule18,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 3400,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x3',
+offset: 2816,
+shaderLocation: 1,
+}, {
+format: 'snorm8x4',
+offset: 1936,
+shaderLocation: 24,
+}, {
+format: 'sint32x4',
+offset: 1420,
+shaderLocation: 26,
+}, {
+format: 'sint16x4',
+offset: 2608,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 38008,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x2',
+offset: 17878,
+shaderLocation: 20,
+}, {
+format: 'sint8x2',
+offset: 16744,
+shaderLocation: 14,
+}, {
+format: 'sint8x2',
+offset: 11560,
+shaderLocation: 7,
+}, {
+format: 'uint8x2',
+offset: 37186,
+shaderLocation: 15,
+}, {
+format: 'float32x2',
+offset: 3196,
+shaderLocation: 19,
+}, {
+format: 'uint32x3',
+offset: 4456,
+shaderLocation: 12,
+}, {
+format: 'float32x4',
+offset: 18032,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint32x3',
+offset: 11128,
+shaderLocation: 18,
+}, {
+format: 'float16x2',
+offset: 9816,
+shaderLocation: 21,
+}, {
+format: 'sint16x4',
+offset: 29480,
+shaderLocation: 6,
+}, {
+format: 'sint32x2',
+offset: 52068,
+shaderLocation: 9,
+}, {
+format: 'snorm8x4',
+offset: 50732,
+shaderLocation: 25,
+}, {
+format: 'float16x2',
+offset: 47720,
+shaderLocation: 4,
+}, {
+format: 'float16x2',
+offset: 23036,
+shaderLocation: 0,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+frontFace: 'cw',
+},
+});
+let imageData33 = new ImageData(232, 204);
+let shaderModule20 = device2.createShaderModule({
+code: `@group(4) @binding(2585)
+var<storage, read_write> function21: array<u32>;
+@group(2) @binding(2585)
+var<storage, read_write> i23: array<u32>;
+@group(0) @binding(3183)
+var<storage, read_write> local12: array<u32>;
+@group(3) @binding(2585)
+var<storage, read_write> local13: array<u32>;
+@group(5) @binding(3183)
+var<storage, read_write> local14: array<u32>;
+@group(0) @binding(2585)
+var<storage, read_write> global14: array<u32>;
+@group(8) @binding(3183)
+var<storage, read_write> i24: array<u32>;
+@group(6) @binding(3183)
+var<storage, read_write> field21: array<u32>;
+@group(4) @binding(3183)
+var<storage, read_write> i25: array<u32>;
+@group(5) @binding(2585)
+var<storage, read_write> type12: array<u32>;
+@group(1) @binding(3183)
+var<storage, read_write> local15: array<u32>;
+@group(1) @binding(2585)
+var<storage, read_write> field22: array<u32>;
+@group(8) @binding(2585)
+var<storage, read_write> parameter21: array<u32>;
+@group(3) @binding(3183)
+var<storage, read_write> global15: array<u32>;
+
+@compute @workgroup_size(7, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(frag_depth) f0: f32,
+  @location(5) f1: vec4<u32>,
+  @location(3) f2: vec4<f32>,
+  @location(2) f3: vec2<u32>,
+  @location(1) f4: vec4<f32>,
+  @builtin(sample_mask) f5: u32,
+  @location(0) f6: vec4<f32>,
+  @location(4) f7: vec3<u32>
+}
+
+@fragment
+fn fragment0(@location(25) a0: vec2<f16>, @location(16) a1: f32, @location(17) a2: vec4<u32>, @location(30) a3: vec2<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S21 {
+  @builtin(instance_index) f0: u32,
+  @location(13) f1: vec3<i32>,
+  @location(10) f2: vec2<f32>,
+  @location(24) f3: f16,
+  @location(6) f4: vec3<f32>,
+  @location(18) f5: f32,
+  @location(8) f6: i32,
+  @location(1) f7: vec3<f32>,
+  @location(17) f8: f32,
+  @location(16) f9: vec4<f32>,
+  @location(19) f10: f32,
+  @location(20) f11: vec3<i32>,
+  @location(22) f12: vec4<f32>,
+  @location(2) f13: vec2<u32>,
+  @location(12) f14: vec3<i32>,
+  @location(9) f15: vec4<f32>,
+  @location(15) f16: vec4<f32>,
+  @location(26) f17: f16,
+  @location(3) f18: vec4<f32>
+}
+struct VertexOutput0 {
+  @location(20) f219: vec3<i32>,
+  @location(25) f220: vec2<f16>,
+  @location(16) f221: f32,
+  @location(10) f222: vec3<u32>,
+  @location(3) f223: f16,
+  @location(5) f224: u32,
+  @location(26) f225: vec2<f16>,
+  @location(23) f226: u32,
+  @location(17) f227: vec4<u32>,
+  @builtin(position) f228: vec4<f32>,
+  @location(30) f229: vec2<f16>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(14) a1: vec2<f16>, @location(25) a2: vec2<u32>, a3: S21, @location(23) a4: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+});
+let texture120 = device2.createTexture({
+size: [828, 60, 1079],
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rg32sint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg32sint', 'rg32sint'],
+});
+let renderBundle90 = renderBundleEncoder35.finish({label: '\u7052\u7005\u{1fd47}\u51a3\uc0f0\u01a3\u43d1\u2a16'});
+let video30 = await videoWithData();
+let bindGroupLayout42 = device2.createBindGroupLayout({
+label: '\u2fb2\u6b15\u01a9\u0815\ued90\u1b9b\u{1ffec}\u0e54',
+entries: [{
+binding: 835,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 3233,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '3d' },
+}, {
+binding: 1720,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+}],
+});
+try {
+device2.queue.writeTexture({
+  texture: texture71,
+  mipLevel: 2,
+  origin: { x: 0, y: 12, z: 0 },
+  aspect: 'stencil-only',
+}, arrayBuffer3, /* required buffer size: 964 */
+{offset: 964}, {width: 80, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let img29 = await imageWithData(237, 211, '#ae1272ba', '#7486688f');
+let commandEncoder78 = device7.createCommandEncoder({label: '\uf8ff\u085e\u4b1d\u0599\ub40e'});
+try {
+commandEncoder74.copyBufferToBuffer(buffer40, 6420, buffer33, 1184, 7860);
+dissociateBuffer(device7, buffer40);
+dissociateBuffer(device7, buffer33);
+} catch {}
+try {
+device7.queue.submit([
+commandBuffer14,
+]);
+} catch {}
+let video31 = await videoWithData();
+let renderBundle91 = renderBundleEncoder70.finish({label: '\ua3ef\u0a32\u0b20\u959d\u397f'});
+try {
+renderBundleEncoder76.setVertexBuffer(4, buffer30, 156, 186);
+} catch {}
+let promise64 = buffer25.mapAsync(GPUMapMode.WRITE);
+try {
+commandEncoder61.clearBuffer(buffer41, 32336, 6884);
+dissociateBuffer(device6, buffer41);
+} catch {}
+try {
+commandEncoder61.resolveQuerySet(querySet65, 70, 530, buffer34, 22272);
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: { x: 264, y: 1, z: 0 },
+  aspect: 'all',
+}, arrayBuffer11, /* required buffer size: 798 */
+{offset: 798}, {width: 609, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet69 = device0.createQuerySet({
+type: 'occlusion',
+count: 2579,
+});
+let renderBundleEncoder87 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm', 'r8sint', undefined], sampleCount: 4, depthReadOnly: true});
+let renderBundle92 = renderBundleEncoder53.finish({label: '\ub70a\u02d2\ubff5\u61df\ub3ab\u3859\u0022\u063d'});
+try {
+commandEncoder75.resolveQuerySet(querySet21, 147, 791, buffer12, 27904);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 239, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 9144 */
+{offset: 44}, {width: 2275, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise51;
+} catch {}
+document.body.prepend(img17);
+let bindGroupLayout43 = device7.createBindGroupLayout({
+label: '\u04df\u8eb4\u14fe\uf69d\u58cf\u0ba2',
+entries: [{
+binding: 4028,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '1d' },
+}, {
+binding: 3740,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+let buffer44 = device7.createBuffer({
+  label: '\u0ecb\u8312\u052d\u134d',
+  size: 59847,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let pipeline77 = device7.createComputePipeline({
+label: '\u3352\uc03f\u0896\u02e3\u64fa\u0854\u{1fa4f}\uf156\u0c20\u{1fb36}\u{1fa7b}',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+},
+});
+let adapter13 = await promise56;
+try {
+  await promise52;
+} catch {}
+let bindGroupLayout44 = device7.createBindGroupLayout({
+entries: [{
+binding: 4461,
+visibility: 0,
+sampler: { type: 'filtering' },
+}],
+});
+let texture121 = device7.createTexture({
+label: '\ub13d\u0338\ufd41\u{1ff2f}\ue3c1\ue3cf\u12ef',
+size: {width: 9984, height: 1, depthOrArrayLayers: 2},
+mipLevelCount: 11,
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['depth24plus-stencil8'],
+});
+let renderBundleEncoder88 = device7.createRenderBundleEncoder({
+  label: '\u61ce\u5ac1\u04ad\ued16\uafbe\u{1fbc3}\ub5cb\u0cf7',
+  colorFormats: [],
+  depthStencilFormat: 'depth32float-stencil8'
+});
+let renderBundle93 = renderBundleEncoder86.finish({label: '\u8f1d\ua5e1\u{1fc13}\u1d14\u63ec\u3d78\u015c'});
+let sampler85 = device7.createSampler({
+label: '\u{1f83e}\u71be\u2250\u042b\u03b3\u09b6\u5bf1\u94c0\u0b4e',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+lodMaxClamp: 86.301,
+compare: 'always',
+});
+try {
+renderBundleEncoder64.setVertexBuffer(10, buffer42, 14432, 9368);
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(buffer39, 10772, buffer40, 9628, 2352);
+dissociateBuffer(device7, buffer39);
+dissociateBuffer(device7, buffer40);
+} catch {}
+try {
+device7.queue.writeBuffer(buffer40, 10208, new DataView(new ArrayBuffer(28629)), 23166, 2188);
+} catch {}
+let pipeline78 = device7.createComputePipeline({
+label: '\u{1f7a7}\u00ee\uf0fa\u{1fd67}\ua768\u13b4\u0649\u0a93\u{1f8ca}\u2ce4\u0025',
+layout: pipelineLayout16,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let bindGroup32 = device0.createBindGroup({
+label: '\u4dd5\u3f75\u5e13\u6b35\uc485\u7c88\u{1ffa9}\uc212\u80e5',
+layout: bindGroupLayout4,
+entries: [],
+});
+let buffer45 = device0.createBuffer({
+  label: '\ud0c6\u9b6c\u9330\uaec5\u03ec\u{1f881}\u01a7\u0984\u0fa6\u0cab',
+  size: 58308,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true
+});
+let texture122 = device0.createTexture({
+label: '\u1d47\ue30e\u1143\u0a44\u{1fb41}\u4813\u94eb\u9887\u{1fae8}\uf3d3',
+size: [20, 240, 1],
+mipLevelCount: 7,
+format: 'stencil8',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView94 = texture12.createView({dimension: '2d', aspect: 'all', baseMipLevel: 2, mipLevelCount: 1, baseArrayLayer: 244, arrayLayerCount: 1});
+try {
+renderBundleEncoder80.drawIndexedIndirect(buffer3, 8000);
+} catch {}
+try {
+renderBundleEncoder38.drawIndirect(buffer36, 21348);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder75.clearBuffer(buffer23, 27620, 13236);
+dissociateBuffer(device0, buffer23);
+} catch {}
+let pipeline79 = await promise53;
+let imageData34 = new ImageData(112, 220);
+try {
+renderBundleEncoder61.draw(56, 64, 0);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(0, buffer32, 1304);
+} catch {}
+try {
+commandEncoder75.copyBufferToBuffer(buffer37, 13408, buffer3, 26920, 1940);
+dissociateBuffer(device0, buffer37);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder75.clearBuffer(buffer3);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+gpuCanvasContext16.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba32sint', 'rgba8uint'],
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 24400, new DataView(new ArrayBuffer(61873)), 6389, 316);
+} catch {}
+try {
+  await promise64;
+} catch {}
+let commandEncoder79 = device2.createCommandEncoder();
+let querySet70 = device2.createQuerySet({
+label: '\u0f63\ucaea\u{1fa97}\u894d\ue68c',
+type: 'occlusion',
+count: 1565,
+});
+let commandBuffer19 = commandEncoder79.finish({
+label: '\u038b\u{1ff26}\u2bbd\u{1fdcd}\u0c1f\u0bea\u1468\u073d\u0a22\u{1fc16}\u7202',
+});
+let textureView95 = texture101.createView({label: '\u0449\u12cb\u039f\u094e\u8d0d\udb51\uc23c\u3e80\u0f41\u0d30\ub137', dimension: '2d-array'});
+let renderBundle94 = renderBundleEncoder59.finish({label: '\u1dd3\u0fe1\u{1fc00}\u08fa\u{1f614}\u{1fbe0}\u4161\u40e5\u808b\uf0c0\ud7be'});
+try {
+computePassEncoder62.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder84.setBindGroup(4, bindGroup25);
+} catch {}
+try {
+computePassEncoder23.insertDebugMarker('\u6619');
+} catch {}
+try {
+device2.queue.writeBuffer(buffer43, 17524, new Float32Array(33544), 16579, 392);
+} catch {}
+let gpuCanvasContext31 = offscreenCanvas34.getContext('webgpu');
+offscreenCanvas31.width = 239;
+let commandEncoder80 = device7.createCommandEncoder({label: '\u5cbb\u08f8\u01c6\ud570\u0884\u{1fb55}\u{1fb4c}\u{1fd40}\u543f\u5f43\uc729'});
+try {
+commandEncoder80.clearBuffer(buffer33, 5848, 4088);
+dissociateBuffer(device7, buffer33);
+} catch {}
+try {
+commandEncoder80.resolveQuerySet(querySet48, 550, 262, buffer26, 24832);
+} catch {}
+let video32 = await videoWithData();
+document.body.prepend(img8);
+gc();
+let textureView96 = texture109.createView({dimension: '2d-array', format: 'etc2-rgba8unorm', baseMipLevel: 9, baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+device8.queue.writeTexture({
+  texture: texture104,
+  mipLevel: 1,
+  origin: { x: 40, y: 60, z: 23 },
+  aspect: 'all',
+}, new Int8Array(arrayBuffer10), /* required buffer size: 52461 */
+{offset: 981, bytesPerRow: 44, rowsPerImage: 8}, {width: 0, height: 30, depthOrArrayLayers: 147});
+} catch {}
+let texture123 = device6.createTexture({
+label: '\u0c96\u072e\u92b8\u38bd\u26ba',
+size: {width: 564, height: 1, depthOrArrayLayers: 111},
+mipLevelCount: 10,
+sampleCount: 1,
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['r16uint'],
+});
+let renderBundleEncoder89 = device6.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb'], depthStencilFormat: 'depth24plus-stencil8', stencilReadOnly: true});
+let renderBundle95 = renderBundleEncoder74.finish({label: '\u282e\u8339\ueed9\u{1fbac}\u08be\u1cfb'});
+try {
+commandEncoder61.copyBufferToBuffer(buffer31, 25312, buffer41, 57292, 2132);
+dissociateBuffer(device6, buffer31);
+dissociateBuffer(device6, buffer41);
+} catch {}
+try {
+device6.queue.writeBuffer(buffer41, 2176, new DataView(new ArrayBuffer(19576)), 12787, 4556);
+} catch {}
+document.body.prepend(canvas28);
+try {
+renderBundleEncoder88.setVertexBuffer(4, buffer42, 18316);
+} catch {}
+try {
+commandEncoder78.copyBufferToBuffer(buffer39, 12796, buffer33, 1408, 616);
+dissociateBuffer(device7, buffer39);
+dissociateBuffer(device7, buffer33);
+} catch {}
+try {
+commandEncoder78.clearBuffer(buffer40, 7060, 3860);
+dissociateBuffer(device7, buffer40);
+} catch {}
+try {
+gpuCanvasContext17.configure({
+device: device7,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture115,
+  mipLevel: 0,
+  origin: { x: 751, y: 1, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 117 */
+{offset: 117}, {width: 378, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let texture124 = device9.createTexture({
+label: '\u0d87\u911a\ua70e\uae70\u5ee3\ue673\u{1fb38}\u5ca8',
+size: [512, 120, 1],
+mipLevelCount: 4,
+format: 'etc2-rgb8a1unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['etc2-rgb8a1unorm'],
+});
+let renderBundleEncoder90 = device9.createRenderBundleEncoder({
+  colorFormats: [undefined, 'rgba8sint', 'rg32float', 'bgra8unorm', 'rg32uint', 'r32uint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let commandEncoder81 = device9.createCommandEncoder({});
+let textureView97 = texture118.createView({
+  label: '\u4bc2\ue945\u76ec\u2ae9\ua420\u6194\u6624',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 38
+});
+let sampler86 = device9.createSampler({
+label: '\u{1fac3}\ua1ab\ue3a4\u2861\u3cfa\u20a2\u0404\u{1f9e2}\u184f',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 13.932,
+lodMaxClamp: 71.712,
+compare: 'never',
+});
+try {
+gpuCanvasContext20.configure({
+device: device9,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm-srgb', 'depth24plus', 'rgba8unorm-srgb'],
+alphaMode: 'opaque',
+});
+} catch {}
+let computePassEncoder63 = commandEncoder61.beginComputePass({label: '\uc6d4\u01f1\u{1f8fa}\u2003\u87be'});
+try {
+computePassEncoder63.end();
+} catch {}
+try {
+commandEncoder61.copyBufferToBuffer(buffer31, 15960, buffer41, 44352, 6632);
+dissociateBuffer(device6, buffer31);
+dissociateBuffer(device6, buffer41);
+} catch {}
+try {
+commandEncoder61.clearBuffer(buffer41, 23784, 30552);
+dissociateBuffer(device6, buffer41);
+} catch {}
+try {
+gpuCanvasContext14.configure({
+device: device6,
+format: 'bgra8unorm',
+usage: 0,
+viewFormats: ['bgra8unorm-srgb'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let texture125 = device7.createTexture({
+label: '\uee4d\u089e',
+size: {width: 1680, height: 80, depthOrArrayLayers: 3},
+mipLevelCount: 2,
+dimension: '3d',
+format: 'r32uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['r32uint', 'r32uint', 'r32uint'],
+});
+try {
+commandEncoder74.copyBufferToBuffer(buffer40, 22664, buffer33, 1392, 2504);
+dissociateBuffer(device7, buffer40);
+dissociateBuffer(device7, buffer33);
+} catch {}
+try {
+commandEncoder78.resolveQuerySet(querySet58, 1427, 106, buffer26, 23808);
+} catch {}
+let promise65 = device7.queue.onSubmittedWorkDone();
+let pipeline80 = device7.createRenderPipeline({
+label: '\u0c73\u6e7e',
+layout: pipelineLayout18,
+multisample: {
+count: 4,
+mask: 0xdf2c1dd3,
+},
+fragment: {module: shaderModule15, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'invert',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 3710,
+stencilWriteMask: 1915,
+depthBias: 30,
+depthBiasSlopeScale: 100,
+depthBiasClamp: 92,
+},
+vertex: {
+  module: shaderModule15,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 9228,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm10-10-10-2',
+offset: 2928,
+shaderLocation: 1,
+}, {
+format: 'float32x3',
+offset: 924,
+shaderLocation: 22,
+}, {
+format: 'sint8x4',
+offset: 7228,
+shaderLocation: 18,
+}, {
+format: 'uint32',
+offset: 5848,
+shaderLocation: 9,
+}, {
+format: 'sint32x4',
+offset: 8148,
+shaderLocation: 21,
+}, {
+format: 'sint16x4',
+offset: 6792,
+shaderLocation: 15,
+}, {
+format: 'float16x4',
+offset: 2908,
+shaderLocation: 23,
+}, {
+format: 'uint16x2',
+offset: 1772,
+shaderLocation: 17,
+}, {
+format: 'uint16x2',
+offset: 2076,
+shaderLocation: 7,
+}, {
+format: 'sint32x2',
+offset: 8048,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 1980,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm8x4',
+offset: 1600,
+shaderLocation: 16,
+}, {
+format: 'sint8x2',
+offset: 1218,
+shaderLocation: 4,
+}, {
+format: 'unorm8x4',
+offset: 96,
+shaderLocation: 19,
+}, {
+format: 'unorm10-10-10-2',
+offset: 232,
+shaderLocation: 14,
+}, {
+format: 'sint32',
+offset: 1964,
+shaderLocation: 12,
+}, {
+format: 'unorm10-10-10-2',
+offset: 56,
+shaderLocation: 0,
+}, {
+format: 'float32',
+offset: 1896,
+shaderLocation: 2,
+}, {
+format: 'sint16x2',
+offset: 912,
+shaderLocation: 6,
+}, {
+format: 'sint16x4',
+offset: 636,
+shaderLocation: 20,
+}, {
+format: 'snorm8x4',
+offset: 1852,
+shaderLocation: 10,
+}, {
+format: 'uint16x4',
+offset: 1460,
+shaderLocation: 13,
+}, {
+format: 'uint32x4',
+offset: 1272,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 8900,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x2',
+offset: 8550,
+shaderLocation: 8,
+}, {
+format: 'uint16x4',
+offset: 4388,
+shaderLocation: 3,
+}],
+}
+]
+},
+});
+let offscreenCanvas35 = new OffscreenCanvas(684, 901);
+try {
+adapter11.label = '\uf80e\ubdb3\u064f\u7472';
+} catch {}
+let querySet71 = device7.createQuerySet({
+label: '\ud756\u0aba',
+type: 'occlusion',
+count: 808,
+});
+let texture126 = device7.createTexture({
+label: '\u4cd0\u{1fb5a}',
+size: {width: 840, height: 40, depthOrArrayLayers: 1},
+mipLevelCount: 10,
+format: 'r16uint',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+let textureView98 = texture121.createView({label: '\u425e\u{1fb62}', baseMipLevel: 2, mipLevelCount: 7, arrayLayerCount: 1});
+let sampler87 = device7.createSampler({
+label: '\u279b\u{1f9f1}\u0897\u0962\u{1ffd5}\u5625',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+lodMinClamp: 64.516,
+lodMaxClamp: 94.154,
+});
+try {
+commandEncoder74.copyBufferToBuffer(buffer44, 48100, buffer40, 11696, 5712);
+dissociateBuffer(device7, buffer44);
+dissociateBuffer(device7, buffer40);
+} catch {}
+try {
+commandEncoder74.clearBuffer(buffer40, 12116, 2668);
+dissociateBuffer(device7, buffer40);
+} catch {}
+try {
+  await promise65;
+} catch {}
+document.body.prepend(canvas24);
+let device10 = await promise62;
+try {
+offscreenCanvas35.getContext('2d');
+} catch {}
+let querySet72 = device0.createQuerySet({
+label: '\u5c58\u07ba\u5b30\u003c\u0462\u6e6b\u{1f7c5}\u699d\u{1fc82}\u801c',
+type: 'occlusion',
+count: 2487,
+});
+let texture127 = gpuCanvasContext12.getCurrentTexture();
+try {
+computePassEncoder39.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder38.draw(56, 40, 48, 40);
+} catch {}
+try {
+renderBundleEncoder80.drawIndexed(16, 48, 48, 40, 64);
+} catch {}
+try {
+renderBundleEncoder38.setPipeline(pipeline42);
+} catch {}
+let commandEncoder82 = device7.createCommandEncoder({label: '\u0ec3\u455a\u01d0'});
+let querySet73 = device7.createQuerySet({
+type: 'occlusion',
+count: 2164,
+});
+let textureView99 = texture125.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let externalTexture5 = device7.importExternalTexture({
+label: '\u66a4\u{1fcb1}\u0148\ufea2',
+source: videoFrame7,
+colorSpace: 'display-p3',
+});
+try {
+commandEncoder74.copyBufferToBuffer(buffer44, 31716, buffer33, 5344, 736);
+dissociateBuffer(device7, buffer44);
+dissociateBuffer(device7, buffer33);
+} catch {}
+try {
+commandEncoder74.clearBuffer(buffer33, 7072, 524);
+dissociateBuffer(device7, buffer33);
+} catch {}
+try {
+commandEncoder74.resolveQuerySet(querySet71, 432, 180, buffer26, 6656);
+} catch {}
+try {
+device7.queue.writeBuffer(buffer40, 4928, new Float32Array(47091), 1128, 2056);
+} catch {}
+let texture128 = device6.createTexture({
+label: '\udee8\ue2f3\u{1fcc8}',
+size: {width: 230, height: 1, depthOrArrayLayers: 1568},
+mipLevelCount: 4,
+dimension: '3d',
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle96 = renderBundleEncoder60.finish({label: '\u1287\u0947\u{1fc3c}\u4dbb\u{1f7a0}\u08d6\ud9ec\u0cd1\uae01'});
+let sampler88 = device6.createSampler({
+label: '\ud1b5\u9daa',
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+lodMaxClamp: 73.136,
+});
+try {
+renderBundleEncoder76.setVertexBuffer(6, buffer30);
+} catch {}
+try {
+device6.addEventListener('uncapturederror', e => { log('device6.uncapturederror'); log(e); e.label = device6.label; });
+} catch {}
+let promise66 = buffer41.mapAsync(GPUMapMode.READ, 18216, 15480);
+try {
+commandEncoder61.clearBuffer(buffer41, 47296, 2876);
+dissociateBuffer(device6, buffer41);
+} catch {}
+try {
+commandEncoder61.resolveQuerySet(querySet68, 81, 895, buffer34, 22016);
+} catch {}
+try {
+commandEncoder61.pushDebugGroup('\u0f2e');
+} catch {}
+try {
+device6.queue.writeBuffer(buffer30, 64, new BigUint64Array(32935), 8826, 0);
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: { x: 468, y: 1, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(942), /* required buffer size: 942 */
+{offset: 942, bytesPerRow: 1977, rowsPerImage: 88}, {width: 856, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 57, height: 1, depthOrArrayLayers: 392}
+*/
+{
+  source: video2,
+  origin: { x: 1, y: 2 },
+  flipY: false,
+}, {
+  texture: texture128,
+  mipLevel: 2,
+  origin: { x: 27, y: 0, z: 310 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet74 = device8.createQuerySet({
+label: '\ucc67\u3cfa\u3795\u{1f6bc}\u08f0',
+type: 'occlusion',
+count: 2577,
+});
+try {
+adapter10.label = '\ub0c5\u{1fd9b}\u{1fc05}\u{1ff88}\u{1f74d}\u0a87\u062e\u0c24\u2c46\u{1f9b5}\u82d4';
+} catch {}
+let computePassEncoder64 = commandEncoder76.beginComputePass({label: '\u{1feb8}\u{1faa0}\u0dda\u4701'});
+try {
+computePassEncoder64.insertDebugMarker('\u{1fbde}');
+} catch {}
+try {
+gpuCanvasContext22.configure({
+device: device8,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+await device8.queue.onSubmittedWorkDone();
+} catch {}
+try {
+await adapter4.requestAdapterInfo();
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+let bindGroup33 = device0.createBindGroup({
+label: '\u0494\u{1f8e5}',
+layout: bindGroupLayout4,
+entries: [],
+});
+let commandEncoder83 = device0.createCommandEncoder({label: '\u{1fbe4}\u{1f859}\u0a11\u0388\uc2ee\u{1f637}\u0d0b\u54dd\u{1fdb3}\uc029\u4e86'});
+let sampler89 = device0.createSampler({
+label: '\u24c1\ud916\u0ea5\u{1f906}\u0e9e\u0352\u{1fb04}',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 79.781,
+lodMaxClamp: 87.287,
+});
+try {
+renderBundleEncoder80.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 43680, new DataView(new ArrayBuffer(37227)), 15764, 312);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline81 = device0.createComputePipeline({
+label: '\u07f5\u{1f7b6}\u6bc3\u0f35\u{1fccc}\u68ae\u5ad8\u0e15\u896f\u0526\u1eb0',
+layout: 'auto',
+compute: {
+module: shaderModule14,
+entryPoint: 'compute0',
+},
+});
+let video33 = await videoWithData();
+try {
+adapter11.label = '\u6ca2\u7936\u4cc7\u8b6d\ubbc6\u01ba';
+} catch {}
+let commandEncoder84 = device0.createCommandEncoder({label: '\u{1f9a7}\u{1fa07}'});
+let querySet75 = device0.createQuerySet({
+type: 'occlusion',
+count: 2390,
+});
+try {
+renderBundleEncoder61.drawIndexedIndirect(buffer36, 35104);
+} catch {}
+try {
+commandEncoder84.copyBufferToBuffer(buffer4, 34432, buffer12, 18280, 2724);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder84.clearBuffer(buffer24, 100, 52);
+dissociateBuffer(device0, buffer24);
+} catch {}
+let pipeline82 = await device0.createRenderPipelineAsync({
+label: '\u{1f8de}\ud578\u35b3\u7389\u07dd\u04f6',
+layout: pipelineLayout9,
+fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.ALL}, {format: 'rgba16sint', writeMask: GPUColorWrite.GREEN}, {format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgb10a2uint', writeMask: 0}, {format: 'rg32sint', writeMask: GPUColorWrite.ALL}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-clamp',
+depthFailOp: 'zero',
+passOp: 'zero',
+},
+stencilBack: {
+compare: 'greater',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 732,
+stencilWriteMask: 1607,
+depthBias: 27,
+depthBiasSlopeScale: 1,
+depthBiasClamp: 26,
+},
+vertex: {
+  module: shaderModule12,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 15880,
+stepMode: 'instance',
+attributes: [{
+format: 'uint8x2',
+offset: 4366,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 3432,
+stepMode: 'vertex',
+attributes: [{
+format: 'unorm16x2',
+offset: 152,
+shaderLocation: 13,
+}, {
+format: 'float32x2',
+offset: 76,
+shaderLocation: 3,
+}, {
+format: 'unorm16x4',
+offset: 1588,
+shaderLocation: 2,
+}, {
+format: 'sint32x3',
+offset: 1956,
+shaderLocation: 4,
+}, {
+format: 'sint32',
+offset: 1040,
+shaderLocation: 9,
+}, {
+format: 'float32',
+offset: 1136,
+shaderLocation: 7,
+}, {
+format: 'snorm8x4',
+offset: 1048,
+shaderLocation: 1,
+}, {
+format: 'unorm8x2',
+offset: 1920,
+shaderLocation: 11,
+}, {
+format: 'uint32x2',
+offset: 876,
+shaderLocation: 14,
+}, {
+format: 'sint32x3',
+offset: 708,
+shaderLocation: 0,
+}, {
+format: 'unorm16x4',
+offset: 876,
+shaderLocation: 8,
+}, {
+format: 'sint16x2',
+offset: 3160,
+shaderLocation: 15,
+}, {
+format: 'sint8x2',
+offset: 898,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 9356,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32x3',
+offset: 8052,
+shaderLocation: 5,
+}, {
+format: 'float32x4',
+offset: 5024,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'triangle-strip',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+try {
+window.someLabel = device6.queue.label;
+} catch {}
+let computePassEncoder65 = commandEncoder61.beginComputePass({label: '\u65e6\u090f\u{1f831}\u{1fefd}\u8db2\u4668'});
+try {
+computePassEncoder65.end();
+} catch {}
+try {
+gpuCanvasContext7.configure({
+device: device6,
+format: 'rgb10a2uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['depth24plus', 'rgb10a2uint', 'rgb10a2uint', 'rgb10a2uint'],
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 57, height: 1, depthOrArrayLayers: 392}
+*/
+{
+  source: offscreenCanvas17,
+  origin: { x: 176, y: 38 },
+  flipY: true,
+}, {
+  texture: texture128,
+  mipLevel: 2,
+  origin: { x: 14, y: 1, z: 170 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 43, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let imageData35 = new ImageData(76, 212);
+let pipelineLayout19 = device8.createPipelineLayout({label: '\u3c1d\u08d6\u{1fc59}', bindGroupLayouts: [bindGroupLayout38]});
+let commandBuffer20 = commandEncoder48.finish({
+label: '\u{1fa97}\u{1f873}',
+});
+try {
+computePassEncoder56.end();
+} catch {}
+try {
+renderBundleEncoder81.setBindGroup(7, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder84.setBindGroup(2, bindGroup25, new Uint32Array(4407), 2022, 0);
+} catch {}
+try {
+renderBundleEncoder84.setVertexBuffer(7, buffer35);
+} catch {}
+try {
+commandEncoder64.clearBuffer(buffer19, 59872);
+dissociateBuffer(device2, buffer19);
+} catch {}
+let pipeline83 = await promise60;
+let offscreenCanvas36 = new OffscreenCanvas(155, 330);
+try {
+window.someLabel = texture124.label;
+} catch {}
+let buffer46 = device9.createBuffer({label: '\u1d07\u0fb8', size: 10554, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let computePassEncoder66 = commandEncoder81.beginComputePass({});
+let renderBundle97 = renderBundleEncoder90.finish({label: '\uef02\uafbd\u07fc\u7871\u04a6\uc6b7\u35d4\uf38e\u0f31\uafca'});
+try {
+gpuCanvasContext23.configure({
+device: device9,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise66;
+} catch {}
+let video34 = await videoWithData();
+pseudoSubmit(device8, commandEncoder76);
+let texture129 = device8.createTexture({
+label: '\u9069\u{1f6ba}',
+size: {width: 840, height: 4, depthOrArrayLayers: 1},
+mipLevelCount: 3,
+format: 'eac-r11snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['eac-r11snorm', 'eac-r11snorm'],
+});
+let querySet76 = device10.createQuerySet({
+label: '\u5995\u5c85\u7ac2\u{1f647}\ud989\u129b\u1f84',
+type: 'occlusion',
+count: 181,
+});
+let sampler90 = device10.createSampler({
+addressModeV: 'repeat',
+addressModeW: 'clamp-to-edge',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 99.684,
+lodMaxClamp: 99.847,
+});
+let video35 = await videoWithData();
+pseudoSubmit(device9, commandEncoder81);
+let texture130 = device9.createTexture({
+label: '\u{1f6f6}\ud082\u0e1b\u02dc\u{1fc2c}\u23d2\u09ea\ud5c5\u1a81',
+size: {width: 160, height: 8, depthOrArrayLayers: 173},
+mipLevelCount: 4,
+format: 'astc-10x8-unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: [],
+});
+let offscreenCanvas37 = new OffscreenCanvas(334, 892);
+let commandEncoder85 = device0.createCommandEncoder();
+let renderBundleEncoder91 = device0.createRenderBundleEncoder({
+  label: '\u{1f634}\u8b74\ua26f\u{1fc1e}\u40ad\ueff8\u019b\u2ec5',
+  colorFormats: ['r8uint', undefined, 'rg16sint', 'r8uint', 'rg8sint', 'rgba8unorm', 'r8sint', 'r16sint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4
+});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+computePassEncoder19.setBindGroup(1, bindGroup1, new Uint32Array(6166), 1743, 0);
+} catch {}
+try {
+renderBundleEncoder61.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+commandEncoder83.resolveQuerySet(querySet8, 87, 66, buffer27, 3072);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: { x: 24, y: 96, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 370 */
+{offset: 370}, {width: 24, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let adapter14 = await navigator.gpu.requestAdapter({
+});
+let bindGroupLayout45 = device10.createBindGroupLayout({
+label: '\u{1fac3}\u{1f77b}\ue8f3\u8057\u02df\u793d\u3ff8\u79f9\u00cb\u5d3c\u0b5f',
+entries: [{
+binding: 777,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+sampler: { type: 'comparison' },
+}],
+});
+let querySet77 = device10.createQuerySet({
+label: '\u01e3\u{1f7d7}\ue7bf\u856c\u{1fd7a}',
+type: 'occlusion',
+count: 3760,
+});
+let texture131 = device10.createTexture({
+size: {width: 1040, height: 64, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'rg16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+device10.pushErrorScope('internal');
+} catch {}
+try {
+gpuCanvasContext8.configure({
+device: device10,
+format: 'rgba8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['astc-10x5-unorm', 'astc-10x10-unorm', 'astc-5x4-unorm', 'rgba8unorm-srgb'],
+colorSpace: 'srgb',
+});
+} catch {}
+try {
+window.someLabel = sampler44.label;
+} catch {}
+try {
+offscreenCanvas37.getContext('webgl2');
+} catch {}
+let texture132 = device9.createTexture({
+label: '\u9ba5\udb54',
+size: [512, 120, 1],
+mipLevelCount: 7,
+dimension: '2d',
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm-srgb'],
+});
+try {
+device9.queue.writeTexture({
+  texture: texture130,
+  mipLevel: 0,
+  origin: { x: 10, y: 0, z: 3 },
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 1908114 */
+{offset: 306, bytesPerRow: 334, rowsPerImage: 34}, {width: 50, height: 0, depthOrArrayLayers: 169});
+} catch {}
+let gpuCanvasContext32 = offscreenCanvas36.getContext('webgpu');
+let img30 = await imageWithData(214, 38, '#c03e6732', '#24bede12');
+let video36 = await videoWithData();
+let bindGroupLayout46 = device8.createBindGroupLayout({
+entries: [{
+binding: 87,
+visibility: GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}],
+});
+try {
+renderBundleEncoder72.setVertexBuffer(31, undefined, 3250125943, 86890225);
+} catch {}
+try {
+device8.destroy();
+} catch {}
+let videoFrame25 = new VideoFrame(imageBitmap4, {timestamp: 0});
+let texture133 = device2.createTexture({
+size: {width: 160, height: 55, depthOrArrayLayers: 247},
+mipLevelCount: 3,
+dimension: '3d',
+format: 'r8sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+viewFormats: ['r8sint', 'r8sint'],
+});
+let sampler91 = device2.createSampler({
+label: '\u{1fb3c}\u0992\ua402\u0838\u0f6d\u0515\u58be\u8f17\uccc8',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+lodMinClamp: 81.748,
+lodMaxClamp: 90.147,
+compare: 'always',
+});
+try {
+computePassEncoder41.setBindGroup(5, bindGroup25, new Uint32Array(1133), 1049, 0);
+} catch {}
+try {
+commandEncoder64.resolveQuerySet(querySet28, 919, 182, buffer19, 35072);
+} catch {}
+let promise67 = device2.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+try {
+  await promise67;
+} catch {}
+let canvas33 = document.createElement('canvas');
+let videoFrame26 = new VideoFrame(offscreenCanvas1, {timestamp: 0});
+let gpuCanvasContext33 = canvas33.getContext('webgpu');
+let commandEncoder86 = device6.createCommandEncoder({label: '\u373b\ue589\u0109\ubbae'});
+try {
+device6.queue.writeBuffer(buffer30, 604, new BigUint64Array(59722), 19566, 0);
+} catch {}
+try {
+device6.queue.writeTexture({
+  texture: texture106,
+  mipLevel: 0,
+  origin: { x: 78, y: 0, z: 18 },
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer13), /* required buffer size: 5429060 */
+{offset: 688, bytesPerRow: 1500, rowsPerImage: 201}, {width: 343, height: 1, depthOrArrayLayers: 19});
+} catch {}
+pseudoSubmit(device6, commandEncoder86);
+let computePassEncoder67 = commandEncoder61.beginComputePass();
+let offscreenCanvas38 = new OffscreenCanvas(792, 772);
+try {
+offscreenCanvas38.getContext('bitmaprenderer');
+} catch {}
+let pipelineLayout20 = device7.createPipelineLayout({
+  label: '\u057c\u02fd\u3218\u0dba',
+  bindGroupLayouts: [bindGroupLayout35, bindGroupLayout35, bindGroupLayout34, bindGroupLayout41]
+});
+let texture134 = device7.createTexture({
+label: '\u0701\u1706\ueafb\u0045\u6ce0\u46c5\u63fe\u{1f629}\ued30\ub92d',
+size: [2496, 1, 1],
+mipLevelCount: 5,
+format: 'rg16sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler92 = device7.createSampler({
+label: '\u0fa6\u89cc\ua409\u{1fe6d}\u0d2d',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 28.895,
+lodMaxClamp: 48.699,
+maxAnisotropy: 7,
+});
+canvas0.height = 898;
+let bindGroupLayout47 = device10.createBindGroupLayout({
+label: '\ucb69\u{1fbd3}\u74c1',
+entries: [{
+binding: 587,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+}, {
+binding: 420,
+visibility: 0,
+buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+}, {
+binding: 966,
+visibility: GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '2d-array' },
+}],
+});
+let querySet78 = device10.createQuerySet({
+type: 'occlusion',
+count: 1380,
+});
+let sampler93 = device10.createSampler({
+label: '\ue0da\u0859\ua635\u3f92',
+mipmapFilter: 'nearest',
+lodMinClamp: 64.703,
+lodMaxClamp: 68.646,
+compare: 'not-equal',
+});
+let querySet79 = device9.createQuerySet({
+label: '\u07f5\u9629\u27a2\u{1f68c}\u07c1\u254f\uad5c',
+type: 'occlusion',
+count: 2859,
+});
+let texture135 = device9.createTexture({
+label: '\ufbb3\u064b\u5f2e\u0bde\u{1fabd}',
+size: {width: 40, height: 15, depthOrArrayLayers: 2},
+mipLevelCount: 6,
+sampleCount: 1,
+dimension: '3d',
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST,
+});
+try {
+await adapter3.requestAdapterInfo();
+} catch {}
+let img31 = await imageWithData(172, 116, '#b0c133f2', '#95e99fe0');
+try {
+gpuCanvasContext21.unconfigure();
+} catch {}
+canvas0.height = 867;
+let bindGroupLayout48 = device6.createBindGroupLayout({
+label: '\u027f\u093b\uf613\u{1ff15}\u7811\u9852',
+entries: [{
+binding: 4378,
+visibility: GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 561,
+visibility: GPUShaderStage.COMPUTE,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+}, {
+binding: 3874,
+visibility: GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+}],
+});
+let texture136 = device6.createTexture({
+label: '\u0b00\u87e9\uad30\u002c\uc8be\u016d\u2549\u03f0\ufcbf\ufbf4',
+size: [460, 1, 1],
+mipLevelCount: 2,
+format: 'rgba8unorm-srgb',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8unorm'],
+});
+let renderBundleEncoder92 = device6.createRenderBundleEncoder({
+  label: '\u9f67\u{1fa32}\u7b70\u0dfb\u{1f75f}\u{1fb53}\u60e6\u{1fb41}',
+  colorFormats: ['rg16uint', 'rgba8sint', 'rgb10a2uint', 'rg8sint', 'rgba32sint'],
+  stencilReadOnly: true
+});
+try {
+device6.queue.writeBuffer(buffer30, 336, new Int16Array(17622), 5297, 32);
+} catch {}
+let offscreenCanvas39 = new OffscreenCanvas(716, 1008);
+try {
+device8.queue.label = '\u00ab\u0287\u0fdc\u{1ff20}\u057d';
+} catch {}
+let textureView100 = texture134.createView({label: '\u04e7\u3ed8\ua3b0\ucdad\ucc9c\u{1f719}', dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 2});
+try {
+commandEncoder78.copyTextureToTexture({
+  texture: texture125,
+  mipLevel: 1,
+  origin: { x: 56, y: 7, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture125,
+  mipLevel: 0,
+  origin: { x: 903, y: 41, z: 2 },
+  aspect: 'all',
+}, {width: 250, height: 28, depthOrArrayLayers: 1});
+} catch {}
+try {
+device7.queue.writeBuffer(buffer40, 8168, new BigUint64Array(8531), 6735, 1340);
+} catch {}
+let pipeline84 = device7.createComputePipeline({
+label: '\ue190\u1aa3\u4871\u29a8\u{1f6a7}',
+layout: pipelineLayout18,
+compute: {
+module: shaderModule15,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let pipeline85 = await device7.createRenderPipelineAsync({
+label: '\u{1f930}\ud4f4\u5b31\u8e93\u321f\u080d\ud341\u4e47',
+layout: pipelineLayout16,
+fragment: {module: shaderModule15, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'not-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'invert',
+passOp: 'invert',
+},
+stencilBack: {
+compare: 'less',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 1672,
+stencilWriteMask: 3932,
+depthBiasSlopeScale: 89,
+},
+vertex: {
+  module: shaderModule15,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 8668,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x2',
+offset: 2916,
+shaderLocation: 3,
+}, {
+format: 'sint16x4',
+offset: 3936,
+shaderLocation: 6,
+}, {
+format: 'sint16x4',
+offset: 3444,
+shaderLocation: 18,
+}, {
+format: 'uint8x4',
+offset: 4712,
+shaderLocation: 7,
+}, {
+format: 'sint32x2',
+offset: 656,
+shaderLocation: 12,
+}, {
+format: 'snorm16x2',
+offset: 6516,
+shaderLocation: 22,
+}, {
+format: 'float16x2',
+offset: 7884,
+shaderLocation: 1,
+}, {
+format: 'uint32x2',
+offset: 3616,
+shaderLocation: 9,
+}, {
+format: 'unorm8x2',
+offset: 6114,
+shaderLocation: 10,
+}, {
+format: 'float16x4',
+offset: 4976,
+shaderLocation: 2,
+}, {
+format: 'snorm16x4',
+offset: 852,
+shaderLocation: 0,
+}, {
+format: 'unorm10-10-10-2',
+offset: 7392,
+shaderLocation: 16,
+}, {
+format: 'sint32x3',
+offset: 2988,
+shaderLocation: 21,
+}, {
+format: 'uint16x4',
+offset: 568,
+shaderLocation: 5,
+}, {
+format: 'snorm16x4',
+offset: 7260,
+shaderLocation: 23,
+}, {
+format: 'sint32',
+offset: 7660,
+shaderLocation: 4,
+}, {
+format: 'sint32x4',
+offset: 6232,
+shaderLocation: 11,
+}, {
+format: 'uint16x4',
+offset: 5568,
+shaderLocation: 17,
+}, {
+format: 'float16x2',
+offset: 3316,
+shaderLocation: 19,
+}, {
+format: 'unorm8x2',
+offset: 2066,
+shaderLocation: 14,
+}, {
+format: 'uint8x2',
+offset: 5182,
+shaderLocation: 13,
+}, {
+format: 'uint16x2',
+offset: 6736,
+shaderLocation: 8,
+}, {
+format: 'sint8x2',
+offset: 6206,
+shaderLocation: 20,
+}],
+},
+{
+arrayStride: 1824,
+attributes: [],
+},
+{
+arrayStride: 12364,
+stepMode: 'instance',
+attributes: [{
+format: 'sint32',
+offset: 9096,
+shaderLocation: 15,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let adapter15 = await navigator.gpu.requestAdapter({
+});
+let gpuCanvasContext34 = offscreenCanvas39.getContext('webgpu');
+let offscreenCanvas40 = new OffscreenCanvas(719, 270);
+let texture137 = device9.createTexture({
+label: '\u15dc\u2665\u52db\ub7cc\u0e7d\ua83c\u585f\u5204\u81be\udbba\uc593',
+size: {width: 640, height: 32, depthOrArrayLayers: 1},
+mipLevelCount: 8,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-8x8-unorm', 'astc-8x8-unorm', 'astc-8x8-unorm'],
+});
+let textureView101 = texture118.createView({label: '\u58bf\u3310\u{1fd03}', baseMipLevel: 1, mipLevelCount: 2, baseArrayLayer: 8, arrayLayerCount: 3});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageData36 = new ImageData(64, 36);
+let videoFrame27 = new VideoFrame(img24, {timestamp: 0});
+let gpuCanvasContext35 = offscreenCanvas40.getContext('webgpu');
+let pipelineLayout21 = device6.createPipelineLayout({
+  label: '\u83ee\u{1f9c6}\u5338\u0697\ueb90\uc0cf\u40b6\u4f8d\u88fb\uea58\u0695',
+  bindGroupLayouts: [bindGroupLayout48, bindGroupLayout48]
+});
+let commandEncoder87 = device6.createCommandEncoder({label: '\ue080\u{1f807}\u0e67\u0757'});
+let renderBundle98 = renderBundleEncoder92.finish({label: '\u{1fa6d}\ue721\u0716\ua2bb\u00f6'});
+try {
+buffer30.destroy();
+} catch {}
+try {
+commandEncoder87.resolveQuerySet(querySet44, 514, 106, buffer34, 14080);
+} catch {}
+let offscreenCanvas41 = new OffscreenCanvas(728, 46);
+let img32 = await imageWithData(170, 293, '#4fc80a7b', '#f24b3d91');
+try {
+offscreenCanvas41.getContext('webgl2');
+} catch {}
+let querySet80 = device2.createQuerySet({
+label: '\uecbd\u03ba\ucc6a\u{1fd0f}\u0244\u{1fbe3}',
+type: 'occlusion',
+count: 1536,
+});
+let computePassEncoder68 = commandEncoder64.beginComputePass({});
+let sampler94 = device2.createSampler({
+label: '\u{1fb99}\u{1fc01}\u0e0c\u0038\u017b\uc6bc\u{1fe70}\u0497',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 75.145,
+maxAnisotropy: 2,
+});
+try {
+renderBundleEncoder84.setPipeline(pipeline71);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+offscreenCanvas16.height = 1022;
+let video37 = await videoWithData();
+let pipelineLayout22 = device10.createPipelineLayout({bindGroupLayouts: [bindGroupLayout47, bindGroupLayout47, bindGroupLayout45]});
+let sampler95 = device10.createSampler({
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 71.465,
+lodMaxClamp: 72.713,
+});
+try {
+gpuCanvasContext10.configure({
+device: device10,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['astc-5x5-unorm', 'bgra8unorm-srgb', 'astc-10x5-unorm', 'rg32uint'],
+colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device10.queue.writeTexture({
+  texture: texture131,
+  mipLevel: 6,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 18 */
+{offset: 18}, {width: 2, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let querySet81 = device10.createQuerySet({
+type: 'occlusion',
+count: 1848,
+});
+try {
+gpuCanvasContext6.configure({
+device: device10,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['r32float', 'astc-6x6-unorm-srgb', 'rgba16float'],
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let img33 = await imageWithData(260, 109, '#da72d65b', '#39af1241');
+let texture138 = device6.createTexture({
+size: [495],
+sampleCount: 1,
+dimension: '1d',
+format: 'rg32uint',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rg32uint'],
+});
+let buffer47 = device7.createBuffer({label: '\u5ceb\u01cc\u{1fbc6}\u{1f78f}\u0b12\u0a9b\u099e', size: 24740, usage: GPUBufferUsage.INDIRECT});
+let textureView102 = texture96.createView({
+  label: '\u1951\u5bbe\u{1f6c5}\u{1f7cb}\u{1f6e3}\u0c50\u{1f73c}\u08c0',
+  aspect: 'depth-only',
+  baseMipLevel: 3,
+  baseArrayLayer: 184,
+  arrayLayerCount: 11
+});
+let renderBundleEncoder93 = device7.createRenderBundleEncoder({
+  label: '\u{1f692}\u9926\u1429\u6b7b\u024c',
+  colorFormats: [],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler96 = device7.createSampler({
+label: '\u04f3\ubfcf\u0b15\u0354\ube4d\u6bab\u1a54\u07a4\ue063',
+addressModeU: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+lodMinClamp: 35.070,
+lodMaxClamp: 96.004,
+});
+try {
+renderBundleEncoder93.setVertexBuffer(10, buffer42, 2064, 38624);
+} catch {}
+try {
+renderBundleEncoder38.draw(40);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexedIndirect(buffer36, 27416);
+} catch {}
+try {
+renderBundleEncoder61.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder84.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 0,
+  origin: { x: 10, y: 280, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 112 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 35920 */
+offset: 3808,
+bytesPerRow: 256,
+buffer: buffer23,
+}, {width: 35, height: 630, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer23);
+} catch {}
+try {
+commandEncoder85.clearBuffer(buffer24, 184, 48);
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 36180, new Float32Array(64756), 61452, 416);
+} catch {}
+let promise68 = adapter15.requestDevice({
+label: '\u12d5\u88b1\u{1f8af}\ufeb2\u{1fd77}\u36b1',
+requiredFeatures: [
+'texture-compression-astc',
+'shader-f16',
+'rg11b10ufloat-renderable'
+],
+requiredLimits: {
+maxBindGroups: 7,
+maxColorAttachmentBytesPerSample: 43,
+maxVertexBufferArrayStride: 40887,
+maxStorageTexturesPerShaderStage: 42,
+maxStorageBuffersPerShaderStage: 31,
+maxDynamicStorageBuffersPerPipelineLayout: 36380,
+maxBindingsPerBindGroup: 8761,
+maxTextureDimension1D: 14023,
+maxTextureDimension2D: 9135,
+maxVertexBuffers: 11,
+minStorageBufferOffsetAlignment: 64,
+minUniformBufferOffsetAlignment: 128,
+maxUniformBufferBindingSize: 242500217,
+maxUniformBuffersPerShaderStage: 37,
+maxInterStageShaderVariables: 73,
+maxInterStageShaderComponents: 119,
+},
+});
+let imageBitmap25 = await createImageBitmap(video1);
+try {
+gpuCanvasContext31.unconfigure();
+} catch {}
+let shaderModule21 = device7.createShaderModule({
+label: '\u{1fa9a}\ue099\uae1c\u1279\u313a\u0d27',
+code: `@group(3) @binding(932)
+var<storage, read_write> field23: array<u32>;
+@group(3) @binding(930)
+var<storage, read_write> function22: array<u32>;
+@group(0) @binding(4885)
+var<storage, read_write> global16: array<u32>;
+@group(3) @binding(5657)
+var<storage, read_write> function23: array<u32>;
+
+@compute @workgroup_size(3, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S23 {
+  @builtin(sample_mask) f0: u32
+}
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, a1: S23, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S22 {
+  @location(10) f0: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: f32, @location(20) a1: vec3<i32>, @location(9) a2: vec2<u32>, @location(23) a3: vec4<f32>, a4: S22, @location(5) a5: f32, @location(6) a6: u32, @location(0) a7: vec2<i32>, @location(17) a8: vec2<u32>, @location(1) a9: vec2<u32>, @location(12) a10: vec4<f16>, @location(2) a11: vec4<i32>, @location(8) a12: vec2<f32>, @builtin(instance_index) a13: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+try {
+renderBundleEncoder88.setVertexBuffer(60, undefined, 587408777);
+} catch {}
+try {
+commandEncoder82.copyBufferToTexture({
+/* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 1374 */
+offset: 1374,
+buffer: buffer44,
+}, {
+  texture: texture126,
+  mipLevel: 7,
+  origin: { x: 2, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device7, buffer44);
+} catch {}
+let pipeline86 = device7.createRenderPipeline({
+label: '\u0c1f\ua104\u0831\u02ee\u{1fcdc}\u0cce\u{1fce1}\u6fc3',
+layout: pipelineLayout16,
+multisample: {
+count: 4,
+mask: 0x7daa7a6e,
+},
+fragment: {module: shaderModule21, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'stencil8',
+depthWriteEnabled: false,
+depthCompare: 'always',
+stencilFront: {
+compare: 'less-equal',
+failOp: 'increment-wrap',
+depthFailOp: 'increment-clamp',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'equal',
+failOp: 'zero',
+depthFailOp: 'decrement-clamp',
+passOp: 'increment-clamp',
+},
+stencilReadMask: 188,
+depthBias: 34,
+depthBiasSlopeScale: 13,
+},
+vertex: {
+  module: shaderModule21,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 15944,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x4',
+offset: 13380,
+shaderLocation: 9,
+}, {
+format: 'unorm16x4',
+offset: 14268,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 15708,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint32x4',
+offset: 6268,
+shaderLocation: 20,
+}],
+},
+{
+arrayStride: 10808,
+stepMode: 'instance',
+attributes: [{
+format: 'uint32x3',
+offset: 6824,
+shaderLocation: 1,
+}, {
+format: 'uint32x4',
+offset: 7764,
+shaderLocation: 6,
+}, {
+format: 'sint32x3',
+offset: 9436,
+shaderLocation: 2,
+}, {
+format: 'float32x2',
+offset: 2604,
+shaderLocation: 5,
+}, {
+format: 'unorm16x4',
+offset: 9260,
+shaderLocation: 10,
+}, {
+format: 'float32',
+offset: 1664,
+shaderLocation: 23,
+}, {
+format: 'unorm10-10-10-2',
+offset: 9780,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 16140,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x3',
+offset: 15340,
+shaderLocation: 12,
+}, {
+format: 'sint8x4',
+offset: 8116,
+shaderLocation: 0,
+}, {
+format: 'uint8x4',
+offset: 3136,
+shaderLocation: 17,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+let imageBitmap26 = await createImageBitmap(imageData23);
+let bindGroupLayout49 = device10.createBindGroupLayout({
+label: '\u3c5b\u101d\u1522\ud438\u{1fe28}\u6b50',
+entries: [{
+binding: 646,
+visibility: GPUShaderStage.FRAGMENT,
+storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '2d' },
+}, {
+binding: 173,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}, {
+binding: 343,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '3d' },
+}],
+});
+let commandEncoder88 = device10.createCommandEncoder({});
+try {
+device10.queue.writeTexture({
+  texture: texture131,
+  mipLevel: 0,
+  origin: { x: 537, y: 4, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(265), /* required buffer size: 265 */
+{offset: 265, bytesPerRow: 1321}, {width: 284, height: 35, depthOrArrayLayers: 0});
+} catch {}
+video35.height = 219;
+let texture139 = device9.createTexture({
+size: [256, 60, 1],
+mipLevelCount: 8,
+format: 'depth32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['depth32float', 'depth32float'],
+});
+let promise69 = device9.popErrorScope();
+let shaderModule22 = device10.createShaderModule({
+label: '\u0bcf\u{1fb8d}\u0916\uf8b5',
+code: `@group(2) @binding(777)
+var<storage, read_write> global17: array<u32>;
+@group(1) @binding(420)
+var<storage, read_write> field24: array<u32>;
+@group(0) @binding(587)
+var<storage, read_write> field25: array<u32>;
+@group(1) @binding(587)
+var<storage, read_write> global18: array<u32>;
+@group(0) @binding(420)
+var<storage, read_write> parameter22: array<u32>;
+
+@compute @workgroup_size(8, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S25 {
+  @location(1) f0: vec4<i32>,
+  @location(14) f1: vec2<i32>
+}
+struct FragmentOutput0 {
+  @location(5) f0: vec4<f32>,
+  @location(4) f1: vec4<i32>,
+  @location(1) f2: vec4<u32>,
+  @location(0) f3: vec2<f32>,
+  @location(3) f4: u32,
+  @location(2) f5: vec4<f32>,
+  @location(7) f6: i32
+}
+
+@fragment
+fn fragment0(@location(2) a0: vec4<f16>, @builtin(sample_index) a1: u32, @location(0) a2: vec4<i32>, @location(13) a3: vec4<f32>, @location(8) a4: vec2<f32>, a5: S25, @location(11) a6: vec3<u32>, @location(12) a7: vec2<f32>, @location(3) a8: vec3<f16>, @location(4) a9: f16) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S24 {
+  @location(13) f0: vec3<f32>
+}
+struct VertexOutput0 {
+  @location(11) f230: vec3<u32>,
+  @location(4) f231: f16,
+  @location(13) f232: vec4<f32>,
+  @location(10) f233: vec4<i32>,
+  @location(1) f234: vec4<i32>,
+  @builtin(position) f235: vec4<f32>,
+  @location(8) f236: vec2<f32>,
+  @location(2) f237: vec4<f16>,
+  @location(12) f238: vec2<f32>,
+  @location(6) f239: u32,
+  @location(0) f240: vec4<i32>,
+  @location(9) f241: i32,
+  @location(14) f242: vec2<i32>,
+  @location(3) f243: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(4) a0: f16, @location(7) a1: vec3<f16>, @location(8) a2: vec2<u32>, @location(12) a3: vec2<u32>, @location(10) a4: i32, @location(0) a5: vec2<u32>, @location(11) a6: f16, a7: S24) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let buffer48 = device10.createBuffer({
+  label: '\uaaee\u0905\u3b08\u{1f701}\u4df6\u3cb3\u070e\u7a2e\u3123\u30d4\ufab6',
+  size: 42836,
+  usage: GPUBufferUsage.INDIRECT
+});
+let commandEncoder89 = device10.createCommandEncoder({label: '\u57a1\u24a8\u24d6\u0196\u095a'});
+try {
+buffer48.unmap();
+} catch {}
+try {
+gpuCanvasContext32.configure({
+device: device10,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb', 'r8unorm'],
+colorSpace: 'display-p3',
+});
+} catch {}
+let textureView103 = texture132.createView({label: '\u25f8\u815d\u4056\u7238\ufbd1\u{1f87e}\u{1fd94}', dimension: '2d', baseMipLevel: 2});
+let img34 = await imageWithData(74, 193, '#1624d110', '#e80c6c44');
+try {
+gpuCanvasContext32.unconfigure();
+} catch {}
+let shaderModule23 = device8.createShaderModule({
+label: '\u38b0\u{1f866}\u{1ff99}\u11cb\ua3c4\u0ffb\ue36a\u0e9d\u0344',
+code: `@group(0) @binding(232)
+var<storage, read_write> field26: array<u32>;
+@group(0) @binding(442)
+var<storage, read_write> function24: array<u32>;
+
+@compute @workgroup_size(7, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S27 {
+  @builtin(sample_mask) f0: u32
+}
+struct FragmentOutput0 {
+  @location(4) f0: vec4<f32>,
+  @location(1) f1: vec4<f32>,
+  @location(5) f2: vec4<u32>,
+  @location(0) f3: vec2<i32>,
+  @location(2) f4: vec2<i32>,
+  @location(3) f5: vec3<u32>
+}
+
+@fragment
+fn fragment0(a0: S27, @builtin(sample_index) a1: u32, @builtin(position) a2: vec4<f32>, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S26 {
+  @location(3) f0: i32,
+  @location(7) f1: i32,
+  @location(12) f2: vec3<f32>,
+  @location(13) f3: vec3<i32>,
+  @location(11) f4: vec3<i32>,
+  @location(9) f5: f32,
+  @location(2) f6: f32,
+  @builtin(instance_index) f7: u32,
+  @location(6) f8: vec3<u32>,
+  @builtin(vertex_index) f9: u32,
+  @location(8) f10: vec4<i32>,
+  @location(14) f11: f16,
+  @location(5) f12: u32,
+  @location(4) f13: vec4<f16>,
+  @location(1) f14: vec3<f32>,
+  @location(0) f15: u32
+}
+
+@vertex
+fn vertex0(a0: S26, @location(15) a1: vec3<u32>, @location(10) a2: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let bindGroupLayout50 = device8.createBindGroupLayout({
+entries: [{
+binding: 134,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}],
+});
+let texture140 = gpuCanvasContext27.getCurrentTexture();
+let textureView104 = texture140.createView({
+  label: '\uecbf\ube89\u{1fed5}\u{1f9be}\u0eb9\u6550\u{1faeb}\u81bc',
+  dimension: '2d-array',
+  aspect: 'depth-only'
+});
+let sampler97 = device8.createSampler({
+label: '\u1fba\u{1f89b}\u0038\ub31a\u0778',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'repeat',
+lodMinClamp: 10.177,
+lodMaxClamp: 96.464,
+compare: 'equal',
+maxAnisotropy: 1,
+});
+let externalTexture6 = device8.importExternalTexture({
+label: '\ue262\u{1f83a}\u08f1',
+source: video30,
+colorSpace: 'srgb',
+});
+try {
+device8.queue.writeTexture({
+  texture: texture129,
+  mipLevel: 1,
+  origin: { x: 32, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 1326 */
+{offset: 782, bytesPerRow: 571}, {width: 272, height: 4, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let img35 = await imageWithData(49, 115, '#c1c0153d', '#15ce4f81');
+let video38 = await videoWithData();
+let imageData37 = new ImageData(60, 208);
+let renderBundle99 = renderBundleEncoder67.finish({label: '\u0932\uc2d9\u0cce\u{1f9ba}\u056c\u0147'});
+let sampler98 = device6.createSampler({
+label: '\u{1fbcf}\ufcdd\u7ae2\ue7fd',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 4.464,
+maxAnisotropy: 1,
+});
+let commandEncoder90 = device6.createCommandEncoder({label: '\u1714\u2079\ud3b8'});
+let computePassEncoder69 = commandEncoder90.beginComputePass();
+let renderBundleEncoder94 = device6.createRenderBundleEncoder({
+  label: '\u9f78\u3fae\u02f7\u2ccb',
+  colorFormats: ['rg32uint', 'r32sint', 'rgb10a2uint', 'rg8uint', 'rgba8unorm-srgb', 'rgb10a2uint', undefined],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+commandEncoder87.clearBuffer(buffer41, 38260, 580);
+dissociateBuffer(device6, buffer41);
+} catch {}
+let videoFrame28 = new VideoFrame(canvas31, {timestamp: 0});
+let querySet82 = device8.createQuerySet({
+label: '\u6b8f\u7d00\udaf2\u0db4\u{1fd03}\ue2c3\u0b8b',
+type: 'occlusion',
+count: 1204,
+});
+let renderBundleEncoder95 = device8.createRenderBundleEncoder({
+  label: '\ua4ab\u0832\u8573\u04e9\u60e1\uea51\u01ca',
+  colorFormats: ['rg8sint', 'bgra8unorm-srgb', 'r16sint', 'r8uint', 'rgb10a2unorm', 'rg32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle100 = renderBundleEncoder79.finish({label: '\u7619\u{1f626}\ucadf\ub3ff\u0a57'});
+let pipeline87 = device8.createRenderPipeline({
+label: '\ud9bc\u2052\u72f3\u{1fcb9}\u6251\udc56\ufde4\u{1f9c2}\u532f',
+layout: pipelineLayout19,
+fragment: {
+  module: shaderModule23,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8sint', writeMask: 0}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE
+}, {format: 'r16sint', writeMask: 0}, {format: 'r8uint', writeMask: 0}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL}, {format: 'rg32uint', writeMask: 0}]
+},
+vertex: {
+  module: shaderModule23,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x2',
+offset: 124,
+shaderLocation: 4,
+}, {
+format: 'unorm16x2',
+offset: 920,
+shaderLocation: 12,
+}, {
+format: 'uint32',
+offset: 916,
+shaderLocation: 6,
+}, {
+format: 'uint32x3',
+offset: 1832,
+shaderLocation: 0,
+}, {
+format: 'unorm16x2',
+offset: 620,
+shaderLocation: 10,
+}, {
+format: 'snorm8x4',
+offset: 1572,
+shaderLocation: 1,
+}],
+},
+{
+arrayStride: 616,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint8x4',
+offset: 252,
+shaderLocation: 7,
+}, {
+format: 'sint16x2',
+offset: 236,
+shaderLocation: 3,
+}, {
+format: 'float32x3',
+offset: 360,
+shaderLocation: 2,
+}, {
+format: 'sint32x4',
+offset: 292,
+shaderLocation: 8,
+}, {
+format: 'uint8x2',
+offset: 114,
+shaderLocation: 5,
+}, {
+format: 'sint8x2',
+offset: 472,
+shaderLocation: 11,
+}, {
+format: 'float32',
+offset: 408,
+shaderLocation: 14,
+}, {
+format: 'uint32x3',
+offset: 68,
+shaderLocation: 15,
+}],
+},
+{
+arrayStride: 640,
+attributes: [],
+},
+{
+arrayStride: 652,
+stepMode: 'instance',
+attributes: [{
+format: 'sint16x4',
+offset: 432,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 1780,
+attributes: [{
+format: 'unorm16x4',
+offset: 1272,
+shaderLocation: 9,
+}],
+}
+]
+},
+});
+let texture141 = device6.createTexture({
+label: '\u{1fcb9}\u8208\u67a3\u{1f7a7}\u015e\u{1f78e}\u06cd',
+size: [920, 1, 13],
+mipLevelCount: 6,
+format: 'rg32uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rg32uint', 'rg32uint'],
+});
+try {
+commandEncoder87.copyBufferToBuffer(buffer31, 9316, buffer41, 30996, 23964);
+dissociateBuffer(device6, buffer31);
+dissociateBuffer(device6, buffer41);
+} catch {}
+try {
+commandEncoder87.copyTextureToTexture({
+  texture: texture128,
+  mipLevel: 0,
+  origin: { x: 65, y: 1, z: 2 },
+  aspect: 'all',
+}, {
+  texture: texture128,
+  mipLevel: 3,
+  origin: { x: 5, y: 0, z: 15 },
+  aspect: 'all',
+}, {width: 16, height: 0, depthOrArrayLayers: 35});
+} catch {}
+try {
+commandEncoder87.clearBuffer(buffer30, 192, 364);
+dissociateBuffer(device6, buffer30);
+} catch {}
+let pipelineLayout23 = device0.createPipelineLayout({
+  label: '\u02e8\u9ae2\ud908\u3794\u{1f6a8}\u8113\u4696\u00ef\ueb46\u{1ff39}',
+  bindGroupLayouts: [bindGroupLayout1]
+});
+let commandEncoder91 = device0.createCommandEncoder({});
+let computePassEncoder70 = commandEncoder91.beginComputePass({label: '\u{1fac2}\u0f98'});
+let sampler99 = device0.createSampler({
+label: '\u735a\u335c\u4e26\uc7e5\uecc8',
+addressModeU: 'repeat',
+addressModeV: 'mirror-repeat',
+addressModeW: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 98.577,
+lodMaxClamp: 98.765,
+compare: 'equal',
+});
+try {
+computePassEncoder54.end();
+} catch {}
+try {
+renderBundleEncoder61.draw(40, 56, 24, 40);
+} catch {}
+try {
+renderBundleEncoder87.setVertexBuffer(2, buffer1, 6388, 9792);
+} catch {}
+try {
+commandEncoder85.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: { x: 509, y: 1, z: 0 },
+  aspect: 'all',
+}, {
+  texture: texture60,
+  mipLevel: 3,
+  origin: { x: 107, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 515, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder83.resolveQuerySet(querySet23, 1280, 925, buffer12, 12288);
+} catch {}
+try {
+renderBundleEncoder91.insertDebugMarker('\udf20');
+} catch {}
+try {
+gpuCanvasContext19.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm'],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 1,
+  origin: { x: 56, y: 0, z: 125 },
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 1871729 */
+{offset: 20, bytesPerRow: 955, rowsPerImage: 102}, {width: 216, height: 22, depthOrArrayLayers: 20});
+} catch {}
+try {
+renderBundleEncoder43.label = '\u0ec4\u06e9\ubba4\u9360\u5cda\u015d\u{1fc42}\u4593\u0389\u0297\u0f51';
+} catch {}
+try {
+computePassEncoder40.setBindGroup(1, bindGroup25, []);
+} catch {}
+try {
+renderBundleEncoder73.setBindGroup(7, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder77.setBindGroup(2, bindGroup25, new Uint32Array(5597), 1938, 0);
+} catch {}
+try {
+renderBundleEncoder84.draw(72);
+} catch {}
+try {
+renderBundleEncoder84.drawIndexed(32, 32, 24, -696);
+} catch {}
+try {
+device2.queue.submit([
+commandBuffer19,
+]);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture119,
+  mipLevel: 0,
+  origin: { x: 436, y: 0, z: 1 },
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer9), /* required buffer size: 230 */
+{offset: 230}, {width: 52, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline88 = await promise54;
+let renderBundleEncoder96 = device10.createRenderBundleEncoder({
+  label: '\u{1fca2}\u0bd0\u{1fe3d}',
+  colorFormats: ['rg16sint', 'rg32float', 'rgba16sint', 'rg16sint', undefined, 'r32uint'],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+let sampler100 = device10.createSampler({
+label: '\udd96\u9676\ud206\u575d\u{1ffbf}\u{1fb95}\u0b4b\u{1fb69}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 7.703,
+maxAnisotropy: 1,
+});
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+try {
+  await promise69;
+} catch {}
+try {
+await adapter14.requestAdapterInfo();
+} catch {}
+try {
+window.someLabel = device5.queue.label;
+} catch {}
+let bindGroupLayout51 = device6.createBindGroupLayout({
+entries: [{
+binding: 3211,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '2d-array' },
+}],
+});
+let commandBuffer21 = commandEncoder87.finish({
+});
+try {
+device6.queue.writeTexture({
+  texture: texture100,
+  mipLevel: 0,
+  origin: { x: 72, y: 0, z: 16 },
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 507376 */
+{offset: 226, bytesPerRow: 735, rowsPerImage: 138}, {width: 150, height: 0, depthOrArrayLayers: 6});
+} catch {}
+let promise70 = device6.queue.onSubmittedWorkDone();
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 28, height: 1, depthOrArrayLayers: 196}
+*/
+{
+  source: offscreenCanvas5,
+  origin: { x: 173, y: 356 },
+  flipY: true,
+}, {
+  texture: texture128,
+  mipLevel: 3,
+  origin: { x: 2, y: 1, z: 144 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 8, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise70;
+} catch {}
+let imageData38 = new ImageData(244, 120);
+try {
+window.someLabel = renderBundle72.label;
+} catch {}
+let commandEncoder92 = device1.createCommandEncoder({label: '\u0974\u3d71\u3df9\ud6ec\udcb0\u6135\u{1f8b1}\u2be7\u49f4'});
+let textureView105 = texture89.createView({label: '\u{1fb43}\ud3ba\u5a37\u5534\u9dc6\u404a\ud427\u5d14', mipLevelCount: 1});
+let renderBundleEncoder97 = device6.createRenderBundleEncoder({
+  colorFormats: ['rg16uint', 'rgba8sint', 'rgb10a2uint', 'rg8sint', 'rgba32sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let sampler101 = device6.createSampler({
+label: '\u{1fd92}\u565c\u073d\u0ac1\uf00c\u{1f8e5}\ub105',
+addressModeU: 'mirror-repeat',
+addressModeV: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 68.049,
+lodMaxClamp: 95.399,
+maxAnisotropy: 8,
+});
+try {
+commandEncoder92.resolveQuerySet(querySet55, 1671, 167, buffer34, 18944);
+} catch {}
+video24.width = 62;
+let offscreenCanvas42 = new OffscreenCanvas(324, 353);
+let img36 = await imageWithData(123, 233, '#4321e9a8', '#8d96064e');
+let buffer49 = device7.createBuffer({
+  label: '\u0bdd\u1e4f\u0a38\u009f\u5c75\ud23d\u3f2a',
+  size: 13463,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+});
+let renderBundleEncoder98 = device7.createRenderBundleEncoder({
+  label: '\u{1ffea}\u7e59\u{1f98e}\u046d\uc0c5\uec09\u{1f89d}\uc430\u03bd\u{1fb9d}\u{1f827}',
+  colorFormats: ['rg8unorm', 'rg16float', undefined, undefined, undefined, 'r16uint', 'rgba16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let externalTexture7 = device7.importExternalTexture({
+label: '\u{1f6fd}\u{1f643}\u3f91\u0f04\u8d84\u{1f60a}\u07a0\u7a70\u{1f6d9}',
+source: video18,
+colorSpace: 'srgb',
+});
+let querySet83 = device9.createQuerySet({
+label: '\u28f1\u07f3\u{1f97d}\u7963\u0742\uf816',
+type: 'occlusion',
+count: 1287,
+});
+video4.height = 28;
+let buffer50 = device7.createBuffer({label: '\u09eb\u0270\u{1fb03}', size: 55770, usage: GPUBufferUsage.COPY_DST});
+let textureView106 = texture114.createView({label: '\u{1fdf7}\ub5ca\u0b83\u185f\u30ca'});
+try {
+commandEncoder82.copyBufferToTexture({
+/* bytesInLastRow: 348 widthInBlocks: 348 aspectSpecificFormat.texelBlockSize: 1 */
+/* end: 8458 */
+offset: 8458,
+bytesPerRow: 768,
+rowsPerImage: 64,
+buffer: buffer44,
+}, {
+  texture: texture93,
+  mipLevel: 0,
+  origin: { x: 249, y: 1, z: 0 },
+  aspect: 'all',
+}, {width: 348, height: 39, depthOrArrayLayers: 0});
+dissociateBuffer(device7, buffer44);
+} catch {}
+let querySet84 = device6.createQuerySet({
+label: '\u08d1\ua230\u{1fed8}\ufc38\u27f3\u0f9b\u7872\u566f\uc560',
+type: 'occlusion',
+count: 3421,
+});
+try {
+commandEncoder92.copyBufferToBuffer(buffer25, 1672, buffer30, 480, 60);
+dissociateBuffer(device6, buffer25);
+dissociateBuffer(device6, buffer30);
+} catch {}
+try {
+commandEncoder92.clearBuffer(buffer30, 36, 284);
+dissociateBuffer(device6, buffer30);
+} catch {}
+let gpuCanvasContext36 = offscreenCanvas42.getContext('webgpu');
+let imageData39 = new ImageData(136, 104);
+let offscreenCanvas43 = new OffscreenCanvas(871, 897);
+let bindGroupLayout52 = device10.createBindGroupLayout({
+label: '\u6cf7\u03c1\u0cc7\ue85e\u04eb\u{1ff2d}',
+entries: [{
+binding: 778,
+visibility: GPUShaderStage.VERTEX,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}, {
+binding: 279,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+}, {
+binding: 423,
+visibility: 0,
+buffer: { type: 'read-only-storage', minBindingSize: 821739, hasDynamicOffset: true },
+}],
+});
+let textureView107 = texture131.createView({
+  label: '\u0325\ud1f5\ue233\u1189\u6e0e\uf380\u8638\ue035\udb8f\u1db5',
+  dimension: '2d-array',
+  mipLevelCount: 2,
+  baseArrayLayer: 0
+});
+let computePassEncoder71 = commandEncoder88.beginComputePass({label: '\u0660\ub31e\ucf43\u42fd\u0125'});
+let renderBundleEncoder99 = device10.createRenderBundleEncoder({
+  label: '\u{1feba}\ucd7f\ud12c\ue409\ueba6\u620f\u8fdd\ub028\u3907\ua7ec',
+  colorFormats: ['rg16sint', 'rg32float', 'rgba16sint', 'rg16sint', undefined, 'r32uint'],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+try {
+computePassEncoder71.insertDebugMarker('\u{1fb6b}');
+} catch {}
+try {
+gpuCanvasContext26.configure({
+device: device10,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'srgb',
+alphaMode: 'opaque',
+});
+} catch {}
+try {
+device10.queue.writeTexture({
+  texture: texture131,
+  mipLevel: 6,
+  origin: { x: 7, y: 0, z: 1 },
+  aspect: 'all',
+}, new Float64Array(new ArrayBuffer(0)), /* required buffer size: 640 */
+{offset: 640, bytesPerRow: 131}, {width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device10.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData14,
+  origin: { x: 121, y: 23 },
+  flipY: false,
+}, {
+  texture: texture131,
+  mipLevel: 6,
+  origin: { x: 5, y: 0, z: 0 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline89 = device10.createRenderPipeline({
+layout: pipelineLayout22,
+fragment: {
+  module: shaderModule22,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {
+  format: 'rgba16float',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'dst-alpha'},
+},
+  writeMask: 0
+}, {format: 'r16uint', writeMask: 0}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'src'},
+alpha: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN
+}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'greater-equal',
+stencilFront: {
+failOp: 'replace',
+depthFailOp: 'zero',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'not-equal',
+failOp: 'invert',
+depthFailOp: 'replace',
+passOp: 'invert',
+},
+stencilReadMask: 3491,
+stencilWriteMask: 2937,
+depthBias: 100,
+depthBiasSlopeScale: 79,
+depthBiasClamp: 6,
+},
+vertex: {
+  module: shaderModule22,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1308,
+stepMode: 'vertex',
+attributes: [{
+format: 'float16x2',
+offset: 700,
+shaderLocation: 7,
+}, {
+format: 'float32x2',
+offset: 156,
+shaderLocation: 11,
+}, {
+format: 'uint8x2',
+offset: 432,
+shaderLocation: 0,
+}, {
+format: 'uint32x2',
+offset: 20,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 1120,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x3',
+offset: 4,
+shaderLocation: 13,
+}, {
+format: 'uint8x4',
+offset: 1072,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 920,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint16x2',
+offset: 736,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 1056,
+attributes: [{
+format: 'unorm16x2',
+offset: 756,
+shaderLocation: 4,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+},
+});
+let img37 = await imageWithData(94, 22, '#25c1512f', '#fa4ca945');
+let bindGroupLayout53 = pipeline89.getBindGroupLayout(1);
+let textureView108 = texture131.createView({dimension: '2d-array', aspect: 'all', baseMipLevel: 5, mipLevelCount: 1});
+let computePassEncoder72 = commandEncoder89.beginComputePass({label: '\u0894\uaa48\u{1f981}\ub184\u1e72\uf888\u408e'});
+let canvas34 = document.createElement('canvas');
+let offscreenCanvas44 = new OffscreenCanvas(971, 966);
+let sampler102 = device2.createSampler({
+label: '\u0941\u7fd1\u20aa\u0f49\u080e',
+addressModeU: 'repeat',
+addressModeV: 'repeat',
+addressModeW: 'repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 98.550,
+compare: 'always',
+maxAnisotropy: 8,
+});
+try {
+renderBundleEncoder84.drawIndexedIndirect(buffer38, 7160);
+} catch {}
+let gpuCanvasContext37 = offscreenCanvas43.getContext('webgpu');
+gc();
+try {
+await adapter1.requestAdapterInfo();
+} catch {}
+let gpuCanvasContext38 = canvas34.getContext('webgpu');
+let shaderModule24 = device2.createShaderModule({
+label: '\u0ba6\u{1fd33}\u7f77\u{1fc3b}\u0f58\uf767',
+code: `@group(4) @binding(3183)
+var<storage, read_write> function25: array<u32>;
+@group(5) @binding(2585)
+var<storage, read_write> global19: array<u32>;
+@group(3) @binding(2585)
+var<storage, read_write> field27: array<u32>;
+@group(0) @binding(2585)
+var<storage, read_write> parameter23: array<u32>;
+@group(6) @binding(3183)
+var<storage, read_write> global20: array<u32>;
+@group(7) @binding(2585)
+var<storage, read_write> global21: array<u32>;
+@group(8) @binding(3183)
+var<storage, read_write> type13: array<u32>;
+@group(4) @binding(2585)
+var<storage, read_write> local16: array<u32>;
+@group(6) @binding(2585)
+var<storage, read_write> global22: array<u32>;
+@group(2) @binding(2585)
+var<storage, read_write> function26: array<u32>;
+@group(8) @binding(2585)
+var<storage, read_write> local17: array<u32>;
+@group(5) @binding(3183)
+var<storage, read_write> field28: array<u32>;
+@group(7) @binding(3183)
+var<storage, read_write> i26: array<u32>;
+@group(1) @binding(3183)
+var<storage, read_write> parameter24: array<u32>;
+@group(3) @binding(3183)
+var<storage, read_write> local18: array<u32>;
+@group(1) @binding(2585)
+var<storage, read_write> type14: array<u32>;
+@group(2) @binding(3183)
+var<storage, read_write> local19: array<u32>;
+
+@compute @workgroup_size(2, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@location(18) a0: vec3<f32>, @location(13) a1: vec4<f16>, @location(19) a2: vec4<f32>, @location(20) a3: vec3<u32>, @location(3) a4: vec4<u32>, @location(17) a5: f16, @location(12) a6: vec3<i32>, @builtin(sample_index) a7: u32, @builtin(position) a8: vec4<f32>, @location(4) a9: i32, @location(0) a10: vec4<u32>, @location(2) a11: f16) -> @builtin(sample_mask) u32 {
+return u32();
+}
+
+struct S28 {
+  @location(14) f0: vec2<f32>,
+  @location(22) f1: vec4<f32>,
+  @location(7) f2: u32,
+  @location(13) f3: vec2<u32>,
+  @builtin(vertex_index) f4: u32,
+  @location(9) f5: vec3<f16>,
+  @builtin(instance_index) f6: u32,
+  @location(20) f7: vec3<f16>,
+  @location(2) f8: f32,
+  @location(21) f9: vec3<f16>,
+  @location(4) f10: vec3<u32>,
+  @location(1) f11: vec4<u32>,
+  @location(6) f12: vec3<f32>,
+  @location(18) f13: vec2<i32>,
+  @location(24) f14: vec4<f16>,
+  @location(25) f15: vec2<f32>,
+  @location(5) f16: u32,
+  @location(8) f17: vec2<f32>,
+  @location(17) f18: vec2<f16>,
+  @location(15) f19: vec3<f32>,
+  @location(19) f20: i32,
+  @location(12) f21: f16,
+  @location(11) f22: u32,
+  @location(23) f23: vec2<f32>,
+  @location(0) f24: vec2<f32>,
+  @location(26) f25: vec4<f32>
+}
+struct VertexOutput0 {
+  @builtin(position) f244: vec4<f32>,
+  @location(20) f245: vec3<u32>,
+  @location(14) f246: vec4<f16>,
+  @location(25) f247: vec4<u32>,
+  @location(10) f248: vec2<u32>,
+  @location(18) f249: vec3<f32>,
+  @location(0) f250: vec4<u32>,
+  @location(13) f251: vec4<f16>,
+  @location(7) f252: vec2<f32>,
+  @location(29) f253: vec3<u32>,
+  @location(21) f254: vec4<i32>,
+  @location(26) f255: vec2<i32>,
+  @location(2) f256: f16,
+  @location(4) f257: i32,
+  @location(3) f258: vec4<u32>,
+  @location(5) f259: f16,
+  @location(6) f260: vec2<f16>,
+  @location(9) f261: vec2<u32>,
+  @location(12) f262: vec3<i32>,
+  @location(19) f263: vec4<f32>,
+  @location(30) f264: vec2<f32>,
+  @location(31) f265: vec4<i32>,
+  @location(17) f266: f16
+}
+
+@vertex
+fn vertex0(@location(16) a0: i32, @location(10) a1: vec3<u32>, @location(3) a2: vec3<f32>, a3: S28) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let renderBundle101 = renderBundleEncoder35.finish({label: '\u007e\uc2df\u0417\u{1f9f1}\u8595\ub75b'});
+try {
+computePassEncoder53.setPipeline(pipeline83);
+} catch {}
+try {
+renderBundleEncoder84.drawIndexedIndirect(buffer38, 22608);
+} catch {}
+try {
+renderBundleEncoder82.setVertexBuffer(1, buffer35, 29968, 1913);
+} catch {}
+let arrayBuffer16 = buffer17.getMappedRange(34808, 7180);
+let pipeline90 = device2.createRenderPipeline({
+layout: 'auto',
+fragment: {module: shaderModule7, entryPoint: 'fragment0', constants: {}, targets: []},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'never',
+stencilFront: {
+depthFailOp: 'increment-clamp',
+passOp: 'replace',
+},
+stencilBack: {
+compare: 'greater-equal',
+failOp: 'invert',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-wrap',
+},
+stencilReadMask: 2477,
+stencilWriteMask: 2951,
+depthBias: 32,
+depthBiasSlopeScale: 96,
+},
+vertex: {
+  module: shaderModule7,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 21252,
+attributes: [{
+format: 'uint8x2',
+offset: 3890,
+shaderLocation: 1,
+}, {
+format: 'uint16x2',
+offset: 15968,
+shaderLocation: 8,
+}, {
+format: 'unorm8x2',
+offset: 5578,
+shaderLocation: 14,
+}, {
+format: 'uint8x2',
+offset: 8392,
+shaderLocation: 2,
+}, {
+format: 'uint8x4',
+offset: 8792,
+shaderLocation: 25,
+}, {
+format: 'float32',
+offset: 4076,
+shaderLocation: 15,
+}, {
+format: 'snorm16x4',
+offset: 2316,
+shaderLocation: 16,
+}, {
+format: 'float16x2',
+offset: 6076,
+shaderLocation: 22,
+}, {
+format: 'snorm16x2',
+offset: 11324,
+shaderLocation: 5,
+}, {
+format: 'sint32',
+offset: 7232,
+shaderLocation: 19,
+}, {
+format: 'uint16x2',
+offset: 13868,
+shaderLocation: 24,
+}, {
+format: 'uint8x2',
+offset: 7788,
+shaderLocation: 20,
+}, {
+format: 'sint32x4',
+offset: 17680,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 39512,
+attributes: [{
+format: 'uint32x2',
+offset: 38716,
+shaderLocation: 21,
+}, {
+format: 'sint8x2',
+offset: 14244,
+shaderLocation: 23,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-list',
+frontFace: 'cw',
+cullMode: 'front',
+},
+});
+try {
+offscreenCanvas44.getContext('2d');
+} catch {}
+let adapter16 = await navigator.gpu.requestAdapter({
+});
+let commandEncoder93 = device2.createCommandEncoder({label: '\uf258\uc854\u{1f9b0}\u416a'});
+let texture142 = device2.createTexture({
+size: [1522, 1, 15],
+mipLevelCount: 9,
+dimension: '2d',
+format: 'depth24plus-stencil8',
+usage: GPUTextureUsage.RENDER_ATTACHMENT,
+viewFormats: ['depth24plus-stencil8', 'depth24plus-stencil8'],
+});
+let renderBundle102 = renderBundleEncoder37.finish();
+let sampler103 = device2.createSampler({
+label: '\uc182\u5183\u76ea\ucac9\u{1ff60}\u39ce\uc41b\ud1fd\u3427\ucfab\u407f',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMaxClamp: 24.637,
+});
+try {
+computePassEncoder62.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder84.draw(16, 48, 64, 8);
+} catch {}
+try {
+renderBundleEncoder84.drawIndexedIndirect(buffer38, 13536);
+} catch {}
+try {
+commandEncoder93.resolveQuerySet(querySet54, 832, 217, buffer19, 34816);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture71,
+  mipLevel: 2,
+  origin: { x: 0, y: 3, z: 0 },
+  aspect: 'all',
+}, new Int16Array(arrayBuffer8), /* required buffer size: 152 */
+{offset: 152}, {width: 80, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline91 = await device2.createComputePipelineAsync({
+label: '\u{1faee}\u2195',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+gc();
+let shaderModule25 = device6.createShaderModule({
+code: `@group(1) @binding(4378)
+var<storage, read_write> global23: array<u32>;
+@group(0) @binding(3874)
+var<storage, read_write> i27: array<u32>;
+@group(1) @binding(561)
+var<storage, read_write> type15: array<u32>;
+@group(1) @binding(3874)
+var<storage, read_write> parameter25: array<u32>;
+@group(0) @binding(4378)
+var<storage, read_write> global24: array<u32>;
+@group(0) @binding(561)
+var<storage, read_write> local20: array<u32>;
+
+@compute @workgroup_size(1, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec4<f32>,
+  @location(0) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S29 {
+  @location(17) f0: vec2<f16>,
+  @location(4) f1: vec4<f16>,
+  @location(11) f2: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(3) a0: u32, @location(1) a1: i32, @location(12) a2: vec2<i32>, @location(20) a3: vec4<u32>, @builtin(instance_index) a4: u32, @location(19) a5: vec4<i32>, @location(23) a6: f32, @location(6) a7: vec3<u32>, @location(15) a8: u32, @location(21) a9: vec2<i32>, @location(18) a10: f16, @location(22) a11: f32, @location(5) a12: vec4<f16>, @location(2) a13: u32, @location(9) a14: vec4<f16>, @location(13) a15: vec2<i32>, @location(14) a16: vec3<i32>, @location(10) a17: vec3<i32>, @location(8) a18: f16, @location(7) a19: i32, a20: S29, @location(0) a21: vec3<f16>, @location(16) a22: f16, @builtin(vertex_index) a23: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let commandEncoder94 = device6.createCommandEncoder({label: '\u{1f838}\u6a5c\u{1fa7e}\ud3e1\u006e\ua449\u647f\u06fa\u03da\u{1f708}'});
+try {
+device6.queue.writeTexture({
+  texture: texture128,
+  mipLevel: 0,
+  origin: { x: 84, y: 0, z: 334 },
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer1), /* required buffer size: 2578829 */
+{offset: 621, bytesPerRow: 368, rowsPerImage: 226}, {width: 30, height: 0, depthOrArrayLayers: 32});
+} catch {}
+let img38 = await imageWithData(280, 223, '#2d4caf47', '#def09494');
+canvas31.height = 523;
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let imageBitmap27 = await createImageBitmap(canvas22);
+let bindGroup34 = device0.createBindGroup({
+label: '\u8443\u5a36\u05fc\u05c5\u3859\ud9e0\u6d4d\u8ee3\u{1f98f}\u0879',
+layout: bindGroupLayout0,
+entries: [{
+binding: 1160,
+resource: externalTexture0
+}],
+});
+let querySet85 = device0.createQuerySet({
+type: 'occlusion',
+count: 1399,
+});
+let sampler104 = device0.createSampler({
+label: '\u6e73\ud92f\u{1ff84}\u0969\ub2d6\u0678\u0283\u{1ffc3}\u646e\ud07a\u{1ff79}',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'mirror-repeat',
+addressModeW: 'mirror-repeat',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 20.445,
+lodMaxClamp: 87.648,
+});
+try {
+renderBundleEncoder61.setBindGroup(3, bindGroup30, new Uint32Array(5683), 2779, 0);
+} catch {}
+try {
+renderBundleEncoder61.draw(0, 8, 56);
+} catch {}
+try {
+commandEncoder65.copyTextureToBuffer({
+  texture: texture12,
+  mipLevel: 0,
+  origin: { x: 336, y: 24, z: 52 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 2320 widthInBlocks: 145 aspectSpecificFormat.texelBlockSize: 16 */
+/* end: 26928 */
+offset: 22048,
+bytesPerRow: 2560,
+buffer: buffer3,
+}, {width: 1740, height: 24, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder85.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 3,
+  origin: { x: 36, y: 1, z: 29 },
+  aspect: 'all',
+}, {
+  texture: texture19,
+  mipLevel: 2,
+  origin: { x: 57, y: 6, z: 115 },
+  aspect: 'all',
+}, {width: 40, height: 1, depthOrArrayLayers: 37});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+device: device0,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba8unorm-srgb'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 2,
+  origin: { x: 0, y: 0, z: 12 },
+  aspect: 'all',
+}, arrayBuffer14, /* required buffer size: 1202696 */
+{offset: 836, bytesPerRow: 681, rowsPerImage: 49}, {width: 144, height: 1, depthOrArrayLayers: 37});
+} catch {}
+let promise71 = device0.queue.onSubmittedWorkDone();
+offscreenCanvas11.height = 722;
+let commandBuffer22 = commandEncoder94.finish({
+label: '\u0f1d\ue84d\u6aba\u{1ff04}\u7e14\u{1f989}\u9ece\u0675',
+});
+let texture143 = device6.createTexture({
+label: '\u20ba\uf9d7\u{1fe06}\u0dfb\uac13\ua4db\u0016\u02f3\u72be\udbc7\u7188',
+size: [1590],
+dimension: '1d',
+format: 'rg16uint',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device6.queue.writeTexture({
+  texture: texture108,
+  mipLevel: 0,
+  origin: { x: 89, y: 0, z: 3 },
+  aspect: 'all',
+}, new Uint16Array(new ArrayBuffer(48)), /* required buffer size: 2151419 */
+{offset: 964, bytesPerRow: 266, rowsPerImage: 172}, {width: 111, height: 1, depthOrArrayLayers: 48});
+} catch {}
+let promise72 = device6.createRenderPipelineAsync({
+label: '\u{1f66c}\u0347\u7d1c\u0f82\u2d1b\uefd2\u0387',
+layout: pipelineLayout21,
+fragment: {
+  module: shaderModule25,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: false,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'zero',
+depthFailOp: 'keep',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+failOp: 'decrement-clamp',
+depthFailOp: 'decrement-wrap',
+passOp: 'increment-wrap',
+},
+stencilReadMask: 1010,
+stencilWriteMask: 2836,
+depthBias: 60,
+depthBiasClamp: 78,
+},
+vertex: {
+  module: shaderModule25,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 14888,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 4284,
+shaderLocation: 22,
+}, {
+format: 'sint8x4',
+offset: 3252,
+shaderLocation: 13,
+}, {
+format: 'sint16x4',
+offset: 11932,
+shaderLocation: 19,
+}, {
+format: 'float32',
+offset: 9000,
+shaderLocation: 9,
+}, {
+format: 'uint32',
+offset: 2476,
+shaderLocation: 15,
+}, {
+format: 'uint8x2',
+offset: 3136,
+shaderLocation: 3,
+}, {
+format: 'sint16x2',
+offset: 8868,
+shaderLocation: 12,
+}, {
+format: 'uint32x2',
+offset: 13924,
+shaderLocation: 20,
+}, {
+format: 'sint8x2',
+offset: 7228,
+shaderLocation: 21,
+}, {
+format: 'float32x2',
+offset: 4392,
+shaderLocation: 11,
+}, {
+format: 'sint16x4',
+offset: 11952,
+shaderLocation: 10,
+}, {
+format: 'sint8x2',
+offset: 8770,
+shaderLocation: 14,
+}, {
+format: 'sint16x2',
+offset: 8884,
+shaderLocation: 7,
+}, {
+format: 'float16x2',
+offset: 11328,
+shaderLocation: 5,
+}, {
+format: 'float32x2',
+offset: 10592,
+shaderLocation: 18,
+}, {
+format: 'float32x4',
+offset: 920,
+shaderLocation: 8,
+}],
+},
+{
+arrayStride: 15548,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x4',
+offset: 2600,
+shaderLocation: 0,
+}],
+},
+{
+arrayStride: 17656,
+attributes: [{
+format: 'uint32x3',
+offset: 10836,
+shaderLocation: 2,
+}, {
+format: 'sint32x2',
+offset: 12732,
+shaderLocation: 1,
+}, {
+format: 'float32x4',
+offset: 16324,
+shaderLocation: 23,
+}],
+},
+{
+arrayStride: 30980,
+stepMode: 'instance',
+attributes: [{
+format: 'snorm16x4',
+offset: 19080,
+shaderLocation: 17,
+}, {
+format: 'snorm8x4',
+offset: 10600,
+shaderLocation: 4,
+}],
+},
+{
+arrayStride: 32700,
+stepMode: 'vertex',
+attributes: [],
+},
+{
+arrayStride: 36628,
+stepMode: 'instance',
+attributes: [{
+format: 'float16x2',
+offset: 14524,
+shaderLocation: 16,
+}],
+},
+{
+arrayStride: 0,
+attributes: [{
+format: 'uint32x3',
+offset: 6712,
+shaderLocation: 6,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint16',
+frontFace: 'cw',
+},
+});
+try {
+gpuCanvasContext36.unconfigure();
+} catch {}
+let buffer51 = device0.createBuffer({
+  label: '\u{1f73a}\u{1ffff}\uee24\u0f7a\u04a4\u0c64\ufb08',
+  size: 3017,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+});
+let texture144 = gpuCanvasContext14.getCurrentTexture();
+try {
+renderBundleEncoder61.drawIndexedIndirect(buffer36, 35128);
+} catch {}
+let arrayBuffer17 = buffer5.getMappedRange(14808, 272);
+try {
+commandEncoder65.clearBuffer(buffer3);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture80,
+  mipLevel: 0,
+  origin: { x: 48, y: 0, z: 32 },
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 4841828 */
+{offset: 992, bytesPerRow: 429, rowsPerImage: 182}, {width: 144, height: 0, depthOrArrayLayers: 63});
+} catch {}
+let computePassEncoder73 = commandEncoder83.beginComputePass({label: '\uf3c3\u01df\ucf4b'});
+try {
+computePassEncoder39.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline25);
+} catch {}
+try {
+renderBundleEncoder61.draw(24);
+} catch {}
+try {
+renderBundleEncoder61.drawIndexed(72);
+} catch {}
+try {
+commandEncoder84.clearBuffer(buffer3);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 1,
+  origin: { x: 640, y: 12, z: 0 },
+  aspect: 'all',
+}, new Uint16Array(new ArrayBuffer(24)), /* required buffer size: 380 */
+{offset: 380, bytesPerRow: 2525, rowsPerImage: 39}, {width: 1160, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline92 = await device0.createRenderPipelineAsync({
+label: '\u{1f90b}\u{1f731}\ua72b\u885e\u72ea\u{1fae4}\u5ba2',
+layout: pipelineLayout23,
+multisample: {
+},
+vertex: {
+  module: shaderModule4,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 0,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint16x4',
+offset: 15688,
+shaderLocation: 0,
+}, {
+format: 'unorm16x4',
+offset: 16924,
+shaderLocation: 5,
+}, {
+format: 'float32x2',
+offset: 15180,
+shaderLocation: 12,
+}, {
+format: 'uint32',
+offset: 15136,
+shaderLocation: 2,
+}, {
+format: 'uint32x4',
+offset: 14880,
+shaderLocation: 8,
+}, {
+format: 'sint8x2',
+offset: 1332,
+shaderLocation: 14,
+}, {
+format: 'unorm16x4',
+offset: 1488,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 12820,
+attributes: [{
+format: 'uint32x3',
+offset: 3488,
+shaderLocation: 13,
+}],
+},
+{
+arrayStride: 14592,
+stepMode: 'instance',
+attributes: [],
+},
+{
+arrayStride: 6540,
+stepMode: 'vertex',
+attributes: [{
+format: 'snorm8x4',
+offset: 6236,
+shaderLocation: 7,
+}],
+}
+]
+},
+primitive: {
+topology: 'line-strip',
+stripIndexFormat: 'uint32',
+frontFace: 'ccw',
+unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let bindGroup35 = device7.createBindGroup({
+label: '\u3f44\u7af8\u007b\u{1f61c}',
+layout: bindGroupLayout44,
+entries: [{
+binding: 4461,
+resource: sampler83
+}],
+});
+let querySet86 = device7.createQuerySet({
+label: '\u{1fcce}\u1e3f',
+type: 'occlusion',
+count: 1440,
+});
+let texture145 = device7.createTexture({
+size: {width: 420, height: 20, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'r8snorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder61.setBindGroup(3, bindGroup35, []);
+} catch {}
+try {
+renderBundleEncoder93.setBindGroup(0, bindGroup35);
+} catch {}
+try {
+commandEncoder74.clearBuffer(buffer50, 28848, 7164);
+dissociateBuffer(device7, buffer50);
+} catch {}
+try {
+commandEncoder78.resolveQuerySet(querySet47, 934, 503, buffer26, 27904);
+} catch {}
+try {
+device7.queue.writeBuffer(buffer40, 8036, new BigUint64Array(19381), 19230, 20);
+} catch {}
+let offscreenCanvas45 = new OffscreenCanvas(207, 342);
+let img39 = await imageWithData(278, 233, '#cd1b8d84', '#9be9a7d1');
+let texture146 = device8.createTexture({
+label: '\uc3e6\ud562\ue717',
+size: [50, 10, 40],
+mipLevelCount: 2,
+format: 'astc-10x10-unorm-srgb',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: [],
+});
+let renderBundleEncoder100 = device8.createRenderBundleEncoder({
+  label: '\u{1fa40}\u03b0\ub16b\u{1fd5c}\u0471\u91a4\u0110\u04b0\u{1fd4e}',
+  colorFormats: ['rg8sint', 'bgra8unorm-srgb', 'r16sint', 'r8uint', 'rgb10a2unorm', 'rg32uint'],
+  depthReadOnly: false,
+  stencilReadOnly: true
+});
+let pipeline93 = device8.createComputePipeline({
+label: '\u3b26\ue5ce\u0945\u0cc8\u{1fceb}',
+layout: pipelineLayout19,
+compute: {
+module: shaderModule23,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let imageData40 = new ImageData(32, 44);
+let commandEncoder95 = device10.createCommandEncoder({label: '\uf4d9\u06d3'});
+let textureView109 = texture131.createView({label: '\u5ce1\u4c17', dimension: '2d-array', aspect: 'all', baseMipLevel: 4, baseArrayLayer: 0});
+let computePassEncoder74 = commandEncoder95.beginComputePass({label: '\u5756\u868d\u5e89\u950d\u43e8\ua415\u26f5\u01d5'});
+try {
+renderBundleEncoder96.setVertexBuffer(50, undefined, 981846451, 2091285391);
+} catch {}
+let promise73 = adapter14.requestDevice({
+label: '\u09fd\ud3c5\u0fa4\u{1fda2}\uf6f5\u51a5\u1450\u0a3b',
+requiredFeatures: [
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 34,
+maxVertexAttributes: 19,
+maxVertexBufferArrayStride: 23461,
+maxStorageTexturesPerShaderStage: 15,
+maxStorageBuffersPerShaderStage: 34,
+maxDynamicStorageBuffersPerPipelineLayout: 64175,
+maxBindingsPerBindGroup: 6138,
+maxTextureDimension1D: 10254,
+maxTextureDimension2D: 16202,
+maxVertexBuffers: 12,
+minStorageBufferOffsetAlignment: 32,
+maxUniformBufferBindingSize: 202685382,
+maxUniformBuffersPerShaderStage: 16,
+maxInterStageShaderVariables: 83,
+maxInterStageShaderComponents: 64,
+maxSamplersPerShaderStage: 20,
+},
+});
+gc();
+let promise74 = navigator.gpu.requestAdapter({
+});
+try {
+offscreenCanvas45.getContext('bitmaprenderer');
+} catch {}
+let img40 = await imageWithData(27, 175, '#13291890', '#6ad9ed1a');
+let commandEncoder96 = device0.createCommandEncoder({});
+let commandBuffer23 = commandEncoder75.finish({
+label: '\u{1fa55}\ubcce\u90d0\u{1f997}\u{1fc74}\u0ea5\u{1fca9}\u0022\udadd',
+});
+let textureView110 = texture45.createView({label: '\u{1f73e}\u3c7e\u0a7e\u5520\uca13', baseMipLevel: 2, mipLevelCount: 2});
+let renderBundleEncoder101 = device0.createRenderBundleEncoder({
+  label: '\u{1f761}\u{1f9e5}\u{1f87f}',
+  colorFormats: ['rg8unorm', undefined],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true
+});
+let renderBundle103 = renderBundleEncoder68.finish({label: '\ue359\uae17\uaad6\u02bf\u07c6\u0850\u0e83\u{1faba}'});
+let sampler105 = device0.createSampler({
+label: '\uaefc\u6cf0\u{1fc0f}',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 89.412,
+lodMaxClamp: 90.256,
+maxAnisotropy: 10,
+});
+try {
+renderBundleEncoder80.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+renderBundleEncoder85.setIndexBuffer(buffer10, 'uint32', 47216, 8595);
+} catch {}
+try {
+commandEncoder96.resolveQuerySet(querySet10, 1350, 17, buffer24, 0);
+} catch {}
+try {
+device0.queue.submit([
+commandBuffer23,
+commandBuffer4,
+]);
+} catch {}
+let promise75 = device0.queue.onSubmittedWorkDone();
+gc();
+let img41 = await imageWithData(242, 68, '#7c7935da', '#1202e075');
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let canvas35 = document.createElement('canvas');
+let video39 = await videoWithData();
+let buffer52 = device9.createBuffer({
+  label: '\u02ab\u6341\u9270\u0c1b\u0525\u060d',
+  size: 41636,
+  usage: GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false
+});
+try {
+gpuCanvasContext12.configure({
+device: device9,
+format: 'r32sint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+colorSpace: 'display-p3',
+alphaMode: 'opaque',
+});
+} catch {}
+let texture147 = device9.createTexture({
+label: '\u9253\uaed1\u8ad9\u16c6\u32a0\u{1f9b9}\u{1febe}\ub0fa\uf8a7\u{1fb58}',
+size: [40],
+dimension: '1d',
+format: 'rg8snorm',
+usage: GPUTextureUsage.COPY_DST,
+viewFormats: ['rg8snorm'],
+});
+let gpuCanvasContext39 = canvas35.getContext('webgpu');
+try {
+adapter9.label = '\u033f\u03f1\ud362\ub439\uda80\ucbe4\u{1f788}\u813f\u6037';
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let offscreenCanvas46 = new OffscreenCanvas(98, 925);
+try {
+offscreenCanvas46.getContext('webgpu');
+} catch {}
+let commandEncoder97 = device7.createCommandEncoder({});
+let renderBundleEncoder102 = device7.createRenderBundleEncoder({
+  label: '\u283c\u7337\u6e79\u7fb3\u61cb\ud4da\u8c99\u09a3\u46cc',
+  colorFormats: [],
+  depthStencilFormat: 'depth32float-stencil8'
+});
+try {
+renderBundleEncoder64.setVertexBuffer(5, buffer42, 40908);
+} catch {}
+try {
+commandEncoder97.clearBuffer(buffer50, 29200, 11096);
+dissociateBuffer(device7, buffer50);
+} catch {}
+try {
+commandEncoder97.resolveQuerySet(querySet86, 1001, 343, buffer26, 4608);
+} catch {}
+let querySet87 = device6.createQuerySet({
+label: '\u1aeb\u1339\u{1f8cf}\u0aab\u4fe6\ub1f5\ueeba\u{1f650}',
+type: 'occlusion',
+count: 2559,
+});
+let computePassEncoder75 = commandEncoder92.beginComputePass({});
+let renderBundleEncoder103 = device6.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb'], depthStencilFormat: 'depth24plus-stencil8', depthReadOnly: true});
+let sampler106 = device6.createSampler({
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 42.121,
+lodMaxClamp: 97.594,
+maxAnisotropy: 16,
+});
+try {
+device6.queue.writeTexture({
+  texture: texture136,
+  mipLevel: 0,
+  origin: { x: 57, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 792 */
+{offset: 792}, {width: 354, height: 1, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas5.height = 921;
+let buffer53 = device0.createBuffer({
+  label: '\u0b0b\u3bc6',
+  size: 13920,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true
+});
+let texture148 = device0.createTexture({
+label: '\ua961\u8e51\ub6d7\uacd0\u0a7b\u0cdb\u050a\u8c0c\u0ae2\u5e2a',
+size: [80, 960, 1],
+mipLevelCount: 9,
+format: 'astc-8x8-unorm',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundleEncoder104 = device0.createRenderBundleEncoder({
+  label: '\ue652\u0b47\u0ab3\u2784\u1751\u9bc2',
+  colorFormats: ['r8sint', 'rg8uint', 'rgba32sint', 'rgba8unorm', 'r8uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+let renderBundle104 = renderBundleEncoder6.finish({label: '\u409e\ufb21\u0fa5\u{1f9eb}\u6758\uf8ca\u0060'});
+try {
+computePassEncoder36.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline81);
+} catch {}
+try {
+renderBundleEncoder61.draw(48, 72, 64);
+} catch {}
+try {
+renderBundleEncoder80.drawIndexed(64, 80, 16, -608, 0);
+} catch {}
+try {
+commandEncoder65.copyBufferToBuffer(buffer45, 32884, buffer12, 4472, 15068);
+dissociateBuffer(device0, buffer45);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder85.copyBufferToTexture({
+/* bytesInLastRow: 350 widthInBlocks: 175 aspectSpecificFormat.texelBlockSize: 2 */
+/* end: 17044 */
+offset: 17044,
+buffer: buffer37,
+}, {
+  texture: texture18,
+  mipLevel: 2,
+  origin: { x: 35, y: 0, z: 0 },
+  aspect: 'all',
+}, {width: 175, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer37);
+} catch {}
+try {
+commandEncoder84.clearBuffer(buffer12, 11424, 14316);
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder84.resolveQuerySet(querySet69, 790, 1636, buffer27, 27648);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer51, 3012, new DataView(new ArrayBuffer(27422)), 2269, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer13, /* required buffer size: 152 */
+{offset: 134}, {width: 9, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let texture149 = device9.createTexture({
+label: '\u7b32\u{1fefb}\u35c6\u747e',
+size: {width: 40, height: 15, depthOrArrayLayers: 1},
+sampleCount: 1,
+format: 'astc-8x5-unorm',
+usage: GPUTextureUsage.COPY_SRC,
+viewFormats: ['astc-8x5-unorm'],
+});
+let renderBundleEncoder105 = device9.createRenderBundleEncoder({
+  label: '\ucbdd\u4b94\u013d\u13c3\u0cec\ub6f5\u{1fdce}',
+  colorFormats: [undefined, 'rgba8sint', 'rg32float', 'bgra8unorm', 'rg32uint', 'r32uint'],
+  depthStencilFormat: 'depth32float-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+try {
+renderBundleEncoder105.setVertexBuffer(60, undefined, 1893619484, 1240299974);
+} catch {}
+try {
+device9.queue.writeTexture({
+  texture: texture135,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, arrayBuffer8, /* required buffer size: 31 */
+{offset: 31}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas47 = new OffscreenCanvas(211, 475);
+let commandEncoder98 = device0.createCommandEncoder({});
+let querySet88 = device0.createQuerySet({
+type: 'occlusion',
+count: 3979,
+});
+try {
+renderBundleEncoder80.drawIndexedIndirect(buffer3, 38900);
+} catch {}
+try {
+commandEncoder85.copyBufferToBuffer(buffer37, 25836, buffer53, 5668, 2816);
+dissociateBuffer(device0, buffer37);
+dissociateBuffer(device0, buffer53);
+} catch {}
+try {
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline94 = device0.createRenderPipeline({
+label: '\u3b53\u015f\ucfc4\u6aae\u39f8\u{1f82d}\u0150',
+layout: pipelineLayout2,
+multisample: {
+mask: 0x6bc250ff,
+},
+fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: 0}, {format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'r16float'}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'never',
+stencilFront: {
+compare: 'greater',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+failOp: 'invert',
+depthFailOp: 'zero',
+},
+stencilReadMask: 1092,
+depthBias: 30,
+depthBiasSlopeScale: 80,
+depthBiasClamp: 77,
+},
+vertex: {
+  module: shaderModule14,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 5472,
+stepMode: 'instance',
+attributes: [{
+format: 'unorm16x4',
+offset: 2756,
+shaderLocation: 15,
+}, {
+format: 'snorm8x4',
+offset: 2504,
+shaderLocation: 10,
+}, {
+format: 'float32x3',
+offset: 1040,
+shaderLocation: 5,
+}, {
+format: 'snorm8x4',
+offset: 2708,
+shaderLocation: 2,
+}, {
+format: 'snorm8x2',
+offset: 2502,
+shaderLocation: 8,
+}, {
+format: 'unorm16x2',
+offset: 2640,
+shaderLocation: 13,
+}, {
+format: 'snorm8x2',
+offset: 2044,
+shaderLocation: 1,
+}, {
+format: 'snorm8x2',
+offset: 4458,
+shaderLocation: 4,
+}, {
+format: 'sint16x4',
+offset: 2136,
+shaderLocation: 6,
+}, {
+format: 'sint32x4',
+offset: 4892,
+shaderLocation: 14,
+}, {
+format: 'sint32',
+offset: 3604,
+shaderLocation: 3,
+}, {
+format: 'sint32',
+offset: 5152,
+shaderLocation: 11,
+}],
+},
+{
+arrayStride: 4872,
+attributes: [],
+},
+{
+arrayStride: 2088,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint16x4',
+offset: 272,
+shaderLocation: 9,
+}, {
+format: 'float16x4',
+offset: 316,
+shaderLocation: 7,
+}, {
+format: 'snorm8x4',
+offset: 652,
+shaderLocation: 0,
+}, {
+format: 'sint32',
+offset: 444,
+shaderLocation: 12,
+}],
+}
+]
+},
+primitive: {
+topology: 'point-list',
+frontFace: 'cw',
+},
+});
+try {
+  await promise71;
+} catch {}
+let commandEncoder99 = device9.createCommandEncoder({label: '\u0257\u2f3c\u{1f8df}\u05aa\u{1fb5c}\u0af7\u4356\u067c\u84fe'});
+try {
+computePassEncoder66.pushDebugGroup('\u895a');
+} catch {}
+let bindGroupLayout54 = pipeline89.getBindGroupLayout(0);
+let commandEncoder100 = device10.createCommandEncoder({label: '\u0bb6\u{1fe5f}\ua929\ua1de\ucf49\u17f0\ud69e\u{1fad6}'});
+let texture150 = device10.createTexture({
+label: '\u9d60\u{1f9b0}',
+size: [120],
+dimension: '1d',
+format: 'rg16uint',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let textureView111 = texture131.createView({label: '\u0aa7\u0f28\u0762\u{1f9dc}', baseMipLevel: 2, mipLevelCount: 2});
+try {
+device10.queue.writeTexture({
+  texture: texture131,
+  mipLevel: 0,
+  origin: { x: 201, y: 36, z: 1 },
+  aspect: 'all',
+}, arrayBuffer16, /* required buffer size: 484 */
+{offset: 484, bytesPerRow: 3519}, {width: 824, height: 25, depthOrArrayLayers: 0});
+} catch {}
+let pipeline95 = await device10.createRenderPipelineAsync({
+label: '\u509a\u02a6\u{1fd98}\ue943\uc15f\u{1fbd5}',
+layout: 'auto',
+multisample: {
+count: 4,
+},
+fragment: {
+  module: shaderModule22,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {format: 'rgba8uint', writeMask: GPUColorWrite.RED}, {format: 'rgba16float', writeMask: 0}, {
+  format: 'r16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'bgra8unorm', writeMask: 0}]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'greater-equal',
+stencilFront: {
+compare: 'equal',
+failOp: 'decrement-clamp',
+passOp: 'decrement-clamp',
+},
+stencilBack: {
+compare: 'greater',
+depthFailOp: 'zero',
+},
+stencilReadMask: 2150,
+stencilWriteMask: 4000,
+depthBias: 62,
+depthBiasSlopeScale: 25,
+depthBiasClamp: 38,
+},
+vertex: {
+  module: shaderModule22,
+  entryPoint: 'vertex0',
+  constants: {},
+  buffers: [
+{
+arrayStride: 1988,
+attributes: [{
+format: 'uint32',
+offset: 856,
+shaderLocation: 0,
+}, {
+format: 'uint32',
+offset: 1504,
+shaderLocation: 12,
+}, {
+format: 'unorm8x4',
+offset: 1512,
+shaderLocation: 13,
+}, {
+format: 'sint8x4',
+offset: 1512,
+shaderLocation: 10,
+}],
+},
+{
+arrayStride: 1564,
+stepMode: 'instance',
+attributes: [{
+format: 'float32x4',
+offset: 760,
+shaderLocation: 4,
+}, {
+format: 'uint32x4',
+offset: 1180,
+shaderLocation: 8,
+}, {
+format: 'snorm8x2',
+offset: 412,
+shaderLocation: 11,
+}, {
+format: 'unorm10-10-10-2',
+offset: 880,
+shaderLocation: 7,
+}],
+}
+]
+},
+});
+let canvas36 = document.createElement('canvas');
+let textureView112 = texture89.createView({label: '\u{1ffe7}\ue107\u9f0e\u05fa\u{1faba}\u890f\u3cdc\uc5e4\u63a6\u0c6e\u931b', dimension: '1d'});
+try {
+device6.queue.copyExternalImageToTexture(/*
+{width: 115, height: 1, depthOrArrayLayers: 784}
+*/
+{
+  source: video11,
+  origin: { x: 4, y: 10 },
+  flipY: false,
+}, {
+  texture: texture128,
+  mipLevel: 1,
+  origin: { x: 66, y: 1, z: 443 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline96 = await device6.createComputePipelineAsync({
+label: '\ue1f5\u{1fad6}\u2a03\ua858\u0060\ud41d\u0c42\uf953\u7f71',
+layout: 'auto',
+compute: {
+module: shaderModule25,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+try {
+  await promise75;
+} catch {}
+let imageData41 = new ImageData(204, 256);
+let querySet89 = device10.createQuerySet({
+type: 'occlusion',
+count: 3533,
+});
+let renderBundle105 = renderBundleEncoder99.finish({});
+let sampler107 = device10.createSampler({
+label: '\u7b86\u7b70\u{1fc0c}',
+addressModeU: 'mirror-repeat',
+addressModeV: 'clamp-to-edge',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 31.787,
+lodMaxClamp: 71.667,
+});
+try {
+device10.queue.writeTexture({
+  texture: texture131,
+  mipLevel: 1,
+  origin: { x: 134, y: 11, z: 0 },
+  aspect: 'all',
+}, new Float32Array(arrayBuffer1), /* required buffer size: 31576 */
+{offset: 1000, bytesPerRow: 1624}, {width: 336, height: 19, depthOrArrayLayers: 1});
+} catch {}
+let pipeline97 = device10.createComputePipeline({
+label: '\u0a4c\u9577\u0ff0\u06dd\u{1fa58}\u0107\u0625\uc9fb\u492a\udb8b\u07e4',
+layout: pipelineLayout22,
+compute: {
+module: shaderModule22,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let gpuCanvasContext40 = canvas36.getContext('webgpu');
+document.body.prepend(canvas12);
+offscreenCanvas30.width = 72;
+let img42 = await imageWithData(255, 271, '#ab3f62fc', '#2678e2e6');
+let computePassEncoder76 = commandEncoder93.beginComputePass({});
+let renderBundleEncoder106 = device2.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'depth24plus-stencil8', sampleCount: 4, stencilReadOnly: true});
+let renderBundle106 = renderBundleEncoder43.finish({label: '\u1a64\uac30\u1f31\u25d9\u6121\ua1a4\ua99a\u0aca\u{1fa31}\u0fcf'});
+try {
+renderBundleEncoder84.drawIndirect(buffer38, 6984);
+} catch {}
+try {
+await device2.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext41 = offscreenCanvas47.getContext('webgpu');
+try {
+gpuCanvasContext39.unconfigure();
+} catch {}
+let querySet90 = device7.createQuerySet({
+type: 'occlusion',
+count: 3221,
+});
+let texture151 = device7.createTexture({
+label: '\u8d7f\uecdc\u6c58\u32ae\u6208\u{1fa4c}\uc639\u24f5',
+size: {width: 1248, height: 1, depthOrArrayLayers: 249},
+mipLevelCount: 1,
+sampleCount: 1,
+dimension: '3d',
+format: 'rgba16sint',
+usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderBundleEncoder102.setBindGroup(2, bindGroup35);
+} catch {}
+try {
+device7.queue.writeBuffer(buffer50, 2292, new BigUint64Array(60087), 2111, 4656);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let bindGroupLayout55 = device2.createBindGroupLayout({
+label: '\u0e6e\u29c5\u0253\u33fa\ud6cf\u06a6\u{1f99b}\u{1fcb4}',
+entries: [{
+binding: 3171,
+visibility: 0,
+externalTexture: {},
+}],
+});
+let sampler108 = device2.createSampler({
+label: '\u0ede\u26d5\u9c78\u4078\u6c29\u{1ffa9}\u038f\u0699\ub2a0\ue776\u0c46',
+addressModeU: 'repeat',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 0.958,
+lodMaxClamp: 37.076,
+compare: 'never',
+maxAnisotropy: 14,
+});
+try {
+computePassEncoder41.setBindGroup(8, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder84.drawIndexedIndirect(buffer38, 27692);
+} catch {}
+try {
+renderBundleEncoder84.drawIndirect(buffer38, 9844);
+} catch {}
+try {
+renderBundleEncoder84.setPipeline(pipeline71);
+} catch {}
+let promise76 = device2.createComputePipelineAsync({
+label: '\u8420\u2f7e\uf454\udb30\ua4eb\u0959\u7ad5\u512c',
+layout: pipelineLayout11,
+compute: {
+module: shaderModule7,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let computePassEncoder77 = commandEncoder99.beginComputePass({});
+try {
+await device9.queue.onSubmittedWorkDone();
+} catch {}
+let device11 = await adapter16.requestDevice({
+label: '\ua5ba\u0ff7\u{1f6a5}\u17db\u1743\u5b34',
+requiredFeatures: [
+'depth-clip-control',
+'depth32float-stencil8',
+'texture-compression-etc2',
+'texture-compression-astc',
+'indirect-first-instance',
+'shader-f16',
+'rg11b10ufloat-renderable',
+'bgra8unorm-storage'
+],
+requiredLimits: {
+maxBindGroups: 5,
+maxColorAttachmentBytesPerSample: 33,
+maxVertexAttributes: 17,
+maxVertexBufferArrayStride: 24454,
+maxStorageTexturesPerShaderStage: 18,
+maxStorageBuffersPerShaderStage: 10,
+maxDynamicStorageBuffersPerPipelineLayout: 56122,
+maxBindingsPerBindGroup: 7210,
+maxTextureDimension1D: 15228,
+maxTextureDimension2D: 8555,
+maxVertexBuffers: 10,
+minStorageBufferOffsetAlignment: 32,
+minUniformBufferOffsetAlignment: 64,
+maxUniformBufferBindingSize: 134276143,
+maxUniformBuffersPerShaderStage: 39,
+maxInterStageShaderVariables: 23,
+maxInterStageShaderComponents: 68,
+maxSamplersPerShaderStage: 21,
+},
+});
+let video40 = await videoWithData();
+let adapter17 = await promise74;
+let canvas37 = document.createElement('canvas');
+try {
+await adapter0.requestAdapterInfo();
+} catch {}
+let buffer54 = device7.createBuffer({
+  label: '\u3754\u0be5\ub1d4\ua210\u0289\u9e77\u0b81\u{1fe72}\u{1f823}',
+  size: 18020,
+  usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true
+});
+let querySet91 = device7.createQuerySet({
+label: '\ufcaf\u7f07\u27bd\u0a00\u0763',
+type: 'occlusion',
+count: 658,
+});
+let textureView113 = texture126.createView({
+  label: '\u8047\u015b\u{1ff8d}\u0105\ucf66\uff86\u01cb\u02c4\u83ac\u{1fc19}\u0620',
+  dimension: '2d-array',
+  baseMipLevel: 7,
+  mipLevelCount: 2
+});
+let renderBundleEncoder107 = device7.createRenderBundleEncoder({
+  label: '\u0f5c\u01e2\u{1fdaa}\u018e\uc903',
+  colorFormats: ['rg8unorm', 'rg16float', undefined, undefined, undefined, 'r16uint', 'rgba16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  depthReadOnly: true
+});
+let renderBundle107 = renderBundleEncoder83.finish({label: '\u{1f7f2}\ub821\u1c3e\u2de5\uf6dd\u{1fd0f}\u{1fc67}\ucaf4'});
+try {
+renderBundleEncoder88.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+computePassEncoder47.insertDebugMarker('\ud0fa');
+} catch {}
+let device12 = await promise73;
+let querySet92 = device12.createQuerySet({
+label: '\ub237\u024c\u04e2\u34e6',
+type: 'occlusion',
+count: 3921,
+});
+try {
+gpuCanvasContext26.configure({
+device: device12,
+format: 'rgba16float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['depth16unorm', 'rgba16float', 'rgba16float', 'r32float'],
+colorSpace: 'srgb',
+alphaMode: 'premultiplied',
+});
+} catch {}
+let imageData42 = new ImageData(208, 176);
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let shaderModule26 = device6.createShaderModule({
+label: '\u334f\u03f8\u{1faee}\u54be\u15ee\u0b00\u09ae\u{1fdc0}\u0144',
+code: `@group(1) @binding(3874)
+var<storage, read_write> global25: array<u32>;
+@group(1) @binding(4378)
+var<storage, read_write> parameter26: array<u32>;
+@group(0) @binding(3874)
+var<storage, read_write> type16: array<u32>;
+@group(1) @binding(561)
+var<storage, read_write> parameter27: array<u32>;
+@group(0) @binding(561)
+var<storage, read_write> global26: array<u32>;
+@group(0) @binding(4378)
+var<storage, read_write> parameter28: array<u32>;
+
+@compute @workgroup_size(7, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec3<u32>,
+  @location(4) f1: vec4<f32>,
+  @location(2) f2: vec4<u32>,
+  @location(5) f3: vec4<u32>,
+  @location(0) f4: vec2<u32>,
+  @location(1) f5: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(25) a0: vec3<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(2) f267: f32,
+  @location(25) f268: vec3<f16>,
+  @location(18) f269: vec4<u32>,
+  @builtin(position) f270: vec4<f32>,
+  @location(24) f271: f16
+}
+
+@vertex
+fn vertex0(@location(17) a0: vec4<u32>, @builtin(instance_index) a1: u32, @location(13) a2: vec3<u32>, @location(6) a3: vec4<u32>, @location(23) a4: vec2<u32>, @location(7) a5: f16, @location(3) a6: vec3<f16>, @location(14) a7: vec4<f32>, @location(11) a8: vec3<i32>, @location(12) a9: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let textureView114 = texture123.createView({dimension: '2d', baseMipLevel: 1, mipLevelCount: 2, baseArrayLayer: 89});
+let renderBundleEncoder108 = device6.createRenderBundleEncoder({
+  label: '\u0f74\u0c06\u5dd1\u1996',
+  colorFormats: ['rgba8unorm-srgb'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1
+});
+try {
+device6.queue.writeTexture({
+  texture: texture136,
+  mipLevel: 1,
+  origin: { x: 52, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 720 */
+{offset: 720, rowsPerImage: 265}, {width: 147, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas8);
+let shaderModule27 = device7.createShaderModule({
+label: '\u901f\u844c\u{1fc63}\u{1f8ba}\u{1fddd}\u0c69\u2d1d\u0fd4\u0c32\uc21d\udb73',
+code: `@group(0) @binding(3660)
+var<storage, read_write> field29: array<u32>;
+@group(0) @binding(4730)
+var<storage, read_write> global27: array<u32>;
+@group(1) @binding(4730)
+var<storage, read_write> global28: array<u32>;
+@group(1) @binding(3660)
+var<storage, read_write> field30: array<u32>;
+
+@compute @workgroup_size(7, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S30 {
+  @location(27) f0: f16,
+  @location(23) f1: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @location(19) a1: vec4<i32>, @location(29) a2: vec3<u32>, @location(41) a3: vec3<f16>, @location(9) a4: vec4<f32>, @builtin(position) a5: vec4<f32>, @location(11) a6: vec2<f16>, @location(7) a7: f16, @location(22) a8: vec4<i32>, @location(6) a9: i32, @builtin(sample_mask) a10: u32, @location(25) a11: vec4<f16>, @location(5) a12: i32, a13: S30, @builtin(sample_index) a14: u32, @location(15) a15: vec4<f16>, @location(3) a16: vec3<f32>, @location(16) a17: i32, @location(38) a18: i32, @location(43) a19: vec2<i32>, @location(44) a20: f16, @location(30) a21: vec4<i32>, @location(37) a22: vec4<u32>, @location(32) a23: vec4<i32>, @location(13) a24: u32, @location(2) a25: vec4<f32>) {
+
+}
+
+struct VertexOutput0 {
+  @location(5) f272: i32,
+  @location(41) f273: vec3<f16>,
+  @location(32) f274: vec4<i32>,
+  @location(6) f275: i32,
+  @location(23) f276: vec3<f32>,
+  @builtin(position) f277: vec4<f32>,
+  @location(27) f278: f16,
+  @location(22) f279: vec4<i32>,
+  @location(25) f280: vec4<f16>,
+  @location(3) f281: vec3<f32>,
+  @location(11) f282: vec2<f16>,
+  @location(37) f283: vec4<u32>,
+  @location(15) f284: vec4<f16>,
+  @location(44) f285: f16,
+  @location(19) f286: vec4<i32>,
+  @location(9) f287: vec4<f32>,
+  @location(13) f288: u32,
+  @location(38) f289: i32,
+  @location(28) f290: vec2<u32>,
+  @location(21) f291: vec4<f32>,
+  @location(17) f292: vec4<i32>,
+  @location(30) f293: vec4<i32>,
+  @location(31) f294: vec2<f16>,
+  @location(29) f295: vec3<u32>,
+  @location(7) f296: f16,
+  @location(2) f297: vec4<f32>,
+  @location(16) f298: i32,
+  @location(43) f299: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec3<i32>, @location(0) a1: vec2<f16>, @location(20) a2: vec2<f32>, @location(6) a3: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+sourceMap: {},
+hints: {},
+});
+let pipelineLayout24 = device7.createPipelineLayout({label: '\u0dba\ua5a0', bindGroupLayouts: [bindGroupLayout34, bindGroupLayout40]});
+let commandEncoder101 = device7.createCommandEncoder({label: '\ud2f8\u{1f900}'});
+let texture152 = device7.createTexture({
+label: '\ub4d5\u{1fc80}\u2bf4\u803e\u6a48\u03c9\u0898\u3915\ua06f\u{1fadb}\u{1f8e0}',
+size: {width: 2496, height: 1, depthOrArrayLayers: 196},
+mipLevelCount: 5,
+format: 'rg8unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rg8unorm'],
+});
+let renderBundle108 = renderBundleEncoder86.finish({label: '\uc271\u2c96\u29d0\ue810\u8f0c\uf2b6\u0830\u04d5\u4dea\uc9e0\uce97'});
+try {
+computePassEncoder60.end();
+} catch {}
+try {
+commandEncoder78.copyTextureToBuffer({
+  texture: texture125,
+  mipLevel: 1,
+  origin: { x: 133, y: 3, z: 0 },
+  aspect: 'all',
+}, {
+/* bytesInLastRow: 464 widthInBlocks: 116 aspectSpecificFormat.texelBlockSize: 4 */
+/* end: 27100 */
+offset: 27100,
+bytesPerRow: 512,
+buffer: buffer50,
+}, {width: 116, height: 5, depthOrArrayLayers: 0});
+dissociateBuffer(device7, buffer50);
+} catch {}
+try {
+commandEncoder101.clearBuffer(buffer40, 21560, 40);
+dissociateBuffer(device7, buffer40);
+} catch {}
+try {
+computePassEncoder59.insertDebugMarker('\uc880');
+} catch {}
+try {
+device7.queue.writeTexture({
+  texture: texture114,
+  mipLevel: 0,
+  origin: { x: 2458, y: 0, z: 0 },
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 999 */
+{offset: 999}, {width: 970, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device12.pushErrorScope('validation');
+} catch {}
+let commandEncoder102 = device12.createCommandEncoder({label: '\u96a7\u11d7'});
+try {
+await device12.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder103 = device11.createCommandEncoder({label: '\uef91\u{1f9a5}\ua26e'});
+let texture153 = device11.createTexture({
+label: '\u33ea\uee8e\u0d38',
+size: [31, 15, 205],
+mipLevelCount: 2,
+sampleCount: 1,
+format: 'rgba8snorm',
+usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgba8snorm'],
+});
+let gpuCanvasContext42 = canvas37.getContext('webgpu');
+let querySet93 = device12.createQuerySet({
+label: '\u89bb\u009b\u9116\u33dd\u0bfc\u{1f877}\u3624\u9546\uffb0\u{1ffc4}\u{1f7b7}',
+type: 'occlusion',
+count: 1288,
+});
+let texture154 = gpuCanvasContext3.getCurrentTexture();
+let textureView115 = texture154.createView({label: '\u2d7e\u9b20\u{1f897}\u9cf4\u{1f8e4}'});
+let sampler109 = device12.createSampler({
+label: '\uf1c2\u{1fbdc}\ub40a\u{1f655}\u00c4',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'mirror-repeat',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMaxClamp: 93.026,
+maxAnisotropy: 6,
+});
+let videoFrame29 = new VideoFrame(canvas20, {timestamp: 0});
+try {
+window.someLabel = querySet87.label;
+} catch {}
+let texture155 = device6.createTexture({
+label: '\ub5f2\u{1f72f}\u380d\u8faf\uacbc\u12b6\u{1f676}',
+size: {width: 480, height: 4, depthOrArrayLayers: 1},
+mipLevelCount: 7,
+format: 'rg8uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: [],
+});
+let renderBundle109 = renderBundleEncoder103.finish({label: '\u6157\u{1fd93}\ua0d2\u0a60\ue28e\u46af\u8a29\u2b05\u3654'});
+let sampler110 = device6.createSampler({
+label: '\u4933\u33c4',
+addressModeU: 'mirror-repeat',
+addressModeW: 'repeat',
+magFilter: 'nearest',
+minFilter: 'nearest',
+mipmapFilter: 'nearest',
+lodMinClamp: 21.742,
+lodMaxClamp: 22.279,
+});
+try {
+computePassEncoder67.setPipeline(pipeline96);
+} catch {}
+try {
+buffer31.destroy();
+} catch {}
+let img43 = await imageWithData(132, 48, '#104671e2', '#2c7c7cb3');
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+let canvas38 = document.createElement('canvas');
+let querySet94 = device12.createQuerySet({
+label: '\u0075\u0016\u0f53\u8e53\ucaae\u550b\u{1ff9f}\u4348',
+type: 'occlusion',
+count: 1596,
+});
+try {
+device12.queue.writeTexture({
+  texture: texture154,
+  mipLevel: 0,
+  origin: { x: 0, y: 1, z: 0 },
+  aspect: 'all',
+}, arrayBuffer16, /* required buffer size: 715 */
+{offset: 715, rowsPerImage: 213}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img44 = await imageWithData(255, 41, '#423bf4e0', '#32d49f07');
+try {
+canvas38.getContext('webgl2');
+} catch {}
+let querySet95 = device10.createQuerySet({
+label: '\u0dc5\u5aa4\u08ba\u9903\ud75b\uff9b\u{1faa9}\u0b2c',
+type: 'occlusion',
+count: 2315,
+});
+let renderBundle110 = renderBundleEncoder99.finish({});
+let sampler111 = device10.createSampler({
+label: '\u{1fe4b}\u{1f929}\ud9f6\u9c8c\u09ee\u05bf\u{1fc76}\u{1fdf5}\u6f55',
+addressModeU: 'clamp-to-edge',
+addressModeV: 'clamp-to-edge',
+addressModeW: 'clamp-to-edge',
+mipmapFilter: 'nearest',
+lodMinClamp: 88.248,
+lodMaxClamp: 93.334,
+});
+let promise77 = device10.createRenderPipelineAsync({
+layout: pipelineLayout22,
+multisample: {
+count: 4,
+mask: 0xca623cff,
+},
+fragment: {
+  module: shaderModule22,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {
+  format: 'rgba8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+}, {
+  format: 'rgba16float',
+  blend: {
+color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED
+}, {format: 'r16uint', writeMask: 0}, {format: 'rg8sint'}, {
+  format: 'bgra8unorm',
+  blend: {
+color: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'constant'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.RED
+}]
+},
+depthStencil: {
+format: 'depth24plus-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'less',
+stencilFront: {
+compare: 'greater',
+failOp: 'increment-clamp',
+depthFailOp: 'invert',
+passOp: 'increment-wrap',
+},
+stencilBack: {
+compare: 'less-equal',
+failOp: 'zero',
+depthFailOp: 'increment-clamp',
+passOp: 'decrement-clamp',
+},
+stencilReadMask: 2112,
+stencilWriteMask: 622,
+depthBias: 99,
+depthBiasSlopeScale: 40,
+},
+vertex: {
+  module: shaderModule22,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 1444,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32x3',
+offset: 700,
+shaderLocation: 4,
+}, {
+format: 'sint8x2',
+offset: 1122,
+shaderLocation: 10,
+}, {
+format: 'unorm10-10-10-2',
+offset: 776,
+shaderLocation: 7,
+}, {
+format: 'uint16x2',
+offset: 964,
+shaderLocation: 12,
+}],
+},
+{
+arrayStride: 1168,
+stepMode: 'vertex',
+attributes: [{
+format: 'float32',
+offset: 864,
+shaderLocation: 13,
+}, {
+format: 'uint8x2',
+offset: 134,
+shaderLocation: 0,
+}, {
+format: 'uint8x4',
+offset: 528,
+shaderLocation: 8,
+}, {
+format: 'float32x4',
+offset: 1060,
+shaderLocation: 11,
+}],
+}
+]
+},
+});
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+offscreenCanvas31.height = 433;
+let imageData43 = new ImageData(172, 124);
+let texture156 = device2.createTexture({
+size: {width: 207, height: 15, depthOrArrayLayers: 39},
+mipLevelCount: 7,
+dimension: '3d',
+format: 'rgb10a2unorm',
+usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+viewFormats: ['rgb10a2unorm', 'rgb10a2unorm'],
+});
+let renderBundleEncoder109 = device2.createRenderBundleEncoder({
+  label: '\u08a8\ua611\u6901\u{1ffb3}',
+  colorFormats: [],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 4,
+  stencilReadOnly: true
+});
+let renderBundle111 = renderBundleEncoder59.finish({label: '\udd94\udb06\u07fa\u{1fd6a}\ue4b3\u0b62\u{1fc3b}\u97a2\u0c06\u0fa6'});
+try {
+renderBundleEncoder84.drawIndexedIndirect(buffer38, 200);
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+gc();
+let commandEncoder104 = device10.createCommandEncoder({label: '\u2d50\u7065\u0a96\u{1fe42}'});
+let querySet96 = device10.createQuerySet({
+label: '\u766f\u2d82\u8664\ubace\u8db9\u0dd9\u{1f6a7}',
+type: 'occlusion',
+count: 2799,
+});
+let computePassEncoder78 = commandEncoder100.beginComputePass({label: '\ucc39\u0d79\uee54\u0b32\u{1f89e}\uccaa\u5eb8\u9717\u01dd\ue5d8\u0bb3'});
+let renderBundle112 = renderBundleEncoder96.finish();
+try {
+gpuCanvasContext35.unconfigure();
+} catch {}
+let pipelineLayout25 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout15, bindGroupLayout25, bindGroupLayout13, bindGroupLayout29, bindGroupLayout10, bindGroupLayout17]
+});
+let querySet97 = device0.createQuerySet({
+label: '\u7b26\u041a\u5e2b\u752f\u27dd\u{1ff64}',
+type: 'occlusion',
+count: 2062,
+});
+let textureView116 = texture16.createView({label: '\u04fc\u0cd8\ud1b6\u73aa\u0031', aspect: 'all'});
+try {
+computePassEncoder57.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder85.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder91.setBindGroup(4, bindGroup4, new Uint32Array(2210), 526, 0);
+} catch {}
+try {
+renderBundleEncoder80.draw(80, 64, 72, 48);
+} catch {}
+try {
+renderBundleEncoder104.setVertexBuffer(7, buffer32, 1720);
+} catch {}
+try {
+commandEncoder96.copyBufferToBuffer(buffer45, 19652, buffer3, 7392, 22724);
+dissociateBuffer(device0, buffer45);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 147, height: 1, depthOrArrayLayers: 58}
+*/
+{
+  source: video33,
+  origin: { x: 0, y: 3 },
+  flipY: false,
+}, {
+  texture: texture45,
+  mipLevel: 2,
+  origin: { x: 48, y: 0, z: 55 },
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 16, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline98 = device0.createComputePipeline({
+label: '\u0170\u{1f61f}\u877d\u6742\u0af5',
+layout: pipelineLayout5,
+compute: {
+module: shaderModule3,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+let renderBundleEncoder110 = device11.createRenderBundleEncoder({
+  label: '\u{1fd8d}\ucca8\u56de\u9197\u521d\u09e5\u9822\uc0ba',
+  colorFormats: ['rgba8uint', 'r16float'],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+let textureView117 = texture154.createView({label: '\u0e1f\ufffb'});
+try {
+device12.queue.writeTexture({
+  texture: texture154,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer15), /* required buffer size: 38 */
+{offset: 38, rowsPerImage: 128}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas18);
+let img45 = await imageWithData(292, 48, '#9c53950b', '#f1000238');
+let querySet98 = device6.createQuerySet({
+label: '\u67e1\u82cb\u4faf\ud39a\u0d0d\u04a6\u042a\u0627',
+type: 'occlusion',
+count: 310,
+});
+let renderBundleEncoder111 = device6.createRenderBundleEncoder({
+  label: '\u85bf\ub100\u0ada\u0832\u0ed7\u{1fb0b}\ufc31\u5da5',
+  colorFormats: ['rg16uint', 'rgba8sint', 'rgb10a2uint', 'rg8sint', 'rgba32sint'],
+  stencilReadOnly: true
+});
+try {
+device6.queue.writeTexture({
+  texture: texture106,
+  mipLevel: 2,
+  origin: { x: 109, y: 0, z: 1 },
+  aspect: 'all',
+}, new ArrayBuffer(231081), /* required buffer size: 231081 */
+{offset: 682, bytesPerRow: 699, rowsPerImage: 47}, {width: 107, height: 1, depthOrArrayLayers: 8});
+} catch {}
+let bindGroupLayout56 = device1.createBindGroupLayout({
+label: '\u0e1f\uaef4\u9432\u3a83\udec5\u3b21\u0c1b\u0cac\u0bd9\u0b42\uab2a',
+entries: [{
+binding: 3176,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+}, {
+binding: 5681,
+visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+externalTexture: {},
+}, {
+binding: 4251,
+visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '2d-array' },
+}],
+});
+let commandEncoder105 = device1.createCommandEncoder({label: '\u4222\u00d0\u{1fcf0}\u0fcd\u2f4f\u0754\ufadf\u{1fe86}\ufa13\ue171'});
+let commandBuffer24 = commandEncoder24.finish({
+label: '\ud959\u0c72\u1230\u06c6\uf8b8\u{1f9e9}\ua978',
+});
+pseudoSubmit(device1, commandEncoder31);
+let textureView118 = texture33.createView({label: '\u{1f6d1}\uc6dc\u6216\u0912\u4fb5', dimension: '2d-array', baseMipLevel: 7});
+try {
+device1.queue.writeBuffer(buffer9, 20128, new Float32Array(19569), 18022, 156);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 4,
+  origin: { x: 0, y: 0, z: 13 },
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(72)), /* required buffer size: 726751 */
+{offset: 267, bytesPerRow: 44, rowsPerImage: 209}, {width: 0, height: 0, depthOrArrayLayers: 80});
+} catch {}
+canvas2.width = 13;
+let img46 = await imageWithData(174, 34, '#c1d21653', '#d37a6bb5');
+try {
+adapter14.label = '\ue435\u8b7f\u{1fc54}\u0d75';
+} catch {}
+let texture157 = device11.createTexture({
+size: {width: 55, height: 30, depthOrArrayLayers: 178},
+mipLevelCount: 8,
+dimension: '3d',
+format: 'rg16uint',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder112 = device11.createRenderBundleEncoder({
+  label: '\u08b7\u08a6\u71df\u018d\ub3ee\ue984\u0cbb\u05f1\u750a\u04e0\u7e42',
+  colorFormats: ['r8uint', 'rg32uint', 'rgba16uint', 'rg8sint', 'r8uint'],
+  depthReadOnly: true
+});
+try {
+device11.queue.writeTexture({
+  texture: texture157,
+  mipLevel: 0,
+  origin: { x: 7, y: 0, z: 20 },
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 1892568 */
+{offset: 478, bytesPerRow: 170, rowsPerImage: 148}, {width: 40, height: 30, depthOrArrayLayers: 76});
+} catch {}
+let texture158 = device11.createTexture({
+label: '\u0eed\u63e1\u{1fa85}\u0b34\u0450\u7150\u{1ff07}\u310d\u09d9\u7a4d\u85c9',
+size: {width: 222, height: 120, depthOrArrayLayers: 61},
+mipLevelCount: 3,
+dimension: '2d',
+format: 'rgba16float',
+usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView119 = texture157.createView({baseMipLevel: 3, mipLevelCount: 4, baseArrayLayer: 0});
+let renderBundleEncoder113 = device11.createRenderBundleEncoder({
+  label: '\u09a4\u058e\u{1fe6d}\ua43b\u221b\u846f\ud0e7\ufe18\uad2d\u{1fd3f}',
+  colorFormats: ['r8uint', 'rg32uint', 'rgba16uint', 'rg8sint', 'r8uint'],
+  depthReadOnly: true
+});
+let renderBundle113 = renderBundleEncoder110.finish({label: '\u28f6\u0ee8\ue4bb\u4392\u9edb\u08c5\u60ec\u3c81'});
+try {
+await device11.queue.onSubmittedWorkDone();
+} catch {}
+let img47 = await imageWithData(131, 135, '#ec245917', '#fc27423f');
+try {
+await adapter3.requestAdapterInfo();
+} catch {}
+let renderBundleEncoder114 = device6.createRenderBundleEncoder({
+  label: '\uae49\u{1f6a6}\u{1fc54}\u{1f854}\ucad4\u0530\ue8b1\u92e5\u7de1',
+  colorFormats: ['rg16sint', undefined],
+  sampleCount: 4
+});
+try {
+await device6.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas48 = new OffscreenCanvas(114, 130);
+let commandEncoder106 = device10.createCommandEncoder({label: '\u0ef5\u0285\ud3b5\u{1fcb1}\u442e\u058f\u73bb'});
+let querySet99 = device10.createQuerySet({
+type: 'occlusion',
+count: 3803,
+});
+let commandBuffer25 = commandEncoder104.finish({
+});
+try {
+await device10.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline99 = device10.createComputePipeline({
+label: '\u7bf9\u022a\u{1fce3}\u{1fc12}\u9781\u040c\u{1fd79}\uf1ec\u4eac\u{1f804}',
+layout: pipelineLayout22,
+compute: {
+module: shaderModule22,
+entryPoint: 'compute0',
+constants: {},
+},
+});
+document.body.prepend(img4);
+let textureView120 = texture43.createView({
+  label: '\u21e8\u{1fc8d}\u0953\ud901\u0da7\uf38f\u{1f9d8}',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+  mipLevelCount: 1
+});
+try {
+renderBundleEncoder38.draw(8, 64, 64, 16);
+} catch {}
+try {
+renderBundleEncoder80.drawIndexedIndirect(buffer36, 3216);
+} catch {}
+try {
+commandEncoder85.copyBufferToBuffer(buffer0, 15264, buffer24, 116, 72);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+commandEncoder96.clearBuffer(buffer3, 39364, 3560);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture44,
+  mipLevel: 0,
+  origin: { x: 76, y: 0, z: 0 },
+  aspect: 'all',
+}, new ArrayBuffer(409), /* required buffer size: 409 */
+{offset: 409, bytesPerRow: 2968}, {width: 710, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout57 = device0.createBindGroupLayout({
+label: '\ufd02\ue6be\u7cbf\u0156',
+entries: [],
+});
+let bindGroup36 = device0.createBindGroup({
+label: '\u05e7\ucc17\u06bf\u2ce5\u{1fee6}\u4f61\uf6c2\u5c92\u096d',
+layout: bindGroupLayout10,
+entries: [{
+binding: 1160,
+resource: externalTexture3
+}],
+});
+let texture159 = device0.createTexture({
+label: '\u0532\u0abc\u0f68\u0151\ub4c5\ub26c\u0304\u{1f8e3}\ua0e8\u027d\u{1fe2d}',
+size: {width: 880, height: 1, depthOrArrayLayers: 1116},
+mipLevelCount: 6,
+dimension: '3d',
+format: 'rgba32float',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle114 = renderBundleEncoder51.finish({label: '\ua768\ud497\u{1fc7b}\u{1f9e8}\uf9f9\u{1ff29}\uc964\u03b4\u0e2d'});
+let sampler112 = device0.createSampler({
+label: '\ub543\u0905\u0b4c\u{1f9fc}\u1536\u{1fcd0}\uc7f7\uf289\u062d\uc417\u{1f6b0}',
+addressModeU: 'repeat',
+addressModeV: 'clamp-to-edge',
+magFilter: 'linear',
+minFilter: 'linear',
+mipmapFilter: 'linear',
+lodMinClamp: 40.111,
+lodMaxClamp: 57.790,
+maxAnisotropy: 11,
+});
+try {
+renderBundleEncoder36.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder80.draw(56, 8);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(5, buffer1);
+} catch {}
+try {
+buffer3.destroy();
+} catch {}
+try {
+  await buffer51.mapAsync(GPUMapMode.READ, 368, 620);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture159,
+  mipLevel: 0,
+  origin: { x: 446, y: 0, z: 661 },
+  aspect: 'all',
+}, new ArrayBuffer(194431385), /* required buffer size: 194431385 */
+{offset: 73, bytesPerRow: 5338, rowsPerImage: 232}, {width: 322, height: 0, depthOrArrayLayers: 158});
+} catch {}
+let texture160 = device2.createTexture({
+label: '\u5935\u088b\u2c40\u{1f7bb}\u603b\u44fb\uf467\u0206\u891d\u{1f8d8}',
+size: [3, 3, 1],
+format: 'rgba32sint',
+usage: GPUTextureUsage.STORAGE_BINDING,
+viewFormats: ['rgba32sint', 'rgba32sint', 'rgba32sint'],
+});
+try {
+renderBundleEncoder84.drawIndexedIndirect(buffer38, 18648);
+} catch {}
+try {
+renderBundleEncoder84.drawIndirect(buffer38, 28680);
+} catch {}
+try {
+renderBundleEncoder84.setPipeline(pipeline71);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer43, 12936, new Int16Array(23587), 12003, 984);
+} catch {}
+try {
+gpuCanvasContext27.unconfigure();
+} catch {}
+try {
+offscreenCanvas48.getContext('2d');
+} catch {}
+let videoFrame30 = new VideoFrame(video17, {timestamp: 0});
+let querySet100 = device9.createQuerySet({
+label: '\u{1fc0e}\u{1fb30}\u{1ff42}\u45fb\udf8b\u0512\u5678\u{1fa45}\u{1f74d}\u0cbb',
+type: 'occlusion',
+count: 535,
+});
+let textureView121 = texture135.createView({label: '\u03d5\u1d96\u09cc', baseMipLevel: 5, mipLevelCount: 1});
+let imageData44 = new ImageData(180, 168);
+let bindGroupLayout58 = device0.createBindGroupLayout({
+entries: [],
+});
+let commandBuffer26 = commandEncoder96.finish({
+label: '\u09dd\u06c7\u49b3\u{1f7dd}\u{1f9bb}\ub006\ubb55\u{1fe3f}\u036a\u0b0c\u{1f96d}',
+});
+let textureView122 = texture54.createView({baseMipLevel: 2, mipLevelCount: 1, arrayLayerCount: 1});
+let renderBundleEncoder115 = device0.createRenderBundleEncoder({
+  label: '\u0fc0\u{1fe7e}\uc474\u6a30',
+  colorFormats: ['r16float', 'rgba32float', 'rgba32uint', 'rgba8unorm', undefined, 'rgba16float'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true
+});
+try {
+renderBundleEncoder38.drawIndirect(buffer36, 10704);
+} catch {}
+try {
+commandEncoder65.copyBufferToBuffer(buffer1, 13216, buffer24, 132, 64);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer24);
+} catch {}
+try {
+commandEncoder84.clearBuffer(buffer23, 19764, 8076);
+dissociateBuffer(device0, buffer23);
+} catch {}
+let promise78 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData34,
+  origin: { x: 66, y: 33 },
+  flipY: true,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: { x: 0, y: 0, z: 1 },
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline100 = device0.createRenderPipeline({
+label: '\u01d6\u87a4\u033d\u4eb2\u{1fece}\u8b15\uef01\ua175',
+layout: pipelineLayout5,
+fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+},
+  writeMask: GPUColorWrite.RED
+}, undefined]
+},
+depthStencil: {
+format: 'depth32float-stencil8',
+depthWriteEnabled: true,
+depthCompare: 'not-equal',
+stencilFront: {
+compare: 'never',
+failOp: 'replace',
+passOp: 'decrement-wrap',
+},
+stencilBack: {
+compare: 'greater-equal',
+depthFailOp: 'increment-wrap',
+passOp: 'replace',
+},
+stencilReadMask: 984,
+stencilWriteMask: 2471,
+depthBiasClamp: 41,
+},
+vertex: {
+  module: shaderModule11,
+  entryPoint: 'vertex0',
+  buffers: [
+{
+arrayStride: 40,
+stepMode: 'vertex',
+attributes: [{
+format: 'sint16x2',
+offset: 32,
+shaderLocation: 8,
+}, {
+format: 'uint8x4',
+offset: 4,
+shaderLocation: 12,
+}, {
+format: 'sint8x2',
+offset: 26,
+shaderLocation: 1,
+}, {
+format: 'float32x4',
+offset: 8,
+shaderLocation: 2,
+}],
+},
+{
+arrayStride: 6040,
+stepMode: 'vertex',
+attributes: [{
+format: 'uint8x4',
+offset: 1796,
+shaderLocation: 4,
+}, {
+format: 'sint16x2',
+offset: 524,
+shaderLocation: 11,
+}, {
+format: 'unorm8x4',
+offset: 4536,
+shaderLocation: 7,
+}, {
+format: 'sint16x2',
+offset: 2340,
+shaderLocation: 5,
+}],
+},
+{
+arrayStride: 7044,
+stepMode: 'instance',
+attributes: [{
+format: 'uint16x4',
+offset: 2692,
+shaderLocation: 9,
+}, {
+format: 'unorm8x2',
+offset: 5508,
+shaderLocation: 15,
+}, {
+format: 'unorm16x2',
+offset: 572,
+shaderLocation: 10,
+}],
+}
+]
+},
+primitive: {
+frontFace: 'cw',
+cullMode: 'back',
+unclippedDepth: true,
+},
+});
+let textureView123 = texture157.createView({
+  label: '\u06dd\u3405\u39ba\ufd55\uad0f\u009e\u9a48\u0461',
+  baseMipLevel: 5,
+  mipLevelCount: 1,
+  arrayLayerCount: 1
+});
+let renderBundleEncoder116 = device11.createRenderBundleEncoder({
+  label: '\ufad8\u59a1\u028a\udc7d\ubca0\u{1faea}\u7928\u0486\u0b59\u0410',
+  colorFormats: ['rgba8uint', 'r16float'],
+  depthStencilFormat: 'depth24plus-stencil8'
+});
+let renderBundle115 = renderBundleEncoder110.finish({label: '\u04cc\u{1f807}'});
+try {
+device11.pushErrorScope('internal');
+} catch {}
+try {
+gpuCanvasContext13.configure({
+device: device11,
+format: 'bgra8unorm',
+usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+colorSpace: 'display-p3',
+alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device11.queue.writeTexture({
+  texture: texture157,
+  mipLevel: 3,
+  origin: { x: 2, y: 0, z: 2 },
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer12), /* required buffer size: 1054472 */
+{offset: 656, bytesPerRow: 220, rowsPerImage: 252}, {width: 4, height: 3, depthOrArrayLayers: 20});
+} catch {}
+let canvas39 = document.createElement('canvas');
+try {
+window.someLabel = texture55.label;
+} catch {}
+try {
+  await promise78;
+} catch {}
+let offscreenCanvas49 = new OffscreenCanvas(722, 246);
+let renderBundleEncoder117 = device4.createRenderBundleEncoder({colorFormats: ['rg32float', 'rgba32sint']});
+try {
+renderBundleEncoder48.pushDebugGroup('\ub07d');
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -187,8 +187,9 @@ void Queue::onSubmittedWorkScheduled(Function<void()>&& completionHandler)
 NSString* Queue::errorValidatingSubmit(const Vector<std::reference_wrapper<CommandBuffer>>& commands) const
 {
     for (auto command : commands) {
-        if (!isValidToUseWith(command.get(), *this) || command.get().bufferMapCount())
-            return command.get().lastError() ?: @"Validation failure.";
+        auto& commandBuffer = command.get();
+        if (!isValidToUseWith(commandBuffer, *this) || commandBuffer.bufferMapCount() || commandBuffer.commandBuffer().status >= MTLCommandBufferStatusCommitted)
+            return commandBuffer.lastError() ?: @"Validation failure.";
     }
 
     // FIXME: "Every GPUQuerySet referenced in a command in any element of commandBuffers is in the available state."


### PR DESCRIPTION
#### 1aa9df849f39cec5ea2277ad8ce17b7ced915634
<pre>
[WebGPU] Queue should not allow command buffer to be committed twice
<a href="https://bugs.webkit.org/show_bug.cgi?id=273585">https://bugs.webkit.org/show_bug.cgi?id=273585</a>
&lt;radar://127364831&gt;

Reviewed by Cameron McCormack.

Check the command buffer status during validation to ensure
addCompleted / scheduled handler doesn&apos;t occur after commit.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/fuzz-273585-expected.txt: Added.
* LayoutTests/fast/webgpu/fuzz-273585.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::errorValidatingSubmit const):

Canonical link: <a href="https://commits.webkit.org/278362@main">https://commits.webkit.org/278362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48ea9b04518582d09f3b36b47b088a75c8707075

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53572 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1003 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/651 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27264 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43308 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22148 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/24674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/561 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8691 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/625 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55158 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25409 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26672 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43491 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47484 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11036 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27534 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26402 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->