### PR TITLE
[JSC] Start using limited variant of Handler IC

### DIFF
--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -295,14 +295,24 @@ RefPtr<AccessCase> AccessCase::fromStructureStubInfo(
     }
 }
 
-bool AccessCase::hasAlternateBaseImpl() const
+JSObject* AccessCase::tryGetAlternateBaseImpl() const
 {
-    return !conditionSet().isEmpty();
-}
-
-JSObject* AccessCase::alternateBaseImpl() const
-{
-    return conditionSet().slotBaseCondition().object();
+    switch (m_type) {
+    case AccessCase::Getter:
+    case AccessCase::Setter:
+    case AccessCase::CustomValueGetter:
+    case AccessCase::CustomAccessorGetter:
+    case AccessCase::CustomValueSetter:
+    case AccessCase::CustomAccessorSetter:
+    case AccessCase::IntrinsicGetter:
+    case AccessCase::Load:
+    case AccessCase::GetGetter:
+        if (!conditionSet().isEmpty())
+            return conditionSet().slotBaseCondition().object();
+        return nullptr;
+    default:
+        return nullptr;
+    }
 }
 
 Ref<AccessCase> AccessCase::cloneImpl() const
@@ -1402,12 +1412,6 @@ void AccessCase::checkConsistency(StructureStubInfo& stubInfo)
 
 bool AccessCase::canBeShared(const AccessCase& lhs, const AccessCase& rhs)
 {
-    // And we say "false" if either of them have m_polyProtoAccessChain.
-    if (lhs.m_polyProtoAccessChain || rhs.m_polyProtoAccessChain)
-        return false;
-    if (lhs.additionalSet() || rhs.additionalSet())
-        return false;
-
     if (lhs.m_type != rhs.m_type)
         return false;
     if (lhs.m_offset != rhs.m_offset)
@@ -1419,6 +1423,17 @@ bool AccessCase::canBeShared(const AccessCase& lhs, const AccessCase& rhs)
     if (lhs.m_identifier != rhs.m_identifier)
         return false;
     if (lhs.m_conditionSet != rhs.m_conditionSet)
+        return false;
+    if (lhs.additionalSet() != rhs.additionalSet())
+        return false;
+    if (lhs.m_polyProtoAccessChain || rhs.m_polyProtoAccessChain) {
+        if (!lhs.m_polyProtoAccessChain || !rhs.m_polyProtoAccessChain)
+            return false;
+        if (*lhs.m_polyProtoAccessChain != *rhs.m_polyProtoAccessChain)
+            return false;
+    }
+
+    if (lhs.tryGetAlternateBase() != rhs.tryGetAlternateBase())
         return false;
 
     switch (lhs.m_type) {
@@ -1521,6 +1536,15 @@ bool AccessCase::canBeShared(const AccessCase& lhs, const AccessCase& rhs)
     case InstanceOfGeneric:
         return true;
 
+    case CustomValueGetter:
+    case CustomAccessorGetter:
+    case CustomValueSetter:
+    case CustomAccessorSetter: {
+        auto& lhsd = lhs.as<GetterSetterAccessCase>();
+        auto& rhsd = rhs.as<GetterSetterAccessCase>();
+        return lhsd.m_customAccessor == rhsd.m_customAccessor;
+    }
+
     case Getter:
     case Setter:
     case ProxyObjectHas:
@@ -1528,14 +1552,6 @@ bool AccessCase::canBeShared(const AccessCase& lhs, const AccessCase& rhs)
     case ProxyObjectStore:
     case IndexedProxyObjectLoad: {
         // Getter / Setter / ProxyObjectHas / ProxyObjectLoad / ProxyObjectStore / IndexedProxyObjectLoad rely on CodeBlock, which makes sharing impossible.
-        return false;
-    }
-
-    case CustomValueGetter:
-    case CustomAccessorGetter:
-    case CustomValueSetter:
-    case CustomAccessorSetter: {
-        // They are embedding JSGlobalObject that are not tied to sharing JITStubRoutine.
         return false;
     }
 
@@ -1590,20 +1606,11 @@ WatchpointSet* AccessCase::additionalSet() const
     return result;
 }
 
-bool AccessCase::hasAlternateBase() const
-{
-    bool result = false;
-    const_cast<AccessCase*>(this)->runWithDowncast([&](auto* accessCase) {
-        result = accessCase->hasAlternateBaseImpl();
-    });
-    return result;
-}
-
-JSObject* AccessCase::alternateBase() const
+JSObject* AccessCase::tryGetAlternateBase() const
 {
     JSObject* result = nullptr;
     const_cast<AccessCase*>(this)->runWithDowncast([&](auto* accessCase) {
-        result = accessCase->alternateBaseImpl();
+        result = accessCase->tryGetAlternateBaseImpl();
     });
     return result;
 }

--- a/Source/JavaScriptCore/bytecode/AccessCase.h
+++ b/Source/JavaScriptCore/bytecode/AccessCase.h
@@ -219,9 +219,8 @@ public:
 
     ObjectPropertyConditionSet conditionSet() const { return m_conditionSet; }
 
-    bool hasAlternateBase() const;
-    JSObject* alternateBase() const;
-    
+    JSObject* tryGetAlternateBase() const;
+
     WatchpointSet* additionalSet() const;
     bool viaGlobalProxy() const { return m_viaGlobalProxy; }
 
@@ -281,10 +280,6 @@ public:
 
     UniquedStringImpl* uid() const { return m_identifier.uid(); }
     CacheableIdentifier identifier() const { return m_identifier; }
-    void updateIdentifier(CacheableIdentifier identifier)
-    {
-        m_identifier = identifier;
-    }
 
 #if ASSERT_ENABLED
     void checkConsistency(StructureStubInfo&);
@@ -330,9 +325,8 @@ protected:
 
     Ref<AccessCase> cloneImpl() const;
     WatchpointSet* additionalSetImpl() const { return nullptr; }
-    bool hasAlternateBaseImpl() const;
+    JSObject* tryGetAlternateBaseImpl() const;
     void dumpImpl(PrintStream&, CommaPrinter&, Indenter&) const { }
-    JSObject* alternateBaseImpl() const;
 
     bool guardedByStructureCheckSkippingConstantIdentifierCheck() const;
 

--- a/Source/JavaScriptCore/bytecode/GetByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.cpp
@@ -332,7 +332,9 @@ GetByStatus GetByStatus::computeForStubInfoWithoutExitSiteFeedback(const Concurr
                 if (!conditionSet.isStillValid())
                     continue;
 
-                Structure* currStructure = access.hasAlternateBase() ? access.alternateBase()->structure() : access.structure();
+                Structure* currStructure = access.structure();
+                if (auto* object = access.tryGetAlternateBase())
+                    currStructure = object->structure();
                 // For now, we only support cases which JSGlobalObject is the same to the currently profiledBlock.
                 if (currStructure->globalObject() != profiledBlock->globalObject())
                     return GetByStatus(JSC::slowVersion(summary), stubInfo);

--- a/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.cpp
@@ -75,18 +75,11 @@ Ref<AccessCase> GetterSetterAccessCase::cloneImpl() const
     return adoptRef(*new GetterSetterAccessCase(*this));
 }
 
-bool GetterSetterAccessCase::hasAlternateBaseImpl() const
+JSObject* GetterSetterAccessCase::tryGetAlternateBaseImpl() const
 {
-    if (customSlotBase())
-        return true;
-    return Base::hasAlternateBaseImpl();
-}
-
-JSObject* GetterSetterAccessCase::alternateBaseImpl() const
-{
-    if (customSlotBase())
-        return customSlotBase();
-    return Base::alternateBaseImpl();
+    if (auto* object = customSlotBase())
+        return object;
+    return Base::tryGetAlternateBaseImpl();
 }
 
 void GetterSetterAccessCase::dumpImpl(PrintStream& out, CommaPrinter& comma, Indenter& indent) const

--- a/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.h
+++ b/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.h
@@ -65,8 +65,7 @@ private:
 
     GetterSetterAccessCase(const GetterSetterAccessCase&);
 
-    bool hasAlternateBaseImpl() const;
-    JSObject* alternateBaseImpl() const;
+    JSObject* tryGetAlternateBaseImpl() const;
     void dumpImpl(PrintStream&, CommaPrinter&, Indenter&) const;
     Ref<AccessCase> cloneImpl() const;
 

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -560,128 +560,6 @@ static bool isStateless(AccessCase::AccessType type)
     return false;
 }
 
