### PR TITLE
XPCSPI.h build fix for "[visionOS] Add SPI module for LinearMediaKit"

### DIFF
--- a/Source/WTF/wtf/spi/darwin/XPCSPI.h
+++ b/Source/WTF/wtf/spi/darwin/XPCSPI.h
@@ -120,20 +120,7 @@ extern "C" void xpc_activity_register(const char *identifier, xpc_object_t crite
 #if USE(APPLE_INTERNAL_SDK)
 #include <os/transaction_private.h>
 #include <xpc/private.h>
-#if HAVE(OS_LAUNCHD_JOB)
-#include <AppServerSupport/OSLaunchdJob.h>
-#endif // HAVE(OS_LAUNCHD_JOB)
 #else // USE(APPLE_INTERNAL_SDK)
-
-#ifdef __OBJC__
-#import <Foundation/NSError.h>
-#if HAVE(OS_LAUNCHD_JOB)
-@interface OSLaunchdJob : NSObject
-- (instancetype)initWithPlist:(xpc_object_t)plist;
-- (BOOL)submit:(NSError **)errorOut;
-@end
-#endif // HAVE(OS_LAUNCHD_JOB)
-#endif // __OBJC__
 
 extern "C" const char * const XPC_ACTIVITY_RANDOM_INITIAL_DELAY;
 extern "C" const char * const XPC_ACTIVITY_REQUIRE_NETWORK_CONNECTIVITY;

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
@@ -34,6 +34,18 @@
 
 #if HAVE(OS_LAUNCHD_JOB) && (PLATFORM(MAC) || PLATFORM(IOS))
 
+#if USE(APPLE_INTERNAL_SDK)
+// AppServerSupport cannot be safely imported within modules, so avoid putting
+// this SPI declaration in headers.
+#import <AppServerSupport/OSLaunchdJob.h>
+#else
+#import <Foundation/NSError.h>
+@interface OSLaunchdJob : NSObject
+- (instancetype)initWithPlist:(xpc_object_t)plist;
+- (BOOL)submit:(NSError **)errorOut;
+@end
+#endif
+
 using WebKit::WebPushD::PushMessageForTesting;
 
 __attribute__((__noreturn__))

--- a/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm
@@ -46,6 +46,18 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 #endif
 
+#if USE(APPLE_INTERNAL_SDK)
+// AppServerSupport cannot be safely imported within modules, so avoid putting
+// this SPI declaration in headers.
+#import <AppServerSupport/OSLaunchdJob.h>
+#else
+#import <Foundation/NSError.h>
+@interface OSLaunchdJob : NSObject
+- (instancetype)initWithPlist:(xpc_object_t)plist;
+- (BOOL)submit:(NSError **)errorOut;
+@end
+#endif
+
 namespace TestWebKitAPI {
 
 static RetainPtr<NSURL> currentExecutableLocation()


### PR DESCRIPTION
#### a46102b5ed12caaef2727c844d00884740f577dd
<pre>
XPCSPI.h build fix for &quot;[visionOS] Add SPI module for LinearMediaKit&quot;
<a href="https://rdar.apple.com/127327242">rdar://127327242</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=273527">https://bugs.webkit.org/show_bug.cgi?id=273527</a>

Reviewed by NOBODY (OOPS!).

In <a href="https://commits.webkit.org/278232@main">https://commits.webkit.org/278232@main</a>, XPCSPI.h was added to the
include graph of WebKitSwift on visionOS. This header imports
&lt;AppServerSupport/OSLaunchdJob.h&gt;, which is fine when included
textually, but when imported as a module it pulls in AppServerSupport.h.
That header contains an error diagnostic which fails the build (because
the framework is only supposed to be used by XPC servers).

Fix by moving the OSLaunchdJob.h import out of XPCSPI.h and into the two
places where it&apos;s actually used. This will likely be a problem again if
webpushd starts building with modules enabled, but it will be isolated
to the target which actually uses this class.

* Source/WTF/wtf/spi/darwin/XPCSPI.h:
* Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm:
* Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a46102b5ed12caaef2727c844d00884740f577dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50087 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29377 "Hash a46102b5 for PR 28057 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2375 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53336 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/768 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52390 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35541 "Hash a46102b5 for PR 28057 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/332 "Hash a46102b5 for PR 28057 does not build (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52185 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/35541 "Hash a46102b5 for PR 28057 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/2375 "") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/21970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/35541 "Hash a46102b5 for PR 28057 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/2375 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8462 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/43411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/35541 "Hash a46102b5 for PR 28057 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/2375 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54924 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49584 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25181 "Build is in progress. Recent messages:") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/332 "Hash a46102b5 for PR 28057 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26439 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/2375 "") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10980 "Hash a46102b5 for PR 28057 does not build (failure)") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/27308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57064 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/26171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11722 "Passed tests") | 
<!--EWS-Status-Bubble-End-->