### PR TITLE
[UnifiedPDF] Move annotationsForFieldName to SPI

### DIFF
--- a/Source/WebKit/Platform/spi/Cocoa/PDFKitSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/PDFKitSPI.h
@@ -110,6 +110,7 @@
 -(instancetype)initWithProvider:(CGDataProviderRef)dataProvider;
 -(void)preloadDataOfPagesInRange:(NSRange)range onQueue:(dispatch_queue_t)queue completion:(void (^)(NSIndexSet* loadedPageIndexes))completionBlock;
 -(void)resetFormFields:(PDFActionResetForm *) action;
+- (NSArray *)annotationsForFieldName:(NSString *)fieldname;
 @property (readwrite, nonatomic) BOOL hasHighLatencyDataProvider;
 @end
 #endif // HAVE(INCREMENTAL_PDF_APIS)
@@ -117,7 +118,6 @@
 #if ENABLE(UNIFIED_PDF)
 @interface PDFDocument (IPI)
 - (PDFDestination *)namedDestination:(NSString *)name;
-- (NSArray *)annotationsForFieldName:(NSString *)fieldname;
 @end
 
 #if HAVE(COREGRAPHICS_WITH_PDF_AREA_OF_INTEREST_SUPPORT)


### PR DESCRIPTION
#### 0c9cc953c10789f59d1e30cf2cc6b7284f920e40
<pre>
[UnifiedPDF] Move annotationsForFieldName to SPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=273643">https://bugs.webkit.org/show_bug.cgi?id=273643</a>
<a href="https://rdar.apple.com/124102337">rdar://124102337</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/Platform/spi/Cocoa/PDFKitSPI.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c9cc953c10789f59d1e30cf2cc6b7284f920e40

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50238 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29531 "Hash 0c9cc953 for PR 28066 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53497 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/928 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35758 "Hash 0c9cc953 for PR 28066 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40991 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52337 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/35758 "Hash 0c9cc953 for PR 28066 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43243 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22090 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/35758 "Hash 0c9cc953 for PR 28066 does not build (failure)") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8616 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/35758 "Hash 0c9cc953 for PR 28066 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/557 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55082 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25334 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/488 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48391 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26595 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43428 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47414 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27459 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26327 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->