### PR TITLE
transform-style:preserve-3d doesn't work across display:contents ancestors

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-014-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-014-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Reftest Reference</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <style>
+      div {
+        height: 100px;
+        width: 100px;
+        background: lime;
+      }
+    </style>
+  </head>
+  <body>
+    <div></div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-014.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-014.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Preserve-3D With display:contents intermediate</title>
+    <link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#transform-style-property">
+    <meta name="assert" content="This tests that when preserve-3d is specified,
+    a 90-degree rotation on the parent plus a 90-degree rotation on the child
+    cancel out, adding to a 180-degree rotation (which has no visible effect on
+    a lime square). This still happens despite an intermediary div with display:contents.
+    scale(2) is added to ensure that the test doesn't pass if the transforms are just ignored.">
+    <link rel="match" href="transform-lime-square-ref.html">
+  </head>
+  <body style="padding:25px">
+    <div style="transform: rotatex(90deg); transform-style: preserve-3d">
+      <div style="display: contents">
+        <div style="transform: rotatex(90deg) scale(2); width: 50px; height: 50px; background: lime"></div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2272,15 +2272,16 @@ webkit.org/b/259712 [ Monterey+ ] media/media-source/media-source-paint-after-di
 
 webkit.org/b/259190 http/tests/images/heic-as-heif.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/260224 [ Ventura+ ] compositing/geometry/clipped-out-perspective.html [ ImageOnlyFailure ]
-webkit.org/b/260224 [ Ventura+ ] compositing/overlap-blending/opacity-and-infinity.html [ ImageOnlyFailure ]
-webkit.org/b/260224 [ Ventura+ ] imported/w3c/web-platform-tests/css/css-transforms/perspective-split-by-zero-w.html [ ImageOnlyFailure ]
-webkit.org/b/260224 [ Ventura+ ] imported/w3c/web-platform-tests/css/css-transforms/preserve3d-and-filter-with-perspective.html [ ImageOnlyFailure ]
-webkit.org/b/260224 [ Ventura+ ] imported/w3c/web-platform-tests/css/css-transforms/preserve3d-pseudo-element.html [ ImageOnlyFailure ]
-webkit.org/b/260224 [ Ventura+ ] imported/w3c/web-platform-tests/css/css-transforms/transform-table-009.html [ ImageOnlyFailure ]
-webkit.org/b/260224 [ Ventura+ ] imported/w3c/web-platform-tests/css/css-transforms/transform-table-010.html [ ImageOnlyFailure ]
-webkit.org/b/260224 [ Ventura+ ] imported/w3c/web-platform-tests/css/css-transforms/transform-table-011.html [ ImageOnlyFailure ]
-webkit.org/b/260224 [ Ventura+ ] imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-011.html [ ImageOnlyFailure ]
+webkit.org/b/260224 [ Ventura ] compositing/geometry/clipped-out-perspective.html [ ImageOnlyFailure ]
+webkit.org/b/260224 [ Ventura ] compositing/overlap-blending/opacity-and-infinity.html [ ImageOnlyFailure ]
+webkit.org/b/260224 [ Ventura ] imported/w3c/web-platform-tests/css/css-transforms/perspective-split-by-zero-w.html [ ImageOnlyFailure ]
+webkit.org/b/260224 [ Ventura ] imported/w3c/web-platform-tests/css/css-transforms/preserve3d-and-filter-with-perspective.html [ ImageOnlyFailure ]
+webkit.org/b/260224 [ Ventura ] imported/w3c/web-platform-tests/css/css-transforms/preserve3d-pseudo-element.html [ ImageOnlyFailure ]
+webkit.org/b/260224 [ Ventura ] imported/w3c/web-platform-tests/css/css-transforms/transform-table-009.html [ ImageOnlyFailure ]
+webkit.org/b/260224 [ Ventura ] imported/w3c/web-platform-tests/css/css-transforms/transform-table-010.html [ ImageOnlyFailure ]
+webkit.org/b/260224 [ Ventura ] imported/w3c/web-platform-tests/css/css-transforms/transform-table-011.html [ ImageOnlyFailure ]
+webkit.org/b/260224 [ Ventura ] imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-011.html [ ImageOnlyFailure ]
+webkit.org/b/260224 [ Ventura ] imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-014.html [ ImageOnlyFailure ]
 
 webkit.org/b/130490 media/video-remote-control-playpause.html [ Pass Timeout Crash ]
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -4096,11 +4096,25 @@ Ref<HitTestingTransformState> RenderLayer::createLocalTransformState(RenderLayer
     return transformState.releaseNonNull();
 }
 
+static RefPtr<Element> flattenedParent(Element* element)
+{
+    if (!element)
+        return nullptr;
+    RefPtr parent = element->parentElementInComposedTree();
+    while (parent) {
+        if (parent->computedStyle()->display() != DisplayType::Contents)
+            break;
+        parent = parent->parentElementInComposedTree();
+    }
+    return parent;
+}
+
 bool RenderLayer::ancestorLayerIsDOMParent(const RenderLayer* ancestor) const
 {
     if (!ancestor)
         return false;
-    if (renderer().element() && ancestor->renderer().element() == renderer().element()->parentElementInComposedTree())
+    auto parent = flattenedParent(renderer().element());
+    if (parent && ancestor->renderer().element() == parent)
         return true;
 
     std::optional<PseudoId> parentPseudoId = parentPseudoElement(renderer().style().pseudoElementType());


### PR DESCRIPTION
#### adf1f00fb1ff19e7927fb3f519fe19e7d99caf22
<pre>
transform-style:preserve-3d doesn&apos;t work across display:contents ancestors
<a href="https://bugs.webkit.org/show_bug.cgi?id=273627">https://bugs.webkit.org/show_bug.cgi?id=273627</a>
&lt;<a href="https://rdar.apple.com/127468969">rdar://127468969</a>&gt;

Reviewed by Alan Baradlay.

When looking for the ancestor element to see if it has &apos;preserve-3d&apos;, any intermediate
ancestors with display:contents should be skipped.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-014-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-014.html: Added.
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::flattenedParent):
(WebCore::RenderLayer::ancestorLayerIsDOMParent const):

Canonical link: <a href="https://commits.webkit.org/278499@main">https://commits.webkit.org/278499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8e6277a1f260b0f4f6e361bec15ce80bac64ba2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53950 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1382 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1032 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41312 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52790 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43666 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22430 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/50542 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25017 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/922 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9132 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/44027 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46998 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/984 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55540 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/50194 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25793 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/882 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48726 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/50712 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27050 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/43793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47787 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11122 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27918 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57669 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26782 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11869 "Passed tests") | 
<!--EWS-Status-Bubble-End-->