### PR TITLE
[UnifedPDF] Occasional crash at GraphicsLayerCA::setNeedsDisplayInRect() with slow-rendering PDFs

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -182,8 +182,11 @@ void UnifiedPDFPlugin::teardown()
 
     PDFPluginBase::teardown();
 
-    if (m_rootLayer)
-        m_rootLayer->removeFromParent();
+    GraphicsLayer::unparentAndClear(m_rootLayer);
+    GraphicsLayer::unparentAndClear(m_contentsLayer);
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+    GraphicsLayer::unparentAndClear(m_selectionLayer);
+#endif
 
     RefPtr page = this->page();
     if (m_scrollingNodeID && page) {


### PR DESCRIPTION
#### 593a44258e5e7a802caee79c99b7a31c807bb029
<pre>
[UnifedPDF] Occasional crash at GraphicsLayerCA::setNeedsDisplayInRect() with slow-rendering PDFs
<a href="https://bugs.webkit.org/show_bug.cgi?id=273661">https://bugs.webkit.org/show_bug.cgi?id=273661</a>
<a href="https://rdar.apple.com/127443945">rdar://127443945</a>

Reviewed by Abrar Rahman Protyasha.

We should use `unparentAndClear()` on the GraphicsLayers to both unparent them, and clear their
GraphicsLayerClient. Do this on the layers which draw content, since those are the ones whose
clients can get called after a delay.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::teardown):

Canonical link: <a href="https://commits.webkit.org/278298@main">https://commits.webkit.org/278298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c52e006398f419f9ed68a0f9332a67dc3ae8b69

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53380 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/812 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/367 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52221 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27078 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43139 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21999 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24488 "Build is in progress. Recent messages:") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8499 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46505 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/449 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54961 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25218 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26479 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43324 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10987 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27342 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->