### PR TITLE
ImageBuffer should not have canMapBackingStore

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -117,7 +117,6 @@ public:
     {
         return {
             BackendType::renderingMode,
-            BackendType::canMapBackingStore,
             BackendType::calculateBaseTransform(parameters, BackendType::isOriginAtBottomLeftCorner),
             BackendType::calculateMemoryCost(parameters),
             BackendType::calculateExternalMemoryCost(parameters)
@@ -162,7 +161,6 @@ public:
     const Parameters& parameters() const { return m_parameters; }
 
     RenderingMode renderingMode() const { return m_backendInfo.renderingMode; }
-    bool canMapBackingStore() const { return m_backendInfo.canMapBackingStore; }
     AffineTransform baseTransform() const { return m_backendInfo.baseTransform; }
     size_t memoryCost() const { return m_backendInfo.memoryCost; }
     size_t externalMemoryCost() const { return m_backendInfo.externalMemoryCost; }

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -101,7 +101,6 @@ public:
 
     struct Info {
         RenderingMode renderingMode;
-        bool canMapBackingStore;
         AffineTransform baseTransform;
         size_t memoryCost;
         size_t externalMemoryCost;
@@ -150,9 +149,9 @@ public:
     static constexpr bool isOriginAtBottomLeftCorner = false;
     virtual bool originAtBottomLeftCorner() const { return isOriginAtBottomLeftCorner; }
 
-    static constexpr bool canMapBackingStore = true;
     static constexpr RenderingMode renderingMode = RenderingMode::Unaccelerated;
 
+    virtual bool canMapBackingStore() const = 0;
     virtual void ensureNativeImagesHaveCopiedBackingStore() { }
 
     virtual ImageBufferBackendSharing* toBackendSharing() { return nullptr; }

--- a/Source/WebCore/platform/graphics/NullImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/NullImageBufferBackend.cpp
@@ -68,6 +68,11 @@ unsigned NullImageBufferBackend::bytesPerRow() const
     return 0;
 }
 
+bool NullImageBufferBackend::canMapBackingStore() const
+{
+    return false;
+}
+
 String NullImageBufferBackend::debugDescription() const
 {
     TextStream stream;

--- a/Source/WebCore/platform/graphics/NullImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/NullImageBufferBackend.h
@@ -46,6 +46,7 @@ public:
     RefPtr<NativeImage> createNativeImageReference() final;
     void getPixelBuffer(const IntRect&, PixelBuffer&) final;
     void putPixelBuffer(const PixelBuffer&, const IntRect&, const IntPoint&, AlphaPremultiplication) final;
+    bool canMapBackingStore() const final;
     String debugDescription() const final;
 
 protected:

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp
@@ -79,6 +79,11 @@ RefPtr<NativeImage> ImageBufferCairoSurfaceBackend::createNativeImageReference()
     return NativeImage::create(RefPtr { m_surface.get() });
 }
 
+bool ImageBufferCairoSurfaceBackend::canMapBackingStore() const
+{
+    return true;
+}
+
 RefPtr<cairo_surface_t> ImageBufferCairoSurfaceBackend::createCairoSurface()
 {
     return RefPtr { m_surface.get() };

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.h
@@ -43,8 +43,8 @@ public:
     RefPtr<NativeImage> copyNativeImage() override;
     RefPtr<NativeImage> createNativeImageReference() override;
 
+    bool canMapBackingStore() const final;
     RefPtr<cairo_surface_t> createCairoSurface() override;
-
     void getPixelBuffer(const IntRect&, PixelBuffer&) override;
     void putPixelBuffer(const PixelBuffer&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat) override;
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
@@ -117,6 +117,11 @@ unsigned ImageBufferCGBitmapBackend::bytesPerRow() const
     return calculateBytesPerRow(m_parameters.backendSize);
 }
 
+bool ImageBufferCGBitmapBackend::canMapBackingStore() const
+{
+    return true;
+}
+
 RefPtr<NativeImage> ImageBufferCGBitmapBackend::copyNativeImage()
 {
     return NativeImage::create(adoptCF(CGBitmapContextCreateImage(context().platformContext())));

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h
@@ -43,7 +43,7 @@ public:
     static size_t calculateMemoryCost(const Parameters&);
 
     static std::unique_ptr<ImageBufferCGBitmapBackend> create(const Parameters&, const ImageBufferCreationContext&);
-
+    bool canMapBackingStore() const final;
     GraphicsContext& context() final;
 
 private:

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -199,6 +199,11 @@ void ImageBufferIOSurfaceBackend::putPixelBuffer(const PixelBuffer& pixelBuffer,
         ImageBufferBackend::putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat, lock->surfaceBaseAddress());
 }
 
+bool ImageBufferIOSurfaceBackend::canMapBackingStore() const
+{
+    return true;
+}
+
 IOSurface* ImageBufferIOSurfaceBackend::surface()
 {
     prepareForExternalWrite(); // This is conservative. At the time of writing this is not used.

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
@@ -49,6 +49,7 @@ public:
     ~ImageBufferIOSurfaceBackend();
     
     static constexpr RenderingMode renderingMode = RenderingMode::Accelerated;
+    bool canMapBackingStore() const final;
 
     IOSurface* surface() override;
     GraphicsContext& context() override;

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
@@ -110,6 +110,11 @@ ImageBufferShareableBitmapBackend::ImageBufferShareableBitmapBackend(const Param
     m_context->applyDeviceScaleFactor(resolutionScale());
 }
 
+bool ImageBufferShareableBitmapBackend::canMapBackingStore() const
+{
+    return true;
+}
+
 std::optional<ImageBufferBackendHandle> ImageBufferShareableBitmapBackend::createBackendHandle(SharedMemory::Protection protection) const
 {
     if (auto handle = m_bitmap->createHandle(protection))

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h
@@ -66,6 +66,7 @@ public:
 
     ImageBufferShareableBitmapBackend(const Parameters&, Ref<WebCore::ShareableBitmap>&&, std::unique_ptr<WebCore::GraphicsContext>&&);
 
+    bool canMapBackingStore() const final;
     WebCore::GraphicsContext& context() final { return *m_context; }
 
     std::optional<ImageBufferBackendHandle> createBackendHandle(WebCore::SharedMemory::Protection = WebCore::SharedMemory::Protection::ReadWrite) const final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -163,6 +163,13 @@ void RemoteRenderingBackendProxy::createRemoteImageBuffer(ImageBuffer& imageBuff
     send(Messages::RemoteRenderingBackend::CreateImageBuffer(imageBuffer.logicalSize(), imageBuffer.renderingMode(), imageBuffer.renderingPurpose(), imageBuffer.resolutionScale(), imageBuffer.colorSpace(), imageBuffer.pixelFormat(), imageBuffer.renderingResourceIdentifier()));
 }
 
+bool RemoteRenderingBackendProxy::canMapRemoteImageBufferBackendBackingStore()
+{
+    // When DOM rendering happens in WebContent process, we need to paint 2D contexts
+    // into the tiles. In this case ImageBuffers should be created as mappable.
+    return !WebProcess::singleton().shouldUseRemoteRenderingFor(RenderingPurpose::DOM);
+}
+
 RefPtr<ImageBuffer> RemoteRenderingBackendProxy::createImageBuffer(const FloatSize& size, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, PixelFormat pixelFormat, OptionSet<ImageBufferOptions> options)
 {
     RefPtr<ImageBuffer> imageBuffer;
@@ -171,10 +178,7 @@ RefPtr<ImageBuffer> RemoteRenderingBackendProxy::createImageBuffer(const FloatSi
 
 #if HAVE(IOSURFACE)
     if (options.contains(ImageBufferOptions::Accelerated)) {
-        // Unless DOM rendering is always enabled when any GPU process rendering is enabled,
-        // we need to create ImageBuffers for e.g. Canvas that are actually mapped into the
-        // Web Content process, so they can be painted into the tiles.
-        if (!WebProcess::singleton().shouldUseRemoteRenderingFor(RenderingPurpose::DOM))
+        if (canMapRemoteImageBufferBackendBackingStore())
             imageBuffer = RemoteImageBufferProxy::create<ImageBufferShareableMappedIOSurfaceBackend>(size, resolutionScale, colorSpace, pixelFormat, purpose, *this, avoidBackendSizeCheckForTesting);
         else
             imageBuffer = RemoteImageBufferProxy::create<ImageBufferRemoteIOSurfaceBackend>(size, resolutionScale, colorSpace, pixelFormat, purpose, *this, avoidBackendSizeCheckForTesting);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -93,6 +93,8 @@ public:
 
     ~RemoteRenderingBackendProxy();
 
+    static bool canMapRemoteImageBufferBackendBackingStore();
+
     const RemoteRenderingBackendCreationParameters& parameters() const { return m_parameters; }
 
     RemoteResourceCacheProxy& remoteResourceCacheProxy() { return m_remoteResourceCacheProxy; }

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
@@ -90,6 +90,11 @@ void ImageBufferRemoteIOSurfaceBackend::clearBackendHandle()
     m_handle = { };
 }
 
+bool ImageBufferRemoteIOSurfaceBackend::canMapBackingStore() const
+{
+    return false;
+}
+
 GraphicsContext& ImageBufferRemoteIOSurfaceBackend::context()
 {
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
@@ -51,8 +51,8 @@ public:
     }
 
     static constexpr bool isOriginAtBottomLeftCorner = true;
-    static constexpr bool canMapBackingStore = false;
     static constexpr WebCore::RenderingMode renderingMode = WebCore::RenderingMode::Accelerated;
+    bool canMapBackingStore() const final;
 
     WebCore::GraphicsContext& context() final;
     std::optional<ImageBufferBackendHandle> createBackendHandle(WebCore::SharedMemory::Protection = WebCore::SharedMemory::Protection::ReadWrite) const final;

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp
@@ -74,6 +74,11 @@ ImageBufferShareableMappedIOSurfaceBitmapBackend::~ImageBufferShareableMappedIOS
     IOSurface::moveToPool(WTFMove(m_surface), m_ioSurfacePool.get());
 }
 
+bool ImageBufferShareableMappedIOSurfaceBitmapBackend::canMapBackingStore() const
+{
+    return true;
+}
+
 std::optional<ImageBufferBackendHandle> ImageBufferShareableMappedIOSurfaceBitmapBackend::createBackendHandle(SharedMemory::Protection) const
 {
     return ImageBufferBackendHandle(m_surface->createSendRight());

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h
@@ -51,6 +51,7 @@ public:
 
     static constexpr WebCore::RenderingMode renderingMode = WebCore::RenderingMode::Accelerated;
     static constexpr bool isOriginAtBottomLeftCorner = true;
+    bool canMapBackingStore() const final;
 
     std::optional<ImageBufferBackendHandle> createBackendHandle(WebCore::SharedMemory::Protection = WebCore::SharedMemory::Protection::ReadWrite) const final;
     WebCore::GraphicsContext& context() final;


### PR DESCRIPTION
#### 8d2e51d04796823702b47e48943d3dd735d67eae
<pre>
ImageBuffer should not have canMapBackingStore
<a href="https://bugs.webkit.org/show_bug.cgi?id=273678">https://bugs.webkit.org/show_bug.cgi?id=273678</a>
<a href="https://rdar.apple.com/127482725">rdar://127482725</a>

Reviewed by Simon Fraser.

The &quot;canMapBackingStore&quot; information is used only in
RemoteImageBufferProxy. Also, currently it is based on the backend type,
but the correct backend type is not known at the creation time. Move it
to ImageBufferBackend virtual function for now.

This is work towards removing the
RemoteImageBufferProxy::create&lt;Backend&gt; template parameter. That is work
towards being able to fix deadlocks wrt. cross-thread ImageBuffer use in
GPUP.

* Source/WebCore/platform/graphics/ImageBuffer.h:
(WebCore::ImageBuffer::populateBackendInfo):
(WebCore::ImageBuffer::renderingMode const):
(WebCore::ImageBuffer::canMapBackingStore const): Deleted.
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
* Source/WebCore/platform/graphics/NullImageBufferBackend.cpp:
(WebCore::NullImageBufferBackend::canMapBackingStore const):
* Source/WebCore/platform/graphics/NullImageBufferBackend.h:
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp:
(WebCore::ImageBufferCairoSurfaceBackend::canMapBackingStore const):
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp:
(WebCore::ImageBufferCGBitmapBackend::canMapBackingStore const):
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::canMapBackingStore const):
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferSqhareableBitmapBackend.cpp:
(WebKit::ImageBufferShareableBitmapBackend::canMapBackingStore const):
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::didCreateBackend):
Avoid using canMapBackingStore(), as that is property of the backing store.
If the ImageBuffer has not received a backing store, this would reflect
the case what the create() caller expected to ask. In this case, it would
be same as the shouldMapAcceleratedImageBufferBackend().

(WebKit::RemoteImageBufferProxy::copyNativeImage const):
(WebKit::RemoteImageBufferProxy::createNativeImageReference const):
(WebKit::RemoteImageBufferProxy::getPixelBuffer const):
(WebKit::RemoteImageBufferProxy::putPixelBuffer):
(WebKit::RemoteImageBufferProxy::prepareForBackingStoreChange):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::canMapRemoteImageBufferBackendBackingStore):
(WebKit::RemoteRenderingBackendProxy::createImageBuffer):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp:
(WebKit::ImageBufferRemoteIOSurfaceBackend::canMapBackingStore const):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp:
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::canMapBackingStore const):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h:

Canonical link: <a href="https://commits.webkit.org/278445@main">https://commits.webkit.org/278445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bddda3530e1019490e1c943df52e324061d0151

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53507 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/938 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52551 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41000 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43250 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22099 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24624 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/502 "Passed tests") | [❌ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8626 "Hash 2bddda35 for PR 28089 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46610 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/564 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55092 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25344 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/498 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48406 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26606 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43434 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47429 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11075 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27469 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26337 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->