### PR TITLE
Always log internal loader errors to stderr

### DIFF
--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -230,9 +230,6 @@ WTF_EXPORT_PRIVATE void WTFReportBacktraceWithPrefixAndPrintStream(WTF::PrintStr
 WTF_EXPORT_PRIVATE void WTFPrintBacktraceWithPrefixAndPrintStream(WTF::PrintStream&, void** stack, int size, const char* prefix);
 #endif
 WTF_EXPORT_PRIVATE void WTFPrintBacktrace(void** stack, int size);
-#if !RELEASE_LOG_DISABLED
-WTF_EXPORT_PRIVATE void WTFReleaseLogStackTrace(WTFLogChannel*);
-#endif
 
 WTF_EXPORT_PRIVATE bool WTFIsDebuggerAttached(void);
 
@@ -622,8 +619,6 @@ constexpr bool assertionFailureDueToUnreachableCode = false;
 #define RELEASE_LOG_WITH_LEVEL(channel, level, ...) ((void)0)
 #define RELEASE_LOG_WITH_LEVEL_IF(isAllowed, channel, level, ...) do { if (isAllowed) RELEASE_LOG_WITH_LEVEL(channel, level, __VA_ARGS__); } while (0)
 
-#define RELEASE_LOG_STACKTRACE(channel) ((void)0)
-
 #elif USE(OS_LOG)
 
 #define PUBLIC_LOG_STRING "{public}s"
@@ -702,13 +697,10 @@ constexpr bool assertionFailureDueToUnreachableCode = false;
 #endif
 
 #if !RELEASE_LOG_DISABLED
-#define RELEASE_LOG_STACKTRACE(channel) WTFReleaseLogStackTrace(&LOG_CHANNEL(channel))
 #define RELEASE_LOG_IF(isAllowed, channel, ...) do { if (isAllowed) RELEASE_LOG(channel, __VA_ARGS__); } while (0)
 #define RELEASE_LOG_ERROR_IF(isAllowed, channel, ...) do { if (isAllowed) RELEASE_LOG_ERROR(channel, __VA_ARGS__); } while (0)
 #define RELEASE_LOG_INFO_IF(isAllowed, channel, ...) do { if (isAllowed) RELEASE_LOG_INFO(channel, __VA_ARGS__); } while (0)
 #define RELEASE_LOG_DEBUG_IF(isAllowed, channel, ...) do { if (isAllowed) RELEASE_LOG_DEBUG(channel, __VA_ARGS__); } while (0)
-
-#define RELEASE_LOG_STACKTRACE(channel) WTFReleaseLogStackTrace(&LOG_CHANNEL(channel))
 #endif
 
 /* ALWAYS_LOG */

--- a/Source/WebCore/platform/graphics/cv/PixelBufferConformerCV.cpp
+++ b/Source/WebCore/platform/graphics/cv/PixelBufferConformerCV.cpp
@@ -31,11 +31,33 @@
 #include "ImageBufferUtilitiesCG.h"
 #include "Logging.h"
 #include <pal/spi/cg/CoreGraphicsSPI.h>
+#include <wtf/StackTrace.h>
 
 #include "CoreVideoSoftLink.h"
 #include "VideoToolboxSoftLink.h"
 
 namespace WebCore {
+
+#if RELEASE_LOG_DISABLED
+#define RELEASE_LOG_STACKTRACE(channel) ((void)0)
+#else
+static constexpr int kDefaultFramesToShow = 31;
+static constexpr int kDefaultFramesToSkip = 2;
+
+static void logStackTrace(WTFLogChannel* channel)
+{
+    void* stack[kDefaultFramesToShow + kDefaultFramesToSkip];
+    int frames = kDefaultFramesToShow + kDefaultFramesToSkip;
+    WTFGetBacktrace(stack, &frames);
+    StackTraceSymbolResolver { { stack, static_cast<size_t>(frames) } }.forEach([&](int frameNumber, void* stackFrame, const char* name) {
+        if (name)
+            os_log(channel->osLogChannel, "%-3d %p %{public}s", frameNumber, stackFrame, name);
+        else
+            os_log(channel->osLogChannel, "%-3d %p", frameNumber, stackFrame);
+    });
+}
+#define RELEASE_LOG_STACKTRACE(channel) logStackTrace(&LOG_CHANNEL(channel))
+#endif
 
 PixelBufferConformerCV::PixelBufferConformerCV(CFDictionaryRef attributes)
 {

--- a/Source/WebCore/platform/network/ResourceErrorBase.cpp
+++ b/Source/WebCore/platform/network/ResourceErrorBase.cpp
@@ -91,10 +91,13 @@ bool ResourceErrorBase::compare(const ResourceError& a, const ResourceError& b)
     return ResourceError::platformCompare(a, b);
 }
 
-ResourceError internalError(const URL& url)
+ResourceError createInternalError(const URL& url, ASCIILiteral filename, uint32_t line, ASCIILiteral functionName)
 {
-    RELEASE_LOG_ERROR(Loading, "Internal error called");
-    RELEASE_LOG_STACKTRACE(Loading);
+    // Always print internal errors to stderr so we have some chance to figure out what went wrong
+    // when an internal error occurs unexpectedly. Release logging is insufficient because internal
+    // errors occur unexpectedly and we don't want to require manual logging configuration in order
+    // to record them.
+    WTFReportError(filename.characters(), line, functionName.characters(), "WebKit encountered an internal error. This is a WebKit bug.");
 
     return ResourceError("WebKitErrorDomain"_s, 300, url, WEB_UI_STRING("WebKit encountered an internal error", "WebKitErrorInternal description"));
 }

--- a/Source/WebCore/platform/network/ResourceErrorBase.h
+++ b/Source/WebCore/platform/network/ResourceErrorBase.h
@@ -111,7 +111,11 @@ private:
     const ResourceError& asResourceError() const;
 };
 
-WEBCORE_EXPORT ResourceError internalError(const URL&);
+// FIXME: Replace this with std::source_location when libc++ on the macOS and iOS bots is new enough to support C++ 20.
+// WEBCORE_EXPORT ResourceError internalError(const URL&, std::source_location = std::source_location::current());
+WEBCORE_EXPORT ResourceError createInternalError(const URL&, ASCIILiteral filename, uint32_t line, ASCIILiteral functionName);
+#define internalError(url) createInternalError(url, ASCIILiteral::fromLiteralUnsafe(__FILE__), __LINE__, ASCIILiteral::fromLiteralUnsafe(__FUNCTION__))
+
 WEBCORE_EXPORT ResourceError badResponseHeadersError(const URL&);
 
 inline bool operator==(const ResourceError& a, const ResourceError& b) { return ResourceErrorBase::compare(a, b); }


### PR DESCRIPTION
#### 6ad266d724e52b52c46da253141d58173559079f
<pre>
Always log internal loader errors to stderr
<a href="https://bugs.webkit.org/show_bug.cgi?id=273662">https://bugs.webkit.org/show_bug.cgi?id=273662</a>

Reviewed by Philippe Normand.

Currently when WebKit encounters an internal error during loading, we
release log a stacktrace showing the location of the error. However,
there are several downsides:

 * Release stacktraces are generally very poor quality, so this is
   effectively useless. (On Linux, better backtraces are available if
   built with libbacktrace enabled, but libbacktrace has no releases, so
   I believe no Linux distros do this.)

 * The stacktrace is only logged to the system journal, not to stderr,
   so it&apos;s unlikely to actually be noticed.

 * I think it&apos;s only logged by default on Linux, because the journald
   implementation of WTFReleaseLogStackTrace ignores whether log
   channels are enabled. (I believe this is a bug in the Linux
   implementation of WTFReleaseLogStackTrace.)

 * Otherwise, release logging has to be enabled manually (using the
   defaults database on macOS, or environment variables on Linux), so
   naturally it won&apos;t ever be enabled when needed.

RELEASE_LOG_BACKTRACE is used from only two places:
ResourceErrorBase.cpp, when logging an internal error, and
PixelBufferConformerCV.cpp, which isn&apos;t built on Linux. This commit
removes the use of RELEASE_LOG_BACKTRACE from ResourceErrorBase.cpp.
Since there are no other remaining uses of RELEASE_LOG_BACKTRACE, and
since I don&apos;t like it, let&apos;s move the implementation to
PixelBufferConformerCV.cpp to discourage further use. This allows
simplifying it to assume use of os_log.

WebKit internal loader errors are bugs and worth printing more visibly
so we have a better chance to debug problems, especially sporadic or
unexpected problems that will naturally never occur when we are looking
for them with release logging manually enabled. The backtrace is
probably not really needed here anyway; it&apos;s probably generally
sufficient to just log the source file location. Here is what a sample
error message looks like for a fake error that I introduced for test
purposes:

ERROR: WebKit encountered an internal error. This is a WebKit bug.
/home/mcatanzaro/Projects/WebKit/Source/WebKit/WebProcess/gtk/WebProcessMainGtk.cpp(75) : virtual bool WebKit::WebProcessMainGtk::platformInitialize()

In contrast, the release backtrace that I found in my system journal
after encountering an internal error yesterday only tells me that the
problem lies somewhere in libwebkitgtk-6.0.so.4, which is not useful.

* Source/WTF/wtf/Assertions.cpp:
* Source/WTF/wtf/Assertions.h:
* Source/WebCore/platform/graphics/cv/PixelBufferConformerCV.cpp:
(WebCore::logStackTrace):
* Source/WebCore/platform/network/ResourceErrorBase.cpp:
(WebCore::createInternalError):
(WebCore::internalError): Deleted.
* Source/WebCore/platform/network/ResourceErrorBase.h:

Canonical link: <a href="https://commits.webkit.org/278778@main">https://commits.webkit.org/278778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fed5ccb3371d25640d8cbb705aa1ce454b16c3c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53762 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1193 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52806 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/843 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41197 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27459 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43484 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22305 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24866 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/743 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8881 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43836 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46849 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55351 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/50003 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25601 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/727 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26862 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43636 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11276 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27726 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57481 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26594 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11811 "Passed tests") | 
<!--EWS-Status-Bubble-End-->