### PR TITLE
Drop StringBuilder:append() overload taking in a `const char*`

### DIFF
--- a/Source/JavaScriptCore/API/tests/PingPongStackOverflowTest.cpp
+++ b/Source/JavaScriptCore/API/tests/PingPongStackOverflowTest.cpp
@@ -55,10 +55,10 @@ static bool PingPongStackOverflowObject_hasInstance(JSContextRef context, JSObje
         result = JSObjectCallAsFunction(context, function, constructor, 1, &possibleValue, exception);
     } else {
         StringBuilder builder;
-        builder.append("dummy.valueOf([0]");
+        builder.append("dummy.valueOf([0]"_s);
         for (int i = 1; i < 35000; i++)
-            builder.append(", [", i, ']');
-        builder.append(");");
+            builder.append(", ["_s, i, ']');
+        builder.append(");"_s);
         JSStringRef script = JSStringCreateWithUTF8CString(builder.toString().utf8().data());
         result = JSEvaluateScript(context, script, nullptr, nullptr, 1, exception);
         JSStringRelease(script);

--- a/Source/JavaScriptCore/bytecode/Instruction.h
+++ b/Source/JavaScriptCore/bytecode/Instruction.h
@@ -38,7 +38,7 @@ struct JSOpcodeTraits {
     static constexpr OpcodeID wide16 = op_wide16;
     static constexpr OpcodeID wide32 = op_wide32;
     static constexpr const unsigned* opcodeLengths = ::JSC::opcodeLengths;
-    static constexpr const char* const* opcodeNames = ::JSC::opcodeNames;
+    static constexpr const ASCIILiteral* opcodeNames = ::JSC::opcodeNames;
     static constexpr auto checkpointCountTable = bytecodeCheckpointCountTable;
     static constexpr OpcodeSize maxOpcodeIDWidth = maxJSOpcodeIDWidth;
 };

--- a/Source/JavaScriptCore/bytecode/Opcode.cpp
+++ b/Source/JavaScriptCore/bytecode/Opcode.cpp
@@ -46,8 +46,8 @@ const unsigned opcodeLengths[] = {
 #undef OPCODE_LENGTH
 };
 
-const char* const opcodeNames[] = {
-#define OPCODE_NAME_ENTRY(opcode, size) #opcode,
+const ASCIILiteral opcodeNames[] = {
+#define OPCODE_NAME_ENTRY(opcode, size) #opcode ## _s,
     FOR_EACH_OPCODE_ID(OPCODE_NAME_ENTRY)
 #undef OPCODE_NAME_ENTRY
 };
@@ -70,7 +70,7 @@ inline const char* padOpcodeName(OpcodeID op, unsigned width)
 {
     auto padding = "                                ";
     auto paddingLength = strlen(padding);
-    auto opcodeNameLength = strlen(opcodeNames[op]);
+    auto opcodeNameLength = opcodeNames[op].length();
     if (opcodeNameLength >= width)
         return "";
     if (paddingLength + opcodeNameLength < width)
@@ -153,7 +153,7 @@ OpcodeStats::~OpcodeStats()
 
     for (int i = 0; i < numOpcodeIDs; ++i) {
         int index = sortedIndices[i];
-        dataLogF("%s:%s %lld - %.2f%%\n", opcodeNames[index], padOpcodeName((OpcodeID)index, 28), opcodeCounts[index], ((double) opcodeCounts[index]) / ((double) totalInstructions) * 100.0);    
+        dataLogF("%s:%s %lld - %.2f%%\n", opcodeNames[index].characters(), padOpcodeName((OpcodeID)index, 28), opcodeCounts[index], ((double) opcodeCounts[index]) / ((double) totalInstructions) * 100.0);
     }
     
     dataLogF("\n");
@@ -166,7 +166,7 @@ OpcodeStats::~OpcodeStats()
         if (!count)
             break;
         
-        dataLogF("%s%s %s:%s %lld %.2f%%\n", opcodeNames[indexPair.first], padOpcodeName((OpcodeID)indexPair.first, 28), opcodeNames[indexPair.second], padOpcodeName((OpcodeID)indexPair.second, 28), count, ((double) count) / ((double) totalInstructionPairs) * 100.0);
+        dataLogF("%s%s %s:%s %lld %.2f%%\n", opcodeNames[indexPair.first].characters(), padOpcodeName((OpcodeID)indexPair.first, 28), opcodeNames[indexPair.second].characters(), padOpcodeName((OpcodeID)indexPair.second, 28), count, ((double) count) / ((double) totalInstructionPairs) * 100.0);
     }
     
     dataLogF("\n");
@@ -178,7 +178,7 @@ OpcodeStats::~OpcodeStats()
         double opcodeProportion = ((double) opcodeCount) / ((double) totalInstructions);
         if (opcodeProportion < 0.0001)
             break;
-        dataLogF("\n%s:%s %lld - %.2f%%\n", opcodeNames[index], padOpcodeName((OpcodeID)index, 28), opcodeCount, opcodeProportion * 100.0);
+        dataLogF("\n%s:%s %lld - %.2f%%\n", opcodeNames[index].characters(), padOpcodeName((OpcodeID)index, 28), opcodeCount, opcodeProportion * 100.0);
 
         for (int j = 0; j < numOpcodeIDs * numOpcodeIDs; ++j) {
             std::pair<int, int> indexPair = sortedPairIndices[j];
@@ -191,7 +191,7 @@ OpcodeStats::~OpcodeStats()
             if (indexPair.first != index && indexPair.second != index)
                 continue;
 
-            dataLogF("    %s%s %s:%s %lld - %.2f%%\n", opcodeNames[indexPair.first], padOpcodeName((OpcodeID)indexPair.first, 28), opcodeNames[indexPair.second], padOpcodeName((OpcodeID)indexPair.second, 28), pairCount, pairProportion * 100.0);
+            dataLogF("    %s%s %s:%s %lld - %.2f%%\n", opcodeNames[indexPair.first].characters(), padOpcodeName((OpcodeID)indexPair.first, 28), opcodeNames[indexPair.second].characters(), padOpcodeName((OpcodeID)indexPair.second, 28), pairCount, pairProportion * 100.0);
         }
         
     }

--- a/Source/JavaScriptCore/bytecode/Opcode.h
+++ b/Source/JavaScriptCore/bytecode/Opcode.h
@@ -38,6 +38,7 @@
 
 #include <wtf/Assertions.h>
 #include <wtf/MathExtras.h>
+#include <wtf/text/ASCIILiteral.h>
 
 namespace JSC {
 
@@ -195,7 +196,7 @@ typedef void* Opcode;
 typedef OpcodeID Opcode;
 #endif
 
-extern const char* const opcodeNames[];
+extern ASCIILiteral const opcodeNames[];
 extern const char* const wasmOpcodeNames[];
 
 #if ENABLE(OPCODE_STATS)

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -5610,7 +5610,7 @@ void ArrayPatternNode::toString(StringBuilder& builder) const
             break;
 
         case BindingType::RestElement:
-            builder.append("...");
+            builder.append("..."_s);
             target.pattern->toString(builder);
             break;
         }
@@ -5926,7 +5926,7 @@ void RestParameterNode::collectBoundIdentifiers(Vector<Identifier>& identifiers)
 
 void RestParameterNode::toString(StringBuilder& builder) const
 {
-    builder.append("...");
+    builder.append("..."_s);
     m_pattern->toString(builder);
 }
 

--- a/Source/JavaScriptCore/heap/GCLogging.cpp
+++ b/Source/JavaScriptCore/heap/GCLogging.cpp
@@ -30,18 +30,18 @@
 
 namespace JSC {
 
-const char* GCLogging::levelAsString(Level level)
+ASCIILiteral GCLogging::levelAsString(Level level)
 {
     switch (level) {
     case None:
-        return "None";
+        return "None"_s;
     case Basic:
-        return "Basic";
+        return "Basic"_s;
     case Verbose:
-        return "Verbose";
+        return "Verbose"_s;
     default:
         RELEASE_ASSERT_NOT_REACHED();
-        return "";
+        return ""_s;
     }
 }
 

--- a/Source/JavaScriptCore/heap/GCLogging.h
+++ b/Source/JavaScriptCore/heap/GCLogging.h
@@ -39,7 +39,7 @@ public:
         Verbose
     };
 
-    static const char* levelAsString(Level);
+    static ASCIILiteral levelAsString(Level);
     static void dumpObjectGraph(Heap*);
 };
 

--- a/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
+++ b/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
@@ -459,18 +459,18 @@ String HeapSnapshotBuilder::json(Function<bool (const HeapSnapshotNode&)> allowN
     };
 
     // version
-    json.append("{\"version\":2");
+    json.append("{\"version\":2"_s);
 
     // type
-    json.append(",\"type\":\"", snapshotTypeToString(m_snapshotType), '"');
+    json.append(",\"type\":\""_s, snapshotTypeToString(m_snapshotType), '"');
 
     // nodes
-    json.append(",\"nodes\":[");
+    json.append(",\"nodes\":["_s);
     // <root>
     if (m_snapshotType == SnapshotType::GCDebuggingSnapshot)
-        json.append("0,0,0,0,0,\"0x0\",\"0x0\"");
+        json.append("0,0,0,0,0,\"0x0\",\"0x0\""_s);
     else
-        json.append("0,0,0,0");
+        json.append("0,0,0,0"_s);
 
     for (HeapSnapshot* snapshot = m_profiler.mostRecentSnapshot(); snapshot; snapshot = snapshot->previous()) {
         for (auto& node : snapshot->m_nodes)
@@ -479,7 +479,7 @@ String HeapSnapshotBuilder::json(Function<bool (const HeapSnapshotNode&)> allowN
     json.append(']');
 
     // node class names
-    json.append(",\"nodeClassNames\":[");
+    json.append(",\"nodeClassNames\":["_s);
     Vector<String> orderedClassNames(classNameIndexes.size());
     for (auto& entry : classNameIndexes)
         orderedClassNames[entry.value] = entry.key;
@@ -539,16 +539,16 @@ String HeapSnapshotBuilder::json(Function<bool (const HeapSnapshotNode&)> allowN
     });
 
     // edges
-    json.append(",\"edges\":[");
+    json.append(",\"edges\":["_s);
     for (auto& edge : m_edges)
         appendEdgeJSON(edge);
     json.append(']');
 
     // edge types
-    json.append(",\"edgeTypes\":[\"", edgeTypeToString(EdgeType::Internal), "\",\"", edgeTypeToString(EdgeType::Property), "\",\"", edgeTypeToString(EdgeType::Index), "\",\"", edgeTypeToString(EdgeType::Variable), "\"]");
+    json.append(",\"edgeTypes\":[\""_s, edgeTypeToString(EdgeType::Internal), "\",\""_s, edgeTypeToString(EdgeType::Property), "\",\""_s, edgeTypeToString(EdgeType::Index), "\",\""_s, edgeTypeToString(EdgeType::Variable), "\"]"_s);
 
     // edge names
-    json.append(",\"edgeNames\":[");
+    json.append(",\"edgeNames\":["_s);
     Vector<UniquedStringImpl*> orderedEdgeNames(edgeNameIndexes.size());
     for (auto& entry : edgeNameIndexes)
         orderedEdgeNames[entry.value] = entry.key;
@@ -564,7 +564,7 @@ String HeapSnapshotBuilder::json(Function<bool (const HeapSnapshotNode&)> allowN
     json.append(']');
 
     if (m_snapshotType == SnapshotType::GCDebuggingSnapshot) {
-        json.append(",\"roots\":[");
+        json.append(",\"roots\":["_s);
 
         HeapSnapshot* snapshot = m_profiler.mostRecentSnapshot();
 
@@ -605,7 +605,7 @@ String HeapSnapshotBuilder::json(Function<bool (const HeapSnapshotNode&)> allowN
 
     if (m_snapshotType == SnapshotType::GCDebuggingSnapshot) {
         // internal node descriptions
-        json.append(",\"labels\":[");
+        json.append(",\"labels\":["_s);
 
         Vector<String> orderedLabels(labelIndexes.size());
         for (auto& entry : labelIndexes)

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -1725,7 +1725,7 @@ JSC_DEFINE_HOST_FUNCTION(functionJSCStack, (JSGlobalObject* globalObject, CallFr
 {
     VM& vm = globalObject->vm();
     StringBuilder trace;
-    trace.append("--> Stack trace:\n");
+    trace.append("--> Stack trace:\n"_s);
 
     FunctionJSCStackFunctor functor(trace);
     StackVisitor::visit(callFrame, vm, functor);

--- a/Source/JavaScriptCore/runtime/ConsoleClient.cpp
+++ b/Source/JavaScriptCore/runtime/ConsoleClient.cpp
@@ -179,7 +179,7 @@ static void appendMessagePrefix(StringBuilder& builder, MessageSource source, Me
         break;
     }
 
-    builder.append("CONSOLE");
+    builder.append("CONSOLE"_s);
     if (!sourceString.isEmpty())
         builder.append(' ', sourceString);
     if (!typeString.isEmpty())
@@ -194,7 +194,7 @@ void ConsoleClient::printConsoleMessage(MessageSource source, MessageType type, 
 
     if (!url.isEmpty()) {
         appendURLAndPosition(builder, url, lineNumber, columnNumber);
-        builder.append(": ");
+        builder.append(": "_s);
     }
 
     appendMessagePrefix(builder, source, type, level);
@@ -214,7 +214,7 @@ void ConsoleClient::printConsoleMessageWithArguments(MessageSource source, Messa
 
     if (!lastCaller.sourceURL().isEmpty()) {
         appendURLAndPosition(builder, lastCaller.sourceURL(), lastCaller.lineNumber(), lastCaller.columnNumber());
-        builder.append(": ");
+        builder.append(": "_s);
     }
 
     appendMessagePrefix(builder, source, type, level);

--- a/Source/JavaScriptCore/runtime/DateConversion.cpp
+++ b/Source/JavaScriptCore/runtime/DateConversion.cpp
@@ -66,7 +66,7 @@ String formatDateTime(const GregorianDateTime& t, DateTimeFormat format, bool as
         builder.append(WTF::weekdayName[(t.weekDay() + 6) % 7]);
 
         if (asUTCVariant) {
-            builder.append(", ");
+            builder.append(", "_s);
             appendNumber<2>(builder, t.monthDay());
             builder.append(' ', WTF::monthName[t.month()]);
         } else {
@@ -86,7 +86,7 @@ String formatDateTime(const GregorianDateTime& t, DateTimeFormat format, bool as
         appendNumber<2>(builder, t.minute());
         builder.append(':');
         appendNumber<2>(builder, t.second());
-        builder.append(" GMT");
+        builder.append(" GMT"_s);
 
         if (!asUTCVariant) {
             int offset = std::abs(t.utcOffsetInMinute());
@@ -95,7 +95,7 @@ String formatDateTime(const GregorianDateTime& t, DateTimeFormat format, bool as
             appendNumber<2>(builder, offset % 60);
             String timeZoneName = dateCache.timeZoneDisplayName(t.isDST());
             if (!timeZoneName.isEmpty())
-                builder.append(" (", timeZoneName, ')');
+                builder.append(" ("_s, timeZoneName, ')');
         }
     }
 

--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
@@ -176,10 +176,10 @@ String notAFunctionSourceAppender(const String& originalMessage, StringView sour
     StringBuilder builder(StringBuilder::OverflowHandler::RecordOverflow);
     builder.append(base, " is not a function. (In '", sourceText, "', '", base, "' is ");
     if (type == TypeSymbol)
-        builder.append("a Symbol");
+        builder.append("a Symbol"_s);
     else {
         if (type == TypeObject)
-            builder.append("an instance of ");
+            builder.append("an instance of "_s);
         builder.append(displayValue);
     }
     builder.append(')');

--- a/Source/JavaScriptCore/runtime/FileBasedFuzzerAgent.cpp
+++ b/Source/JavaScriptCore/runtime/FileBasedFuzzerAgent.cpp
@@ -98,7 +98,7 @@ SpeculatedType FileBasedFuzzerAgent::getPredictionInternal(CodeBlock* codeBlock,
         break;
 
     default:
-        RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled opcode %s", opcodeNames[target.opcodeId]);
+        RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled opcode %s", opcodeNames[target.opcodeId].characters());
     }
     if (!generated) {
         if (Options::dumpFuzzerAgentPredictions())

--- a/Source/JavaScriptCore/runtime/FileBasedFuzzerAgentBase.cpp
+++ b/Source/JavaScriptCore/runtime/FileBasedFuzzerAgentBase.cpp
@@ -40,11 +40,11 @@ String FileBasedFuzzerAgentBase::createLookupKey(const String& sourceFilename, O
 {
     StringBuilder lookupKey;
     lookupKey.append(sourceFilename);
-    lookupKey.append("|");
+    lookupKey.append('|');
     lookupKey.append(opcodeNames[opcodeAliasForLookupKey(opcodeId)]);
-    lookupKey.append("|");
+    lookupKey.append('|');
     lookupKey.append(startLocation);
-    lookupKey.append("|");
+    lookupKey.append('|');
     lookupKey.append(endLocation);
     return lookupKey.toString();
 }

--- a/Source/JavaScriptCore/runtime/FunctionConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionConstructor.cpp
@@ -111,7 +111,7 @@ static String stringifyFunction(JSGlobalObject* globalObject, const ArgList& arg
             RETURN_IF_EXCEPTION(scope, { });
             auto viewWithString = jsString->viewWithUnderlyingString(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
-            builder.append(",", viewWithString.view);
+            builder.append(',', viewWithString.view);
         }
         if (UNLIKELY(builder.hasOverflowed())) {
             throwOutOfMemoryError(globalObject, scope);
@@ -124,7 +124,7 @@ static String stringifyFunction(JSGlobalObject* globalObject, const ArgList& arg
         RETURN_IF_EXCEPTION(scope, { });
         auto body = bodyString->viewWithUnderlyingString(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        builder.append("\n) {\n", body.view, "\n}");
+        builder.append("\n) {\n"_s, body.view, "\n}"_s);
         if (UNLIKELY(builder.hasOverflowed())) {
             throwOutOfMemoryError(globalObject, scope);
             return { };

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -474,13 +474,13 @@ String IntlDateTimeFormat::buildSkeleton(Weekday weekday, Era era, Year year, Mo
 
     switch (weekday) {
     case Weekday::Narrow:
-        skeletonBuilder.append("EEEEE");
+        skeletonBuilder.append("EEEEE"_s);
         break;
     case Weekday::Short:
-        skeletonBuilder.append("EEE");
+        skeletonBuilder.append("EEE"_s);
         break;
     case Weekday::Long:
-        skeletonBuilder.append("EEEE");
+        skeletonBuilder.append("EEEE"_s);
         break;
     case Weekday::None:
         break;
@@ -488,13 +488,13 @@ String IntlDateTimeFormat::buildSkeleton(Weekday weekday, Era era, Year year, Mo
 
     switch (era) {
     case Era::Narrow:
-        skeletonBuilder.append("GGGGG");
+        skeletonBuilder.append("GGGGG"_s);
         break;
     case Era::Short:
-        skeletonBuilder.append("GGG");
+        skeletonBuilder.append("GGG"_s);
         break;
     case Era::Long:
-        skeletonBuilder.append("GGGG");
+        skeletonBuilder.append("GGGG"_s);
         break;
     case Era::None:
         break;
@@ -502,7 +502,7 @@ String IntlDateTimeFormat::buildSkeleton(Weekday weekday, Era era, Year year, Mo
 
     switch (year) {
     case Year::TwoDigit:
-        skeletonBuilder.append("yy");
+        skeletonBuilder.append("yy"_s);
         break;
     case Year::Numeric:
         skeletonBuilder.append('y');
@@ -513,19 +513,19 @@ String IntlDateTimeFormat::buildSkeleton(Weekday weekday, Era era, Year year, Mo
 
     switch (month) {
     case Month::TwoDigit:
-        skeletonBuilder.append("MM");
+        skeletonBuilder.append("MM"_s);
         break;
     case Month::Numeric:
         skeletonBuilder.append('M');
         break;
     case Month::Narrow:
-        skeletonBuilder.append("MMMMM");
+        skeletonBuilder.append("MMMMM"_s);
         break;
     case Month::Short:
-        skeletonBuilder.append("MMM");
+        skeletonBuilder.append("MMM"_s);
         break;
     case Month::Long:
-        skeletonBuilder.append("MMMM");
+        skeletonBuilder.append("MMMM"_s);
         break;
     case Month::None:
         break;
@@ -533,7 +533,7 @@ String IntlDateTimeFormat::buildSkeleton(Weekday weekday, Era era, Year year, Mo
 
     switch (day) {
     case Day::TwoDigit:
-        skeletonBuilder.append("dd");
+        skeletonBuilder.append("dd"_s);
         break;
     case Day::Numeric:
         skeletonBuilder.append('d');
@@ -593,13 +593,13 @@ String IntlDateTimeFormat::buildSkeleton(Weekday weekday, Era era, Year year, Mo
     // https://unicode-org.atlassian.net/browse/ICU-20731
     switch (dayPeriod) {
     case DayPeriod::Narrow:
-        skeletonBuilder.append("BBBBB");
+        skeletonBuilder.append("BBBBB"_s);
         break;
     case DayPeriod::Short:
         skeletonBuilder.append('B');
         break;
     case DayPeriod::Long:
-        skeletonBuilder.append("BBBB");
+        skeletonBuilder.append("BBBB"_s);
         break;
     case DayPeriod::None:
         break;
@@ -607,7 +607,7 @@ String IntlDateTimeFormat::buildSkeleton(Weekday weekday, Era era, Year year, Mo
 
     switch (minute) {
     case Minute::TwoDigit:
-        skeletonBuilder.append("mm");
+        skeletonBuilder.append("mm"_s);
         break;
     case Minute::Numeric:
         skeletonBuilder.append('m');
@@ -618,7 +618,7 @@ String IntlDateTimeFormat::buildSkeleton(Weekday weekday, Era era, Year year, Mo
 
     switch (second) {
     case Second::TwoDigit:
-        skeletonBuilder.append("ss");
+        skeletonBuilder.append("ss"_s);
         break;
     case Second::Numeric:
         skeletonBuilder.append('s');
@@ -635,19 +635,19 @@ String IntlDateTimeFormat::buildSkeleton(Weekday weekday, Era era, Year year, Mo
         skeletonBuilder.append('z');
         break;
     case TimeZoneName::Long:
-        skeletonBuilder.append("zzzz");
+        skeletonBuilder.append("zzzz"_s);
         break;
     case TimeZoneName::ShortOffset:
         skeletonBuilder.append('O');
         break;
     case TimeZoneName::LongOffset:
-        skeletonBuilder.append("OOOO");
+        skeletonBuilder.append("OOOO"_s);
         break;
     case TimeZoneName::ShortGeneric:
         skeletonBuilder.append('v');
         break;
     case TimeZoneName::LongGeneric:
-        skeletonBuilder.append("vvvv");
+        skeletonBuilder.append("vvvv"_s);
         break;
     case TimeZoneName::None:
         break;
@@ -1431,7 +1431,7 @@ UDateIntervalFormat* IntlDateTimeFormat::createDateIntervalFormatIfNecessary(JSG
     StringBuilder localeBuilder;
     localeBuilder.append(m_dataLocale, "-u-ca-", m_calendar, "-nu-", m_numberingSystem);
     if (m_hourCycle != HourCycle::None)
-        localeBuilder.append("-hc-", hourCycleString(m_hourCycle));
+        localeBuilder.append("-hc-"_s, hourCycleString(m_hourCycle));
     CString dataLocaleWithExtensions = localeBuilder.toString().utf8();
 
     UErrorCode status = U_ZERO_ERROR;

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
@@ -336,7 +336,7 @@ static Vector<Element> collectElements(JSGlobalObject* globalObject, const IntlD
         double value = duration[unit];
 
         StringBuilder skeletonBuilder;
-        skeletonBuilder.append("rounding-mode-half-up");
+        skeletonBuilder.append("rounding-mode-half-up"_s);
 
         switch (unit) {
         // 3.j. If unit is "seconds", "milliseconds", or "microseconds", then
@@ -362,7 +362,7 @@ static Vector<Element> collectElements(JSGlobalObject* globalObject, const IntlD
                     value = value + duration[TemporalUnit::Nanosecond] / 1000.0;
                 }
                 // https://github.com/unicode-org/icu/blob/master/docs/userguide/format_parse/numbers/skeletons.md#fraction-precision
-                skeletonBuilder.append(" .");
+                skeletonBuilder.append(" ."_s);
                 for (unsigned i = 0; i < durationFormat->fractionalDigits(); ++i)
                     skeletonBuilder.append('0');
                 done = true;
@@ -375,9 +375,9 @@ static Vector<Element> collectElements(JSGlobalObject* globalObject, const IntlD
 
         // 3.k. If style is "2-digit", then
         //     i. Perform ! CreateDataPropertyOrThrow(nfOpts, "minimumIntegerDigits", 2F).
-        skeletonBuilder.append(" integer-width/", WTF::ICU::majorVersion() >= 67 ? '*' : '+'); // Prior to ICU 67, use the symbol + instead of *.
+        skeletonBuilder.append(" integer-width/"_s, WTF::ICU::majorVersion() >= 67 ? '*' : '+'); // Prior to ICU 67, use the symbol + instead of *.
         if (unitData.style() == IntlDurationFormat::UnitStyle::TwoDigit)
-            skeletonBuilder.append("00");
+            skeletonBuilder.append("00"_s);
         else
             skeletonBuilder.append('0');
 
@@ -463,15 +463,15 @@ static Vector<Element> collectElements(JSGlobalObject* globalObject, const IntlD
             case IntlDurationFormat::UnitStyle::Long:
             case IntlDurationFormat::UnitStyle::Short:
             case IntlDurationFormat::UnitStyle::Narrow: {
-                skeletonBuilder.append(" measure-unit/duration-");
+                skeletonBuilder.append(" measure-unit/duration-"_s);
                 skeletonBuilder.append(String(temporalUnitSingularPropertyName(vm, unit).uid()));
                 if (unitData.style() == IntlDurationFormat::UnitStyle::Long)
-                    skeletonBuilder.append(" unit-width-full-name");
+                    skeletonBuilder.append(" unit-width-full-name"_s);
                 else if (unitData.style() == IntlDurationFormat::UnitStyle::Short)
-                    skeletonBuilder.append(" unit-width-short");
+                    skeletonBuilder.append(" unit-width-short"_s);
                 else {
                     ASSERT(unitData.style() == IntlDurationFormat::UnitStyle::Narrow);
-                    skeletonBuilder.append(" unit-width-narrow");
+                    skeletonBuilder.append(" unit-width-narrow"_s);
                 }
 
                 auto formattedNumber = formatDouble(skeletonBuilder.toString());

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
@@ -416,24 +416,24 @@ void IntlNumberFormat::initializeNumberFormat(JSGlobalObject* globalObject, JSVa
         // No skeleton is needed.
         break;
     case Style::Percent:
-        skeletonBuilder.append(" percent scale/100");
+        skeletonBuilder.append(" percent scale/100"_s);
         break;
     case Style::Currency: {
-        skeletonBuilder.append(" currency/", currency);
+        skeletonBuilder.append(" currency/"_s, currency);
 
         // https://github.com/unicode-org/icu/blob/master/docs/userguide/format_parse/numbers/skeletons.md#unit-width
         switch (m_currencyDisplay) {
         case CurrencyDisplay::Code:
-            skeletonBuilder.append(" unit-width-iso-code");
+            skeletonBuilder.append(" unit-width-iso-code"_s);
             break;
         case CurrencyDisplay::Symbol:
             // Default option. Do not specify unit-width.
             break;
         case CurrencyDisplay::NarrowSymbol:
-            skeletonBuilder.append(" unit-width-narrow");
+            skeletonBuilder.append(" unit-width-narrow"_s);
             break;
         case CurrencyDisplay::Name:
-            skeletonBuilder.append(" unit-width-full-name");
+            skeletonBuilder.append(" unit-width-full-name"_s);
             break;
         }
         break;
@@ -442,24 +442,24 @@ void IntlNumberFormat::initializeNumberFormat(JSGlobalObject* globalObject, JSVa
         // The measure-unit stem takes one required option: the unit identifier of the unit to be formatted.
         // The full unit identifier is required: both the type and the subtype (for example, length-meter).
         // https://github.com/unicode-org/icu/blob/master/docs/userguide/format_parse/numbers/skeletons.md#unit
-        skeletonBuilder.append(" measure-unit/");
+        skeletonBuilder.append(" measure-unit/"_s);
         auto numeratorUnit = wellFormedUnit->numerator;
         skeletonBuilder.append(numeratorUnit.type, '-', numeratorUnit.subType);
         if (auto denominatorUnitValue = wellFormedUnit->denominator) {
             auto denominatorUnit = denominatorUnitValue.value();
-            skeletonBuilder.append(" per-measure-unit/", denominatorUnit.type, '-', denominatorUnit.subType);
+            skeletonBuilder.append(" per-measure-unit/"_s, denominatorUnit.type, '-', denominatorUnit.subType);
         }
 
         // https://github.com/unicode-org/icu/blob/master/docs/userguide/format_parse/numbers/skeletons.md#unit-width
         switch (m_unitDisplay) {
         case UnitDisplay::Short:
-            skeletonBuilder.append(" unit-width-short");
+            skeletonBuilder.append(" unit-width-short"_s);
             break;
         case UnitDisplay::Narrow:
-            skeletonBuilder.append(" unit-width-narrow");
+            skeletonBuilder.append(" unit-width-narrow"_s);
             break;
         case UnitDisplay::Long:
-            skeletonBuilder.append(" unit-width-full-name");
+            skeletonBuilder.append(" unit-width-full-name"_s);
             break;
         }
         break;
@@ -473,18 +473,18 @@ void IntlNumberFormat::initializeNumberFormat(JSGlobalObject* globalObject, JSVa
     case IntlNotation::Standard:
         break;
     case IntlNotation::Scientific:
-        skeletonBuilder.append(" scientific");
+        skeletonBuilder.append(" scientific"_s);
         break;
     case IntlNotation::Engineering:
-        skeletonBuilder.append(" engineering");
+        skeletonBuilder.append(" engineering"_s);
         break;
     case IntlNotation::Compact:
         switch (m_compactDisplay) {
         case CompactDisplay::Short:
-            skeletonBuilder.append(" compact-short");
+            skeletonBuilder.append(" compact-short"_s);
             break;
         case CompactDisplay::Long:
-            skeletonBuilder.append(" compact-long");
+            skeletonBuilder.append(" compact-long"_s);
             break;
         }
         break;
@@ -496,33 +496,33 @@ void IntlNumberFormat::initializeNumberFormat(JSGlobalObject* globalObject, JSVa
     switch (m_signDisplay) {
     case SignDisplay::Auto:
         if (useAccounting)
-            skeletonBuilder.append(" sign-accounting");
+            skeletonBuilder.append(" sign-accounting"_s);
         else
-            skeletonBuilder.append(" sign-auto");
+            skeletonBuilder.append(" sign-auto"_s);
         break;
     case SignDisplay::Never:
-        skeletonBuilder.append(" sign-never");
+        skeletonBuilder.append(" sign-never"_s);
         break;
     case SignDisplay::Always:
         if (useAccounting)
-            skeletonBuilder.append(" sign-accounting-always");
+            skeletonBuilder.append(" sign-accounting-always"_s);
         else
-            skeletonBuilder.append(" sign-always");
+            skeletonBuilder.append(" sign-always"_s);
         break;
     case SignDisplay::ExceptZero:
         if (useAccounting)
-            skeletonBuilder.append(" sign-accounting-except-zero");
+            skeletonBuilder.append(" sign-accounting-except-zero"_s);
         else
-            skeletonBuilder.append(" sign-except-zero");
+            skeletonBuilder.append(" sign-except-zero"_s);
         break;
     case SignDisplay::Negative:
         // Only ICU69~ supports negative sign display. Ignore this option if linked ICU does not support it.
         // https://github.com/unicode-org/icu/commit/1aa0dad8e06ecc99bff442dd37f6daa2d39d9a5a
         if (WTF::ICU::majorVersion() >= 69) {
             if (useAccounting)
-                skeletonBuilder.append(" sign-accounting-negative");
+                skeletonBuilder.append(" sign-accounting-negative"_s);
             else
-                skeletonBuilder.append(" sign-negative");
+                skeletonBuilder.append(" sign-negative"_s);
         }
         break;
     }
@@ -531,16 +531,16 @@ void IntlNumberFormat::initializeNumberFormat(JSGlobalObject* globalObject, JSVa
     // https://github.com/unicode-org/icu/blob/main/docs/userguide/format_parse/numbers/skeletons.md#grouping
     switch (m_useGrouping) {
     case UseGrouping::False:
-        skeletonBuilder.append(" group-off");
+        skeletonBuilder.append(" group-off"_s);
         break;
     case UseGrouping::Min2:
-        skeletonBuilder.append(" group-min2");
+        skeletonBuilder.append(" group-min2"_s);
         break;
     case UseGrouping::Auto:
-        skeletonBuilder.append(" group-auto");
+        skeletonBuilder.append(" group-auto"_s);
         break;
     case UseGrouping::Always:
-        skeletonBuilder.append(" group-on-aligned");
+        skeletonBuilder.append(" group-on-aligned"_s);
         break;
     }
 

--- a/Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h
@@ -186,56 +186,56 @@ void appendNumberFormatDigitOptionsToSkeleton(IntlType* intlInstance, StringBuil
 {
     switch (intlInstance->m_roundingMode) {
     case RoundingMode::Ceil:
-        skeletonBuilder.append(" rounding-mode-ceiling");
+        skeletonBuilder.append(" rounding-mode-ceiling"_s);
         break;
     case RoundingMode::Floor:
-        skeletonBuilder.append(" rounding-mode-floor");
+        skeletonBuilder.append(" rounding-mode-floor"_s);
         break;
     case RoundingMode::Expand:
-        skeletonBuilder.append(" rounding-mode-up");
+        skeletonBuilder.append(" rounding-mode-up"_s);
         break;
     case RoundingMode::Trunc:
-        skeletonBuilder.append(" rounding-mode-down");
+        skeletonBuilder.append(" rounding-mode-down"_s);
         break;
     case RoundingMode::HalfCeil: {
         // Only ICU69~ supports half-ceiling. Ignore this option if linked ICU does not support it.
         // https://github.com/unicode-org/icu/commit/e8dfea9bb6bb27596731173b352759e44ad06b21
         if (WTF::ICU::majorVersion() >= 69)
-            skeletonBuilder.append(" rounding-mode-half-ceiling");
+            skeletonBuilder.append(" rounding-mode-half-ceiling"_s);
         else
-            skeletonBuilder.append(" rounding-mode-half-up"); // Default option.
+            skeletonBuilder.append(" rounding-mode-half-up"_s); // Default option.
         break;
     }
     case RoundingMode::HalfFloor: {
         // Only ICU69~ supports half-flooring. Ignore this option if linked ICU does not support it.
         // https://github.com/unicode-org/icu/commit/e8dfea9bb6bb27596731173b352759e44ad06b21
         if (WTF::ICU::majorVersion() >= 69)
-            skeletonBuilder.append(" rounding-mode-half-floor");
+            skeletonBuilder.append(" rounding-mode-half-floor"_s);
         else
-            skeletonBuilder.append(" rounding-mode-half-up"); // Default option.
+            skeletonBuilder.append(" rounding-mode-half-up"_s); // Default option.
         break;
     }
     case RoundingMode::HalfExpand:
-        skeletonBuilder.append(" rounding-mode-half-up");
+        skeletonBuilder.append(" rounding-mode-half-up"_s);
         break;
     case RoundingMode::HalfTrunc:
-        skeletonBuilder.append(" rounding-mode-half-down");
+        skeletonBuilder.append(" rounding-mode-half-down"_s);
         break;
     case RoundingMode::HalfEven:
-        skeletonBuilder.append(" rounding-mode-half-even");
+        skeletonBuilder.append(" rounding-mode-half-even"_s);
         break;
     }
 
     // https://github.com/unicode-org/icu/blob/master/docs/userguide/format_parse/numbers/skeletons.md#integer-width
-    skeletonBuilder.append(" integer-width/", WTF::ICU::majorVersion() >= 67 ? '*' : '+'); // Prior to ICU 67, use the symbol + instead of *.
+    skeletonBuilder.append(" integer-width/"_s, WTF::ICU::majorVersion() >= 67 ? '*' : '+'); // Prior to ICU 67, use the symbol + instead of *.
     for (unsigned i = 0; i < intlInstance->m_minimumIntegerDigits; ++i)
         skeletonBuilder.append('0');
 
     if (intlInstance->m_roundingIncrement != 1) {
-        skeletonBuilder.append(" precision-increment/");
+        skeletonBuilder.append(" precision-increment/"_s);
         auto string = numberToStringUnsigned<Vector<LChar, 10>>(intlInstance->m_roundingIncrement);
         if (intlInstance->m_maximumFractionDigits >= string.size()) {
-            skeletonBuilder.append("0.");
+            skeletonBuilder.append("0."_s);
             for (unsigned i = 0; i < (intlInstance->m_maximumFractionDigits - string.size()); ++i)
                 skeletonBuilder.append('0');
             skeletonBuilder.append(string);
@@ -247,7 +247,7 @@ void appendNumberFormatDigitOptionsToSkeleton(IntlType* intlInstance, StringBuil
         switch (intlInstance->m_roundingType) {
         case IntlRoundingType::FractionDigits: {
             // https://github.com/unicode-org/icu/blob/master/docs/userguide/format_parse/numbers/skeletons.md#fraction-precision
-            skeletonBuilder.append(" .");
+            skeletonBuilder.append(" ."_s);
             for (unsigned i = 0; i < intlInstance->m_minimumFractionDigits; ++i)
                 skeletonBuilder.append('0');
             for (unsigned i = 0; i < intlInstance->m_maximumFractionDigits - intlInstance->m_minimumFractionDigits; ++i)
@@ -270,7 +270,7 @@ void appendNumberFormatDigitOptionsToSkeleton(IntlType* intlInstance, StringBuil
             if (WTF::ICU::majorVersion() >= 69) {
                 // https://github.com/unicode-org/icu/commit/d7db6c1f8655bb53153695b09a50029fd04a8364
                 // https://github.com/unicode-org/icu/blob/main/docs/userguide/format_parse/numbers/skeletons.md#precision
-                skeletonBuilder.append(" .");
+                skeletonBuilder.append(" ."_s);
                 for (unsigned i = 0; i < intlInstance->m_minimumFractionDigits; ++i)
                     skeletonBuilder.append('0');
                 for (unsigned i = 0; i < intlInstance->m_maximumFractionDigits - intlInstance->m_minimumFractionDigits; ++i)
@@ -295,7 +295,7 @@ void appendNumberFormatDigitOptionsToSkeleton(IntlType* intlInstance, StringBuil
         // Only ICU69~ supports trailing zero display. Ignore this option if linked ICU does not support it.
         // https://github.com/unicode-org/icu/commit/b79c299f90d4023ac237db3d0335d568bf21cd36
         if (WTF::ICU::majorVersion() >= 69)
-            skeletonBuilder.append("/w");
+            skeletonBuilder.append("/w"_s);
         break;
     }
 }

--- a/Source/JavaScriptCore/runtime/Options.h
+++ b/Source/JavaScriptCore/runtime/Options.h
@@ -142,11 +142,11 @@ private:
         DontDumpDefaults,
         DumpDefaults
     };
-    static void dumpAllOptions(DumpLevel, const char* title = nullptr);
-    static void dumpAllOptions(StringBuilder&, DumpLevel, const char* title,
-        const char* separator, const char* optionHeader, const char* optionFooter, DumpDefaultsOption);
+    static void dumpAllOptions(DumpLevel, ASCIILiteral title = { });
+    static void dumpAllOptions(StringBuilder&, DumpLevel, ASCIILiteral title,
+        ASCIILiteral separator, ASCIILiteral optionHeader, ASCIILiteral optionFooter, DumpDefaultsOption);
     static void dumpOption(StringBuilder&, DumpLevel, ID,
-        const char* optionHeader, const char* optionFooter, DumpDefaultsOption);
+        ASCIILiteral optionHeader, ASCIILiteral optionFooter, DumpDefaultsOption);
 
     static bool setOptionWithoutAlias(const char* arg, bool verify = true);
     static bool setAliasedOption(const char* arg, bool verify = true);

--- a/Source/JavaScriptCore/runtime/PredictionFileCreatingFuzzerAgent.cpp
+++ b/Source/JavaScriptCore/runtime/PredictionFileCreatingFuzzerAgent.cpp
@@ -62,7 +62,7 @@ SpeculatedType PredictionFileCreatingFuzzerAgent::getPredictionInternal(CodeBloc
         break;
 
     default:
-        RELEASE_ASSERT_WITH_MESSAGE(false, "unhandled opcode: %s", opcodeNames[predictionTarget.opcodeId]);
+        RELEASE_ASSERT_WITH_MESSAGE(false, "unhandled opcode: %s", opcodeNames[predictionTarget.opcodeId].characters());
     }
     return original;
 }

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -581,9 +581,9 @@ inline void appendLineTerminatorEscape<UChar>(StringBuilder& builder, UChar line
     else if (lineTerminator == '\r')
         builder.append('r');
     else if (lineTerminator == 0x2028)
-        builder.append("u2028");
+        builder.append("u2028"_s);
     else
-        builder.append("u2029");
+        builder.append("u2029"_s);
 }
 
 template <typename CharacterType>

--- a/Source/JavaScriptCore/runtime/TypeProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/TypeProfiler.cpp
@@ -88,17 +88,17 @@ String TypeProfiler::typeInformationForExpressionAtOffset(TypeProfilerSearchDesc
 
     json.append('{');
 
-    json.append("\"globalTypeSet\":");
+    json.append("\"globalTypeSet\":"_s);
     if (location->m_globalTypeSet && location->m_globalVariableID != TypeProfilerNoGlobalIDExists)
         json.append(location->m_globalTypeSet->toJSONString());
     else
-        json.append("null");
+        json.append("null"_s);
     json.append(',');
 
-    json.append("\"instructionTypeSet\":", location->m_instructionTypeSet->toJSONString(), ',');
+    json.append("\"instructionTypeSet\":"_s, location->m_instructionTypeSet->toJSONString(), ',');
 
     bool isOverflown = location->m_instructionTypeSet->isOverflown() || (location->m_globalTypeSet && location->m_globalTypeSet->isOverflown());
-    json.append("\"isOverflown\":", isOverflown ? "true" : "false");
+    json.append("\"isOverflown\":"_s, isOverflown ? "true"_s : "false"_s);
 
     json.append('}');
 

--- a/Source/JavaScriptCore/runtime/TypeSet.cpp
+++ b/Source/JavaScriptCore/runtime/TypeSet.cpp
@@ -95,36 +95,36 @@ String TypeSet::dumpTypes() const
     StringBuilder seen;
 
     if (m_seenTypes & TypeFunction)
-        seen.append("Function ");
+        seen.append("Function "_s);
     if (m_seenTypes & TypeUndefined)
-        seen.append("Undefined ");
+        seen.append("Undefined "_s);
     if (m_seenTypes & TypeNull)
-        seen.append("Null ");
+        seen.append("Null "_s);
     if (m_seenTypes & TypeBoolean)
-        seen.append("Boolean ");
+        seen.append("Boolean "_s);
     if (m_seenTypes & TypeAnyInt)
-        seen.append("AnyInt ");
+        seen.append("AnyInt "_s);
     if (m_seenTypes & TypeNumber)
-        seen.append("Number ");
+        seen.append("Number "_s);
     if (m_seenTypes & TypeString)
-        seen.append("String ");
+        seen.append("String "_s);
     if (m_seenTypes & TypeObject)
-        seen.append("Object ");
+        seen.append("Object "_s);
     if (m_seenTypes & TypeSymbol)
-        seen.append("Symbol ");
+        seen.append("Symbol "_s);
 
     for (const auto& shape : m_structureHistory)
         seen.append(shape->m_constructorName, ' ');
 
     if (m_structureHistory.size()) 
-        seen.append("\nStructures:[ ");
+        seen.append("\nStructures:[ "_s);
     for (const auto& shape : m_structureHistory)
         seen.append(shape->stringRepresentation(), ' ');
     if (m_structureHistory.size())
         seen.append(']');
 
     if (m_structureHistory.size())
-        seen.append("\nLeast Common Ancestor: ", leastCommonAncestor());
+        seen.append("\nLeast Common Ancestor: "_s, leastCommonAncestor());
 
     return seen.toString();
 }
@@ -252,57 +252,57 @@ String TypeSet::toJSONString() const
     StringBuilder json;
     json.append('{');
 
-    json.append("\"displayTypeName\":");
+    json.append("\"displayTypeName\":"_s);
     json.appendQuotedJSONString(displayName());
     json.append(',');
 
-    json.append("\"primitiveTypeNames\":[");
+    json.append("\"primitiveTypeNames\":["_s);
     bool hasAnItem = false;
     if (m_seenTypes & TypeUndefined) {
         hasAnItem = true;
-        json.append("\"Undefined\"");
+        json.append("\"Undefined\""_s);
     }
     if (m_seenTypes & TypeNull) {
         if (hasAnItem)
             json.append(',');
         hasAnItem = true;
-        json.append("\"Null\"");
+        json.append("\"Null\""_s);
     }
     if (m_seenTypes & TypeBoolean) {
         if (hasAnItem)
             json.append(',');
         hasAnItem = true;
-        json.append("\"Boolean\"");
+        json.append("\"Boolean\""_s);
     }
     if (m_seenTypes & TypeAnyInt) {
         if (hasAnItem)
             json.append(',');
         hasAnItem = true;
-        json.append("\"Integer\"");
+        json.append("\"Integer\""_s);
     }
     if (m_seenTypes & TypeNumber) {
         if (hasAnItem)
             json.append(',');
         hasAnItem = true;
-        json.append("\"Number\"");
+        json.append("\"Number\""_s);
     }
     if (m_seenTypes & TypeString) {
         if (hasAnItem)
             json.append(',');
         hasAnItem = true;
-        json.append("\"String\"");
+        json.append("\"String\""_s);
     }
     if (m_seenTypes & TypeSymbol) {
         if (hasAnItem)
             json.append(',');
         hasAnItem = true;
-        json.append("\"Symbol\"");
+        json.append("\"Symbol\""_s);
     }
     json.append(']');
 
     json.append(',');
 
-    json.append("\"structures\":[");
+    json.append("\"structures\":["_s);
     hasAnItem = false;
     for (size_t i = 0; i < m_structureHistory.size(); i++) {
         if (hasAnItem)
@@ -353,7 +353,7 @@ String StructureShape::propertyHash()
     }
 
     if (m_proto)
-        builder.append(":__proto__", m_proto->propertyHash());
+        builder.append(":__proto__"_s, m_proto->propertyHash());
 
     m_propertyHash = makeUnique<String>(builder.toString());
     return *m_propertyHash;
@@ -403,7 +403,7 @@ String StructureShape::stringRepresentation()
         for (auto& field : curShape->m_fields)
             representation.append(StringView { field.get() }, ", ");
         if (curShape->m_proto)
-            representation.append("__proto__ [", curShape->m_proto->m_constructorName, "], ");
+            representation.append("__proto__ ["_s, curShape->m_proto->m_constructorName, "], "_s);
         curShape = curShape->m_proto;
     }
 
@@ -426,18 +426,18 @@ String StructureShape::toJSONString() const
     StringBuilder json;
     json.append('{');
 
-    json.append("\"constructorName\":");
+    json.append("\"constructorName\":"_s);
     json.appendQuotedJSONString(m_constructorName);
     json.append(',');
 
-    json.append("\"isInDictionaryMode\":");
+    json.append("\"isInDictionaryMode\":"_s);
     if (m_isInDictionaryMode)
-        json.append("true");
+        json.append("true"_s);
     else
-        json.append("false");
+        json.append("false"_s);
     json.append(',');
 
-    json.append("\"fields\":[");
+    json.append("\"fields\":["_s);
     bool hasAnItem = false;
     for (auto& field : m_fields) {
         if (hasAnItem)
@@ -447,9 +447,9 @@ String StructureShape::toJSONString() const
         String fieldName(field.get());
         json.appendQuotedJSONString(fieldName);
     }
-    json.append("],");
+    json.append("],"_s);
 
-    json.append("\"optionalFields\":[");
+    json.append("\"optionalFields\":["_s);
     hasAnItem = false;
     for (auto& field : m_optionalFields) {
         if (hasAnItem)
@@ -462,11 +462,11 @@ String StructureShape::toJSONString() const
     json.append(']');
     json.append(',');
 
-    json.append("\"proto\":");
+    json.append("\"proto\":"_s);
     if (m_proto)
         json.append(m_proto->toJSONString());
     else
-        json.append("null");
+        json.append("null"_s);
 
     json.append('}');
 

--- a/Source/JavaScriptCore/tools/FunctionOverrides.cpp
+++ b/Source/JavaScriptCore/tools/FunctionOverrides.cpp
@@ -238,7 +238,7 @@ static String parseClause(const char* keyword, size_t keywordLength, FILE* file,
             builder.append(std::span { line, p + 1 });
             return builder.toString();
         }
-        builder.append(line);
+        builder.append(span(line));
 
     } while ((line = fgets(buffer, bufferSize, file)));
 

--- a/Source/WTF/wtf/JSONValues.cpp
+++ b/Source/WTF/wtf/JSONValues.cpp
@@ -656,13 +656,13 @@ void Value::writeJSONImpl(StringBuilder& output) const
 {
     switch (m_type) {
     case Type::Null:
-        output.append("null");
+        output.append("null"_s);
         break;
     case Type::Boolean:
         if (m_value.boolean)
-            output.append("true");
+            output.append("true"_s);
         else
-            output.append("false");
+            output.append("false"_s);
         break;
     case Type::String:
         output.appendQuotedJSONString(m_value.string);
@@ -670,7 +670,7 @@ void Value::writeJSONImpl(StringBuilder& output) const
     case Type::Double:
     case Type::Integer: {
         if (!std::isfinite(m_value.number))
-            output.append("null");
+            output.append("null"_s);
         else
             output.append(m_value.number);
         break;

--- a/Source/WTF/wtf/text/StringBuilder.h
+++ b/Source/WTF/wtf/text/StringBuilder.h
@@ -60,10 +60,10 @@ public:
     void append(const String&);
     void append(StringView);
     void append(ASCIILiteral);
+    void append(const char*) = delete; // Pass ASCIILiteral or span instead.
     void append(UChar);
     void append(LChar);
     void append(char character) { append(static_cast<LChar>(character)); }
-    void append(const char*);
 
     // FIXME: Add a StringTypeAdapter so we can append one string builder to another with variadic append.
     void append(const StringBuilder&);
@@ -224,11 +224,6 @@ inline void StringBuilder::append(ASCIILiteral string)
 inline void StringBuilder::appendSubstring(const String& string, unsigned offset, unsigned length)
 {
     append(StringView { string }.substring(offset, length));
-}
-
-inline void StringBuilder::append(const char* characters)
-{
-    append(StringView::fromLatin1(characters));
 }
 
 inline String StringBuilder::toString()

--- a/Source/WTF/wtf/text/TextStream.cpp
+++ b/Source/WTF/wtf/text/TextStream.cpp
@@ -107,7 +107,7 @@ TextStream& TextStream::operator<<(double d)
 
 TextStream& TextStream::operator<<(const char* string)
 {
-    m_text.append(string);
+    m_text.append(span(string));
     return *this;
 }
 

--- a/Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp
+++ b/Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp
@@ -73,28 +73,28 @@ static bool flagsAreSet(MediaProducerMediaStateFlags value, MediaProducerMediaSt
 String mediaProducerStateString(MediaProducerMediaStateFlags flags)
 {
     StringBuilder string;
-    string.append(" { ");
+    string.append(" { "_s);
     if (flags & MediaProducerMediaState::IsPlayingAudio)
-        string.append("IsPlayingAudio+");
+        string.append("IsPlayingAudio+"_s);
     if (flags & MediaProducerMediaState::IsPlayingVideo)
-        string.append("IsPlayingVideo+");
+        string.append("IsPlayingVideo+"_s);
     if (flags & MediaProducerMediaState::IsPlayingToExternalDevice)
-        string.append("IsPlayingToExternalDevice+");
+        string.append("IsPlayingToExternalDevice+"_s);
     if (flags & MediaProducerMediaState::HasPlaybackTargetAvailabilityListener)
-        string.append("HasTargetAvailabilityListener+");
+        string.append("HasTargetAvailabilityListener+"_s);
     if (flags & MediaProducerMediaState::RequiresPlaybackTargetMonitoring)
-        string.append("RequiresTargetMonitoring+");
+        string.append("RequiresTargetMonitoring+"_s);
     if (flags & MediaProducerMediaState::ExternalDeviceAutoPlayCandidate)
-        string.append("ExternalDeviceAutoPlayCandidate+");
+        string.append("ExternalDeviceAutoPlayCandidate+"_s);
     if (flags & MediaProducerMediaState::DidPlayToEnd)
-        string.append("DidPlayToEnd+");
+        string.append("DidPlayToEnd+"_s);
     if (flags & MediaProducerMediaState::HasAudioOrVideo)
-        string.append("HasAudioOrVideo+");
+        string.append("HasAudioOrVideo+"_s);
     if (string.isEmpty())
-        string.append("IsNotPlaying");
+        string.append("IsNotPlaying"_s);
     else
         string.shrink(string.length() - 1);
-    string.append(" }");
+    string.append(" }"_s);
     return string.toString();
 }
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -719,8 +719,8 @@ void MediaKeySession::updateKeyStatuses(CDMInstanceSession::KeyStatusVector&& in
         if (!statusCount.value)
             continue;
         if (!statusString.isEmpty())
-            statusString.append(", ");
-        statusString.append(makeString(convertEnumerationToString(statusCount.key), ": ", statusCount.value));
+            statusString.append(", "_s);
+        statusString.append(makeString(convertEnumerationToString(statusCount.key), ": "_s, statusCount.value));
     }
     ALWAYS_LOG(LOGIDENTIFIER, "statuses: {", statusString.toString(), "}");
 #endif

--- a/Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp
@@ -50,10 +50,10 @@ struct LogArgument<Vector<T>> {
     static String toString(const Vector<T>& value)
     {
         StringBuilder builder;
-        builder.append("[");
+        builder.append('[');
         for (auto item : value)
             builder.append(LogArgument<T>::toString(item));
-        builder.append("]");
+        builder.append(']');
         return builder.toString();
     }
 };

--- a/Source/WebCore/Modules/fetch/FetchHeaders.cpp
+++ b/Source/WebCore/Modules/fetch/FetchHeaders.cpp
@@ -206,7 +206,7 @@ ExceptionOr<void> FetchHeaders::remove(const String& name)
 ExceptionOr<String> FetchHeaders::get(const String& name) const
 {
     if (!isValidHTTPToken(name))
-        return Exception { ExceptionCode::TypeError, makeString("Invalid header name: '", name, "'") };
+        return Exception { ExceptionCode::TypeError, makeString("Invalid header name: '"_s, name, "'"_s) };
 
     if (equalIgnoringASCIICase(name, "set-cookie"_s)) {
         if (m_setCookieValues.isEmpty())
@@ -214,7 +214,7 @@ ExceptionOr<String> FetchHeaders::get(const String& name) const
         StringBuilder builder;
         for (const auto& value : m_setCookieValues) {
             if (!builder.isEmpty())
-                builder.append(", ");
+                builder.append(", "_s);
             builder.append(value);
         }
         return builder.toString();

--- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
+++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
@@ -335,17 +335,17 @@ int Geolocation::watchPosition(Ref<PositionCallback>&& successCallback, RefPtr<P
 static void logError(const String& target, const bool isSecure, const bool isMixedContent, Document* document)
 {
     StringBuilder message;
-    message.append("[blocked] Access to geolocation was blocked over");
+    message.append("[blocked] Access to geolocation was blocked over"_s);
     
     if (!isSecure)
-        message.append(" insecure connection to ");
+        message.append(" insecure connection to "_s);
     else if (isMixedContent)
-        message.append(" secure connection with mixed content to ");
+        message.append(" secure connection with mixed content to "_s);
     else
         return;
     
     message.append(target);
-    message.append(".\n");
+    message.append(".\n"_s);
     document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, message.toString());
 }
     

--- a/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
@@ -320,24 +320,24 @@ String IDBKeyData::loggingString() const
         return "<invalid>"_s;
     case IndexedDB::KeyType::Array: {
         StringBuilder builder;
-        builder.append("<array> - { ");
+        builder.append("<array> - { "_s);
         auto& array = std::get<Vector<IDBKeyData>>(m_value);
         for (size_t i = 0; i < array.size(); ++i) {
             builder.append(array[i].loggingString());
             if (i < array.size() - 1)
-                builder.append(", ");
+                builder.append(", "_s);
         }
-        builder.append(" }");
+        builder.append(" }"_s);
         result = builder.toString();
         break;
     }
     case IndexedDB::KeyType::Binary: {
         StringBuilder builder;
-        builder.append("<binary> - ");
+        builder.append("<binary> - "_s);
 
         auto* data = std::get<ThreadSafeDataBuffer>(m_value).data();
         if (!data) {
-            builder.append("(null)");
+            builder.append("(null)"_s);
             result = builder.toString();
             break;
         }
@@ -350,7 +350,7 @@ String IDBKeyData::loggingString() const
         }
 
         if (data->size() > 8)
-            builder.append("...");
+            builder.append("..."_s);
 
         result = builder.toString();
         break;

--- a/Source/WebCore/Modules/indexeddb/IDBKeyPath.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyPath.cpp
@@ -216,13 +216,13 @@ String loggingString(const IDBKeyPath& path)
             return "< >"_str;
 
         StringBuilder builder;
-        builder.append("< ");
+        builder.append("< "_s);
         for (size_t i = 0; i < strings.size() - 1; ++i) {
             builder.append(strings[i]);
-            builder.append(", ");
+            builder.append(", "_s);
         }
         builder.append(strings.last());
-        builder.append(" >");
+        builder.append(" >"_s);
 
         return builder.toString();
     });

--- a/Source/WebCore/Modules/indexeddb/server/IndexValueStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IndexValueStore.cpp
@@ -401,7 +401,7 @@ String IndexValueStore::loggingString() const
 {
     StringBuilder builder;
     for (auto& key : m_orderedKeys)
-        builder.append("Key: ", key.loggingString(), "  Entry has ", m_records.get(key)->getCount(), " entries");
+        builder.append("Key: "_s, key.loggingString(), "  Entry has "_s, m_records.get(key)->getCount(), " entries"_s);
     return builder.toString();
 }
 #endif

--- a/Source/WebCore/Modules/indexeddb/shared/IDBDatabaseInfo.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBDatabaseInfo.cpp
@@ -158,7 +158,7 @@ void IDBDatabaseInfo::deleteObjectStore(uint64_t objectStoreIdentifier)
 String IDBDatabaseInfo::loggingString() const
 {
     StringBuilder builder;
-    builder.append("Database:", m_name, " version ", m_version, '\n');
+    builder.append("Database:"_s, m_name, " version "_s, m_version, '\n');
     for (auto& objectStore : m_objectStoreMap.values())
         builder.append(objectStore.loggingString(1), '\n');
     return builder.toString();

--- a/Source/WebCore/Modules/indexeddb/shared/IDBObjectStoreInfo.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBObjectStoreInfo.cpp
@@ -135,7 +135,7 @@ String IDBObjectStoreInfo::loggingString(int indent) const
     StringBuilder builder;
     for (int i = 0; i < indent; ++i)
         builder.append(' ');
-    builder.append("Object store: ", m_name, m_identifier);
+    builder.append("Object store: "_s, m_name, m_identifier);
     for (auto index : m_indexMap.values())
         builder.append(index.loggingString(indent + 1), '\n');
     return builder.toString();

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
@@ -185,7 +185,7 @@ static inline RTCRtpCodecParameters toRTCCodecParameters(const webrtc::RtpCodecP
         parameters.channels = *rtcParameters.num_channels;
 
     StringBuilder sdpFmtpLineBuilder;
-    sdpFmtpLineBuilder.append("a=fmtp:", parameters.payloadType, ' ');
+    sdpFmtpLineBuilder.append("a=fmtp:"_s, parameters.payloadType, ' ');
 
     bool isFirst = true;
     for (auto& keyValue : rtcParameters.parameters) {

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -111,9 +111,9 @@ static String encodeProtocolString(const String& protocol)
     StringBuilder builder;
     for (size_t i = 0; i < protocol.length(); i++) {
         if (protocol[i] < 0x20 || protocol[i] > 0x7E)
-            builder.append("\\u", hex(protocol[i], 4));
+            builder.append("\\u"_s, hex(protocol[i], 4));
         else if (protocol[i] == 0x5c)
-            builder.append("\\\\");
+            builder.append("\\\\"_s);
         else
             builder.append(protocol[i]);
     }

--- a/Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp
@@ -65,7 +65,7 @@ const String WebSocketExtensionDispatcher::createHeaderValue() const
     StringBuilder builder;
     builder.append(m_processors[0]->handshakeString());
     for (size_t i = 1; i < numProcessors; ++i)
-        builder.append(", ", m_processors[i]->handshakeString());
+        builder.append(", "_s, m_processors[i]->handshakeString());
     return builder.toString();
 }
 
@@ -74,7 +74,7 @@ void WebSocketExtensionDispatcher::appendAcceptedExtension(const String& extensi
     m_acceptedExtensionsBuilder.append(m_acceptedExtensionsBuilder.isEmpty() ? "" : ", ", extensionToken);
     // FIXME: Should use ListHashSet to keep the order of the parameters.
     for (auto& parameter : extensionParameters) {
-        m_acceptedExtensionsBuilder.append("; ", parameter.key);
+        m_acceptedExtensionsBuilder.append("; "_s, parameter.key);
         if (!parameter.value.isNull())
             m_acceptedExtensionsBuilder.append('=', parameter.value);
     }

--- a/Source/WebCore/PAL/pal/avfoundation/OutputContext.mm
+++ b/Source/WebCore/PAL/pal/avfoundation/OutputContext.mm
@@ -82,7 +82,7 @@ String OutputContext::deviceName()
         builder.append(iterator->name());
 
         if (++iterator != devices.end())
-            builder.append(" + ");
+            builder.append(" + "_s);
     }
 
     return builder.toString();

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -646,7 +646,7 @@ ValueOrException ScriptController::callInWorld(RunJavaScriptParameters&& paramet
     String errorMessage;
 
     // Build up a new script string that is an async function with arguments, and deserialize those arguments.
-    functionStringBuilder.append("(async function(");
+    functionStringBuilder.append("(async function("_s);
     for (auto argument = parameters.arguments->begin(); argument != parameters.arguments->end();) {
         functionStringBuilder.append(argument->key);
         auto serializedArgument = SerializedScriptValue::createFromWireBytes(WTFMove(argument->value));
@@ -669,7 +669,7 @@ ValueOrException ScriptController::callInWorld(RunJavaScriptParameters&& paramet
     if (!errorMessage.isEmpty())
         return makeUnexpected(ExceptionDetails { errorMessage });
 
-    functionStringBuilder.append("){", parameters.source, "})");
+    functionStringBuilder.append("){"_s, parameters.source, "})"_s);
 
     auto sourceCode = ScriptSourceCode { functionStringBuilder.toString(), parameters.taintedness, WTFMove(parameters.sourceURL), TextPosition(), JSC::SourceProviderSourceType::Program, CachedScriptFetcher::create(m_frame.document()->charset()) };
     const auto& jsSourceCode = sourceCode.jsSourceCode();

--- a/Source/WebCore/contentextensions/CombinedURLFilters.cpp
+++ b/Source/WebCore/contentextensions/CombinedURLFilters.cpp
@@ -98,8 +98,8 @@ static String prefixTreeVertexToString(const PrefixTreeVertex& vertex, const Has
 {
     StringBuilder builder;
     while (depth--)
-        builder.append("  ");
-    builder.append("vertex actions: ");
+        builder.append("  "_s);
+    builder.append("vertex actions: "_s);
 
     auto actionsSlot = actions.find(&vertex);
     if (actionsSlot != actions.end()) {
@@ -117,7 +117,7 @@ static void recursivePrint(const PrefixTreeVertex& vertex, const HashMap<const P
         StringBuilder builder;
         for (unsigned i = 0; i < depth * 2; ++i)
             builder.append(' ');
-        builder.append("vertex edge: ", edge.term->toString(), '\n');
+        builder.append("vertex edge: "_s, edge.term->toString(), '\n');
         dataLogF("%s", builder.toString().utf8().data());
         ASSERT(edge.child);
         recursivePrint(*edge.child.get(), actions, depth + 1);

--- a/Source/WebCore/contentextensions/Term.h
+++ b/Source/WebCore/contentextensions/Term.h
@@ -243,7 +243,7 @@ inline String Term::toString() const
                 if (isASCIIPrintable(c) && !isUnicodeCompatibleASCIIWhitespace(c))
                     builder.append(c);
                 else
-                    builder.append("\\u", c);
+                    builder.append("\\u"_s, c);
             }
         }
         builder.append(']');

--- a/Source/WebCore/css/CSSBasicShapes.cpp
+++ b/Source/WebCore/css/CSSBasicShapes.cpp
@@ -146,7 +146,7 @@ Ref<CSSEllipseValue> CSSEllipseValue::create(RefPtr<CSSValue>&& radiusX, RefPtr<
 static String buildEllipseString(const String& radiusX, const String& radiusY, const String& centerX, const String& centerY)
 {
     StringBuilder result;
-    result.append("ellipse(");
+    result.append("ellipse("_s);
     bool needsSeparator = false;
     if (!radiusX.isNull()) {
         result.append(radiusX);
@@ -161,7 +161,7 @@ static String buildEllipseString(const String& radiusX, const String& radiusY, c
     if (!centerX.isNull() || !centerY.isNull()) {
         if (needsSeparator)
             result.append(' ');
-        result.append("at ", centerX, ' ', centerY);
+        result.append("at "_s, centerX, ' ', centerY);
     }
     result.append(')');
     return result.toString();
@@ -470,7 +470,7 @@ static String buildInsetString(const String& top, const String& right, const Str
     const String& bottomLeftRadiusWidth, const String& bottomLeftRadiusHeight)
 {
     StringBuilder result;
-    result.append("inset(", top);
+    result.append("inset("_s, top);
 
     bool showLeftArg = !left.isNull() && left != right;
     bool showBottomArg = !bottom.isNull() && (bottom != top || showLeftArg);

--- a/Source/WebCore/css/CSSContainerRule.cpp
+++ b/Source/WebCore/css/CSSContainerRule.cpp
@@ -52,7 +52,7 @@ const StyleRuleContainer& CSSContainerRule::styleRuleContainer() const
 String CSSContainerRule::cssText() const
 {
     StringBuilder builder;
-    builder.append("@container ");
+    builder.append("@container "_s);
     CQ::serialize(builder, styleRuleContainer().containerQuery());
     appendCSSTextForItems(builder);
     return builder.toString();

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
@@ -469,15 +469,15 @@ String CSSCounterStyleDescriptors::rangesCSSText() const
     StringBuilder builder;
     for (size_t i = 0; i < m_ranges.size(); ++i) {
         if (i)
-            builder.append(", ");
+            builder.append(", "_s);
         auto& range = m_ranges[i];
         if (range.first == std::numeric_limits<int>::min())
-            builder.append("infinite");
+            builder.append("infinite"_s);
         else
             builder.append(range.first);
-        builder.append(" ");
+        builder.append(" "_s);
         if (range.second== std::numeric_limits<int>::max())
-            builder.append("infinite");
+            builder.append("infinite"_s);
         else
             builder.append(range.second);
     }
@@ -510,7 +510,7 @@ String CSSCounterStyleDescriptors::symbolsCSSText() const
     StringBuilder builder;
     for (size_t i = 0; i < m_symbols.size(); ++i) {
         if (i)
-            builder.append(" ");
+            builder.append(" "_s);
         builder.append(m_symbols[i].cssText());
     }
     return builder.toString();
@@ -523,9 +523,9 @@ String CSSCounterStyleDescriptors::additiveSymbolsCSSText() const
     StringBuilder builder;
     for (size_t i = 0; i < m_additiveSymbols.size(); ++i) {
         if (i)
-            builder.append(", ");
+            builder.append(", "_s);
         builder.append(m_additiveSymbols[i].second);
-        builder.append(" ");
+        builder.append(" "_s);
         builder.append(m_additiveSymbols[i].first.cssText());
     }
     return builder.toString();

--- a/Source/WebCore/css/CSSFontFaceSrcValue.cpp
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.cpp
@@ -148,12 +148,12 @@ String CSSFontFaceSrcResourceValue::customCSSText() const
     else
         builder.append(serializeURL(m_location.specifiedURLString));
     if (!m_format.isEmpty())
-        builder.append(" format(", serializeString(m_format), ')');
+        builder.append(" format("_s, serializeString(m_format), ')');
     if (!m_technologies.isEmpty()) {
-        builder.append(" tech(");
+        builder.append(" tech("_s);
         for (size_t i = 0; i < m_technologies.size(); ++i) {
             if (i)
-                builder.append(", ");
+                builder.append(", "_s);
             builder.append(cssTextFromFontTech(m_technologies[i]));
         }
         builder.append(')');

--- a/Source/WebCore/css/CSSFontFeatureValuesRule.cpp
+++ b/Source/WebCore/css/CSSFontFeatureValuesRule.cpp
@@ -39,7 +39,7 @@ CSSFontFeatureValuesRule::CSSFontFeatureValuesRule(StyleRuleFontFeatureValues& f
 String CSSFontFeatureValuesRule::cssText() const
 {
     StringBuilder builder;
-    builder.append("@font-feature-values ");
+    builder.append("@font-feature-values "_s);
     auto joinFontFamiliesWithSeparator = [&builder] (const auto& elements, ASCIILiteral separator) {
         bool first = true;
         for (auto element : elements) {
@@ -50,20 +50,20 @@ String CSSFontFeatureValuesRule::cssText() const
         }
     };
     joinFontFamiliesWithSeparator(m_fontFeatureValuesRule->fontFamilies(), ", "_s);
-    builder.append(" { ");
+    builder.append(" { "_s);
     const auto& value = m_fontFeatureValuesRule->value();
     
     auto addVariant = [&builder] (const String& variantName, const auto& tags) {
         if (!tags.isEmpty()) {
-            builder.append("@", variantName, " { ");
+            builder.append('@', variantName, " { "_s);
             for (auto tag : tags) {
                 serializeIdentifier(tag.key, builder);
                 builder.append(':');
                 for (auto integer : tag.value)
                     builder.append(' ', integer);
-                builder.append("; ");
+                builder.append("; "_s);
             }
-            builder.append("} ");
+            builder.append("} "_s);
         }
     };
     

--- a/Source/WebCore/css/CSSFontFeatureValuesRule.h
+++ b/Source/WebCore/css/CSSFontFeatureValuesRule.h
@@ -50,7 +50,7 @@ public:
             if (first)
                 first = false;
             else
-                builder.append(", ");
+                builder.append(", "_s);
             
             builder.append(family);
         }

--- a/Source/WebCore/css/CSSFontPaletteValuesRule.cpp
+++ b/Source/WebCore/css/CSSFontPaletteValuesRule.cpp
@@ -79,7 +79,7 @@ String CSSFontPaletteValuesRule::overrideColors() const
     StringBuilder result;
     for (size_t i = 0; i < m_fontPaletteValuesRule->overrideColors().size(); ++i) {
         if (i)
-            result.append(", ");
+            result.append(", "_s);
         const auto& item = m_fontPaletteValuesRule->overrideColors()[i];
         result.append(item.first, ' ', serializationForCSS(item.second));
     }
@@ -89,32 +89,32 @@ String CSSFontPaletteValuesRule::overrideColors() const
 String CSSFontPaletteValuesRule::cssText() const
 {
     StringBuilder builder;
-    builder.append("@font-palette-values ", name(), " { ");
+    builder.append("@font-palette-values "_s, name(), " { "_s);
     if (!m_fontPaletteValuesRule->fontFamilies().isEmpty())
-        builder.append("font-family: ", fontFamily(), "; ");
+        builder.append("font-family: "_s, fontFamily(), "; "_s);
 
     if (m_fontPaletteValuesRule->basePalette()) {
         switch (m_fontPaletteValuesRule->basePalette()->type) {
         case FontPaletteIndex::Type::Light:
-            builder.append("base-palette: light; ");
+            builder.append("base-palette: light; "_s);
             break;
         case FontPaletteIndex::Type::Dark:
-            builder.append("base-palette: dark; ");
+            builder.append("base-palette: dark; "_s);
             break;
         case FontPaletteIndex::Type::Integer:
-            builder.append("base-palette: ", m_fontPaletteValuesRule->basePalette()->integer, "; ");
+            builder.append("base-palette: "_s, m_fontPaletteValuesRule->basePalette()->integer, "; "_s);
             break;
         }
     }
 
     if (!m_fontPaletteValuesRule->overrideColors().isEmpty()) {
-        builder.append("override-colors:");
+        builder.append("override-colors:"_s);
         for (size_t i = 0; i < m_fontPaletteValuesRule->overrideColors().size(); ++i) {
             if (i)
                 builder.append(',');
             builder.append(' ', m_fontPaletteValuesRule->overrideColors()[i].first, ' ', serializationForCSS(m_fontPaletteValuesRule->overrideColors()[i].second));
         }
-        builder.append("; ");
+        builder.append("; "_s);
     }
     builder.append('}');
     return builder.toString();

--- a/Source/WebCore/css/CSSGradientValue.cpp
+++ b/Source/WebCore/css/CSSGradientValue.cpp
@@ -210,11 +210,11 @@ static void appendGradientStops(StringBuilder& builder, const Vector<CSSGradient
     for (auto& stop : stops) {
         double position = stop.position->doubleValue(CSSUnitType::CSS_NUMBER);
         if (!position)
-            builder.append(", from(", stop.color->cssText(), ')');
+            builder.append(", from("_s, stop.color->cssText(), ')');
         else if (position == 1)
-            builder.append(", to(", stop.color->cssText(), ')');
+            builder.append(", to("_s, stop.color->cssText(), ')');
         else
-            builder.append(", color-stop(", position, ", ", stop.color->cssText(), ')');
+            builder.append(", color-stop("_s, position, ", "_s, stop.color->cssText(), ')');
     }
 }
 
@@ -266,7 +266,7 @@ String CSSLinearGradientValue::customCSSText() const
 {
     StringBuilder result;
 
-    result.append(m_repeating == CSSGradientRepeat::Repeating ? "repeating-linear-gradient(" : "linear-gradient(");
+    result.append(m_repeating == CSSGradientRepeat::Repeating ? "repeating-linear-gradient("_s : "linear-gradient("_s);
     bool wroteSomething = false;
 
     WTF::switchOn(m_data.gradientLine,
@@ -279,18 +279,18 @@ String CSSLinearGradientValue::customCSSText() const
             wroteSomething = true;
         },
         [&] (Horizontal horizontal) {
-            result.append("to ", WebCore::cssText(horizontal));
+            result.append("to "_s, WebCore::cssText(horizontal));
             wroteSomething = true;
         },
         [&] (Vertical vertical) {
             if (vertical == Vertical::Bottom)
                 return;
     
-            result.append("to ", WebCore::cssText(vertical));
+            result.append("to "_s, WebCore::cssText(vertical));
             wroteSomething = true;
         },
         [&] (const std::pair<Horizontal, Vertical>& pair) {
-            result.append("to ", WebCore::cssText(pair.first), ' ', WebCore::cssText(pair.second));
+            result.append("to "_s, WebCore::cssText(pair.first), ' ', WebCore::cssText(pair.second));
             wroteSomething = true;
         }
     );
@@ -300,7 +300,7 @@ String CSSLinearGradientValue::customCSSText() const
 
     for (auto& stop : m_stops) {
         if (wroteSomething)
-            result.append(", ");
+            result.append(", "_s);
         wroteSomething = true;
         writeColorStop(result, stop);
     }
@@ -350,11 +350,11 @@ String CSSPrefixedLinearGradientValue::customCSSText() const
 {
     StringBuilder result;
 
-    result.append(m_repeating == CSSGradientRepeat::Repeating ? "-webkit-repeating-linear-gradient(" : "-webkit-linear-gradient(");
+    result.append(m_repeating == CSSGradientRepeat::Repeating ? "-webkit-repeating-linear-gradient("_s : "-webkit-linear-gradient("_s);
 
     WTF::switchOn(m_data.gradientLine,
         [&] (std::monostate) {
-            result.append("top");
+            result.append("top"_s);
         },
         [&] (const Angle& angle) {
             result.append(angle.value->cssText());
@@ -371,7 +371,7 @@ String CSSPrefixedLinearGradientValue::customCSSText() const
     );
 
     for (auto& stop : m_stops) {
-        result.append(", ");
+        result.append(", "_s);
         writeColorStop(result, stop);
     }
 
@@ -397,7 +397,7 @@ bool CSSPrefixedLinearGradientValue::equals(const CSSPrefixedLinearGradientValue
 String CSSDeprecatedLinearGradientValue::customCSSText() const
 {
     StringBuilder result;
-    result.append("-webkit-gradient(linear, ", m_data.firstX->cssText(), ' ', m_data.firstY->cssText(), ", ", m_data.secondX->cssText(), ' ', m_data.secondY->cssText());
+    result.append("-webkit-gradient(linear, "_s, m_data.firstX->cssText(), ' ', m_data.firstY->cssText(), ", ", m_data.secondX->cssText(), ' ', m_data.secondY->cssText());
     appendGradientStops(result, m_stops);
     result.append(')');
     return result.toString();
@@ -452,7 +452,7 @@ String CSSRadialGradientValue::customCSSText() const
 {
     StringBuilder result;
 
-    result.append(m_repeating == CSSGradientRepeat::Repeating ? "repeating-radial-gradient(" : "radial-gradient(");
+    result.append(m_repeating == CSSGradientRepeat::Repeating ? "repeating-radial-gradient("_s : "radial-gradient("_s);
 
     bool wroteSomething = false;
 
@@ -460,7 +460,7 @@ String CSSRadialGradientValue::customCSSText() const
         if (!isCenterPosition(position)) {
             if (wroteSomething)
                 result.append(' ');
-            result.append("at ");
+            result.append("at "_s);
             appendSpaceSeparatedOptionalCSSPtrText(result, position.first.ptr(), position.second.ptr());
             wroteSomething = true;
         }
@@ -476,7 +476,7 @@ String CSSRadialGradientValue::customCSSText() const
         [&] (std::monostate) { },
         [&] (const Shape& data) {
             if (data.shape != ShapeKeyword::Ellipse) {
-                result.append("circle");
+                result.append("circle"_s);
                 wroteSomething = true;
             }
             appendOptionalPosition(data.position);
@@ -503,9 +503,9 @@ String CSSRadialGradientValue::customCSSText() const
         },
         [&] (const CircleOfExtent& data) {
             if (data.extent != ExtentKeyword::FarthestCorner)
-                result.append("circle ", WebCore::cssText(data.extent));
+                result.append("circle "_s, WebCore::cssText(data.extent));
             else
-                result.append("circle");
+                result.append("circle"_s);
             wroteSomething = true;
             appendOptionalPosition(data.position);
         },
@@ -535,12 +535,12 @@ String CSSRadialGradientValue::customCSSText() const
         wroteSomething = true;
 
     if (wroteSomething)
-        result.append(", ");
+        result.append(", "_s);
 
     bool wroteFirstStop = false;
     for (auto& stop : m_stops) {
         if (wroteFirstStop)
-            result.append(", ");
+            result.append(", "_s);
         wroteFirstStop = true;
         writeColorStop(result, stop);
     }
@@ -620,31 +620,31 @@ String CSSPrefixedRadialGradientValue::customCSSText() const
 {
     StringBuilder result;
 
-    result.append(m_repeating == CSSGradientRepeat::Repeating ? "-webkit-repeating-radial-gradient(" : "-webkit-radial-gradient(");
+    result.append(m_repeating == CSSGradientRepeat::Repeating ? "-webkit-repeating-radial-gradient("_s : "-webkit-radial-gradient("_s);
 
     if (m_data.position)
         result.append(m_data.position->first->cssText(), ' ', m_data.position->second->cssText());
     else
-        result.append("center");
+        result.append("center"_s);
 
     WTF::switchOn(m_data.gradientBox,
         [&] (std::monostate) { },
         [&] (const ShapeKeyword& shape) {
-            result.append(", ", WebCore::cssText(shape), " cover");
+            result.append(", "_s, WebCore::cssText(shape), " cover"_s);
         },
         [&] (const ExtentKeyword& extent) {
-            result.append(", ellipse ", WebCore::cssText(extent));
+            result.append(", ellipse "_s, WebCore::cssText(extent));
         },
         [&] (const ShapeAndExtent& shapeAndExtent) {
-            result.append(", ", WebCore::cssText(shapeAndExtent.shape), ' ', WebCore::cssText(shapeAndExtent.extent));
+            result.append(", "_s, WebCore::cssText(shapeAndExtent.shape), ' ', WebCore::cssText(shapeAndExtent.extent));
         },
         [&] (const MeasuredSize& measuredSize) {
-            result.append(", ", measuredSize.size.first->cssText(), ' ', measuredSize.size.second->cssText());
+            result.append(", "_s, measuredSize.size.first->cssText(), ' ', measuredSize.size.second->cssText());
         }
     );
 
     for (auto& stop : m_stops) {
-        result.append(", ");
+        result.append(", "_s);
         writeColorStop(result, stop);
     }
 
@@ -673,9 +673,9 @@ String CSSDeprecatedRadialGradientValue::customCSSText() const
 {
     StringBuilder result;
 
-    result.append("-webkit-gradient(radial, ",
-        m_data.firstX->cssText(), ' ', m_data.firstY->cssText(), ", ", m_data.firstRadius->cssText(), ", ",
-        m_data.secondX->cssText(), ' ', m_data.secondY->cssText(), ", ", m_data.secondRadius->cssText());
+    result.append("-webkit-gradient(radial, "_s,
+        m_data.firstX->cssText(), ' ', m_data.firstY->cssText(), ", "_s, m_data.firstRadius->cssText(), ", "_s,
+        m_data.secondX->cssText(), ' ', m_data.secondY->cssText(), ", "_s, m_data.secondRadius->cssText());
 
     appendGradientStops(result, m_stops);
 
@@ -707,19 +707,19 @@ String CSSConicGradientValue::customCSSText() const
 {
     StringBuilder result;
 
-    result.append(m_repeating == CSSGradientRepeat::Repeating ? "repeating-conic-gradient(" : "conic-gradient(");
+    result.append(m_repeating == CSSGradientRepeat::Repeating ? "repeating-conic-gradient("_s : "conic-gradient("_s);
 
     bool wroteSomething = false;
 
     if (m_data.angle.value && m_data.angle.value->computeDegrees()) {
-        result.append("from ", m_data.angle.value->cssText());
+        result.append("from "_s, m_data.angle.value->cssText());
         wroteSomething = true;
     }
 
     if (m_data.position && !isCenterPosition(*m_data.position)) {
         if (wroteSomething)
             result.append(' ');
-        result.append("at ", m_data.position->first->cssText(), ' ', m_data.position->second->cssText());
+        result.append("at "_s, m_data.position->first->cssText(), ' ', m_data.position->second->cssText());
         wroteSomething = true;
     }
 
@@ -727,12 +727,12 @@ String CSSConicGradientValue::customCSSText() const
         wroteSomething = true;
 
     if (wroteSomething)
-        result.append(", ");
+        result.append(", "_s);
 
     bool wroteFirstStop = false;
     for (auto& stop : m_stops) {
         if (wroteFirstStop)
-            result.append(", ");
+            result.append(", "_s);
         wroteFirstStop = true;
         writeColorStop(result, stop);
     }

--- a/Source/WebCore/css/CSSGroupingRule.cpp
+++ b/Source/WebCore/css/CSSGroupingRule.cpp
@@ -119,9 +119,9 @@ ExceptionOr<void> CSSGroupingRule::deleteRule(unsigned index)
 
 void CSSGroupingRule::appendCSSTextForItemsInternal(StringBuilder& builder, StringBuilder& rules) const
 {
-    builder.append(" {");
+    builder.append(" {"_s);
     if (rules.isEmpty()) {
-        builder.append("\n}");
+        builder.append("\n}"_s);
         return;
     }
 
@@ -140,7 +140,7 @@ void CSSGroupingRule::cssTextForRules(StringBuilder& rules) const
     auto& childRules = m_groupRule->childRules();
     for (unsigned index = 0; index < childRules.size(); index++) {
         auto wrappedRule = item(index);
-        rules.append("\n  ", wrappedRule->cssText());
+        rules.append("\n  "_s, wrappedRule->cssText());
     }
 }
 
@@ -156,7 +156,7 @@ void CSSGroupingRule::cssTextForRulesWithReplacementURLs(StringBuilder& rules, c
     auto& childRules = m_groupRule->childRules();
     for (unsigned index = 0; index < childRules.size(); index++) {
         auto wrappedRule = item(index);
-        rules.append("\n  ", wrappedRule->cssTextWithReplacementURLs(replacementURLStrings, replacementURLStringsForCSSStyleSheet));
+        rules.append("\n  "_s, wrappedRule->cssTextWithReplacementURLs(replacementURLStrings, replacementURLStringsForCSSStyleSheet));
     }
 }
 

--- a/Source/WebCore/css/CSSImportRule.cpp
+++ b/Source/WebCore/css/CSSImportRule.cpp
@@ -76,18 +76,18 @@ String CSSImportRule::supportsText() const
 String CSSImportRule::cssTextInternal(const String& urlString) const
 {
     StringBuilder builder;
-    builder.append("@import ", serializeURL(urlString));
+    builder.append("@import "_s, serializeURL(urlString));
 
     if (auto layerName = this->layerName(); !layerName.isNull()) {
         if (layerName.isEmpty())
-            builder.append(" layer");
+            builder.append(" layer"_s);
         else
-            builder.append(" layer(", layerName, ')');
+            builder.append(" layer("_s, layerName, ')');
     }
 
     auto supports = supportsText();
     if (!supports.isNull())
-        builder.append(" supports(", WTFMove(supports), ')');
+        builder.append(" supports("_s, WTFMove(supports), ')');
 
     if (!mediaQueries().isEmpty()) {
         builder.append(' ');

--- a/Source/WebCore/css/CSSLayerBlockRule.cpp
+++ b/Source/WebCore/css/CSSLayerBlockRule.cpp
@@ -52,9 +52,9 @@ String CSSLayerBlockRule::cssText() const
 {
     StringBuilder builder;
 
-    builder.append("@layer");
+    builder.append("@layer"_s);
     if (auto name = this->name(); !name.isEmpty())
-        builder.append(" ", name);
+        builder.append(' ', name);
     appendCSSTextForItems(builder);
     return builder.toString();
 }

--- a/Source/WebCore/css/CSSLayerStatementRule.cpp
+++ b/Source/WebCore/css/CSSLayerStatementRule.cpp
@@ -55,13 +55,13 @@ String CSSLayerStatementRule::cssText() const
 {
     StringBuilder result;
 
-    result.append("@layer ");
+    result.append("@layer "_s);
 
     auto nameList = this->nameList();
     for (auto& name : nameList) {
         result.append(name);
         if (&name != &nameList.last())
-            result.append(", ");
+            result.append(", "_s);
     }
     result.append(';');
 

--- a/Source/WebCore/css/CSSLineBoxContainValue.cpp
+++ b/Source/WebCore/css/CSSLineBoxContainValue.cpp
@@ -40,19 +40,19 @@ String CSSLineBoxContainValue::customCSSText() const
 {
     StringBuilder text;
     if (m_value.contains(LineBoxContain::Block))
-        text.append("block");
+        text.append("block"_s);
     if (m_value.contains(LineBoxContain::Inline))
-        text.append(text.isEmpty() ? "" : " ", "inline");
+        text.append(text.isEmpty() ? ""_s : " "_s, "inline"_s);
     if (m_value.contains(LineBoxContain::Font))
-        text.append(text.isEmpty() ? "" : " ", "font");
+        text.append(text.isEmpty() ? ""_s : " "_s, "font"_s);
     if (m_value.contains(LineBoxContain::Glyphs))
-        text.append(text.isEmpty() ? "" : " ", "glyphs");
+        text.append(text.isEmpty() ? ""_s : " "_s, "glyphs"_s);
     if (m_value.contains(LineBoxContain::Replaced))
-        text.append(text.isEmpty() ? "" : " ", "replaced");
+        text.append(text.isEmpty() ? ""_s : " "_s, "replaced"_s);
     if (m_value.contains(LineBoxContain::InlineBox))
-        text.append(text.isEmpty() ? "" : " ", "inline-box");
+        text.append(text.isEmpty() ? ""_s : " "_s, "inline-box"_s);
     if (m_value.contains(LineBoxContain::InitialLetter))
-        text.append(text.isEmpty() ? "" : " ", "initial-letter");
+        text.append(text.isEmpty() ? ""_s : " "_s, "initial-letter"_s);
     return text.toString();
 }
 

--- a/Source/WebCore/css/CSSMarkup.cpp
+++ b/Source/WebCore/css/CSSMarkup.cpp
@@ -141,7 +141,7 @@ String serializeString(const String& string)
 String serializeURL(const String& string)
 {
     StringBuilder builder;
-    builder.append("url(");
+    builder.append("url("_s);
     serializeString(string, builder);
     builder.append(')');
     return builder.toString();

--- a/Source/WebCore/css/CSSMediaRule.cpp
+++ b/Source/WebCore/css/CSSMediaRule.cpp
@@ -55,7 +55,7 @@ void CSSMediaRule::setMediaQueries(MQ::MediaQueryList&& queries)
 String CSSMediaRule::cssText() const
 {
     StringBuilder builder;
-    builder.append("@media ", conditionText());
+    builder.append("@media "_s, conditionText());
     appendCSSTextForItems(builder);
     return builder.toString();
 }
@@ -63,7 +63,7 @@ String CSSMediaRule::cssText() const
 String CSSMediaRule::cssTextWithReplacementURLs(const HashMap<String, String>& replacementURLStrings, const HashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet) const
 {
     StringBuilder builder;
-    builder.append("@media ", conditionText());
+    builder.append("@media "_s, conditionText());
     appendCSSTextWithReplacementURLsForItems(builder, replacementURLStrings, replacementURLStringsForCSSStyleSheet);
     return builder.toString();
 }

--- a/Source/WebCore/css/CSSNamespaceRule.cpp
+++ b/Source/WebCore/css/CSSNamespaceRule.cpp
@@ -54,9 +54,9 @@ String CSSNamespaceRule::cssText() const
 {
     auto prefix = this->prefix();
     StringBuilder result;
-    result.append("@namespace ");
+    result.append("@namespace "_s);
     serializeIdentifier(prefix, result);
-    result.append(prefix.isEmpty() ? "" : " ", "url(", serializeString(namespaceURI()), ");");
+    result.append(prefix.isEmpty() ? ""_s : " "_s, "url("_s, serializeString(namespaceURI()), ");"_s);
     return result.toString();
 }
 

--- a/Source/WebCore/css/CSSPropertyRule.cpp
+++ b/Source/WebCore/css/CSSPropertyRule.cpp
@@ -76,23 +76,23 @@ String CSSPropertyRule::cssText() const
 
     auto& descriptor = m_propertyRule->descriptor();
 
-    builder.append("@property ");
+    builder.append("@property "_s);
     serializeIdentifier(descriptor.name, builder);
-    builder.append(" { ");
+    builder.append(" { "_s);
 
     if (!descriptor.syntax.isNull()) {
-        builder.append("syntax: ");
+        builder.append("syntax: "_s);
         serializeString(syntax(), builder);
-        builder.append("; ");
+        builder.append("; "_s);
     }
 
     if (descriptor.inherits)
-        builder.append("inherits: ", *descriptor.inherits ? "true" : "false", "; ");
+        builder.append("inherits: "_s, *descriptor.inherits ? "true"_s : "false"_s, "; "_s);
 
     if (descriptor.initialValue)
-        builder.append("initial-value: ", initialValue(), "; ");
+        builder.append("initial-value: "_s, initialValue(), "; "_s);
 
-    builder.append("}");
+    builder.append('}');
 
     return builder.toString();
 }

--- a/Source/WebCore/css/CSSScopeRule.cpp
+++ b/Source/WebCore/css/CSSScopeRule.cpp
@@ -49,13 +49,13 @@ const StyleRuleScope& CSSScopeRule::styleRuleScope() const
 String CSSScopeRule::cssText() const
 {
     StringBuilder builder;
-    builder.append("@scope");
+    builder.append("@scope"_s);
     auto start = this->start();
     if (!start.isEmpty())
-        builder.append(" (", start, ')');
+        builder.append(" ("_s, start, ')');
     auto end = this->end();
     if (!end.isEmpty())
-        builder.append(" to ", '(', end, ')');
+        builder.append(" to "_s, '(', end, ')');
     appendCSSTextForItems(builder);
     return builder.toString();
 }

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -118,7 +118,7 @@ void CSSSelectorList::buildSelectorsText(StringBuilder& stringBuilder) const
     const CSSSelector* firstSubselector = first();
     for (const CSSSelector* subSelector = firstSubselector; subSelector; subSelector = CSSSelectorList::next(subSelector)) {
         if (subSelector != firstSubselector)
-            stringBuilder.append(", ");
+            stringBuilder.append(", "_s);
         stringBuilder.append(subSelector->selectorText());
     }
 }

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -159,7 +159,7 @@ String CSSStyleRule::cssText() const
 void CSSStyleRule::cssTextForRules(StringBuilder& rules) const
 {
     for (unsigned index = 0; index < length(); index++)
-        rules.append("\n  ", item(index)->cssText());
+        rules.append("\n  "_s, item(index)->cssText());
 }
 
 String CSSStyleRule::cssTextWithReplacementURLs(const HashMap<String, String>& replacementURLStrings, const HashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet) const
@@ -181,37 +181,37 @@ String CSSStyleRule::cssTextWithReplacementURLs(const HashMap<String, String>& r
 void CSSStyleRule::cssTextForRulesWithReplacementURLs(StringBuilder& rules, const HashMap<String, String>& replacementURLStrings, const HashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet) const
 {
     for (unsigned index = 0; index < length(); index++)
-        rules.append("\n  ", item(index)->cssTextWithReplacementURLs(replacementURLStrings, replacementURLStringsForCSSStyleSheet));
+        rules.append("\n  "_s, item(index)->cssTextWithReplacementURLs(replacementURLStrings, replacementURLStringsForCSSStyleSheet));
 }
 
 String CSSStyleRule::cssTextInternal(StringBuilder& declarations, StringBuilder& rules) const
 {
     StringBuilder builder;
     builder.append(selectorText());
-    builder.append(" {");
+    builder.append(" {"_s);
 
     if (declarations.isEmpty() && rules.isEmpty()) {
-        builder.append(" }");
+        builder.append(" }"_s);
         return builder.toString();
     }
 
     if (rules.isEmpty()) {
         builder.append(' ');
         builder.append(declarations);
-        builder.append(" }");
+        builder.append(" }"_s);
         return builder.toString();
     }
 
     if (declarations.isEmpty()) {
         builder.append(rules);
-        builder.append("\n}");
+        builder.append("\n}"_s);
         return builder.toString();
     }
 
-    builder.append("\n  ");
+    builder.append("\n  "_s);
     builder.append(declarations);
     builder.append(rules);
-    builder.append("\n}");
+    builder.append("\n}"_s);
     return builder.toString();
 }
 

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -502,7 +502,7 @@ String CSSStyleSheet::cssTextWithReplacementURLs(const HashMap<String, String>& 
 
         auto ruleText = rule->cssTextWithReplacementURLs(replacementURLStrings, replacementURLStringsForCSSStyleSheet);
         if (!result.isEmpty() && !ruleText.isEmpty())
-            result.append(" ");
+            result.append(' ');
 
         result.append(ruleText);
     }

--- a/Source/WebCore/css/CSSSupportsRule.cpp
+++ b/Source/WebCore/css/CSSSupportsRule.cpp
@@ -51,7 +51,7 @@ Ref<CSSSupportsRule> CSSSupportsRule::create(StyleRuleSupports& rule, CSSStyleSh
 String CSSSupportsRule::cssText() const
 {
     StringBuilder builder;
-    builder.append("@supports ", conditionText());
+    builder.append("@supports "_s, conditionText());
     appendCSSTextForItems(builder);
     return builder.toString();
 }
@@ -59,7 +59,7 @@ String CSSSupportsRule::cssText() const
 String CSSSupportsRule::cssTextWithReplacementURLs(const HashMap<String, String>& replacementURLStrings, const HashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet) const
 {
     StringBuilder builder;
-    builder.append("@supports ", conditionText());
+    builder.append("@supports "_s, conditionText());
     appendCSSTextWithReplacementURLsForItems(builder, replacementURLStrings, replacementURLStringsForCSSStyleSheet);
     return builder.toString();
 }

--- a/Source/WebCore/css/CSSTimingFunctionValue.cpp
+++ b/Source/WebCore/css/CSSTimingFunctionValue.cpp
@@ -37,10 +37,10 @@ String CSSLinearTimingFunctionValue::customCSSText() const
         return "linear"_s;
 
     StringBuilder builder;
-    builder.append("linear(");
+    builder.append("linear("_s);
     for (size_t i = 0; i < m_points.size(); ++i) {
         if (i)
-            builder.append(", ");
+            builder.append(", "_s);
 
         const auto& point = m_points[i];
         builder.append(FormattedNumber::fixedPrecision(point.value), ' ', FormattedNumber::fixedPrecision(point.progress * 100.0), '%');

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -865,7 +865,7 @@ String ShorthandSerializer::serializeBorderRadius() const
     };
     serializeRadii(horizontalRadii);
     if (serializeBoth) {
-        result.append(" / ");
+        result.append(" / "_s);
         serializeRadii(verticalRadii);
     }
     return result.toString();
@@ -1193,7 +1193,7 @@ String ShorthandSerializer::serializeGridTemplate() const
         }
     }
     if (!isLonghandValueNone(columnsIndex))
-        result.append(" / ", serializeLonghandValue(columnsIndex));
+        result.append(" / "_s, serializeLonghandValue(columnsIndex));
     return result.toString();
 }
 

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
@@ -1066,7 +1066,7 @@ void CSSCalcOperationNode::buildCSSText(const CSSCalcExpressionNode& node, Strin
     
     bool outputCalc = shouldOutputEnclosingCalc(node);
     if (outputCalc)
-        builder.append("calc(");
+        builder.append("calc("_s);
 
     buildCSSTextRecursive(node, builder, GroupingParens::Omit);
 

--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -623,12 +623,12 @@ void CSSParserToken::serialize(StringBuilder& builder, const CSSParserToken* nex
 
         CSSParserTokenType nextType = nextToken->type();
         if (tokensNeedingComment.buffer[nextType]) {
-            builder.append("/**/");
+            builder.append("/**/"_s);
             return;
         }
 
         if (nextType == DelimiterToken && ((delimitersNeedingComment == nextToken->delimiter()) || ... || false)) {
-            builder.append("/**/");
+            builder.append("/**/"_s);
             return;
         }
     };
@@ -653,14 +653,14 @@ void CSSParserToken::serialize(StringBuilder& builder, const CSSParserToken* nex
         appendCommentIfNeeded({ IdentToken, FunctionToken, UrlToken, BadUrlToken, NumberToken, PercentageToken, DimensionToken, CDCToken }, '-');
         break;
     case UrlToken:
-        builder.append("url(");
+        builder.append("url("_s);
         serializeIdentifier(value().toString(), builder);
         builder.append(')');
         break;
     case DelimiterToken:
         switch (delimiter()) {
         case '\\':
-            builder.append("\\\n");
+            builder.append("\\\n"_s);
             break;
 
         case '#':
@@ -722,34 +722,34 @@ void CSSParserToken::serialize(StringBuilder& builder, const CSSParserToken* nex
         break;
 
     case IncludeMatchToken:
-        builder.append("~=");
+        builder.append("~="_s);
         break;
     case DashMatchToken:
-        builder.append("|=");
+        builder.append("|="_s);
         break;
     case PrefixMatchToken:
-        builder.append("^=");
+        builder.append("^="_s);
         break;
     case SuffixMatchToken:
-        builder.append("$=");
+        builder.append("$="_s);
         break;
     case SubstringMatchToken:
-        builder.append("*=");
+        builder.append("*="_s);
         break;
     case ColumnToken:
-        builder.append("||");
+        builder.append("||"_s);
         break;
     case CDOToken:
-        builder.append("<!--");
+        builder.append("<!--"_s);
         break;
     case CDCToken:
-        builder.append("-->");
+        builder.append("-->"_s);
         break;
     case BadStringToken:
-        builder.append("'\n");
+        builder.append("'\n"_s);
         break;
     case BadUrlToken:
-        builder.append("url(()");
+        builder.append("url(()"_s);
         break;
     case WhitespaceToken: {
         auto count = mode == SerializationMode::CustomProperty ? m_whitespaceCount : 1;

--- a/Source/WebCore/css/query/GenericMediaQuerySerialization.cpp
+++ b/Source/WebCore/css/query/GenericMediaQuerySerialization.cpp
@@ -50,14 +50,14 @@ static void serialize(StringBuilder& builder, const QueryInParens& queryInParens
 void serialize(StringBuilder& builder, const Condition& condition)
 {
     if (condition.queries.size() == 1 && condition.logicalOperator == LogicalOperator::Not) {
-        builder.append("not ");
+        builder.append("not "_s);
         serialize(builder, condition.queries.first());
         return;
     }
 
     for (auto& query : condition.queries) {
         if (&query != &condition.queries.first())
-            builder.append(condition.logicalOperator == LogicalOperator::And ? " and " : " or ");
+            builder.append(condition.logicalOperator == LogicalOperator::And ? " and "_s : " or "_s);
         serialize(builder, query);
     }
 }
@@ -71,7 +71,7 @@ void serialize(StringBuilder& builder, const Feature& feature)
             builder.append('<');
             break;
         case ComparisonOperator::LessThanOrEqual:
-            builder.append("<=");
+            builder.append("<="_s);
             break;
         case ComparisonOperator::Equal:
             builder.append('=');
@@ -80,7 +80,7 @@ void serialize(StringBuilder& builder, const Feature& feature)
             builder.append('>');
             break;
         case ComparisonOperator::GreaterThanOrEqual:
-            builder.append(">=");
+            builder.append(">="_s);
             break;
         }
         builder.append(' ');
@@ -94,12 +94,12 @@ void serialize(StringBuilder& builder, const Feature& feature)
     case Syntax::Plain:
         switch (feature.rightComparison->op) {
         case MQ::ComparisonOperator::LessThanOrEqual:
-            builder.append("max-");
+            builder.append("max-"_s);
             break;
         case MQ::ComparisonOperator::Equal:
             break;
         case MQ::ComparisonOperator::GreaterThanOrEqual:
-            builder.append("min-");
+            builder.append("min-"_s);
             break;
         case MQ::ComparisonOperator::LessThan:
         case MQ::ComparisonOperator::GreaterThan:
@@ -108,7 +108,7 @@ void serialize(StringBuilder& builder, const Feature& feature)
         }
         serializeIdentifier(feature.name, builder);
 
-        builder.append(": ");
+        builder.append(": "_s);
         builder.append(feature.rightComparison->value->cssText());
         break;
 

--- a/Source/WebCore/css/query/MediaQueryParser.cpp
+++ b/Source/WebCore/css/query/MediaQueryParser.cpp
@@ -191,7 +191,7 @@ void serialize(StringBuilder& builder, const MediaQueryList& list)
 {
     for (auto& query : list) {
         if (&query != &list.first())
-            builder.append(", ");
+            builder.append(", "_s);
         serialize(builder, query);
     }
 }
@@ -201,10 +201,10 @@ void serialize(StringBuilder& builder, const MediaQuery& query)
     if (query.prefix) {
         switch (*query.prefix) {
         case Prefix::Not:
-            builder.append("not ");
+            builder.append("not "_s);
             break;
         case Prefix::Only:
-            builder.append("only ");
+            builder.append("only "_s);
             break;
         }
     }
@@ -212,7 +212,7 @@ void serialize(StringBuilder& builder, const MediaQuery& query)
     if (!query.mediaType.isEmpty() && (!query.condition || query.prefix || query.mediaType != allAtom())) {
         serializeIdentifier(query.mediaType, builder);
         if (query.condition)
-            builder.append(" and ");
+            builder.append(" and "_s);
     }
 
     if (query.condition)

--- a/Source/WebCore/css/typedom/CSSOMVariableReferenceValue.cpp
+++ b/Source/WebCore/css/typedom/CSSOMVariableReferenceValue.cpp
@@ -65,7 +65,7 @@ String CSSOMVariableReferenceValue::toString() const
 
 void CSSOMVariableReferenceValue::serialize(StringBuilder& builder, OptionSet<SerializationArguments> arguments) const
 {
-    builder.append("var(");
+    builder.append("var("_s);
     builder.append(m_variable);
     if (m_fallback) {
         builder.append(',');

--- a/Source/WebCore/css/typedom/numeric/CSSMathInvert.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSMathInvert.cpp
@@ -76,8 +76,8 @@ void CSSMathInvert::serialize(StringBuilder& builder, OptionSet<SerializationArg
 {
     // https://drafts.css-houdini.org/css-typed-om/#calc-serialization
     if (!arguments.contains(SerializationArguments::WithoutParentheses))
-        builder.append(arguments.contains(SerializationArguments::Nested) ? "(" : "calc(");
-    builder.append("1 / ");
+        builder.append(arguments.contains(SerializationArguments::Nested) ? "("_s : "calc("_s);
+    builder.append("1 / "_s);
     m_value->serialize(builder, arguments);
     if (!arguments.contains(SerializationArguments::WithoutParentheses))
         builder.append(')');

--- a/Source/WebCore/css/typedom/numeric/CSSMathMax.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSMathMax.cpp
@@ -70,10 +70,10 @@ void CSSMathMax::serialize(StringBuilder& builder, OptionSet<SerializationArgume
 {
     // https://drafts.css-houdini.org/css-typed-om/#calc-serialization
     if (!arguments.contains(SerializationArguments::WithoutParentheses))
-        builder.append("max(");
+        builder.append("max("_s);
     m_values->forEach([&](auto& numericValue, bool first) {
         if (!first)
-            builder.append(", ");
+            builder.append(", "_s);
         numericValue.serialize(builder, { SerializationArguments::Nested, SerializationArguments::WithoutParentheses });
     });
     if (!arguments.contains(SerializationArguments::WithoutParentheses))

--- a/Source/WebCore/css/typedom/numeric/CSSMathMin.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSMathMin.cpp
@@ -69,10 +69,10 @@ void CSSMathMin::serialize(StringBuilder& builder, OptionSet<SerializationArgume
 {
     // https://drafts.css-houdini.org/css-typed-om/#calc-serialization
     if (!arguments.contains(SerializationArguments::WithoutParentheses))
-        builder.append("min(");
+        builder.append("min("_s);
     m_values->forEach([&](auto& numericValue, bool first) {
         if (!first)
-            builder.append(", ");
+            builder.append(", "_s);
         numericValue.serialize(builder, { SerializationArguments::Nested, SerializationArguments::WithoutParentheses });
     });
     if (!arguments.contains(SerializationArguments::WithoutParentheses))

--- a/Source/WebCore/css/typedom/numeric/CSSMathNegate.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSMathNegate.cpp
@@ -57,7 +57,7 @@ void CSSMathNegate::serialize(StringBuilder& builder, OptionSet<SerializationArg
 {
     // https://drafts.css-houdini.org/css-typed-om/#calc-serialization
     if (!arguments.contains(SerializationArguments::WithoutParentheses))
-        builder.append(arguments.contains(SerializationArguments::Nested) ? "(" : "calc(");
+        builder.append(arguments.contains(SerializationArguments::Nested) ? "("_s : "calc("_s);
     builder.append('-');
     m_value->serialize(builder, arguments);
     if (!arguments.contains(SerializationArguments::WithoutParentheses))

--- a/Source/WebCore/css/typedom/numeric/CSSMathProduct.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSMathProduct.cpp
@@ -64,17 +64,17 @@ void CSSMathProduct::serialize(StringBuilder& builder, OptionSet<SerializationAr
 {
     // https://drafts.css-houdini.org/css-typed-om/#calc-serialization
     if (!arguments.contains(SerializationArguments::WithoutParentheses))
-        builder.append(arguments.contains(SerializationArguments::Nested) ? "(" : "calc(");
+        builder.append(arguments.contains(SerializationArguments::Nested) ? "("_s : "calc("_s);
     m_values->forEach([&](auto& numericValue, bool first) {
         OptionSet<SerializationArguments> operandSerializationArguments { SerializationArguments::Nested };
         operandSerializationArguments.set(SerializationArguments::WithoutParentheses, arguments.contains(SerializationArguments::WithoutParentheses));
         if (!first) {
             if (auto* mathNegate = dynamicDowncast<CSSMathInvert>(numericValue)) {
-                builder.append(" / ");
+                builder.append(" / "_s);
                 mathNegate->value().serialize(builder, operandSerializationArguments);
                 return;
             }
-            builder.append(" * ");
+            builder.append(" * "_s);
         }
         numericValue.serialize(builder, operandSerializationArguments);
     });

--- a/Source/WebCore/css/typedom/numeric/CSSMathSum.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSMathSum.cpp
@@ -65,17 +65,17 @@ void CSSMathSum::serialize(StringBuilder& builder, OptionSet<SerializationArgume
 {
     // https://drafts.css-houdini.org/css-typed-om/#calc-serialization
     if (!arguments.contains(SerializationArguments::WithoutParentheses))
-        builder.append(arguments.contains(SerializationArguments::Nested) ? "(" : "calc(");
+        builder.append(arguments.contains(SerializationArguments::Nested) ? "("_s : "calc("_s);
     m_values->forEach([&](auto& numericValue, bool first) {
         OptionSet<SerializationArguments> operandSerializationArguments { SerializationArguments::Nested };
         operandSerializationArguments.set(SerializationArguments::WithoutParentheses, arguments.contains(SerializationArguments::WithoutParentheses));
         if (!first) {
             if (auto* mathNegate = dynamicDowncast<CSSMathNegate>(numericValue)) {
-                builder.append(" - ");
+                builder.append(" - "_s);
                 mathNegate->value().serialize(builder, operandSerializationArguments);
                 return;
             }
-            builder.append(" + ");
+            builder.append(" + "_s);
         }
         numericValue.serialize(builder, operandSerializationArguments);
     });

--- a/Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp
@@ -103,53 +103,53 @@ CSSMatrixComponent::CSSMatrixComponent(Ref<DOMMatrixReadOnly>&& matrix, Is2D is2
 void CSSMatrixComponent::serialize(StringBuilder& builder) const
 {
     if (is2D()) {
-        builder.append("matrix(");
+        builder.append("matrix("_s);
         builder.append(String::number(m_matrix->a()));
-        builder.append(", ");
+        builder.append(", "_s);
         builder.append(String::number(m_matrix->b()));
-        builder.append(", ");
+        builder.append(", "_s);
         builder.append(String::number(m_matrix->c()));
-        builder.append(", ");
+        builder.append(", "_s);
         builder.append(String::number(m_matrix->d()));
-        builder.append(", ");
+        builder.append(", "_s);
         builder.append(String::number(m_matrix->e()));
-        builder.append(", ");
+        builder.append(", "_s);
         builder.append(String::number(m_matrix->f()));
-        builder.append(")");
+        builder.append(')');
     } else {
-        builder.append("matrix3d(");
+        builder.append("matrix3d("_s);
         builder.append(String::number(m_matrix->m11()));
-        builder.append(", ");
+        builder.append(", "_s);
         builder.append(String::number(m_matrix->m12()));
-        builder.append(", ");
+        builder.append(", "_s);
         builder.append(String::number(m_matrix->m13()));
-        builder.append(", ");
+        builder.append(", "_s);
         builder.append(String::number(m_matrix->m14()));
-        builder.append(", ");
+        builder.append(", "_s);
         builder.append(String::number(m_matrix->m21()));
-        builder.append(", ");
+        builder.append(", "_s);
         builder.append(String::number(m_matrix->m22()));
-        builder.append(", ");
+        builder.append(", "_s);
         builder.append(String::number(m_matrix->m23()));
-        builder.append(", ");
+        builder.append(", "_s);
         builder.append(String::number(m_matrix->m24()));
-        builder.append(", ");
+        builder.append(", "_s);
         builder.append(String::number(m_matrix->m31()));
-        builder.append(", ");
+        builder.append(", "_s);
         builder.append(String::number(m_matrix->m32()));
-        builder.append(", ");
+        builder.append(", "_s);
         builder.append(String::number(m_matrix->m33()));
-        builder.append(", ");
+        builder.append(", "_s);
         builder.append(String::number(m_matrix->m34()));
-        builder.append(", ");
+        builder.append(", "_s);
         builder.append(String::number(m_matrix->m41()));
-        builder.append(", ");
+        builder.append(", "_s);
         builder.append(String::number(m_matrix->m42()));
-        builder.append(", ");
+        builder.append(", "_s);
         builder.append(String::number(m_matrix->m43()));
-        builder.append(", ");
+        builder.append(", "_s);
         builder.append(String::number(m_matrix->m44()));
-        builder.append(")");
+        builder.append(')');
     }
 }
 

--- a/Source/WebCore/css/typedom/transform/CSSPerspective.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSPerspective.cpp
@@ -119,11 +119,11 @@ void CSSPerspective::setIs2D(bool)
 void CSSPerspective::serialize(StringBuilder& builder) const
 {
     // https://drafts.css-houdini.org/css-typed-om/#serialize-a-cssperspective
-    builder.append("perspective(");
+    builder.append("perspective("_s);
     WTF::switchOn(m_length,
         [&] (const RefPtr<CSSNumericValue>& value) {
             if (auto* unitValue = dynamicDowncast<CSSUnitValue>(value.get()); unitValue && unitValue->value() < 0.0) {
-                builder.append("calc(");
+                builder.append("calc("_s);
                 value->serialize(builder);
                 builder.append(')');
                 return;

--- a/Source/WebCore/css/typedom/transform/CSSRotate.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSRotate.cpp
@@ -166,14 +166,14 @@ ExceptionOr<void> CSSRotate::setAngle(Ref<CSSNumericValue> angle)
 void CSSRotate::serialize(StringBuilder& builder) const
 {
     // https://drafts.css-houdini.org/css-typed-om/#serialize-a-cssrotate
-    builder.append(is2D() ? "rotate(" : "rotate3d(");
+    builder.append(is2D() ? "rotate("_s : "rotate3d("_s);
     if (!is2D()) {
         m_x->serialize(builder);
-        builder.append(", ");
+        builder.append(", "_s);
         m_y->serialize(builder);
-        builder.append(", ");
+        builder.append(", "_s);
         m_z->serialize(builder);
-        builder.append(", ");
+        builder.append(", "_s);
     }
     m_angle->serialize(builder);
     builder.append(')');

--- a/Source/WebCore/css/typedom/transform/CSSScale.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSScale.cpp
@@ -146,12 +146,12 @@ void CSSScale::setZ(CSSNumberish z)
 void CSSScale::serialize(StringBuilder& builder) const
 {
     // https://drafts.css-houdini.org/css-typed-om/#serialize-a-cssscale
-    builder.append(is2D() ? "scale(" : "scale3d(");
+    builder.append(is2D() ? "scale("_s : "scale3d("_s);
     m_x->serialize(builder);
-    builder.append(", ");
+    builder.append(", "_s);
     m_y->serialize(builder);
     if (!is2D()) {
-        builder.append(", ");
+        builder.append(", "_s);
         m_z->serialize(builder);
     }
     builder.append(')');

--- a/Source/WebCore/css/typedom/transform/CSSSkewX.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSSkewX.cpp
@@ -88,7 +88,7 @@ ExceptionOr<void> CSSSkewX::setAx(Ref<CSSNumericValue> ax)
 void CSSSkewX::serialize(StringBuilder& builder) const
 {
     // https://drafts.css-houdini.org/css-typed-om/#serialize-a-cssskewx
-    builder.append("skewX(");
+    builder.append("skewX("_s);
     m_ax->serialize(builder);
     builder.append(')');
 }

--- a/Source/WebCore/css/typedom/transform/CSSSkewY.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSSkewY.cpp
@@ -88,7 +88,7 @@ ExceptionOr<void> CSSSkewY::setAy(Ref<CSSNumericValue> ay)
 void CSSSkewY::serialize(StringBuilder& builder) const
 {
     // https://drafts.css-houdini.org/css-typed-om/#serialize-a-cssskewy
-    builder.append("skewY(");
+    builder.append("skewY("_s);
     m_ay->serialize(builder);
     builder.append(')');
 }

--- a/Source/WebCore/css/typedom/transform/CSSTranslate.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTranslate.cpp
@@ -121,12 +121,12 @@ CSSTranslate::CSSTranslate(CSSTransformComponent::Is2D is2D, Ref<CSSNumericValue
 void CSSTranslate::serialize(StringBuilder& builder) const
 {
     // https://drafts.css-houdini.org/css-typed-om/#serialize-a-csstranslate
-    builder.append(is2D() ? "translate(" : "translate3d(");
+    builder.append(is2D() ? "translate("_s : "translate3d("_s);
     m_x->serialize(builder);
-    builder.append(", ");
+    builder.append(", "_s);
     m_y->serialize(builder);
     if (!is2D()) {
-        builder.append(", ");
+        builder.append(", "_s);
         m_z->serialize(builder);
     }
     builder.append(')');

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3190,10 +3190,10 @@ void Element::finishParsingChildren()
 static void appendAttributes(StringBuilder& builder, const Element& element)
 {
     if (element.hasID())
-        builder.append(" id=\'", element.getIdAttribute(), '\'');
+        builder.append(" id=\'"_s, element.getIdAttribute(), '\'');
 
     if (element.hasClass()) {
-        builder.append(" class=\'");
+        builder.append(" class=\'"_s);
         size_t classNamesToDump = element.classNames().size();
         constexpr size_t maxNumClassNames = 7;
         bool addEllipsis = false;
@@ -3208,7 +3208,7 @@ static void appendAttributes(StringBuilder& builder, const Element& element)
             builder.append(element.classNames()[i]);
         }
         if (addEllipsis)
-            builder.append(" ...");
+            builder.append(" ..."_s);
         builder.append('\'');
     }
 }

--- a/Source/WebCore/dom/FragmentDirectiveGenerator.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveGenerator.cpp
@@ -115,7 +115,7 @@ void FragmentDirectiveGenerator::generateFragmentDirective(const SimpleRange& te
         StringBuilder textDirectiveBuilder;
         textDirectiveBuilder.append(textDirectivePrefix);
         textDirectiveBuilder.append(startText);
-        textDirectiveBuilder.append(",");
+        textDirectiveBuilder.append(',');
         textDirectiveBuilder.append(endText);
         url.setFragmentIdentifier(StringView(textDirectiveBuilder));
     }
@@ -132,9 +132,9 @@ void FragmentDirectiveGenerator::generateFragmentDirective(const SimpleRange& te
         StringBuilder textDirectiveBuilder;
         textDirectiveBuilder.append(textDirectivePrefix);
         textDirectiveBuilder.append(percentEncodeFragmentDirectiveSpecialCharacters(prefix));
-        textDirectiveBuilder.append("-,");
+        textDirectiveBuilder.append("-,"_s);
         textDirectiveBuilder.append(percentEncodeFragmentDirectiveSpecialCharacters(textFromRange));
-        textDirectiveBuilder.append(",-");
+        textDirectiveBuilder.append(",-"_s);
         textDirectiveBuilder.append(percentEncodeFragmentDirectiveSpecialCharacters(suffix));
         url.setFragmentIdentifier(StringView(textDirectiveBuilder));
     }

--- a/Source/WebCore/dom/SecurityContext.cpp
+++ b/Source/WebCore/dom/SecurityContext.cpp
@@ -166,7 +166,7 @@ SandboxFlags SecurityContext::parseSandboxPolicy(StringView policy, String& inva
             flags &= ~SandboxStorageAccessByUserActivation;
         else {
             if (numberOfTokenErrors)
-                tokenErrors.append(", '");
+                tokenErrors.append(", '"_s);
             else
                 tokenErrors.append('\'');
             tokenErrors.append(sandboxToken, '\'');
@@ -178,9 +178,9 @@ SandboxFlags SecurityContext::parseSandboxPolicy(StringView policy, String& inva
 
     if (numberOfTokenErrors) {
         if (numberOfTokenErrors > 1)
-            tokenErrors.append(" are invalid sandbox flags.");
+            tokenErrors.append(" are invalid sandbox flags."_s);
         else
-            tokenErrors.append(" is an invalid sandbox flag.");
+            tokenErrors.append(" is an invalid sandbox flag."_s);
         invalidTokensErrorMessage = tokenErrors.toString();
     }
 

--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -212,9 +212,9 @@ static void appendTextRepresentation(StringBuilder& builder, const Text& text)
     
     constexpr size_t maxDumpLength = 30;
     if (value.length() > maxDumpLength)
-        builder.append(" \"", StringView(value).left(maxDumpLength - 10), "...\"");
+        builder.append(" \""_s, StringView(value).left(maxDumpLength - 10), "...\""_s);
     else
-        builder.append(" \"", value, '\"');
+        builder.append(" \""_s, value, '\"');
 }
 
 String Text::description() const

--- a/Source/WebCore/editing/FontShadow.cpp
+++ b/Source/WebCore/editing/FontShadow.cpp
@@ -41,11 +41,11 @@ String serializationForCSS(const FontShadow& shadow)
         return noneAtom();
 
     StringBuilder builder;
-    builder.append(shadow.offset.width(), "px ");
-    builder.append(shadow.offset.height(), "px ");
+    builder.append(shadow.offset.width(), "px "_s);
+    builder.append(shadow.offset.height(), "px "_s);
     builder.append(serializationForCSS(shadow.color));
     if (shadow.blurRadius)
-        builder.append(" ", shadow.blurRadius, "px");
+        builder.append(' ', shadow.blurRadius, "px"_s);
     return builder.toString();
 }
 

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -494,11 +494,11 @@ void StyledMarkupAccumulator::appendStyleNodeOpenTag(StringBuilder& out, StylePr
     // With AnnotateForInterchange::Yes, wrappingStyleForSerialization should have removed -webkit-text-decorations-in-effect
     ASSERT(!shouldAnnotate() || propertyMissingOrEqualToNone(style, CSSPropertyWebkitTextDecorationsInEffect));
     if (isBlock)
-        out.append("<div style=\"");
+        out.append("<div style=\""_s);
     else
-        out.append("<span style=\"");
+        out.append("<span style=\""_s);
     appendAttributeValue(out, style->asText(), document.isHTMLDocument());
-    out.append("\">");
+    out.append("\">"_s);
 }
 
 const String& StyledMarkupAccumulator::styleNodeCloseTag(bool isBlock)
@@ -650,7 +650,7 @@ void StyledMarkupAccumulator::appendStartTag(StringBuilder& out, const Element& 
 
     auto replacementType = spanReplacementForElement(element);
     if (UNLIKELY(replacementType != SpanReplacementType::None))
-        out.append("<span");
+        out.append("<span"_s);
     else
         appendOpenTag(out, element, nullptr);
 
@@ -713,7 +713,7 @@ void StyledMarkupAccumulator::appendStartTag(StringBuilder& out, const Element& 
         }
 
         if (!newInlineStyle->isEmpty()) {
-            out.append(" style=\"");
+            out.append(" style=\""_s);
             appendAttributeValue(out, newInlineStyle->style()->asText(), documentIsHTML);
             out.append('"');
         }
@@ -725,7 +725,7 @@ void StyledMarkupAccumulator::appendStartTag(StringBuilder& out, const Element& 
 void StyledMarkupAccumulator::appendEndTag(StringBuilder& out, const Element& element)
 {
     if (UNLIKELY(spanReplacementForElement(element) != SpanReplacementType::None))
-        out.append("</span>");
+        out.append("</span>"_s);
     else
         MarkupAccumulator::appendEndTag(out, element);
 }
@@ -1080,7 +1080,7 @@ static String serializePreservingVisualAppearanceInternal(const Position& start,
     
     if (accumulator.needRelativeStyleWrapper() && needsPositionStyleConversion) {
         if (accumulator.needClearingDiv())
-            accumulator.append("<div style=\"clear: both;\"></div>");
+            accumulator.append("<div style=\"clear: both;\"></div>"_s);
         RefPtr<EditingStyle> positionRelativeStyle = styleFromMatchedRulesAndInlineDecl(*body);
         positionRelativeStyle->style()->setProperty(CSSPropertyPosition, CSSValueRelative);
         accumulator.wrapWithStyleNode(positionRelativeStyle->style(), document, true);
@@ -1375,9 +1375,9 @@ String documentTypeString(const Document& document)
 String urlToMarkup(const URL& url, const String& title)
 {
     StringBuilder markup;
-    markup.append("<a href=\"", url.string(), "\">");
+    markup.append("<a href=\""_s, url.string(), "\">"_s);
     MarkupAccumulator::appendCharactersReplacingEntities(markup, title, 0, title.length(), EntityMaskInPCDATA);
-    markup.append("</a>");
+    markup.append("</a>"_s);
     return markup.toString();
 }
 

--- a/Source/WebCore/html/FormController.cpp
+++ b/Source/WebCore/html/FormController.cpp
@@ -197,7 +197,7 @@ static String formSignature(const HTMLFormElement& form)
 
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
     unsigned count = 0;
-    builder.append(" [");
+    builder.append(" ["_s);
     for (const auto& element : descendantsOfType<Element>(form)) {
         if (!shouldBeUsedForFormSignature(element) || element.hasAttributeWithoutSynchronization(HTMLNames::formAttr))
             continue;

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -791,7 +791,7 @@ String HTMLElement::accessKeyLabel() const
 #else
     // Currently accessKeyModifier in non-cocoa platforms is hardcoded to Alt, so no reason to do extra work here.
     // If this ever becomes configurable, make this code use EventHandler::accessKeyModifiers().
-    result.append("Alt+");
+    result.append("Alt+"_s);
 #endif
 
     result.append(accessKey);

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -675,7 +675,7 @@ String HTMLImageElement::completeURLsInAttributeValue(const URL& base, const Att
         StringBuilder result;
         for (const auto& candidate : imageCandidates) {
             if (&candidate != &imageCandidates[0])
-                result.append(", ");
+                result.append(", "_s);
             result.append(resolveURLStringIfNeeded(candidate.string.toString(), resolveURLs, base));
             if (candidate.density != UninitializedDescriptor)
                 result.append(' ', candidate.density, 'x');

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -89,8 +89,8 @@ static String restrictionNames(MediaElementSession::BehaviorRestrictions restric
 #define CASE(restrictionType) \
     if (restriction & MediaElementSession::restrictionType) { \
         if (!restrictionBuilder.isEmpty()) \
-            restrictionBuilder.append(", "); \
-        restrictionBuilder.append(#restrictionType); \
+            restrictionBuilder.append(", "_s); \
+        restrictionBuilder.append(#restrictionType ## _s); \
     } \
 
     CASE(NoRestrictions)

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
@@ -238,7 +238,7 @@ String replaceURLsInSrcsetAttribute(const Element& element, StringView attribute
     StringBuilder result;
     for (const auto& candidate : imageCandidates) {
         if (&candidate != &imageCandidates[0])
-            result.append(", ");
+            result.append(", "_s);
 
         auto resolvedURLString = element.resolveURLStringIfNeeded(candidate.string.toString());
         auto replacementURLString = replacementURLStrings.get(resolvedURLString);

--- a/Source/WebCore/inspector/InspectorFrontendAPIDispatcher.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendAPIDispatcher.cpp
@@ -118,12 +118,12 @@ JSDOMGlobalObject* InspectorFrontendAPIDispatcher::frontendGlobalObject()
 static String expressionForEvaluatingCommand(const String& command, Vector<Ref<JSON::Value>>&& arguments)
 {
     StringBuilder expression;
-    expression.append("InspectorFrontendAPI.dispatch([\"", command, '"');
+    expression.append("InspectorFrontendAPI.dispatch([\""_s, command, '"');
     for (auto& argument : arguments) {
-        expression.append(", ");
+        expression.append(", "_s);
         argument->writeJSON(expression);
     }
-    expression.append("])");
+    expression.append("])"_s);
     return expression.toString();
 }
 

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -2047,14 +2047,14 @@ std::optional<InspectorOverlay::Highlight::FlexHighlightOverlay> InspectorOverla
                 StringBuilder orderNumbers;
 
                 if (auto index = renderChildrenInDOMOrder.find(renderChild); index != notFound) {
-                    orderNumbers.append("Item #");
+                    orderNumbers.append("Item #"_s);
                     orderNumbers.append(index + 1);
                 }
 
                 if (auto order = renderChild->style().order(); order || hasCustomOrder) {
                     if (!orderNumbers.isEmpty())
                         orderNumbers.append('\n');
-                    orderNumbers.append("order: ");
+                    orderNumbers.append("order: "_s);
                     orderNumbers.append(order);
                 }
 

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -1540,7 +1540,7 @@ ExceptionOr<void> InspectorStyleSheet::setRuleStyleText(const InspectorCSSId& id
             replacementBodyText.append(atRuleIdentifierForType(childRuleSourceData->type));
 
         replacementBodyText.appendSubstring(styleSheetText, childStart, childEnd - childStart);
-        replacementBodyText.append("}\n");
+        replacementBodyText.append("}\n"_s);
     }
 
     auto closingIndentationLineStart = newText.reverseFind('\n');

--- a/Source/WebCore/loader/ResourceLoadStatistics.cpp
+++ b/Source/WebCore/loader/ResourceLoadStatistics.cpp
@@ -351,7 +351,7 @@ bool ResourceLoadStatistics::decode(KeyedDecoder& decoder, unsigned modelVersion
 
 static void appendBoolean(StringBuilder& builder, ASCIILiteral label, bool flag)
 {
-    builder.append("    ", label, ": ", flag ? "Yes" : "No");
+    builder.append("    "_s, label, ": "_s, flag ? "Yes"_s : "No"_s);
 }
 
 static void appendHashSet(StringBuilder& builder, const String& label, const HashSet<RegistrableDomain>& hashSet)
@@ -359,9 +359,9 @@ static void appendHashSet(StringBuilder& builder, const String& label, const Has
     if (hashSet.isEmpty())
         return;
 
-    builder.append("    ", label, ":\n");
+    builder.append("    "_s, label, ":\n"_s);
     for (auto& entry : hashSet)
-        builder.append("        ", entry.string(), '\n');
+        builder.append("        "_s, entry.string(), '\n');
 }
 
 #if ENABLE(WEB_API_STATISTICS)
@@ -370,9 +370,9 @@ static void appendHashSet(StringBuilder& builder, const String& label, const Has
     if (hashSet.isEmpty())
         return;
 
-    builder.append("    ", label, ":\n");
+    builder.append("    "_s, label, ":\n"_s);
     for (auto& entry : hashSet)
-        builder.append("        ", entry, '\n');
+        builder.append("        "_s, entry, '\n');
 }
 
 static ASCIILiteral navigatorAPIEnumToString(NavigatorAPIsAccessed navigatorEnum)
@@ -419,18 +419,18 @@ static void appendNavigatorAPIOptionSet(StringBuilder& builder, const OptionSet<
 {
     if (optionSet.isEmpty())
         return;
-    builder.append("    navigatorFunctionsAccessed:\n");
+    builder.append("    navigatorFunctionsAccessed:\n"_s);
     for (auto navigatorAPI : optionSet)
-        builder.append("        ", navigatorAPIEnumToString(navigatorAPI), '\n');
+        builder.append("        "_s, navigatorAPIEnumToString(navigatorAPI), '\n');
 }
 
 static void appendScreenAPIOptionSet(StringBuilder& builder, const OptionSet<ScreenAPIsAccessed>& optionSet)
 {
     if (optionSet.isEmpty())
         return;
-    builder.append("    screenFunctionsAccessed:\n");
+    builder.append("    screenFunctionsAccessed:\n"_s);
     for (auto screenAPI : optionSet) {
-        builder.append("        ", screenAPIEnumToString(screenAPI), '\n');
+        builder.append("        "_s, screenAPIEnumToString(screenAPI), '\n');
     }
 }
 #endif
@@ -443,7 +443,7 @@ static bool hasHadRecentUserInteraction(Seconds interactionTimeSeconds)
 String ResourceLoadStatistics::toString() const
 {
     StringBuilder builder;
-    builder.append("Registrable domain: ", registrableDomain.string(), '\n');
+    builder.append("Registrable domain: "_s, registrableDomain.string(), '\n');
 
     // User interaction
     appendBoolean(builder, "hadUserInteraction"_s, hadUserInteraction);
@@ -477,7 +477,7 @@ String ResourceLoadStatistics::toString() const
     builder.append('\n');
     appendBoolean(builder, "isVeryPrevalentResource"_s, isVeryPrevalentResource);
     builder.append('\n');
-    builder.append("    dataRecordsRemoved: ", dataRecordsRemoved);
+    builder.append("    dataRecordsRemoved: "_s, dataRecordsRemoved);
     builder.append('\n');
 
 #if ENABLE(WEB_API_STATISTICS)

--- a/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
+++ b/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
@@ -67,7 +67,7 @@ static String generateRandomBoundary()
     std::array<uint8_t, randomValuesLength> randomValues;
     cryptographicallyRandomValues(randomValues);
     StringBuilder stringBuilder;
-    stringBuilder.append("----=_NextPart_000_");
+    stringBuilder.append("----=_NextPart_000_"_s);
     for (size_t i = 0; i < randomValues.size(); ++i) {
         if (i == 2)
             stringBuilder.append('_');
@@ -144,25 +144,25 @@ Ref<FragmentedSharedBuffer> MHTMLArchive::generateMHTMLData(Page* page)
     String dateString = makeRFC2822DateString(now.weekDay(), now.monthDay(), now.month(), now.year(), now.hour(), now.minute(), now.second(), now.utcOffsetInMinute());
 
     StringBuilder stringBuilder;
-    stringBuilder.append("From: <Saved by WebKit>\r\n");
+    stringBuilder.append("From: <Saved by WebKit>\r\n"_s);
     auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
     if (localMainFrame) {
-        stringBuilder.append("Subject: ");
+        stringBuilder.append("Subject: "_s);
         // We replace non ASCII characters with '?' characters to match IE's behavior.
         stringBuilder.append(replaceNonPrintableCharacters(localMainFrame->document()->title()));
     }
-    stringBuilder.append("\r\nDate: ");
+    stringBuilder.append("\r\nDate: "_s);
     stringBuilder.append(dateString);
-    stringBuilder.append("\r\nMIME-Version: 1.0\r\n");
-    stringBuilder.append("Content-Type: multipart/related;\r\n");
+    stringBuilder.append("\r\nMIME-Version: 1.0\r\n"_s);
+    stringBuilder.append("Content-Type: multipart/related;\r\n"_s);
     if (localMainFrame) {
-        stringBuilder.append("\ttype=\"");
+        stringBuilder.append("\ttype=\""_s);
         stringBuilder.append(localMainFrame->document()->suggestedMIMEType());
     }
-    stringBuilder.append("\";\r\n");
-    stringBuilder.append("\tboundary=\"");
+    stringBuilder.append("\";\r\n"_s);
+    stringBuilder.append("\tboundary=\""_s);
     stringBuilder.append(boundary);
-    stringBuilder.append("\"\r\n\r\n");
+    stringBuilder.append("\"\r\n\r\n"_s);
 
     // We use utf8() below instead of ascii() as ascii() replaces CRLFs with ?? (we still only have put ASCII characters in it).
     ASSERT(stringBuilder.toString().containsOnlyASCII());

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
@@ -462,7 +462,7 @@ String CaptionUserPreferencesMediaAF::captionsDefaultFontCSS() const
         return emptyString();
 
     StringBuilder builder;
-    builder.append("font-family: \"", name.get(), '"');
+    builder.append("font-family: \""_s, name.get(), '"');
     if (RetainPtr cascadeList = adoptCF(static_cast<CFArrayRef>(CTFontDescriptorCopyAttribute(font.get(), kCTFontCascadeListAttribute)))) {
         for (CFIndex i = 0; i < CFArrayGetCount(cascadeList.get()); i++) {
             auto fontCascade = static_cast<CTFontDescriptorRef>(CFArrayGetValueAtIndex(cascadeList.get(), i));
@@ -471,10 +471,10 @@ String CaptionUserPreferencesMediaAF::captionsDefaultFontCSS() const
             RetainPtr fontCascadeName = adoptCF(static_cast<CFStringRef>(CTFontDescriptorCopyAttribute(fontCascade, kCTFontNameAttribute)));
             if (!fontCascadeName)
                 continue;
-            builder.append(", \"", fontCascadeName.get(), '"');
+            builder.append(", \""_s, fontCascadeName.get(), '"');
         }
     }
-    builder.append(behavior == kMACaptionAppearanceBehaviorUseValue ? " !important;" : ";");
+    builder.append(behavior == kMACaptionAppearanceBehaviorUseValue ? " !important;"_s : ";"_s);
     return builder.toString();
 }
 

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -245,7 +245,7 @@ void PageSerializer::serializeCSSStyleSheet(CSSStyleSheet* styleSheet, const URL
         if (!itemText.isEmpty()) {
             cssText.append(itemText);
             if (i < styleSheet->length() - 1)
-                cssText.append("\n\n");
+                cssText.append("\n\n"_s);
         }
         Document* document = styleSheet->ownerDocument();
         // Some rules have resources associated with them that we need to retrieve.

--- a/Source/WebCore/platform/Decimal.cpp
+++ b/Source/WebCore/platform/Decimal.cpp
@@ -846,7 +846,7 @@ String Decimal::toString() const
             return builder.toString();
         }
 
-        builder.append("0.");
+        builder.append("0."_s);
         for (int i = adjustedExponent + 1; i < 0; ++i)
             builder.append('0');
 

--- a/Source/WebCore/platform/glib/UserAgentGLib.cpp
+++ b/Source/WebCore/platform/glib/UserAgentGLib.cpp
@@ -78,7 +78,7 @@ static const String platformVersionForUAString()
 static String buildUserAgentString(const UserAgentQuirks& quirks)
 {
     StringBuilder uaString;
-    uaString.append("Mozilla/5.0 (");
+    uaString.append("Mozilla/5.0 ("_s);
 
     if (quirks.contains(UserAgentQuirks::NeedsMacintoshPlatform))
         uaString.append(UserAgentQuirks::stringForQuirk(UserAgentQuirks::NeedsMacintoshPlatform));
@@ -95,7 +95,7 @@ static String buildUserAgentString(const UserAgentQuirks& quirks)
         return uaString.toString();
     }
 
-    uaString.append(") AppleWebKit/605.1.15 (KHTML, like Gecko) ");
+    uaString.append(") AppleWebKit/605.1.15 (KHTML, like Gecko) "_s);
 
     // Note that Chrome UAs advertise *both* Chrome/X and Safari/X, but it does
     // not advertise Version/X.
@@ -104,11 +104,11 @@ static String buildUserAgentString(const UserAgentQuirks& quirks)
     // Version/X is mandatory *before* Safari/X to be a valid Safari UA. See
     // https://bugs.webkit.org/show_bug.cgi?id=133403 for details.
     } else
-        uaString.append("Version/17.0 ");
+        uaString.append("Version/17.0 "_s);
 
     if (chassisType() == WTF::ChassisType::Mobile)
-        uaString.append("Mobile ");
-    uaString.append("Safari/605.1.15");
+        uaString.append("Mobile "_s);
+    uaString.append("Safari/605.1.15"_s);
 
     return uaString.toString();
 }

--- a/Source/WebCore/platform/graphics/AV1Utilities.cpp
+++ b/Source/WebCore/platform/graphics/AV1Utilities.cpp
@@ -210,7 +210,7 @@ String createAV1CodecParametersString(const AV1CodecConfigurationRecord& configu
     // fields.
 
     StringBuilder builder;
-    builder.append("av01");
+    builder.append("av01"_s);
 
     auto appendOneDigit = [&](uint8_t number) {
         builder.append(static_cast<LChar>('0' + number % 10));

--- a/Source/WebCore/platform/graphics/CodecUtilities.cpp
+++ b/Source/WebCore/platform/graphics/CodecUtilities.cpp
@@ -44,13 +44,13 @@ String humanReadableStringFromCodecString(const String& codecString)
             builder.append(WEB_UI_STRING_KEY("VP8", "VP8 (Codec String)", "Codec Strings"));
         else if (parameters->codecName == "vp09"_s)
             builder.append(WEB_UI_STRING_KEY("VP9", "VP9 (Codec String)", "Codec Strings"));
-        builder.append(" (");
+        builder.append(" ("_s);
 
         uint8_t levelMajor = parameters->level / 10;
         uint8_t levelMinor = parameters->level % 10;
         auto levelString = levelMinor ? WEB_UI_FORMAT_STRING("%d.%d", "Codec Level (Codec Strings)", levelMajor, levelMinor) : String::number(levelMajor);
         builder.append(WEB_UI_FORMAT_STRING("Profile %d, Level %s", "VP8/9 Codec Level & Profile (Codec Strings)", parameters->profile, levelString.utf8().data()));
-        builder.append(")");
+        builder.append(')');
 
         return builder.toString();
     }
@@ -58,35 +58,35 @@ String humanReadableStringFromCodecString(const String& codecString)
     if (auto parameters = parseAVCCodecParameters(codecString)) {
         StringBuilder builder;
         builder.append(WEB_UI_STRING_KEY("AVC", "AVC (Codec String)", "Codec Strings"));
-        builder.append(" (");
+        builder.append(" ("_s);
         switch (parameters->profileIDC) {
         case 66:
             builder.append(WEB_UI_STRING_KEY("Baseline Profile", "Baseline Profile (AVC Codec Profile)", "Codec Strings"));
-            builder.append(", ");
+            builder.append(", "_s);
             break;
         case 77:
             builder.append(WEB_UI_STRING_KEY("Main Profile", "Main Profile (AVC Codec Profile)", "Codec Strings"));
-            builder.append(", ");
+            builder.append(", "_s);
             break;
         case 88:
             builder.append(WEB_UI_STRING_KEY("Extended Profile", "Extended Profile (AVC Codec Profile)", "Codec Strings"));
-            builder.append(", ");
+            builder.append(", "_s);
             break;
         case 100:
             builder.append(WEB_UI_STRING_KEY("High Profile", "High Profile (AVC Codec Profile)", "Codec Strings"));
-            builder.append(", ");
+            builder.append(", "_s);
             break;
         case 110:
             builder.append(WEB_UI_STRING_KEY("High 10 Profile", "High 10 Profile (AVC Codec Profile)", "Codec Strings"));
-            builder.append(", ");
+            builder.append(", "_s);
             break;
         case 122:
             builder.append(WEB_UI_STRING_KEY("High 422 Profile", "High 422 Profile (AVC Codec Profile)", "Codec Strings"));
-            builder.append(", ");
+            builder.append(", "_s);
             break;
         case 244:
             builder.append(WEB_UI_STRING_KEY("High 444 Predictive Profile", "High 444 Predictive Profile (AVC Codec Profile)", "Codec Strings"));
-            builder.append(", ");
+            builder.append(", "_s);
             break;
         }
         if (parameters->levelIDC == 11)
@@ -97,48 +97,48 @@ String humanReadableStringFromCodecString(const String& codecString)
             auto levelString = levelMinor ? WEB_UI_FORMAT_STRING("Level %d.%d", "Level %d.%d (AVC Codec Level)", levelMajor, levelMinor) : WEB_UI_FORMAT_STRING("Level %d", "Level %d (AVC Codec Level)", levelMajor);
             builder.append(levelString);
         }
-        builder.append(")");
+        builder.append(')');
         return builder.toString();
     }
 
     if (auto parameters = parseHEVCCodecParameters(codecString)) {
         StringBuilder builder;
         builder.append(WEB_UI_STRING_KEY("HEVC", "HEVC (Codec String)", "Codec Strings"));
-        builder.append(" (");
+        builder.append(" ("_s);
         switch (parameters->generalProfileIDC) {
         case 1:
             builder.append(WEB_UI_STRING_KEY("Main Profile", "Main Profile (HEVC Codec Profile)", "Codec Strings"));
-            builder.append(", ");
+            builder.append(", "_s);
             break;
         case 2:
             builder.append(WEB_UI_STRING_KEY("Main 10 Profile", "Main 10 Profile (HEVC Codec Profile)", "Codec Strings"));
-            builder.append(", ");
+            builder.append(", "_s);
             break;
         }
         if (parameters->generalTierFlag)
             builder.append(WEB_UI_STRING_KEY("High Tier", "High Tier (HEVC Codec Tier", "Codec Strings"));
         else
             builder.append(WEB_UI_STRING_KEY("Main Tier", "Main Tier (HEVC Codec Tier", "Codec Strings"));
-        builder.append(")");
+        builder.append(')');
         return builder.toString();
     }
 
     if (auto parameters = parseAV1CodecParameters(codecString)) {
         StringBuilder builder;
         builder.append(WEB_UI_STRING_KEY("AV1", "AV1 (Codec String)", "Codec Strings"));
-        builder.append(" (");
+        builder.append(" ("_s);
         switch (parameters->profile) {
         case AV1ConfigurationProfile::Main:
             builder.append(WEB_UI_STRING_KEY("Main Profile, ", "Main Profile (AV1 Codec Profile)", "Codec Strings"));
-            builder.append(", ");
+            builder.append(", "_s);
             break;
         case AV1ConfigurationProfile::High:
             builder.append(WEB_UI_STRING_KEY("High Profile, ", "High Profile (AV1 Codec Profile)", "Codec Strings"));
-            builder.append(", ");
+            builder.append(", "_s);
             break;
         case AV1ConfigurationProfile::Professional:
             builder.append(WEB_UI_STRING_KEY("Professional Profile, ", "Professional Profile (AV1 Codec Profile)", "Codec Strings"));
-            builder.append(", ");
+            builder.append(", "_s);
             break;
         };
 
@@ -216,7 +216,7 @@ String humanReadableStringFromCodecString(const String& codecString)
             builder.append(WEB_UI_STRING_KEY("Level 7.3", "Level 7.3 (AV1 Codec Level)", "Codec Strings"));
             break;
         }
-        builder.append(")");
+        builder.append(')');
         return builder.toString();
     }
 

--- a/Source/WebCore/platform/graphics/ColorInterpolationMethod.cpp
+++ b/Source/WebCore/platform/graphics/ColorInterpolationMethod.cpp
@@ -42,13 +42,13 @@ void serializationForCSS(StringBuilder& builder, HueInterpolationMethod hueInter
     case HueInterpolationMethod::Shorter:
         break;
     case HueInterpolationMethod::Longer:
-        builder.append(" longer hue");
+        builder.append(" longer hue"_s);
         break;
     case HueInterpolationMethod::Increasing:
-        builder.append(" increasing hue");
+        builder.append(" increasing hue"_s);
         break;
     case HueInterpolationMethod::Decreasing:
-        builder.append(" decreasing hue");
+        builder.append(" decreasing hue"_s);
         break;
     }
 }

--- a/Source/WebCore/platform/graphics/HEVCUtilities.cpp
+++ b/Source/WebCore/platform/graphics/HEVCUtilities.cpp
@@ -445,7 +445,7 @@ String createDoViCodecParametersString(const DoViParameters& parameters)
 {
     // The format of the DoVi codec string is specified in "Dolby Vision Profiles and Levels Version 1.3.2"
     StringBuilder builder;
-    builder.append("dvh1.");
+    builder.append("dvh1."_s);
     if (parameters.bitstreamProfileID < 10)
         builder.append('0');
     builder.append(parameters.bitstreamProfileID);

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -2099,11 +2099,11 @@ String MediaPlayer::lastErrorMessage() const
 String SeekTarget::toString() const
 {
     StringBuilder builder;
-    builder.append("[");
+    builder.append('[');
     builder.append(WTF::LogArgument<MediaTime>::toString(time));
     builder.append(WTF::LogArgument<MediaTime>::toString(negativeThreshold));
     builder.append(WTF::LogArgument<MediaTime>::toString(positiveThreshold));
-    builder.append("]");
+    builder.append(']');
     return builder.toString();
 }
 

--- a/Source/WebCore/platform/graphics/VP9Utilities.cpp
+++ b/Source/WebCore/platform/graphics/VP9Utilities.cpp
@@ -296,7 +296,7 @@ String createVPCodecParametersString(const VPCodecConfigurationRecord& configura
         || !isValidRange(configuration.videoFullRangeFlag))
         return resultBuilder.toString();
 
-    resultBuilder.append(".0");
+    resultBuilder.append(".0"_s);
     resultBuilder.append(numberToStringUnsigned<String>(configuration.profile));
 
     resultBuilder.append('.');
@@ -319,7 +319,7 @@ String createVPCodecParametersString(const VPCodecConfigurationRecord& configura
         && configuration.matrixCoefficients == defaultConfiguration->matrixCoefficients)
         return resultBuilder.toString();
 
-    resultBuilder.append(".0");
+    resultBuilder.append(".0"_s);
     resultBuilder.append(numberToStringUnsigned<String>(configuration.chromaSubsampling));
 
     resultBuilder.append('.');
@@ -337,7 +337,7 @@ String createVPCodecParametersString(const VPCodecConfigurationRecord& configura
         resultBuilder.append('0');
     resultBuilder.append(numberToStringUnsigned<String>(configuration.matrixCoefficients));
 
-    resultBuilder.append(".0");
+    resultBuilder.append(".0"_s);
     resultBuilder.append(numberToStringUnsigned<String>(configuration.videoFullRangeFlag));
 
     return resultBuilder.toString();

--- a/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
@@ -152,7 +152,7 @@ Ref<InbandGenericCue> InbandTextTrackPrivateAVF::processCueAttributes(CFAttribut
                 if (value != kCFBooleanTrue)
                     continue;
 
-                tagStart.append("<b>");
+                tagStart.append("<b>"_s);
                 tagEnd = "</b>" + tagEnd;
                 continue;
             }
@@ -161,7 +161,7 @@ Ref<InbandGenericCue> InbandTextTrackPrivateAVF::processCueAttributes(CFAttribut
                 if (value != kCFBooleanTrue)
                     continue;
 
-                tagStart.append("<i>");
+                tagStart.append("<i>"_s);
                 tagEnd = "</i>" + tagEnd;
                 continue;
             }
@@ -170,7 +170,7 @@ Ref<InbandGenericCue> InbandTextTrackPrivateAVF::processCueAttributes(CFAttribut
                 if (value != kCFBooleanTrue)
                     continue;
 
-                tagStart.append("<u>");
+                tagStart.append("<u>"_s);
                 tagEnd = "</u>" + tagEnd;
                 continue;
             }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -199,10 +199,10 @@ struct LogArgument<WebCore::CDMInstanceFairPlayStreamingAVFObjC::Keys> {
     static String toString(const WebCore::CDMInstanceFairPlayStreamingAVFObjC::Keys& keys)
     {
         StringBuilder builder;
-        builder.append("[");
+        builder.append('[');
         for (auto key : keys)
             builder.append(key->toHexString());
-        builder.append("]");
+        builder.append(']');
         return builder.toString();
     }
 };

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp
@@ -533,7 +533,7 @@ Ref<TextureMapperShaderProgram> TextureMapperShaderProgram::create(TextureMapper
 {
 #define SET_APPLIER_FROM_OPTIONS(Applier) \
     optionsApplierBuilder.append(\
-        (options & TextureMapperShaderProgram::Applier) ? ENABLE_APPLIER(Applier) : DISABLE_APPLIER(Applier))
+        (options & TextureMapperShaderProgram::Applier) ? span(ENABLE_APPLIER(Applier)) : span(DISABLE_APPLIER(Applier)))
 
     unsigned glVersion = GLContext::current()->version();
 
@@ -571,10 +571,10 @@ Ref<TextureMapperShaderProgram> TextureMapperShaderProgram::create(TextureMapper
     vertexShaderBuilder.append(optionsApplierBuilder.toString());
 
     // Append the appropriate input/output variable definitions.
-    vertexShaderBuilder.append(vertexTemplateLT320Vars);
+    vertexShaderBuilder.append(span(vertexTemplateLT320Vars));
 
     // Append the common code.
-    vertexShaderBuilder.append(vertexTemplateCommon);
+    vertexShaderBuilder.append(span(vertexTemplateCommon));
 
     StringBuilder fragmentShaderBuilder;
 
@@ -582,18 +582,18 @@ Ref<TextureMapperShaderProgram> TextureMapperShaderProgram::create(TextureMapper
     fragmentShaderBuilder.append(optionsApplierBuilder.toString());
 
     if (glVersion >= 300)
-        fragmentShaderBuilder.append(GLSL_DIRECTIVE(define GaussianKernelHalfSize u_gaussianKernelHalfSize));
+        fragmentShaderBuilder.append(span(GLSL_DIRECTIVE(define GaussianKernelHalfSize u_gaussianKernelHalfSize)));
     else
-        fragmentShaderBuilder.append(GLSL_DIRECTIVE(define GaussianKernelHalfSize GAUSSIAN_KERNEL_MAX_HALF_SIZE));
+        fragmentShaderBuilder.append(span(GLSL_DIRECTIVE(define GaussianKernelHalfSize GAUSSIAN_KERNEL_MAX_HALF_SIZE)));
 
     // Append the common header.
-    fragmentShaderBuilder.append(fragmentTemplateHeaderCommon);
+    fragmentShaderBuilder.append(span(fragmentTemplateHeaderCommon));
 
     // Append the appropriate input/output variable definitions.
-    fragmentShaderBuilder.append(fragmentTemplateLT320Vars);
+    fragmentShaderBuilder.append(span(fragmentTemplateLT320Vars));
 
     // Append the common code.
-    fragmentShaderBuilder.append(fragmentTemplateCommon);
+    fragmentShaderBuilder.append(span(fragmentTemplateCommon));
 
     return adoptRef(*new TextureMapperShaderProgram(vertexShaderBuilder.toString(), fragmentShaderBuilder.toString()));
 }

--- a/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
@@ -194,11 +194,11 @@ static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> vpxCapsFromCodecString(cons
     auto outputCaps = adoptGRef(gst_caps_new_empty_simple("video/x-vp9"));
     auto profile = makeString(parameters->profile);
     gst_caps_set_simple(outputCaps.get(), "profile", G_TYPE_STRING, profile.ascii().data(), nullptr);
-    const char* yuvFormat = "I420";
+    auto yuvFormat = "I420"_s;
     if (parameters->chromaSubsampling == VPConfigurationChromaSubsampling::Subsampling_422)
-        yuvFormat = "I422";
+        yuvFormat = "I422"_s;
     else if (parameters->chromaSubsampling == VPConfigurationChromaSubsampling::Subsampling_444)
-        yuvFormat = "Y444";
+        yuvFormat = "Y444"_s;
     StringBuilder formatBuilder;
     formatBuilder.append(yuvFormat);
     if (parameters->bitDepth > 8 || parameters->profile == 2) {
@@ -326,14 +326,14 @@ static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> av1CapsFromCodecString(cons
     auto outputCaps = adoptGRef(gst_caps_new_simple("video/x-av1", "profile", G_TYPE_STRING, profile, "bit-depth-luma", G_TYPE_UINT, configurationRecord->bitDepth, "bit-depth-chroma", G_TYPE_UINT, configurationRecord->bitDepth, nullptr));
 
     const char* chromaFormat = nullptr;
-    const char* yuvFormat = "I420";
+    auto yuvFormat = "I420"_s;
     switch (static_cast<AV1ConfigurationChromaSubsampling>(configurationRecord->chromaSubsampling)) {
     case AV1ConfigurationChromaSubsampling::Subsampling_422:
-        yuvFormat = "I422";
+        yuvFormat = "I422"_s;
         chromaFormat = "4:2:2";
         break;
     case AV1ConfigurationChromaSubsampling::Subsampling_444:
-        yuvFormat = "Y444";
+        yuvFormat = "Y444"_s;
         chromaFormat = "4:4:4";
         break;
     case AV1ConfigurationChromaSubsampling::Subsampling_420_Unknown:

--- a/Source/WebCore/platform/gtk/SelectionData.cpp
+++ b/Source/WebCore/platform/gtk/SelectionData.cpp
@@ -109,12 +109,12 @@ void SelectionData::setURL(const URL& url, const String& label)
         actualLabel = url.string();
 
     StringBuilder markup;
-    markup.append("<a href=\"");
+    markup.append("<a href=\""_s);
     markup.append(url.string());
-    markup.append("\">");
+    markup.append("\">"_s);
     GUniquePtr<gchar> escaped(g_markup_escape_text(actualLabel.utf8().data(), -1));
     markup.append(String::fromUTF8(escaped.get()));
-    markup.append("</a>");
+    markup.append("</a>"_s);
     setMarkup(markup.toString());
 }
 

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.cpp
@@ -71,7 +71,7 @@ void MediaRecorderPrivateMock::resumeRecording(CompletionHandler<void()>&& compl
 void MediaRecorderPrivateMock::videoFrameAvailable(VideoFrame&, VideoFrameTimeMetadata)
 {
     Locker locker { m_bufferLock };
-    m_buffer.append("Video Track ID: ");
+    m_buffer.append("Video Track ID: "_s);
     m_buffer.append(m_videoTrackID);
     generateMockCounterString();
 }
@@ -82,14 +82,14 @@ void MediaRecorderPrivateMock::audioSamplesAvailable(const MediaTime&, const Pla
     // explicitly allow the following allocation(s).
     DisableMallocRestrictionsForCurrentThreadScope disableMallocRestrictions;
     Locker locker { m_bufferLock };
-    m_buffer.append("Audio Track ID: ");
+    m_buffer.append("Audio Track ID: "_s);
     m_buffer.append(m_audioTrackID);
     generateMockCounterString();
 }
 
 void MediaRecorderPrivateMock::generateMockCounterString()
 {
-    m_buffer.append(" Counter: ", ++m_counter, "\r\n---------\r\n");
+    m_buffer.append(" Counter: ", ++m_counter, "\r\n---------\r\n"_s);
 }
 
 void MediaRecorderPrivateMock::fetchData(FetchDataCallback&& completionHandler)

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
@@ -61,66 +61,66 @@ String RealtimeMediaSourceSettings::convertFlagsToString(const OptionSet<Realtim
 {
     StringBuilder builder;
 
-    builder.append("[ ");
+    builder.append("[ "_s);
     for (auto flag : flags) {
         if (!builder.isEmpty())
-            builder.append(", ");
+            builder.append(", "_s);
 
         switch (flag) {
         case RealtimeMediaSourceSettings::Width:
-            builder.append("Width");
+            builder.append("Width"_s);
             break;
         case RealtimeMediaSourceSettings::Height:
-            builder.append("Height");
+            builder.append("Height"_s);
             break;
         case RealtimeMediaSourceSettings::FrameRate:
-            builder.append("FrameRate");
+            builder.append("FrameRate"_s);
             break;
         case RealtimeMediaSourceSettings::FacingMode:
-            builder.append("FacingMode");
+            builder.append("FacingMode"_s);
             break;
         case RealtimeMediaSourceSettings::Volume:
-            builder.append("Volume");
+            builder.append("Volume"_s);
             break;
         case RealtimeMediaSourceSettings::SampleRate:
-            builder.append("SampleRate");
+            builder.append("SampleRate"_s);
             break;
         case RealtimeMediaSourceSettings::SampleSize:
-            builder.append("SampleSize");
+            builder.append("SampleSize"_s);
             break;
         case RealtimeMediaSourceSettings::EchoCancellation:
-            builder.append("EchoCancellation");
+            builder.append("EchoCancellation"_s);
             break;
         case RealtimeMediaSourceSettings::DeviceId:
-            builder.append("DeviceId");
+            builder.append("DeviceId"_s);
             break;
         case RealtimeMediaSourceSettings::GroupId:
-            builder.append("GroupId");
+            builder.append("GroupId"_s);
             break;
         case RealtimeMediaSourceSettings::Label:
-            builder.append("Label");
+            builder.append("Label"_s);
             break;
         case RealtimeMediaSourceSettings::DisplaySurface:
-            builder.append("DisplaySurface");
+            builder.append("DisplaySurface"_s);
             break;
         case RealtimeMediaSourceSettings::LogicalSurface:
-            builder.append("LogicalSurface");
+            builder.append("LogicalSurface"_s);
             break;
         case RealtimeMediaSourceSettings::WhiteBalanceMode:
-            builder.append("WhiteBalanceMode");
+            builder.append("WhiteBalanceMode"_s);
             break;
         case RealtimeMediaSourceSettings::Zoom:
-            builder.append("Zoom");
+            builder.append("Zoom"_s);
             break;
         case RealtimeMediaSourceSettings::Torch:
-            builder.append("Torch");
+            builder.append("Torch"_s);
             break;
         case RealtimeMediaSourceSettings::BackgroundBlur:
-            builder.append("BackgroundBlur");
+            builder.append("BackgroundBlur"_s);
             break;
         }
     }
-    builder.append(" ]");
+    builder.append(" ]"_s);
 
     return builder.toString();
 }

--- a/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp
+++ b/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp
@@ -74,10 +74,10 @@ static std::pair<String, bool> cookiesForSession(const NetworkStorageSession& se
     if (auto result = session.cookieDatabase().searchCookies(firstParty, url, searchHTTPOnly, secure, std::nullopt)) {
         for (const auto& cookie : *result) {
             if (!cookies.isEmpty())
-                cookies.append("; ");
+                cookies.append("; "_s);
             if (!cookie.name.isEmpty()) {
                 cookies.append(cookie.name);
-                cookies.append("=");
+                cookies.append('=');
             }
             if (cookie.secure)
                 didAccessSecureCookies = true;

--- a/Source/WebCore/platform/network/curl/OpenSSLHelper.cpp
+++ b/Source/WebCore/platform/network/curl/OpenSSLHelper.cpp
@@ -339,8 +339,8 @@ String canonicalizeIPv6Address(std::span<uint8_t, 16> data)
     for (int j = 0; j < 8; j++) {
         if (j == start && maxZeros > minimum) {
             if (ipAddress.isEmpty())
-                ipAddress.append(":");
-            ipAddress.append(":");
+                ipAddress.append(':');
+            ipAddress.append(':');
 
             j = end.value();
             continue;
@@ -354,7 +354,7 @@ String canonicalizeIPv6Address(std::span<uint8_t, 16> data)
         ipAddress.append(newSection.toString());
 
         if (j != 7)
-            ipAddress.append(":");
+            ipAddress.append(':');
     }
     return ipAddress.toString();
 }

--- a/Source/WebCore/platform/text/DateTimeFormat.cpp
+++ b/Source/WebCore/platform/text/DateTimeFormat.cpp
@@ -263,7 +263,7 @@ void DateTimeFormat::quoteAndAppendLiteral(const String& literal, StringBuilder&
 
     for (unsigned i = 0; i < literal.length(); ++i) {
         if (literal[i] == '\'')
-            buffer.append("''");
+            buffer.append("''"_s);
         else {
             buffer.append('\'', makeStringByReplacingAll(literal.substring(i), '\'', "''"_s), '\'');
             return;

--- a/Source/WebCore/platform/text/win/LocaleWin.cpp
+++ b/Source/WebCore/platform/text/win/LocaleWin.cpp
@@ -323,7 +323,7 @@ String LocaleWin::shortTimeFormat()
         format = getLocaleInfoString(LOCALE_STIMEFORMAT);
         StringBuilder builder;
         builder.append(getLocaleInfoString(LOCALE_STIME));
-        builder.append("ss");
+        builder.append("ss"_s);
         size_t pos = format.reverseFind(builder.toString());
         if (pos != notFound)
             format = makeStringByRemoving(format, pos, builder.length());

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -293,7 +293,7 @@ void replaceNewlinesWithWindowsStyleNewlines(String& str)
         if (str[index] != '\n' || (index > 0 && str[index - 1] == '\r'))
             result.append(str[index]);
         else
-            result.append("\r\n");
+            result.append("\r\n"_s);
     }
     str = result.toString();
 }

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -162,16 +162,16 @@ String quoteAndEscapeNonPrintables(StringView s)
     for (unsigned i = 0; i != s.length(); ++i) {
         UChar c = s[i];
         if (c == '\\') {
-            result.append("\\\\");
+            result.append("\\\\"_s);
         } else if (c == '"') {
-            result.append("\\\"");
+            result.append("\\\""_s);
         } else if (c == '\n' || c == noBreakSpace)
             result.append(' ');
         else {
             if (c >= 0x20 && c < 0x7F)
                 result.append(c);
             else
-                result.append("\\x{", hex(c), '}');
+                result.append("\\x{"_s, hex(c), '}');
         }
     }
     result.append('"');
@@ -796,19 +796,19 @@ static String nodePosition(Node* node)
     for (Node* n = node; n; n = parent) {
         parent = n->parentOrShadowHostNode();
         if (n != node)
-            result.append(" of ");
+            result.append(" of "_s);
         if (parent) {
             if (body && n == body) {
                 // We don't care what offset body may be in the document.
-                result.append("body");
+                result.append("body"_s);
                 break;
             }
             if (n->isShadowRoot())
                 result.append('{', getTagName(n), '}');
             else
-                result.append("child ", n->computeNodeIndex(), " {", getTagName(n), '}');
+                result.append("child "_s, n->computeNodeIndex(), " {"_s, getTagName(n), '}');
         } else
-            result.append("document");
+            result.append("document"_s);
     }
 
     return result.toString();

--- a/Source/WebCore/svg/SVGPathStringBuilder.cpp
+++ b/Source/WebCore/svg/SVGPathStringBuilder.cpp
@@ -69,9 +69,9 @@ static void appendPoint(StringBuilder& stringBuilder, const FloatPoint& point)
 void SVGPathStringBuilder::moveTo(const FloatPoint& targetPoint, bool, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates)
-        m_stringBuilder.append("M ");
+        m_stringBuilder.append("M "_s);
     else
-        m_stringBuilder.append("m ");
+        m_stringBuilder.append("m "_s);
 
     appendPoint(m_stringBuilder, targetPoint);
 }
@@ -79,9 +79,9 @@ void SVGPathStringBuilder::moveTo(const FloatPoint& targetPoint, bool, PathCoord
 void SVGPathStringBuilder::lineTo(const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates)
-        m_stringBuilder.append("L ");
+        m_stringBuilder.append("L "_s);
     else
-        m_stringBuilder.append("l ");
+        m_stringBuilder.append("l "_s);
 
     appendPoint(m_stringBuilder, targetPoint);
 }
@@ -89,9 +89,9 @@ void SVGPathStringBuilder::lineTo(const FloatPoint& targetPoint, PathCoordinateM
 void SVGPathStringBuilder::lineToHorizontal(float x, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates)
-        m_stringBuilder.append("H ");
+        m_stringBuilder.append("H "_s);
     else
-        m_stringBuilder.append("h ");
+        m_stringBuilder.append("h "_s);
 
     appendNumber(m_stringBuilder, x);
 }
@@ -99,9 +99,9 @@ void SVGPathStringBuilder::lineToHorizontal(float x, PathCoordinateMode mode)
 void SVGPathStringBuilder::lineToVertical(float y, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates)
-        m_stringBuilder.append("V ");
+        m_stringBuilder.append("V "_s);
     else
-        m_stringBuilder.append("v ");
+        m_stringBuilder.append("v "_s);
 
     appendNumber(m_stringBuilder, y);
 }
@@ -109,9 +109,9 @@ void SVGPathStringBuilder::lineToVertical(float y, PathCoordinateMode mode)
 void SVGPathStringBuilder::curveToCubic(const FloatPoint& point1, const FloatPoint& point2, const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates)
-        m_stringBuilder.append("C ");
+        m_stringBuilder.append("C "_s);
     else
-        m_stringBuilder.append("c ");
+        m_stringBuilder.append("c "_s);
 
     appendPoint(m_stringBuilder, point1);
     appendPoint(m_stringBuilder, point2);
@@ -121,9 +121,9 @@ void SVGPathStringBuilder::curveToCubic(const FloatPoint& point1, const FloatPoi
 void SVGPathStringBuilder::curveToCubicSmooth(const FloatPoint& point2, const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates)
-        m_stringBuilder.append("S ");
+        m_stringBuilder.append("S "_s);
     else
-        m_stringBuilder.append("s ");
+        m_stringBuilder.append("s "_s);
 
     appendPoint(m_stringBuilder, point2);
     appendPoint(m_stringBuilder, targetPoint);
@@ -132,9 +132,9 @@ void SVGPathStringBuilder::curveToCubicSmooth(const FloatPoint& point2, const Fl
 void SVGPathStringBuilder::curveToQuadratic(const FloatPoint& point1, const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates)
-        m_stringBuilder.append("Q ");
+        m_stringBuilder.append("Q "_s);
     else
-        m_stringBuilder.append("q ");
+        m_stringBuilder.append("q "_s);
 
     appendPoint(m_stringBuilder, point1);
     appendPoint(m_stringBuilder, targetPoint);
@@ -143,9 +143,9 @@ void SVGPathStringBuilder::curveToQuadratic(const FloatPoint& point1, const Floa
 void SVGPathStringBuilder::curveToQuadraticSmooth(const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates)
-        m_stringBuilder.append("T ");
+        m_stringBuilder.append("T "_s);
     else
-        m_stringBuilder.append("t ");
+        m_stringBuilder.append("t "_s);
 
     appendPoint(m_stringBuilder, targetPoint);
 }
@@ -153,9 +153,9 @@ void SVGPathStringBuilder::curveToQuadraticSmooth(const FloatPoint& targetPoint,
 void SVGPathStringBuilder::arcTo(float r1, float r2, float angle, bool largeArcFlag, bool sweepFlag, const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     if (mode == AbsoluteCoordinates)
-        m_stringBuilder.append("A ");
+        m_stringBuilder.append("A "_s);
     else
-        m_stringBuilder.append("a ");
+        m_stringBuilder.append("a "_s);
 
     appendNumber(m_stringBuilder, r1);
     appendNumber(m_stringBuilder, r2);
@@ -167,7 +167,7 @@ void SVGPathStringBuilder::arcTo(float r1, float r2, float angle, bool largeArcF
 
 void SVGPathStringBuilder::closePath()
 {
-    m_stringBuilder.append("Z ");
+    m_stringBuilder.append("Z "_s);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1183,16 +1183,16 @@ AtomString Internals::imageLastDecodingOptions(HTMLImageElement& element)
 
     auto options = bitmapImage->currentFrameDecodingOptions();
     StringBuilder builder;
-    builder.append("{ decodingMode : ");
-    builder.append(options.decodingMode() == DecodingMode::Asynchronous ? "Asynchronous" : "Synchronous");
+    builder.append("{ decodingMode : "_s);
+    builder.append(options.decodingMode() == DecodingMode::Asynchronous ? "Asynchronous"_s : "Synchronous"_s);
     if (auto sizeForDrawing = options.sizeForDrawing()) {
-        builder.append(", sizeForDrawing : { ");
+        builder.append(", sizeForDrawing : { "_s);
         builder.append(sizeForDrawing->width());
-        builder.append(", ");
+        builder.append(", "_s);
         builder.append(sizeForDrawing->height());
-        builder.append(" }");
+        builder.append(" }"_s);
     }
-    builder.append(" }");
+    builder.append(" }"_s);
     return builder.toAtomString();
 }
 
@@ -2042,9 +2042,9 @@ ExceptionOr<String> Internals::dumpMarkerRects(const String& markerTypeString)
 
     // FIXME: Using fixed precision here for width because of test results that contain numbers with specific precision. Would be nice to update the test results and move to default formatting.
     StringBuilder rectString;
-    rectString.append("marker rects: ");
+    rectString.append("marker rects: "_s);
     for (const auto& rect : rects)
-        rectString.append('(', rect.x(), ", ", rect.y(), ", ", FormattedNumber::fixedPrecision(rect.width()), ", ", rect.height(), ") ");
+        rectString.append('(', rect.x(), ", "_s, rect.y(), ", "_s, FormattedNumber::fixedPrecision(rect.width()), ", "_s, rect.height(), ") "_s);
     return rectString.toString();
 }
 
@@ -4770,21 +4770,21 @@ ExceptionOr<String> Internals::mediaSessionRestrictions(const String& mediaTypeS
 
     StringBuilder builder;
     if (restrictions & PlatformMediaSessionManager::ConcurrentPlaybackNotPermitted)
-        builder.append("concurrentplaybacknotpermitted");
+        builder.append("concurrentplaybacknotpermitted"_s);
     if (restrictions & PlatformMediaSessionManager::BackgroundProcessPlaybackRestricted) {
         if (!builder.isEmpty())
             builder.append(',');
-        builder.append("backgroundprocessplaybackrestricted");
+        builder.append("backgroundprocessplaybackrestricted"_s);
     }
     if (restrictions & PlatformMediaSessionManager::BackgroundTabPlaybackRestricted) {
         if (!builder.isEmpty())
             builder.append(',');
-        builder.append("backgroundtabplaybackrestricted");
+        builder.append("backgroundtabplaybackrestricted"_s);
     }
     if (restrictions & PlatformMediaSessionManager::InterruptedPlaybackNotPermitted) {
         if (!builder.isEmpty())
             builder.append(',');
-        builder.append("interruptedplaybacknotpermitted");
+        builder.append("interruptedplaybacknotpermitted"_s);
     }
     return builder.toString();
 }
@@ -5192,68 +5192,68 @@ String Internals::pageMediaState()
     auto state = document->page()->mediaState();
     StringBuilder string;
     if (state.containsAny(MediaProducerMediaState::IsPlayingAudio))
-        string.append("IsPlayingAudio,");
+        string.append("IsPlayingAudio,"_s);
     if (state.containsAny(MediaProducerMediaState::IsPlayingVideo))
-        string.append("IsPlayingVideo,");
+        string.append("IsPlayingVideo,"_s);
     if (state.containsAny(MediaProducerMediaState::IsPlayingToExternalDevice))
-        string.append("IsPlayingToExternalDevice,");
+        string.append("IsPlayingToExternalDevice,"_s);
     if (state.containsAny(MediaProducerMediaState::RequiresPlaybackTargetMonitoring))
-        string.append("RequiresPlaybackTargetMonitoring,");
+        string.append("RequiresPlaybackTargetMonitoring,"_s);
     if (state.containsAny(MediaProducerMediaState::ExternalDeviceAutoPlayCandidate))
-        string.append("ExternalDeviceAutoPlayCandidate,");
+        string.append("ExternalDeviceAutoPlayCandidate,"_s);
     if (state.containsAny(MediaProducerMediaState::DidPlayToEnd))
-        string.append("DidPlayToEnd,");
+        string.append("DidPlayToEnd,"_s);
     if (state.containsAny(MediaProducerMediaState::IsSourceElementPlaying))
-        string.append("IsSourceElementPlaying,");
+        string.append("IsSourceElementPlaying,"_s);
 
     if (state.containsAny(MediaProducerMediaState::IsNextTrackControlEnabled))
-        string.append("IsNextTrackControlEnabled,");
+        string.append("IsNextTrackControlEnabled,"_s);
     if (state.containsAny(MediaProducerMediaState::IsPreviousTrackControlEnabled))
-        string.append("IsPreviousTrackControlEnabled,");
+        string.append("IsPreviousTrackControlEnabled,"_s);
 
     if (state.containsAny(MediaProducerMediaState::HasPlaybackTargetAvailabilityListener))
-        string.append("HasPlaybackTargetAvailabilityListener,");
+        string.append("HasPlaybackTargetAvailabilityListener,"_s);
     if (state.containsAny(MediaProducerMediaState::HasAudioOrVideo))
-        string.append("HasAudioOrVideo,");
+        string.append("HasAudioOrVideo,"_s);
 
     if (state.containsAny(MediaProducerMediaState::HasActiveAudioCaptureDevice))
-        string.append("HasActiveAudioCaptureDevice,");
+        string.append("HasActiveAudioCaptureDevice,"_s);
     if (state.containsAny(MediaProducerMediaState::HasMutedAudioCaptureDevice))
-        string.append("HasMutedAudioCaptureDevice,");
+        string.append("HasMutedAudioCaptureDevice,"_s);
     if (state.containsAny(MediaProducerMediaState::HasInterruptedAudioCaptureDevice))
-        string.append("HasInterruptedAudioCaptureDevice,");
+        string.append("HasInterruptedAudioCaptureDevice,"_s);
 
     if (state.containsAny(MediaProducerMediaState::HasActiveVideoCaptureDevice))
-        string.append("HasActiveVideoCaptureDevice,");
+        string.append("HasActiveVideoCaptureDevice,"_s);
     if (state.containsAny(MediaProducerMediaState::HasMutedVideoCaptureDevice))
-        string.append("HasMutedVideoCaptureDevice,");
+        string.append("HasMutedVideoCaptureDevice,"_s);
     if (state.containsAny(MediaProducerMediaState::HasInterruptedVideoCaptureDevice))
-        string.append("HasInterruptedVideoCaptureDevice,");
+        string.append("HasInterruptedVideoCaptureDevice,"_s);
 
     if (state.containsAny(MediaProducerMediaState::HasUserInteractedWithMediaElement))
-        string.append("HasUserInteractedWithMediaElement,");
+        string.append("HasUserInteractedWithMediaElement,"_s);
 
     if (state.containsAny(MediaProducerMediaState::HasActiveScreenCaptureDevice))
-        string.append("HasActiveScreenCaptureDevice,");
+        string.append("HasActiveScreenCaptureDevice,"_s);
     if (state.containsAny(MediaProducerMediaState::HasMutedScreenCaptureDevice))
-        string.append("HasMutedScreenCaptureDevice,");
+        string.append("HasMutedScreenCaptureDevice,"_s);
 
     if (state.containsAny(MediaProducerMediaState::HasActiveWindowCaptureDevice))
-        string.append("HasActiveWindowCaptureDevice,");
+        string.append("HasActiveWindowCaptureDevice,"_s);
     if (state.containsAny(MediaProducerMediaState::HasMutedWindowCaptureDevice))
-        string.append("HasMutedWindowCaptureDevice,");
+        string.append("HasMutedWindowCaptureDevice,"_s);
     if (state.containsAny(MediaProducerMediaState::HasInterruptedWindowCaptureDevice))
-        string.append("HasInterruptedWindowCaptureDevice,");
+        string.append("HasInterruptedWindowCaptureDevice,"_s);
 
     if (state.containsAny(MediaProducerMediaState::HasActiveSystemAudioCaptureDevice))
-        string.append("HasActiveSystemAudioCaptureDevice,");
+        string.append("HasActiveSystemAudioCaptureDevice,"_s);
     if (state.containsAny(MediaProducerMediaState::HasMutedSystemAudioCaptureDevice))
-        string.append("HasMutedSystemAudioCaptureDevice,");
+        string.append("HasMutedSystemAudioCaptureDevice,"_s);
     if (state.containsAny(MediaProducerMediaState::HasInterruptedSystemAudioCaptureDevice))
-        string.append("HasInterruptedSystemAudioCaptureDevice,");
+        string.append("HasInterruptedSystemAudioCaptureDevice,"_s);
 
     if (string.isEmpty())
-        string.append("IsNotPlaying");
+        string.append("IsNotPlaying"_s);
     else
         string.shrink(string.length() - 1);
 
@@ -5345,18 +5345,18 @@ static void appendOffsets(StringBuilder& builder, const Vector<SnapOffset<Layout
 {
     bool justStarting = true;
 
-    builder.append("{ ");
+    builder.append("{ "_s);
     for (auto& coordinate : snapOffsets) {
         if (!justStarting)
-            builder.append(", ");
+            builder.append(", "_s);
         else
             justStarting = false;
         builder.append(coordinate.offset.toUnsigned());
         if (coordinate.stop == ScrollSnapStop::Always)
-            builder.append(" (always)");
+            builder.append(" (always)"_s);
 
     }
-    builder.append(" }");
+    builder.append(" }"_s);
 }
 
 void Internals::setPlatformMomentumScrollingPredictionEnabled(bool enabled)
@@ -5377,14 +5377,14 @@ ExceptionOr<String> Internals::scrollSnapOffsets(Element& element)
     auto* offsetInfo = scrollableArea->snapOffsetsInfo();
     StringBuilder result;
     if (offsetInfo && !offsetInfo->horizontalSnapOffsets.isEmpty()) {
-        result.append("horizontal = ");
+        result.append("horizontal = "_s);
         appendOffsets(result, offsetInfo->horizontalSnapOffsets);
     }
 
     if (offsetInfo && !offsetInfo->verticalSnapOffsets.isEmpty()) {
         if (result.length())
-            result.append(", ");
-        result.append("vertical = ");
+            result.append(", "_s);
+        result.append("vertical = "_s);
         appendOffsets(result, offsetInfo->verticalSnapOffsets);
     }
 
@@ -7220,16 +7220,16 @@ String Internals::dumpStyleResolvers()
             return currentIdentifier++;
         }).iterator->value;
 
-        result.append("(", name, " ");
-        result.append("(identifier=", identifier, ") ");
-        result.append("(author rule count=", resolver.ruleSets().authorStyle().ruleCount(), ")");
-        result.append(")\n");
+        result.append('(', name, ' ');
+        result.append("(identifier="_s, identifier, ") "_s);
+        result.append("(author rule count="_s, resolver.ruleSets().authorStyle().ruleCount(), ')');
+        result.append(")\n"_s);
     };
 
-    dumpResolver("document resolver", document->styleScope().resolver());
+    dumpResolver("document resolver"_s, document->styleScope().resolver());
 
     for (auto& shadowRoot : document->inDocumentShadowRoots()) {
-        auto* name = shadowRoot.mode() == ShadowRootMode::UserAgent ? "shadow root resolver (user agent)" : "shadow root resolver (author)";
+        auto name = shadowRoot.mode() == ShadowRootMode::UserAgent ? "shadow root resolver (user agent)"_s : "shadow root resolver (author)"_s;
         dumpResolver(name, const_cast<ShadowRoot&>(shadowRoot).styleScope().resolver());
     }
 

--- a/Source/WebDriver/SessionHost.cpp
+++ b/Source/WebDriver/SessionHost.cpp
@@ -45,9 +45,9 @@ long SessionHost::sendCommandToBackend(const String& command, RefPtr<JSON::Objec
     long sequenceID = ++lastSequenceID;
     m_commandRequests.add(sequenceID, WTFMove(responseHandler));
     StringBuilder messageBuilder;
-    messageBuilder.append("{\"id\":", sequenceID, ",\"method\":\"Automation.", command, '"');
+    messageBuilder.append("{\"id\":"_s, sequenceID, ",\"method\":\"Automation."_s, command, '"');
     if (parameters)
-        messageBuilder.append(",\"params\":", parameters->toJSONString());
+        messageBuilder.append(",\"params\":"_s, parameters->toJSONString());
     messageBuilder.append('}');
     sendMessageToBackend(messageBuilder.toString());
 

--- a/Source/WebDriver/socket/HTTPServerSocket.cpp
+++ b/Source/WebDriver/socket/HTTPServerSocket.cpp
@@ -115,20 +115,20 @@ void HTTPRequestHandler::sendResponse(HTTPRequestHandler::Response&& response)
 String HTTPRequestHandler::packHTTPMessage(HTTPRequestHandler::Response&& response) const
 {
     StringBuilder builder;
-    const char* EOL = "\r\n";
+    auto EOL = "\r\n"_s;
 
-    builder.append("HTTP/1.0 ", response.statusCode, ' ', response.statusCode == 200 ? "OK" : "ERROR", EOL);
+    builder.append("HTTP/1.0 "_s, response.statusCode, ' ', response.statusCode == 200 ? "OK"_s : "ERROR"_s, EOL);
 
     if (!response.data.isNull()) {
-        builder.append("Content-Type: ", response.contentType, EOL,
-            "Content-Length: ", response.data.length(), EOL,
-            "Cache-Control: no-cache", EOL);
+        builder.append("Content-Type: "_s, response.contentType, EOL,
+            "Content-Length: "_s, response.data.length(), EOL,
+            "Cache-Control: no-cache"_s, EOL);
     }
 
     builder.append(EOL);
 
     if (!response.data.isNull())
-        builder.append(response.data.data());
+        builder.append(response.data.span());
 
     return builder.toString();
 }

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -187,253 +187,253 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
 {
     if (m_shaderModule.usesExternalTextures()) {
         m_shaderModule.clearUsesExternalTextures();
-        m_stringBuilder.append("struct texture_external {\n");
+        m_stringBuilder.append("struct texture_external {\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "texture2d<float> FirstPlane;\n");
-            m_stringBuilder.append(m_indent, "texture2d<float> SecondPlane;\n");
-            m_stringBuilder.append(m_indent, "float3x2 UVRemapMatrix;\n");
-            m_stringBuilder.append(m_indent, "float4x3 ColorSpaceConversionMatrix;\n");
-            m_stringBuilder.append(m_indent, "uint get_width(uint lod = 0) const { return FirstPlane.get_width(lod); }\n");
-            m_stringBuilder.append(m_indent, "uint get_height(uint lod = 0) const { return FirstPlane.get_height(lod); }\n");
+            m_stringBuilder.append(m_indent, "texture2d<float> FirstPlane;\n"_s);
+            m_stringBuilder.append(m_indent, "texture2d<float> SecondPlane;\n"_s);
+            m_stringBuilder.append(m_indent, "float3x2 UVRemapMatrix;\n"_s);
+            m_stringBuilder.append(m_indent, "float4x3 ColorSpaceConversionMatrix;\n"_s);
+            m_stringBuilder.append(m_indent, "uint get_width(uint lod = 0) const { return FirstPlane.get_width(lod); }\n"_s);
+            m_stringBuilder.append(m_indent, "uint get_height(uint lod = 0) const { return FirstPlane.get_height(lod); }\n"_s);
         }
-        m_stringBuilder.append("};\n\n");
+        m_stringBuilder.append("};\n\n"_s);
     }
 
     if (m_shaderModule.usesPackArray()) {
         m_shaderModule.clearUsesPackArray();
-        m_stringBuilder.append(m_indent, "template<typename T, size_t N>\n");
-        m_stringBuilder.append(m_indent, "array<typename T::PackedType, N> __pack(array<T, N> unpacked)\n");
-        m_stringBuilder.append(m_indent, "{\n");
+        m_stringBuilder.append(m_indent, "template<typename T, size_t N>\n"_s);
+        m_stringBuilder.append(m_indent, "array<typename T::PackedType, N> __pack(array<T, N> unpacked)\n"_s);
+        m_stringBuilder.append(m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "array<typename T::PackedType, N> packed;\n");
-            m_stringBuilder.append(m_indent, "for (size_t i = 0; i < N; ++i)\n");
+            m_stringBuilder.append(m_indent, "array<typename T::PackedType, N> packed;\n"_s);
+            m_stringBuilder.append(m_indent, "for (size_t i = 0; i < N; ++i)\n"_s);
             {
                 IndentationScope scope(m_indent);
-                m_stringBuilder.append(m_indent, "packed[i] = __pack(unpacked[i]);\n");
+                m_stringBuilder.append(m_indent, "packed[i] = __pack(unpacked[i]);\n"_s);
             }
-            m_stringBuilder.append(m_indent, "return packed;\n");
+            m_stringBuilder.append(m_indent, "return packed;\n"_s);
         }
-        m_stringBuilder.append(m_indent, "}\n\n");
+        m_stringBuilder.append(m_indent, "}\n\n"_s);
     }
 
     if (m_shaderModule.usesUnpackArray()) {
         m_shaderModule.clearUsesUnpackArray();
-        m_stringBuilder.append(m_indent, "template<typename T, size_t N>\n");
-        m_stringBuilder.append(m_indent, "array<typename T::UnpackedType, N> __unpack(array<T, N> packed)\n");
-        m_stringBuilder.append(m_indent, "{\n");
+        m_stringBuilder.append(m_indent, "template<typename T, size_t N>\n"_s);
+        m_stringBuilder.append(m_indent, "array<typename T::UnpackedType, N> __unpack(array<T, N> packed)\n"_s);
+        m_stringBuilder.append(m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "array<typename T::UnpackedType, N> unpacked;\n");
-            m_stringBuilder.append(m_indent, "for (size_t i = 0; i < N; ++i)\n");
+            m_stringBuilder.append(m_indent, "array<typename T::UnpackedType, N> unpacked;\n"_s);
+            m_stringBuilder.append(m_indent, "for (size_t i = 0; i < N; ++i)\n"_s);
             {
                 IndentationScope scope(m_indent);
-                m_stringBuilder.append(m_indent, "unpacked[i] = __unpack(packed[i]);\n");
+                m_stringBuilder.append(m_indent, "unpacked[i] = __unpack(packed[i]);\n"_s);
             }
-            m_stringBuilder.append(m_indent, "return unpacked;\n");
+            m_stringBuilder.append(m_indent, "return unpacked;\n"_s);
         }
-        m_stringBuilder.append(m_indent, "}\n\n");
+        m_stringBuilder.append(m_indent, "}\n\n"_s);
     }
 
     if (m_shaderModule.usesWorkgroupUniformLoad()) {
-        m_stringBuilder.append(m_indent, "template<typename T>\n");
-        m_stringBuilder.append(m_indent, "T __workgroup_uniform_load(threadgroup T* const ptr)\n");
-        m_stringBuilder.append(m_indent, "{\n");
+        m_stringBuilder.append(m_indent, "template<typename T>\n"_s);
+        m_stringBuilder.append(m_indent, "T __workgroup_uniform_load(threadgroup T* const ptr)\n"_s);
+        m_stringBuilder.append(m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "threadgroup_barrier(mem_flags::mem_threadgroup);\n");
-            m_stringBuilder.append(m_indent, "auto result = *ptr;\n");
-            m_stringBuilder.append(m_indent, "threadgroup_barrier(mem_flags::mem_threadgroup);\n");
-            m_stringBuilder.append(m_indent, "return result;\n");
+            m_stringBuilder.append(m_indent, "threadgroup_barrier(mem_flags::mem_threadgroup);\n"_s);
+            m_stringBuilder.append(m_indent, "auto result = *ptr;\n"_s);
+            m_stringBuilder.append(m_indent, "threadgroup_barrier(mem_flags::mem_threadgroup);\n"_s);
+            m_stringBuilder.append(m_indent, "return result;\n"_s);
         }
-        m_stringBuilder.append(m_indent, "}\n\n");
+        m_stringBuilder.append(m_indent, "}\n\n"_s);
     }
 
     if (m_shaderModule.usesDivision()) {
-        m_stringBuilder.append(m_indent, "template<typename T, typename U, typename V = conditional_t<is_scalar_v<U>, T, U>>\n");
-        m_stringBuilder.append(m_indent, "V __wgslDiv(T lhs, U rhs)\n");
-        m_stringBuilder.append(m_indent, "{\n");
+        m_stringBuilder.append(m_indent, "template<typename T, typename U, typename V = conditional_t<is_scalar_v<U>, T, U>>\n"_s);
+        m_stringBuilder.append(m_indent, "V __wgslDiv(T lhs, U rhs)\n"_s);
+        m_stringBuilder.append(m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "auto predicate = V(rhs) == V(0);\n");
-            m_stringBuilder.append(m_indent, "if constexpr (is_signed_v<U>)\n");
+            m_stringBuilder.append(m_indent, "auto predicate = V(rhs) == V(0);\n"_s);
+            m_stringBuilder.append(m_indent, "if constexpr (is_signed_v<U>)\n"_s);
             {
                 IndentationScope scope(m_indent);
-                m_stringBuilder.append(m_indent, "predicate = predicate || (V(lhs) == V(numeric_limits<T>::lowest()) && V(rhs) == V(-1));\n");
+                m_stringBuilder.append(m_indent, "predicate = predicate || (V(lhs) == V(numeric_limits<T>::lowest()) && V(rhs) == V(-1));\n"_s);
             }
-            m_stringBuilder.append(m_indent, "return lhs / select(V(rhs), V(1), predicate);\n");
+            m_stringBuilder.append(m_indent, "return lhs / select(V(rhs), V(1), predicate);\n"_s);
         }
-        m_stringBuilder.append(m_indent, "}\n\n");
+        m_stringBuilder.append(m_indent, "}\n\n"_s);
     }
 
     if (m_shaderModule.usesModulo()) {
-        m_stringBuilder.append(m_indent, "template<typename T, typename U, typename V = conditional_t<is_scalar_v<U>, T, U>>\n");
-        m_stringBuilder.append(m_indent, "V __wgslMod(T lhs, U rhs)\n");
-        m_stringBuilder.append(m_indent, "{\n");
+        m_stringBuilder.append(m_indent, "template<typename T, typename U, typename V = conditional_t<is_scalar_v<U>, T, U>>\n"_s);
+        m_stringBuilder.append(m_indent, "V __wgslMod(T lhs, U rhs)\n"_s);
+        m_stringBuilder.append(m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "auto predicate = V(rhs) == V(0);\n");
-            m_stringBuilder.append(m_indent, "if constexpr (is_signed_v<U>)\n");
+            m_stringBuilder.append(m_indent, "auto predicate = V(rhs) == V(0);\n"_s);
+            m_stringBuilder.append(m_indent, "if constexpr (is_signed_v<U>)\n"_s);
             {
                 IndentationScope scope(m_indent);
-                m_stringBuilder.append(m_indent, "predicate = predicate || (V(lhs) == V(numeric_limits<T>::lowest()) && V(rhs) == V(-1));\n");
+                m_stringBuilder.append(m_indent, "predicate = predicate || (V(lhs) == V(numeric_limits<T>::lowest()) && V(rhs) == V(-1));\n"_s);
             }
-            m_stringBuilder.append(m_indent, "return select(lhs % V(rhs), V(0), predicate);\n");
+            m_stringBuilder.append(m_indent, "return select(lhs % V(rhs), V(0), predicate);\n"_s);
         }
-        m_stringBuilder.append(m_indent, "}\n\n");
+        m_stringBuilder.append(m_indent, "}\n\n"_s);
     }
 
 
     if (m_shaderModule.usesFrexp()) {
-        m_stringBuilder.append(m_indent, "template<typename T, typename U>\n");
-        m_stringBuilder.append(m_indent, "struct __frexp_result {\n");
+        m_stringBuilder.append(m_indent, "template<typename T, typename U>\n"_s);
+        m_stringBuilder.append(m_indent, "struct __frexp_result {\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "T fract;\n");
-            m_stringBuilder.append(m_indent, "U exp;\n");
+            m_stringBuilder.append(m_indent, "T fract;\n"_s);
+            m_stringBuilder.append(m_indent, "U exp;\n"_s);
         }
-        m_stringBuilder.append(m_indent, "};\n\n");
+        m_stringBuilder.append(m_indent, "};\n\n"_s);
 
-        m_stringBuilder.append(m_indent, "template<typename T, typename U = conditional_t<is_vector_v<T>, vec<int, vec_elements<T>::value ?: 2>, int>>\n");
-        m_stringBuilder.append(m_indent, "__frexp_result<T, U> __wgslFrexp(T value)\n");
-        m_stringBuilder.append(m_indent, "{\n");
+        m_stringBuilder.append(m_indent, "template<typename T, typename U = conditional_t<is_vector_v<T>, vec<int, vec_elements<T>::value ?: 2>, int>>\n"_s);
+        m_stringBuilder.append(m_indent, "__frexp_result<T, U> __wgslFrexp(T value)\n"_s);
+        m_stringBuilder.append(m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "__frexp_result<T, U> result;\n");
-            m_stringBuilder.append(m_indent, "result.fract = frexp(value, result.exp);\n");
-            m_stringBuilder.append(m_indent, "return result;\n");
+            m_stringBuilder.append(m_indent, "__frexp_result<T, U> result;\n"_s);
+            m_stringBuilder.append(m_indent, "result.fract = frexp(value, result.exp);\n"_s);
+            m_stringBuilder.append(m_indent, "return result;\n"_s);
         }
-        m_stringBuilder.append(m_indent, "}\n\n");
+        m_stringBuilder.append(m_indent, "}\n\n"_s);
     }
 
     if (m_shaderModule.usesModf()) {
-        m_stringBuilder.append(m_indent, "template<typename T, typename U>\n");
-        m_stringBuilder.append(m_indent, "struct __modf_result {\n");
+        m_stringBuilder.append(m_indent, "template<typename T, typename U>\n"_s);
+        m_stringBuilder.append(m_indent, "struct __modf_result {\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "T fract;\n");
-            m_stringBuilder.append(m_indent, "U whole;\n");
+            m_stringBuilder.append(m_indent, "T fract;\n"_s);
+            m_stringBuilder.append(m_indent, "U whole;\n"_s);
         }
-        m_stringBuilder.append(m_indent, "};\n\n");
+        m_stringBuilder.append(m_indent, "};\n\n"_s);
 
-        m_stringBuilder.append(m_indent, "template<typename T>\n");
-        m_stringBuilder.append(m_indent, "__modf_result<T, T> __wgslModf(T value)\n");
-        m_stringBuilder.append(m_indent, "{\n");
+        m_stringBuilder.append(m_indent, "template<typename T>\n"_s);
+        m_stringBuilder.append(m_indent, "__modf_result<T, T> __wgslModf(T value)\n"_s);
+        m_stringBuilder.append(m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "__modf_result<T, T> result;\n");
-            m_stringBuilder.append(m_indent, "result.fract = modf(value, result.whole);\n");
-            m_stringBuilder.append(m_indent, "return result;\n");
+            m_stringBuilder.append(m_indent, "__modf_result<T, T> result;\n"_s);
+            m_stringBuilder.append(m_indent, "result.fract = modf(value, result.whole);\n"_s);
+            m_stringBuilder.append(m_indent, "return result;\n"_s);
         }
-        m_stringBuilder.append(m_indent, "}\n\n");
+        m_stringBuilder.append(m_indent, "}\n\n"_s);
     }
 
     if (m_shaderModule.usesAtomicCompareExchange()) {
-        m_stringBuilder.append(m_indent, "template<typename T, typename U = bool>\n");
-        m_stringBuilder.append(m_indent, "struct __atomic_compare_exchange_result {\n");
+        m_stringBuilder.append(m_indent, "template<typename T, typename U = bool>\n"_s);
+        m_stringBuilder.append(m_indent, "struct __atomic_compare_exchange_result {\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "T old_value;\n");
-            m_stringBuilder.append(m_indent, "U exchanged;\n");
+            m_stringBuilder.append(m_indent, "T old_value;\n"_s);
+            m_stringBuilder.append(m_indent, "U exchanged;\n"_s);
         }
-        m_stringBuilder.append(m_indent, "};\n\n");
+        m_stringBuilder.append(m_indent, "};\n\n"_s);
 
-        m_stringBuilder.append(m_indent, "#define __wgslAtomicCompareExchangeWeak(atomic, compare, value) \\\n");
+        m_stringBuilder.append(m_indent, "#define __wgslAtomicCompareExchangeWeak(atomic, compare, value) \\\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "({ auto innerCompare = compare; \\\n");
-            m_stringBuilder.append(m_indent, "bool exchanged = atomic_compare_exchange_weak_explicit((atomic), &innerCompare, value, memory_order_relaxed, memory_order_relaxed); \\\n");
-            m_stringBuilder.append(m_indent, "__atomic_compare_exchange_result<decltype(compare)> { innerCompare, exchanged }; \\\n");
-            m_stringBuilder.append(m_indent, "})\n");
+            m_stringBuilder.append(m_indent, "({ auto innerCompare = compare; \\\n"_s);
+            m_stringBuilder.append(m_indent, "bool exchanged = atomic_compare_exchange_weak_explicit((atomic), &innerCompare, value, memory_order_relaxed, memory_order_relaxed); \\\n"_s);
+            m_stringBuilder.append(m_indent, "__atomic_compare_exchange_result<decltype(compare)> { innerCompare, exchanged }; \\\n"_s);
+            m_stringBuilder.append(m_indent, "})\n"_s);
         }
     }
 
     if (m_shaderModule.usesDot()) {
-        m_stringBuilder.append(m_indent, "template<typename T, unsigned N>\n");
-        m_stringBuilder.append(m_indent, "T __wgslDot(vec<T, N> lhs, vec<T, N> rhs)\n");
-        m_stringBuilder.append(m_indent, "{\n");
+        m_stringBuilder.append(m_indent, "template<typename T, unsigned N>\n"_s);
+        m_stringBuilder.append(m_indent, "T __wgslDot(vec<T, N> lhs, vec<T, N> rhs)\n"_s);
+        m_stringBuilder.append(m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "auto result = lhs[0] * rhs[0] + lhs[1] * rhs[1];\n");
-            m_stringBuilder.append(m_indent, "if constexpr (N > 2) result += lhs[2] * rhs[2];\n");
-            m_stringBuilder.append(m_indent, "if constexpr (N > 3) result += lhs[3] * rhs[3];\n");
-            m_stringBuilder.append(m_indent, "return result;\n");
+            m_stringBuilder.append(m_indent, "auto result = lhs[0] * rhs[0] + lhs[1] * rhs[1];\n"_s);
+            m_stringBuilder.append(m_indent, "if constexpr (N > 2) result += lhs[2] * rhs[2];\n"_s);
+            m_stringBuilder.append(m_indent, "if constexpr (N > 3) result += lhs[3] * rhs[3];\n"_s);
+            m_stringBuilder.append(m_indent, "return result;\n"_s);
         }
-        m_stringBuilder.append(m_indent, "}\n");
+        m_stringBuilder.append(m_indent, "}\n"_s);
     }
 
     if (m_shaderModule.usesDot4I8Packed()) {
-        m_stringBuilder.append(m_indent, "int __wgslDot4I8Packed(uint lhs, uint rhs)\n");
-        m_stringBuilder.append(m_indent, "{\n");
+        m_stringBuilder.append(m_indent, "int __wgslDot4I8Packed(uint lhs, uint rhs)\n"_s);
+        m_stringBuilder.append(m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "auto vec1 = as_type<packed_char4>(lhs);");
-            m_stringBuilder.append(m_indent, "auto vec2 = as_type<packed_char4>(rhs);");
-            m_stringBuilder.append(m_indent, "return vec1[0] * vec2[0] + vec1[1] * vec2[1] + vec1[2] * vec2[2] + vec1[3] * vec2[3];");
+            m_stringBuilder.append(m_indent, "auto vec1 = as_type<packed_char4>(lhs);"_s);
+            m_stringBuilder.append(m_indent, "auto vec2 = as_type<packed_char4>(rhs);"_s);
+            m_stringBuilder.append(m_indent, "return vec1[0] * vec2[0] + vec1[1] * vec2[1] + vec1[2] * vec2[2] + vec1[3] * vec2[3];"_s);
         }
-        m_stringBuilder.append(m_indent, "}\n");
+        m_stringBuilder.append(m_indent, "}\n"_s);
     }
 
     if (m_shaderModule.usesDot4U8Packed()) {
-        m_stringBuilder.append(m_indent, "uint __wgslDot4U8Packed(uint lhs, uint rhs)\n");
-        m_stringBuilder.append(m_indent, "{\n");
+        m_stringBuilder.append(m_indent, "uint __wgslDot4U8Packed(uint lhs, uint rhs)\n"_s);
+        m_stringBuilder.append(m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "auto vec1 = as_type<packed_uchar4>(lhs);");
-            m_stringBuilder.append(m_indent, "auto vec2 = as_type<packed_uchar4>(rhs);");
-            m_stringBuilder.append(m_indent, "return vec1[0] * vec2[0] + vec1[1] * vec2[1] + vec1[2] * vec2[2] + vec1[3] * vec2[3];");
+            m_stringBuilder.append(m_indent, "auto vec1 = as_type<packed_uchar4>(lhs);"_s);
+            m_stringBuilder.append(m_indent, "auto vec2 = as_type<packed_uchar4>(rhs);"_s);
+            m_stringBuilder.append(m_indent, "return vec1[0] * vec2[0] + vec1[1] * vec2[1] + vec1[2] * vec2[2] + vec1[3] * vec2[3];"_s);
         }
-        m_stringBuilder.append(m_indent, "}\n");
+        m_stringBuilder.append(m_indent, "}\n"_s);
     }
 
     if (m_shaderModule.usesFirstLeadingBit()) {
-        m_stringBuilder.append(m_indent, "template<typename T>\n");
-        m_stringBuilder.append(m_indent, "T __wgslFirstLeadingBit(T e)\n");
-        m_stringBuilder.append(m_indent, "{\n");
+        m_stringBuilder.append(m_indent, "template<typename T>\n"_s);
+        m_stringBuilder.append(m_indent, "T __wgslFirstLeadingBit(T e)\n"_s);
+        m_stringBuilder.append(m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "if constexpr (is_signed_v<T>)\n");
-            m_stringBuilder.append(m_indent, "    return select(T(31 - select(clz(e), clz(~e), e < T(0))), T(-1), e == T(0) || e == T(-1));\n");
-            m_stringBuilder.append(m_indent, "else\n");
-            m_stringBuilder.append(m_indent, "    return select(T(31 - clz(e)), T(-1), e == T(0));\n");
+            m_stringBuilder.append(m_indent, "if constexpr (is_signed_v<T>)\n"_s);
+            m_stringBuilder.append(m_indent, "    return select(T(31 - select(clz(e), clz(~e), e < T(0))), T(-1), e == T(0) || e == T(-1));\n"_s);
+            m_stringBuilder.append(m_indent, "else\n"_s);
+            m_stringBuilder.append(m_indent, "    return select(T(31 - clz(e)), T(-1), e == T(0));\n"_s);
         }
-        m_stringBuilder.append(m_indent, "}\n");
+        m_stringBuilder.append(m_indent, "}\n"_s);
     }
 
     if (m_shaderModule.usesFirstTrailingBit()) {
-        m_stringBuilder.append(m_indent, "template<typename T>\n");
-        m_stringBuilder.append(m_indent, "T __wgslFirstTrailingBit(T e)\n");
-        m_stringBuilder.append(m_indent, "{\n");
+        m_stringBuilder.append(m_indent, "template<typename T>\n"_s);
+        m_stringBuilder.append(m_indent, "T __wgslFirstTrailingBit(T e)\n"_s);
+        m_stringBuilder.append(m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "return select(ctz(e), T(-1), e == T(0));\n");
+            m_stringBuilder.append(m_indent, "return select(ctz(e), T(-1), e == T(0));\n"_s);
         }
-        m_stringBuilder.append(m_indent, "}\n");
+        m_stringBuilder.append(m_indent, "}\n"_s);
     }
 
     if (m_shaderModule.usesSign()) {
-        m_stringBuilder.append(m_indent, "template<typename T>\n");
-        m_stringBuilder.append(m_indent, "T __wgslSign(T e)\n");
-        m_stringBuilder.append(m_indent, "{\n");
+        m_stringBuilder.append(m_indent, "template<typename T>\n"_s);
+        m_stringBuilder.append(m_indent, "T __wgslSign(T e)\n"_s);
+        m_stringBuilder.append(m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "return select(select(T(-1), T(1), e > 0), T(0), e == 0);\n");
+            m_stringBuilder.append(m_indent, "return select(select(T(-1), T(1), e > 0), T(0), e == 0);\n"_s);
         }
-        m_stringBuilder.append(m_indent, "}\n");
+        m_stringBuilder.append(m_indent, "}\n"_s);
     }
 
     if (m_shaderModule.usesExtractBits()) {
-        m_stringBuilder.append(m_indent, "template<typename T>\n");
-        m_stringBuilder.append(m_indent, "T __wgslExtractBits(T e, uint offset, uint count)\n");
-        m_stringBuilder.append(m_indent, "{\n");
+        m_stringBuilder.append(m_indent, "template<typename T>\n"_s);
+        m_stringBuilder.append(m_indent, "T __wgslExtractBits(T e, uint offset, uint count)\n"_s);
+        m_stringBuilder.append(m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "auto o = min(offset, 32u);\n");
-            m_stringBuilder.append(m_indent, "auto c = min(count, 32u - o);\n");
-            m_stringBuilder.append(m_indent, "return extract_bits(e, o, c);\n");
+            m_stringBuilder.append(m_indent, "auto o = min(offset, 32u);\n"_s);
+            m_stringBuilder.append(m_indent, "auto c = min(count, 32u - o);\n"_s);
+            m_stringBuilder.append(m_indent, "return extract_bits(e, o, c);\n"_s);
         }
-        m_stringBuilder.append(m_indent, "}\n");
+        m_stringBuilder.append(m_indent, "}\n"_s);
     }
 }
 
@@ -448,26 +448,26 @@ void FunctionDefinitionWriter::visit(AST::Function& functionDefinition)
     // FIXME: visit return attributes
     for (auto& attribute : functionDefinition.attributes()) {
         checkErrorAndVisit(attribute);
-        m_stringBuilder.append(" ");
+        m_stringBuilder.append(' ');
     }
 
     if (functionDefinition.maybeReturnType())
         visit(functionDefinition.maybeReturnType()->inferredType());
     else
-        m_stringBuilder.append("void");
+        m_stringBuilder.append("void"_s);
 
-    m_stringBuilder.append(" ", functionDefinition.name(), "(");
+    m_stringBuilder.append(' ', functionDefinition.name(), '(');
     bool first = true;
     for (auto& parameter : functionDefinition.parameters()) {
         if (!first)
-            m_stringBuilder.append(", ");
+            m_stringBuilder.append(", "_s);
         switch (parameter.role()) {
         case AST::ParameterRole::UserDefined:
             checkErrorAndVisit(parameter);
             break;
         case AST::ParameterRole::StageIn:
             checkErrorAndVisit(parameter);
-            m_stringBuilder.append(" [[stage_in]]");
+            m_stringBuilder.append(" [[stage_in]]"_s);
             break;
         case AST::ParameterRole::BindGroup:
             visitArgumentBufferParameter(parameter);
@@ -480,9 +480,9 @@ void FunctionDefinitionWriter::visit(AST::Function& functionDefinition)
     m_entryPointStage = std::nullopt;
 
     m_currentFunction = &functionDefinition;
-    m_stringBuilder.append(")\n");
+    m_stringBuilder.append(")\n"_s);
     checkErrorAndVisit(functionDefinition.body());
-    m_stringBuilder.append("\n\n");
+    m_stringBuilder.append("\n\n"_s);
 
     m_currentFunction = nullptr;
 }
@@ -491,74 +491,74 @@ void FunctionDefinitionWriter::visit(AST::Structure& structDecl)
 {
     // FIXME: visit struct attributes
     m_structRole = { structDecl.role() };
-    m_stringBuilder.append(m_indent, "struct ", structDecl.name(), " {\n");
+    m_stringBuilder.append(m_indent, "struct "_s, structDecl.name(), " {\n"_s);
     {
         IndentationScope scope(m_indent);
         unsigned paddingID = 0;
         bool shouldPack = structDecl.role() == AST::StructureRole::PackedResource;
         const auto& addPadding = [&](unsigned paddingSize) {
             ASSERT(shouldPack);
-            m_stringBuilder.append(m_indent, "uint8_t __padding", ++paddingID, "[", String::number(paddingSize), "]; \n");
+            m_stringBuilder.append(m_indent, "uint8_t __padding"_s, ++paddingID, '[', String::number(paddingSize), "]; \n"_s);
         };
 
         if (structDecl.role() == AST::StructureRole::PackedResource)
-            m_stringBuilder.append(m_indent, "using UnpackedType = struct ", structDecl.original()->name(), ";\n\n");
+            m_stringBuilder.append(m_indent, "using UnpackedType = struct "_s, structDecl.original()->name(), ";\n\n"_s);
         else if (structDecl.role() == AST::StructureRole::UserDefinedResource)
-            m_stringBuilder.append(m_indent, "using PackedType = struct ", structDecl.packed()->name(), ";\n\n");
+            m_stringBuilder.append(m_indent, "using PackedType = struct "_s, structDecl.packed()->name(), ";\n\n"_s);
 
         for (auto& member : structDecl.members()) {
             auto& name = member.name();
             auto* type = member.type().inferredType();
             if (isPrimitiveReference(type, Types::Primitive::TextureExternal)) {
-                m_stringBuilder.append(m_indent, "texture2d<float> __", name, "_FirstPlane;\n");
-                m_stringBuilder.append(m_indent, "texture2d<float> __", name, "_SecondPlane;\n");
-                m_stringBuilder.append(m_indent, "float3x2 __", name, "_UVRemapMatrix;\n");
-                m_stringBuilder.append(m_indent, "float4x3 __", name, "_ColorSpaceConversionMatrix;\n");
+                m_stringBuilder.append(m_indent, "texture2d<float> __"_s, name, "_FirstPlane;\n"_s);
+                m_stringBuilder.append(m_indent, "texture2d<float> __"_s, name, "_SecondPlane;\n"_s);
+                m_stringBuilder.append(m_indent, "float3x2 __"_s, name, "_UVRemapMatrix;\n"_s);
+                m_stringBuilder.append(m_indent, "float4x3 __"_s, name, "_ColorSpaceConversionMatrix;\n"_s);
                 continue;
             }
 
             m_stringBuilder.append(m_indent);
             visit(member.type().inferredType());
-            m_stringBuilder.append(" ", name);
+            m_stringBuilder.append(' ', name);
             for (auto &attribute : member.attributes()) {
-                m_stringBuilder.append(" ");
+                m_stringBuilder.append(' ');
                 visit(attribute);
             }
-            m_stringBuilder.append(";\n");
+            m_stringBuilder.append(";\n"_s);
 
             if (shouldPack && member.padding())
                 addPadding(member.padding());
         }
 
         if (structDecl.role() == AST::StructureRole::VertexOutput || structDecl.role() == AST::StructureRole::FragmentOutput) {
-            m_stringBuilder.append("\n");
-            m_stringBuilder.append(m_indent, "template<typename T>\n");
-            m_stringBuilder.append(m_indent, structDecl.name(), "(const thread T& other)\n");
+            m_stringBuilder.append('\n');
+            m_stringBuilder.append(m_indent, "template<typename T>\n"_s);
+            m_stringBuilder.append(m_indent, structDecl.name(), "(const thread T& other)\n"_s);
             {
                 IndentationScope scope(m_indent);
                 char prefix = ':';
                 for (auto& member : structDecl.members()) {
                     auto& name = member.name();
-                    m_stringBuilder.append(m_indent, prefix, " ", name, "(other.", name, ")\n");
+                    m_stringBuilder.append(m_indent, prefix, ' ', name, "(other."_s, name, ")\n"_s);
                     prefix = ',';
                 }
             }
-            m_stringBuilder.append(m_indent, "{ }\n");
+            m_stringBuilder.append(m_indent, "{ }\n"_s);
         } else if (structDecl.role() == AST::StructureRole::FragmentOutputWrapper) {
             ASSERT(structDecl.members().size() == 1);
             auto& member = structDecl.members()[0];
 
-            m_stringBuilder.append("\n");
-            m_stringBuilder.append(m_indent, "template<typename T>\n");
-            m_stringBuilder.append(m_indent, structDecl.name(), "(T value)\n");
+            m_stringBuilder.append('\n');
+            m_stringBuilder.append(m_indent, "template<typename T>\n"_s);
+            m_stringBuilder.append(m_indent, structDecl.name(), "(T value)\n"_s);
             {
                 IndentationScope scope(m_indent);
-                m_stringBuilder.append(m_indent, ": ", member.name(), "(value)\n");
+                m_stringBuilder.append(m_indent, ": "_s, member.name(), "(value)\n"_s);
             }
-            m_stringBuilder.append(m_indent, "{ }\n");
+            m_stringBuilder.append(m_indent, "{ }\n"_s);
         }
     }
-    m_stringBuilder.append(m_indent, "};\n\n");
+    m_stringBuilder.append(m_indent, "};\n\n"_s);
     m_structRole = std::nullopt;
 }
 
@@ -570,37 +570,37 @@ void FunctionDefinitionWriter::generatePackingHelpers(AST::Structure& structure)
     const String& packedName = structure.name();
     auto unpackedName = structure.original()->name();
 
-    m_stringBuilder.append(m_indent, packedName, " __pack(", unpackedName, " unpacked)\n");
-    m_stringBuilder.append(m_indent, "{\n");
+    m_stringBuilder.append(m_indent, packedName, " __pack("_s, unpackedName, " unpacked)\n"_s);
+    m_stringBuilder.append(m_indent, "{\n"_s);
     {
         IndentationScope scope(m_indent);
-        m_stringBuilder.append(m_indent, packedName, " packed;\n");
+        m_stringBuilder.append(m_indent, packedName, " packed;\n"_s);
         for (auto& member : structure.members()) {
             auto& name = member.name();
             if (member.type().inferredType()->packing() == Packing::PackedStruct)
-                m_stringBuilder.append(m_indent, "packed.", name, " = __pack(unpacked.", name, ");\n");
+                m_stringBuilder.append(m_indent, "packed."_s, name, " = __pack(unpacked."_s, name, ");\n"_s);
             else
-                m_stringBuilder.append(m_indent, "packed.", name, " = unpacked.", name, ";\n");
+                m_stringBuilder.append(m_indent, "packed."_s, name, " = unpacked."_s, name, ";\n"_s);
         }
-        m_stringBuilder.append(m_indent, "return packed;\n");
+        m_stringBuilder.append(m_indent, "return packed;\n"_s);
     }
-    m_stringBuilder.append(m_indent, "}\n\n");
+    m_stringBuilder.append(m_indent, "}\n\n"_s);
 
-    m_stringBuilder.append(m_indent, unpackedName, " __unpack(", packedName, " packed)\n");
-    m_stringBuilder.append(m_indent, "{\n");
+    m_stringBuilder.append(m_indent, unpackedName, " __unpack("_s, packedName, " packed)\n"_s);
+    m_stringBuilder.append(m_indent, "{\n"_s);
     {
         IndentationScope scope(m_indent);
-        m_stringBuilder.append(m_indent, unpackedName, " unpacked;\n");
+        m_stringBuilder.append(m_indent, unpackedName, " unpacked;\n"_s);
         for (auto& member : structure.members()) {
             auto& name = member.name();
             if (member.type().inferredType()->packing() == Packing::PackedStruct)
-                m_stringBuilder.append(m_indent, "unpacked.", name, " = __unpack(packed.", name, ");\n");
+                m_stringBuilder.append(m_indent, "unpacked."_s, name, " = __unpack(packed."_s, name, ");\n"_s);
             else
-                m_stringBuilder.append(m_indent, "unpacked.", name, " = packed.", name, ";\n");
+                m_stringBuilder.append(m_indent, "unpacked."_s, name, " = packed."_s, name, ";\n"_s);
         }
-        m_stringBuilder.append(m_indent, "return unpacked;\n");
+        m_stringBuilder.append(m_indent, "return unpacked;\n"_s);
     }
-    m_stringBuilder.append(m_indent, "}\n\n");
+    m_stringBuilder.append(m_indent, "}\n\n"_s);
 }
 
 bool FunctionDefinitionWriter::emitPackedVector(const Types::Vector& vector)
@@ -618,17 +618,17 @@ bool FunctionDefinitionWriter::emitPackedVector(const Types::Vector& vector)
     switch (primitive.kind) {
     case Types::Primitive::AbstractInt:
     case Types::Primitive::I32:
-        m_stringBuilder.append("packed_int", String::number(vector.size));
+        m_stringBuilder.append("packed_int"_s, String::number(vector.size));
         break;
     case Types::Primitive::U32:
-        m_stringBuilder.append("packed_uint", String::number(vector.size));
+        m_stringBuilder.append("packed_uint"_s, String::number(vector.size));
         break;
     case Types::Primitive::AbstractFloat:
     case Types::Primitive::F32:
-        m_stringBuilder.append("packed_float", String::number(vector.size));
+        m_stringBuilder.append("packed_float"_s, String::number(vector.size));
         break;
     case Types::Primitive::F16:
-        m_stringBuilder.append("packed_half", String::number(vector.size));
+        m_stringBuilder.append("packed_half"_s, String::number(vector.size));
         break;
     case Types::Primitive::Bool:
     case Types::Primitive::Void:
@@ -676,22 +676,22 @@ void FunctionDefinitionWriter::serializeVariable(AST::Variable& variable)
     const Type* type = variable.storeType();
     if (isPrimitiveReference(type, Types::Primitive::TextureExternal)) {
         ASSERT(variable.maybeInitializer());
-        m_stringBuilder.append("texture_external ", variable.name(), " { ");
+        m_stringBuilder.append("texture_external "_s, variable.name(), " { "_s);
         visit(*variable.maybeInitializer());
-        m_stringBuilder.append("_FirstPlane, ");
+        m_stringBuilder.append("_FirstPlane, "_s);
         visit(*variable.maybeInitializer());
-        m_stringBuilder.append("_SecondPlane, ");
+        m_stringBuilder.append("_SecondPlane, "_s);
         visit(*variable.maybeInitializer());
-        m_stringBuilder.append("_UVRemapMatrix, ");
+        m_stringBuilder.append("_UVRemapMatrix, "_s);
         visit(*variable.maybeInitializer());
-        m_stringBuilder.append("_ColorSpaceConversionMatrix }");
+        m_stringBuilder.append("_ColorSpaceConversionMatrix }"_s);
         return;
     }
 
     if (auto* qualifier = variable.maybeQualifier()) {
         switch (qualifier->addressSpace()) {
         case AddressSpace::Workgroup:
-            m_stringBuilder.append("threadgroup ");
+            m_stringBuilder.append("threadgroup "_s);
             break;
         case AddressSpace::Function:
         case AddressSpace::Handle:
@@ -703,16 +703,16 @@ void FunctionDefinitionWriter::serializeVariable(AST::Variable& variable)
     }
 
     visit(type);
-    m_stringBuilder.append(" ", variable.name());
+    m_stringBuilder.append(' ', variable.name());
 
     if (variable.flavor() == AST::VariableFlavor::Override)
         return;
 
     if (auto* initializer = variable.maybeInitializer()) {
-        m_stringBuilder.append(" = ");
+        m_stringBuilder.append(" = "_s);
         visit(type, *initializer);
     } else
-        m_stringBuilder.append(" { }");
+        m_stringBuilder.append(" { }"_s);
 }
 
 void FunctionDefinitionWriter::visit(AST::Attribute& attribute)
@@ -730,40 +730,40 @@ void FunctionDefinitionWriter::visit(AST::BuiltinAttribute& builtin)
 
     switch (builtin.builtin()) {
     case Builtin::FragDepth:
-        m_stringBuilder.append("[[depth(any)]]");
+        m_stringBuilder.append("[[depth(any)]]"_s);
         break;
     case Builtin::FrontFacing:
-        m_stringBuilder.append("[[front_facing]]");
+        m_stringBuilder.append("[[front_facing]]"_s);
         break;
     case Builtin::GlobalInvocationId:
-        m_stringBuilder.append("[[thread_position_in_grid]]");
+        m_stringBuilder.append("[[thread_position_in_grid]]"_s);
         break;
     case Builtin::InstanceIndex:
-        m_stringBuilder.append("[[instance_id]]");
+        m_stringBuilder.append("[[instance_id]]"_s);
         break;
     case Builtin::LocalInvocationId:
-        m_stringBuilder.append("[[thread_position_in_threadgroup]]");
+        m_stringBuilder.append("[[thread_position_in_threadgroup]]"_s);
         break;
     case Builtin::LocalInvocationIndex:
-        m_stringBuilder.append("[[thread_index_in_threadgroup]]");
+        m_stringBuilder.append("[[thread_index_in_threadgroup]]"_s);
         break;
     case Builtin::NumWorkgroups:
-        m_stringBuilder.append("[[threadgroups_per_grid]]");
+        m_stringBuilder.append("[[threadgroups_per_grid]]"_s);
         break;
     case Builtin::Position:
-        m_stringBuilder.append("[[position]]");
+        m_stringBuilder.append("[[position]]"_s);
         break;
     case Builtin::SampleIndex:
-        m_stringBuilder.append("[[sample_id]]");
+        m_stringBuilder.append("[[sample_id]]"_s);
         break;
     case Builtin::SampleMask:
-        m_stringBuilder.append("[[sample_mask]]");
+        m_stringBuilder.append("[[sample_mask]]"_s);
         break;
     case Builtin::VertexIndex:
-        m_stringBuilder.append("[[vertex_id]]");
+        m_stringBuilder.append("[[vertex_id]]"_s);
         break;
     case Builtin::WorkgroupId:
-        m_stringBuilder.append("[[threadgroup_position_in_grid]]");
+        m_stringBuilder.append("[[threadgroup_position_in_grid]]"_s);
         break;
     }
 }
@@ -773,13 +773,13 @@ void FunctionDefinitionWriter::visit(AST::StageAttribute& stage)
     m_entryPointStage = { stage.stage() };
     switch (stage.stage()) {
     case ShaderStage::Vertex:
-        m_stringBuilder.append("[[vertex]]");
+        m_stringBuilder.append("[[vertex]]"_s);
         break;
     case ShaderStage::Fragment:
-        m_stringBuilder.append("[[fragment]]");
+        m_stringBuilder.append("[[fragment]]"_s);
         break;
     case ShaderStage::Compute:
-        m_stringBuilder.append("[[kernel]]");
+        m_stringBuilder.append("[[kernel]]"_s);
         break;
     }
 }
@@ -792,12 +792,12 @@ void FunctionDefinitionWriter::visit(AST::GroupAttribute& group)
         auto max = m_shaderModule.configuration().maxBuffersPlusVertexBuffersForVertexStage - 1;
         bufferIndex = vertexBufferIndexForBindGroup(bufferIndex, max);
     }
-    m_stringBuilder.append("[[buffer(", bufferIndex, ")]]");
+    m_stringBuilder.append("[[buffer("_s, bufferIndex, ")]]"_s);
 }
 
 void FunctionDefinitionWriter::visit(AST::BindingAttribute& binding)
 {
-    m_stringBuilder.append("[[id(", binding.binding().constantValue()->integerValue(), ")]]");
+    m_stringBuilder.append("[[id("_s, binding.binding().constantValue()->integerValue(), ")]]"_s);
 }
 
 void FunctionDefinitionWriter::visit(AST::LocationAttribute& location)
@@ -807,7 +807,7 @@ void FunctionDefinitionWriter::visit(AST::LocationAttribute& location)
         switch (role) {
         case AST::StructureRole::VertexOutput:
         case AST::StructureRole::FragmentInput:
-            m_stringBuilder.append("[[user(loc", location.location().constantValue()->integerValue(), ")]]");
+            m_stringBuilder.append("[[user(loc"_s, location.location().constantValue()->integerValue(), ")]]"_s);
             return;
         case AST::StructureRole::BindGroup:
         case AST::StructureRole::UserDefined:
@@ -818,10 +818,10 @@ void FunctionDefinitionWriter::visit(AST::LocationAttribute& location)
         case AST::StructureRole::FragmentOutputWrapper:
             RELEASE_ASSERT_NOT_REACHED();
         case AST::StructureRole::FragmentOutput:
-            m_stringBuilder.append("[[color(", location.location().constantValue()->integerValue(), ")]]");
+            m_stringBuilder.append("[[color("_s, location.location().constantValue()->integerValue(), ")]]"_s);
             return;
         case AST::StructureRole::VertexInput:
-            m_stringBuilder.append("[[attribute(", location.location().constantValue()->integerValue(), ")]]");
+            m_stringBuilder.append("[[attribute("_s, location.location().constantValue()->integerValue(), ")]]"_s);
             break;
         }
     }
@@ -876,7 +876,7 @@ static const char* convertToSampleMode(InterpolationType type, InterpolationSamp
 
 void FunctionDefinitionWriter::visit(AST::InterpolateAttribute& attribute)
 {
-    m_stringBuilder.append("[[", convertToSampleMode(attribute.type(), attribute.sampling()), "]]");
+    m_stringBuilder.append("[["_s, convertToSampleMode(attribute.type(), attribute.sampling()), "]]"_s);
 }
 
 // Types
@@ -888,17 +888,17 @@ void FunctionDefinitionWriter::visit(const Type* type)
             switch (primitive.kind) {
             case Types::Primitive::AbstractInt:
             case Types::Primitive::I32:
-                m_stringBuilder.append("int");
+                m_stringBuilder.append("int"_s);
                 break;
             case Types::Primitive::U32:
-                m_stringBuilder.append("unsigned");
+                m_stringBuilder.append("unsigned"_s);
                 break;
             case Types::Primitive::AbstractFloat:
             case Types::Primitive::F32:
-                m_stringBuilder.append("float");
+                m_stringBuilder.append("float"_s);
                 break;
             case Types::Primitive::F16:
-                m_stringBuilder.append("half");
+                m_stringBuilder.append("half"_s);
                 break;
             case Types::Primitive::Void:
             case Types::Primitive::Bool:
@@ -906,10 +906,10 @@ void FunctionDefinitionWriter::visit(const Type* type)
                 m_stringBuilder.append(*type);
                 break;
             case Types::Primitive::SamplerComparison:
-                m_stringBuilder.append("sampler");
+                m_stringBuilder.append("sampler"_s);
                 break;
             case Types::Primitive::TextureExternal:
-                m_stringBuilder.append("texture_external");
+                m_stringBuilder.append("texture_external"_s);
                 break;
             case Types::Primitive::AccessMode:
             case Types::Primitive::TexelFormat:
@@ -920,42 +920,42 @@ void FunctionDefinitionWriter::visit(const Type* type)
         [&](const Vector& vector) {
             if (emitPackedVector(vector))
                 return;
-            m_stringBuilder.append("vec<");
+            m_stringBuilder.append("vec<"_s);
             visit(vector.element);
-            m_stringBuilder.append(", ", vector.size, ">");
+            m_stringBuilder.append(", "_s, vector.size, '>');
         },
         [&](const Matrix& matrix) {
-            m_stringBuilder.append("matrix<");
+            m_stringBuilder.append("matrix<"_s);
             visit(matrix.element);
-            m_stringBuilder.append(", ", matrix.columns, ", ", matrix.rows, ">");
+            m_stringBuilder.append(", "_s, matrix.columns, ", "_s, matrix.rows, '>');
         },
         [&](const Array& array) {
-            m_stringBuilder.append("array<");
+            m_stringBuilder.append("array<"_s);
             visit(array.element);
-            m_stringBuilder.append(", ");
+            m_stringBuilder.append(", "_s);
             WTF::switchOn(array.size,
                 [&](unsigned size) { m_stringBuilder.append(size); },
                 [&](std::monostate) { m_stringBuilder.append(1); },
                 [&](AST::Expression* size) {
                     visit(*size);
                 });
-            m_stringBuilder.append(">");
+            m_stringBuilder.append('>');
         },
         [&](const Struct& structure) {
             m_stringBuilder.append(structure.structure.name());
             if (m_structRole.has_value() && *m_structRole == AST::StructureRole::PackedResource && structure.structure.role() == AST::StructureRole::UserDefinedResource)
-                m_stringBuilder.append("::PackedType");
+                m_stringBuilder.append("::PackedType"_s);
         },
         [&](const PrimitiveStruct& structure) {
-            m_stringBuilder.append(structure.name, "<");
+            m_stringBuilder.append(structure.name, '<');
             bool first = true;
             for (auto& value : structure.values) {
                 if (!first)
-                    m_stringBuilder.append(", ");
+                    m_stringBuilder.append(", "_s);
                 first = false;
                 visit(value);
             }
-            m_stringBuilder.append(">");
+            m_stringBuilder.append('>');
         },
         [&](const Texture& texture) {
             const char* type;
@@ -984,9 +984,9 @@ void FunctionDefinitionWriter::visit(const Type* type)
                 access = "read";
                 break;
             }
-            m_stringBuilder.append(type, "<");
+            m_stringBuilder.append(type, '<');
             visit(texture.element);
-            m_stringBuilder.append(", access::", access, ">");
+            m_stringBuilder.append(", access::"_s, access, '>');
         },
         [&](const TextureStorage& texture) {
             const char* base;
@@ -1016,9 +1016,9 @@ void FunctionDefinitionWriter::visit(const Type* type)
                 mode = "read_write";
                 break;
             }
-            m_stringBuilder.append(base, "<");
+            m_stringBuilder.append(base, '<');
             visit(shaderTypeForTexelFormat(texture.format, m_shaderModule.types()));
-            m_stringBuilder.append(", access::", mode, ">");
+            m_stringBuilder.append(", access::"_s, mode, '>');
         },
         [&](const TextureDepth& texture) {
             const char* base;
@@ -1039,7 +1039,7 @@ void FunctionDefinitionWriter::visit(const Type* type)
                 base = "depth2d_ms";
                 break;
             }
-            m_stringBuilder.append(base, "<float>");
+            m_stringBuilder.append(base, "<float>"_s);
         },
         [&](const Reference& reference) {
             const char* addressSpace = serializeAddressSpace(reference.addressSpace);
@@ -1048,25 +1048,25 @@ void FunctionDefinitionWriter::visit(const Type* type)
                 return;
             }
             if (reference.accessMode == AccessMode::Read)
-                m_stringBuilder.append("const ");
-            m_stringBuilder.append(addressSpace, " ");
+                m_stringBuilder.append("const "_s);
+            m_stringBuilder.append(addressSpace, ' ');
             visit(reference.element);
-            m_stringBuilder.append("&");
+            m_stringBuilder.append('&');
         },
         [&](const Pointer& pointer) {
             const char* addressSpace = serializeAddressSpace(pointer.addressSpace);
             if (pointer.accessMode == AccessMode::Read)
-                m_stringBuilder.append("const ");
+                m_stringBuilder.append("const "_s);
             if (addressSpace)
-                m_stringBuilder.append(addressSpace, " ");
+                m_stringBuilder.append(addressSpace, ' ');
             visit(pointer.element);
-            m_stringBuilder.append("*");
+            m_stringBuilder.append('*');
         },
         [&](const Atomic& atomic) {
             if (atomic.element == m_shaderModule.types().i32Type())
-                m_stringBuilder.append("atomic_int");
+                m_stringBuilder.append("atomic_int"_s);
             else
-                m_stringBuilder.append("atomic_uint");
+                m_stringBuilder.append("atomic_uint"_s);
         },
         [&](const Function&) {
             RELEASE_ASSERT_NOT_REACHED();
@@ -1082,20 +1082,20 @@ void FunctionDefinitionWriter::visit(const Type* type)
 void FunctionDefinitionWriter::visit(AST::Parameter& parameter)
 {
     visit(parameter.typeName().inferredType());
-    m_stringBuilder.append(" ", parameter.name());
+    m_stringBuilder.append(' ', parameter.name());
     for (auto& attribute : parameter.attributes()) {
-        m_stringBuilder.append(" ");
+        m_stringBuilder.append(' ');
         checkErrorAndVisit(attribute);
     }
 }
 
 void FunctionDefinitionWriter::visitArgumentBufferParameter(AST::Parameter& parameter)
 {
-    m_stringBuilder.append("constant ");
+    m_stringBuilder.append("constant "_s);
     visit(parameter.typeName().inferredType());
-    m_stringBuilder.append("& ", parameter.name());
+    m_stringBuilder.append("& "_s, parameter.name());
     for (auto& attribute : parameter.attributes()) {
-        m_stringBuilder.append(" ");
+        m_stringBuilder.append(' ');
         checkErrorAndVisit(attribute);
     }
 }
@@ -1122,42 +1122,42 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::Expression& expressi
 
 static void visitArguments(FunctionDefinitionWriter* writer, AST::CallExpression& call, unsigned startOffset = 0)
 {
-    writer->stringBuilder().append("(");
+    writer->stringBuilder().append('(');
     for (unsigned i = startOffset; i < call.arguments().size(); ++i) {
         if (i != startOffset)
-            writer->stringBuilder().append(", ");
+            writer->stringBuilder().append(", "_s);
         writer->visit(call.arguments()[i]);
     }
-    writer->stringBuilder().append(")");
+    writer->stringBuilder().append(')');
 }
 
 static void emitTextureDimensions(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
     const auto& get = [&](const char* property) {
         writer->visit(call.arguments()[0]);
-        writer->stringBuilder().append(".get_", property, "(");
+        writer->stringBuilder().append(".get_"_s, property, '(');
         if (call.arguments().size() > 1)
             writer->visit(call.arguments()[1]);
-        writer->stringBuilder().append(")");
+        writer->stringBuilder().append(')');
     };
 
     const auto* vector = std::get_if<Types::Vector>(call.inferredType());
     if (!vector) {
-        get("width");
+        get("width"_s);
         return;
     }
 
     auto size = vector->size;
     ASSERT(size >= 2 && size <= 3);
-    writer->stringBuilder().append("uint", String::number(size), "(");
-    get("width");
-    writer->stringBuilder().append(", ");
-    get("height");
+    writer->stringBuilder().append("uint"_s, String::number(size), '(');
+    get("width"_s);
+    writer->stringBuilder().append(", "_s);
+    get("height"_s);
     if (size > 2) {
-        writer->stringBuilder().append(", ");
-        get("depth");
+        writer->stringBuilder().append(", "_s);
+        get("depth"_s);
     }
-    writer->stringBuilder().append(")");
+    writer->stringBuilder().append(')');
 }
 
 static void emitTextureGather(FunctionDefinitionWriter* writer, AST::CallExpression& call)
@@ -1195,24 +1195,24 @@ static void emitTextureGather(FunctionDefinitionWriter* writer, AST::CallExpress
         }
     }
     writer->visit(call.arguments()[offset]);
-    writer->stringBuilder().append(".gather(");
+    writer->stringBuilder().append(".gather("_s);
     for (unsigned i = offset + 1; i < call.arguments().size(); ++i) {
         if (i != offset + 1)
-            writer->stringBuilder().append(", ");
+            writer->stringBuilder().append(", "_s);
         writer->visit(call.arguments()[i]);
     }
     if (!hasOffset)
-        writer->stringBuilder().append(", int2(0)");
+        writer->stringBuilder().append(", int2(0)"_s);
     if (component)
-        writer->stringBuilder().append(", component::", component);
-    writer->stringBuilder().append(")");
+        writer->stringBuilder().append(", component::"_s, component);
+    writer->stringBuilder().append(')');
 }
 
 static void emitTextureGatherCompare(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
     ASSERT(call.arguments().size() > 1);
     writer->visit(call.arguments()[0]);
-    writer->stringBuilder().append(".gather_compare");
+    writer->stringBuilder().append(".gather_compare"_s);
     visitArguments(writer, call, 1);
 }
 
@@ -1226,8 +1226,8 @@ static void emitTextureLoad(FunctionDefinitionWriter* writer, AST::CallExpressio
     bool isExternalTexture = primitive && primitive->kind == Types::Primitive::TextureExternal;
     if (!isExternalTexture) {
         writer->visit(call.arguments()[0]);
-        writer->stringBuilder().append(".read");
-        writer->stringBuilder().append("(");
+        writer->stringBuilder().append(".read"_s);
+        writer->stringBuilder().append('(');
         bool is1d = true;
         const char* cast = "uint";
         if (const auto* vector = std::get_if<Types::Vector>(call.arguments()[1].inferredType())) {
@@ -1247,59 +1247,59 @@ static void emitTextureLoad(FunctionDefinitionWriter* writer, AST::CallExpressio
         auto argumentCount = call.arguments().size();
         for (unsigned i = 1; i < argumentCount; ++i) {
             if (first) {
-                writer->stringBuilder().append(cast, "(");
+                writer->stringBuilder().append(cast, '(');
                 writer->visit(call.arguments()[i]);
-                writer->stringBuilder().append(")");
+                writer->stringBuilder().append(')');
             } else if (is1d && i == argumentCount - 1) {
                 // From the MSL spec for texture1d::read:
                 // > Since mipmaps are not supported for 1D textures, lod must be 0.
                 continue;
             } else {
-                writer->stringBuilder().append(", ");
+                writer->stringBuilder().append(", "_s);
                 writer->visit(call.arguments()[i]);
             }
             first = false;
         }
-        writer->stringBuilder().append(")");
+        writer->stringBuilder().append(')');
         return;
     }
 
     auto& coordinates = call.arguments()[1];
-    writer->stringBuilder().append("({\n");
+    writer->stringBuilder().append("({\n"_s);
     {
         IndentationScope scope(writer->indent());
         {
-            writer->stringBuilder().append(writer->indent(), "auto __coords = uint2((");
+            writer->stringBuilder().append(writer->indent(), "auto __coords = uint2(("_s);
             writer->visit(texture);
-            writer->stringBuilder().append(".UVRemapMatrix * float3(float2(");
+            writer->stringBuilder().append(".UVRemapMatrix * float3(float2("_s);
             writer->visit(coordinates);
-            writer->stringBuilder().append("), 1)).xy);\n");
+            writer->stringBuilder().append("), 1)).xy);\n"_s);
         }
         {
-            writer->stringBuilder().append(writer->indent(), "auto __y = float(");
+            writer->stringBuilder().append(writer->indent(), "auto __y = float("_s);
             writer->visit(texture);
-            writer->stringBuilder().append(".FirstPlane.read(__coords).r);\n");
+            writer->stringBuilder().append(".FirstPlane.read(__coords).r);\n"_s);
         }
         {
-            writer->stringBuilder().append(writer->indent(), "auto __cbcr = float2(");
+            writer->stringBuilder().append(writer->indent(), "auto __cbcr = float2("_s);
             writer->visit(texture);
-            writer->stringBuilder().append(".SecondPlane.read(__coords).rg);\n");
+            writer->stringBuilder().append(".SecondPlane.read(__coords).rg);\n"_s);
         }
-        writer->stringBuilder().append(writer->indent(), "auto __ycbcr = float3(__y, __cbcr);\n");
+        writer->stringBuilder().append(writer->indent(), "auto __ycbcr = float3(__y, __cbcr);\n"_s);
         {
-            writer->stringBuilder().append(writer->indent(), "float4(");
+            writer->stringBuilder().append(writer->indent(), "float4("_s);
             writer->visit(texture);
-            writer->stringBuilder().append(".ColorSpaceConversionMatrix * float4(__ycbcr, 1), 1);\n");
+            writer->stringBuilder().append(".ColorSpaceConversionMatrix * float4(__ycbcr, 1), 1);\n"_s);
         }
     }
-    writer->stringBuilder().append(writer->indent(), "})");
+    writer->stringBuilder().append(writer->indent(), "})"_s);
 }
 
 static void emitTextureSample(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
     ASSERT(call.arguments().size() > 1);
     writer->visit(call.arguments()[0]);
-    writer->stringBuilder().append(".sample");
+    writer->stringBuilder().append(".sample"_s);
     visitArguments(writer, call, 1);
 }
 
@@ -1307,7 +1307,7 @@ static void emitTextureSampleCompare(FunctionDefinitionWriter* writer, AST::Call
 {
     ASSERT(call.arguments().size() > 1);
     writer->visit(call.arguments()[0]);
-    writer->stringBuilder().append(".sample_compare");
+    writer->stringBuilder().append(".sample_compare"_s);
     visitArguments(writer, call, 1);
 }
 
@@ -1349,22 +1349,22 @@ static void emitTextureSampleGrad(FunctionDefinitionWriter* writer, AST::CallExp
         break;
     }
     writer->visit(texture);
-    writer->stringBuilder().append(".sample(");
+    writer->stringBuilder().append(".sample("_s);
     for (unsigned i = 1; i < gradientIndex; ++i) {
         if (i != 1)
-            writer->stringBuilder().append(", ");
+            writer->stringBuilder().append(", "_s);
         writer->visit(call.arguments()[i]);
     }
-    writer->stringBuilder().append(", ", gradientFunction, "(");
+    writer->stringBuilder().append(", "_s, gradientFunction, '(');
     writer->visit(call.arguments()[gradientIndex]);
-    writer->stringBuilder().append(", ");
+    writer->stringBuilder().append(", "_s);
     writer->visit(call.arguments()[gradientIndex + 1]);
-    writer->stringBuilder().append(")");
+    writer->stringBuilder().append(')');
     for (unsigned i = gradientIndex + 2; i < call.arguments().size(); ++i) {
-        writer->stringBuilder().append(", ");
+        writer->stringBuilder().append(", "_s);
         writer->visit(call.arguments()[i]);
     }
-    writer->stringBuilder().append(")");
+    writer->stringBuilder().append(')');
 }
 
 static void emitTextureSampleLevel(FunctionDefinitionWriter* writer, AST::CallExpression& call)
@@ -1410,20 +1410,20 @@ static void emitTextureSampleLevel(FunctionDefinitionWriter* writer, AST::CallEx
 
     unsigned levelIndex = isArray ? 4 : 3;
     writer->visit(texture);
-    writer->stringBuilder().append(".sample(");
+    writer->stringBuilder().append(".sample("_s);
     for (unsigned i = 1; i < levelIndex; ++i) {
         if (i != 1)
-            writer->stringBuilder().append(",");
+            writer->stringBuilder().append(',');
         writer->visit(call.arguments()[i]);
     }
-    writer->stringBuilder().append(", level(");
+    writer->stringBuilder().append(", level("_s);
     writer->visit(call.arguments()[levelIndex]);
-    writer->stringBuilder().append(")");
+    writer->stringBuilder().append(')');
     for (unsigned i = levelIndex + 1; i < call.arguments().size(); ++i) {
-        writer->stringBuilder().append(",");
+        writer->stringBuilder().append(',');
         writer->visit(call.arguments()[i]);
     }
-    writer->stringBuilder().append(")");
+    writer->stringBuilder().append(')');
 }
 
 static void emitTextureSampleBaseClampToEdge(FunctionDefinitionWriter* writer, AST::CallExpression& call)
@@ -1434,45 +1434,45 @@ static void emitTextureSampleBaseClampToEdge(FunctionDefinitionWriter* writer, A
     if (textureType) {
         // FIXME: this needs to clamp the coordinates
         writer->visit(texture);
-        writer->stringBuilder().append(".sample");
+        writer->stringBuilder().append(".sample"_s);
         visitArguments(writer, call, 1);
         return;
     }
 
     auto& sampler = call.arguments()[1];
     auto& coordinates = call.arguments()[2];
-    writer->stringBuilder().append("({\n");
+    writer->stringBuilder().append("({\n"_s);
     {
         IndentationScope scope(writer->indent());
         {
-            writer->stringBuilder().append(writer->indent(), "auto __coords = (");
+            writer->stringBuilder().append(writer->indent(), "auto __coords = ("_s);
             writer->visit(texture);
-            writer->stringBuilder().append(".UVRemapMatrix * float3(");
+            writer->stringBuilder().append(".UVRemapMatrix * float3("_s);
             writer->visit(coordinates);
-            writer->stringBuilder().append(", 1)).xy;\n");
+            writer->stringBuilder().append(", 1)).xy;\n"_s);
         }
         {
-            writer->stringBuilder().append(writer->indent(), "auto __y = float(");
+            writer->stringBuilder().append(writer->indent(), "auto __y = float("_s);
             writer->visit(texture);
-            writer->stringBuilder().append(".FirstPlane.sample(");
+            writer->stringBuilder().append(".FirstPlane.sample("_s);
             writer->visit(sampler);
-            writer->stringBuilder().append(", __coords).r);\n");
+            writer->stringBuilder().append(", __coords).r);\n"_s);
         }
         {
-            writer->stringBuilder().append(writer->indent(), "auto __cbcr = float2(");
+            writer->stringBuilder().append(writer->indent(), "auto __cbcr = float2("_s);
             writer->visit(texture);
-            writer->stringBuilder().append(".SecondPlane.sample(");
+            writer->stringBuilder().append(".SecondPlane.sample("_s);
             writer->visit(sampler);
-            writer->stringBuilder().append(", __coords).rg);\n");
+            writer->stringBuilder().append(", __coords).rg);\n"_s);
         }
-        writer->stringBuilder().append(writer->indent(), "auto __ycbcr = float3(__y, __cbcr);\n");
+        writer->stringBuilder().append(writer->indent(), "auto __ycbcr = float3(__y, __cbcr);\n"_s);
         {
-            writer->stringBuilder().append(writer->indent(), "float4(");
+            writer->stringBuilder().append(writer->indent(), "float4("_s);
             writer->visit(texture);
-            writer->stringBuilder().append(".ColorSpaceConversionMatrix * float4(__ycbcr, 1), 1);\n");
+            writer->stringBuilder().append(".ColorSpaceConversionMatrix * float4(__ycbcr, 1), 1);\n"_s);
         }
     }
-    writer->stringBuilder().append(writer->indent(), "})");
+    writer->stringBuilder().append(writer->indent(), "})"_s);
 }
 
 static void emitTextureSampleBias(FunctionDefinitionWriter* writer, AST::CallExpression& call)
@@ -1495,38 +1495,38 @@ static void emitTextureSampleBias(FunctionDefinitionWriter* writer, AST::CallExp
 
     unsigned biasIndex = isArray ? 4 : 3;
     writer->visit(texture);
-    writer->stringBuilder().append(".sample(");
+    writer->stringBuilder().append(".sample("_s);
     for (unsigned i = 1; i < biasIndex; ++i) {
         if (i != 1)
-            writer->stringBuilder().append(", ");
+            writer->stringBuilder().append(", "_s);
         writer->visit(call.arguments()[i]);
     }
-    writer->stringBuilder().append(", bias(");
+    writer->stringBuilder().append(", bias("_s);
     writer->visit(call.arguments()[biasIndex]);
-    writer->stringBuilder().append(")");
+    writer->stringBuilder().append(')');
     for (unsigned i = biasIndex + 1; i < call.arguments().size(); ++i) {
-        writer->stringBuilder().append(", ");
+        writer->stringBuilder().append(", "_s);
         writer->visit(call.arguments()[i]);
     }
-    writer->stringBuilder().append(")");
+    writer->stringBuilder().append(')');
 }
 
 static void emitTextureNumLayers(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
     writer->visit(call.arguments()[0]);
-    writer->stringBuilder().append(".get_array_size()");
+    writer->stringBuilder().append(".get_array_size()"_s);
 }
 
 static void emitTextureNumLevels(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
     writer->visit(call.arguments()[0]);
-    writer->stringBuilder().append(".get_num_mip_levels()");
+    writer->stringBuilder().append(".get_num_mip_levels()"_s);
 }
 
 static void emitTextureNumSamples(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
     writer->visit(call.arguments()[0]);
-    writer->stringBuilder().append(".get_num_samples()");
+    writer->stringBuilder().append(".get_num_samples()"_s);
 }
 
 static void emitTextureStore(FunctionDefinitionWriter* writer, AST::CallExpression& call)
@@ -1557,101 +1557,101 @@ static void emitTextureStore(FunctionDefinitionWriter* writer, AST::CallExpressi
     }
 
     writer->visit(texture);
-    writer->stringBuilder().append(".write(");
+    writer->stringBuilder().append(".write("_s);
     writer->visit(*value);
-    writer->stringBuilder().append(", ", cast, "(");
+    writer->stringBuilder().append(", "_s, cast, '(');
     writer->visit(coords);
-    writer->stringBuilder().append(")");
+    writer->stringBuilder().append(')');
     if (arrayIndex) {
-        writer->stringBuilder().append(", ");
+        writer->stringBuilder().append(", "_s);
         writer->visit(*arrayIndex);
     }
-    writer->stringBuilder().append(")");
+    writer->stringBuilder().append(')');
 }
 
 static void emitStorageBarrier(FunctionDefinitionWriter* writer, AST::CallExpression&)
 {
-    writer->stringBuilder().append("threadgroup_barrier(mem_flags::mem_device)");
+    writer->stringBuilder().append("threadgroup_barrier(mem_flags::mem_device)"_s);
 }
 
 static void emitTextureBarrier(FunctionDefinitionWriter* writer, AST::CallExpression&)
 {
-    writer->stringBuilder().append("threadgroup_barrier(mem_flags::mem_texture)");
+    writer->stringBuilder().append("threadgroup_barrier(mem_flags::mem_texture)"_s);
 }
 
 static void emitWorkgroupBarrier(FunctionDefinitionWriter* writer, AST::CallExpression&)
 {
-    writer->stringBuilder().append("threadgroup_barrier(mem_flags::mem_threadgroup)");
+    writer->stringBuilder().append("threadgroup_barrier(mem_flags::mem_threadgroup)"_s);
 }
 
 static void emitWorkgroupUniformLoad(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    writer->stringBuilder().append("__workgroup_uniform_load(");
+    writer->stringBuilder().append("__workgroup_uniform_load("_s);
     writer->visit(call.arguments()[0]);
-    writer->stringBuilder().append(")");
+    writer->stringBuilder().append(')');
 }
 
 static void atomicFunction(const char* name, FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    writer->stringBuilder().append(name, "(");
+    writer->stringBuilder().append(name, '(');
     bool first = true;
     for (auto& argument : call.arguments()) {
         if (!first)
-            writer->stringBuilder().append(", ");
+            writer->stringBuilder().append(", "_s);
         first = false;
         writer->visit(argument);
     }
-    writer->stringBuilder().append(", memory_order_relaxed)");
+    writer->stringBuilder().append(", memory_order_relaxed)"_s);
 }
 
 static void emitAtomicLoad(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    atomicFunction("atomic_load_explicit", writer, call);
+    atomicFunction("atomic_load_explicit"_s, writer, call);
 }
 
 static void emitAtomicStore(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    atomicFunction("atomic_store_explicit", writer, call);
+    atomicFunction("atomic_store_explicit"_s, writer, call);
 }
 
 static void emitAtomicAdd(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    atomicFunction("atomic_fetch_add_explicit", writer, call);
+    atomicFunction("atomic_fetch_add_explicit"_s, writer, call);
 }
 
 static void emitAtomicSub(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    atomicFunction("atomic_fetch_sub_explicit", writer, call);
+    atomicFunction("atomic_fetch_sub_explicit"_s, writer, call);
 }
 
 static void emitAtomicMax(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    atomicFunction("atomic_fetch_max_explicit", writer, call);
+    atomicFunction("atomic_fetch_max_explicit"_s, writer, call);
 }
 
 static void emitAtomicMin(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    atomicFunction("atomic_fetch_min_explicit", writer, call);
+    atomicFunction("atomic_fetch_min_explicit"_s, writer, call);
 }
 
 static void emitAtomicAnd(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    atomicFunction("atomic_fetch_and_explicit", writer, call);
+    atomicFunction("atomic_fetch_and_explicit"_s, writer, call);
 }
 
 static void emitAtomicOr(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    atomicFunction("atomic_fetch_or_explicit", writer, call);
+    atomicFunction("atomic_fetch_or_explicit"_s, writer, call);
 }
 
 static void emitAtomicXor(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    atomicFunction("atomic_fetch_xor_explicit", writer, call);
+    atomicFunction("atomic_fetch_xor_explicit"_s, writer, call);
 }
 
 static void emitAtomicExchange(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    atomicFunction("atomic_exchange_explicit", writer, call);
+    atomicFunction("atomic_exchange_explicit"_s, writer, call);
 }
 
 [[noreturn]] static void emitArrayLength(FunctionDefinitionWriter*, AST::CallExpression&)
@@ -1663,11 +1663,11 @@ static void emitDistance(FunctionDefinitionWriter* writer, AST::CallExpression& 
 {
     auto* argumentType = call.arguments()[0].inferredType();
     if (std::holds_alternative<Types::Primitive>(*argumentType)) {
-        writer->stringBuilder().append("abs(");
+        writer->stringBuilder().append("abs("_s);
         writer->visit(call.arguments()[0]);
-        writer->stringBuilder().append(" - ");
+        writer->stringBuilder().append(" - "_s);
         writer->visit(call.arguments()[1]);
-        writer->stringBuilder().append(")");
+        writer->stringBuilder().append(')');
         return;
     }
     writer->visit(call.target());
@@ -1678,17 +1678,17 @@ static void emitLength(FunctionDefinitionWriter* writer, AST::CallExpression& ca
 {
     auto* argumentType = call.arguments()[0].inferredType();
     if (!holds_alternative<Types::Vector>(*argumentType))
-        writer->stringBuilder().append("abs");
+        writer->stringBuilder().append("abs"_s);
     else
-        writer->stringBuilder().append("length");
+        writer->stringBuilder().append("length"_s);
     visitArguments(writer, call);
 }
 
 static void emitDegrees(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    writer->stringBuilder().append("(");
+    writer->stringBuilder().append('(');
     writer->visit(call.arguments()[0]);
-    writer->stringBuilder().append(" * ", String::number(180 / std::numbers::pi), ")");
+    writer->stringBuilder().append(" * "_s, String::number(180 / std::numbers::pi), ')');
 }
 
 static void emitDynamicOffset(FunctionDefinitionWriter* writer, AST::CallExpression& call)
@@ -1697,71 +1697,71 @@ static void emitDynamicOffset(FunctionDefinitionWriter* writer, AST::CallExpress
     auto& pointer = std::get<Types::Pointer>(*targetType);
     auto* addressSpace = serializeAddressSpace(pointer.addressSpace);
 
-    writer->stringBuilder().append("(*(");
+    writer->stringBuilder().append("(*("_s);
     writer->visit(targetType);
-    writer->stringBuilder().append(")(((", addressSpace, " uint8_t*)&(");
+    writer->stringBuilder().append(")((("_s, addressSpace, " uint8_t*)&("_s);
     writer->visit(call.arguments()[0]);
-    writer->stringBuilder().append(")) + __DynamicOffsets[");
+    writer->stringBuilder().append(")) + __DynamicOffsets["_s);
     writer->visit(call.arguments()[1]);
-    writer->stringBuilder().append("]))");
+    writer->stringBuilder().append("]))"_s);
 }
 
 static void emitBitcast(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    writer->stringBuilder().append("as_type<");
+    writer->stringBuilder().append("as_type<"_s);
     writer->visit(call.target().inferredType());
-    writer->stringBuilder().append(">(");
+    writer->stringBuilder().append(">("_s);
     writer->visit(call.arguments()[0]);
-    writer->stringBuilder().append(")");
+    writer->stringBuilder().append(')');
 }
 
 static void emitPack2x16Float(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    writer->stringBuilder().append("as_type<uint>(half2(");
+    writer->stringBuilder().append("as_type<uint>(half2("_s);
     writer->visit(call.arguments()[0]);
-    writer->stringBuilder().append("))");
+    writer->stringBuilder().append("))"_s);
 }
 
 static void emitUnpack2x16Float(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    writer->stringBuilder().append("float2(as_type<half2>(");
+    writer->stringBuilder().append("float2(as_type<half2>("_s);
     writer->visit(call.arguments()[0]);
-    writer->stringBuilder().append("))");
+    writer->stringBuilder().append("))"_s);
 }
 
 static void emitPack4xI8(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    writer->stringBuilder().append("as_type<uint>(char4(");
+    writer->stringBuilder().append("as_type<uint>(char4("_s);
     writer->visit(call.arguments()[0]);
-    writer->stringBuilder().append("))");
+    writer->stringBuilder().append("))"_s);
 }
 
 static void emitPack4xI8Clamp(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    writer->stringBuilder().append("as_type<uint>(char4(clamp(");
+    writer->stringBuilder().append("as_type<uint>(char4(clamp("_s);
     writer->visit(call.arguments()[0]);
-    writer->stringBuilder().append(", -128, 127)))");
+    writer->stringBuilder().append(", -128, 127)))"_s);
 }
 
 static void emitUnpack4xI8(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    writer->stringBuilder().append("int4(as_type<char4>(");
+    writer->stringBuilder().append("int4(as_type<char4>("_s);
     writer->visit(call.arguments()[0]);
-    writer->stringBuilder().append("))");
+    writer->stringBuilder().append("))"_s);
 }
 
 static void emitPack4xU8(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    writer->stringBuilder().append("as_type<uint>(uchar4(");
+    writer->stringBuilder().append("as_type<uint>(uchar4("_s);
     writer->visit(call.arguments()[0]);
-    writer->stringBuilder().append("))");
+    writer->stringBuilder().append("))"_s);
 }
 
 static void emitPack4xU8Clamp(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    writer->stringBuilder().append("as_type<uint>(uchar4(min(");
+    writer->stringBuilder().append("as_type<uint>(uchar4(min("_s);
     writer->visit(call.arguments()[0]);
-    writer->stringBuilder().append(", 255)))");
+    writer->stringBuilder().append(", 255)))"_s);
 }
 
 static void emitQuantizeToF16(FunctionDefinitionWriter* writer, AST::CallExpression& call)
@@ -1770,23 +1770,23 @@ static void emitQuantizeToF16(FunctionDefinitionWriter* writer, AST::CallExpress
     String suffix = ""_s;
     if (auto* vectorType = std::get_if<Types::Vector>(argument.inferredType()))
         suffix = String::number(vectorType->size);
-    writer->stringBuilder().append("float", suffix, "(half", suffix, "(");
+    writer->stringBuilder().append("float"_s, suffix, "(half"_s, suffix, '(');
     writer->visit(argument);
-    writer->stringBuilder().append("))");
+    writer->stringBuilder().append("))"_s);
 }
 
 static void emitRadians(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    writer->stringBuilder().append("(");
+    writer->stringBuilder().append('(');
     writer->visit(call.arguments()[0]);
-    writer->stringBuilder().append(" * ", String::number(std::numbers::pi / 180), ")");
+    writer->stringBuilder().append(" * "_s, String::number(std::numbers::pi / 180), ')');
 }
 
 static void emitUnpack4xU8(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    writer->stringBuilder().append("uint4(as_type<uchar4>(");
+    writer->stringBuilder().append("uint4(as_type<uchar4>("_s);
     writer->visit(call.arguments()[0]);
-    writer->stringBuilder().append("))");
+    writer->stringBuilder().append("))"_s);
 }
 
 void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call)
@@ -1802,12 +1802,12 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
     auto isStruct = !isArray && std::holds_alternative<Types::Struct>(*call.target().inferredType());
     if (isArray || isStruct) {
         visit(type);
-        m_stringBuilder.append("(");
+        m_stringBuilder.append('(');
         const Type* arrayElementType = nullptr;
         if (isArray)
             arrayElementType = std::get<Types::Array>(*type).element;
 
-        m_stringBuilder.append("{\n");
+        m_stringBuilder.append("{\n"_s);
         {
             IndentationScope scope(m_indent);
             for (auto& argument : call.arguments()) {
@@ -1816,10 +1816,10 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
                     visit(argument);
                 else
                     visit(arrayElementType, argument);
-                m_stringBuilder.append(",\n");
+                m_stringBuilder.append(",\n"_s);
             }
         }
-        m_stringBuilder.append(m_indent, "})");
+        m_stringBuilder.append(m_indent, "})"_s);
         return;
     }
 
@@ -1930,26 +1930,26 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
 
 void FunctionDefinitionWriter::visit(AST::UnaryExpression& unary)
 {
-    m_stringBuilder.append("(");
+    m_stringBuilder.append('(');
     switch (unary.operation()) {
     case AST::UnaryOperation::Complement:
-        m_stringBuilder.append("~");
+        m_stringBuilder.append('~');
         break;
     case AST::UnaryOperation::Negate:
-        m_stringBuilder.append("-");
+        m_stringBuilder.append('-');
         break;
     case AST::UnaryOperation::Not:
-        m_stringBuilder.append("!");
+        m_stringBuilder.append('!');
         break;
     case AST::UnaryOperation::AddressOf:
-        m_stringBuilder.append("&");
+        m_stringBuilder.append('&');
         break;
     case AST::UnaryOperation::Dereference:
-        m_stringBuilder.append("*");
+        m_stringBuilder.append('*');
         break;
     }
     visit(unary.expression());
-    m_stringBuilder.append(")");
+    m_stringBuilder.append(')');
 }
 
 void FunctionDefinitionWriter::serializeBinaryExpression(AST::Expression& lhs, AST::BinaryOperation operation, AST::Expression& rhs)
@@ -1972,78 +1972,78 @@ void FunctionDefinitionWriter::serializeBinaryExpression(AST::Expression& lhs, A
             helperFunction = "fmod";
 
         if (helperFunction) {
-            m_stringBuilder.append(helperFunction, "(");
+            m_stringBuilder.append(helperFunction, '(');
             visit(lhs);
-            m_stringBuilder.append(", ");
+            m_stringBuilder.append(", "_s);
             visit(rhs);
-            m_stringBuilder.append(")");
+            m_stringBuilder.append(')');
             return;
         }
     }
 
-    m_stringBuilder.append("(");
+    m_stringBuilder.append('(');
     visit(lhs);
     switch (operation) {
     case AST::BinaryOperation::Add:
-        m_stringBuilder.append(" + ");
+        m_stringBuilder.append(" + "_s);
         break;
     case AST::BinaryOperation::Subtract:
-        m_stringBuilder.append(" - ");
+        m_stringBuilder.append(" - "_s);
         break;
     case AST::BinaryOperation::Multiply:
-        m_stringBuilder.append(" * ");
+        m_stringBuilder.append(" * "_s);
         break;
     case AST::BinaryOperation::Divide:
-        m_stringBuilder.append(" / ");
+        m_stringBuilder.append(" / "_s);
         break;
     case AST::BinaryOperation::Modulo:
-        m_stringBuilder.append(" % ");
+        m_stringBuilder.append(" % "_s);
         break;
     case AST::BinaryOperation::And:
-        m_stringBuilder.append(" & ");
+        m_stringBuilder.append(" & "_s);
         break;
     case AST::BinaryOperation::Or:
-        m_stringBuilder.append(" | ");
+        m_stringBuilder.append(" | "_s);
         break;
     case AST::BinaryOperation::Xor:
-        m_stringBuilder.append(" ^ ");
+        m_stringBuilder.append(" ^ "_s);
         break;
 
     case AST::BinaryOperation::LeftShift:
-        m_stringBuilder.append(" << ");
+        m_stringBuilder.append(" << "_s);
         break;
     case AST::BinaryOperation::RightShift:
-        m_stringBuilder.append(" >> ");
+        m_stringBuilder.append(" >> "_s);
         break;
 
     case AST::BinaryOperation::Equal:
-        m_stringBuilder.append(" == ");
+        m_stringBuilder.append(" == "_s);
         break;
     case AST::BinaryOperation::NotEqual:
-        m_stringBuilder.append(" != ");
+        m_stringBuilder.append(" != "_s);
         break;
     case AST::BinaryOperation::GreaterThan:
-        m_stringBuilder.append(" > ");
+        m_stringBuilder.append(" > "_s);
         break;
     case AST::BinaryOperation::GreaterEqual:
-        m_stringBuilder.append(" >= ");
+        m_stringBuilder.append(" >= "_s);
         break;
     case AST::BinaryOperation::LessThan:
-        m_stringBuilder.append(" < ");
+        m_stringBuilder.append(" < "_s);
         break;
     case AST::BinaryOperation::LessEqual:
-        m_stringBuilder.append(" <= ");
+        m_stringBuilder.append(" <= "_s);
         break;
 
     case AST::BinaryOperation::ShortCircuitAnd:
-        m_stringBuilder.append(" && ");
+        m_stringBuilder.append(" && "_s);
         break;
     case AST::BinaryOperation::ShortCircuitOr:
-        m_stringBuilder.append(" || ");
+        m_stringBuilder.append(" || "_s);
         break;
     }
     visit(rhs);
-    m_stringBuilder.append(")");
+    m_stringBuilder.append(')');
 }
 
 void FunctionDefinitionWriter::visit(AST::BinaryExpression& binary)
@@ -2053,25 +2053,25 @@ void FunctionDefinitionWriter::visit(AST::BinaryExpression& binary)
 
 void FunctionDefinitionWriter::visit(AST::PointerDereferenceExpression& pointerDereference)
 {
-    m_stringBuilder.append("(*");
+    m_stringBuilder.append("(*"_s);
     visit(pointerDereference.target());
-    m_stringBuilder.append(")");
+    m_stringBuilder.append(')');
 }
 void FunctionDefinitionWriter::visit(AST::IndexAccessExpression& access)
 {
     visit(access.base());
-    m_stringBuilder.append("[");
+    m_stringBuilder.append('[');
     visit(access.index());
-    m_stringBuilder.append("]");
+    m_stringBuilder.append(']');
 }
 
 void FunctionDefinitionWriter::visit(AST::IdentifierExpression& identifier)
 {
     auto it = m_overrides.find(identifier.identifier());
     if (UNLIKELY(it != m_overrides.end())) {
-        m_stringBuilder.append("(");
+        m_stringBuilder.append('(');
         serializeConstant(identifier.inferredType(), it->value);
-        m_stringBuilder.append(")");
+        m_stringBuilder.append(')');
         return;
     }
     m_stringBuilder.append(identifier.identifier());
@@ -2082,15 +2082,15 @@ void FunctionDefinitionWriter::visit(AST::FieldAccessExpression& access)
     visit(access.base());
     auto* baseType = access.base().inferredType();
     if (baseType && std::holds_alternative<Types::Pointer>(*baseType))
-        m_stringBuilder.append("->");
+        m_stringBuilder.append("->"_s);
     else
-        m_stringBuilder.append(".");
+        m_stringBuilder.append('.');
     m_stringBuilder.append(access.fieldName());
 }
 
 void FunctionDefinitionWriter::visit(AST::BoolLiteral& literal)
 {
-    m_stringBuilder.append(literal.value() ? "true" : "false");
+    m_stringBuilder.append(literal.value() ? "true"_s : "false"_s);
 }
 
 void FunctionDefinitionWriter::visit(AST::AbstractIntegerLiteral& literal)
@@ -2098,7 +2098,7 @@ void FunctionDefinitionWriter::visit(AST::AbstractIntegerLiteral& literal)
     m_stringBuilder.append(literal.value());
     auto& primitiveType = std::get<Types::Primitive>(*literal.inferredType());
     if (primitiveType.kind == Types::Primitive::U32)
-        m_stringBuilder.append("u");
+        m_stringBuilder.append('u');
 }
 
 void FunctionDefinitionWriter::visit(AST::Signed32Literal& literal)
@@ -2108,7 +2108,7 @@ void FunctionDefinitionWriter::visit(AST::Signed32Literal& literal)
 
 void FunctionDefinitionWriter::visit(AST::Unsigned32Literal& literal)
 {
-    m_stringBuilder.append(literal.value(), "u");
+    m_stringBuilder.append(literal.value(), 'u');
 }
 
 void FunctionDefinitionWriter::visit(AST::AbstractFloatLiteral& literal)
@@ -2143,7 +2143,7 @@ void FunctionDefinitionWriter::visit(AST::Statement& statement)
 void FunctionDefinitionWriter::visit(AST::AssignmentStatement& assignment)
 {
     visit(assignment.lhs());
-    m_stringBuilder.append(" = ");
+    m_stringBuilder.append(" = "_s);
     const auto* assignmentType = assignment.lhs().inferredType();
     if (!assignmentType) {
         // In theory this should never happen, but the assignments generated by
@@ -2164,18 +2164,18 @@ void FunctionDefinitionWriter::visit(AST::CallStatement& statement)
 void FunctionDefinitionWriter::visit(AST::CompoundAssignmentStatement& statement)
 {
     visit(statement.leftExpression());
-    m_stringBuilder.append(" = ");
+    m_stringBuilder.append(" = "_s);
     serializeBinaryExpression(statement.leftExpression(), statement.operation(), statement.rightExpression());
 }
 
 void FunctionDefinitionWriter::visit(AST::CompoundStatement& statement)
 {
-    m_stringBuilder.append("{\n");
+    m_stringBuilder.append("{\n"_s);
     {
         IndentationScope scope(m_indent);
         visitStatements(statement.statements());
     }
-    m_stringBuilder.append(m_indent, "}");
+    m_stringBuilder.append(m_indent, '}');
 }
 
 void FunctionDefinitionWriter::visitStatements(AST::Statement::List& statements)
@@ -2208,36 +2208,36 @@ void FunctionDefinitionWriter::visit(AST::DecrementIncrementStatement& statement
     visit(statement.expression());
     switch (statement.operation()) {
     case AST::DecrementIncrementStatement::Operation::Increment:
-        m_stringBuilder.append("++");
+        m_stringBuilder.append("++"_s);
         break;
     case AST::DecrementIncrementStatement::Operation::Decrement:
-        m_stringBuilder.append("--");
+        m_stringBuilder.append("--"_s);
         break;
     }
 }
 
 void FunctionDefinitionWriter::visit(AST::DiscardStatement&)
 {
-    m_stringBuilder.append("discard_fragment()");
+    m_stringBuilder.append("discard_fragment()"_s);
 }
 
 void FunctionDefinitionWriter::visit(AST::IfStatement& statement)
 {
-    m_stringBuilder.append("if (");
+    m_stringBuilder.append("if ("_s);
     visit(statement.test());
-    m_stringBuilder.append(") ");
+    m_stringBuilder.append(") "_s);
     visit(statement.trueBody());
     if (statement.maybeFalseBody()) {
-        m_stringBuilder.append(" else ");
+        m_stringBuilder.append(" else "_s);
         visit(*statement.maybeFalseBody());
     }
 }
 
 void FunctionDefinitionWriter::visit(AST::PhonyAssignmentStatement& statement)
 {
-    m_stringBuilder.append("(void)(");
+    m_stringBuilder.append("(void)("_s);
     visit(statement.rhs());
-    m_stringBuilder.append(")");
+    m_stringBuilder.append(')');
 }
 
 static std::optional<std::pair<String, String>> fragDepthIdentifierForFunction(AST::Function* function)
@@ -2271,42 +2271,42 @@ void FunctionDefinitionWriter::visit(AST::ReturnStatement& statement)
 {
     auto fragDepthIdentifier = fragDepthIdentifierForFunction(m_currentFunction);
     if (fragDepthIdentifier)
-        m_stringBuilder.append(fragDepthIdentifier->first, " __wgslFragmentReturnResult = ");
+        m_stringBuilder.append(fragDepthIdentifier->first, " __wgslFragmentReturnResult = "_s);
     else
-        m_stringBuilder.append("return");
+        m_stringBuilder.append("return"_s);
     if (statement.maybeExpression()) {
-        m_stringBuilder.append(" ");
+        m_stringBuilder.append(' ');
         visit(*statement.maybeExpression());
     }
 
     if (fragDepthIdentifier) {
-        m_stringBuilder.append(";\n__wgslFragmentReturnResult.", fragDepthIdentifier->second, " = clamp(__wgslFragmentReturnResult.", fragDepthIdentifier->second, ", as_type<float>(__DynamicOffsets[0]), as_type<float>(__DynamicOffsets[1]));\n");
-        m_stringBuilder.append("return __wgslFragmentReturnResult");
+        m_stringBuilder.append(";\n__wgslFragmentReturnResult."_s, fragDepthIdentifier->second, " = clamp(__wgslFragmentReturnResult."_s, fragDepthIdentifier->second, ", as_type<float>(__DynamicOffsets[0]), as_type<float>(__DynamicOffsets[1]));\n"_s);
+        m_stringBuilder.append("return __wgslFragmentReturnResult"_s);
     }
 }
 
 void FunctionDefinitionWriter::visit(AST::ForStatement& statement)
 {
-    m_stringBuilder.append("for (");
+    m_stringBuilder.append("for ("_s);
     if (auto* initializer = statement.maybeInitializer())
         visit(*initializer);
-    m_stringBuilder.append(";");
+    m_stringBuilder.append(';');
     if (auto* test = statement.maybeTest()) {
-        m_stringBuilder.append(" ");
+        m_stringBuilder.append(' ');
         visit(*test);
     }
-    m_stringBuilder.append(";");
+    m_stringBuilder.append(';');
     if (auto* update = statement.maybeUpdate()) {
-        m_stringBuilder.append(" ");
+        m_stringBuilder.append(' ');
         visit(*update);
     }
-    m_stringBuilder.append(") ");
+    m_stringBuilder.append(") "_s);
     visit(statement.body());
 }
 
 void FunctionDefinitionWriter::visit(AST::LoopStatement& statement)
 {
-    m_stringBuilder.append("while (true) {\n");
+    m_stringBuilder.append("while (true) {\n"_s);
     {
         auto& continuing = statement.continuing();
         SetForScope continuingScope(m_continuing, continuing.has_value() ? &*continuing : nullptr);
@@ -2319,7 +2319,7 @@ void FunctionDefinitionWriter::visit(AST::LoopStatement& statement)
             visit(*continuing);
         }
     }
-    m_stringBuilder.append(m_indent, "}");
+    m_stringBuilder.append(m_indent, '}');
 }
 
 void FunctionDefinitionWriter::visit(AST::Continuing& continuing)
@@ -2327,28 +2327,28 @@ void FunctionDefinitionWriter::visit(AST::Continuing& continuing)
     // Do not emit the same continuing for continue statements within the continuing block
     SetForScope continuingScope(m_continuing, nullptr);
 
-    m_stringBuilder.append("{\n");
+    m_stringBuilder.append("{\n"_s);
     {
         IndentationScope scope(m_indent);
         visitStatements(continuing.body);
 
         if (auto* breakIf = continuing.breakIf) {
-            m_stringBuilder.append(m_indent, "if (");
+            m_stringBuilder.append(m_indent, "if ("_s);
             visit(*breakIf);
-            m_stringBuilder.append(")\n");
+            m_stringBuilder.append(")\n"_s);
 
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "break;\n");
+            m_stringBuilder.append(m_indent, "break;\n"_s);
         }
     }
-    m_stringBuilder.append(m_indent, "}\n");
+    m_stringBuilder.append(m_indent, "}\n"_s);
 }
 
 void FunctionDefinitionWriter::visit(AST::WhileStatement& statement)
 {
-    m_stringBuilder.append("while (");
+    m_stringBuilder.append("while ("_s);
     visit(statement.test());
-    m_stringBuilder.append(") ");
+    m_stringBuilder.append(") "_s);
     visit(statement.body());
 }
 
@@ -2356,34 +2356,34 @@ void FunctionDefinitionWriter::visit(AST::SwitchStatement& statement)
 {
     const auto& visitClause = [&](AST::SwitchClause& clause, bool isDefault = false) {
         for (auto& selector : clause.selectors) {
-            m_stringBuilder.append("\n");
-            m_stringBuilder.append(m_indent, "case ");
+            m_stringBuilder.append('\n');
+            m_stringBuilder.append(m_indent, "case "_s);
             visit(selector);
-            m_stringBuilder.append(":");
+            m_stringBuilder.append(':');
         }
         if (isDefault) {
-            m_stringBuilder.append("\n");
-            m_stringBuilder.append(m_indent, "default:");
+            m_stringBuilder.append('\n');
+            m_stringBuilder.append(m_indent, "default:"_s);
         }
-        m_stringBuilder.append(" ");
+        m_stringBuilder.append(' ');
         visit(clause.body);
 
         IndentationScope scope(m_indent);
-        m_stringBuilder.append("\n", m_indent, "break;");
+        m_stringBuilder.append('\n', m_indent, "break;"_s);
     };
 
-    m_stringBuilder.append("switch (");
+    m_stringBuilder.append("switch ("_s);
     visit(statement.value());
-    m_stringBuilder.append(") {");
+    m_stringBuilder.append(") {"_s);
     for (auto& clause : statement.clauses())
         visitClause(clause);
     visitClause(statement.defaultClause(), true);
-    m_stringBuilder.append("\n", m_indent, "}");
+    m_stringBuilder.append('\n', m_indent, '}');
 }
 
 void FunctionDefinitionWriter::visit(AST::BreakStatement&)
 {
-    m_stringBuilder.append("break");
+    m_stringBuilder.append("break"_s);
 }
 
 void FunctionDefinitionWriter::visit(AST::ContinueStatement&)
@@ -2392,7 +2392,7 @@ void FunctionDefinitionWriter::visit(AST::ContinueStatement&)
         visit(*m_continuing);
         m_stringBuilder.append(m_indent);
     }
-    m_stringBuilder.append("continue");
+    m_stringBuilder.append("continue"_s);
 }
 
 void FunctionDefinitionWriter::serializeConstant(const Type* type, ConstantValue value)
@@ -2409,7 +2409,7 @@ void FunctionDefinitionWriter::serializeConstant(const Type* type, ConstantValue
                 m_stringBuilder.append(std::get<int32_t>(value));
                 break;
             case Primitive::U32:
-                m_stringBuilder.append(std::get<uint32_t>(value), "u");
+                m_stringBuilder.append(std::get<uint32_t>(value), 'u');
                 break;
             case Primitive::AbstractFloat: {
                 NumberToStringBuffer buffer;
@@ -2426,11 +2426,11 @@ void FunctionDefinitionWriter::serializeConstant(const Type* type, ConstantValue
             case Primitive::F16: {
                 NumberToStringBuffer buffer;
                 WTF::numberToStringWithTrailingPoint(std::get<half>(value), buffer);
-                m_stringBuilder.append(&buffer[0], "h");
+                m_stringBuilder.append(&buffer[0], 'h');
                 break;
             }
             case Primitive::Bool:
-                m_stringBuilder.append(std::get<bool>(value) ? "true" : "false");
+                m_stringBuilder.append(std::get<bool>(value) ? "true"_s : "false"_s);
                 break;
             case Primitive::Void:
             case Primitive::Sampler:
@@ -2448,78 +2448,78 @@ void FunctionDefinitionWriter::serializeConstant(const Type* type, ConstantValue
         [&](const Vector& vectorType) {
             auto& vector = std::get<ConstantVector>(value);
             visit(type);
-            m_stringBuilder.append("(");
+            m_stringBuilder.append('(');
             bool first = true;
             for (auto& element : vector.elements) {
                 if (!first)
-                    m_stringBuilder.append(", ");
+                    m_stringBuilder.append(", "_s);
                 first = false;
                 serializeConstant(vectorType.element, element);
             }
-            m_stringBuilder.append(")");
+            m_stringBuilder.append(')');
         },
         [&](const Array& arrayType) {
             auto& array = std::get<ConstantArray>(value);
             visit(type);
-            m_stringBuilder.append("{");
+            m_stringBuilder.append('{');
             bool first = true;
             for (auto& element : array.elements) {
                 if (!first)
-                    m_stringBuilder.append(", ");
+                    m_stringBuilder.append(", "_s);
                 first = false;
                 serializeConstant(arrayType.element, element);
             }
-            m_stringBuilder.append("}");
+            m_stringBuilder.append('}');
         },
         [&](const Matrix& matrixType) {
             auto& matrix = std::get<ConstantMatrix>(value);
-            m_stringBuilder.append("matrix<");
+            m_stringBuilder.append("matrix<"_s);
             visit(matrixType.element);
-            m_stringBuilder.append(", ", matrixType.columns, ", ", matrixType.rows, ">(");
+            m_stringBuilder.append(", "_s, matrixType.columns, ", "_s, matrixType.rows, ">("_s);
             bool first = true;
             for (auto& element : matrix.elements) {
                 if (!first)
-                    m_stringBuilder.append(", ");
+                    m_stringBuilder.append(", "_s);
                 first = false;
                 serializeConstant(matrixType.element, element);
             }
-            m_stringBuilder.append(")");
+            m_stringBuilder.append(')');
         },
         [&](const Struct& structType) {
             auto& constantStruct = std::get<ConstantStruct>(value);
-            m_stringBuilder.append(structType.structure.name(), " { ");
+            m_stringBuilder.append(structType.structure.name(), " { "_s);
             for (auto& member : structType.structure.members()) {
-                m_stringBuilder.append(".", member.name(), " = ");
+                m_stringBuilder.append('.', member.name(), " = "_s);
                 serializeConstant(structType.fields.get(member.originalName()), constantStruct.fields.get(member.originalName()));
-                m_stringBuilder.append(", ");
+                m_stringBuilder.append(", "_s);
             }
-            m_stringBuilder.append(" }");
+            m_stringBuilder.append(" }"_s);
         },
         [&](const PrimitiveStruct& primitiveStruct) {
             auto& constantStruct = std::get<ConstantStruct>(value);
             const auto& keys = Types::PrimitiveStruct::keys[primitiveStruct.kind];
 
-            m_stringBuilder.append(primitiveStruct.name, "<");
+            m_stringBuilder.append(primitiveStruct.name, '<');
             bool first = true;
             for (auto& value : primitiveStruct.values) {
                 if (!first)
-                    m_stringBuilder.append(", ");
+                    m_stringBuilder.append(", "_s);
                 first = false;
                 visit(value);
             }
-            m_stringBuilder.append("> {");
+            m_stringBuilder.append("> {"_s);
             first = true;
             for (auto& entry : constantStruct.fields) {
                 if (!first)
-                    m_stringBuilder.append(", ");
+                    m_stringBuilder.append(", "_s);
                 first = false;
-                m_stringBuilder.append(".", entry.key, " = ");
+                m_stringBuilder.append('.', entry.key, " = "_s);
                 auto* key = keys.tryGet(entry.key);
                 RELEASE_ASSERT(key);
                 auto* type = primitiveStruct.values[*key];
                 serializeConstant(type, entry.value);
             }
-            m_stringBuilder.append("}");
+            m_stringBuilder.append('}');
         },
         [&](const Pointer&) {
             RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -101,9 +101,9 @@ struct TemplateTypes<TT> {
     auto name##Expected = consumeType(TokenType::type); \
     if (!name##Expected) { \
         StringBuilder builder; \
-        builder.append("Expected a "); \
+        builder.append("Expected a "_s); \
         builder.append(toString(TokenType::type)); \
-        builder.append(", but got a "); \
+        builder.append(", but got a "_s); \
         builder.append(toString(name##Expected.error())); \
         FAIL(builder.toString()); \
     } \
@@ -114,9 +114,9 @@ struct TemplateTypes<TT> {
         auto expectedToken = consumeType(TokenType::type); \
         if (!expectedToken) { \
             StringBuilder builder; \
-            builder.append("Expected a "); \
+            builder.append("Expected a "_s); \
             builder.append(toString(TokenType::type)); \
-            builder.append(", but got a "); \
+            builder.append(", but got a "_s); \
             builder.append(toString(expectedToken.error())); \
             FAIL(builder.toString()); \
         } \
@@ -126,9 +126,9 @@ struct TemplateTypes<TT> {
     auto name##Expected = consumeTypes<__VA_ARGS__>(); \
     if (!name##Expected) { \
         StringBuilder builder; \
-        builder.append("Expected one of ["); \
+        builder.append("Expected one of ["_s); \
         TemplateTypes<__VA_ARGS__>::appendNameTo(builder); \
-        builder.append("], but got a "); \
+        builder.append("], but got a "_s); \
         builder.append(toString(name##Expected.error())); \
         FAIL(builder.toString()); \
     } \

--- a/Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyData.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyData.cpp
@@ -32,9 +32,9 @@ namespace WebKit {
 String ITPThirdPartyData::toString() const
 {
     StringBuilder stringBuilder;
-    stringBuilder.append("Third Party Registrable Domain: ", thirdPartyDomain.string(), "\n    {");
+    stringBuilder.append("Third Party Registrable Domain: "_s, thirdPartyDomain.string(), "\n    {"_s);
     for (auto firstParty : underFirstParties)
-        stringBuilder.append("{ ", firstParty.toString(), " },");
+        stringBuilder.append("{ "_s, firstParty.toString(), " },"_s);
     stringBuilder.append('}');
     return stringBuilder.toString();
 }

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
@@ -2186,13 +2186,13 @@ void ResourceLoadStatisticsStore::dumpResourceLoadStatistics(CompletionHandler<v
     std::sort(domains.begin(), domains.end(), WTF::codePointCompareLessThan);
 
     StringBuilder result;
-    result.append("Resource load statistics:\n\n");
+    result.append("Resource load statistics:\n\n"_s);
     for (auto& domain : domains)
         resourceToString(result, domain);
 
     auto thirdPartyData = aggregatedThirdPartyData();
     if (!thirdPartyData.isEmpty()) {
-        result.append("\nITP Data:\n");
+        result.append("\nITP Data:\n"_s);
         for (auto thirdParty : thirdPartyData)
             result.append(thirdParty.toString(), '\n');
     }
@@ -3007,12 +3007,12 @@ bool ResourceLoadStatisticsStore::isCorrectSubStatisticsCount(const RegistrableD
 
 static void appendBoolean(StringBuilder& builder, ASCIILiteral label, bool flag)
 {
-    builder.append("    ", label, ": ", flag ? "Yes" : "No");
+    builder.append("    "_s, label, ": "_s, flag ? "Yes"_s : "No"_s);
 }
 
 static void appendNextEntry(StringBuilder& builder, const String& entry)
 {
-    builder.append("        ", entry, '\n');
+    builder.append("        "_s, entry, '\n');
 }
 
 String ResourceLoadStatisticsStore::getDomainStringFromDomainID(unsigned domainID) const
@@ -3073,7 +3073,7 @@ void ResourceLoadStatisticsStore::appendSubStatisticList(StringBuilder& builder,
     if (data->step() != SQLITE_ROW)
         return;
 
-    builder.append("    ", tableName, ":\n");
+    builder.append("    "_s, tableName, ":\n"_s);
 
     auto result = getDomainStringFromDomainID(data->columnInt(0));
     appendNextEntry(builder, result);
@@ -3099,16 +3099,16 @@ void ResourceLoadStatisticsStore::resourceToString(StringBuilder& builder, const
         return;
     }
 
-    builder.append("Registrable domain: ", domain, '\n');
+    builder.append("Registrable domain: "_s, domain, '\n');
 
     // User interaction
     appendBoolean(builder, "hadUserInteraction"_s, m_getResourceDataByDomainNameStatement->columnInt(HadUserInteractionIndex));
     builder.append('\n');
-    builder.append("    mostRecentUserInteraction: ");
+    builder.append("    mostRecentUserInteraction: "_s);
     if (hasHadRecentUserInteraction(Seconds(m_getResourceDataByDomainNameStatement->columnDouble(MostRecentUserInteractionTimeIndex)), nowTime(m_timeAdvanceForTesting)))
-        builder.append("within 24 hours");
+        builder.append("within 24 hours"_s);
     else
-        builder.append("-1");
+        builder.append("-1"_s);
     builder.append('\n');
     appendBoolean(builder, "grandfathered"_s, m_getResourceDataByDomainNameStatement->columnInt(GrandfatheredIndex));
     builder.append('\n');
@@ -3124,7 +3124,7 @@ void ResourceLoadStatisticsStore::resourceToString(StringBuilder& builder, const
     appendSubStatisticList(builder, "TopFrameLoadedThirdPartyScripts"_s, domain);
 
     auto dataRemovalFrequencyValue = m_getResourceDataByDomainNameStatement->columnInt(IsScheduledForAllButCookieDataRemovalIndex);
-    builder.append("    DataRemovalFrequency: ", dataRemovalFrequencyToString(toDataRemovalFrequency(dataRemovalFrequencyValue)), '\n');
+    builder.append("    DataRemovalFrequency: "_s, dataRemovalFrequencyToString(toDataRemovalFrequency(dataRemovalFrequencyValue)), '\n');
 
     // Subframe stats
     appendSubStatisticList(builder, "SubframeUnderTopFrameDomains"_s, domain);
@@ -3139,7 +3139,7 @@ void ResourceLoadStatisticsStore::resourceToString(StringBuilder& builder, const
     builder.append('\n');
     appendBoolean(builder, "isVeryPrevalentResource"_s, m_getResourceDataByDomainNameStatement->columnInt(IsVeryPrevalentIndex));
     builder.append('\n');
-    builder.append("    dataRecordsRemoved: ", m_getResourceDataByDomainNameStatement->columnInt(DataRecordsRemovedIndex));
+    builder.append("    dataRecordsRemoved: "_s, m_getResourceDataByDomainNameStatement->columnInt(DataRecordsRemovedIndex));
     builder.append('\n');
 }
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
@@ -419,8 +419,8 @@ String Database::privateClickMeasurementToStringForTesting() const
     unsigned attributedNumber = 0;
     while (attributedScopedStatement->step() == SQLITE_ROW) {
         if (!attributedNumber)
-            builder.append(unattributedNumber ? "\n" : "", "Attributed Private Click Measurements:");
-        builder.append("\nWebCore::PrivateClickMeasurement ", ++attributedNumber + unattributedNumber, '\n',
+            builder.append(unattributedNumber ? "\n"_s : ""_s, "Attributed Private Click Measurements:"_s);
+        builder.append("\nWebCore::PrivateClickMeasurement "_s, ++attributedNumber + unattributedNumber, '\n',
             attributionToStringForTesting(buildPrivateClickMeasurementFromDatabase(*attributedScopedStatement.get(), PrivateClickMeasurementAttributionType::Attributed)));
     }
     return builder.toString();
@@ -434,29 +434,29 @@ String Database::attributionToStringForTesting(const WebCore::PrivateClickMeasur
     auto sourceID = pcm.sourceID();
 
     StringBuilder builder;
-    builder.append("Source site: ", sourceSiteDomain, "\nAttribute on site: ", destinationSiteDomain, "\nSource ID: ", sourceID);
+    builder.append("Source site: "_s, sourceSiteDomain, "\nAttribute on site: "_s, destinationSiteDomain, "\nSource ID: "_s, sourceID);
 
     if (auto& triggerData = pcm.attributionTriggerData()) {
         auto attributionTriggerData = triggerData->data;
         auto priority = triggerData->priority;
         auto earliestTimeToSend = pcm.timesToSend().sourceEarliestTimeToSend;
 
-        builder.append("\nAttribution trigger data: ", attributionTriggerData, "\nAttribution priority: ", priority, "\nAttribution earliest time to send: ");
+        builder.append("\nAttribution trigger data: "_s, attributionTriggerData, "\nAttribution priority: "_s, priority, "\nAttribution earliest time to send: "_s);
         if (!earliestTimeToSend)
-            builder.append("Not set");
+            builder.append("Not set"_s);
         else {
             auto secondsUntilSend = *earliestTimeToSend - WallTime::now();
-            builder.append((secondsUntilSend >= 24_h && secondsUntilSend <= 48_h) ? "Within 24-48 hours" : "Outside 24-48 hours");
+            builder.append((secondsUntilSend >= 24_h && secondsUntilSend <= 48_h) ? "Within 24-48 hours"_s : "Outside 24-48 hours"_s);
         }
 
-        builder.append("\nDestination token: ");
+        builder.append("\nDestination token: "_s);
         if (!triggerData->destinationSecretToken)
-            builder.append("Not set");
+            builder.append("Not set"_s);
         else
-            builder.append("\ntoken: ", triggerData->destinationSecretToken->tokenBase64URL, "\nsignature: ", triggerData->destinationSecretToken->signatureBase64URL, "\nkey: ", triggerData->destinationSecretToken->keyIDBase64URL);
+            builder.append("\ntoken: "_s, triggerData->destinationSecretToken->tokenBase64URL, "\nsignature: "_s, triggerData->destinationSecretToken->signatureBase64URL, "\nkey: "_s, triggerData->destinationSecretToken->keyIDBase64URL);
     } else
-        builder.append("\nNo attribution trigger data.");
-    builder.append("\nApplication bundle identifier: ", pcm.sourceApplicationBundleID(), '\n');
+        builder.append("\nNo attribution trigger data."_s);
+    builder.append("\nApplication bundle identifier: "_s, pcm.sourceApplicationBundleID(), '\n');
 
     return builder.toString();
 }

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -674,7 +674,7 @@ void Cache::dumpContentsToFile()
 
         StringBuilder json;
         entry->asJSON(json, info);
-        json.append(",\n");
+        json.append(",\n"_s);
         auto writeData = json.toString().utf8();
         writeToFile(fd, writeData.data(), writeData.length());
     });

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
@@ -231,34 +231,34 @@ void Entry::setNeedsValidation(bool value)
 
 void Entry::asJSON(StringBuilder& json, const Storage::RecordInfo& info) const
 {
-    json.append("{\n"
-        "\"hash\": ");
+    json.append("{\n"_s
+        "\"hash\": "_s);
     json.appendQuotedJSONString(m_key.hashAsString());
-    json.append(",\n"
-        "\"bodySize\": ", info.bodySize, ",\n"
-        "\"worth\": ", info.worth, ",\n"
-        "\"partition\": ");
+    json.append(",\n"_s
+        "\"bodySize\": "_s, info.bodySize, ",\n"_s
+        "\"worth\": "_s, info.worth, ",\n"_s
+        "\"partition\": "_s);
     json.appendQuotedJSONString(m_key.partition());
-    json.append(",\n"
-        "\"timestamp\": ", m_timeStamp.secondsSinceEpoch().milliseconds(), ",\n"
-        "\"URL\": ");
+    json.append(",\n"_s
+        "\"timestamp\": "_s, m_timeStamp.secondsSinceEpoch().milliseconds(), ",\n"_s
+        "\"URL\": "_s);
     json.appendQuotedJSONString(m_response.url().string());
-    json.append(",\n"
-        "\"bodyHash\": ");
+    json.append(",\n"_s
+        "\"bodyHash\": "_s);
     json.appendQuotedJSONString(info.bodyHash);
-    json.append(",\n"
-        "\"bodyShareCount\": ", info.bodyShareCount, ",\n"
-        "\"headers\": {\n");
+    json.append(",\n"_s
+        "\"bodyShareCount\": "_s, info.bodyShareCount, ",\n"_s
+        "\"headers\": {\n"_s);
     bool firstHeader = true;
     for (auto& header : m_response.httpHeaderFields()) {
-        json.append(std::exchange(firstHeader, false) ? "" : ",\n", "    ");
+        json.append(std::exchange(firstHeader, false) ? ""_s : ",\n"_s, "    "_s);
         json.appendQuotedJSONString(header.key);
-        json.append(": ");
+        json.append(": "_s);
         json.appendQuotedJSONString(header.value);
     }
-    json.append("\n"
-        "}\n"
-        "}");
+    json.append("\n"_s
+        "}\n"_s
+        "}"_s);
 }
 
 }

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -2098,15 +2098,15 @@ void NetworkSessionCocoa::donateToSKAdNetwork(WebCore::PrivateClickMeasurement&&
         return;
 
     StringBuilder debugString;
-    debugString.append("Submitting potential install attribution for AdamId: ");
+    debugString.append("Submitting potential install attribution for AdamId: "_s);
     debugString.append(makeString(*pcm.adamID()));
-    debugString.append(", adNetworkRegistrableDomain: ");
+    debugString.append(", adNetworkRegistrableDomain: "_s);
     debugString.append(pcm.destinationSite().registrableDomain.string());
-    debugString.append(", impressionId: ");
+    debugString.append(", impressionId: "_s);
     debugString.append(pcm.ephemeralSourceNonce()->nonce);
-    debugString.append(", sourceWebRegistrableDomain: ");
+    debugString.append(", sourceWebRegistrableDomain: "_s);
     debugString.append(pcm.sourceSite().registrableDomain.string());
-    debugString.append(", version: 3");
+    debugString.append(", version: 3"_s);
     networkProcess().broadcastConsoleMessage(sessionID(), MessageSource::PrivateClickMeasurement, MessageLevel::Debug, debugString.toString());
 }
 

--- a/Source/WebKit/NetworkProcess/soup/NetworkProcessSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkProcessSoup.cpp
@@ -79,7 +79,7 @@ static CString buildAcceptLanguages(const Vector<String>& languages)
             continue;
 
         if (i)
-            builder.append(",");
+            builder.append(',');
 
         builder.append(languages[i]);
 
@@ -87,7 +87,7 @@ static CString buildAcceptLanguages(const Vector<String>& languages)
         if (quality > 0 && quality < 100) {
             char buffer[8];
             g_ascii_formatd(buffer, 8, "%.2f", quality / 100.0);
-            builder.append(";q=", buffer);
+            builder.append(";q="_s, buffer);
         }
     }
 

--- a/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp
@@ -134,7 +134,7 @@ String WebSocketTask::acceptedExtensions() const
         auto* extension = SOUP_WEBSOCKET_EXTENSION(it->data);
 
         if (!result.isEmpty())
-            result.append(", ");
+            result.append(", "_s);
         result.append(String::fromUTF8(SOUP_WEBSOCKET_EXTENSION_GET_CLASS(extension)->name));
 
         GUniquePtr<char> params(soup_websocket_extension_get_response_params(extension));

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -519,29 +519,29 @@ bool CacheStorageManager::isActive()
 String CacheStorageManager::representationString()
 {
     StringBuilder builder;
-    builder.append("{ \"persistent\": [");
+    builder.append("{ \"persistent\": ["_s);
 
     bool isFirst = true;
     for (auto& cache : m_caches) {
         if (!isFirst)
-            builder.append(", ");
+            builder.append(", "_s);
         isFirst = false;
-        builder.append("\"");
+        builder.append("\""_s);
         builder.append(cache->name());
-        builder.append("\"");
+        builder.append("\""_s);
     }
 
-    builder.append("], \"removed\": [");
+    builder.append("], \"removed\": ["_s);
     isFirst = true;
     for (auto& cache : m_removedCaches.values()) {
         if (!isFirst)
-            builder.append(", ");
+            builder.append(", "_s);
         isFirst = false;
-        builder.append("\"");
+        builder.append("\""_s);
         builder.append(cache->name());
-        builder.append("\"");
+        builder.append("\""_s);
     }
-    builder.append("]}\n");
+    builder.append("]}\n"_s);
     return builder.toString();
 }
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1828,7 +1828,7 @@ void NetworkStorageManager::cacheStorageRepresentation(CompletionHandler<void(St
         auto fetchedTypes = originStorageManager(origin).fetchDataTypesInList(targetTypes, false);
         if (!fetchedTypes.isEmpty()) {
             StringBuilder originBuilder;
-            originBuilder.append("\n{ \"origin\" : { \"topOrigin\" : \"", origin.topOrigin.toString(), "\", \"clientOrigin\": \"", origin.clientOrigin.toString(), "\" }, \"caches\" : ");
+            originBuilder.append("\n{ \"origin\" : { \"topOrigin\" : \""_s, origin.topOrigin.toString(), "\", \"clientOrigin\": \""_s, origin.clientOrigin.toString(), "\" }, \"caches\" : "_s);
             originBuilder.append(originStorageManager(origin).cacheStorageManager(*m_cacheStorageRegistry, origin, m_queue.copyRef()).representationString());
             originBuilder.append('}');
             originStrings.append(originBuilder.toString());

--- a/Source/WebKit/Shared/Gamepad/GamepadData.cpp
+++ b/Source/WebKit/Shared/Gamepad/GamepadData.cpp
@@ -66,12 +66,12 @@ String GamepadData::loggingString() const
     builder.append(m_axisValues.size(), " axes, ", m_buttonValues.size(), " buttons\n");
 
     for (size_t i = 0; i < m_axisValues.size(); ++i)
-        builder.append(" Axis ", i, ": ", m_axisValues[i]);
+        builder.append(" Axis "_s, i, ": "_s, m_axisValues[i]);
 
     builder.append('\n');
 
     for (size_t i = 0; i < m_buttonValues.size(); ++i)
-        builder.append(" Button ", i, ": ", FormattedNumber::fixedPrecision(m_buttonValues[i]));
+        builder.append(" Button "_s, i, ": "_s, FormattedNumber::fixedPrecision(m_buttonValues[i]));
 
     return builder.toString();
 }

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -274,10 +274,10 @@ static String sandboxDirectory(WebCore::AuxiliaryProcessType processType, const 
     directory.append(parentDirectory);
     switch (processType) {
     case WebCore::AuxiliaryProcessType::WebContent:
-        directory.append("/com.apple.WebKit.WebContent.Sandbox");
+        directory.append("/com.apple.WebKit.WebContent.Sandbox"_s);
         break;
     case WebCore::AuxiliaryProcessType::Network:
-        directory.append("/com.apple.WebKit.Networking.Sandbox");
+        directory.append("/com.apple.WebKit.Networking.Sandbox"_s);
         break;
     case WebCore::AuxiliaryProcessType::Plugin:
         WTFLogAlways("sandboxDirectory: Unexpected Plugin process initialization.");
@@ -285,14 +285,14 @@ static String sandboxDirectory(WebCore::AuxiliaryProcessType processType, const 
         break;
 #if ENABLE(GPU_PROCESS)
     case WebCore::AuxiliaryProcessType::GPU:
-        directory.append("/com.apple.WebKit.GPU.Sandbox");
+        directory.append("/com.apple.WebKit.GPU.Sandbox"_s);
         break;
 #endif
     }
 
 #if !USE(APPLE_INTERNAL_SDK)
     // Add .OpenSource suffix so that open source builds don't try to access a data vault used by system Safari.
-    directory.append(".OpenSource");
+    directory.append(".OpenSource"_s);
 #endif
 
     return directory.toString();
@@ -300,7 +300,7 @@ static String sandboxDirectory(WebCore::AuxiliaryProcessType processType, const 
 
 static String sandboxFilePath(const String& directoryPath)
 {
-    return makeString(directoryPath, "/CompiledSandbox");
+    return makeString(directoryPath, "/CompiledSandbox"_s);
 }
 
 static bool ensureSandboxCacheDirectory(const SandboxInfo& info)

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -184,7 +184,7 @@ static String dmabufRendererWithSupportedBuffers()
         buffers.append("Hardware"_s);
     if (mode.contains(DMABufRendererBufferMode::SharedMemory)) {
         if (mode.contains(DMABufRendererBufferMode::Hardware))
-            buffers.append(", ");
+            buffers.append(", "_s);
         buffers.append("Shared Memory"_s);
     }
 
@@ -325,7 +325,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
             for (GLint i = 0; i < numExtensions; ++i) {
                 if (i)
                     extensionsBuilder.append(' ');
-                extensionsBuilder.append(reinterpret_cast<const char*>(glGetStringi(GL_EXTENSIONS, i)));
+                extensionsBuilder.append(span(reinterpret_cast<const char*>(glGetStringi(GL_EXTENSIONS, i))));
             }
             addTableRow(jsonObject, "GL_EXTENSIONS"_s, extensionsBuilder.toString());
             break;

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -4108,7 +4108,7 @@ static void webkitWebViewRunJavaScriptWithParams(WebKitWebView* webView, RunJava
                     if (exceptionDetails.columnNumber > 0)
                         builder.append(':', exceptionDetails.columnNumber);
                 }
-                builder.append(": ");
+                builder.append(": "_s);
             }
             builder.append(exceptionDetails.message);
             g_task_return_new_error(task.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED,

--- a/Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp
@@ -165,7 +165,7 @@ void DropTarget::accept(GdkDrop* drop, std::optional<WebCore::IntPoint> position
                 // Convert files transferred by the File Transfer portal into URIs
                 for (auto& fileUri : fileUris) {
                     if (!m_uriListBuilder.isEmpty())
-                        m_uriListBuilder.append("\r\n");
+                        m_uriListBuilder.append("\r\n"_s);
                     m_uriListBuilder.append(fileUri);
                 }
 
@@ -226,7 +226,7 @@ void DropTarget::accept(GdkDrop* drop, std::optional<WebCore::IntPoint> position
                         }
 
                         if (!m_uriListBuilder.isEmpty())
-                            m_uriListBuilder.append("\r\n");
+                            m_uriListBuilder.append("\r\n"_s);
                         m_uriListBuilder.append(line);
                     }
                 }

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp
@@ -152,7 +152,7 @@ void RemoteInspectorProtocolHandler::targetListChanged(RemoteInspectorClient& cl
     if (client.targets().isEmpty())
         html.append("<p>No targets found</p>"_s);
     else {
-        html.append("<table>");
+        html.append("<table>"_s);
         for (auto& connectionID : client.targets().keys()) {
             for (auto& target : client.targets().get(connectionID)) {
                 html.append(makeString(
@@ -163,7 +163,7 @@ void RemoteInspectorProtocolHandler::targetListChanged(RemoteInspectorClient& cl
                 ));
             }
         }
-        html.append("</table>");
+        html.append("</table>"_s);
     }
     m_targetListsHtml = html.toString();
     if (m_pageLoaded)
@@ -223,8 +223,8 @@ void RemoteInspectorProtocolHandler::platformStartTask(WebPageProxy& pageProxy, 
             "let targetDiv = document.getElementById('targetlist');"
             "targetDiv.innerHTML = str;"
         "}"
-        "</script>");
-    htmlBuilder.append("</html>");
+        "</script>"_s);
+    htmlBuilder.append("</html>"_s);
 
     auto html = htmlBuilder.toString().utf8();
     auto data = SharedBuffer::create(html.span());

--- a/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp
+++ b/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp
@@ -78,19 +78,19 @@ void ProcessLauncher::launchProcess()
         return;
 
     StringBuilder commandLineBuilder;
-    commandLineBuilder.append("\"");
+    commandLineBuilder.append("\""_s);
     commandLineBuilder.append(String(pathStr));
-    commandLineBuilder.append("\"");
-    commandLineBuilder.append(" -type ");
+    commandLineBuilder.append("\""_s);
+    commandLineBuilder.append(" -type "_s);
     commandLineBuilder.append(String::number(static_cast<int>(m_launchOptions.processType)));
-    commandLineBuilder.append(" -processIdentifier ");
+    commandLineBuilder.append(" -processIdentifier "_s);
     commandLineBuilder.append(String::number(m_launchOptions.processIdentifier.toUInt64()));
-    commandLineBuilder.append(" -clientIdentifier ");
+    commandLineBuilder.append(" -clientIdentifier "_s);
     commandLineBuilder.append(String::number(reinterpret_cast<uintptr_t>(clientIdentifier)));
     if (m_client->shouldConfigureJSCForTesting())
-        commandLineBuilder.append(" -configure-jsc-for-testing");
+        commandLineBuilder.append(" -configure-jsc-for-testing"_s);
     if (!m_client->isJITEnabled())
-        commandLineBuilder.append(" -disable-jit");
+        commandLineBuilder.append(" -disable-jit"_s);
     commandLineBuilder.append('\0');
 
     auto commandLine = commandLineBuilder.toString().wideCharacters();

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -274,25 +274,25 @@ String ViewGestureController::SnapshotRemovalTracker::eventsDescription(Events e
     StringBuilder description;
 
     if (event & ViewGestureController::SnapshotRemovalTracker::VisuallyNonEmptyLayout)
-        description.append("VisuallyNonEmptyLayout ");
+        description.append("VisuallyNonEmptyLayout "_s);
 
     if (event & ViewGestureController::SnapshotRemovalTracker::RenderTreeSizeThreshold)
-        description.append("RenderTreeSizeThreshold ");
+        description.append("RenderTreeSizeThreshold "_s);
 
     if (event & ViewGestureController::SnapshotRemovalTracker::RepaintAfterNavigation)
-        description.append("RepaintAfterNavigation ");
+        description.append("RepaintAfterNavigation "_s);
 
     if (event & ViewGestureController::SnapshotRemovalTracker::MainFrameLoad)
-        description.append("MainFrameLoad ");
+        description.append("MainFrameLoad "_s);
 
     if (event & ViewGestureController::SnapshotRemovalTracker::SubresourceLoads)
-        description.append("SubresourceLoads ");
+        description.append("SubresourceLoads "_s);
 
     if (event & ViewGestureController::SnapshotRemovalTracker::ScrollPositionRestoration)
-        description.append("ScrollPositionRestoration ");
+        description.append("ScrollPositionRestoration "_s);
 
     if (event & ViewGestureController::SnapshotRemovalTracker::SwipeAnimationEnd)
-        description.append("SwipeAnimationEnd ");
+        description.append("SwipeAnimationEnd "_s);
 
     return description.toString();
 }

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -546,7 +546,7 @@ String WebBackForwardList::loggingString()
 {
     StringBuilder builder;
 
-    builder.append("WebBackForwardList 0x", hex(reinterpret_cast<uintptr_t>(this)), " - ", m_entries.size(), " entries, has current index ", m_currentIndex ? "YES" : "NO", " (", m_currentIndex ? *m_currentIndex : 0, ')');
+    builder.append("WebBackForwardList 0x"_s, hex(reinterpret_cast<uintptr_t>(this)), " - "_s, m_entries.size(), " entries, has current index "_s, m_currentIndex ? "YES"_s : "NO"_s, " ("_s, m_currentIndex ? *m_currentIndex : 0, ')');
 
     for (size_t i = 0; i < m_entries.size(); ++i) {
         const char* prefix;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -804,7 +804,7 @@ void WebLocalFrameLoaderClient::dispatchDidReachLayoutMilestone(OptionSet<WebCor
     auto addIfSet = [&milestones, &builder] (WebCore::LayoutMilestone milestone, const String& toAdd) {
         if (milestones.contains(milestone)) {
             if (!builder.isEmpty())
-                builder.append(", ");
+                builder.append(", "_s);
             builder.append(toAdd);
         }
     };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2460,7 +2460,7 @@ void WebPage::setPageZoomFactor(double zoomFactor)
 static void dumpHistoryItem(HistoryItem& item, size_t indent, bool isCurrentItem, StringBuilder& stringBuilder, const String& directoryName)
 {
     if (isCurrentItem)
-        stringBuilder.append("curr->  ");
+        stringBuilder.append("curr->  "_s);
     else {
         for (size_t i = 0; i < indent; ++i)
             stringBuilder.append(' ');
@@ -2473,16 +2473,16 @@ static void dumpHistoryItem(HistoryItem& item, size_t indent, bool isCurrentItem
             start = 0;
         else
             start += directoryName.length();
-        stringBuilder.append("(file test):", StringView { url.string() }.substring(start));
+        stringBuilder.append("(file test):"_s, StringView { url.string() }.substring(start));
     } else
         stringBuilder.append(url.string());
 
     auto& target = item.target();
     if (target.length())
-        stringBuilder.append(" (in frame \"", target, "\")");
+        stringBuilder.append(" (in frame \""_s, target, "\")"_s);
 
     if (item.isTargetItem())
-        stringBuilder.append("  **nav target**");
+        stringBuilder.append("  **nav target**"_s);
 
     stringBuilder.append('\n');
 

--- a/Tools/TestWebKitAPI/Tests/WTF/CrossThreadTask.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CrossThreadTask.cpp
@@ -46,8 +46,8 @@ struct LifetimeLogger {
         defaultConstructorSet.add(fullName());
     }
 
-    LifetimeLogger(const char* inputName)
-        : name(*inputName)
+    LifetimeLogger(ASCIILiteral inputName)
+        : name(inputName)
     {
         nameConstructorSet.add(fullName());
     }
@@ -82,16 +82,16 @@ struct LifetimeLogger {
     String fullName()
     {
         StringBuilder builder;
-        builder.append(&name);
-        builder.append("-");
+        builder.append(name);
+        builder.append('-');
         builder.append(String::number(copyGeneration));
-        builder.append("-");
+        builder.append('-');
         builder.append(String::number(moveGeneration));
 
         return builder.toString();
     }
 
-    const char& name { *"<default>" };
+    ASCIILiteral name { "<default>"_s };
     int copyGeneration { 0 };
     int moveGeneration { 0 };
 };
@@ -106,7 +106,7 @@ TEST(WTF_CrossThreadTask, Basic)
     {
         LifetimeLogger logger1;
         LifetimeLogger logger2(logger1);
-        LifetimeLogger logger3("logger");
+        LifetimeLogger logger3("logger"_s);
 
         auto task = createCrossThreadTask(testFunction, logger1, logger2, logger3);
         task.performTask();

--- a/Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp
@@ -66,11 +66,11 @@ TEST(StringBuilderTest, Append)
     StringBuilder builder;
     builder.append(String("0123456789"_s));
     expectBuilderContent("0123456789"_s, builder);
-    builder.append("abcd");
+    builder.append("abcd"_s);
     expectBuilderContent("0123456789abcd"_s, builder);
     builder.append(std::span { reinterpret_cast<const LChar*>("efgh"), 3 });
     expectBuilderContent("0123456789abcdefg"_s, builder);
-    builder.append("");
+    builder.append(""_s);
     expectBuilderContent("0123456789abcdefg"_s, builder);
     builder.append('#');
     expectBuilderContent("0123456789abcdefg#"_s, builder);
@@ -80,18 +80,18 @@ TEST(StringBuilderTest, Append)
     builder.append(""_span);
     expectBuilderContent("0123456789abcdefg#"_s, builder);
     builder1.append(builder.span<LChar>());
-    builder1.append("XYZ");
+    builder1.append("XYZ"_s);
     builder.append(builder1.span<LChar>());
     expectBuilderContent("0123456789abcdefg#0123456789abcdefg#XYZ"_s, builder);
 
     StringBuilder builder2;
     builder2.reserveCapacity(100);
-    builder2.append("xyz");
+    builder2.append("xyz"_s);
     const LChar* characters = builder2.characters8();
-    builder2.append("0123456789");
+    builder2.append("0123456789"_s);
     EXPECT_EQ(characters, builder2.characters8());
     builder2.toStringPreserveCapacity(); // Test after reifyString with buffer preserved.
-    builder2.append("abcd");
+    builder2.append("abcd"_s);
     EXPECT_EQ(characters, builder2.characters8());
 
     // Test appending char32_t characters to StringBuilder.
@@ -140,11 +140,11 @@ TEST(StringBuilderTest, VariadicAppend)
         StringBuilder builder;
         builder.append(String("0123456789"_s));
         expectBuilderContent("0123456789"_s, builder);
-        builder.append("abcd");
+        builder.append("abcd"_s);
         expectBuilderContent("0123456789abcd"_s, builder);
         builder.append('e');
         expectBuilderContent("0123456789abcde"_s, builder);
-        builder.append("");
+        builder.append(""_s);
         expectBuilderContent("0123456789abcde"_s, builder);
     }
 
@@ -191,20 +191,20 @@ TEST(StringBuilderTest, VariadicAppend)
 TEST(StringBuilderTest, ToString)
 {
     StringBuilder builder;
-    builder.append("0123456789");
+    builder.append("0123456789"_s);
     String string = builder.toString();
     EXPECT_EQ(String("0123456789"_s), string);
     EXPECT_EQ(string.impl(), builder.toString().impl());
 
     // Changing the StringBuilder should not affect the original result of toString().
-    builder.append("abcdefghijklmnopqrstuvwxyz");
+    builder.append("abcdefghijklmnopqrstuvwxyz"_s);
     EXPECT_EQ(String("0123456789"_s), string);
 
     // Changing the StringBuilder should not affect the original result of toString() in case the capacity is not changed.
     builder.reserveCapacity(200);
     string = builder.toString();
     EXPECT_EQ(String("0123456789abcdefghijklmnopqrstuvwxyz"_s), string);
-    builder.append("ABC");
+    builder.append("ABC"_s);
     EXPECT_EQ(String("0123456789abcdefghijklmnopqrstuvwxyz"_s), string);
 
     // Changing the original result of toString() should not affect the content of the StringBuilder.
@@ -217,14 +217,14 @@ TEST(StringBuilderTest, ToString)
     // Resizing the StringBuilder should not affect the original result of toString().
     string1 = builder.toString();
     builder.shrink(10);
-    builder.append("###");
+    builder.append("###"_s);
     EXPECT_EQ(String("0123456789abcdefghijklmnopqrstuvwxyzABC"_s), string1);
 }
 
 TEST(StringBuilderTest, ToStringPreserveCapacity)
 {
     StringBuilder builder;
-    builder.append("0123456789");
+    builder.append("0123456789"_s);
     unsigned capacity = builder.capacity();
     String string = builder.toStringPreserveCapacity();
     EXPECT_EQ(capacity, builder.capacity());
@@ -233,7 +233,7 @@ TEST(StringBuilderTest, ToStringPreserveCapacity)
     EXPECT_EQ(string.span8().data(), builder.characters8());
 
     // Changing the StringBuilder should not affect the original result of toStringPreserveCapacity().
-    builder.append("abcdefghijklmnopqrstuvwxyz");
+    builder.append("abcdefghijklmnopqrstuvwxyz"_s);
     EXPECT_EQ(String("0123456789"_s), string);
 
     // Changing the StringBuilder should not affect the original result of toStringPreserveCapacity() in case the capacity is not changed.
@@ -243,7 +243,7 @@ TEST(StringBuilderTest, ToStringPreserveCapacity)
     EXPECT_EQ(capacity, builder.capacity());
     EXPECT_EQ(string.span8().data(), builder.characters8());
     EXPECT_EQ(String("0123456789abcdefghijklmnopqrstuvwxyz"_s), string);
-    builder.append("ABC");
+    builder.append("ABC"_s);
     EXPECT_EQ(String("0123456789abcdefghijklmnopqrstuvwxyz"_s), string);
 
     // Changing the original result of toStringPreserveCapacity() should not affect the content of the StringBuilder.
@@ -262,14 +262,14 @@ TEST(StringBuilderTest, ToStringPreserveCapacity)
     EXPECT_EQ(capacity, builder.capacity());
     EXPECT_EQ(string.span8().data(), builder.characters8());
     builder.shrink(10);
-    builder.append("###");
+    builder.append("###"_s);
     EXPECT_EQ(String("0123456789abcdefghijklmnopqrstuvwxyzABC"_s), string1);
 }
 
 TEST(StringBuilderTest, Clear)
 {
     StringBuilder builder;
-    builder.append("0123456789");
+    builder.append("0123456789"_s);
     builder.clear();
     expectEmpty(builder);
 }
@@ -277,7 +277,7 @@ TEST(StringBuilderTest, Clear)
 TEST(StringBuilderTest, Array)
 {
     StringBuilder builder;
-    builder.append("0123456789");
+    builder.append("0123456789"_s);
     EXPECT_EQ('0', static_cast<char>(builder[0]));
     EXPECT_EQ('9', static_cast<char>(builder[9]));
     builder.toString(); // Test after reifyString().
@@ -288,7 +288,7 @@ TEST(StringBuilderTest, Array)
 TEST(StringBuilderTest, Resize)
 {
     StringBuilder builder;
-    builder.append("0123456789");
+    builder.append("0123456789"_s);
     builder.shrink(10);
     EXPECT_EQ(10U, builder.length());
     expectBuilderContent("0123456789"_s, builder);
@@ -314,15 +314,15 @@ TEST(StringBuilderTest, Equal)
     EXPECT_TRUE(String() == builder1);
     EXPECT_TRUE(builder1 != String("abc"_s));
 
-    builder1.append("123");
+    builder1.append("123"_s);
     builder1.reserveCapacity(32);
-    builder2.append("123");
+    builder2.append("123"_s);
     builder1.reserveCapacity(64);
     EXPECT_TRUE(builder1 == builder2);
     EXPECT_TRUE(builder1 == String("123"_s));
     EXPECT_TRUE(String("123"_s) == builder1);
 
-    builder2.append("456");
+    builder2.append("456"_s);
     EXPECT_TRUE(builder1 != builder2);
     EXPECT_TRUE(builder2 != builder1);
     EXPECT_TRUE(String("123"_s) != builder2);
@@ -351,7 +351,7 @@ TEST(StringBuilderTest, ShouldShrinkToFit)
 TEST(StringBuilderTest, ToAtomString)
 {
     StringBuilder builder;
-    builder.append("123");
+    builder.append("123"_s);
     AtomString atomString = builder.toAtomString();
     EXPECT_EQ(String("123"_s), atomString);
 
@@ -415,7 +415,7 @@ TEST(StringBuilderTest, ToAtomStringOnEmpty)
     }
     { // Cleared StringBuilder.
         StringBuilder builder;
-        builder.append("WebKit");
+        builder.append("WebKit"_s);
         builder.clear();
         AtomString atomString = builder.toAtomString();
         EXPECT_EQ(emptyAtom(), atomString);

--- a/Tools/TestWebKitAPI/Tests/WebCore/TextCodec.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/TextCodec.cpp
@@ -55,10 +55,10 @@ static Vector<uint8_t> decodeHexTestBytes(const char* input)
 // that is completely unambiguous.
 static const char* escapeNonASCIIPrintableCharacters(StringView string)
 {
-    static char resultBuffer[100];
+    static std::array<char, 100> resultBuffer;
     size_t i = 0;
     auto append = [&i] (char character) {
-        if (i < sizeof(resultBuffer))
+        if (i < resultBuffer.size())
             resultBuffer[i++] = character;
     };
     auto appendNibble = [append] (char nibble) {
@@ -82,7 +82,7 @@ static const char* escapeNonASCIIPrintableCharacters(StringView string)
     if (i == sizeof(resultBuffer))
         return "";
     resultBuffer[i] = '\0';
-    return resultBuffer;
+    return resultBuffer.data();
 }
 
 static const char* testDecode(const char* encodingName, std::initializer_list<const char*> inputs)
@@ -94,9 +94,9 @@ static const char* testDecode(const char* encodingName, std::initializer_list<co
         auto vector = decodeHexTestBytes(inputs.begin()[i]);
         bool last = i == size - 1;
         bool sawError = false;
-        resultBuilder.append(escapeNonASCIIPrintableCharacters(codec->decode(vector.span(), last, false, sawError)));
+        resultBuilder.append(span(escapeNonASCIIPrintableCharacters(codec->decode(vector.span(), last, false, sawError))));
         if (sawError)
-            resultBuilder.append(" ERROR");
+            resultBuilder.append(" ERROR"_s);
     }
     return escapeNonASCIIPrintableCharacters(resultBuilder.toString());
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
@@ -124,15 +124,15 @@ static String wkMediaCaptureStateString(_WKMediaCaptureStateDeprecated flags)
 {
     StringBuilder string;
     if (flags & _WKMediaCaptureStateDeprecatedActiveMicrophone)
-        string.append("_WKMediaCaptureStateDeprecatedActiveMicrophone + ");
+        string.append("_WKMediaCaptureStateDeprecatedActiveMicrophone + "_s);
     if (flags & _WKMediaCaptureStateDeprecatedActiveCamera)
-        string.append("_WKMediaCaptureStateDeprecatedActiveCamera + ");
+        string.append("_WKMediaCaptureStateDeprecatedActiveCamera + "_s);
     if (flags & _WKMediaCaptureStateDeprecatedMutedMicrophone)
-        string.append("_WKMediaCaptureStateDeprecatedMutedMicrophone + ");
+        string.append("_WKMediaCaptureStateDeprecatedMutedMicrophone + "_s);
     if (flags & _WKMediaCaptureStateDeprecatedMutedCamera)
-        string.append("_WKMediaCaptureStateDeprecatedMutedCamera + ");
+        string.append("_WKMediaCaptureStateDeprecatedMutedCamera + "_s);
     if (string.isEmpty())
-        string.append("_WKMediaCaptureStateDeprecatedNone");
+        string.append("_WKMediaCaptureStateDeprecatedNone"_s);
     else
         string.shrink(string.length() - 2);
     return string.toString();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PermissionsAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PermissionsAPI.mm
@@ -122,7 +122,7 @@ TEST(PermissionsAPI, DataURL)
     </script>";
 
     StringBuilder buffer;
-    buffer.append("data:text/html,");
+    buffer.append("data:text/html,"_s);
     for (size_t cptr = 0; cptr < sizeof(script) - 1; ++cptr)
         urlEncodeIfNeeded(script[cptr], buffer);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestAutomationSession.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestAutomationSession.cpp
@@ -88,9 +88,9 @@ public:
     {
         static long sequenceID = 0;
         StringBuilder messageBuilder;
-        messageBuilder.append("{\"id\":", ++sequenceID, ",\"method\":\"Automation.", command, '"');
+        messageBuilder.append("{\"id\":"_s, ++sequenceID, ",\"method\":\"Automation."_s, command, '"');
         if (!parameters.isNull())
-            messageBuilder.append(",\"params\":", parameters);
+            messageBuilder.append(",\"params\":"_s, parameters);
         messageBuilder.append('}');
         m_connection->sendMessage("SendMessageToBackend", g_variant_new("(tts)", m_connectionID, m_target.id, messageBuilder.toString().utf8().data()));
     }

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebContext.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebContext.cpp
@@ -210,7 +210,7 @@ String generateHTMLContent(unsigned contentLength)
     unsigned baseLength = baseString.length();
 
     StringBuilder builder;
-    builder.append("<html><body>");
+    builder.append("<html><body>"_s);
 
     if (contentLength <= baseLength)
         builder.appendSubstring(baseString, 0, contentLength);
@@ -226,7 +226,7 @@ String generateHTMLContent(unsigned contentLength)
             currentLength = builder.length() - 12;
         }
     }
-    builder.append("</body></html>");
+    builder.append("</body></html>"_s);
 
     return builder.toString();
 }

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
@@ -588,12 +588,12 @@ Vector<uint8_t> HTTPResponse::bodyFromString(const String& string)
 Vector<uint8_t> HTTPResponse::serialize(IncludeContentLength includeContentLength) const
 {
     StringBuilder responseBuilder;
-    responseBuilder.append("HTTP/1.1 ", statusCode, ' ', statusText(statusCode), "\r\n");
+    responseBuilder.append("HTTP/1.1 "_s, statusCode, ' ', statusText(statusCode), "\r\n"_s);
     if (includeContentLength == IncludeContentLength::Yes)
-        responseBuilder.append("Content-Length: ", body.size(), "\r\n");
+        responseBuilder.append("Content-Length: "_s, body.size(), "\r\n"_s);
     for (auto& pair : headerFields)
-        responseBuilder.append(pair.key, ": ", pair.value, "\r\n");
-    responseBuilder.append("\r\n");
+        responseBuilder.append(pair.key, ": "_s, pair.value, "\r\n"_s);
+    responseBuilder.append("\r\n"_s);
     
     Vector<uint8_t> bytesToSend;
     appendUTF8ToVector(bytesToSend, responseBuilder.toString());

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -207,7 +207,7 @@ static inline void dumpResourceURL(uint64_t identifier, StringBuilder& stringBui
     if (assignedUrlsCache().contains(identifier))
         stringBuilder.append(assignedUrlsCache().get(identifier));
     else
-        stringBuilder.append("<unknown>");
+        stringBuilder.append("<unknown>"_s);
 }
 
 static HashMap<WKBundlePageRef, InjectedBundlePage*>& bundlePageMap()
@@ -441,9 +441,9 @@ static inline void dumpErrorDescriptionSuitableForTestResult(WKErrorRef error, S
     if (errorDomain == "WebKitPolicyError"_s)
         errorDomain = "WebKitErrorDomain"_s;
 
-    stringBuilder.append("<NSError domain ", errorDomain, ", code ", errorCode);
+    stringBuilder.append("<NSError domain "_s, errorDomain, ", code "_s, errorCode);
     if (auto url = adoptWK(WKErrorCopyFailingURL(error)))
-        stringBuilder.append(", failing URL \"", adoptWK(WKURLCopyString(url.get())).get(), '"');
+        stringBuilder.append(", failing URL \""_s, adoptWK(WKURLCopyString(url.get())).get(), '"');
     stringBuilder.append('>');
 }
 
@@ -666,8 +666,8 @@ static void dumpFrameScrollPosition(WKBundleFrameRef frame, StringBuilder& strin
     if (std::abs(x) <= 0.00000001 && std::abs(y) <= 0.00000001)
         return;
     if (shouldIncludeFrameName)
-        stringBuilder.append("frame '", adoptWK(WKBundleFrameCopyName(frame)).get(), "' ");
-    stringBuilder.append("scrolled to ", x, ',', y, '\n');
+        stringBuilder.append("frame '"_s, adoptWK(WKBundleFrameCopyName(frame)).get(), "' "_s);
+    stringBuilder.append("scrolled to "_s, x, ',', y, '\n');
 }
 
 static void dumpDescendantFrameScrollPositions(WKBundleFrameRef frame, StringBuilder& stringBuilder)
@@ -816,9 +816,9 @@ void InjectedBundlePage::didReceiveTitleForFrame(WKStringRef title, WKBundleFram
 
     StringBuilder stringBuilder;
     if (injectedBundle.testRunner()->shouldDumpFrameLoadCallbacks())
-        stringBuilder.append(string(frame), " - didReceiveTitle: ", title, '\n');
+        stringBuilder.append(string(frame), " - didReceiveTitle: "_s, title, '\n');
     if (injectedBundle.testRunner()->shouldDumpTitleChanges())
-        stringBuilder.append("TITLE CHANGED: '", title, "'\n");
+        stringBuilder.append("TITLE CHANGED: '"_s, title, "'\n"_s);
     injectedBundle.outputText(stringBuilder.toString());
 }
 
@@ -953,8 +953,8 @@ WKURLRequestRef InjectedBundlePage::willSendRequestForFrame(WKBundlePageRef page
         && injectedBundle.testRunner()->shouldDumpResourceLoadCallbacks()) {
         StringBuilder stringBuilder;
         dumpResourceURL(identifier, stringBuilder);
-        stringBuilder.append(" - willSendRequest ", string(request),
-            " redirectResponse ", string(response, injectedBundle.testRunner()->shouldDumpAllHTTPRedirectedResponseHeaders()), '\n');
+        stringBuilder.append(" - willSendRequest "_s, string(request),
+            " redirectResponse "_s, string(response, injectedBundle.testRunner()->shouldDumpAllHTTPRedirectedResponseHeaders()), '\n');
         injectedBundle.outputText(stringBuilder.toString());
     }
 
@@ -1023,7 +1023,7 @@ void InjectedBundlePage::didReceiveResponseForResource(WKBundlePageRef page, WKB
     if (injectedBundle.testRunner()->shouldDumpResourceLoadCallbacks()) {
         StringBuilder stringBuilder;
         dumpResourceURL(identifier, stringBuilder);
-        stringBuilder.append(" - didReceiveResponse ", string(response), '\n');
+        stringBuilder.append(" - didReceiveResponse "_s, string(response), '\n');
         injectedBundle.outputText(stringBuilder.toString());
     }
 
@@ -1040,7 +1040,7 @@ void InjectedBundlePage::didReceiveResponseForResource(WKBundlePageRef page, WKB
 
     String platformMimeType = platformResponseMimeType(response);
     if (!platformMimeType.isEmpty() && platformMimeType != toWTFString(mimeTypeString)) {
-        stringBuilder.append(" but platform response has ", platformMimeType);
+        stringBuilder.append(" but platform response has "_s, platformMimeType);
     }
 
     stringBuilder.append('\n');
@@ -1063,7 +1063,7 @@ void InjectedBundlePage::didFinishLoadForResource(WKBundlePageRef, WKBundleFrame
 
     StringBuilder stringBuilder;
     dumpResourceURL(identifier, stringBuilder);
-    stringBuilder.append(" - didFinishLoading\n");
+    stringBuilder.append(" - didFinishLoading\n"_s);
     injectedBundle.outputText(stringBuilder.toString());
 }
 
@@ -1078,7 +1078,7 @@ void InjectedBundlePage::didFailLoadForResource(WKBundlePageRef, WKBundleFrameRe
 
     StringBuilder stringBuilder;
     dumpResourceURL(identifier, stringBuilder);
-    stringBuilder.append(" - didFailLoadingWithError: ");
+    stringBuilder.append(" - didFailLoadingWithError: "_s);
 
     dumpErrorDescriptionSuitableForTestResult(error, stringBuilder);
     stringBuilder.append('\n');

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
@@ -272,25 +272,25 @@ static String attributesOfElement(AccessibilityUIElement& element)
 
     builder.append(element.role()->string(), '\n');
 
-    builder.append("AXParent: ");
+    builder.append("AXParent: "_s);
     if (auto parent = element.parentElement()) {
         builder.append(parent->role()->string().substring(8));
         auto parentName = parent->title()->string().substring(9);
         if (!parentName.isEmpty())
-            builder.append(": ", parentName);
+            builder.append(": "_s, parentName);
     } else
-        builder.append("(null)");
+        builder.append("(null)"_s);
     builder.append('\n');
 
-    builder.append("AXChildren: ", element.childrenCount(), '\n');
+    builder.append("AXChildren: "_s, element.childrenCount(), '\n');
 
-    builder.append("AXPosition:  { ", FormattedNumber::fixedPrecision(element.x(), 6, TrailingZerosPolicy::Keep));
-    builder.append(", ", FormattedNumber::fixedPrecision(element.y(), 6, TrailingZerosPolicy::Keep));
-    builder.append(" }\n");
+    builder.append("AXPosition:  { "_s, FormattedNumber::fixedPrecision(element.x(), 6, TrailingZerosPolicy::Keep));
+    builder.append(", "_s, FormattedNumber::fixedPrecision(element.y(), 6, TrailingZerosPolicy::Keep));
+    builder.append(" }\n"_s);
 
-    builder.append("AXSize: { ", FormattedNumber::fixedPrecision(element.width(), 6, TrailingZerosPolicy::Keep));
-    builder.append(", ", FormattedNumber::fixedPrecision(element.height(), 6, TrailingZerosPolicy::Keep));
-    builder.append(" }\n");
+    builder.append("AXSize: { "_s, FormattedNumber::fixedPrecision(element.width(), 6, TrailingZerosPolicy::Keep));
+    builder.append(", "_s, FormattedNumber::fixedPrecision(element.height(), 6, TrailingZerosPolicy::Keep));
+    builder.append(" }\n"_s);
 
     String title = element.title()->string();
     if (!title.isEmpty()) {
@@ -306,22 +306,22 @@ static String attributesOfElement(AccessibilityUIElement& element)
     if (!value.isEmpty())
         builder.append(value, '\n');
 
-    builder.append("AXFocusable: ", element.isFocusable(), '\n');
-    builder.append("AXFocused: ", element.isFocused(), '\n');
-    builder.append("AXSelectable: ", element.isSelectable(), '\n');
-    builder.append("AXSelected: ", element.isSelected(), '\n');
-    builder.append("AXMultiSelectable: ", element.isMultiSelectable(), '\n');
-    builder.append("AXEnabled: ", element.isEnabled(), '\n');
-    builder.append("AXExpanded: ", element.isExpanded(), '\n');
-    builder.append("AXRequired: ", element.isRequired(), '\n');
-    builder.append("AXChecked: ", element.isChecked(), '\n');
+    builder.append("AXFocusable: "_s, element.isFocusable(), '\n');
+    builder.append("AXFocused: "_s, element.isFocused(), '\n');
+    builder.append("AXSelectable: "_s, element.isSelectable(), '\n');
+    builder.append("AXSelected: "_s, element.isSelected(), '\n');
+    builder.append("AXMultiSelectable: "_s, element.isMultiSelectable(), '\n');
+    builder.append("AXEnabled: "_s, element.isEnabled(), '\n');
+    builder.append("AXExpanded: "_s, element.isExpanded(), '\n');
+    builder.append("AXRequired: "_s, element.isRequired(), '\n');
+    builder.append("AXChecked: "_s, element.isChecked(), '\n');
 
     String url = element.url()->string();
     if (!url.isEmpty())
         builder.append(url, '\n');
 
     // We append the platform attributes as a single line at the end.
-    builder.append("AXPlatformAttributes: ");
+    builder.append("AXPlatformAttributes: "_s);
     auto attributes = element.platformUIElement()->attributes();
     auto keys = copyToVector(attributes.keys());
     std::sort(keys.begin(), keys.end(), WTF::codePointCompareLessThan);
@@ -332,7 +332,7 @@ static String attributesOfElement(AccessibilityUIElement& element)
             continue;
 
         if (!isFirst)
-            builder.append(", ");
+            builder.append(", "_s);
         isFirst = false;
         builder.append(key, ':', attributes.get(key));
     }
@@ -983,7 +983,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::helpText() const
         return JSStringCreateWithCharacters(nullptr, 0);
 
     StringBuilder builder;
-    builder.append("AXHelp: ");
+    builder.append("AXHelp: "_s);
 
     bool isFirst = true;
     for (const auto& target : targets) {
@@ -1254,13 +1254,13 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForRange(unsign
 
     auto buildAttributes = [&](const WebCore::AccessibilityObjectAtspi::TextAttributes& attributes) {
         for (const auto& it : attributes.attributes) {
-            builder.append("\n\t\t");
+            builder.append("\n\t\t"_s);
             builder.append(it.key, ':', it.value);
         }
     };
 
     m_element->updateBackingStore();
-    builder.append("\n\tDefault text attributes:");
+    builder.append("\n\tDefault text attributes:"_s);
     buildAttributes(m_element->textAttributes());
 
     int endOffset = 0;
@@ -1268,7 +1268,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForRange(unsign
         auto attributes = m_element->textAttributes(i);
         auto rangeStart = std::max<int>(location, attributes.startOffset);
         auto rangeEnd = std::min<int>(limit, attributes.endOffset);
-        builder.append("\n\tRange attributes for '", makeStringByReplacingAll(makeStringByReplacingAll(text.substring(rangeStart, rangeEnd - rangeStart), '\n', "<\\n>"_s), objectReplacementCharacter, "<obj>"_s), "':");
+        builder.append("\n\tRange attributes for '"_s, makeStringByReplacingAll(makeStringByReplacingAll(text.substring(rangeStart, rangeEnd - rangeStart), '\n', "<\\n>"_s), objectReplacementCharacter, "<obj>"_s), "':"_s);
         buildAttributes(attributes);
         endOffset = attributes.endOffset;
     }

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1359,15 +1359,15 @@ void TestController::findAndDumpWorldLeaks()
             auto documentURL = it.value.abandonedDocumentURL;
             if (documentURL.isEmpty())
                 documentURL = "(no url)"_s;
-            builder.append("TEST: ");
+            builder.append("TEST: "_s);
             builder.append(it.value.testURL);
             builder.append('\n');
-            builder.append("ABANDONED DOCUMENT: ");
+            builder.append("ABANDONED DOCUMENT: "_s);
             builder.append(documentURL);
             builder.append('\n');
         }
     } else
-        builder.append("no abandoned documents\n");
+        builder.append("no abandoned documents\n"_s);
 
     dumpResponse(builder.toString());
 }
@@ -2703,9 +2703,9 @@ WKStringRef TestController::decideDestinationWithSuggestedFilename(WKDownloadRef
 
     if (m_shouldLogDownloadCallbacks) {
         StringBuilder builder;
-        builder.append("Downloading URL with suggested filename \"");
+        builder.append("Downloading URL with suggested filename \""_s);
         builder.append(suggestedFilename);
-        builder.append("\"\n");
+        builder.append("\"\n"_s);
         m_currentInvocation->outputText(builder.toString());
     }
 
@@ -3240,12 +3240,12 @@ void TestController::decidePolicyForNavigationAction(WKPageRef page, WKNavigatio
         auto urlScheme = adoptWK(WKURLCopyScheme(url.get()));
 
         StringBuilder stringBuilder;
-        stringBuilder.append("Policy delegate: attempt to load ");
+        stringBuilder.append("Policy delegate: attempt to load "_s);
         if (isLocalFileScheme(urlScheme.get()))
             stringBuilder.append(toWTFString(adoptWK(WKURLCopyLastPathComponent(url.get())).get()));
         else
             stringBuilder.append(toWTFString(adoptWK(WKURLCopyString(url.get())).get()));
-        stringBuilder.append(" with navigation type \'", navigationTypeToString(WKNavigationActionGetNavigationType(navigationAction)), '\'');
+        stringBuilder.append(" with navigation type \'"_s, navigationTypeToString(WKNavigationActionGetNavigationType(navigationAction)), '\'');
         stringBuilder.append('\n');
         m_currentInvocation->outputText(stringBuilder.toString());
         if (!m_skipPolicyDelegateNotifyDone)


### PR DESCRIPTION
#### eb7b0b0b9e5e2cda97a1624334713db993fa4ce0
<pre>
Drop StringBuilder:append() overload taking in a `const char*`
<a href="https://bugs.webkit.org/show_bug.cgi?id=273671">https://bugs.webkit.org/show_bug.cgi?id=273671</a>

Reviewed by Tim Nguyen and Darin Adler.

Drop StringBuilder:append() overload taking in a `const char*`, in favor of the
ones taking in an ASCIILiteral or a std::span.

* Source/JavaScriptCore/API/tests/PingPongStackOverflowTest.cpp:
(PingPongStackOverflowObject_hasInstance):
* Source/JavaScriptCore/bytecode/Instruction.h:
* Source/JavaScriptCore/bytecode/Opcode.cpp:
(JSC::padOpcodeName):
(JSC::OpcodeStats::~OpcodeStats):
* Source/JavaScriptCore/bytecode/Opcode.h:
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::ArrayPatternNode::toString const):
(JSC::RestParameterNode::toString const):
* Source/JavaScriptCore/heap/GCLogging.cpp:
(JSC::GCLogging::levelAsString):
* Source/JavaScriptCore/heap/GCLogging.h:
* Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp:
(JSC::HeapSnapshotBuilder::json):
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ConsoleClient.cpp:
(JSC::appendMessagePrefix):
(JSC::ConsoleClient::printConsoleMessage):
(JSC::ConsoleClient::printConsoleMessageWithArguments):
* Source/JavaScriptCore/runtime/DateConversion.cpp:
(JSC::formatDateTime):
* Source/JavaScriptCore/runtime/ExceptionHelpers.cpp:
(JSC::notAFunctionSourceAppender):
* Source/JavaScriptCore/runtime/FileBasedFuzzerAgent.cpp:
(JSC::FileBasedFuzzerAgent::getPredictionInternal):
* Source/JavaScriptCore/runtime/FileBasedFuzzerAgentBase.cpp:
(JSC::FileBasedFuzzerAgentBase::createLookupKey):
* Source/JavaScriptCore/runtime/FunctionConstructor.cpp:
(JSC::stringifyFunction):
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::IntlDateTimeFormat::buildSkeleton):
(JSC::IntlDateTimeFormat::createDateIntervalFormatIfNecessary):
* Source/JavaScriptCore/runtime/IntlDurationFormat.cpp:
(JSC::collectElements):
* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
(JSC::IntlNumberFormat::initializeNumberFormat):
* Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h:
(JSC::appendNumberFormatDigitOptionsToSkeleton):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::asString):
(JSC::Options::executeDumpOptions):
(JSC::Options::dumpAllOptions):
(JSC::Options::dumpAllOptionsInALine):
(JSC::Options::dumpOption):
(JSC::OptionsHelper::Option::dump const):
* Source/JavaScriptCore/runtime/Options.h:
(JSC::Options::dumpAllOptions):
* Source/JavaScriptCore/runtime/PredictionFileCreatingFuzzerAgent.cpp:
(JSC::PredictionFileCreatingFuzzerAgent::getPredictionInternal):
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::appendLineTerminatorEscape&lt;UChar&gt;):
* Source/JavaScriptCore/runtime/TypeProfiler.cpp:
(JSC::TypeProfiler::typeInformationForExpressionAtOffset):
* Source/JavaScriptCore/runtime/TypeSet.cpp:
(JSC::TypeSet::dumpTypes const):
(JSC::TypeSet::toJSONString const):
(JSC::StructureShape::propertyHash):
(JSC::StructureShape::stringRepresentation):
(JSC::StructureShape::toJSONString const):
* Source/JavaScriptCore/tools/FunctionOverrides.cpp:
(JSC::parseClause):
* Source/WTF/wtf/JSONValues.cpp:
(WTF::JSONImpl::Value::writeJSONImpl const):
* Source/WTF/wtf/text/StringBuilder.h:
(WTF::StringBuilder::append):
* Source/WTF/wtf/text/TextStream.cpp:
(WTF::TextStream::operator&lt;&lt;):
* Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp:
(WebCore::mediaProducerStateString):
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
(WebCore::MediaKeySession::updateKeyStatuses):
* Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp:
(WTF::LogArgument&lt;Vector&lt;T&gt;&gt;::toString):
* Source/WebCore/Modules/fetch/FetchHeaders.cpp:
(WebCore::FetchHeaders::get const):
* Source/WebCore/Modules/geolocation/Geolocation.cpp:
(WebCore::logError):
* Source/WebCore/Modules/indexeddb/IDBKeyData.cpp:
(WebCore::IDBKeyData::loggingString const):
* Source/WebCore/Modules/indexeddb/IDBKeyPath.cpp:
(WebCore::loggingString):
* Source/WebCore/Modules/indexeddb/server/IndexValueStore.cpp:
(WebCore::IDBServer::IndexValueStore::loggingString const):
* Source/WebCore/Modules/indexeddb/shared/IDBDatabaseInfo.cpp:
(WebCore::IDBDatabaseInfo::loggingString const):
* Source/WebCore/Modules/indexeddb/shared/IDBObjectStoreInfo.cpp:
(WebCore::IDBObjectStoreInfo::loggingString const):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp:
(WebCore::toRTCCodecParameters):
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::encodeProtocolString):
* Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp:
(WebCore::WebSocketExtensionDispatcher::createHeaderValue const):
(WebCore::WebSocketExtensionDispatcher::appendAcceptedExtension):
* Source/WebCore/PAL/pal/avfoundation/OutputContext.mm:
(PAL::OutputContext::deviceName):
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::callInWorld):
* Source/WebCore/contentextensions/CombinedURLFilters.cpp:
(WebCore::ContentExtensions::prefixTreeVertexToString):
(WebCore::ContentExtensions::recursivePrint):
* Source/WebCore/contentextensions/Term.h:
(WebCore::ContentExtensions::Term::toString const):
* Source/WebCore/css/CSSBasicShapes.cpp:
(WebCore::buildEllipseString):
(WebCore::buildInsetString):
* Source/WebCore/css/CSSContainerRule.cpp:
(WebCore::CSSContainerRule::cssText const):
* Source/WebCore/css/CSSCounterStyleDescriptors.cpp:
(WebCore::CSSCounterStyleDescriptors::rangesCSSText const):
(WebCore::CSSCounterStyleDescriptors::symbolsCSSText const):
(WebCore::CSSCounterStyleDescriptors::additiveSymbolsCSSText const):
* Source/WebCore/css/CSSFontFaceSrcValue.cpp:
(WebCore::CSSFontFaceSrcResourceValue::customCSSText const):
* Source/WebCore/css/CSSFontFeatureValuesRule.cpp:
(WebCore::CSSFontFeatureValuesRule::cssText const):
* Source/WebCore/css/CSSFontFeatureValuesRule.h:
* Source/WebCore/css/CSSFontPaletteValuesRule.cpp:
(WebCore::CSSFontPaletteValuesRule::overrideColors const):
(WebCore::CSSFontPaletteValuesRule::cssText const):
* Source/WebCore/css/CSSGradientValue.cpp:
(WebCore::appendGradientStops):
(WebCore::CSSLinearGradientValue::customCSSText const):
(WebCore::CSSPrefixedLinearGradientValue::customCSSText const):
(WebCore::CSSDeprecatedLinearGradientValue::customCSSText const):
(WebCore::CSSRadialGradientValue::customCSSText const):
(WebCore::CSSPrefixedRadialGradientValue::customCSSText const):
(WebCore::CSSDeprecatedRadialGradientValue::customCSSText const):
(WebCore::CSSConicGradientValue::customCSSText const):
* Source/WebCore/css/CSSGroupingRule.cpp:
(WebCore::CSSGroupingRule::appendCSSTextForItemsInternal const):
(WebCore::CSSGroupingRule::cssTextForRules const):
(WebCore::CSSGroupingRule::cssTextForRulesWithReplacementURLs const):
* Source/WebCore/css/CSSImportRule.cpp:
(WebCore::CSSImportRule::cssTextInternal const):
* Source/WebCore/css/CSSLayerBlockRule.cpp:
(WebCore::CSSLayerBlockRule::cssText const):
* Source/WebCore/css/CSSLayerStatementRule.cpp:
(WebCore::CSSLayerStatementRule::cssText const):
* Source/WebCore/css/CSSLineBoxContainValue.cpp:
(WebCore::CSSLineBoxContainValue::customCSSText const):
* Source/WebCore/css/CSSMarkup.cpp:
(WebCore::serializeURL):
* Source/WebCore/css/CSSMediaRule.cpp:
(WebCore::CSSMediaRule::cssText const):
(WebCore::CSSMediaRule::cssTextWithReplacementURLs const):
* Source/WebCore/css/CSSNamespaceRule.cpp:
(WebCore::CSSNamespaceRule::cssText const):
* Source/WebCore/css/CSSPropertyRule.cpp:
(WebCore::CSSPropertyRule::cssText const):
* Source/WebCore/css/CSSScopeRule.cpp:
(WebCore::CSSScopeRule::cssText const):
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::buildSelectorsText const):
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::cssTextForRules const):
(WebCore::CSSStyleRule::cssTextForRulesWithReplacementURLs const):
(WebCore::CSSStyleRule::cssTextInternal const):
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::cssTextWithReplacementURLs):
* Source/WebCore/css/CSSSupportsRule.cpp:
(WebCore::CSSSupportsRule::cssText const):
(WebCore::CSSSupportsRule::cssTextWithReplacementURLs const):
* Source/WebCore/css/CSSTimingFunctionValue.cpp:
(WebCore::CSSLinearTimingFunctionValue::customCSSText const):
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serializeBorderRadius const):
(WebCore::ShorthandSerializer::serializeGridTemplate const):
* Source/WebCore/css/calc/CSSCalcOperationNode.cpp:
(WebCore::CSSCalcOperationNode::buildCSSText):
* Source/WebCore/css/parser/CSSParserToken.cpp:
(WebCore::CSSParserToken::serialize const):
* Source/WebCore/css/query/GenericMediaQuerySerialization.cpp:
(WebCore::MQ::serialize):
* Source/WebCore/css/query/MediaQueryParser.cpp:
(WebCore::MQ::serialize):
* Source/WebCore/css/typedom/CSSOMVariableReferenceValue.cpp:
(WebCore::CSSOMVariableReferenceValue::serialize const):
* Source/WebCore/css/typedom/numeric/CSSMathInvert.cpp:
(WebCore::CSSMathInvert::serialize const):
* Source/WebCore/css/typedom/numeric/CSSMathMax.cpp:
(WebCore::CSSMathMax::serialize const):
* Source/WebCore/css/typedom/numeric/CSSMathMin.cpp:
(WebCore::CSSMathMin::serialize const):
* Source/WebCore/css/typedom/numeric/CSSMathNegate.cpp:
(WebCore::CSSMathNegate::serialize const):
* Source/WebCore/css/typedom/numeric/CSSMathProduct.cpp:
(WebCore::CSSMathProduct::serialize const):
* Source/WebCore/css/typedom/numeric/CSSMathSum.cpp:
(WebCore::CSSMathSum::serialize const):
* Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp:
(WebCore::CSSMatrixComponent::serialize const):
* Source/WebCore/css/typedom/transform/CSSPerspective.cpp:
(WebCore::CSSPerspective::serialize const):
* Source/WebCore/css/typedom/transform/CSSRotate.cpp:
(WebCore::CSSRotate::serialize const):
* Source/WebCore/css/typedom/transform/CSSScale.cpp:
(WebCore::CSSScale::serialize const):
* Source/WebCore/css/typedom/transform/CSSSkewX.cpp:
(WebCore::CSSSkewX::serialize const):
* Source/WebCore/css/typedom/transform/CSSSkewY.cpp:
(WebCore::CSSSkewY::serialize const):
* Source/WebCore/css/typedom/transform/CSSTranslate.cpp:
(WebCore::CSSTranslate::serialize const):
* Source/WebCore/dom/Element.cpp:
(WebCore::appendAttributes):
* Source/WebCore/dom/FragmentDirectiveGenerator.cpp:
(WebCore::FragmentDirectiveGenerator::generateFragmentDirective):
* Source/WebCore/dom/SecurityContext.cpp:
(WebCore::SecurityContext::parseSandboxPolicy):
* Source/WebCore/dom/Text.cpp:
(WebCore::appendTextRepresentation):
* Source/WebCore/editing/FontShadow.cpp:
(WebCore::serializationForCSS):
* Source/WebCore/editing/markup.cpp:
(WebCore::StyledMarkupAccumulator::appendStyleNodeOpenTag):
(WebCore::StyledMarkupAccumulator::appendStartTag):
(WebCore::StyledMarkupAccumulator::appendEndTag):
(WebCore::serializePreservingVisualAppearanceInternal):
(WebCore::urlToMarkup):
* Source/WebCore/html/FormController.cpp:
(WebCore::formSignature):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::completeURLsInAttributeValue const):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::restrictionNames):
* Source/WebCore/html/parser/HTMLSrcsetParser.cpp:
(WebCore::replaceURLsInSrcsetAttribute):
* Source/WebCore/inspector/InspectorFrontendAPIDispatcher.cpp:
(WebCore::expressionForEvaluatingCommand):
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::InspectorOverlay::buildFlexOverlay):
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::InspectorStyleSheet::setRuleStyleText):
* Source/WebCore/loader/ResourceLoadStatistics.cpp:
(WebCore::appendBoolean):
(WebCore::appendHashSet):
(WebCore::appendNavigatorAPIOptionSet):
(WebCore::appendScreenAPIOptionSet):
(WebCore::ResourceLoadStatistics::toString const):
* Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp:
(WebCore::generateRandomBoundary):
(WebCore::MHTMLArchive::generateMHTMLData):
* Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp:
(WebCore::CaptionUserPreferencesMediaAF::captionsDefaultFontCSS const):
* Source/WebCore/page/PageSerializer.cpp:
(WebCore::PageSerializer::serializeCSSStyleSheet):
* Source/WebCore/platform/Decimal.cpp:
(WebCore::Decimal::toString const):
* Source/WebCore/platform/graphics/AV1Utilities.cpp:
(WebCore::createAV1CodecParametersString):
* Source/WebCore/platform/graphics/CodecUtilities.cpp:
(WebCore::humanReadableStringFromCodecString):
* Source/WebCore/platform/graphics/ColorInterpolationMethod.cpp:
(WebCore::serializationForCSS):
* Source/WebCore/platform/graphics/HEVCUtilities.cpp:
(WebCore::createDoViCodecParametersString):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::SeekTarget::toString const):
* Source/WebCore/platform/graphics/VP9Utilities.cpp:
(WebCore::createVPCodecParametersString):
* Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp:
(WebCore::InbandTextTrackPrivateAVF::processCueAttributes):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WTF::LogArgument&lt;WebCore::CDMInstanceFairPlayStreamingAVFObjC::Keys&gt;::toString):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.cpp:
(WebCore::MediaRecorderPrivateMock::videoFrameAvailable):
(WebCore::MediaRecorderPrivateMock::audioSamplesAvailable):
(WebCore::MediaRecorderPrivateMock::generateMockCounterString):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp:
(WebCore::RealtimeMediaSourceSettings::convertFlagsToString):
* Source/WebCore/platform/text/DateTimeFormat.cpp:
(WebCore::DateTimeFormat::quoteAndAppendLiteral):
* Source/WebCore/platform/text/win/LocaleWin.cpp:
(WebCore::LocaleWin::shortTimeFormat):
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::quoteAndEscapeNonPrintables):
(WebCore::nodePosition):
* Source/WebCore/svg/SVGPathStringBuilder.cpp:
(WebCore::SVGPathStringBuilder::moveTo):
(WebCore::SVGPathStringBuilder::lineTo):
(WebCore::SVGPathStringBuilder::lineToHorizontal):
(WebCore::SVGPathStringBuilder::lineToVertical):
(WebCore::SVGPathStringBuilder::curveToCubic):
(WebCore::SVGPathStringBuilder::curveToCubicSmooth):
(WebCore::SVGPathStringBuilder::curveToQuadratic):
(WebCore::SVGPathStringBuilder::curveToQuadraticSmooth):
(WebCore::SVGPathStringBuilder::arcTo):
(WebCore::SVGPathStringBuilder::closePath):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::imageLastDecodingOptions):
(WebCore::Internals::dumpMarkerRects):
(WebCore::Internals::mediaSessionRestrictions const):
(WebCore::Internals::pageMediaState):
(WebCore::appendOffsets):
(WebCore::Internals::scrollSnapOffsets):
(WebCore::Internals::dumpStyleResolvers):
* Source/WebDriver/SessionHost.cpp:
(WebDriver::SessionHost::sendCommandToBackend):
* Source/WebDriver/socket/HTTPServerSocket.cpp:
(WebDriver::HTTPRequestHandler::packHTTPMessage const):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):
(WGSL::Metal::FunctionDefinitionWriter::visit):
(WGSL::Metal::FunctionDefinitionWriter::generatePackingHelpers):
(WGSL::Metal::FunctionDefinitionWriter::emitPackedVector):
(WGSL::Metal::FunctionDefinitionWriter::serializeVariable):
(WGSL::Metal::FunctionDefinitionWriter::visitArgumentBufferParameter):
(WGSL::Metal::visitArguments):
(WGSL::Metal::emitTextureDimensions):
(WGSL::Metal::emitTextureGather):
(WGSL::Metal::emitTextureGatherCompare):
(WGSL::Metal::emitTextureLoad):
(WGSL::Metal::emitTextureSample):
(WGSL::Metal::emitTextureSampleCompare):
(WGSL::Metal::emitTextureSampleGrad):
(WGSL::Metal::emitTextureSampleLevel):
(WGSL::Metal::emitTextureSampleBaseClampToEdge):
(WGSL::Metal::emitTextureSampleBias):
(WGSL::Metal::emitTextureNumLayers):
(WGSL::Metal::emitTextureNumLevels):
(WGSL::Metal::emitTextureNumSamples):
(WGSL::Metal::emitTextureStore):
(WGSL::Metal::emitStorageBarrier):
(WGSL::Metal::emitTextureBarrier):
(WGSL::Metal::emitWorkgroupBarrier):
(WGSL::Metal::emitWorkgroupUniformLoad):
(WGSL::Metal::atomicFunction):
(WGSL::Metal::emitAtomicLoad):
(WGSL::Metal::emitAtomicStore):
(WGSL::Metal::emitAtomicAdd):
(WGSL::Metal::emitAtomicSub):
(WGSL::Metal::emitAtomicMax):
(WGSL::Metal::emitAtomicMin):
(WGSL::Metal::emitAtomicAnd):
(WGSL::Metal::emitAtomicOr):
(WGSL::Metal::emitAtomicXor):
(WGSL::Metal::emitAtomicExchange):
(WGSL::Metal::emitDistance):
(WGSL::Metal::emitLength):
(WGSL::Metal::emitDegrees):
(WGSL::Metal::emitDynamicOffset):
(WGSL::Metal::emitBitcast):
(WGSL::Metal::emitPack2x16Float):
(WGSL::Metal::emitUnpack2x16Float):
(WGSL::Metal::emitPack4xI8):
(WGSL::Metal::emitPack4xI8Clamp):
(WGSL::Metal::emitUnpack4xI8):
(WGSL::Metal::emitPack4xU8):
(WGSL::Metal::emitPack4xU8Clamp):
(WGSL::Metal::emitQuantizeToF16):
(WGSL::Metal::emitRadians):
(WGSL::Metal::emitUnpack4xU8):
(WGSL::Metal::FunctionDefinitionWriter::serializeBinaryExpression):
(WGSL::Metal::FunctionDefinitionWriter::serializeConstant):
* Source/WebGPU/WGSL/Parser.cpp:
* Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyData.cpp:
(WebKit::ITPThirdPartyData::toString const):
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::ResourceLoadStatisticsStore::dumpResourceLoadStatistics):
(WebKit::appendBoolean):
(WebKit::appendNextEntry):
(WebKit::ResourceLoadStatisticsStore::appendSubStatisticList const):
(WebKit::ResourceLoadStatisticsStore::resourceToString const):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp:
(WebKit::PCM::Database::privateClickMeasurementToStringForTesting const):
(WebKit::PCM::Database::attributionToStringForTesting const):
* Source/WebKit/NetworkProcess/soup/NetworkProcessSoup.cpp:
(WebKit::buildAcceptLanguages):
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
(WebKit::CacheStorageManager::representationString):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::cacheStorageRepresentation):
* Source/WebKit/Shared/Gamepad/GamepadData.cpp:
(WebKit::GamepadData::loggingString const):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewRunJavaScriptWithParams):
* Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp:
(WebKit::DropTarget::accept):
* Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp:
(WebKit::RemoteInspectorProtocolHandler::platformStartTask):
* Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp:
(WebKit::ProcessLauncher::launchProcess):
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::loggingString):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDidReachLayoutMilestone):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::dumpHistoryItem):
* Tools/TestWebKitAPI/Tests/WTF/CrossThreadTask.cpp:
(TestWebKitAPI::LifetimeLogger::fullName):
* Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp:
(TestWebKitAPI::TEST(StringBuilderTest, Append)):
(TestWebKitAPI::TEST(StringBuilderTest, VariadicAppend)):
(TestWebKitAPI::TEST(StringBuilderTest, ToString)):
(TestWebKitAPI::TEST(StringBuilderTest, ToStringPreserveCapacity)):
(TestWebKitAPI::TEST(StringBuilderTest, Clear)):
(TestWebKitAPI::TEST(StringBuilderTest, Array)):
(TestWebKitAPI::TEST(StringBuilderTest, Resize)):
(TestWebKitAPI::TEST(StringBuilderTest, ToAtomString)):
(TestWebKitAPI::TEST(StringBuilderTest, ToAtomStringOnEmpty)):
* Tools/TestWebKitAPI/Tests/WebCore/TextCodec.cpp:
(TestWebKitAPI::testDecode):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestAutomationSession.cpp:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebContext.cpp:
(generateHTMLContent):
* Tools/TestWebKitAPI/cocoa/HTTPServer.mm:
(TestWebKitAPI::HTTPResponse::serialize const):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTR::dumpResourceURL):
(WTR::dumpErrorDescriptionSuitableForTestResult):
(WTR::dumpFrameScrollPosition):
(WTR::InjectedBundlePage::didReceiveTitleForFrame):
(WTR::InjectedBundlePage::willSendRequestForFrame):
(WTR::InjectedBundlePage::didReceiveResponseForResource):
(WTR::InjectedBundlePage::didFinishLoadForResource):
(WTR::InjectedBundlePage::didFailLoadForResource):
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp:
(WTR::attributesOfElement):
(WTR::AccessibilityUIElement::helpText const):
(WTR::AccessibilityUIElement::attributedStringForRange):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::findAndDumpWorldLeaks):
(WTR::TestController::decideDestinationWithSuggestedFilename):
(WTR::TestController::decidePolicyForNavigationAction):

Canonical link: <a href="https://commits.webkit.org/278348@main">https://commits.webkit.org/278348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3dac68541dd1babf9e09e73747a8511eb3795ad4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53518 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/949 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52562 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/587 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41008 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52358 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27218 "Found 1 new test failure: fast/forms/form-submission-crash-4.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22107 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/24635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/512 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8637 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43588 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/575 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55103 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49758 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25355 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/26618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43443 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27480 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57236 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7267 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/26348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11764 "Passed tests") | 
<!--EWS-Status-Bubble-End-->