### PR TITLE
Implement trusted types enforcement for script elements

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5514,7 +5514,6 @@ webkit.org/b/261849 imported/w3c/web-platform-tests/css/css-scroll-anchoring/sta
 webkit.org/b/272196 imported/w3c/web-platform-tests/trusted-types/trusted-types-createHTMLDocument.html [ Pass Failure ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-eval.html [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting.html [ Skip ]
-webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script.html [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-report-only.html [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-importScripts.html [ Pass Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-Node-multiple-arguments-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-Node-multiple-arguments-expected.txt
@@ -33,6 +33,21 @@ CONSOLE MESSAGE: This requires a TrustedScript value else it violates the follow
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 'createScript';
 'createScript';
 'createScript';

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-text-node-insertion-into-script-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-text-node-insertion-into-script-element-expected.txt
@@ -1,30 +1,39 @@
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: ReferenceError: Can't find variable: fail
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: ReferenceError: Can't find variable: fail
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 
-Harness Error (FAIL), message = ReferenceError: Can't find variable: fail
-
-FAIL Regression test: Bypass via insertAdjacentText, initial comment. promise_test: Unhandled rejection with value: "'block' received (beforebegin should be blocked)"
+PASS Regression test: Bypass via insertAdjacentText, initial comment.
 PASS Regression test: Bypass via insertAdjacentText, initial comment. script
-FAIL Regression test: Bypass via appendChild into off-document script elementscript promise_test: Unhandled rejection with value: "'block' received (beforebegin should be blocked)"
+PASS Regression test: Bypass via appendChild into off-document script elementscript
 PASS Regression test: Bypass via appendChild into live script element script
-FAIL Regression test: Bypass via insertAdjacentText, initial comment. svg:script promise_test: Unhandled rejection with value: "'block' received (appendChild with a text node should be blocked)"
+PASS Regression test: Bypass via insertAdjacentText, initial comment. svg:script
 PASS Regression test: Bypass via appendChild into off-document script elementsvg:script
-FAIL Regression test: Bypass via appendChild into live script element svg:script promise_test: Unhandled rejection with value: "'block' received (appendChild with a live text node should be blocked)"
+PASS Regression test: Bypass via appendChild into live script element svg:script
 PASS Prep for subsequent tests: Clear SPV event queue.
-FAIL Spot tests around script + innerHTML interaction. promise_test: Unhandled rejection with value: "'trigger' received, but unexpected counts: expected 3 != actual 2"
+PASS Spot tests around script + innerHTML interaction.
 PASS Prep for subsequent tests: Create default policy.
-FAIL Test that default policy applies. script promise_test: Unhandled rejection with value: "unexpected message received: default"
-FAIL Test a failing default policy. script promise_test: Unhandled rejection with value: "'trigger' received, but unexpected counts: expected 1 != actual 0"
-FAIL Test that default policy applies. svg:script promise_test: Unhandled rejection with value: "'done' received, but unexpected counts: expected 1 != actual 0 (done)"
-FAIL Test a failing default policy. svg:script promise_test: Unhandled rejection with value: "'trigger' received, but unexpected counts: expected 1 != actual 0"
+PASS Test that default policy applies. script
+PASS Test a failing default policy. script
+PASS Test that default policy applies. svg:script
+PASS Test a failing default policy. svg:script
 PASS Spot tests around script + innerHTML interaction with default policy.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-report-only-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-report-only-expected.txt
@@ -1,6 +1,7 @@
 CONSOLE MESSAGE: [Report Only] This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: [Report Only] This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: [Report Only] This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: [Report Only] This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: Hello
 CONSOLE MESSAGE: [Report Only] This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 abc

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script-expected.txt
@@ -1,9 +1,9 @@
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-
-Harness Error (TIMEOUT), message = null
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 
 PASS Assign String to SVGScriptElement.innerHTML.
 PASS Assign TrustedHTML to SVGScriptElement.innerHTML.
-TIMEOUT Assign TrustedHTML to SVGScriptElement.innerHTML and execute it. Test timed out
-NOTRUN Modify SVGScriptElement via DOM manipulation.
+PASS Assign TrustedHTML to SVGScriptElement.innerHTML and execute it.
+PASS Modify SVGScriptElement via DOM manipulation.
 

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -105,8 +105,11 @@ protected:
 
     void didFinishInsertingNode();
     void childrenChanged(const ContainerNode::ChildChange&);
+    void finishParsingChildren();
     void handleSourceAttribute(const String& sourceURL);
     void handleAsyncAttribute();
+
+    void setTrustedScriptText(const String&);
 
 private:
     void executeScriptAndDispatchEvent(LoadableScript&);
@@ -151,6 +154,9 @@ private:
 
     MonotonicTime m_creationTime;
     RefPtr<UserGestureToken> m_userGestureToken;
+
+    // https://w3c.github.io/trusted-types/dist/spec/#slots-with-trusted-values
+    String m_trustedScriptText { emptyString() };
 };
 
 // FIXME: replace with is/downcast<ScriptElement>.

--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -66,6 +66,12 @@ void HTMLScriptElement::childrenChanged(const ChildChange& change)
     ScriptElement::childrenChanged(change);
 }
 
+void HTMLScriptElement::finishParsingChildren()
+{
+    HTMLElement::finishParsingChildren();
+    ScriptElement::finishParsingChildren();
+}
+
 void HTMLScriptElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     if (name == srcAttr)
@@ -108,7 +114,10 @@ ExceptionOr<void> HTMLScriptElement::setTextContent(ExceptionOr<String> value)
     if (value.hasException())
         return value.releaseException();
 
-    setTextContent(value.releaseReturnValue());
+    auto newValue = value.releaseReturnValue();
+
+    setTrustedScriptText(newValue);
+    setTextContent(WTFMove(newValue));
     return { };
 }
 
@@ -118,7 +127,10 @@ ExceptionOr<void> HTMLScriptElement::setInnerText(std::variant<RefPtr<TrustedScr
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();
 
-    setInnerText(stringValueHolder.releaseReturnValue());
+    auto newValue = stringValueHolder.releaseReturnValue();
+
+    setTrustedScriptText(newValue);
+    setInnerText(WTFMove(newValue));
     return { };
 }
 

--- a/Source/WebCore/html/HTMLScriptElement.h
+++ b/Source/WebCore/html/HTMLScriptElement.h
@@ -77,6 +77,7 @@ private:
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void didFinishInsertingNode() final;
     void childrenChanged(const ChildChange&) final;
+    void finishParsingChildren() final;
 
     ExceptionOr<void> setTextContent(ExceptionOr<String>);
 

--- a/Source/WebCore/svg/SVGScriptElement.cpp
+++ b/Source/WebCore/svg/SVGScriptElement.cpp
@@ -80,6 +80,12 @@ void SVGScriptElement::childrenChanged(const ChildChange& change)
     ScriptElement::childrenChanged(change);
 }
 
+void SVGScriptElement::finishParsingChildren()
+{
+    SVGElement::finishParsingChildren();
+    ScriptElement::finishParsingChildren();
+}
+
 void SVGScriptElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
 {
     SVGElement::addSubresourceAttributeURLs(urls);

--- a/Source/WebCore/svg/SVGScriptElement.h
+++ b/Source/WebCore/svg/SVGScriptElement.h
@@ -47,6 +47,7 @@ private:
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void didFinishInsertingNode() final;
     void childrenChanged(const ChildChange&) final;
+    void finishParsingChildren() final;
 
     bool isURLAttribute(const Attribute& attribute) const final { return attribute.name() == AtomString { sourceAttributeValue() }; }
     void addSubresourceAttributeURLs(ListHashSet<URL>&) const final;


### PR DESCRIPTION
#### f33204d52243ae13948a2dee417d69e25442c2d8
<pre>
Implement trusted types enforcement for script elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=269365">https://bugs.webkit.org/show_bug.cgi?id=269365</a>

Reviewed by Darin Adler and Ryosuke Niwa.

Add script text string to script element. This is used to ensure that script elements can&apos;t be manipulated in untrusted ways.

See <a href="https://w3c.github.io/trusted-types/dist/spec/#htmlscriptelement-script-text">https://w3c.github.io/trusted-types/dist/spec/#htmlscriptelement-script-text</a> and <a href="https://w3c.github.io/trusted-types/dist/spec/#slot-value-verification">https://w3c.github.io/trusted-types/dist/spec/#slot-value-verification</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-Node-multiple-arguments-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-text-node-insertion-into-script-element-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-report-only-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script-expected.txt:
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::finishParsingChildren):
(WebCore::ScriptElement::prepareScript):
(WebCore::ScriptElement::setTrustedScriptText):
* Source/WebCore/dom/ScriptElement.h:
* Source/WebCore/html/HTMLScriptElement.cpp:
(WebCore::HTMLScriptElement::finishParsingChildren):
(WebCore::HTMLScriptElement::setTextContent):
(WebCore::HTMLScriptElement::setInnerText):
* Source/WebCore/html/HTMLScriptElement.h:
* Source/WebCore/svg/SVGScriptElement.cpp:
(WebCore::SVGScriptElement::finishParsingChildren):
* Source/WebCore/svg/SVGScriptElement.h:

Canonical link: <a href="https://commits.webkit.org/279117@main">https://commits.webkit.org/279117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcb3d806cce8d6f82cef6c294c69071951dbafd3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52381 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55655 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3104 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42596 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1979 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29421 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45209 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23677 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2484 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1263 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48507 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57251 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27507 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2665 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49985 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28740 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45329 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49235 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11479 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29652 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->