### PR TITLE
[import-w3c-tests] references should be imported as their original filename too

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_importer.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer.py
@@ -384,10 +384,6 @@ class TestImporter(object):
                 if 'slow' in test_info:
                     self._slow_tests.append(fullpath)
 
-                if 'referencefile' in test_info.keys():
-                    # Skip it since, the corresponding reference test should have a link to this file
-                    continue
-
                 if 'match_reference' in test_info.keys() or 'mismatch_reference' in test_info.keys():
                     reftests += 1
                     total_tests += 1

--- a/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
@@ -556,6 +556,27 @@ class TestImporterTest(unittest.TestCase):
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/web-platform-tests/css/css-images/test4.html'))
         self.assertFalse(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/web-platform-tests/css/css-images/test4-expected.html'))
 
+    def test_keep_original_reftest_reference(self):
+        FAKE_FILES = {
+            '/home/user/wpt/web-platform-tests/css/css-images/test1.html': '<html><head><link rel=match href=test1-ref.html></head></html>',
+            '/home/user/wpt/web-platform-tests/css/css-images/test1-ref.html': '<html></html>',
+            '/home/user/wpt/web-platform-tests/css/css-images/test2.html': '<html><head><link rel=mismatch href=test2-notref.html></head></html>',
+            '/home/user/wpt/web-platform-tests/css/css-images/test2-notref.html': '<html></html>',
+        }
+        FAKE_FILES.update(FAKE_RESOURCES)
+
+        fs = self.import_directory(['-s', '/home/user/wpt', '-d', '/mock-checkout/LayoutTests/w3c/web-platform-tests'], FAKE_FILES, ['web-platform-tests/css/css-images'])
+
+        # test1
+        self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/web-platform-tests/css/css-images/test1.html'))
+        self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/web-platform-tests/css/css-images/test1-ref.html'))
+        self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/web-platform-tests/css/css-images/test1-expected.html'))
+
+        # test2
+        self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/web-platform-tests/css/css-images/test2.html'))
+        self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/web-platform-tests/css/css-images/test2-notref.html'))
+        self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/web-platform-tests/css/css-images/test2-expected-mismatch.html'))
+
     def test_template_test(self):
         FAKE_FILES = {
             '/mock-checkout/WebKitBuild/w3c-tests/web-platform-tests/t/test.any.js': '// META: global=window,dedicatedworker,sharedworker,serviceworker\n',

--- a/Tools/Scripts/webkitpy/w3c/test_parser.py
+++ b/Tools/Scripts/webkitpy/w3c/test_parser.py
@@ -98,9 +98,6 @@ class TestParser(object):
                 assert reference_type in ("==", "!=")
                 reference_type = "match" if reference_type == "==" else "mismatch"
 
-                if (ref_file == self.filename):
-                    return {'referencefile': self.filename}
-
                 if ref_contents is not None:
                     ref_doc = Parser(ref_contents)
                 elif self.filesystem.exists(ref_file):
@@ -122,8 +119,6 @@ class TestParser(object):
             test_info = {'test': self.filename, 'crashtest': True}
         elif test_type == "testharness":
             test_info = {'test': self.filename, 'jstest': True}
-        elif test_type == "support" and wpt_sourcefile.name_is_reference:
-            test_info = {'referencefile': self.filename}
         elif self.options['all'] is True:
             test_info = {'test': self.filename}
 

--- a/Tools/Scripts/webkitpy/w3c/test_parser_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_parser_unittest.py
@@ -351,5 +351,52 @@ CONTENT OF TEST
         parser = TestParser(options, os.path.join(test_path, 'test-ref.html'))
         test_info = parser.analyze_test(test_contents=test_html)
 
-        self.assertFalse('referencefile' in test_info, 'test should not be detected as reference file')
         self.assertTrue('match_reference' in test_info.keys())
+
+    def test_reference_self_reference(self):
+        """ Tests analyze_test() using a test that its own reference"""
+
+        test_html = b"""<html>
+<head>
+<title>CSS Test: DESCRIPTION OF TEST</title>
+<link rel="match" href="test-ref.html" />
+<link rel="author" title="NAME_OF_AUTHOR" />
+<style type="text/css"><![CDATA[
+CSS FOR TEST
+]]></style>
+</head>
+<body>
+CONTENT OF TEST
+</body>
+</html>
+"""
+        test_path = os.path.join(os.path.sep, 'some', 'madeup', 'path')
+        parser = TestParser(options, os.path.join(test_path, 'test-ref.html'))
+        test_info = parser.analyze_test(test_contents=test_html)
+
+        self.assertTrue('match_reference' in test_info.keys())
+
+    def test_reference_name(self):
+        names = [
+            "css-namespaces-3/reftest/ref-lime-1.xml",
+            "css21/reference/pass_if_box_ahem.html",
+            "css21/csswg-issues/submitted/css2.1/reference/ref-green-box-100x100.xht",
+            "selectors-3/selectors-empty-001-ref.xml",
+            "css21/text/text-indent-wrap-001-notref-block-margin.xht",
+            "css21/text/text-indent-wrap-001-notref-block-margin.xht",
+            "css21/css-e-notation-ref-1.html",
+            "css21/floats/floats-placement-vertical-004-ref2.xht",
+            "css21/box/rtl-linebreak-notref1.xht",
+            "css21/box/rtl-linebreak-notref2.xht",
+            "html/canvas/element/drawing-images-to-the-canvas/drawimage_html_image_5_ref.html",
+            "html/canvas/element/line-styles/lineto_ref.html",
+            "html/rendering/non-replaced-elements/the-fieldset-element-0/ref.html",
+        ]
+
+        test_html = b"<html></html>"
+
+        for name in names:
+            test_path = os.path.join("/", "wpt", name)
+            parser = TestParser(options, test_path)
+            test_info = parser.analyze_test(test_contents=test_html)
+            self.assertIs(test_info, None)


### PR DESCRIPTION
#### ec1b41b9a866de879a036f55d96bc75bb9b548df
<pre>
[import-w3c-tests] references should be imported as their original filename too
<a href="https://bugs.webkit.org/show_bug.cgi?id=273235">https://bugs.webkit.org/show_bug.cgi?id=273235</a>

Reviewed by Tim Nguyen.

Prior to 277673@main we did import _some_ references under their
original name, as well as copying them to -expected.html.

In that commit, we inadvertently stopped the copying; it was somewhat
surprising behaviour of the existing code that led to some of them being
copied, and arguably a bug, and the obvious rewrite of it led to them
being excluded again.

However, preserving both the original and r-w-t style filenames provides
a clearer path to running the tests based on their &lt;link rel=match&gt;,
thus there is a good reason to do this. (And with git being based on
content addressable storage, there is little cost in duplicating the
files.)

This removes the branch that was always intended to exclude them, and
adds tests to verify we have the now-intended behaviour.

With that now done, the only usage of the `referencefile` metadata is
to exclude reftests which point at themself as the reference, which is
behaviour upstream WPT doesn&apos;t prohibit (but is clearly meaningless!),
so we may as well get rid of the `referencefile` metadata entirely and
just treat references identically to support files.

* Tools/Scripts/webkitpy/w3c/test_importer.py:
(TestImporter.find_importable_tests):
* Tools/Scripts/webkitpy/w3c/test_importer_unittest.py:
* Tools/Scripts/webkitpy/w3c/test_parser.py:
(TestParser.analyze_test):
* Tools/Scripts/webkitpy/w3c/test_parser_unittest.py:
(test_reference_self_reference):
(test_reference_name):

Canonical link: <a href="https://commits.webkit.org/278271@main">https://commits.webkit.org/278271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1acefd1d0539f11f6cf89668040e44eaa588fabd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-10-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7222 "Built successfully and passed tests") | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-10-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->