### PR TITLE
Add site quirk that adjusts a request's same-site property

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3349,6 +3349,10 @@ void FrameLoader::addSameSiteInfoToRequestIfNeeded(ResourceRequest& request, con
         request.setIsSameSite(true);
         return;
     }
+    if (initiator->quirks().needsLaxSameSiteCookieQuirk()) {
+        request.setIsSameSite(true);
+        return;
+    }
 #endif
 
     request.setIsSameSite(initiator->isSameSiteForCookies(request.url()));

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1864,4 +1864,22 @@ bool Quirks::needsRelaxedCorsMixedContentCheckQuirk() const
     return *m_needsRelaxedCorsMixedContentCheckQuirk;
 }
 
+// rdar://127398734
+bool Quirks::needsLaxSameSiteCookieQuirk() const
+{
+    if (!needsQuirks())
+        return false;
+
+    if (m_needsLaxSameSiteCookieQuirk)
+        return *m_needsLaxSameSiteCookieQuirk;
+
+    m_needsLaxSameSiteCookieQuirk = false;
+
+    auto url = m_document->url();
+    if (url.protocolIs("https"_s) && url.host() == "www.bing.com"_s)
+        m_needsLaxSameSiteCookieQuirk = true;
+
+    return *m_needsLaxSameSiteCookieQuirk;
+}
+
 }

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -191,6 +191,7 @@ public:
 
     bool needsGetElementsByNameQuirk() const;
     bool needsRelaxedCorsMixedContentCheckQuirk() const;
+    bool needsLaxSameSiteCookieQuirk() const;
 
 private:
     bool needsQuirks() const;
@@ -264,6 +265,7 @@ private:
     mutable std::optional<bool> m_shouldDisableElementFullscreen;
     mutable std::optional<bool> m_shouldIgnorePlaysInlineRequirementQuirk;
     mutable std::optional<bool> m_needsRelaxedCorsMixedContentCheckQuirk;
+    mutable std::optional<bool> m_needsLaxSameSiteCookieQuirk;
 
     Vector<RegistrableDomain> m_subFrameDomainsForStorageAccessQuirk;
 };


### PR DESCRIPTION
#### 40de96c244426a7bc509135f530794c9e81d80b6
<pre>
Add site quirk that adjusts a request&apos;s same-site property
<a href="https://bugs.webkit.org/show_bug.cgi?id=273607">https://bugs.webkit.org/show_bug.cgi?id=273607</a>
<a href="https://rdar.apple.com/123657946">rdar://123657946</a>

Reviewed by Chris Dumez.

Enforcing same-site requests resolves some compatibility issues. This change
introduces a quirk for setting the request as same-site in some specific cases
where it is safe.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::addSameSiteInfoToRequestIfNeeded):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsLaxSameSiteCookieQuirk const):
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/278277@main">https://commits.webkit.org/278277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdfcedb40f87ecc05b1a2c80e7e6e7090853a841

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53259 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/693 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52317 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/262 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40789 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52114 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26909 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43031 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21921 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24379 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/271 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8386 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46389 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54841 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25110 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/246 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48196 "Build is in progress. Recent messages:Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 44 flakes 138 failures; Uploaded test results; Running layout-tests-repeat-failures") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26368 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43231 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47242 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27230 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7225 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26097 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->