### PR TITLE
[WebGPU] UAF in GPUBuffer::getMappedRange

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1783,15 +1783,16 @@ webkit.org/b/263396 css3/color/text.html [ Skip ]
 
 # WebGPU
 
-[ Release ] http/tests/webgpu/webgpu/api/operation/buffers/map.html [ Pass ]
+http/tests/webgpu/webgpu/api/operation/buffers/map.html [ Pass ]
+# skipped debug due to https://bugs.webkit.org/show_bug.cgi?id=273716
 [ Release ] http/tests/webgpu/webgpu/api/operation/buffers/map_ArrayBuffer.html [ Pass ]
-[ Release ] http/tests/webgpu/webgpu/api/operation/buffers/map_detach.html [ Pass ]
-[ Release ] http/tests/webgpu/webgpu/api/operation/buffers/map_oom.html [ Pass ]
-[ Release ] http/tests/webgpu/webgpu/api/operation/buffers/threading.html [ Pass ]
+http/tests/webgpu/webgpu/api/operation/buffers/map_detach.html [ Pass ]
+http/tests/webgpu/webgpu/api/operation/buffers/map_oom.html [ Pass ]
+http/tests/webgpu/webgpu/api/operation/buffers/threading.html [ Pass ]
 
-[ Release ] http/tests/webgpu/webgpu/api/validation/buffer/create.html [ Pass ]
-[ Release ] http/tests/webgpu/webgpu/api/validation/buffer/destroy.html [ Pass ]
-[ Release ] http/tests/webgpu/webgpu/api/validation/buffer/mapping.html [ Pass ]
+http/tests/webgpu/webgpu/api/validation/buffer/create.html [ Pass ]
+http/tests/webgpu/webgpu/api/validation/buffer/destroy.html [ Pass ]
+http/tests/webgpu/webgpu/api/validation/buffer/mapping.html [ Pass ]
 
 # Skip tests until they can be validated to consistently pass in EWS
 http/tests/webgpu/webgpu/idl/constructable.html [ Skip ]

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.cpp
@@ -70,7 +70,7 @@ void BufferImpl::mapAsync(MapModeFlags mapModeFlags, Size64 offset, std::optiona
     wgpuBufferMapAsync(m_backing.get(), backingMapModeFlags, static_cast<size_t>(offset), static_cast<size_t>(usedSize), &mapAsyncCallback, Block_copy(blockPtr.get())); // Block_copy is matched with Block_release above in mapAsyncCallback().
 }
 
-auto BufferImpl::getMappedRange(Size64 offset, std::optional<Size64> size) -> MappedRange
+void BufferImpl::getMappedRange(Size64 offset, std::optional<Size64> size, Function<void(MappedRange)>&& callback)
 {
     auto usedSize = getMappedSize(m_backing.get(), size, offset);
 
@@ -80,7 +80,7 @@ auto BufferImpl::getMappedRange(Size64 offset, std::optional<Size64> size) -> Ma
     auto bufferSize = wgpuBufferGetSize(m_backing.get());
     size_t actualSize = pointer ? static_cast<size_t>(bufferSize) : 0;
     size_t actualOffset = pointer ? static_cast<size_t>(offset) : 0;
-    return { static_cast<uint8_t*>(pointer) - actualOffset, actualSize };
+    callback({ static_cast<uint8_t*>(pointer) - actualOffset, actualSize });
 }
 
 auto BufferImpl::getBufferContents() -> MappedRange

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.h
@@ -59,7 +59,7 @@ private:
     WGPUBuffer backing() const { return m_backing.get(); }
 
     void mapAsync(MapModeFlags, Size64 offset, std::optional<Size64> sizeForMap, CompletionHandler<void(bool)>&&) final;
-    MappedRange getMappedRange(Size64 offset, std::optional<Size64>) final;
+    void getMappedRange(Size64 offset, std::optional<Size64>, Function<void(MappedRange)>&&) final;
     MappedRange getBufferContents() final;
     void unmap() final;
     void copy(Vector<uint8_t>&&, size_t) final;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h
@@ -54,7 +54,7 @@ public:
         uint8_t* source { nullptr };
         size_t byteLength { 0 };
     };
-    virtual MappedRange getMappedRange(Size64 offset, std::optional<Size64>) = 0;
+    virtual void getMappedRange(Size64 offset, std::optional<Size64>, Function<void(MappedRange)>&&) = 0;
     virtual void unmap() = 0;
 
     virtual void destroy() = 0;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
@@ -71,10 +71,11 @@ void RemoteBuffer::mapAsync(WebCore::WebGPU::MapModeFlags mapModeFlags, WebCore:
 
 void RemoteBuffer::getMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&& callback)
 {
-    auto mappedRange = m_backing->getMappedRange(offset, size);
-    m_isMapped = true;
+    m_backing->getMappedRange(offset, size, [&] (auto mappedRange) {
+        m_isMapped = true;
 
-    callback(Vector(std::span { static_cast<const uint8_t*>(mappedRange.source), mappedRange.byteLength }));
+        callback(Vector(std::span { static_cast<const uint8_t*>(mappedRange.source), mappedRange.byteLength }));
+    });
 }
 
 void RemoteBuffer::unmap()

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
@@ -79,7 +79,7 @@ private:
     }
 
     void mapAsync(WebCore::WebGPU::MapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> sizeForMap, CompletionHandler<void(bool)>&&) final;
-    MappedRange getMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64>) final;
+    void getMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64>, Function<void(MappedRange)>&&) final;
     MappedRange getBufferContents() final;
     void unmap() final;
     void copy(Vector<uint8_t>&&, size_t offset) final;


### PR DESCRIPTION
#### cf23d24d68de75c5442ae4d356af363131335bd9
<pre>
[WebGPU] UAF in GPUBuffer::getMappedRange
<a href="https://bugs.webkit.org/show_bug.cgi?id=273685">https://bugs.webkit.org/show_bug.cgi?id=273685</a>
&lt;radar://127490690&gt;

Reviewed by Dan Glastonbury.

Fix UAF by using a callback and update test expectations to run
in Debug which would have likely caught this issue.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/Modules/WebGPU/GPUBuffer.cpp:
(WebCore::GPUBuffer::getMappedRange):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.cpp:
(WebCore::WebGPU::BufferImpl::getMappedRange):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp:
(WebKit::WebGPU::RemoteBufferProxy::getMappedRange):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h:

Canonical link: <a href="https://commits.webkit.org/278392@main">https://commits.webkit.org/278392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b482d5e8f8bf039a3365844ae43b634866c523c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53583 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1014 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52627 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/662 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41050 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43315 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22154 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24683 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/569 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8702 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46668 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/633 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55169 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25420 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/561 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48456 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43498 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47488 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11053 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27545 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26413 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->