### PR TITLE
[JSC] Clean up InlineCacheCompiler and fix stub lifetime

### DIFF
--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -1213,10 +1213,129 @@ void AccessCase::dump(PrintStream& out) const
 
 bool AccessCase::visitWeak(VM& vm) const
 {
-    if (isAccessor()) {
+    switch (type()) {
+    case Getter:
+    case Setter: {
         auto& accessor = this->as<GetterSetterAccessCase>();
         if (accessor.callLinkInfo())
             accessor.callLinkInfo()->visitWeak(vm);
+        break;
+    }
+    case ProxyObjectHas:
+    case ProxyObjectLoad:
+    case ProxyObjectStore:
+    case IndexedProxyObjectLoad: {
+        auto& accessor = this->as<ProxyObjectAccessCase>();
+        if (accessor.callLinkInfo())
+            accessor.callLinkInfo()->visitWeak(vm);
+        break;
+    }
+    case CustomValueGetter:
+    case CustomValueSetter:
+    case IntrinsicGetter:
+    case ModuleNamespaceLoad:
+    case InstanceOfHit:
+    case InstanceOfMiss:
+    case CustomAccessorGetter:
+    case CustomAccessorSetter:
+    case Load:
+    case LoadMegamorphic:
+    case StoreMegamorphic:
+    case InMegamorphic:
+    case Transition:
+    case Delete:
+    case DeleteNonConfigurable:
+    case DeleteMiss:
+    case Replace:
+    case Miss:
+    case GetGetter:
+    case InHit:
+    case InMiss:
+    case CheckPrivateBrand:
+    case SetPrivateBrand:
+    case ArrayLength:
+    case StringLength:
+    case DirectArgumentsLength:
+    case ScopedArgumentsLength:
+    case InstanceOfGeneric:
+    case IndexedMegamorphicLoad:
+    case IndexedMegamorphicStore:
+    case IndexedMegamorphicIn:
+    case IndexedInt32Load:
+    case IndexedDoubleLoad:
+    case IndexedContiguousLoad:
+    case IndexedArrayStorageLoad:
+    case IndexedScopedArgumentsLoad:
+    case IndexedDirectArgumentsLoad:
+    case IndexedTypedArrayInt8Load:
+    case IndexedTypedArrayUint8Load:
+    case IndexedTypedArrayUint8ClampedLoad:
+    case IndexedTypedArrayInt16Load:
+    case IndexedTypedArrayUint16Load:
+    case IndexedTypedArrayInt32Load:
+    case IndexedTypedArrayUint32Load:
+    case IndexedTypedArrayFloat32Load:
+    case IndexedTypedArrayFloat64Load:
+    case IndexedResizableTypedArrayInt8Load:
+    case IndexedResizableTypedArrayUint8Load:
+    case IndexedResizableTypedArrayUint8ClampedLoad:
+    case IndexedResizableTypedArrayInt16Load:
+    case IndexedResizableTypedArrayUint16Load:
+    case IndexedResizableTypedArrayInt32Load:
+    case IndexedResizableTypedArrayUint32Load:
+    case IndexedResizableTypedArrayFloat32Load:
+    case IndexedResizableTypedArrayFloat64Load:
+    case IndexedStringLoad:
+    case IndexedNoIndexingMiss:
+    case IndexedInt32Store:
+    case IndexedDoubleStore:
+    case IndexedContiguousStore:
+    case IndexedArrayStorageStore:
+    case IndexedTypedArrayInt8Store:
+    case IndexedTypedArrayUint8Store:
+    case IndexedTypedArrayUint8ClampedStore:
+    case IndexedTypedArrayInt16Store:
+    case IndexedTypedArrayUint16Store:
+    case IndexedTypedArrayInt32Store:
+    case IndexedTypedArrayUint32Store:
+    case IndexedTypedArrayFloat32Store:
+    case IndexedTypedArrayFloat64Store:
+    case IndexedResizableTypedArrayInt8Store:
+    case IndexedResizableTypedArrayUint8Store:
+    case IndexedResizableTypedArrayUint8ClampedStore:
+    case IndexedResizableTypedArrayInt16Store:
+    case IndexedResizableTypedArrayUint16Store:
+    case IndexedResizableTypedArrayInt32Store:
+    case IndexedResizableTypedArrayUint32Store:
+    case IndexedResizableTypedArrayFloat32Store:
+    case IndexedResizableTypedArrayFloat64Store:
+    case IndexedInt32InHit:
+    case IndexedDoubleInHit:
+    case IndexedContiguousInHit:
+    case IndexedArrayStorageInHit:
+    case IndexedScopedArgumentsInHit:
+    case IndexedDirectArgumentsInHit:
+    case IndexedTypedArrayInt8InHit:
+    case IndexedTypedArrayUint8InHit:
+    case IndexedTypedArrayUint8ClampedInHit:
+    case IndexedTypedArrayInt16InHit:
+    case IndexedTypedArrayUint16InHit:
+    case IndexedTypedArrayInt32InHit:
+    case IndexedTypedArrayUint32InHit:
+    case IndexedTypedArrayFloat32InHit:
+    case IndexedTypedArrayFloat64InHit:
+    case IndexedResizableTypedArrayInt8InHit:
+    case IndexedResizableTypedArrayUint8InHit:
+    case IndexedResizableTypedArrayUint8ClampedInHit:
+    case IndexedResizableTypedArrayInt16InHit:
+    case IndexedResizableTypedArrayUint16InHit:
+    case IndexedResizableTypedArrayInt32InHit:
+    case IndexedResizableTypedArrayUint32InHit:
+    case IndexedResizableTypedArrayFloat32InHit:
+    case IndexedResizableTypedArrayFloat64InHit:
+    case IndexedStringInHit:
+    case IndexedNoIndexingInMiss:
+        break;
     }
 
     bool isValid = true;

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -775,7 +775,7 @@ void CodeBlock::setupWithUnlinkedBaselineCode(Ref<BaselineJITCode> jitCode)
         for (unsigned index = 0; index < jitCode->m_unlinkedStubInfos.size(); ++index) {
             BaselineUnlinkedStructureStubInfo& unlinkedStubInfo = jitCode->m_unlinkedStubInfos[index];
             auto& stubInfo = baselineJITData->stubInfo(index);
-            stubInfo.initializeFromUnlinkedStructureStubInfo(vm(), unlinkedStubInfo);
+            stubInfo.initializeFromUnlinkedStructureStubInfo(vm(), this, unlinkedStubInfo);
         }
 
         for (size_t i = 0; i < jitCode->m_constantPool.size(); ++i) {

--- a/Source/JavaScriptCore/bytecode/InlineAccess.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineAccess.cpp
@@ -394,29 +394,6 @@ bool InlineAccess::generateSelfInAccess(CodeBlock* codeBlock, StructureStubInfo&
     return linkCodeInline("in access", jit, stubInfo);
 }
 
-void InlineAccess::rewireStubAsJumpInAccess(CodeBlock* codeBlock, StructureStubInfo& stubInfo, InlineCacheHandler& handler)
-{
-    stubInfo.m_handler = &handler;
-    if (codeBlock->useDataIC()) {
-        stubInfo.m_codePtr = handler.callTarget();
-        stubInfo.m_inlineAccessBaseStructureID.clear(); // Clear out the inline access code.
-        return;
-    }
-
-    CCallHelpers::replaceWithJump(stubInfo.startLocation.retagged<JSInternalPtrTag>(), CodeLocationLabel { handler.callTarget() });
-}
-
-void InlineAccess::resetStubAsJumpInAccess(CodeBlock* codeBlock, StructureStubInfo& stubInfo)
-{
-    if (JITCode::isBaselineCode(codeBlock->jitType()) && Options::useHandlerIC()) {
-        auto handler = InlineCacheCompiler::generateSlowPathHandler(codeBlock->vm(), stubInfo.accessType);
-        InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, handler.get());
-        return;
-    }
-    auto handler = InlineCacheHandler::createNonHandlerSlowPath(stubInfo.slowPathStartLocation);
-    InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, handler.get());
-}
-
 } // namespace JSC
 
 #endif // ENABLE(JIT)

