### PR TITLE
Rename "computedCSSPadding()" to "resolveLengthPercentage()"

### DIFF
--- a/Source/WebCore/rendering/RenderBoxInlines.h
+++ b/Source/WebCore/rendering/RenderBoxInlines.h
@@ -118,10 +118,10 @@ inline LayoutRect RenderBox::contentBoxRect() const
 
 inline LayoutRect RenderBox::marginBoxRect() const
 {
-    auto left = computedCSSPadding(style().marginLeft());
-    auto right = computedCSSPadding(style().marginRight());
-    auto top = computedCSSPadding(style().marginTop());
-    auto bottom = computedCSSPadding(style().marginBottom());
+    auto left = resolveLengthPercentageUsingContainerLogicalWidth(style().marginLeft());
+    auto right = resolveLengthPercentageUsingContainerLogicalWidth(style().marginRight());
+    auto top = resolveLengthPercentageUsingContainerLogicalWidth(style().marginTop());
+    auto bottom = resolveLengthPercentageUsingContainerLogicalWidth(style().marginBottom());
     return { -left, -top, size().width() + left + right, size().height() + top + bottom };
 }
 

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -263,7 +263,7 @@ public:
     ContinuationChainNode* continuationChainNode() const;
 
 protected:
-    LayoutUnit computedCSSPadding(const Length&) const;
+    LayoutUnit resolveLengthPercentageUsingContainerLogicalWidth(const Length&) const;
     virtual void absoluteQuadsIgnoringContinuation(const FloatRect&, Vector<FloatQuad>&, bool* /*wasFixed*/) const { ASSERT_NOT_REACHED(); }
     void collectAbsoluteQuadsForContinuation(Vector<FloatQuad>& quads, bool* wasFixed) const;
 

--- a/Source/WebCore/rendering/RenderBoxModelObjectInlines.h
+++ b/Source/WebCore/rendering/RenderBoxModelObjectInlines.h
@@ -45,14 +45,14 @@ inline LayoutUnit RenderBoxModelObject::borderLogicalWidth() const { return bord
 inline LayoutUnit RenderBoxModelObject::borderRight() const { return LayoutUnit(style().borderRightWidth()); }
 inline LayoutUnit RenderBoxModelObject::borderStart() const { return LayoutUnit(style().borderStartWidth()); }
 inline LayoutUnit RenderBoxModelObject::borderTop() const { return LayoutUnit(style().borderTopWidth()); }
-inline LayoutUnit RenderBoxModelObject::computedCSSPaddingAfter() const { return computedCSSPadding(style().paddingAfter()); }
-inline LayoutUnit RenderBoxModelObject::computedCSSPaddingBefore() const { return computedCSSPadding(style().paddingBefore()); }
-inline LayoutUnit RenderBoxModelObject::computedCSSPaddingBottom() const { return computedCSSPadding(style().paddingBottom()); }
-inline LayoutUnit RenderBoxModelObject::computedCSSPaddingEnd() const { return computedCSSPadding(style().paddingEnd()); }
-inline LayoutUnit RenderBoxModelObject::computedCSSPaddingLeft() const { return computedCSSPadding(style().paddingLeft()); }
-inline LayoutUnit RenderBoxModelObject::computedCSSPaddingRight() const { return computedCSSPadding(style().paddingRight()); }
-inline LayoutUnit RenderBoxModelObject::computedCSSPaddingStart() const { return computedCSSPadding(style().paddingStart()); }
-inline LayoutUnit RenderBoxModelObject::computedCSSPaddingTop() const { return computedCSSPadding(style().paddingTop()); }
+inline LayoutUnit RenderBoxModelObject::computedCSSPaddingAfter() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingAfter()); }
+inline LayoutUnit RenderBoxModelObject::computedCSSPaddingBefore() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingBefore()); }
+inline LayoutUnit RenderBoxModelObject::computedCSSPaddingBottom() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingBottom()); }
+inline LayoutUnit RenderBoxModelObject::computedCSSPaddingEnd() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingEnd()); }
+inline LayoutUnit RenderBoxModelObject::computedCSSPaddingLeft() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingLeft()); }
+inline LayoutUnit RenderBoxModelObject::computedCSSPaddingRight() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingRight()); }
+inline LayoutUnit RenderBoxModelObject::computedCSSPaddingStart() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingStart()); }
+inline LayoutUnit RenderBoxModelObject::computedCSSPaddingTop() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingTop()); }
 inline bool RenderBoxModelObject::hasInlineDirectionBordersOrPadding() const { return borderStart() || borderEnd() || paddingStart() || paddingEnd(); }
 inline bool RenderBoxModelObject::hasInlineDirectionBordersPaddingOrMargin() const { return hasInlineDirectionBordersOrPadding() || marginStart() || marginEnd(); }
 inline LayoutUnit RenderBoxModelObject::horizontalBorderAndPaddingExtent() const { return borderLeft() + borderRight() + paddingLeft() + paddingRight(); }
