### PR TITLE
[Legacy line layout removal] Stop measuring text in BreakingContext

### DIFF
--- a/LayoutTests/platform/glib/svg/batik/text/xmlSpace-expected.txt
+++ b/LayoutTests/platform/glib/svg/batik/text/xmlSpace-expected.txt
@@ -23,7 +23,7 @@ layer at (0,0) size 450x500
       RenderSVGText {text} at (10,130) size 98x25 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 98x25
           chunk 1 text run 1 at (10.00,150.00) startOffset 0 endOffset 8 width 98.00: "  X  X  "
-        RenderSVGTSpan {tspan} at (0,0) size 0x0
+        RenderSVGTSpan {tspan} at (-10,-130) size 0x0
       RenderSVGText {text} at (120,133) size 95x19 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 95x10
           chunk 1 text run 1 at (120.00,140.00) startOffset 0 endOffset 19 width 95.00: "Empty tspan at end "

--- a/LayoutTests/platform/ios/svg/batik/text/xmlSpace-expected.txt
+++ b/LayoutTests/platform/ios/svg/batik/text/xmlSpace-expected.txt
@@ -23,7 +23,7 @@ layer at (0,0) size 450x500
       RenderSVGText {text} at (10,130) size 99x25 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 99x25
           chunk 1 text run 1 at (10.00,150.00) startOffset 0 endOffset 8 width 98.68: "  X  X  "
-        RenderSVGTSpan {tspan} at (0,0) size 0x0
+        RenderSVGTSpan {tspan} at (-10,-130) size 0x0
       RenderSVGText {text} at (120,133) size 92x19 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 92x9
           chunk 1 text run 1 at (120.00,140.00) startOffset 0 endOffset 19 width 91.21: "Empty tspan at end "

--- a/LayoutTests/platform/mac/svg/batik/text/xmlSpace-expected.txt
+++ b/LayoutTests/platform/mac/svg/batik/text/xmlSpace-expected.txt
@@ -23,7 +23,7 @@ layer at (0,0) size 450x500
       RenderSVGText {text} at (10,129) size 99x26 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 99x26
           chunk 1 text run 1 at (10.00,150.00) startOffset 0 endOffset 8 width 98.68: "  X  X  "
-        RenderSVGTSpan {tspan} at (0,0) size 0x0
+        RenderSVGTSpan {tspan} at (-10,-130) size 0x1
       RenderSVGText {text} at (120,132) size 92x20 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 92x9
           chunk 1 text run 1 at (120.00,140.00) startOffset 0 endOffset 19 width 91.21: "Empty tspan at end "

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -510,8 +510,7 @@ void LegacyLineLayout::layoutRunsAndFloatsInRange(InlineBidiResolver& resolver)
         lineInfo.setEmpty(true);
         lineInfo.resetRunsFromLeadingWhitespace();
 
-        WordMeasurements wordMeasurements;
-        end = lineBreaker.nextLineBreak(resolver, lineInfo, renderTextInfo, wordMeasurements);
+        end = lineBreaker.nextLineBreak(resolver, lineInfo, renderTextInfo);
         m_flow.cachePriorCharactersIfNeeded(renderTextInfo.lineBreakIteratorFactory);
         renderTextInfo.lineBreakIteratorFactory.priorContext().reset();
         if (resolver.position().atEnd()) {

--- a/Source/WebCore/rendering/LegacyLineLayout.h
+++ b/Source/WebCore/rendering/LegacyLineLayout.h
@@ -47,7 +47,6 @@ struct BidiStatus;
 struct WordMeasurement;
 
 template <class Run> class BidiRunList;
-typedef Vector<WordMeasurement, 64> WordMeasurements;
 
 class LegacyLineLayout {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebCore/rendering/line/LineBreaker.cpp
+++ b/Source/WebCore/rendering/line/LineBreaker.cpp
@@ -43,7 +43,7 @@ void LineBreaker::skipLeadingWhitespace(InlineBidiResolver& resolver, LineInfo& 
     resolver.commitExplicitEmbedding();
 }
 
-LegacyInlineIterator LineBreaker::nextLineBreak(InlineBidiResolver& resolver, LineInfo& lineInfo, RenderTextInfo& renderTextInfo, WordMeasurements& wordMeasurements)
+LegacyInlineIterator LineBreaker::nextLineBreak(InlineBidiResolver& resolver, LineInfo& lineInfo, RenderTextInfo& renderTextInfo)
 {
     ASSERT(resolver.position().root() == &m_block);
 
@@ -63,7 +63,7 @@ LegacyInlineIterator LineBreaker::nextLineBreak(InlineBidiResolver& resolver, Li
         if (context.currentObject()->isRenderInline()) {
             context.handleEmptyInline();
         } else if (context.currentObject()->isRenderText()) {
-            if (context.handleText(wordMeasurements)) {
+            if (context.handleText()) {
                 // We've hit a hard text line break. Our line break iterator is updated, so early return.
                 return context.lineBreak();
             }

--- a/Source/WebCore/rendering/line/LineBreaker.h
+++ b/Source/WebCore/rendering/line/LineBreaker.h
@@ -49,7 +49,7 @@ public:
     {
     }
 
-    LegacyInlineIterator nextLineBreak(InlineBidiResolver&, LineInfo&, RenderTextInfo&, WordMeasurements&);
+    LegacyInlineIterator nextLineBreak(InlineBidiResolver&, LineInfo&, RenderTextInfo&);
 
 private:
     void skipTrailingWhitespace(LegacyInlineIterator&, const LineInfo&);


### PR DESCRIPTION
#### 6d8b441bc01730b462d5f6f3c18e9cbd3e8956f0
<pre>
[Legacy line layout removal] Stop measuring text in BreakingContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=273614">https://bugs.webkit.org/show_bug.cgi?id=273614</a>
<a href="https://rdar.apple.com/127416332">rdar://127416332</a>

Reviewed by Alan Baradlay and Sam Weinig.

SVG doesn&apos;t break lines so there is no need to measure.

* LayoutTests/platform/ios/svg/batik/text/xmlSpace-expected.txt:
* LayoutTests/platform/mac/svg/batik/text/xmlSpace-expected.txt:

Non-visual change (we create an inline box for empty inline whereas previously we didn&apos;t)

* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::LegacyLineLayout::layoutRunsAndFloatsInRange):
* Source/WebCore/rendering/LegacyLineLayout.h:
* Source/WebCore/rendering/line/BreakingContext.h:
(WebCore::BreakingContext::handleText):
(WebCore::WordMeasurement::WordMeasurement): Deleted.
(WebCore::firstPositiveWidth): Deleted.
(WebCore::textWidth): Deleted.
(WebCore::BreakingContext::textWidthConsideringPossibleTrailingSpace): Deleted.
(WebCore::BreakingContext::computeAdditionalBetweenWordsWidth): Deleted.
* Source/WebCore/rendering/line/LineBreaker.cpp:
(WebCore::LineBreaker::nextLineBreak):
* Source/WebCore/rendering/line/LineBreaker.h:

Canonical link: <a href="https://commits.webkit.org/278360@main">https://commits.webkit.org/278360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14fa204d801981c991a675c02c5b495ec8a2189f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53472 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/904 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52517 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40972 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43217 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22070 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24602 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/469 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8592 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46588 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55057 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/465 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48384 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26571 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43404 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47406 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11037 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27435 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26303 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->