### PR TITLE
Remove ImageBufferBackend specific isOriginAtBottomLeftCorner

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -117,7 +117,7 @@ public:
     {
         return {
             BackendType::renderingMode,
-            BackendType::calculateBaseTransform(parameters, BackendType::isOriginAtBottomLeftCorner),
+            ImageBufferBackend::calculateBaseTransform(parameters),
             BackendType::calculateMemoryCost(parameters),
             BackendType::calculateExternalMemoryCost(parameters)
         };

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
@@ -139,17 +139,16 @@ void ImageBufferBackend::putPixelBuffer(const PixelBuffer& sourcePixelBuffer, co
     convertImagePixels(source, destination, destinationRect.size());
 }
 
-AffineTransform ImageBufferBackend::calculateBaseTransform(const Parameters& parameters, bool originAtBottomLeftCorner)
+AffineTransform ImageBufferBackend::calculateBaseTransform(const Parameters& parameters)
 {
     AffineTransform baseTransform;
-
-    if (originAtBottomLeftCorner) {
-        baseTransform.scale(1, -1);
-        baseTransform.translate(0, -parameters.backendSize.height());
-    }
-
+#if USE(CG)
+    // CoreGraphics origin is at bottom left corner. GraphicsContext origin is at top left corner. Flip the drawing with GraphicsContext base
+    // transform.
+    baseTransform.scale(1, -1);
+    baseTransform.translate(0, -parameters.backendSize.height());
+#endif
     baseTransform.scale(parameters.resolutionScale);
-
     return baseTransform;
 }
 

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -110,7 +110,7 @@ public:
 
     WEBCORE_EXPORT static size_t calculateMemoryCost(const IntSize& backendSize, unsigned bytesPerRow);
     static size_t calculateExternalMemoryCost(const Parameters&) { return 0; }
-    WEBCORE_EXPORT static AffineTransform calculateBaseTransform(const Parameters&, bool originAtBottomLeftCorner);
+    WEBCORE_EXPORT static AffineTransform calculateBaseTransform(const Parameters&);
 
     virtual GraphicsContext& context() = 0;
     virtual void flushContext() { }
@@ -145,9 +145,6 @@ public:
     virtual void setVolatilityState(VolatilityState) { }
 
     virtual std::unique_ptr<ThreadSafeImageBufferFlusher> createFlusher() { return nullptr; }
-
-    static constexpr bool isOriginAtBottomLeftCorner = false;
-    virtual bool originAtBottomLeftCorner() const { return isOriginAtBottomLeftCorner; }
 
     static constexpr RenderingMode renderingMode = RenderingMode::Unaccelerated;
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
@@ -70,15 +70,10 @@ std::unique_ptr<ThreadSafeImageBufferFlusher> ImageBufferCGBackend::createFlushe
 
 ImageBufferCGBackend::~ImageBufferCGBackend() = default;
 
-bool ImageBufferCGBackend::originAtBottomLeftCorner() const
-{
-    return isOriginAtBottomLeftCorner;
-}
-
 void ImageBufferCGBackend::applyBaseTransform(GraphicsContextCG& context) const
 {
     context.applyDeviceScaleFactor(m_parameters.resolutionScale);
-    context.setCTM(calculateBaseTransform(m_parameters, originAtBottomLeftCorner()));
+    context.setCTM(calculateBaseTransform(m_parameters));
 }
 
 String ImageBufferCGBackend::debugDescription() const

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
@@ -39,7 +39,6 @@ class WEBCORE_EXPORT ImageBufferCGBackend : public ImageBufferBackend {
 public:
     ~ImageBufferCGBackend() override;
     static unsigned calculateBytesPerRow(const IntSize& backendSize);
-    static constexpr bool isOriginAtBottomLeftCorner = true;
 
 protected:
     using ImageBufferBackend::ImageBufferBackend;
@@ -49,7 +48,6 @@ protected:
 
     String debugDescription() const override;
 
-    bool originAtBottomLeftCorner() const override;
     mutable std::unique_ptr<GraphicsContextCG> m_context;
 };
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -200,15 +200,9 @@ std::unique_ptr<RemoteDisplayListRecorderProxy> RemoteRenderingBackendProxy::cre
     ASSERT(WebProcess::singleton().shouldUseRemoteRenderingFor(RenderingPurpose::DOM));
     ImageBufferParameters parameters { size, resolutionScale, colorSpace, pixelFormat, purpose };
     auto renderingMode = RenderingMode::Unaccelerated;
-    auto transform = ImageBufferBackend::calculateBaseTransform(ImageBuffer::backendParameters(parameters), ImageBufferShareableBitmapBackend::isOriginAtBottomLeftCorner);
-
-#if HAVE(IOSURFACE)
-    if (options.contains(ImageBufferOptions::Accelerated)) {
+    auto transform = ImageBufferBackend::calculateBaseTransform(ImageBuffer::backendParameters(parameters));
+    if (options.contains(ImageBufferOptions::Accelerated))
         renderingMode = RenderingMode::Accelerated;
-        transform = ImageBufferBackend::calculateBaseTransform(ImageBuffer::backendParameters(parameters), ImageBufferRemoteIOSurfaceBackend::isOriginAtBottomLeftCorner);
-    }
-#endif
-
     return makeUnique<RemoteDisplayListRecorderProxy>(*this, renderingResourceIdentifier, colorSpace, renderingMode, FloatRect { { }, size }, transform);
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
@@ -50,7 +50,6 @@ public:
     {
     }
 
-    static constexpr bool isOriginAtBottomLeftCorner = true;
     static constexpr WebCore::RenderingMode renderingMode = WebCore::RenderingMode::Accelerated;
     bool canMapBackingStore() const final;
 
@@ -64,8 +63,6 @@ private:
 
     void getPixelBuffer(const WebCore::IntRect&, WebCore::PixelBuffer&) final;
     void putPixelBuffer(const WebCore::PixelBuffer&, const WebCore::IntRect& srcRect, const WebCore::IntPoint& destPoint, WebCore::AlphaPremultiplication destFormat) final;
-
-    bool originAtBottomLeftCorner() const final { return isOriginAtBottomLeftCorner; }
 
     unsigned bytesPerRow() const final;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h
@@ -50,12 +50,10 @@ public:
     ~ImageBufferShareableMappedIOSurfaceBitmapBackend();
 
     static constexpr WebCore::RenderingMode renderingMode = WebCore::RenderingMode::Accelerated;
-    static constexpr bool isOriginAtBottomLeftCorner = true;
     bool canMapBackingStore() const final;
 
     std::optional<ImageBufferBackendHandle> createBackendHandle(WebCore::SharedMemory::Protection = WebCore::SharedMemory::Protection::ReadWrite) const final;
     WebCore::GraphicsContext& context() final;
-    bool originAtBottomLeftCorner() const override { return isOriginAtBottomLeftCorner; }
 private:
     // ImageBufferBackendSharing
     ImageBufferBackendSharing* toBackendSharing() final { return this; }


### PR DESCRIPTION
#### af6077a91bf70410b102ca95b0fdf0f35245a163
<pre>
Remove ImageBufferBackend specific isOriginAtBottomLeftCorner
<a href="https://bugs.webkit.org/show_bug.cgi?id=273676">https://bugs.webkit.org/show_bug.cgi?id=273676</a>
<a href="https://rdar.apple.com/127480089">rdar://127480089</a>

Reviewed by Simon Fraser.

GraphicsContext has its origin at the top left corner. Currently Cocoa
CG is the only one using
ImageBufferBackendSubclass::originAtBottomLeftCorner == true. Currently
Cocoa does not have any other GraphicsContexts than CG. Hardcode the
logic into ImageBufferBackend. This way the base transform can be
computed without knowing which type backend is. This is needed for
RemoteImageBufferProxy construction, where the backend, currently, is
obtained only after GPUP has decided which backend worked.

This is work towards removeing the
RemoteImageBufferProxy::create&lt;Backend&gt; template parameter. That is work
towards being able to fix deadlocks wrt. cross-thread ImageBuffer use in
GPUP.

* Source/WebCore/platform/graphics/ImageBuffer.h:
(WebCore::ImageBuffer::populateBackendInfo):
* Source/WebCore/platform/graphics/ImageBufferBackend.cpp:
(WebCore::ImageBufferBackend::calculateBaseTransform):
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::originAtBottomLeftCorner const): Deleted.
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp:
(WebCore::ImageBufferCGBackend::applyBaseTransform const):
(WebCore::ImageBufferCGBackend::originAtBottomLeftCorner const): Deleted.
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::createDisplayListRecorder):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h:

Canonical link: <a href="https://commits.webkit.org/278505@main">https://commits.webkit.org/278505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99b0d29ecd5f7d55d1ec5f5f0692912590c63252

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50607 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2921 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53866 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1297 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52910 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/948 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41262 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52706 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27554 "") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43584 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22374 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24944 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/842 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9047 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46930 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55455 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25708 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/809 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48667 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26966 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43731 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47723 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11126 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27832 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26698 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->