@@ -88,12 +88,12 @@ inline RectEdges<LayoutUnit> RenderBoxModelObject::borderWidths() const
     };
 }
 
-inline LayoutUnit RenderBoxModelObject::computedCSSPadding(const Length& padding) const
+inline LayoutUnit RenderBoxModelObject::resolveLengthPercentageUsingContainerLogicalWidth(const Length& value) const
 {
     LayoutUnit containerWidth;
-    if (padding.isPercentOrCalculated())
+    if (value.isPercentOrCalculated())
         containerWidth = containingBlockLogicalWidthForContent();
-    return minimumValueForLength(padding, containerWidth);
+    return minimumValueForLength(value, containerWidth);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 4142d950a6e7766786f1f3e2bd4650e3228628ec
<pre>
Rename &quot;computedCSSPadding()&quot; to &quot;resolveLengthPercentage()&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=273672">https://bugs.webkit.org/show_bug.cgi?id=273672</a>
<a href="https://rdar.apple.com/problem/127473476">rdar://problem/127473476</a>

Reviewed by Tim Nguyen.

`computedCSSPadding()` was called for margin values in `RenderBox::marginBoxRect()`,
so is clearly misnamed. It&apos;s really resolving the CSS `&lt;length-percentage&gt;`[1] values
which use the container&apos;s logical width (which is true for margins and padding)
so name it thusly.

[1] <a href="https://drafts.csswg.org/css-values-4/#mixed-percentages">https://drafts.csswg.org/css-values-4/#mixed-percentages</a>

* Source/WebCore/rendering/RenderBoxInlines.h:
(WebCore::RenderBox::marginBoxRect const):
* Source/WebCore/rendering/RenderBoxModelObject.h:
* Source/WebCore/rendering/RenderBoxModelObjectInlines.h:
(WebCore::RenderBoxModelObject::computedCSSPaddingAfter const):
(WebCore::RenderBoxModelObject::computedCSSPaddingBefore const):
(WebCore::RenderBoxModelObject::computedCSSPaddingBottom const):
(WebCore::RenderBoxModelObject::computedCSSPaddingEnd const):
(WebCore::RenderBoxModelObject::computedCSSPaddingLeft const):
(WebCore::RenderBoxModelObject::computedCSSPaddingRight const):
(WebCore::RenderBoxModelObject::computedCSSPaddingStart const):
(WebCore::RenderBoxModelObject::computedCSSPaddingTop const):
(WebCore::RenderBoxModelObject::resolveLengthPercentageUsingContainerLogicalWidth const):
(WebCore::RenderBoxModelObject::computedCSSPadding const): Deleted.

Canonical link: <a href="https://commits.webkit.org/278335@main">https://commits.webkit.org/278335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29f0a875a1dd196bb1d1ed7e1de60b0cb43974bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53485 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/916 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52529 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/536 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40982 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43227 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22080 "Found 1 new API test failure: /WPE/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/24609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/479 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8604 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55070 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25322 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48380 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/26583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43415 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47402 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11021 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27447 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26315 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->