### PR TITLE
[JSC] Keeping Identifiers in PolymorphicAccessJITStubRoutine is not necessary

### DIFF
--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
@@ -133,16 +133,6 @@ unsigned PolymorphicAccessJITStubRoutine::computeHash(const FixedVector<RefPtr<A
 void PolymorphicAccessJITStubRoutine::addedToSharedJITStubSet()
 {
     m_isInSharedJITStubSet = true;
-    // Since this stub no longer belongs to any CodeBlocks (since it is shared),
-    // identifiers need to be owned by this stub itself.
-    m_identifiers = FixedVector<Identifier>(m_cases.size());
-    unsigned index = 0;
-    for (auto& accessCase : m_cases) {
-        auto identifier = Identifier::fromUid(m_vm, accessCase->uid());
-        accessCase->updateIdentifier(CacheableIdentifier::createFromSharedStub(identifier.impl()));
-        m_identifiers[index] = WTFMove(identifier);
-        ++index;
-    }
 }
 
 MarkingGCAwareJITStubRoutine::MarkingGCAwareJITStubRoutine(

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
@@ -122,7 +122,6 @@ private:
     VM& m_vm;
     FixedVector<RefPtr<AccessCase>> m_cases;
     FixedVector<StructureID> m_weakStructures;
-    FixedVector<Identifier> m_identifiers;
     RefPtr<WatchpointSet> m_watchpointSet;
     std::unique_ptr<WatchpointsOnStructureStubInfo> m_watchpoints;
 };


### PR DESCRIPTION
#### 244f3f7a26912913b7997a11911a44ebaf761865
<pre>
[JSC] Keeping Identifiers in PolymorphicAccessJITStubRoutine is not necessary
<a href="https://bugs.webkit.org/show_bug.cgi?id=273610">https://bugs.webkit.org/show_bug.cgi?id=273610</a>
<a href="https://rdar.apple.com/127411952">rdar://127411952</a>

Reviewed by Justin Michaud.

We are using shared JIT stub only for Baseline JIT IC, and ById case with Baseline JIT IC always has
CodeBlock which holds CacheableIdentifier. So JIT stub itself does not need to keep them.
When the stub is no longer used, then it gets zero-ref-count, and removed from shared JIT stub table automatically.

* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp:
(JSC::PolymorphicAccessJITStubRoutine::addedToSharedJITStubSet):
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h:

Canonical link: <a href="https://commits.webkit.org/278268@main">https://commits.webkit.org/278268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0d7896e1130629d3bddadcc0d5955c28864620d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53261 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/695 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40792 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52116 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/26934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43022 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21924 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24350 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/262 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8388 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43341 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54843 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49513 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25112 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26370 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43222 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27232 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56996 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7220 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26099 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11709 "Passed tests") | 
<!--EWS-Status-Bubble-End-->