--- a/Source/JavaScriptCore/bytecode/InlineAccess.h
+++ b/Source/JavaScriptCore/bytecode/InlineAccess.h
@@ -106,9 +106,6 @@ public:
     static bool generateSelfInAccess(CodeBlock*, StructureStubInfo&, Structure*);
     static bool generateStringLength(CodeBlock*, StructureStubInfo&);
 
-    static void rewireStubAsJumpInAccess(CodeBlock*, StructureStubInfo&, InlineCacheHandler&);
-    static void resetStubAsJumpInAccess(CodeBlock*, StructureStubInfo&);
-
     // This is helpful when determining the size of an IC on
     // various platforms. When adding a new type of IC, implement
     // its placeholder code here, and log the size. That way we

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -191,6 +191,9 @@ public:
 
     static Ref<InlineCacheHandler> createNonHandlerSlowPath(CodePtr<JITStubRoutinePtrTag>);
 
+    void addOwner(CodeBlock*);
+    void removeOwner(CodeBlock*);
+
 private:
     InlineCacheHandler() = default;
     InlineCacheHandler(Ref<PolymorphicAccessJITStubRoutine>&&, std::unique_ptr<StructureStubInfoClearingWatchpoint>&&);
@@ -344,8 +347,6 @@ private:
     ScratchRegisterAllocator::PreservedState m_preservedReusedRegisterState;
     GPRReg m_scratchGPR { InvalidGPRReg };
     FPRReg m_scratchFPR { InvalidFPRReg };
