### PR TITLE
[GLIB] Simplify the GTlsCertificate argument coders

### DIFF
--- a/Source/WebKit/Shared/glib/ArgumentCodersGLib.h
+++ b/Source/WebKit/Shared/glib/ArgumentCodersGLib.h
@@ -35,6 +35,11 @@ typedef struct _GVariant GVariant;
 
 namespace IPC {
 
+template<> struct ArgumentCoder<GRefPtr<GByteArray>> {
+    static void encode(Encoder&, const GRefPtr<GByteArray>&);
+    static std::optional<GRefPtr<GByteArray>> decode(Decoder&);
+};
+
 template<> struct ArgumentCoder<GRefPtr<GVariant>> {
     static void encode(Encoder&, const GRefPtr<GVariant>&);
     static std::optional<GRefPtr<GVariant>> decode(Decoder&);


### PR DESCRIPTION
#### 86235681dd54e9723d90a56cf1f5bfbdb5a94cf9
<pre>
[GLIB] Simplify the GTlsCertificate argument coders
<a href="https://bugs.webkit.org/show_bug.cgi?id=273677">https://bugs.webkit.org/show_bug.cgi?id=273677</a>

Reviewed by Michael Catanzaro.

Instead of handcoding the certificate chain, use a Vector directly, which
has coding support already. Similarly, instead of handcoding GByteArray structs
in a handful of different places, add an argument coder for GByteArray and use it
where needed.

* Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp:
(IPC::ArgumentCoder&lt;GRefPtr&lt;GByteArray&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GByteArray&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GTlsCertificate&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GTlsCertificate&gt;&gt;::decode):
* Source/WebKit/Shared/glib/ArgumentCodersGLib.h:

Canonical link: <a href="https://commits.webkit.org/278316@main">https://commits.webkit.org/278316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6caeaf7afaaab067067a7f3108aee4a916cfe949

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2479 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53443 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/875 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40952 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52284 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43191 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22050 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24575 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8563 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46562 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/503 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55026 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25281 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48351 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26542 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43376 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47366 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27405 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7249 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26274 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->