### PR TITLE
Web Inspector: Can't scroll `overflow: scroll` containers if a remote inspector highlight is visible

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2807,8 +2807,11 @@ void LocalFrameView::setViewportConstrainedObjectsNeedLayout()
 
 void LocalFrameView::didChangeScrollOffset()
 {
-    if (auto* page = m_frame->page())
+    if (auto* page = m_frame->page()) {
         page->pageOverlayController().didScrollFrame(m_frame.get());
+        InspectorInstrumentation::didScroll(*page);
+    }
+
     m_frame->loader().client().didChangeScrollOffset();
 }
 

--- a/Source/WebKit/UIProcess/Inspector/ios/WKInspectorHighlightView.mm
+++ b/Source/WebKit/UIProcess/Inspector/ios/WKInspectorHighlightView.mm
@@ -41,6 +41,7 @@
         return nil;
     _layers = adoptNS([[NSMutableArray alloc] init]);
     self.opaque = NO;
+    self.userInteractionEnabled = NO;
     return self;
 }
 


### PR DESCRIPTION
#### 43ec0e8d0cc6ba4ee3336418a3cc906f62e42e8d
<pre>
Web Inspector: Can&apos;t scroll `overflow: scroll` containers if a remote inspector highlight is visible
<a href="https://rdar.apple.com/124554999">rdar://124554999</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=273599">https://bugs.webkit.org/show_bug.cgi?id=273599</a>

Reviewed by Patrick Angle.

The method InspectorOverlay::update should be called to update the
overlay&apos;s position e.g. when a scroll event happens and elements move.
That function is exposed to the public by the
InspectorInstrumentation::didScroll static method, where objects
without direct access to the inspector overlay use it.

The static method is called in Chrome::scroll, but that path is only
visited when scrolling happens in the root &lt;html&gt; element. If the root
can&apos;t scroll but instead it&apos;s some deeper element being scrolled, we
should also find a way to call the static method to position the
overlay.

This commit gives that duty to LocalFrameView::didChangeScrollOffset
because that method is called when any element scrolls inside the frame.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::didChangeScrollOffset):
   - When any element is scrolled, update the inspector overlay&apos;s
     position.

* Source/WebKit/UIProcess/Inspector/ios/WKInspectorHighlightView.mm:
(-[WKInspectorHighlightView initWithFrame:]):
   - Prevent the inspector overlay from blocking tap events into
     deeper scrollable elements.

Canonical link: <a href="https://commits.webkit.org/278614@main">https://commits.webkit.org/278614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c64d06b3a19218efee9b6850489f0f2a8556f1b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30025 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53987 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1419 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53031 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1069 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41337 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43692 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22460 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25041 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/948 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9169 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47022 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55577 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25830 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/912 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48748 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27087 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47812 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11182 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27955 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26819 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->