### PR TITLE
`UIScriptControllerIOS::sendEventStream` sometimes asserts on debug builds

### DIFF
--- a/Tools/TestRunnerShared/Bindings/JSWrappable.h
+++ b/Tools/TestRunnerShared/Bindings/JSWrappable.h
@@ -25,13 +25,13 @@
 
 #pragma once
 
-#include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
 
 typedef struct OpaqueJSClass* JSClassRef;
 
 namespace WTR {
 
-class JSWrappable : public RefCounted<JSWrappable> {
+class JSWrappable : public ThreadSafeRefCounted<JSWrappable> {
 public:
     virtual ~JSWrappable() { }
     virtual JSClassRef wrapperClass() = 0;


### PR DESCRIPTION
#### 88b97cdbbb91799427d8144d6425d8743fdf301e
<pre>
`UIScriptControllerIOS::sendEventStream` sometimes asserts on debug builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=273601">https://bugs.webkit.org/show_bug.cgi?id=273601</a>
<a href="https://rdar.apple.com/124414379">rdar://124414379</a>

Reviewed by Wenson Hsieh.

Fix following assertion by making JSWrappable inherit from ThreadSafeRefCounted:

```
ASSERTION FAILED: Unsafe to ref/deref from different threads
m_isOwnedByMainThread == isMainThread()
/System/Volumes/Data/otmp/case-sensitive/od.luxon/lw.luxon/sandbox-0/Desktop/Build/Build/Products/webkit/usr/local/include/wtf/RefCounted.h(119) : void WTF::RefCountedBase::applyRefDerefThreadingCheck() const
1   0x10f2736d9 WTFCrash
2   0x10a16f24a WTF::RefCountedBase::applyRefDerefThreadingCheck() const
3   0x10a16f059 WTF::RefCountedBase::derefAllowingPartiallyDestroyedBase() const
4   0x10a16eff0 WTF::RefCountedBase::derefBase() const
5   0x10a1ada69 WTF::RefCounted&lt;WTR::JSWrappable, std::__1::default_delete&lt;WTR::JSWrappable&gt;&gt;::deref() const
6   0x10a1cbda2 WTF::DefaultRefDerefTraits&lt;WTR::UIScriptControllerIOS&gt;::derefIfNotNull(WTR::UIScriptControllerIOS*)
7   0x10a1cbd61 WTF::Ref&lt;WTR::UIScriptControllerIOS, WTF::RawPtrTraits&lt;WTR::UIScriptControllerIOS&gt;, WTF::DefaultRefDerefTraits&lt;WTR::UIScriptControllerIOS&gt;&gt;::~Ref()
8   0x10a1b57a5 WTF::Ref&lt;WTR::UIScriptControllerIOS, WTF::RawPtrTraits&lt;WTR::UIScriptControllerIOS&gt;, WTF::DefaultRefDerefTraits&lt;WTR::UIScriptControllerIOS&gt;&gt;::~Ref()
9   0x10a1c6079 WTR::UIScriptControllerIOS::sendEventStream(OpaqueJSString*, OpaqueJSValue const*)::$_15::~$_15()
10  0x10a1b9195 WTR::UIScriptControllerIOS::sendEventStream(OpaqueJSString*, OpaqueJSValue const*)::$_15::~$_15()
```

* Tools/TestRunnerShared/Bindings/JSWrappable.h:

Canonical link: <a href="https://commits.webkit.org/278254@main">https://commits.webkit.org/278254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c3c417364b5076f4deea38d587393498b26d5d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53224 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/658 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52282 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/227 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40762 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26858 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42991 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21896 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24290 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/231 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8351 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54805 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25075 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48155 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43194 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10961 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27195 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->