-static bool isMegamorphicById(AccessCase::AccessType type)
-{
-    switch (type) {
-    case AccessCase::LoadMegamorphic:
-    case AccessCase::StoreMegamorphic:
-    case AccessCase::InMegamorphic:
-        return true;
-
-    case AccessCase::Load:
-    case AccessCase::Transition:
-    case AccessCase::Delete:
-    case AccessCase::DeleteNonConfigurable:
-    case AccessCase::DeleteMiss:
-    case AccessCase::Replace:
-    case AccessCase::Miss:
-    case AccessCase::GetGetter:
-    case AccessCase::CheckPrivateBrand:
-    case AccessCase::SetPrivateBrand:
-    case AccessCase::IndexedNoIndexingMiss:
-    case AccessCase::Getter:
-    case AccessCase::Setter:
-    case AccessCase::ProxyObjectHas:
-    case AccessCase::ProxyObjectLoad:
-    case AccessCase::ProxyObjectStore:
-    case AccessCase::IndexedProxyObjectLoad:
-    case AccessCase::CustomValueGetter:
-    case AccessCase::CustomAccessorGetter:
-    case AccessCase::CustomValueSetter:
-    case AccessCase::CustomAccessorSetter:
-    case AccessCase::IntrinsicGetter:
-    case AccessCase::ModuleNamespaceLoad:
-    case AccessCase::InstanceOfHit:
-    case AccessCase::InstanceOfMiss:
-    case AccessCase::InHit:
-    case AccessCase::InMiss:
-    case AccessCase::IndexedNoIndexingInMiss:
-    case AccessCase::ArrayLength:
-    case AccessCase::StringLength:
-    case AccessCase::DirectArgumentsLength:
-    case AccessCase::ScopedArgumentsLength:
-    case AccessCase::IndexedMegamorphicLoad:
-    case AccessCase::IndexedMegamorphicStore:
-    case AccessCase::IndexedInt32Load:
-    case AccessCase::IndexedDoubleLoad:
-    case AccessCase::IndexedContiguousLoad:
-    case AccessCase::IndexedArrayStorageLoad:
-    case AccessCase::IndexedScopedArgumentsLoad:
-    case AccessCase::IndexedDirectArgumentsLoad:
-    case AccessCase::IndexedTypedArrayInt8Load:
-    case AccessCase::IndexedTypedArrayUint8Load:
-    case AccessCase::IndexedTypedArrayUint8ClampedLoad:
-    case AccessCase::IndexedTypedArrayInt16Load:
-    case AccessCase::IndexedTypedArrayUint16Load:
-    case AccessCase::IndexedTypedArrayInt32Load:
-    case AccessCase::IndexedTypedArrayUint32Load:
-    case AccessCase::IndexedTypedArrayFloat32Load:
-    case AccessCase::IndexedTypedArrayFloat64Load:
-    case AccessCase::IndexedResizableTypedArrayInt8Load:
-    case AccessCase::IndexedResizableTypedArrayUint8Load:
-    case AccessCase::IndexedResizableTypedArrayUint8ClampedLoad:
-    case AccessCase::IndexedResizableTypedArrayInt16Load:
-    case AccessCase::IndexedResizableTypedArrayUint16Load:
-    case AccessCase::IndexedResizableTypedArrayInt32Load:
-    case AccessCase::IndexedResizableTypedArrayUint32Load:
-    case AccessCase::IndexedResizableTypedArrayFloat32Load:
-    case AccessCase::IndexedResizableTypedArrayFloat64Load:
-    case AccessCase::IndexedInt32Store:
-    case AccessCase::IndexedDoubleStore:
-    case AccessCase::IndexedContiguousStore:
-    case AccessCase::IndexedArrayStorageStore:
-    case AccessCase::IndexedTypedArrayInt8Store:
-    case AccessCase::IndexedTypedArrayUint8Store:
-    case AccessCase::IndexedTypedArrayUint8ClampedStore:
-    case AccessCase::IndexedTypedArrayInt16Store:
-    case AccessCase::IndexedTypedArrayUint16Store:
-    case AccessCase::IndexedTypedArrayInt32Store:
-    case AccessCase::IndexedTypedArrayUint32Store:
-    case AccessCase::IndexedTypedArrayFloat32Store:
-    case AccessCase::IndexedTypedArrayFloat64Store:
-    case AccessCase::IndexedResizableTypedArrayInt8Store:
-    case AccessCase::IndexedResizableTypedArrayUint8Store:
-    case AccessCase::IndexedResizableTypedArrayUint8ClampedStore:
-    case AccessCase::IndexedResizableTypedArrayInt16Store:
-    case AccessCase::IndexedResizableTypedArrayUint16Store:
-    case AccessCase::IndexedResizableTypedArrayInt32Store:
-    case AccessCase::IndexedResizableTypedArrayUint32Store:
-    case AccessCase::IndexedResizableTypedArrayFloat32Store:
-    case AccessCase::IndexedResizableTypedArrayFloat64Store:
-    case AccessCase::IndexedStringLoad:
-    case AccessCase::IndexedInt32InHit:
-    case AccessCase::IndexedDoubleInHit:
-    case AccessCase::IndexedContiguousInHit:
-    case AccessCase::IndexedArrayStorageInHit:
-    case AccessCase::IndexedScopedArgumentsInHit:
-    case AccessCase::IndexedDirectArgumentsInHit:
-    case AccessCase::IndexedTypedArrayInt8InHit:
-    case AccessCase::IndexedTypedArrayUint8InHit:
-    case AccessCase::IndexedTypedArrayUint8ClampedInHit:
-    case AccessCase::IndexedTypedArrayInt16InHit:
-    case AccessCase::IndexedTypedArrayUint16InHit:
-    case AccessCase::IndexedTypedArrayInt32InHit:
-    case AccessCase::IndexedTypedArrayUint32InHit:
-    case AccessCase::IndexedTypedArrayFloat32InHit:
-    case AccessCase::IndexedTypedArrayFloat64InHit:
-    case AccessCase::IndexedResizableTypedArrayInt8InHit:
-    case AccessCase::IndexedResizableTypedArrayUint8InHit:
-    case AccessCase::IndexedResizableTypedArrayUint8ClampedInHit:
-    case AccessCase::IndexedResizableTypedArrayInt16InHit:
-    case AccessCase::IndexedResizableTypedArrayUint16InHit:
-    case AccessCase::IndexedResizableTypedArrayInt32InHit:
-    case AccessCase::IndexedResizableTypedArrayUint32InHit:
-    case AccessCase::IndexedResizableTypedArrayFloat32InHit:
-    case AccessCase::IndexedResizableTypedArrayFloat64InHit:
-    case AccessCase::IndexedStringInHit:
-    case AccessCase::IndexedMegamorphicIn:
-    case AccessCase::InstanceOfGeneric:
-        return false;
-    }
-
-    return false;
-}
-
 static bool doesJSCalls(AccessCase::AccessType type)
 {
     switch (type) {
@@ -2799,7 +2677,10 @@ void InlineCacheCompiler::generateImpl(AccessCase& accessCase)
     case AccessCase::IntrinsicGetter: {
         GPRReg valueRegsPayloadGPR = valueRegs.payloadGPR();
 
-        Structure* currStructure = accessCase.hasAlternateBase() ? accessCase.alternateBase()->structure() : accessCase.structure();
+        Structure* currStructure = accessCase.structure();
+        if (auto* object = accessCase.tryGetAlternateBase())
+            currStructure = object->structure();
+
         if (isValidOffset(accessCase.m_offset))
             currStructure->startWatchingPropertyForReplacements(vm, accessCase.offset());
 
@@ -2819,9 +2700,8 @@ void InlineCacheCompiler::generateImpl(AccessCase& accessCase)
             // and it left the baseForAccess inside scratchGPR. We could re-derive the base,
             // but it'd require emitting the same code to load the base twice.
             propertyOwnerGPR = scratchGPR;
-        } else if (accessCase.hasAlternateBase()) {
-            jit.move(
-                CCallHelpers::TrustedImmPtr(accessCase.alternateBase()), scratchGPR);
+        } else if (auto* object = accessCase.tryGetAlternateBase()) {
+            jit.move(CCallHelpers::TrustedImmPtr(object), scratchGPR);
             propertyOwnerGPR = scratchGPR;
         } else if (accessCase.viaGlobalProxy() && doesPropertyStorageLoads) {
             // We only need this when loading an inline or out of line property. For customs accessors,
@@ -4037,11 +3917,6 @@ static inline ASCIILiteral categoryName(AccessType type)
     return nullptr;
 }
 
-enum class HandlerICType : uint8_t {
-    Stateless,
-    MegamorphicById,
-};
-
 static Vector<WatchpointSet*, 3> collectAdditionalWatchpoints(VM& vm, AccessCase& accessCase)
 {
     // It's fine to commit something that is already committed. That arises when we switch to using
@@ -4357,11 +4232,11 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
             watchpoint = makeUnique<StructureStubInfoClearingWatchpoint>(codeBlock, m_stubInfo);
             stub->watchpointSet().add(watchpoint.get());
         }
+
+        auto& vector = stub->cases();
+        poly.m_list = std::span { vector.begin(), vector.end() };
         auto handler = InlineCacheHandler::create(WTFMove(stub), WTFMove(watchpoint));
         dataLogLnIf(InlineCacheCompilerInternal::verbose, "Returning: ", handler->callTarget());
-
-        poly.m_list = WTFMove(cases);
-        poly.m_list.shrinkToFit();
 
         AccessGenerationResult::Kind resultKind;
         if (generatedMegamorphicCode)
@@ -4375,31 +4250,38 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
     };
 
     std::optional<SharedJITStubSet::StatelessCacheKey> statelessType;
-    std::optional<HandlerICType> handlerICType;
-    if (cases.size() == 1) {
-        auto& accessCase = cases.first();
-        if (useHandlerIC()) {
-            ASSERT(codeBlock->useDataIC());
-            if (isStateless(accessCase->m_type)) {
-                handlerICType = HandlerICType::Stateless;
-                statelessType = std::tuple { SharedJITStubSet::stubInfoKey(*m_stubInfo), accessCase->m_type };
-                if (auto stub = vm().m_sharedJITStubs->getStatelessStub(statelessType.value())) {
-                    dataLogLnIf(InlineCacheCompilerInternal::verbose, "Using ", m_stubInfo->accessType, " / ", stub->cases().first()->m_type);
-                    return finishCodeGeneration(stub.releaseNonNull());
-                }
-            } else if (isMegamorphicById(accessCase->m_type)) {
-                handlerICType = HandlerICType::MegamorphicById;
-                FixedVector<RefPtr<AccessCase>> keys(cases.size());
-                keys[0] = accessCase;
-                SharedJITStubSet::Searcher searcher {
-                    SharedJITStubSet::stubInfoKey(*m_stubInfo),
-                    keys,
-                };
-                if (auto stub = vm().m_sharedJITStubs->find(searcher)) {
-                    dataLogLnIf(InlineCacheCompilerInternal::verbose, "Using ", m_stubInfo->accessType, " / ", stub->cases().first()->m_type);
-                    return finishCodeGeneration(stub.releaseNonNull());
-                }
+    if (useHandlerIC()) {
+        ASSERT(codeBlock->useDataIC());
+        if (cases.size() == 1 && isStateless(cases.first()->m_type)) {
+            auto& accessCase = cases.first();
+            statelessType = std::tuple { SharedJITStubSet::stubInfoKey(*m_stubInfo), accessCase->m_type };
+            if (auto stub = vm().m_sharedJITStubs->getStatelessStub(statelessType.value())) {
+                dataLogLnIf(InlineCacheCompilerInternal::verbose, "Using ", m_stubInfo->accessType, " / ", stub->cases().first()->m_type);
+                return finishCodeGeneration(stub.releaseNonNull());
             }
+        }
+    }
+
+    std::sort(cases.begin(), cases.end(), [](auto& lhs, auto& rhs) {
+        if (lhs->type() == rhs->type()) {
+            if (lhs->structure()->id() == rhs->structure()->id())
+                return bitwise_cast<uintptr_t>(lhs->uid()) < bitwise_cast<uintptr_t>(rhs->uid());
+            return lhs->structure()->id() < rhs->structure()->id();
+        }
+        return lhs->type() < rhs->type();
+    });
+    FixedVector<RefPtr<AccessCase>> keys(WTFMove(cases));
+    if (useHandlerIC() && !statelessType) {
+        SharedJITStubSet::Searcher searcher {
+            SharedJITStubSet::stubInfoKey(*m_stubInfo),
+            keys,
+        };
+        if (auto stub = vm().m_sharedJITStubs->find(searcher)) {
+            if (stub->isStillValid()) {
+                dataLogLnIf(InlineCacheCompilerInternal::verbose, "Using ", m_stubInfo->accessType, " / ", listDump(stub->cases()));
+                return finishCodeGeneration(stub.releaseNonNull());
+            }
+            vm().m_sharedJITStubs->remove(stub.get());
         }
     }
 
@@ -4412,7 +4294,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
     std::optional<FPRReg> scratchFPR;
     bool doesCalls = false;
     bool doesJSCalls = false;
-    bool canBeShared = Options::useDataICSharing();
+    bool canBeShared = useHandlerIC();
     bool needsInt32PropertyCheck = false;
     bool needsStringPropertyCheck = false;
     bool needsSymbolPropertyCheck = false;
@@ -4421,28 +4303,12 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
     if (!m_stubInfo->hasConstantIdentifier)
         allGuardedByStructureCheck = false;
     Vector<JSCell*> cellsToMark;
-    FixedVector<RefPtr<AccessCase>> keys(cases.size());
-    unsigned index = 0;
-    for (auto& entry : cases) {
+    for (auto& entry : keys) {
         if (!scratchFPR && needsScratchFPR(entry->m_type))
             scratchFPR = allocator.allocateScratchFPR();
 
         doesCalls |= entry->doesCalls(vm(), &cellsToMark);
         doesJSCalls |= JSC::doesJSCalls(entry->type());
-        switch (entry->type()) {
-        case AccessCase::CustomValueGetter:
-        case AccessCase::CustomAccessorGetter:
-        case AccessCase::CustomValueSetter:
-        case AccessCase::CustomAccessorSetter:
-            // Custom getter / setter emits JSGlobalObject pointer, which is tied to the linked CodeBlock.
-            canBeShared = false;
-            break;
-        default:
-            break;
-        }
-
-        if (entry->usesPolyProto())
-            canBeShared = false;
 
         if (!m_stubInfo->hasConstantIdentifier) {
             if (entry->requiresIdentifierNameMatch()) {
@@ -4456,14 +4322,11 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
                 acceptValueProperty = true;
         } else
             allGuardedByStructureCheck &= entry->guardedByStructureCheckSkippingConstantIdentifierCheck();
-
-        keys[index] = entry;
-        ++index;
     }
     m_scratchFPR = scratchFPR.value_or(InvalidFPRReg);
     m_doesCalls = doesCalls;
     m_doesJSCalls = doesJSCalls;
-    if (needsSymbolPropertyCheck || needsStringPropertyCheck || needsInt32PropertyCheck || doesJSCalls)
+    if (doesJSCalls)
         canBeShared = false;
 
     CCallHelpers jit(codeBlock);
@@ -4487,10 +4350,10 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
 
     m_preservedReusedRegisterState = allocator.preserveReusedRegistersByPushing(jit, ScratchRegisterAllocator::ExtraStackSpace::NoExtraSpace);
 
-    if (cases.isEmpty()) {
+    if (keys.isEmpty()) {
         // This is super unlikely, but we make it legal anyway.
         m_failAndRepatch.append(jit.jump());
-    } else if (!allGuardedByStructureCheck || cases.size() == 1) {
+    } else if (!allGuardedByStructureCheck || keys.size() == 1) {
         // If there are any proxies in the list, we cannot just use a binary switch over the structure.
         // We need to resort to a cascade. A cascade also happens to be optimal if we only have just
         // one case.
@@ -4507,11 +4370,11 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
 #endif
                 }
                 JIT_COMMENT(jit, "Cases start (needsInt32PropertyCheck)");
-                for (unsigned i = cases.size(); i--;) {
+                for (unsigned i = keys.size(); i--;) {
                     fallThrough.link(&jit);
                     fallThrough.clear();
-                    if (cases[i]->requiresInt32PropertyCheck())
-                        generateWithGuard(*cases[i], fallThrough);
+                    if (keys[i]->requiresInt32PropertyCheck())
+                        generateWithGuard(*keys[i], fallThrough);
                 }
 
                 if (needsStringPropertyCheck || needsSymbolPropertyCheck || acceptValueProperty) {
@@ -4540,11 +4403,11 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
                 m_failAndRepatch.append(jit.branchIfRopeStringImpl(m_scratchGPR));
 
                 JIT_COMMENT(jit, "Cases start (needsStringPropertyCheck)");
-                for (unsigned i = cases.size(); i--;) {
+                for (unsigned i = keys.size(); i--;) {
                     fallThrough.link(&jit);
                     fallThrough.clear();
-                    if (cases[i]->requiresIdentifierNameMatch() && !cases[i]->uid()->isSymbol())
-                        generateWithGuard(*cases[i], fallThrough);
+                    if (keys[i]->requiresIdentifierNameMatch() && !keys[i]->uid()->isSymbol())
+                        generateWithGuard(*keys[i], fallThrough);
                 }
 
                 if (needsSymbolPropertyCheck || acceptValueProperty) {
@@ -4569,11 +4432,11 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
                 }
 
                 JIT_COMMENT(jit, "Cases start (needsSymbolPropertyCheck)");
-                for (unsigned i = cases.size(); i--;) {
+                for (unsigned i = keys.size(); i--;) {
                     fallThrough.link(&jit);
                     fallThrough.clear();
-                    if (cases[i]->requiresIdentifierNameMatch() && cases[i]->uid()->isSymbol())
-                        generateWithGuard(*cases[i], fallThrough);
+                    if (keys[i]->requiresIdentifierNameMatch() && keys[i]->uid()->isSymbol())
+                        generateWithGuard(*keys[i], fallThrough);
                 }
 
                 if (acceptValueProperty) {
@@ -4586,20 +4449,20 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
 
             if (acceptValueProperty) {
                 JIT_COMMENT(jit, "Cases start (remaining)");
-                for (unsigned i = cases.size(); i--;) {
+                for (unsigned i = keys.size(); i--;) {
                     fallThrough.link(&jit);
                     fallThrough.clear();
-                    if (!cases[i]->requiresIdentifierNameMatch() && !cases[i]->requiresInt32PropertyCheck())
-                        generateWithGuard(*cases[i], fallThrough);
+                    if (!keys[i]->requiresIdentifierNameMatch() && !keys[i]->requiresInt32PropertyCheck())
+                        generateWithGuard(*keys[i], fallThrough);
                 }
             }
         } else {
             // Cascade through the list, preferring newer entries.
             JIT_COMMENT(jit, "Cases start !(needsInt32PropertyCheck || needsStringPropertyCheck || needsSymbolPropertyCheck)");
-            for (unsigned i = cases.size(); i--;) {
+            for (unsigned i = keys.size(); i--;) {
                 fallThrough.link(&jit);
                 fallThrough.clear();
-                generateWithGuard(*cases[i], fallThrough);
+                generateWithGuard(*keys[i], fallThrough);
             }
         }
 
@@ -4611,13 +4474,13 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
             CCallHelpers::Address(m_stubInfo->m_baseGPR, JSCell::structureIDOffset()),
             m_scratchGPR);
 
-        Vector<int64_t, 16> caseValues(cases.size());
-        for (unsigned i = 0; i < cases.size(); ++i)
-            caseValues[i] = bitwise_cast<int32_t>(cases[i]->structure()->id());
+        Vector<int64_t, 16> caseValues(keys.size());
+        for (unsigned i = 0; i < keys.size(); ++i)
+            caseValues[i] = bitwise_cast<int32_t>(keys[i]->structure()->id());
 
         BinarySwitch binarySwitch(m_scratchGPR, caseValues.span(), BinarySwitch::Int32);
         while (binarySwitch.advance(jit))
-            generate(*cases[binarySwitch.caseIndex()]);
+            generate(*keys[binarySwitch.caseIndex()]);
         m_failAndRepatch.append(binarySwitch.fallThrough());
     }
 
@@ -4715,19 +4578,6 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
         failure.linkThunk(m_stubInfo->slowPathStartLocation, &jit);
     }
 
-    RefPtr<PolymorphicAccessJITStubRoutine> stub;
-    if (codeBlock->useDataIC() && canBeShared) {
-        SharedJITStubSet::Searcher searcher {
-            SharedJITStubSet::stubInfoKey(*m_stubInfo),
-            keys,
-        };
-        stub = vm().m_sharedJITStubs->find(searcher);
-        if (stub) {
-            dataLogLnIf(InlineCacheCompilerInternal::verbose, "Found existing code stub ", stub->code());
-            return finishCodeGeneration(stub.releaseNonNull());
-        }
-    }
-
     LinkBuffer linkBuffer(jit, codeBlock, LinkBuffer::Profile::InlineCache, JITCompilationCanFail);
     if (linkBuffer.didFailToAllocate()) {
         dataLogLnIf(InlineCacheCompilerInternal::verbose, "Did fail to allocate.");
@@ -4738,25 +4588,25 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
     if (codeBlock->useDataIC())
         ASSERT(m_success.empty());
 
-    dataLogLnIf(InlineCacheCompilerInternal::verbose, FullCodeOrigin(codeBlock, m_stubInfo->codeOrigin), ": Generating polymorphic access stub for ", listDump(cases));
+    dataLogLnIf(InlineCacheCompilerInternal::verbose, FullCodeOrigin(codeBlock, m_stubInfo->codeOrigin), ": Generating polymorphic access stub for ", listDump(keys));
 
-    MacroAssemblerCodeRef<JITStubRoutinePtrTag> code = FINALIZE_CODE_FOR(codeBlock, linkBuffer, JITStubRoutinePtrTag, categoryName(m_stubInfo->accessType), "%s", toCString("Access stub for ", *codeBlock, " ", m_stubInfo->codeOrigin, "with start: ", m_stubInfo->startLocation, " with return point ", successLabel, ": ", listDump(cases)).data());
+    MacroAssemblerCodeRef<JITStubRoutinePtrTag> code = FINALIZE_CODE_FOR(codeBlock, linkBuffer, JITStubRoutinePtrTag, categoryName(m_stubInfo->accessType), "%s", toCString("Access stub for ", *codeBlock, " ", m_stubInfo->codeOrigin, "with start: ", m_stubInfo->startLocation, " with return point ", successLabel, ": ", listDump(keys)).data());
 
     CodeBlock* owner = codeBlock;
-    if (handlerICType) {
+    if (canBeShared) {
         ASSERT(codeBlock->useDataIC());
         ASSERT(cellsToMark.isEmpty());
         owner = nullptr;
     }
 
     FixedVector<StructureID> weakStructures(WTFMove(m_weakStructures));
-    stub = createICJITStubRoutine(code, WTFMove(keys), WTFMove(weakStructures), vm(), owner, doesCalls, cellsToMark, WTFMove(m_callLinkInfos), codeBlockThatOwnsExceptionHandlers, callSiteIndexForExceptionHandling);
+    auto stub = createICJITStubRoutine(code, WTFMove(keys), WTFMove(weakStructures), vm(), owner, doesCalls, cellsToMark, WTFMove(m_callLinkInfos), codeBlockThatOwnsExceptionHandlers, callSiteIndexForExceptionHandling);
 
     {
         std::unique_ptr<WatchpointsOnStructureStubInfo> watchpoints;
 
         for (auto& condition : m_conditions)
-            WatchpointsOnStructureStubInfo::ensureReferenceAndInstallWatchpoint(vm(), watchpoints, stub.get(), condition);
+            WatchpointsOnStructureStubInfo::ensureReferenceAndInstallWatchpoint(vm(), watchpoints, stub.ptr(), condition);
 
         // NOTE: We currently assume that this is relatively rare. It mainly arises for accesses to
         // properties on DOM nodes. For sure we cache many DOM node accesses, but even in
@@ -4764,25 +4614,26 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
         // vanilla objects or exotic objects from within JSC (like Arguments, those are super popular).
         // Those common kinds of JSC object accesses don't hit this case.
         for (WatchpointSet* set : additionalWatchpointSets) {
-            Watchpoint* watchpoint = WatchpointsOnStructureStubInfo::ensureReferenceAndAddWatchpoint(vm(), watchpoints, stub.get());
+            Watchpoint* watchpoint = WatchpointsOnStructureStubInfo::ensureReferenceAndAddWatchpoint(vm(), watchpoints, stub.ptr());
             set->add(watchpoint);
         }
 
         stub->setWatchpoints(WTFMove(watchpoints));
     }
 
-    if (handlerICType) {
+    if (canBeShared) {
         ASSERT(codeBlock->useDataIC());
-        dataLogLnIf(InlineCacheCompilerInternal::verbose, "Installing ", m_stubInfo->accessType, " / ", stub->cases().first()->m_type);
-        if (statelessType)
-            vm().m_sharedJITStubs->setStatelessStub(statelessType.value(), *stub);
-        else {
-            vm().m_sharedJITStubs->add(SharedJITStubSet::Hash::Key(SharedJITStubSet::stubInfoKey(*m_stubInfo), stub.get()));
+        if (statelessType) {
+            dataLogLnIf(InlineCacheCompilerInternal::verbose, "Installing ", m_stubInfo->accessType, " / ", stub->cases().first()->m_type);
+            vm().m_sharedJITStubs->setStatelessStub(statelessType.value(), Ref { stub });
+        } else {
+            dataLogLnIf(InlineCacheCompilerInternal::verbose, "Installing ", m_stubInfo->accessType, " / ", listDump(stub->cases()));
+            vm().m_sharedJITStubs->add(SharedJITStubSet::Hash::Key(SharedJITStubSet::stubInfoKey(*m_stubInfo), stub.ptr()));
             stub->addedToSharedJITStubSet();
         }
     }
 
-    return finishCodeGeneration(stub.releaseNonNull());
+    return finishCodeGeneration(WTFMove(stub));
 }
 
 PolymorphicAccess::PolymorphicAccess() = default;

--- a/Source/JavaScriptCore/bytecode/PutByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/PutByStatus.cpp
@@ -258,7 +258,10 @@ PutByStatus PutByStatus::computeForStubInfo(const ConcurrentJSLocker& locker, Co
                 if (!conditionSet.isStillValid())
                     continue;
 
-                Structure* currStructure = access.hasAlternateBase() ? access.alternateBase()->structure() : access.structure();
+                Structure* currStructure = access.structure();
+                if (auto* object = access.tryGetAlternateBase())
+                    currStructure = object->structure();
+
                 // For now, we only support cases which JSGlobalObject is the same to the currently profiledBlock.
                 if (currStructure->globalObject() != profiledBlock->globalObject())
                     return PutByStatus(JSC::slowVersion(summary), *stubInfo);

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
@@ -115,6 +115,13 @@ public:
     WatchpointSet& watchpointSet() { return *m_watchpointSet.get(); }
     void invalidate();
 
+    bool isStillValid() const
+    {
+        if (!m_watchpointSet)
+            return false;
+        return m_watchpointSet->isStillValid();
+    }
+
 protected:
     void observeZeroRefCountImpl();
 

--- a/Source/JavaScriptCore/runtime/StructureID.h
+++ b/Source/JavaScriptCore/runtime/StructureID.h
@@ -85,7 +85,7 @@ public:
     static StructureID encode(const Structure*);
 
     explicit operator bool() const { return !!m_bits; }
-    friend bool operator==(const StructureID&, const StructureID&) = default;
+    friend auto operator<=>(const StructureID&, const StructureID&) = default;
     constexpr uint32_t bits() const { return m_bits; }
 
     StructureID(WTF::HashTableDeletedValueType) : m_bits(nukedStructureIDBit) { }


### PR DESCRIPTION
#### e67257693a4fbe3e00594b4bad6daaa83f29d2db
<pre>
[JSC] Start using limited variant of Handler IC
<a href="https://bugs.webkit.org/show_bug.cgi?id=273604">https://bugs.webkit.org/show_bug.cgi?id=273604</a>
<a href="https://rdar.apple.com/127402051">rdar://127402051</a>

Reviewed by Keith Miller.

This patch enables limited variant of Handler IC. The limitation means,

1. Only enabled for Baseline JIT.
2. Getter and Setter are not supported yet.
3. We are caching entire code as an one handler. This is not the final form we would like to have.
   Next step is splitting them into one per AccessCase and chain them.
4. After (3) gets done, we would like to put more data into InlineCacheHandler itself so that code
   can be more and more sharable.

But even with this limited form, we are already observing good cache hit rate. So we take an approach starting with this,
and further extending Handler IC based on the above milestones.

We enable Handler IC, which is only enabled for Baseline JIT right now.
The IC is hash-consed via SharedJITStubSet. And InlineCacheCompiler first search for an already compiled stub, if it finds it,
we register watchpoint to this stub and use it without new compilation. If it is not found, we compile a new stub and register it to this table if possible.
When nobody uses this stub, then refCount becomes zero, and it automatically unregister itself from the table.
Each StructureStubInfo site&apos;s access cases is always subsumes stub&apos;s access cases. So GC will check validity via this StructureStubInfo&apos;s access cases, and
drop stub when it is no longer valid (as the same to the current IC).

* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::canBeShared):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::regenerate):
(JSC::InlineCacheHandler::visitWeak const):
(JSC::isMegamorphicById): Deleted.
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp:
(JSC::PolymorphicAccessJITStubRoutine::addedToSharedJITStubSet):
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h:
(JSC::PolymorphicAccessJITStubRoutine::isStillValid const):
* Source/JavaScriptCore/runtime/StructureID.h:

Canonical link: <a href="https://commits.webkit.org/278288@main">https://commits.webkit.org/278288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0edfd99e1f777f8da7d82b90f482368b12043b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50103 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29394 "Build is in progress. Recent messages:") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2394 "Build is in progress. Recent messages:") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52406 "Build is in progress. Recent messages:") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35559 "Build is in progress. Recent messages:") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/348 "Build is in progress. Recent messages:Running configuration; Checked out pull request; Running compile-webkit") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52201 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/35559 "Build is in progress. Recent messages:") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/2394 "Build is in progress. Recent messages:") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/35559 "Build is in progress. Recent messages:") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/2394 "Build is in progress. Recent messages:") | [  ~~🛠 wpe-skia~~](https://ews-build.webkit.org/#/builders/52/builds/8480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/43429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/35559 "Build is in progress. Recent messages:") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/2394 "Build is in progress. Recent messages:") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/54942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/49602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/25200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/54942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/2394 "Build is in progress. Recent messages:") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/54942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/27324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57081 "Build is in progress. Recent messages:") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7236 "Build is in progress. Recent messages:Running configuration") | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-10-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/57081 "Build is in progress. Recent messages:") | 
<!--EWS-Status-Bubble-End-->