### PR TITLE
[Navigation] Dispatch NavigateEvent on reload

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7433,7 +7433,6 @@ imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-requ
 imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/ [ Skip ]
 
 # These failures include UUIDs that change every run.
-imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-reload.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-replace-cross-origin.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-replace-same-document.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-replace.html [ Failure ]
@@ -7445,7 +7444,6 @@ imported/w3c/web-platform-tests/navigation-api/navigation-methods/back-forward-m
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-state-repeated-await.html [ Timeout Failure Pass ]
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-204-205-download.html [ Failure Pass ]
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-detach-in-onnavigate.html [ Crash Pass Failure ]
-imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-pagehide-unserializablestate.html [ Failure Pass ]
 imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reentrant.html?currententrychange [ Failure Pass ]
 imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reentrant.html?no-currententrychange [ Failure Pass ]
 imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reject.html?currententrychange [ Failure Pass ]

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-reload-intercept-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-reload-intercept-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL currententrychange fires for navigation.reload() intercepted by intercept() assert_true: expected true got false
+PASS currententrychange fires for navigation.reload() intercepted by intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-reload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-reload-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL navigate event destination.getState() on location.reload() assert_not_equals: got disallowed value undefined
+PASS navigate event destination.getState() on location.reload()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-reload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-reload-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL NavigationHistoryEntry's key and id after location.reload() assert_equals: expected "dc17d31f-282e-4b1c-bd3d-b76a69dcd382" but got "3bf32a01-b088-40e6-ae3c-5967c1dff230"
+PASS NavigationHistoryEntry's key and id after location.reload()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-info-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-info-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL reload() variant with only info assert_true: expected true got false
+PASS reload() variant with only info
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-no-args-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-no-args-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL reload() variant with no state or info assert_true: expected true got false
+PASS reload() variant with no state or info
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-state-and-info-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-state-and-info-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT reload() variant with info and new state Test timed out
+PASS reload() variant with info and new state
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-state-undefined-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-state-undefined-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT reload() variant with info and state: undefined counts the same as not present (because of Web IDL dictionary semantics), so preserves the state Test timed out
+PASS reload() variant with info and state: undefined counts the same as not present (because of Web IDL dictionary semantics), so preserves the state
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-detach-in-onnavigate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-detach-in-onnavigate-expected.txt
@@ -1,6 +1,3 @@
 
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT reload() promise rejections when detaching an iframe inside onnavigate Test timed out
+PASS reload() promise rejections when detaching an iframe inside onnavigate
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-intercept-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-intercept-expected.txt
@@ -1,3 +1,3 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+PASS reload() and intercept() with a fulfilled promise
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-intercept-rejected-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-intercept-rejected-expected.txt
@@ -1,3 +1,3 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+PASS reload() and intercept() with a rejected promise
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-preventDefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-preventDefault-expected.txt
@@ -1,3 +1,3 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+PASS reload() when the onnavigate handler calls preventDefault()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-unload-unserializablestate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-unload-unserializablestate-expected.txt
@@ -1,4 +1,0 @@
-
-
-FAIL reload() with an unserializable state inside onunload throws "DataCloneError", not "InvalidStateError" assert_equals: expected 1 but got 0
-

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-reload-with-intercept-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-reload-with-intercept-expected.txt
@@ -1,3 +1,3 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+PASS dispose events are not fired when doing a same-document reload using navigation.reload() and intercept()
 

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -73,6 +73,7 @@ class FormSubmission;
 class FrameLoadRequest;
 class FrameNetworkingContext;
 class HistoryItem;
+class LocalDOMWindow;
 class LocalFrameLoaderClient;
 class NavigationAction;
 class NetworkingContext;
@@ -93,7 +94,6 @@ enum class UsedLegacyTLS : bool;
 enum class WasPrivateRelayed : bool;
 enum class IsMainResource : bool { No, Yes };
 enum class ShouldUpdateAppInitiatedValue : bool { No, Yes };
-enum class NavigationNavigationType : uint8_t;
 
 struct WindowFeatures;
 
@@ -241,7 +241,7 @@ public:
     void didExplicitOpen();
 
     // Callbacks from DocumentWriter
-    void didBeginDocument(bool dispatchWindowObjectAvailable);
+    void didBeginDocument(bool dispatchWindowObjectAvailable, LocalDOMWindow* previousWindow);
 
     void receivedFirstData();
 
@@ -457,10 +457,9 @@ private:
     void clearProvisionalLoadForPolicyCheck();
     bool hasOpenedFrames() const;
 
-    void updateNavigationAPIEntries(std::optional<NavigationNavigationType>);
     void updateRequestAndAddExtraFields(Frame&, ResourceRequest&, IsMainResource, FrameLoadType, ShouldUpdateAppInitiatedValue, IsServiceWorkerNavigationLoad, WillOpenInNewWindow, Document*);
 
-    bool dispatchNavigateEvent(const URL& newURL, FrameLoadType, const NavigationAction&, NavigationHistoryBehavior, bool isSameDocument, FormState* = nullptr);
+    bool dispatchNavigateEvent(const URL& newURL, FrameLoadType, const AtomString&, NavigationHistoryBehavior, bool isSameDocument, FormState* = nullptr, SerializedScriptValue* classicHistoryAPIState = nullptr);
 
     WeakRef<LocalFrame> m_frame;
     UniqueRef<LocalFrameLoaderClient> m_client;

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -126,7 +126,7 @@ public:
     bool canGoBack() const;
     bool canGoForward() const;
 