-    Vector<StructureID> m_weakStructures;
-    Vector<ObjectPropertyCondition> m_conditions;
     Bag<OptimizingCallLinkInfo> m_callLinkInfos;
     ScalarRegisterSet m_liveRegistersToPreserveAtExceptionHandlingCallSite;
     ScalarRegisterSet m_liveRegistersForCall;
@@ -356,6 +357,8 @@ private:
     bool m_calculatedCallSiteIndex : 1 { false };
     bool m_doesJSCalls : 1 { false };
     bool m_doesCalls : 1 { false };
+    Vector<StructureID, 4> m_weakStructures;
+    Vector<ObjectPropertyCondition, 64> m_conditions;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -517,10 +517,8 @@ static InlineCacheAction tryCacheGetBy(JSGlobalObject* globalObject, CodeBlock* 
 
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), propertyName, WTFMove(newCase));
 
-        if (result.generatedSomeCode()) {
+        if (result.generatedSomeCode())
             LOG_IC((ICEvent::GetByReplaceWithJump, baseValue.classInfoOrNull(), Identifier::fromUid(vm, propertyName.uid()), slot.slotBase() == baseValue));
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
-        }
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -686,10 +684,8 @@ static InlineCacheAction tryCacheArrayGetByVal(JSGlobalObject* globalObject, Cod
 
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), nullptr, newCase.releaseNonNull());
 
-        if (result.generatedSomeCode()) {
+        if (result.generatedSomeCode())
             LOG_IC((ICEvent::GetByReplaceWithJump, baseValue.classInfoOrNull(), Identifier()));
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
-        }
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -1022,10 +1018,8 @@ static InlineCacheAction tryCachePutBy(JSGlobalObject* globalObject, CodeBlock* 
         
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, slot.isStrictMode() ? ECMAMode::strict() : ECMAMode::sloppy(), propertyName, WTFMove(newCase));
 
-        if (result.generatedSomeCode()) {
+        if (result.generatedSomeCode())
             LOG_IC((ICEvent::PutByReplaceWithJump, oldStructure->classInfoForCells(), ident, slot.base() == baseValue));
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
-        }
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -1150,10 +1144,8 @@ static InlineCacheAction tryCacheArrayPutByVal(JSGlobalObject* globalObject, Cod
         GCSafeConcurrentJSLocker locker(codeBlock->m_lock, globalObject->vm());
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, ecmaModeFor(putByKind), nullptr, AccessCase::create(vm, codeBlock, accessType, nullptr));
 
