### PR TITLE
Hook in Skia rendering on PlayStation

### DIFF
--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -45,7 +45,9 @@
 #include <skia/core/SkPoint3.h>
 #include <skia/core/SkRRect.h>
 #include <skia/core/SkRegion.h>
+IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
 #include <skia/core/SkSurface.h>
+IGNORE_CLANG_WARNINGS_END
 #include <skia/core/SkTileMode.h>
 #include <skia/effects/SkImageFilters.h>
 #include <wtf/MathExtras.h>

--- a/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
@@ -65,6 +65,9 @@ GLContext* PlatformDisplay::skiaGLContext()
 {
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [this] {
+        // The PlayStation OpenGL implementation does not dispatch to the context bound to
+        //  the current thread so Skia cannot use OpenGL with coordinated graphics
+#if !(PLATFORM(PLAYSTATION) && USE(COORDINATED_GRAPHICS))
         const char* enableCPURendering = getenv("WEBKIT_SKIA_ENABLE_CPU_RENDERING");
         if (enableCPURendering && strcmp(enableCPURendering, "0"))
             return;
@@ -78,6 +81,7 @@ GLContext* PlatformDisplay::skiaGLContext()
             m_skiaGLContext = WTFMove(skiaGLContext);
             m_skiaGrContext = WTFMove(skiaGrContext);
         }
+#endif
     });
     return m_skiaGLContext.get();
 }

--- a/Source/WebKit/Shared/API/c/skia/WKImageSkia.cpp
+++ b/Source/WebKit/Shared/API/c/skia/WKImageSkia.cpp
@@ -29,6 +29,7 @@
 #if USE(SKIA)
 #include "WKSharedAPICast.h"
 #include "WebImage.h"
+#include <WebCore/NativeImage.h>
 
 SkImage* WKImageCreateSkImage(WKImageRef imageRef)
 {

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
@@ -42,6 +42,7 @@
 #include <WebCore/NicosiaContentLayer.h>
 #include <WebCore/NicosiaImageBacking.h>
 #include <WebCore/Page.h>
+#include <WebCore/PlatformDisplay.h>
 #include <wtf/MemoryPressureHandler.h>
 #include <wtf/NumberOfCores.h>
 #include <wtf/SetForScope.h>

--- a/Source/WebKit/WebProcess/playstation/WebProcessMainPlayStation.cpp
+++ b/Source/WebKit/WebProcess/playstation/WebProcessMainPlayStation.cpp
@@ -29,10 +29,21 @@
 #include "AuxiliaryProcessMain.h"
 #include "WebProcess.h"
 
+#if USE(SKIA) && !ENABLE(GPU_PROCESS)
+#include <skia/core/SkGraphics.h>
+#endif
+
 namespace WebKit {
-using namespace WebCore;
 
 class WebProcessMainPlayStation final: public AuxiliaryProcessMainBase<WebProcess> {
+public:
+    bool platformInitialize() override
+    {
+#if USE(SKIA) && !ENABLE(GPU_PROCESS)
+        SkGraphics::Init();
+#endif
+        return true;
+    }
 };
 
 int WebProcessMain(int argc, char** argv)


### PR DESCRIPTION
#### 87d0651fa15ce3cdc38e2298f800a810660283bb
<pre>
Hook in Skia rendering on PlayStation
<a href="https://bugs.webkit.org/show_bug.cgi?id=273630">https://bugs.webkit.org/show_bug.cgi?id=273630</a>

Reviewed by Fujii Hironori.

Port any Cairo implementations over to Skia. Get everything compiling.

* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
* Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp:
* Source/WebKit/Shared/API/c/skia/WKImageSkia.cpp:
* Source/WebKit/UIProcess/API/C/playstation/WKPagePrivatePlayStation.cpp:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp:
* Source/WebKit/WebProcess/playstation/WebProcessMainPlayStation.cpp:

Canonical link: <a href="https://commits.webkit.org/278570@main">https://commits.webkit.org/278570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f42e0097567bf6a1ba75b1bc79eb955b9c54f4ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30201 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54160 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1592 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1248 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41453 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43846 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22583 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25174 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1102 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9342 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47158 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1177 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55754 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26004 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1062 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48860 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27261 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43920 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47942 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11161 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28134 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26992 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->