-    void initializeEntries(Ref<HistoryItem>&& currentItem, Vector<Ref<HistoryItem>>& items);
+    void initializeForNewWindow(std::optional<NavigationNavigationType>, LocalDOMWindow* previousWindow);
 
     Result navigate(const String& url, NavigateOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
 

--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -45,7 +45,8 @@ public:
     using RefCounted<NavigationHistoryEntry>::ref;
     using RefCounted<NavigationHistoryEntry>::deref;
 
-    static Ref<NavigationHistoryEntry> create(ScriptExecutionContext* context, Ref<HistoryItem>&& historyItem) { return adoptRef(*new NavigationHistoryEntry(context, WTFMove(historyItem))); }
+    static Ref<NavigationHistoryEntry> create(ScriptExecutionContext* context, Ref<HistoryItem>&& historyItem) { return adoptRef(*new NavigationHistoryEntry(context, WTFMove(historyItem), historyItem->urlString())); }
+    static Ref<NavigationHistoryEntry> create(ScriptExecutionContext*, const NavigationHistoryEntry&);
 
     const String& url() const;
     String key() const;
@@ -59,7 +60,7 @@ public:
     HistoryItem& associatedHistoryItem() const { return m_associatedHistoryItem; }
 
 private:
-    NavigationHistoryEntry(ScriptExecutionContext*, Ref<HistoryItem>&&);
+    NavigationHistoryEntry(ScriptExecutionContext*, Ref<HistoryItem>&&, String urlString, RefPtr<SerializedScriptValue>&& state = { }, WTF::UUID key = WTF::UUID::createVersion4(), WTF::UUID = WTF::UUID::createVersion4());
 
     enum EventTargetInterfaceType eventTargetInterface() const final;
     ScriptExecutionContext* scriptExecutionContext() const final;
@@ -67,7 +68,9 @@ private:
     void derefEventTarget() final { deref(); }
 
     const String m_urlString;
+    const WTF::UUID m_key;
     const WTF::UUID m_id;
+    RefPtr<SerializedScriptValue> m_state;
     Ref<HistoryItem> m_associatedHistoryItem;
 };
 


### PR DESCRIPTION
#### 76a11dfefffc787445970c5150db31e82cca32de
<pre>
[Navigation] Dispatch NavigateEvent on reload
<a href="https://bugs.webkit.org/show_bug.cgi?id=273688">https://bugs.webkit.org/show_bug.cgi?id=273688</a>

Reviewed by Alex Christensen.

Various kinds of reloads, such as navigation.reload() and location.reload() need to dispatch the NavigateEvent [1]. Since a reload triggered
by browser UI (i.e. clicking the reload button on the crome UI) should not dispatch the NavigateEvent, put the logic in FrameLoader::loadFrameRequest
and not in FrameLoader::reload. And for the same reason, make Navigation::reload go through FrameLoader::changeLocation and thus FrameLoader::loadFrameRequest.

This PR also introduces logic to deal with a reload causing an existing window, and matching navigation, to be discarded in favour of a new window and navigation
combination, in that case we have to copy over the navigation entries from the previous Navigation instance.

[1] <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#reloading-and-traversing">https://html.spec.whatwg.org/multipage/browsing-the-web.html#reloading-and-traversing</a>:fire-a-push/replace/reload-navigate-event

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-reload-intercept-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-reload-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-reload-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-info-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-no-args-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-state-and-info-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-state-undefined-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-detach-in-onnavigate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-intercept-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-intercept-rejected-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-preventDefault-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-unload-unserializablestate-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-reload-with-intercept-expected.txt:
* Source/WebCore/loader/DocumentWriter.cpp:
(WebCore::DocumentWriter::begin):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::didBeginDocument):
(WebCore::FrameLoader::loadFrameRequest):
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::loadPostRequest):
(WebCore::FrameLoader::dispatchNavigateEvent):
(WebCore::FrameLoader::updateNavigationAPIEntries): Deleted.
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::initializeForNewWindow):
(WebCore::Navigation::reload):
(WebCore::Navigation::notifyCommittedToEntry):
(WebCore::Navigation::abortOngoingNavigation):
(WebCore::Navigation::innerDispatchNavigateEvent):
(WebCore::Navigation::initializeEntries): Deleted.
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/NavigationHistoryEntry.cpp:
(WebCore::NavigationHistoryEntry::NavigationHistoryEntry):
(WebCore::NavigationHistoryEntry::create):
(WebCore::NavigationHistoryEntry::getState const):
(WebCore::NavigationHistoryEntry::setState):
* Source/WebCore/page/NavigationHistoryEntry.h:

Canonical link: <a href="https://commits.webkit.org/283604@main">https://commits.webkit.org/283604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a58fd6ec54ce7ac59c6ca9bc60b798e23741cab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/46059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/19306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70718 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/17817 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/68802 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17583 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/53435 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/12016 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69751 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/42406 "14 new passes 2 flakes 6 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/57708 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/34103 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/39077 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/15099 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/16171 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60992 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/72420 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10641 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/14800 "Found 1 new test failure: http/tests/IndexedDB/storage-limit-1.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/60761 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57764 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/61096 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14758 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8762 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/2379 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41866 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42943 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/44126 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42686 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->