-        if (result.generatedSomeCode()) {
+        if (result.generatedSomeCode())
             LOG_IC((ICEvent::PutByReplaceWithJump, baseValue.classInfoOrNull(), Identifier()));
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
-        }
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -1225,10 +1217,8 @@ static InlineCacheAction tryCacheDeleteBy(JSGlobalObject* globalObject, CodeBloc
 
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, ecmaMode, propertyName, WTFMove(newCase));
 
-        if (result.generatedSomeCode()) {
+        if (result.generatedSomeCode())
             LOG_IC((ICEvent::DelByReplaceWithJump, oldStructure->classInfoForCells(), Identifier::fromUid(vm, propertyName.uid())));
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
-        }
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -1389,10 +1379,8 @@ static InlineCacheAction tryCacheInBy(
 
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), propertyName, WTFMove(newCase));
 
-        if (result.generatedSomeCode()) {
+        if (result.generatedSomeCode())
             LOG_IC((ICEvent::InReplaceWithJump, structure->classInfoForCells(), ident, slot.slotBase() == base));
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
-        }
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -1456,10 +1444,8 @@ static InlineCacheAction tryCacheHasPrivateBrand(JSGlobalObject* globalObject, C
 
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), brandID, WTFMove(newCase));
 
-        if (result.generatedSomeCode()) {
+        if (result.generatedSomeCode())
             LOG_IC((ICEvent::InReplaceWithJump, structure->classInfoForCells(), ident, isBaseProperty));
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
-        }
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -1501,10 +1487,8 @@ static InlineCacheAction tryCacheCheckPrivateBrand(
 
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), brandID, WTFMove(newCase));
 
-        if (result.generatedSomeCode()) {
+        if (result.generatedSomeCode())
             LOG_IC((ICEvent::CheckPrivateBrandReplaceWithJump, structure->classInfoForCells(), ident, isBaseProperty));
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
-        }
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -1558,10 +1542,8 @@ static InlineCacheAction tryCacheSetPrivateBrand(
 
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), brandID, WTFMove(newCase));
 
-        if (result.generatedSomeCode()) {
+        if (result.generatedSomeCode())
             LOG_IC((ICEvent::SetPrivateBrandReplaceWithJump, oldStructure->classInfoForCells(), ident, isBaseProperty));
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
-        }
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -1623,11 +1605,9 @@ static InlineCacheAction tryCacheInstanceOf(
         LOG_IC((ICEvent::InstanceOfAddAccessCase, structure->classInfoForCells(), Identifier()));
         
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), nullptr, WTFMove(newCase));
-        
-        if (result.generatedSomeCode()) {
+
+        if (result.generatedSomeCode())
             LOG_IC((ICEvent::InstanceOfReplaceWithJump, structure->classInfoForCells(), Identifier()));
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
-        }
     }
     
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -1748,9 +1728,6 @@ static InlineCacheAction tryCacheArrayInByVal(JSGlobalObject* globalObject, Code
             newCase = AccessCase::create(vm, codeBlock, accessType, nullptr);
 
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), nullptr, newCase.releaseNonNull());
-
-        if (result.generatedSomeCode())
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -2050,7 +2027,7 @@ void linkPolymorphicCall(VM& vm, JSCell* owner, CallFrame* callFrame, CallLinkIn
 void resetGetBy(CodeBlock* codeBlock, StructureStubInfo& stubInfo, GetByKind kind)
 {
     repatchSlowPathCall(codeBlock, stubInfo, appropriateGetByOptimizeFunction(kind));
-    InlineAccess::resetStubAsJumpInAccess(codeBlock, stubInfo);
+    stubInfo.resetStubAsJumpInAccess(codeBlock);
 }
 
 void resetPutBy(CodeBlock* codeBlock, StructureStubInfo& stubInfo, PutByKind kind)
@@ -2096,7 +2073,7 @@ void resetPutBy(CodeBlock* codeBlock, StructureStubInfo& stubInfo, PutByKind kin
     }
 
     repatchSlowPathCall(codeBlock, stubInfo, optimizedFunction);
-    InlineAccess::resetStubAsJumpInAccess(codeBlock, stubInfo);
+    stubInfo.resetStubAsJumpInAccess(codeBlock);
 }
 
 void resetDelBy(CodeBlock* codeBlock, StructureStubInfo& stubInfo, DelByKind kind)
