### PR TITLE
[git-webkit] Use label size in reverts

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
@@ -160,7 +160,7 @@ class Revert(Command):
             reverted_changeset += '\n    {}\n'.format(commit_title)
             reverted_changeset += '\n'.join(bug_urls)
             if commit.identifier and commit.branch:
-                commit_repr = '{}@{} ({})'.format(commit.identifier, commit.branch, commit.hash[:7])
+                commit_repr = '{}@{} ({})'.format(commit.identifier, commit.branch, commit.hash[:commit.HASH_LABEL_SIZE])
                 reverted_commits.append(commit_repr)
                 reverted_changeset += '\n    {}\n'.format(commit_repr)
             else:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
@@ -50,7 +50,7 @@ class TestRevert(testing.PathTestCase):
             1: dict(
                 number=1,
                 opened=True,
-                title='Unreviewed, reverting 5@main (d8bce26)',
+                title='Unreviewed, reverting 5@main (d8bce26fa65c)',
                 description='?',
                 creator=result.users.create(name='Tim Contributor', username='tcontributor'),
                 timestamp=1639536160,
@@ -61,7 +61,7 @@ class TestRevert(testing.PathTestCase):
         result.pull_requests = [dict(
             number=1,
             state='open',
-            title='Unreviewed, reverting 5@main (d8bce26)',
+            title='Unreviewed, reverting 5@main (d8bce26fa65c)',
             user=dict(login='tcontributor'),
             body='''#### a5fe8afe9bf7d07158fcd9e9732ff02a712db2fd
     <pre>
@@ -102,7 +102,7 @@ class TestRevert(testing.PathTestCase):
             self.assertEqual(0, result)
             self.assertDictEqual(repo.modified, dict())
             self.assertDictEqual(repo.staged, dict())
-            self.assertEqual(True, 'Unreviewed, reverting 5@main (d8bce26)' in repo.head.message)
+            self.assertEqual(True, 'Unreviewed, reverting 5@main (d8bce26fa65c)' in repo.head.message)
             self.assertEqual(local.Git(self.path).remote().pull_requests.get(1).draft, False)
 
         self.assertEqual(
@@ -110,7 +110,7 @@ class TestRevert(testing.PathTestCase):
             "This issue will track the revert and should not be the issue of the commit(s) to be reverted.\n"
             "Enter issue URL or title of new issue (reason for the revert): \n"
             "Created the local development branch 'eng/Example-feature-1'\n"
-            "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26)'!\n"
+            "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26fa65c)'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n",
         )
         self.assertEqual(captured.stderr.getvalue(), '')
@@ -151,7 +151,7 @@ class TestRevert(testing.PathTestCase):
             self.assertEqual(0, result)
             self.assertDictEqual(repo.modified, dict())
             self.assertDictEqual(repo.staged, dict())
-            self.assertEqual(True, 'Unreviewed, reverting 5@main (d8bce26)' in repo.head.message)
+            self.assertEqual(True, 'Unreviewed, reverting 5@main (d8bce26fa65c)' in repo.head.message)
             with MockTerminal.input('{}/show_bug.cgi?id=2'.format(self.BUGZILLA)):
                 result = program.main(args=('pull-request', '-v', '--no-history'), path=self.path)
             self.assertEqual(0, result)
@@ -162,7 +162,7 @@ class TestRevert(testing.PathTestCase):
             "This issue will track the revert and should not be the issue of the commit(s) to be reverted.\n"
             "Enter issue URL or title of new issue (reason for the revert): \n"
             "Created the local development branch 'eng/Example-feature-1'\n"
-            "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26)'!\n"
+            "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26fa65c)'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n",
         )
         self.assertEqual(captured.stderr.getvalue(), '')
@@ -204,7 +204,7 @@ class TestRevert(testing.PathTestCase):
             self.assertEqual(0, result)
             self.assertDictEqual(repo.modified, dict())
             self.assertDictEqual(repo.staged, dict())
-            self.assertEqual(True, 'Unreviewed, reverting 5@main (d8bce26)' in repo.head.message)
+            self.assertEqual(True, 'Unreviewed, reverting 5@main (d8bce26fa65c)' in repo.head.message)
             with MockTerminal.input('{}/show_bug.cgi?id=2'.format(self.BUGZILLA)):
                 result = program.main(args=('pull-request', '-v', '--no-history'), path=self.path)
             self.assertEqual(0, result)
@@ -213,7 +213,7 @@ class TestRevert(testing.PathTestCase):
         self.assertEqual(
             captured.stdout.getvalue(),
             "Created the local development branch 'eng/Example-feature-1'\n"
-            "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26)'!\n"
+            "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26fa65c)'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n",
         )
         self.assertEqual(captured.stderr.getvalue(), '')
@@ -290,9 +290,9 @@ index 05e8751..0bf3c85 100644
             "This issue will track the revert and should not be the issue of the commit(s) to be reverted.\n"
             "Enter issue URL or title of new issue (reason for the revert): \n"
             "Created the local development branch 'eng/Example-feature-1'\n"
-            "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26)'!\n"
+            "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26fa65c)'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n"
-            "Updated 'PR 1 | Unreviewed, reverting 5@main (d8bce26)'!\n"
+            "Updated 'PR 1 | Unreviewed, reverting 5@main (d8bce26fa65c)'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n",
         )
         self.assertEqual(captured.stderr.getvalue(), '')
@@ -345,11 +345,11 @@ index 05e8751..0bf3c85 100644
             self.assertEqual(0, result)
             self.assertDictEqual(repo.modified, dict())
             self.assertDictEqual(repo.staged, dict())
-            self.assertEqual(True, 'Unreviewed, reverting 5@main (d8bce26)' in repo.head.message)
+            self.assertEqual(True, 'Unreviewed, reverting 5@main (d8bce26fa65c)' in repo.head.message)
             self.assertEqual(
                 captured.stdout.getvalue(),
                 "Created the local development branch 'eng/Example-feature-1'\n"
-                "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26)'!\n"
+                "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26fa65c)'!\n"
                 "https://github.example.com/WebKit/WebKit/pull/1\n"
             )
 
@@ -396,7 +396,7 @@ index 05e8751..0bf3c85 100644
                 "Pushing 'eng/Example-issue-1' to 'fork'...",
                 "Creating 'eng/Example-issue-1-1' as a reference branch",
                 "Creating pull-request for 'eng/Example-issue-1'...",
-                "Adding 'merge-queue' to 'PR 2 | Unreviewed, reverting 5@main (d8bce26)'",
+                "Adding 'merge-queue' to 'PR 2 | Unreviewed, reverting 5@main (d8bce26fa65c)'",
             ],
         )
 
@@ -443,6 +443,6 @@ index 05e8751..0bf3c85 100644
                 "Pushing 'eng/Example-issue-1' to 'fork'...",
                 "Creating 'eng/Example-issue-1-1' as a reference branch",
                 "Creating pull-request for 'eng/Example-issue-1'...",
-                "Adding 'unsafe-merge-queue' to 'PR 2 | Unreviewed, reverting 5@main (d8bce26)'",
+                "Adding 'unsafe-merge-queue' to 'PR 2 | Unreviewed, reverting 5@main (d8bce26fa65c)'",
             ],
         )


### PR DESCRIPTION
#### 628e24b7465d0f8ab2c718578470a45749bb1d22
<pre>
[git-webkit] Use label size in reverts
<a href="https://bugs.webkit.org/show_bug.cgi?id=273691">https://bugs.webkit.org/show_bug.cgi?id=273691</a>
<a href="https://rdar.apple.com/127495362">rdar://127495362</a>

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py:
(Revert.create_revert_commit_msg): Use 12 character hash.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py:
(TestRevert.webserver):
(test_update):
(test_pr):
(test_land_safe):
(test_land_unsafe):

Canonical link: <a href="https://commits.webkit.org/278465@main">https://commits.webkit.org/278465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e72c41256cc6170db0e7726ce0676761be7cd258

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29502 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2505 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53469 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/901 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52514 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35731 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/604 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40968 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43209 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22066 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/50062 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/460 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8589 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55054 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48368 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/50232 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26568 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43394 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47389 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27432 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7333 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26300 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->