### PR TITLE
[JSC] DataView constructor should check if byteOffset exceeds source ArrayBuffer length before creating an instance

### DIFF
--- a/JSTests/stress/dataview-construct.js
+++ b/JSTests/stress/dataview-construct.js
@@ -53,7 +53,7 @@ shouldThrow(() => {
 
 shouldThrow(() => {
     new DataView(buffer, 256);
-}, "RangeError: Length out of range of buffer");
+}, "RangeError: byteOffset exceeds source ArrayBuffer byteLength");
 
 shouldThrow(() => {
     new DataView(buffer, -1);

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -54,9 +54,6 @@ test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-objec
 test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined.js:
   default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Promise should be rejected Thrown value was not an object!'
   strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Promise should be rejected Thrown value was not an object!'
-test/built-ins/DataView/byteOffset-validated-against-initial-buffer-length.js:
-  default: 'Test262Error: Expected a RangeError but got a Test262Error'
-  strict mode: 'Test262Error: Expected a RangeError but got a Test262Error'
 test/built-ins/Function/internals/Construct/derived-return-val-realm.js:
   default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
   strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
@@ -260,6 +260,19 @@ ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl(JSGlobalObject* 
     size_t offset = 0;
     std::optional<size_t> length;
     if (auto* arrayBuffer = jsDynamicCast<JSArrayBuffer*>(firstValue)) {
+        if (argCount > 1) {
+            offset = callFrame->uncheckedArgument(1).toTypedArrayIndex(globalObject, "byteOffset"_s);
+            RETURN_IF_EXCEPTION(scope, { });
+
+            if constexpr (ViewClass::TypedArrayStorageType == TypeDataView) {
+                RefPtr<ArrayBuffer> buffer = arrayBuffer->impl();
+                if (UNLIKELY(offset > buffer->byteLength())) {
+                    throwRangeError(globalObject, scope, "byteOffset exceeds source ArrayBuffer byteLength"_s);
+                    RETURN_IF_EXCEPTION(scope, { });
+                }
+            }
+        }
+
         if (arrayBuffer->isResizableOrGrowableShared()) {
             structure = JSC_GET_DERIVED_STRUCTURE(vm, resizableOrGrowableSharedTypedArrayStructureWithTypedArrayType<ViewClass::TypedArrayStorageType>, newTarget, callFrame->jsCallee());
             RETURN_IF_EXCEPTION(scope, { });
@@ -268,17 +281,12 @@ ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl(JSGlobalObject* 
             RETURN_IF_EXCEPTION(scope, { });
         }
 
-        if (argCount > 1) {
-            offset = callFrame->uncheckedArgument(1).toTypedArrayIndex(globalObject, "byteOffset"_s);
-            RETURN_IF_EXCEPTION(scope, encodedJSValue());
-
-            if (argCount > 2) {
-                // If the length value is present but undefined, treat it as missing.
-                JSValue lengthValue = callFrame->uncheckedArgument(2);
-                if (!lengthValue.isUndefined()) {
-                    length = lengthValue.toTypedArrayIndex(globalObject, ViewClass::TypedArrayStorageType == TypeDataView ? "byteLength"_s : "length"_s);
-                    RETURN_IF_EXCEPTION(scope, encodedJSValue());
-                }
+        if (argCount > 2) {
+            // If the length value is present but undefined, treat it as missing.
+            JSValue lengthValue = callFrame->uncheckedArgument(2);
+            if (!lengthValue.isUndefined()) {
+                length = lengthValue.toTypedArrayIndex(globalObject, ViewClass::TypedArrayStorageType == TypeDataView ? "byteLength"_s : "length"_s);
+                RETURN_IF_EXCEPTION(scope, encodedJSValue());
             }
         }
     } else {


### PR DESCRIPTION
#### b56ff58373f19371af18fbb1a77833d898e80de9
<pre>
[JSC] DataView constructor should check if byteOffset exceeds source ArrayBuffer length before creating an instance
<a href="https://bugs.webkit.org/show_bug.cgi?id=273689">https://bugs.webkit.org/show_bug.cgi?id=273689</a>

Reviewed by Yusuke Suzuki.

According to the spec[1], should check if byteOffset exceeds source ArrayBuffer length before
creating an instance. This patch fixes the test case that is failing in test262[2].

[1]: <a href="https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength">https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength</a>
[2]: <a href="https://github.com/tc39/test262/blob/main/test/built-ins/DataView/byteOffset-validated-against-initial-buffer-length.js">https://github.com/tc39/test262/blob/main/test/built-ins/DataView/byteOffset-validated-against-initial-buffer-length.js</a>

* JSTests/stress/dataview-construct.js:
(shouldThrow):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h:
(JSC::constructGenericTypedArrayViewImpl):

Canonical link: <a href="https://commits.webkit.org/278385@main">https://commits.webkit.org/278385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee196118613eb14dce301a28cf5300e182897582

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50230 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53489 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/920 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/545 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40984 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27193 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43228 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22082 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24613 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/480 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8608 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43559 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55074 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49729 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25326 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/480 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48383 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26587 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47405 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27451 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57207 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7282 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26319 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11757 "Passed tests") | 
<!--EWS-Status-Bubble-End-->