@@ -2115,37 +2092,37 @@ void resetDelBy(CodeBlock* codeBlock, StructureStubInfo& stubInfo, DelByKind kin
         repatchSlowPathCall(codeBlock, stubInfo, operationDeleteByValSloppyOptimize);
         break;
     }
-    InlineAccess::resetStubAsJumpInAccess(codeBlock, stubInfo);
+    stubInfo.resetStubAsJumpInAccess(codeBlock);
 }
 
 void resetInBy(CodeBlock* codeBlock, StructureStubInfo& stubInfo, InByKind kind)
 {
     repatchSlowPathCall(codeBlock, stubInfo, appropriateInByOptimizeFunction(kind));
-    InlineAccess::resetStubAsJumpInAccess(codeBlock, stubInfo);
+    stubInfo.resetStubAsJumpInAccess(codeBlock);
 }
 
 void resetHasPrivateBrand(CodeBlock* codeBlock, StructureStubInfo& stubInfo)
 {
     repatchSlowPathCall(codeBlock, stubInfo, operationHasPrivateBrandOptimize);
-    InlineAccess::resetStubAsJumpInAccess(codeBlock, stubInfo);
+    stubInfo.resetStubAsJumpInAccess(codeBlock);
 }
 
 void resetInstanceOf(CodeBlock* codeBlock, StructureStubInfo& stubInfo)
 {
     repatchSlowPathCall(codeBlock, stubInfo, operationInstanceOfOptimize);
-    InlineAccess::resetStubAsJumpInAccess(codeBlock, stubInfo);
+    stubInfo.resetStubAsJumpInAccess(codeBlock);
 }
 
 void resetCheckPrivateBrand(CodeBlock* codeBlock, StructureStubInfo& stubInfo)
 {
     repatchSlowPathCall(codeBlock, stubInfo, operationCheckPrivateBrandOptimize);
-    InlineAccess::resetStubAsJumpInAccess(codeBlock, stubInfo);
+    stubInfo.resetStubAsJumpInAccess(codeBlock);
 }
 
 void resetSetPrivateBrand(CodeBlock* codeBlock, StructureStubInfo& stubInfo)
 {
     repatchSlowPathCall(codeBlock, stubInfo, operationSetPrivateBrandOptimize);
-    InlineAccess::resetStubAsJumpInAccess(codeBlock, stubInfo);
+    stubInfo.resetStubAsJumpInAccess(codeBlock);
 }
 
 #endif

--- a/Source/JavaScriptCore/bytecode/SharedJITStubSet.h
+++ b/Source/JavaScriptCore/bytecode/SharedJITStubSet.h
@@ -109,7 +109,7 @@ public:
         };
 
         StructureStubInfoKey m_stubInfoKey;
-        const FixedVector<RefPtr<AccessCase>>& m_cases;
+        std::span<const RefPtr<AccessCase>> m_cases;
     };
 
     struct PointerTranslator {

--- a/Source/JavaScriptCore/bytecode/StructureStubInfo.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubInfo.h
@@ -141,8 +141,8 @@ public:
     void deref();
     void aboutToDie();
 
-    void initializeFromUnlinkedStructureStubInfo(VM&, const BaselineUnlinkedStructureStubInfo&);
-    void initializeFromDFGUnlinkedStructureStubInfo(const DFG::UnlinkedStructureStubInfo&);
+    void initializeFromUnlinkedStructureStubInfo(VM&, CodeBlock*, const BaselineUnlinkedStructureStubInfo&);
+    void initializeFromDFGUnlinkedStructureStubInfo(CodeBlock*, const DFG::UnlinkedStructureStubInfo&);
 
     DECLARE_VISIT_AGGREGATE;
 
@@ -365,6 +365,9 @@ private:
         CacheableIdentifier m_byValId;
     };
 
