### PR TITLE
[WebGPU] GPUBuffer should not destroy the underlying buffer from its destructor

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
@@ -32,12 +32,7 @@
 
 namespace WebCore {
 
-GPUBuffer::~GPUBuffer()
-{
-    m_bufferSize = 0;
-    m_backing->destroy();
-    m_arrayBuffers.clear();
-}
+GPUBuffer::~GPUBuffer() = default;
 
 GPUBuffer::GPUBuffer(Ref<WebGPU::Buffer>&& backing, size_t bufferSize, GPUBufferUsageFlags usage, bool mappedAtCreation, GPUDevice& device)
     : m_backing(WTFMove(backing))

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -191,7 +191,7 @@ bool validateBindGroup(BindGroup& bindGroup)
 
             auto bufferSize = bufferBinding->minBindingSize;
             if (bufferSize && buffer->get()) {
-                if (!buffer->get()->isDestroyed() && buffer->get()->buffer().length < bufferSize)
+                if (buffer->get()->buffer().length < bufferSize)
                     return false;
             }
         }


### PR DESCRIPTION
#### 0a9423a613b0c0c3fd2eb10cafee1b8c03d2148b
<pre>
[WebGPU] GPUBuffer should not destroy the underlying buffer from its destructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=273606">https://bugs.webkit.org/show_bug.cgi?id=273606</a>
&lt;radar://127408015&gt;

Reviewed by Dan Glastonbury.

The first and last line of the dtor were useless but the destroy
call should have not existed, since the buffer may still be used in the GPU
process after it is GC&apos;ed from the JS layer.

Observed in a flaky fashion from <a href="https://webgpu.github.io/webgpu-samples/?sample=deferredRendering">https://webgpu.github.io/webgpu-samples/?sample=deferredRendering</a>
where some command buffers were failing, occassionally.

* Source/WebCore/Modules/WebGPU/GPUBuffer.cpp:
(WebCore::GPUBuffer::~GPUBuffer): Deleted.

Canonical link: <a href="https://commits.webkit.org/278412@main">https://commits.webkit.org/278412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e145877d02230304e4c75b891c667642f5b2ebe6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2620 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53582 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1013 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52626 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35846 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41048 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52422 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27271 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43314 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22152 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24681 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/568 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8701 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46666 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/632 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55173 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25419 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/560 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48461 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26682 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43497 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47495 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11062 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27544 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26412 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->