### PR TITLE
Fix legacy_stats_collector.cc c++11-narrowing-const-reference compilation warnings

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/legacy_stats_collector.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/legacy_stats_collector.cc
@@ -56,6 +56,20 @@
 #include "rtc_base/time_utils.h"
 #include "rtc_base/trace_event.h"
 
+#if WEBRTC_WEBKIT_BUILD
+
+#ifdef __clang__
+#define RTC_PUSH_IGNORING_NARROWING_CONST_REFERENCE() \
+    _Pragma("clang diagnostic push")             \
+    _Pragma("clang diagnostic ignored \"-Wc++11-narrowing-const-reference\"")
+#define RTC_POP_IGNORING_NARROWING_CONST_REFERENCE() _Pragma("clang diagnostic pop")
+#else
+#define RTC_PUSH_IGNORING_NARROWING_CONST_REFERENCE()
+#define RTC_POP_IGNORING_NARROWING_CONST_REFERENCE()
+#endif
+
+#endif // WEBRTC_WEBKIT_BUILD
+
 namespace webrtc {
 namespace {
 
@@ -188,9 +202,11 @@ void ExtractStats(const cricket::VoiceReceiverInfo& info,
       {StatsReport::kStatsValueNameAccelerateRate, info.accelerate_rate},
       {StatsReport::kStatsValueNamePreemptiveExpandRate,
        info.preemptive_expand_rate},
+RTC_PUSH_IGNORING_NARROWING_CONST_REFERENCE()
       {StatsReport::kStatsValueNameTotalAudioEnergy, static_cast<float>(info.total_output_energy)},
       {StatsReport::kStatsValueNameTotalSamplesDuration,
        static_cast<float>(info.total_output_duration)}};
+RTC_POP_IGNORING_NARROWING_CONST_REFERENCE()
 
   const IntForAdd ints[] = {
       {StatsReport::kStatsValueNameCurrentDelayMs, info.delay_estimate_ms},
@@ -243,10 +259,12 @@ void ExtractStats(const cricket::VoiceSenderInfo& info,
 
   SetAudioProcessingStats(report, info.apm_statistics);
 
+RTC_PUSH_IGNORING_NARROWING_CONST_REFERENCE()
   const FloatForAdd floats[] = {
       {StatsReport::kStatsValueNameTotalAudioEnergy, static_cast<float>(info.total_input_energy)},
       {StatsReport::kStatsValueNameTotalSamplesDuration,
        static_cast<float>(info.total_input_duration)}};
+RTC_POP_IGNORING_NARROWING_CONST_REFERENCE()
 
   RTC_DCHECK_GE(info.audio_level, 0);
   const IntForAdd ints[] = {
@@ -340,7 +358,9 @@ void ExtractStats(const cricket::VideoReceiverInfo& info,
       {StatsReport::kStatsValueNamePlisSent, info.plis_sent},
       {StatsReport::kStatsValueNameRenderDelayMs, info.render_delay_ms},
       {StatsReport::kStatsValueNameTargetDelayMs, info.target_delay_ms},
+RTC_PUSH_IGNORING_NARROWING_CONST_REFERENCE()
       {StatsReport::kStatsValueNameFramesDecoded, static_cast<int>(info.frames_decoded)},
+RTC_POP_IGNORING_NARROWING_CONST_REFERENCE()
   };
 
   for (const auto& i : ints)
@@ -384,6 +404,7 @@ void ExtractStats(const cricket::VideoSenderInfo& info,
        info.encode_usage_percent},
       {StatsReport::kStatsValueNameFirsReceived, info.firs_received},
       {StatsReport::kStatsValueNameFrameHeightSent, info.send_frame_height},
+RTC_PUSH_IGNORING_NARROWING_CONST_REFERENCE()
       {StatsReport::kStatsValueNameFrameRateInput, static_cast<int>(round(info.framerate_input))},
       {StatsReport::kStatsValueNameFrameRateSent, info.framerate_sent},
       {StatsReport::kStatsValueNameFrameWidthSent, info.send_frame_width},
@@ -393,6 +414,7 @@ void ExtractStats(const cricket::VideoSenderInfo& info,
       {StatsReport::kStatsValueNamePlisReceived, info.plis_received},
       {StatsReport::kStatsValueNameFramesEncoded, static_cast<int>(info.frames_encoded)},
       {StatsReport::kStatsValueNameHugeFramesSent, static_cast<int>(info.huge_frames_sent)},
+RTC_POP_IGNORING_NARROWING_CONST_REFERENCE()
   };
 
   for (const auto& i : ints)
@@ -779,6 +801,7 @@ StatsReport* LegacyStatsCollector::AddConnectionInfoReport(
   report->AddId(StatsReport::kStatsValueNameRemoteCandidateId,
                 AddCandidateReport(remote_candidate_stats, false)->id());
 
+RTC_PUSH_IGNORING_NARROWING_CONST_REFERENCE()
   const Int64ForAdd int64s[] = {
       {StatsReport::kStatsValueNameBytesReceived,
        static_cast<int64_t>(info.recv_total_bytes)},
@@ -800,6 +823,7 @@ StatsReport* LegacyStatsCollector::AddConnectionInfoReport(
       {StatsReport::kStatsValueNameRecvPingResponses,
        static_cast<int64_t>(info.recv_ping_responses)},
   };
+RTC_POP_IGNORING_NARROWING_CONST_REFERENCE()
   for (const auto& i : int64s)
     report->AddInt64(i.name, i.value);
 


### PR DESCRIPTION
#### 23b2bfee5e5df8abaf7ada251d3493716be61de0
<pre>
Fix legacy_stats_collector.cc c++11-narrowing-const-reference compilation warnings
<a href="https://rdar.apple.com/126233560">rdar://126233560</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=273615">https://bugs.webkit.org/show_bug.cgi?id=273615</a>

Reviewed by NOBODY (OOPS!).

* Source/ThirdParty/libwebrtc/Source/webrtc/pc/legacy_stats_collector.cc:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23b2bfee5e5df8abaf7ada251d3493716be61de0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50034 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53277 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/711 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/280 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52132 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26902 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43037 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21937 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24327 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/277 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8404 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/324 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54859 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25128 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/26386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43237 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/27249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26115 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->