+    void replaceHandler(CodeBlock*, Ref<InlineCacheHandler>&&);
+    void rewireStubAsJumpInAccess(CodeBlock*, InlineCacheHandler&);
+
 public:
     static ptrdiff_t offsetOfByIdSelfOffset() { return OBJECT_OFFSETOF(StructureStubInfo, byIdSelfOffset); }
     static ptrdiff_t offsetOfInlineAccessBaseStructureID() { return OBJECT_OFFSETOF(StructureStubInfo, m_inlineAccessBaseStructureID); }
@@ -375,6 +378,8 @@ public:
     static ptrdiff_t offsetOfCountdown() { return OBJECT_OFFSETOF(StructureStubInfo, countdown); }
     static ptrdiff_t offsetOfCallSiteIndex() { return OBJECT_OFFSETOF(StructureStubInfo, callSiteIndex); }
     static ptrdiff_t offsetOfHandler() { return OBJECT_OFFSETOF(StructureStubInfo, m_handler); }
+
+    void resetStubAsJumpInAccess(CodeBlock*);
 
     GPRReg thisGPR() const { return m_extraGPR; }
     GPRReg prototypeGPR() const { return m_extraGPR; }
@@ -420,8 +425,8 @@ public:
 
     CodePtr<JITStubRoutinePtrTag> m_codePtr;
     std::unique_ptr<PolymorphicAccess> m_stub;
-    RefPtr<InlineCacheHandler> m_handler;
 private:
+    RefPtr<InlineCacheHandler> m_handler;
     // Represents those structures that already have buffered AccessCases in the PolymorphicAccess.
     // Note that it's always safe to clear this. If we clear it prematurely, then if we see the same
     // structure again during this buffering countdown, we will create an AccessCase object for it.

