### PR TITLE
Refactor logic for muting autoplaying video elements in background tabs

### DIFF
--- a/LayoutTests/fast/element-targeting/target-video-in-subframe-expected.txt
+++ b/LayoutTests/fast/element-targeting/target-video-in-subframe-expected.txt
@@ -1,0 +1,14 @@
+PASS originalVideo.muted is false
+PASS originalVideo.volume is 1
+PASS internals.isEffectivelyMuted(originalVideo) is true
+PASS clonedVideo.muted is false
+PASS clonedVideo.volume is 1
+PASS internals.isEffectivelyMuted(clonedVideo) is true
+After reset:
+PASS internals.isEffectivelyMuted(originalVideo) is false
+PASS internals.isEffectivelyMuted(clonedVideo) is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+This test requires WebKitTestRunner

--- a/LayoutTests/fast/element-targeting/target-video-in-subframe.html
+++ b/LayoutTests/fast/element-targeting/target-video-in-subframe.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+body, html {
+    margin: 0;
+}
+
+div.container {
+    width: 320px;
+    height: 240px;
+    border: 1px solid gray;
+    box-sizing: border-box;
+    text-align: center;
+}
+
+iframe {
+    width: 100%;
+    height: 100%;
+}
+</style>
+</head>
+<body>
+    <div class="container">
+        <iframe></iframe>
+    </div>
+    <div>This test requires WebKitTestRunner</div>
+</body>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async event => {
+    const frame = document.querySelector("iframe");
+    await new Promise(resolve => {
+        frame.addEventListener("load", resolve, { once: true });
+        frame.srcdoc = `
+            <head>
+                <style>
+                    video {
+                        width: 160px;
+                        height: 120px;
+                    }
+                </style>
+            </head>
+            <body>
+                <video src="../../media/content/audio-describes-video.mp4" loop autoplay />
+                <script>
+                    function cloneVideo() {
+                        const originalVideo = document.querySelector("video");
+                        const clonedVideo = document.createElement("video");
+                        clonedVideo.src = originalVideo.src;
+                        clonedVideo.autoplay = true;
+                        clonedVideo.loop = true;
+                        document.body.appendChild(clonedVideo);
+                        return [originalVideo, clonedVideo];
+                    }
+                </` + `script>
+            </body>`;
+    });
+
+    await UIHelper.adjustVisibilityForFrontmostTarget(100, 100);
+
+    [originalVideo, clonedVideo] = frame.contentWindow.cloneVideo();
+
+    shouldBeFalse("originalVideo.muted");
+    shouldBe("originalVideo.volume", "1");
+    shouldBeTrue("internals.isEffectivelyMuted(originalVideo)");
+
+    shouldBeFalse("clonedVideo.muted");
+    shouldBe("clonedVideo.volume", "1");
+    shouldBeTrue("internals.isEffectivelyMuted(clonedVideo)");
+
+    await UIHelper.resetVisibilityAdjustments();
+
+    debug("After reset:");
+    shouldBeFalse("internals.isEffectivelyMuted(originalVideo)");
+    shouldBeFalse("internals.isEffectivelyMuted(clonedVideo)");
+    finishJSTest();
+});
+</script>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2184,6 +2184,15 @@ window.UIHelper = class UIHelper {
             })()`, resolve);
         });
     }
+
+    static resetVisibilityAdjustments() {
+        if (!this.isWebKit2())
+            return Promise.resolve();
+
+        return new Promise(resolve => {
+            testRunner.runUIScript("uiController.resetVisibilityAdjustments(result => uiController.uiScriptComplete(result));", resolve);
+        });
+    }
 }
 
 UIHelper.EventStreamBuilder = class {

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5253,6 +5253,12 @@ void Document::updateIsPlayingMedia()
 #endif
 }
 
+void Document::visibilityAdjustmentStateDidChange()
+{
+    for (auto& audioProducer : m_audioProducers)
+        audioProducer.visibilityAdjustmentStateDidChange();
+}
+
 void Document::pageMutedStateDidChange()
 {
     for (auto& audioProducer : m_audioProducers)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1623,6 +1623,7 @@ public:
     inline bool isCapturing() const;
     WEBCORE_EXPORT void updateIsPlayingMedia();
     void pageMutedStateDidChange();
+    void visibilityAdjustmentStateDidChange();
 
     bool hasEverHadSelectionInsideTextFormControl() const { return m_hasEverHadSelectionInsideTextFormControl; }
     void setHasEverHadSelectionInsideTextFormControl() { m_hasEverHadSelectionInsideTextFormControl = true; }

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -642,6 +642,7 @@ public:
 
     OptionSet<VisibilityAdjustment> visibilityAdjustment() const;
     void setVisibilityAdjustment(OptionSet<VisibilityAdjustment>);
+    bool isInVisibilityAdjustmentSubtree() const;
 
     bool isSpellCheckingEnabled() const;
     WEBCORE_EXPORT bool isWritingSuggestionsEnabled() const;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -599,6 +599,7 @@ public:
 
     bool willLog(WTFLogLevel) const;
 
+    bool isAudible() const final { return canProduceAudio(); }
     bool isSuspended() const final;
 
     WEBCORE_EXPORT void didBecomeFullscreenElement() final;
@@ -998,7 +999,6 @@ private:
     bool shouldOverrideBackgroundPlaybackRestriction(PlatformMediaSession::InterruptionType) const override;
     bool shouldOverrideBackgroundLoadingRestriction() const override;
     bool canProduceAudio() const final;
-    bool isAudible() const final { return canProduceAudio(); };
     bool isEnded() const final { return ended(); }
     MediaTime mediaSessionDuration() const final;
     bool hasMediaStreamSource() const final;
@@ -1008,6 +1008,7 @@ private:
     std::optional<NowPlayingInfo> nowPlayingInfo() const final;
     WeakPtr<PlatformMediaSession> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSession>>&, PlatformMediaSession::PlaybackControlsPurpose) final;
 
+    void visibilityAdjustmentStateDidChange() final;
     void pageMutedStateDidChange() override;
 
 #if USE(AUDIO_SESSION) && PLATFORM(MAC)
@@ -1019,7 +1020,7 @@ private:
 
     bool processingUserGestureForMedia() const;
 
-    bool effectiveMuted() const;
+    WEBCORE_EXPORT bool effectiveMuted() const;
     double effectiveVolume() const;
 
     void registerWithDocument(Document&);
@@ -1255,6 +1256,7 @@ private:
     bool m_shouldAudioPlaybackRequireUserGesture : 1;
     bool m_shouldVideoPlaybackRequireUserGesture : 1;
     bool m_volumeLocked : 1;
+    bool m_cachedIsInVisibilityAdjustmentSubtree : 1 { false };
 
     enum class ControlsState : uint8_t { None, Initializing, Ready, PartiallyDeinitialized };
     friend String convertEnumerationToString(HTMLMediaElement::ControlsState enumerationValue);

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -42,6 +42,7 @@
 #include "FloatRect.h"
 #include "HTMLBodyElement.h"
 #include "HTMLFrameOwnerElement.h"
+#include "HTMLMediaElement.h"
 #include "HTMLNames.h"
 #include "HitTestRequest.h"
 #include "HitTestResult.h"
@@ -566,6 +567,24 @@ static String searchableTextForTarget(Element& target)
     return emptyString();
 }
 
+static bool hasAudibleMedia(const Element& element)
+{
+    if (RefPtr media = dynamicDowncast<HTMLMediaElement>(element))
+        return media->isAudible();
+
+    for (auto& media : descendantsOfType<HTMLMediaElement>(element)) {
+        if (media.isAudible())
+            return true;
+    }
+
+    for (auto& documentElement : collectDocumentElementsFromChildFrames(element)) {
+        if (hasAudibleMedia(documentElement))
+            return true;
+    }
+
+    return false;
+}
+
 enum class IsNearbyTarget : bool { No, Yes };
 static TargetedElementInfo targetedElementInfo(Element& element, IsNearbyTarget isNearbyTarget, ElementSelectorCache& cache)
 {
@@ -584,12 +603,13 @@ static TargetedElementInfo targetedElementInfo(Element& element, IsNearbyTarget 
         .isNearbyTarget = isNearbyTarget == IsNearbyTarget::Yes,
         .isPseudoElement = element.isPseudoElement(),
         .isInShadowTree = element.isInShadowTree(),
+        .hasAudibleMedia = hasAudibleMedia(element)
     };
 }
 
-static inline HTMLElement* findOnlyMainElement(HTMLBodyElement& bodyElement)
+static const HTMLElement* findOnlyMainElement(const HTMLBodyElement& bodyElement)
 {
-    RefPtr<HTMLElement> onlyMainElement;
+    RefPtr<const HTMLElement> onlyMainElement;
     for (auto& descendant : descendantsOfType<HTMLElement>(bodyElement)) {
         if (!descendant.hasTagName(HTMLNames::mainTag))
             continue;
@@ -604,7 +624,7 @@ static inline HTMLElement* findOnlyMainElement(HTMLBodyElement& bodyElement)
     return onlyMainElement.get();
 }
 
-static bool isNavigationalElement(Element& element)
+static bool isNavigationalElement(const Element& element)
 {
     if (element.hasTagName(HTMLNames::navTag))
         return true;
@@ -613,7 +633,7 @@ static bool isNavigationalElement(Element& element)
     return AccessibilityObject::ariaRoleToWebCoreRole(roleValue) == AccessibilityRole::LandmarkNavigation;
 }
 
-static bool containsNavigationalElement(Element& element)
+static bool containsNavigationalElement(const Element& element)
 {
     if (isNavigationalElement(element))
         return true;
@@ -1081,6 +1101,10 @@ bool ElementTargetingController::adjustVisibility(const Vector<std::pair<Element
             adjustedElement->invalidateStyle();
         m_adjustedElements.add(element);
     }
+
+    if (changed)
+        dispatchVisibilityAdjustmentStateDidChange();
+
     return changed;
 }
 
@@ -1181,6 +1205,9 @@ void ElementTargetingController::adjustVisibilityInRepeatedlyTargetedRegions(Doc
         elementsToAdjust.append(element.releaseNonNull());
     }
 
+    if (elementsToAdjust.isEmpty())
+        return;
+
     for (auto& element : elementsToAdjust) {
         auto [adjustedElement, invalidateSubtree] = adjustVisibilityIfNeeded(element);
         if (!adjustedElement)
@@ -1192,6 +1219,8 @@ void ElementTargetingController::adjustVisibilityInRepeatedlyTargetedRegions(Doc
             adjustedElement->invalidateStyle();
         m_adjustedElements.add(element);
     }
+
+    dispatchVisibilityAdjustmentStateDidChange();
 }
 
 void ElementTargetingController::applyVisibilityAdjustmentFromSelectors(Document& document)
@@ -1330,8 +1359,11 @@ void ElementTargetingController::applyVisibilityAdjustmentFromSelectors(Document
         return selectors.isEmpty();
     });
 
-    if (!matchingSelectors.isEmpty())
-        page->chrome().client().didAdjustVisibilityWithSelectors(WTFMove(matchingSelectors));
+    if (matchingSelectors.isEmpty())
+        return;
+
+    dispatchVisibilityAdjustmentStateDidChange();
+    page->chrome().client().didAdjustVisibilityWithSelectors(WTFMove(matchingSelectors));
 }
 
 void ElementTargetingController::reset()
@@ -1419,6 +1451,9 @@ bool ElementTargetingController::resetVisibilityAdjustments(const Vector<std::pa
         }
     }
 
+    if (changed)
+        dispatchVisibilityAdjustmentStateDidChange();
+
     return changed;
 }
 
@@ -1475,6 +1510,17 @@ uint64_t ElementTargetingController::numberOfVisibilityAdjustmentRects() const
 void ElementTargetingController::cleanUpAdjustmentClientRects()
 {
     m_recentAdjustmentClientRects = { };
+}
+
+void ElementTargetingController::dispatchVisibilityAdjustmentStateDidChange()
+{
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    page->forEachDocument([](auto& document) {
+        document.visibilityAdjustmentStateDidChange();
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/ElementTargetingController.h
+++ b/Source/WebCore/page/ElementTargetingController.h
@@ -66,6 +66,8 @@ private:
     void cleanUpAdjustmentClientRects();
     void applyVisibilityAdjustmentFromSelectors(Document&);
 
+    void dispatchVisibilityAdjustmentStateDidChange();
+
     std::pair<Vector<Ref<Node>>, RefPtr<Element>> findNodes(FloatPoint location, bool shouldIgnorePointerEventsNone);
     std::pair<Vector<Ref<Node>>, RefPtr<Element>> findNodes(const String& searchText);
 

--- a/Source/WebCore/page/ElementTargetingTypes.h
+++ b/Source/WebCore/page/ElementTargetingTypes.h
@@ -57,6 +57,7 @@ struct TargetedElementInfo {
     bool isNearbyTarget { true };
     bool isPseudoElement { false };
     bool isInShadowTree { false };
+    bool hasAudibleMedia { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/MediaProducer.h
+++ b/Source/WebCore/page/MediaProducer.h
@@ -138,6 +138,7 @@ public:
     static constexpr MutedStateFlags AudioAndVideoCaptureIsMuted = { MutedState::AudioCaptureIsMuted, MutedState::VideoCaptureIsMuted };
     static constexpr MutedStateFlags MediaStreamCaptureIsMuted = { MutedState::AudioCaptureIsMuted, MutedState::VideoCaptureIsMuted, MutedState::ScreenCaptureIsMuted, MutedState::WindowCaptureIsMuted, MutedState::SystemAudioCaptureIsMuted };
 
+    virtual void visibilityAdjustmentStateDidChange() { }
     virtual void pageMutedStateDidChange() = 0;
 
 protected:

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1560,6 +1560,8 @@ void Page::didCommitLoad()
     m_isEditableRegionEnabled = false;
 #endif
 
+    m_hasEverSetVisibilityAdjustment = false;
+
     resetSeenPlugins();
     resetSeenMediaEngines();
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1053,6 +1053,9 @@ public:
     void resetImageAnalysisQueue();
 #endif
 
+    bool hasEverSetVisibilityAdjustment() const { return m_hasEverSetVisibilityAdjustment; }
+    void didSetVisibilityAdjustment() { m_hasEverSetVisibilityAdjustment = true; }
+
     WEBCORE_EXPORT StorageConnection& storageConnection();
 
     ModelPlayerProvider& modelPlayerProvider();
@@ -1380,6 +1383,7 @@ private:
     bool m_hasResourceLoadClient { false };
     bool m_delegatesScaling { false };
 
+    bool m_hasEverSetVisibilityAdjustment { false };
 
 #if ENABLE(EDITABLE_REGION)
     bool m_isEditableRegionEnabled { false };

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7442,4 +7442,9 @@ const String& Internals::defaultSpatialTrackingLabel() const
     return nullString();
 }
 
+bool Internals::isEffectivelyMuted(const HTMLMediaElement& element)
+{
+    return element.effectiveMuted();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1468,6 +1468,8 @@ public:
 
     const String& defaultSpatialTrackingLabel() const;
 
+    bool isEffectivelyMuted(const HTMLMediaElement&);
+
 private:
     explicit Internals(Document&);
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1348,4 +1348,6 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     undefined setPDFDisplayModeForTesting(Element element, DOMString mode);
 
     readonly attribute DOMString defaultSpatialTrackingLabel;
+
+    boolean isEffectivelyMuted(HTMLMediaElement element);
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -906,6 +906,7 @@ header: <WebCore/ElementTargetingTypes.h>
     bool isNearbyTarget
     bool isPseudoElement
     bool isInShadowTree
+    bool hasAudibleMedia
 };
 
 header: <WebCore/RenderStyleConstants.h>

--- a/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
@@ -61,6 +61,7 @@ public:
     bool isNearbyTarget() const { return m_info.isNearbyTarget; }
     bool isPseudoElement() const { return m_info.isPseudoElement; }
     bool isInShadowTree() const { return m_info.isInShadowTree; }
+    bool hasAudibleMedia() const { return m_info.hasAudibleMedia; }
 
     void childFrames(CompletionHandler<void(Vector<Ref<FrameTreeNode>>&&)>&&) const;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h
@@ -46,6 +46,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @property (nonatomic, readonly, getter=isNearbyTarget) BOOL nearbyTarget;
 @property (nonatomic, readonly, getter=isPseudoElement) BOOL pseudoElement;
 @property (nonatomic, readonly, getter=isInShadowTree) BOOL inShadowTree;
+@property (nonatomic, readonly) BOOL hasAudibleMedia;
 
 @property (nonatomic, readonly, copy) NSArray<NSString *> *selectors;
 @property (nonatomic, readonly, copy) NSArray<NSArray<NSString *> *> *selectorsIncludingShadowHosts;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
@@ -158,4 +158,9 @@
     return _info->isInShadowTree();
 }
 
+- (BOOL)hasAudibleMedia
+{
+    return _info->hasAudibleMedia();
+}
+
 @end

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -421,4 +421,5 @@ interface UIScriptController {
 
     undefined requestRenderedTextForFrontmostTarget(long x, long y, object callback);
     undefined adjustVisibilityForFrontmostTarget(long x, long y, object callback);
+    undefined resetVisibilityAdjustments(object callback);
 };

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -420,6 +420,7 @@ public:
     // Element Targeting
     virtual void requestRenderedTextForFrontmostTarget(int, int, JSValueRef) { notImplemented(); }
     virtual void adjustVisibilityForFrontmostTarget(int, int, JSValueRef) { notImplemented(); }
+    virtual void resetVisibilityAdjustments(JSValueRef) { notImplemented(); }
 
 protected:
     explicit UIScriptController(UIScriptContext&);

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
@@ -92,6 +92,7 @@ private:
 
     void requestRenderedTextForFrontmostTarget(int x, int y, JSValueRef callback) final;
     void adjustVisibilityForFrontmostTarget(int x, int y, JSValueRef callback) final;
+    void resetVisibilityAdjustments(JSValueRef callback) final;
 };
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -379,4 +379,12 @@ void UIScriptControllerCocoa::adjustVisibilityForFrontmostTarget(int x, int y, J
     }];
 }
 
+void UIScriptControllerCocoa::resetVisibilityAdjustments(JSValueRef callback)
+{
+    unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
+    [webView() _resetVisibilityAdjustmentsForTargetedElements:nil completionHandler:[callbackID, this](BOOL success) {
+        m_context->asyncTaskComplete(callbackID, { JSValueMakeBoolean(m_context->jsContext(), success) });
+    }];
+}
+
 } // namespace WTR


### PR DESCRIPTION
#### 04fce867503f4cab34c98b03c5b5c117dd914767
<pre>
Refactor logic for muting autoplaying video elements in background tabs
<a href="https://bugs.webkit.org/show_bug.cgi?id=273633">https://bugs.webkit.org/show_bug.cgi?id=273633</a>
<a href="https://rdar.apple.com/125859510">rdar://125859510</a>

Reviewed by Aditya Keerthi.

Refactor some logic related to muting media elements. See below for more details.

* LayoutTests/fast/element-targeting/target-video-in-subframe-expected.txt: Added.
* LayoutTests/fast/element-targeting/target-video-in-subframe.html: Added.
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.resetVisibilityAdjustments):
(window.UIHelper):

Add a new layout test (and testing hooks) to exercise the change.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::visibilityAdjustmentStateDidChange):

Add plumbing to propagate visibility state change to all audio producers.

* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setVisibilityAdjustment):

Set a flag on `Page` to indicate that we&apos;ve applied visibility adjustment to at least one element
before. Used in `isInVisibilityAdjustmentSubtree()` below to exit right away, in the common case
where there has never been visibility adjustment.

(WebCore::Element::isInVisibilityAdjustmentSubtree const):

Add a helper method to compute whether or not the element is inside of a visibility adjustment
subtree, by traversing ancestors in the DOM.

* Source/WebCore/dom/Element.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::didFinishInsertingNode):
(WebCore::HTMLMediaElement::removedFromAncestor):
(WebCore::HTMLMediaElement::visibilityAdjustmentStateDidChange):

Recompute and cache the visibility adjustment subtree state whenever the media element is
unparented, re-parented, or visibility state otherwise changes.

(WebCore::HTMLMediaElement::effectiveMuted const):

Consult the cached state flag that&apos;s updated above when determining whether the media element should
be `effectivelyMuted()`.

* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::hasAudibleMedia):
(WebCore::targetedElementInfo):

Add support for a `hasAudibleMedia` flag on targeted element info.

(WebCore::findOnlyMainElement):
(WebCore::isNavigationalElement):
(WebCore::containsNavigationalElement):

Drive-by fix: mark the arguments to a few helper functions as `const`.

(WebCore::ElementTargetingController::adjustVisibility):
(WebCore::ElementTargetingController::adjustVisibilityInRepeatedlyTargetedRegions):
(WebCore::ElementTargetingController::resetVisibilityAdjustments):
(WebCore::ElementTargetingController::dispatchVisibilityAdjustmentStateDidChange):
* Source/WebCore/page/ElementTargetingController.h:
* Source/WebCore/page/ElementTargetingTypes.h:
* Source/WebCore/page/MediaProducer.h:
(WebCore::MediaProducer::visibilityAdjustmentStateDidChange):

Add a new delegate hook to inform media producers when visibility state changes. Currently, this is
only implemented by `HTMLMediaElement`, which allows it to adjust whether or not the underlying
media player should be muted, through `effectiveMuted()`.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::didCommitLoad):
* Source/WebCore/page/Page.h:

Add a boolean flag to track whether or not there has ever been any visibility adjustment in the
page (this bit is cleared out in `didCommitLoad` above).

(WebCore::Page::hasEverSetVisibilityAdjustment const):
(WebCore::Page::didSetVisibilityAdjustment):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isEffectivelyMuted):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Add a new testing-only hook to ask for `HTMLMediaElement::effectiveMuted()`.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/APITargetedElementInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm:
(-[_WKTargetedElementInfo hasAudibleMedia]):
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::resetVisibilityAdjustments):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::resetVisibilityAdjustments):

Canonical link: <a href="https://commits.webkit.org/278356@main">https://commits.webkit.org/278356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd966747b177abc82dadabcf4e8a1bf2e6a92628

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2578 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53540 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/971 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52584 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/618 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27240 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22130 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/24653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/535 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8659 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55126 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25377 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26640 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43465 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47461 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11033 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27502 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/26370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->