### PR TITLE
WebCore::XMLDocumentParserScope does not restore xmlStructuredErrorContext properly

### DIFF
--- a/Source/WebCore/xml/parser/XMLDocumentParserScope.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserScope.cpp
@@ -39,7 +39,7 @@ WeakPtr<CachedResourceLoader>& XMLDocumentParserScope::currentCachedResourceLoad
 
 #if ENABLE(XSLT)
 XMLDocumentParserScope::XMLDocumentParserScope(CachedResourceLoader* cachedResourceLoader)
-    : XMLDocumentParserScope(cachedResourceLoader, xmlGenericError, xmlStructuredError, xmlGenericErrorContext)
+    : XMLDocumentParserScope(cachedResourceLoader, xmlGenericError, xmlStructuredError, xmlGenericErrorContext, xmlStructuredErrorContext)
 {
 }
 #else
@@ -54,20 +54,21 @@ XMLDocumentParserScope::XMLDocumentParserScope(CachedResourceLoader* cachedResou
 #endif // ENABLE(XSLT)
 
 #if ENABLE(XSLT)
-XMLDocumentParserScope::XMLDocumentParserScope(CachedResourceLoader* cachedResourceLoader, xmlGenericErrorFunc genericErrorFunc, xmlStructuredErrorFunc structuredErrorFunc, void* errorContext)
+XMLDocumentParserScope::XMLDocumentParserScope(CachedResourceLoader* cachedResourceLoader, xmlGenericErrorFunc genericErrorFunc, xmlStructuredErrorFunc structuredErrorFunc, void* genericErrorContext, void* structuredErrorContext)
     : m_oldCachedResourceLoader(currentCachedResourceLoader())
     , m_oldGenericErrorFunc(xmlGenericError)
     , m_oldStructuredErrorFunc(xmlStructuredError)
-    , m_oldErrorContext(xmlGenericErrorContext)
+    , m_oldGenericErrorContext(xmlGenericErrorContext)
+    , m_oldStructuredErrorContext(xmlStructuredErrorContext)
 {
     initializeXMLParser();
     m_oldEntityLoader = xmlGetExternalEntityLoader();
     currentCachedResourceLoader() = cachedResourceLoader;
     xmlSetExternalEntityLoader(WebCore::externalEntityLoader);
     if (genericErrorFunc)
-        xmlSetGenericErrorFunc(errorContext, genericErrorFunc);
+        xmlSetGenericErrorFunc(genericErrorContext, genericErrorFunc);
     if (structuredErrorFunc)
-        xmlSetStructuredErrorFunc(errorContext, structuredErrorFunc);
+        xmlSetStructuredErrorFunc(structuredErrorContext ?: genericErrorContext, structuredErrorFunc);
 }
 #endif
 
@@ -76,8 +77,8 @@ XMLDocumentParserScope::~XMLDocumentParserScope()
     currentCachedResourceLoader() = m_oldCachedResourceLoader;
     xmlSetExternalEntityLoader(m_oldEntityLoader);
 #if ENABLE(XSLT)
-    xmlSetGenericErrorFunc(m_oldErrorContext, m_oldGenericErrorFunc);
-    xmlSetStructuredErrorFunc(m_oldErrorContext, m_oldStructuredErrorFunc);
+    xmlSetGenericErrorFunc(m_oldGenericErrorContext, m_oldGenericErrorFunc);
+    xmlSetStructuredErrorFunc(m_oldStructuredErrorContext, m_oldStructuredErrorFunc);
 #endif
 }
 

--- a/Source/WebCore/xml/parser/XMLDocumentParserScope.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParserScope.h
@@ -47,7 +47,7 @@ public:
     static WeakPtr<CachedResourceLoader>& currentCachedResourceLoader();
 
 #if ENABLE(XSLT)
-    XMLDocumentParserScope(CachedResourceLoader*, xmlGenericErrorFunc, xmlStructuredErrorFunc = nullptr, void* errorContext = nullptr);
+    XMLDocumentParserScope(CachedResourceLoader*, xmlGenericErrorFunc, xmlStructuredErrorFunc = nullptr, void* genericErrorContext = nullptr, void* structuredErrorContext = nullptr);
 #endif
 
 private:
@@ -57,7 +57,8 @@ private:
 #if ENABLE(XSLT)
     xmlGenericErrorFunc m_oldGenericErrorFunc { nullptr };
     xmlStructuredErrorFunc m_oldStructuredErrorFunc { nullptr };
-    void* m_oldErrorContext { nullptr };
+    void* m_oldGenericErrorContext { nullptr };
+    void* m_oldStructuredErrorContext { nullptr };
 #endif
 };
 


### PR DESCRIPTION
#### c864765c693d31b70ece9a455e7b82b413041a6a
<pre>
WebCore::XMLDocumentParserScope does not restore xmlStructuredErrorContext properly
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=273665">https://bugs.webkit.org/show_bug.cgi?id=273665</a>&gt;
&lt;<a href="https://rdar.apple.com/127468626">rdar://127468626</a>&gt;

Reviewed by Alex Christensen.

Prior to this change, XMLDocumentParserScope would restore
xmlStructuredErrorContext using the saved value of
xmlGenericErrorContext.

The fix is to store the original value of xmlStructuredErrorContext in
its own instance variable so it can be restored separately.

If the structuredErrorContext parameter is not set when calling the
XMLDocumentParserScope() constructor, the value of genericErrorContext
is used for structuredErrorContext (as before).

API Test:
    TestWebKitAPI.XMLParsing.WebCoreRestoresLibxml2GenericAndStructuredErrorState

* Source/WebCore/xml/parser/XMLDocumentParserScope.cpp:
(WebCore::XMLDocumentParserScope::XMLDocumentParserScope):
- Add structuredErrorContext argument to constructor so that the
  single-argument constructor can pass in the correct value.
- Store xmlStructuredErrorContext in m_oldStructuredErrorContext.
- Set the structuredErrorContext using that argument, or fall back to
  genericErrorContext if structuredErrorContext is nullptr.
(WebCore::XMLDocumentParserScope::~XMLDocumentParserScope):
- Properly restore saved structuredErrorContext in
  m_oldStructuredErrorContext in the destructor.
* Source/WebCore/xml/parser/XMLDocumentParserScope.h:
(WebCore::XMLDocumentParserScope::XMLDocumentParserScope):
- Declare optional structuredErrorContext argument.
- Rename m_oldErrorContext to m_oldGenericErrorContext.
- Add m_oldStructuredErrorContext.

* Tools/TestWebKitAPI/Tests/WebCore/cocoa/XMLParsing.mm:
(TestWebKitAPI::TEST_F(XMLParsing, WebCoreRestoresLibxml2GenericAndStructuredErrorState)): Add.
- Add test for this change.

Canonical link: <a href="https://commits.webkit.org/278436@main">https://commits.webkit.org/278436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3062d551b5c5a85749e86c9fec014a8f2814cf06

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53783 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1214 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52827 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36069 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41198 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27471 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43496 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22306 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24875 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/755 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8902 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46859 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/816 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55372 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25622 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/737 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48608 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26883 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47655 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27747 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7318 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26615 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->