--- a/Source/JavaScriptCore/dfg/DFGJITCode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.cpp
@@ -94,7 +94,7 @@ bool JITData::tryInitialize(VM& vm, CodeBlock* codeBlock, const JITCode& jitCode
 
     for (unsigned index = 0; index < jitCode.m_unlinkedStubInfos.size(); ++index) {
         const UnlinkedStructureStubInfo& unlinkedStubInfo = jitCode.m_unlinkedStubInfos[index];
-        stubInfo(index).initializeFromDFGUnlinkedStructureStubInfo(unlinkedStubInfo);
+        stubInfo(index).initializeFromDFGUnlinkedStructureStubInfo(codeBlock, unlinkedStubInfo);
     }
 
     unsigned indexOfWatchpoints = 0;

--- a/Source/JavaScriptCore/heap/JITStubRoutineSet.cpp
+++ b/Source/JavaScriptCore/heap/JITStubRoutineSet.cpp
@@ -126,8 +126,8 @@ void JITStubRoutineSet::deleteUnmarkedJettisonedStubRoutines(VM& vm)
     while (srcIndex < m_routines.size()) {
         Routine routine = m_routines[srcIndex++];
         auto* stub = routine.routine;
-        if (!stub->m_ownerIsDead && stub->owner())
-            stub->m_ownerIsDead = !vm.heap.isMarked(stub->owner());
+        if (!stub->m_ownerIsDead)
+            stub->m_ownerIsDead = stub->removeDeadOwners(vm);
 
         // If the stub is running right now, we should keep it alive regardless of whether owner CodeBlock gets dead.
         // It is OK since we already marked all the related cells.

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
@@ -73,6 +73,8 @@ public:
     void makeGCAware(VM&, bool isCodeImmutable);
 
     JSCell* owner() const { return m_owner; }
+
+    bool removeDeadOwners(VM&);
     
 protected:
     void observeZeroRefCountImpl();
@@ -92,6 +94,7 @@ class PolymorphicAccessJITStubRoutine : public GCAwareJITStubRoutine {
 public:
     using Base = GCAwareJITStubRoutine;
     friend class JITStubRoutine;
+    friend class GCAwareJITStubRoutine;
 
     PolymorphicAccessJITStubRoutine(Type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&, FixedVector<RefPtr<AccessCase>>&&, FixedVector<StructureID>&&, JSCell* owner);
     ~PolymorphicAccessJITStubRoutine();
@@ -106,9 +109,10 @@ public:
         return m_hash;
     }
 
-    static unsigned computeHash(const FixedVector<RefPtr<AccessCase>>&);
+    static unsigned computeHash(std::span<const RefPtr<AccessCase>>);
 
     void addedToSharedJITStubSet();
+
 
     const WatchpointsOnStructureStubInfo* watchpoints() const { return m_watchpoints.get(); }
     void setWatchpoints(std::unique_ptr<WatchpointsOnStructureStubInfo>&&);
@@ -119,7 +123,21 @@ public:
     {
         if (!m_watchpointSet)
             return false;
-        return m_watchpointSet->isStillValid();
+        if (!m_watchpointSet->isStillValid())
+            return false;
+        return !m_ownerIsDead;
+    }
+
+    void addOwner(CodeBlock* codeBlock)
+    {
+        if (m_isInSharedJITStubSet)
+            m_owners.add(codeBlock);
+    }
+
+    void removeOwner(CodeBlock* codeBlock)
+    {
+        if (m_isInSharedJITStubSet)
+            m_owners.remove(codeBlock);
     }
 
 protected:
@@ -130,6 +148,7 @@ private:
     FixedVector<RefPtr<AccessCase>> m_cases;
     FixedVector<StructureID> m_weakStructures;
     RefPtr<WatchpointSet> m_watchpointSet;
+    HashCountedSet<CodeBlock*> m_owners;
     std::unique_ptr<WatchpointsOnStructureStubInfo> m_watchpoints;
 };
 

--- a/Source/WTF/wtf/FixedVector.h
+++ b/Source/WTF/wtf/FixedVector.h
@@ -192,6 +192,19 @@ public:
 
     Storage* storage() { return m_storage.get(); }
 
+    std::span<const T> span() const { return { data(), size() }; }
+    std::span<T> mutableSpan() { return { data(), size() }; }
+
+    Vector<T> subvector(size_t offset, size_t length = std::dynamic_extent) const
+    {
+        return { span().subspan(offset, length) };
+    }
+
+    std::span<const T> subspan(size_t offset, size_t length = std::dynamic_extent) const
+    {
+        return span().subspan(offset, length);
+    }
+
 private:
     friend class JSC::LLIntOffsetsExtractor;
 

--- a/Source/WTF/wtf/HashCountedSet.h
+++ b/Source/WTF/wtf/HashCountedSet.h
@@ -100,6 +100,9 @@ public:
     bool removeAll(iterator);
     bool removeAll(const ValueType&);
 
+    template<typename Functor>
+    bool removeAllIf(const Functor&);
+
     // Clears the whole set.
     void clear();
 
@@ -278,6 +281,13 @@ inline bool HashCountedSet<Value, HashFunctions, Traits>::removeAll(iterator it)
 
     m_impl.remove(it);
     return true;
+}
+
+template<typename Value, typename HashFunctions, typename Traits>
+template<typename Functor>
+inline bool HashCountedSet<Value, HashFunctions, Traits>::removeAllIf(const Functor& functor)
+{
+    return m_impl.removeIf(functor);
 }
 
 template<typename Value, typename HashFunctions, typename Traits>


### PR DESCRIPTION
#### e5e8c91ee011f39dc8edd97584491c0160553a6d
<pre>
[JSC] Clean up InlineCacheCompiler and fix stub lifetime
<a href="https://bugs.webkit.org/show_bug.cgi?id=273668">https://bugs.webkit.org/show_bug.cgi?id=273668</a>
<a href="https://rdar.apple.com/127471278">rdar://127471278</a>

Reviewed by NOBODY (OOPS!).

