### PR TITLE
Write data before creating mapping in mapToFile

### DIFF
--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -476,22 +476,44 @@ void finalizeMappedFileData(MappedFileData& mappedFileData, size_t bytesSize)
 
 MappedFileData mapToFile(const String& path, size_t bytesSize, Function<void(const Function<bool(std::span<const uint8_t>)>&)>&& apply, PlatformFileHandle* outputHandle)
 {
-    auto mappedFile = createMappedFileData(path, bytesSize, outputHandle);
-    if (!mappedFile)
+    constexpr bool failIfFileExists = true;
+    auto handle = FileSystem::openFile(path, FileSystem::FileOpenMode::ReadWrite, FileSystem::FileAccessPermission::User, failIfFileExists);
+
+    auto fileCloser = WTF::makeScopeExit([&handle]() {
+        FileSystem::closeFile(handle);
+    });
+
+    if (!FileSystem::isHandleValid(handle))
         return { };
 
-    void* map = const_cast<void*>(mappedFile.data());
-    uint8_t* mapData = static_cast<uint8_t*>(map);
+    if (!FileSystem::makeSafeToUseMemoryMapForPath(path))
+        return { };
 
-    apply([&mapData](std::span<const uint8_t> chunk) {
-        memcpy(mapData, chunk.data(), chunk.size());
-        mapData += chunk.size();
+    size_t totalBytesWritten = 0;
+    bool writeFailed = false;
+    apply([&](std::span<const uint8_t> chunk) {
+        auto bytesWritten = writeToFile(handle, chunk.data(), chunk.size());
+        if (bytesWritten < 0 || static_cast<size_t>(bytesWritten) != chunk.size()) {
+            writeFailed = true;
+            return false;
+        }
+        totalBytesWritten += bytesWritten;
         return true;
     });
 
-    finalizeMappedFileData(mappedFile, bytesSize);
+    if (writeFailed || totalBytesWritten > bytesSize || (totalBytesWritten < bytesSize && !FileSystem::truncateFile(handle, bytesSize)))
+        return { };
 
-    return mappedFile;
+    auto result = MappedFileData::create(handle, FileOpenMode::Read, MappedFileMode::Shared);
+    if (!result)
+        return { };
+
+    if (outputHandle) {
+        fileCloser.release();
+        *outputHandle = handle;
+    }
+
+    return WTFMove(*result);
 }
 
 static Salt makeSalt()


### PR DESCRIPTION
#### bfc5950efa54e2ea4957966af01147f4ff446718
<pre>
Write data before creating mapping in mapToFile
<a href="https://bugs.webkit.org/show_bug.cgi?id=273670">https://bugs.webkit.org/show_bug.cgi?id=273670</a>
<a href="https://rdar.apple.com/127472470">rdar://127472470</a>

Reviewed by NOBODY (OOPS!).

Currently FileSystem::mapToFile creates a mapping, memcpys data into it, and then msyncs the data
back to the file. The issue I see with this in profiles is that we are paging in data from the file
system at page fault time when doing the memcpy only to instantly discard that data by overwriting
it. We should probably just write the data out to the file and then create a mapping instead.

I did think about using writev instead of write here, but technically the semantics of
`dispatch_data_apply` don&apos;t allow that without changing the interface of `mapToFile`, which probably
isn&apos;t worth it.

* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::mapToFile):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfc5950efa54e2ea4957966af01147f4ff446718

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53409 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/841 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35666 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/555 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40926 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27118 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43159 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22023 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24542 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/410 "Found 1 new test failure: imported/w3c/web-platform-tests/editing/run/outdent.html?2001-last (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8528 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43479 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46533 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54992 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49649 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25247 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48324 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47351 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27371 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57128 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26240 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11739 "Passed tests") | 
<!--EWS-Status-Bubble-End-->