### PR TITLE
[WebXR] Override compositor textures sRGB transfer function

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_utils.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_utils.h
@@ -89,6 +89,10 @@ struct Format : public FormatBase
     // Need conversion between source format and this format?
     bool needConversion(angle::FormatID srcFormatId) const;
 
+    // Are the formats view compatible without requiring
+    // MTLTextureUsagePixelFormatView?
+    bool isViewCompatible(const Format &srcFormat) const;
+
     MTLPixelFormat metalFormat = MTLPixelFormatInvalid;
 
     LoadFunctionMap textureLoadFunctions       = nullptr;

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_utils.mm
@@ -161,6 +161,26 @@ bool Format::needConversion(angle::FormatID srcFormatId) const
     return srcFormatId != actualFormatId;
 }
 
+bool Format::isViewCompatible(const Format &srcFormat) const
+{
+    if (srcFormat.metalFormat == metalFormat)
+        return true;
+
+    // The pixel layout is considered different if the number of components differs,
+    if (srcFormat.caps.channels != caps.channels)
+        return false;
+
+    // ... or if their size or order is different from the components in the original pixel format.
+    if (srcFormat.caps.pixelBytes != caps.pixelBytes)
+        return false;
+
+    // This is overly conservative but reject compressed formats
+    if (srcFormat.caps.compressed || caps.compressed)
+        return false;
+
+    return true;
+}
+
 bool Format::isPVRTC() const
 {
     switch (metalFormat)

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_resources.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_resources.h
@@ -217,6 +217,11 @@ class Texture final : public Resource,
     TextureRef createCubeFaceView(uint32_t face);
     // Create a view of one slice at a level.
     TextureRef createSliceMipView(uint32_t slice, const MipmapNativeLevel &level);
+    // Same as above but the target format must be compatible, for example sRGB to linear. In this
+    // case texture doesn't need format view usage flag.
+    TextureRef createSliceMipViewWithCompatibleFormat(uint32_t slice,
+                                                      const MipmapNativeLevel &level,
+                                                      MTLPixelFormat format);
     // Create a view of a level.
     TextureRef createMipView(const MipmapNativeLevel &level);
     // Create a view with different format

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_resources.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_resources.mm
@@ -675,7 +675,9 @@ TextureRef Texture::createCubeFaceView(uint32_t face)
     }
 }
 
-TextureRef Texture::createSliceMipView(uint32_t slice, const MipmapNativeLevel &level)
+TextureRef Texture::createSliceMipViewWithCompatibleFormat(uint32_t slice,
+                                                           const MipmapNativeLevel &level,
+                                                           MTLPixelFormat format)
 {
     ANGLE_MTL_OBJC_SCOPE
     {
@@ -684,13 +686,18 @@ TextureRef Texture::createSliceMipView(uint32_t slice, const MipmapNativeLevel &
             case MTLTextureTypeCube:
             case MTLTextureType2D:
             case MTLTextureType2DArray:
-                return TextureRef(new Texture(this, pixelFormat(), MTLTextureType2D,
+                return TextureRef(new Texture(this, format, MTLTextureType2D,
                                               NSMakeRange(level.get(), 1), NSMakeRange(slice, 1)));
             default:
                 UNREACHABLE();
                 return nullptr;
         }
     }
+}
+
+TextureRef Texture::createSliceMipView(uint32_t slice, const MipmapNativeLevel &level)
+{
+    return createSliceMipViewWithCompatibleFormat(slice, level, pixelFormat());
 }
 
 TextureRef Texture::createMipView(const MipmapNativeLevel &level)

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -163,7 +163,7 @@ void WebXROpaqueFramebuffer::startFrame(const PlatformXR::FrameData::LayerData& 
     int layerCount = (m_displayLayout == PlatformXR::Layout::Layered) ? 2 : 1;
     for (int layer = 0; layer < layerCount; ++layer) {
         auto colorTextureSource = makeExternalImageSource(std::tuple<MachSendRight, bool> { data.colorTexture });
-        createAndBindCompositorBuffer(*gl, m_displayAttachments[layer].colorBuffer, GL::NONE, WTFMove(colorTextureSource), layer);
+        createAndBindCompositorBuffer(*gl, m_displayAttachments[layer].colorBuffer, GL::BGRA_EXT, WTFMove(colorTextureSource), layer);
         ASSERT(m_displayAttachments[layer].colorBuffer.image);
         if (!m_displayAttachments[layer].colorBuffer.image)
             return;


### PR DESCRIPTION
#### a4251036b8d09d57de47d9f37b0dcd3a06fa97dc
<pre>
[WebXR] Override compositor textures sRGB transfer function
<a href="https://bugs.webkit.org/show_bug.cgi?id=273603">https://bugs.webkit.org/show_bug.cgi?id=273603</a>
<a href="https://rdar.apple.com/127400068">rdar://127400068</a>

Reviewed by Mike Wyrzykowski.

Immersive VR sessions in WebXR look washed out compared to the inline version.

CompositorServices provides textures with pixel format
MTLPixelFormatBGRA8Unorm_sRGB. Since glBlitFramebuffer is implemented as a draw
in ANGLE, when blitting shared to layered layout an unwanted gamma conversion is
being applied which is resulting in &quot;lighter&quot; than expected values.

To fix this, override the format with GL_BGRA8_EXT (aka
MTLPixelFormatBGRA8Unorm) when attaching the compositor images as external
images to avoid this conversion.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ImageMtl.mm:
(rx::TextureImageSiblingMtl::ValidateClientBuffer):
(rx::TextureImageSiblingMtl::initImpl):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_utils.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_format_utils.mm:
(rx::mtl::Format::isViewCompatible const):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_resources.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_resources.mm:
(rx::mtl::Texture::createSliceMipViewWithCompatibleFormat):
(rx::mtl::Texture::createSliceMipView):
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::startFrame):

Canonical link: <a href="https://commits.webkit.org/278252@main">https://commits.webkit.org/278252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9515aefa0c7b9a5a5ef81ca957772ed6bdc8f19b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53243 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/677 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52301 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/246 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40782 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52098 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26867 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43006 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21913 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24302 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/248 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8370 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/296 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54824 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25094 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Running apply-patch; Checked out pull request; Running compile-webkit") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48165 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 85 flakes 60 failures; Uploaded test results; 3 flakes 53 failures; Running compile-webkit-without-change") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26352 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43211 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/27214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7211 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26081 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->