This is cleaning up InlineCacheCompiler. And it also fixes lifetime issue in shared stub.
Stubs are unregistering themselves from SharedJITStubSet when it reaches to zero-ref-count.
But this does not work well since CodeBlock can be destroyed lazily: if CodeBlock is dead, during that,
no GC scanning happens to this stub while ref-count is still non-zero.

For normal JIT stubs, we have owner concept for JIT stub. At GC end phase, we iterate stubs and check whether the owner is already dead.
And if it is dead, we mark it m_ownerIsDead. But shared JIT stub does not have this concept.
Instead, we have HashCountedSet for shared JIT stub, and register multiple owners for shared JIT stub. And at GC end phase, we scan owners
to wipe dead owners, and when live owners become zero, we mark the stub as m_ownerIsDead too.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::setupWithUnlinkedBaselineCode):
* Source/JavaScriptCore/bytecode/InlineAccess.cpp:
(JSC::InlineAccess::rewireStubAsJumpInAccess): Deleted.
(JSC::InlineAccess::resetStubAsJumpInAccess): Deleted.
* Source/JavaScriptCore/bytecode/InlineAccess.h:
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::regenerate):
(JSC::InlineCacheHandler::addOwner):
(JSC::InlineCacheHandler::removeOwner):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.h:
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::tryCacheGetBy):
(JSC::tryCacheArrayGetByVal):
(JSC::tryCachePutBy):
(JSC::tryCacheArrayPutByVal):
(JSC::tryCacheDeleteBy):
(JSC::tryCacheInBy):
(JSC::tryCacheHasPrivateBrand):
(JSC::tryCacheCheckPrivateBrand):
(JSC::tryCacheSetPrivateBrand):
(JSC::tryCacheInstanceOf):
(JSC::tryCacheArrayInByVal):
(JSC::resetGetBy):
(JSC::resetPutBy):
(JSC::resetDelBy):
(JSC::resetInBy):
(JSC::resetHasPrivateBrand):
(JSC::resetInstanceOf):
(JSC::resetCheckPrivateBrand):
(JSC::resetSetPrivateBrand):
* Source/JavaScriptCore/bytecode/SharedJITStubSet.h:
* Source/JavaScriptCore/bytecode/StructureStubInfo.cpp:
(JSC::StructureStubInfo::addAccessCase):
(JSC::StructureStubInfo::initializeFromUnlinkedStructureStubInfo):
(JSC::StructureStubInfo::initializeFromDFGUnlinkedStructureStubInfo):
(JSC::StructureStubInfo::replaceHandler):
(JSC::StructureStubInfo::rewireStubAsJumpInAccess):
(JSC::StructureStubInfo::resetStubAsJumpInAccess):
* Source/JavaScriptCore/bytecode/StructureStubInfo.h:
* Source/JavaScriptCore/dfg/DFGJITCode.cpp:
(JSC::DFG::JITData::tryInitialize):
* Source/JavaScriptCore/heap/JITStubRoutineSet.cpp:
(JSC::JITStubRoutineSet::deleteUnmarkedJettisonedStubRoutines):
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp:
(JSC::PolymorphicAccessJITStubRoutine::removeDeadOwners):
(JSC::PolymorphicAccessJITStubRoutine::computeHash):
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h:
(JSC::PolymorphicAccessJITStubRoutine::isStillValid const):
(JSC::PolymorphicAccessJITStubRoutine::addOwner):
(JSC::PolymorphicAccessJITStubRoutine::removeOwner):
* Source/WTF/wtf/HashCountedSet.h:
(WTF::Traits&gt;::removeAllIf):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5e8c91ee011f39dc8edd97584491c0160553a6d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53423 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/855 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35682 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40933 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27132 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43172 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22030 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24555 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/423 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8543 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43493 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46543 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/484 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55006 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49663 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25261 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/423 "Exiting early after 60 failures. 51886 tests run. 60 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48330 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26522 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43357 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27385 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57142 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26254 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11744 "Passed tests") | 
<!--EWS-Status-Bubble-End-->