### PR TITLE
[JSC] Reland Handler IC

### DIFF
--- a/Source/JavaScriptCore/bytecode/AccessCase.h
+++ b/Source/JavaScriptCore/bytecode/AccessCase.h
@@ -219,9 +219,8 @@ public:
 
     ObjectPropertyConditionSet conditionSet() const { return m_conditionSet; }
 
-    bool hasAlternateBase() const;
-    JSObject* alternateBase() const;
-    
+    JSObject* tryGetAlternateBase() const;
+
     WatchpointSet* additionalSet() const;
     bool viaGlobalProxy() const { return m_viaGlobalProxy; }
 
@@ -281,10 +280,6 @@ public:
 
     UniquedStringImpl* uid() const { return m_identifier.uid(); }
     CacheableIdentifier identifier() const { return m_identifier; }
-    void updateIdentifier(CacheableIdentifier identifier)
-    {
-        m_identifier = identifier;
-    }
 
 #if ASSERT_ENABLED
     void checkConsistency(StructureStubInfo&);
@@ -330,9 +325,8 @@ protected:
 
     Ref<AccessCase> cloneImpl() const;
     WatchpointSet* additionalSetImpl() const { return nullptr; }
-    bool hasAlternateBaseImpl() const;
+    JSObject* tryGetAlternateBaseImpl() const;
     void dumpImpl(PrintStream&, CommaPrinter&, Indenter&) const { }
-    JSObject* alternateBaseImpl() const;
 
     bool guardedByStructureCheckSkippingConstantIdentifierCheck() const;
 

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -775,7 +775,7 @@ void CodeBlock::setupWithUnlinkedBaselineCode(Ref<BaselineJITCode> jitCode)
         for (unsigned index = 0; index < jitCode->m_unlinkedStubInfos.size(); ++index) {
             BaselineUnlinkedStructureStubInfo& unlinkedStubInfo = jitCode->m_unlinkedStubInfos[index];
             auto& stubInfo = baselineJITData->stubInfo(index);
-            stubInfo.initializeFromUnlinkedStructureStubInfo(vm(), unlinkedStubInfo);
+            stubInfo.initializeFromUnlinkedStructureStubInfo(vm(), this, unlinkedStubInfo);
         }
 
         for (size_t i = 0; i < jitCode->m_constantPool.size(); ++i) {

--- a/Source/JavaScriptCore/bytecode/GetByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.cpp
@@ -332,7 +332,9 @@ GetByStatus GetByStatus::computeForStubInfoWithoutExitSiteFeedback(const Concurr
                 if (!conditionSet.isStillValid())
                     continue;
 
-                Structure* currStructure = access.hasAlternateBase() ? access.alternateBase()->structure() : access.structure();
+                Structure* currStructure = access.structure();
+                if (auto* object = access.tryGetAlternateBase())
+                    currStructure = object->structure();
                 // For now, we only support cases which JSGlobalObject is the same to the currently profiledBlock.
                 if (currStructure->globalObject() != profiledBlock->globalObject())
                     return GetByStatus(JSC::slowVersion(summary), stubInfo);

--- a/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.cpp
@@ -75,18 +75,11 @@ Ref<AccessCase> GetterSetterAccessCase::cloneImpl() const
     return adoptRef(*new GetterSetterAccessCase(*this));
 }
 
-bool GetterSetterAccessCase::hasAlternateBaseImpl() const
+JSObject* GetterSetterAccessCase::tryGetAlternateBaseImpl() const
 {
-    if (customSlotBase())
-        return true;
-    return Base::hasAlternateBaseImpl();
-}
-
-JSObject* GetterSetterAccessCase::alternateBaseImpl() const
-{
-    if (customSlotBase())
-        return customSlotBase();
-    return Base::alternateBaseImpl();
+    if (auto* object = customSlotBase())
+        return object;
+    return Base::tryGetAlternateBaseImpl();
 }
 
 void GetterSetterAccessCase::dumpImpl(PrintStream& out, CommaPrinter& comma, Indenter& indent) const

--- a/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.h
+++ b/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.h
@@ -65,8 +65,7 @@ private:
 
     GetterSetterAccessCase(const GetterSetterAccessCase&);
 
-    bool hasAlternateBaseImpl() const;
-    JSObject* alternateBaseImpl() const;
+    JSObject* tryGetAlternateBaseImpl() const;
     void dumpImpl(PrintStream&, CommaPrinter&, Indenter&) const;
     Ref<AccessCase> cloneImpl() const;
 

--- a/Source/JavaScriptCore/bytecode/InlineAccess.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineAccess.cpp
@@ -394,29 +394,6 @@ bool InlineAccess::generateSelfInAccess(CodeBlock* codeBlock, StructureStubInfo&
     return linkCodeInline("in access", jit, stubInfo);
 }
 
-void InlineAccess::rewireStubAsJumpInAccess(CodeBlock* codeBlock, StructureStubInfo& stubInfo, InlineCacheHandler& handler)
-{
-    stubInfo.m_handler = &handler;
-    if (codeBlock->useDataIC()) {
-        stubInfo.m_codePtr = handler.callTarget();
-        stubInfo.m_inlineAccessBaseStructureID.clear(); // Clear out the inline access code.
-        return;
-    }
-
-    CCallHelpers::replaceWithJump(stubInfo.startLocation.retagged<JSInternalPtrTag>(), CodeLocationLabel { handler.callTarget() });
-}
-
-void InlineAccess::resetStubAsJumpInAccess(CodeBlock* codeBlock, StructureStubInfo& stubInfo)
-{
-    if (JITCode::isBaselineCode(codeBlock->jitType()) && Options::useHandlerIC()) {
-        auto handler = InlineCacheCompiler::generateSlowPathHandler(codeBlock->vm(), stubInfo.accessType);
-        InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, handler.get());
-        return;
-    }
-    auto handler = InlineCacheHandler::createNonHandlerSlowPath(stubInfo.slowPathStartLocation);
-    InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, handler.get());
-}
-
 } // namespace JSC
 
 #endif // ENABLE(JIT)

--- a/Source/JavaScriptCore/bytecode/InlineAccess.h
+++ b/Source/JavaScriptCore/bytecode/InlineAccess.h
@@ -106,9 +106,6 @@ public:
     static bool generateSelfInAccess(CodeBlock*, StructureStubInfo&, Structure*);
     static bool generateStringLength(CodeBlock*, StructureStubInfo&);
 
-    static void rewireStubAsJumpInAccess(CodeBlock*, StructureStubInfo&, InlineCacheHandler&);
-    static void resetStubAsJumpInAccess(CodeBlock*, StructureStubInfo&);
-
     // This is helpful when determining the size of an IC on
     // various platforms. When adding a new type of IC, implement
     // its placeholder code here, and log the size. That way we

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -560,128 +560,6 @@ static bool isStateless(AccessCase::AccessType type)
     return false;
 }
 
-static bool isMegamorphicById(AccessCase::AccessType type)
-{
-    switch (type) {
-    case AccessCase::LoadMegamorphic:
-    case AccessCase::StoreMegamorphic:
-    case AccessCase::InMegamorphic:
-        return true;
-
-    case AccessCase::Load:
-    case AccessCase::Transition:
-    case AccessCase::Delete:
-    case AccessCase::DeleteNonConfigurable:
-    case AccessCase::DeleteMiss:
-    case AccessCase::Replace:
-    case AccessCase::Miss:
-    case AccessCase::GetGetter:
-    case AccessCase::CheckPrivateBrand:
-    case AccessCase::SetPrivateBrand:
-    case AccessCase::IndexedNoIndexingMiss:
-    case AccessCase::Getter:
-    case AccessCase::Setter:
-    case AccessCase::ProxyObjectHas:
-    case AccessCase::ProxyObjectLoad:
-    case AccessCase::ProxyObjectStore:
-    case AccessCase::IndexedProxyObjectLoad:
-    case AccessCase::CustomValueGetter:
-    case AccessCase::CustomAccessorGetter:
-    case AccessCase::CustomValueSetter:
-    case AccessCase::CustomAccessorSetter:
-    case AccessCase::IntrinsicGetter:
-    case AccessCase::ModuleNamespaceLoad:
-    case AccessCase::InstanceOfHit:
-    case AccessCase::InstanceOfMiss:
-    case AccessCase::InHit:
-    case AccessCase::InMiss:
-    case AccessCase::IndexedNoIndexingInMiss:
-    case AccessCase::ArrayLength:
-    case AccessCase::StringLength:
-    case AccessCase::DirectArgumentsLength:
-    case AccessCase::ScopedArgumentsLength:
-    case AccessCase::IndexedMegamorphicLoad:
-    case AccessCase::IndexedMegamorphicStore:
-    case AccessCase::IndexedInt32Load:
-    case AccessCase::IndexedDoubleLoad:
-    case AccessCase::IndexedContiguousLoad:
-    case AccessCase::IndexedArrayStorageLoad:
-    case AccessCase::IndexedScopedArgumentsLoad:
-    case AccessCase::IndexedDirectArgumentsLoad:
-    case AccessCase::IndexedTypedArrayInt8Load:
-    case AccessCase::IndexedTypedArrayUint8Load:
-    case AccessCase::IndexedTypedArrayUint8ClampedLoad:
-    case AccessCase::IndexedTypedArrayInt16Load:
-    case AccessCase::IndexedTypedArrayUint16Load:
-    case AccessCase::IndexedTypedArrayInt32Load:
-    case AccessCase::IndexedTypedArrayUint32Load:
-    case AccessCase::IndexedTypedArrayFloat32Load:
-    case AccessCase::IndexedTypedArrayFloat64Load:
-    case AccessCase::IndexedResizableTypedArrayInt8Load:
-    case AccessCase::IndexedResizableTypedArrayUint8Load:
-    case AccessCase::IndexedResizableTypedArrayUint8ClampedLoad:
-    case AccessCase::IndexedResizableTypedArrayInt16Load:
-    case AccessCase::IndexedResizableTypedArrayUint16Load:
-    case AccessCase::IndexedResizableTypedArrayInt32Load:
-    case AccessCase::IndexedResizableTypedArrayUint32Load:
-    case AccessCase::IndexedResizableTypedArrayFloat32Load:
-    case AccessCase::IndexedResizableTypedArrayFloat64Load:
-    case AccessCase::IndexedInt32Store:
-    case AccessCase::IndexedDoubleStore:
-    case AccessCase::IndexedContiguousStore:
-    case AccessCase::IndexedArrayStorageStore:
-    case AccessCase::IndexedTypedArrayInt8Store:
-    case AccessCase::IndexedTypedArrayUint8Store:
-    case AccessCase::IndexedTypedArrayUint8ClampedStore:
-    case AccessCase::IndexedTypedArrayInt16Store:
-    case AccessCase::IndexedTypedArrayUint16Store:
-    case AccessCase::IndexedTypedArrayInt32Store:
-    case AccessCase::IndexedTypedArrayUint32Store:
-    case AccessCase::IndexedTypedArrayFloat32Store:
-    case AccessCase::IndexedTypedArrayFloat64Store:
-    case AccessCase::IndexedResizableTypedArrayInt8Store:
-    case AccessCase::IndexedResizableTypedArrayUint8Store:
-    case AccessCase::IndexedResizableTypedArrayUint8ClampedStore:
-    case AccessCase::IndexedResizableTypedArrayInt16Store:
-    case AccessCase::IndexedResizableTypedArrayUint16Store:
-    case AccessCase::IndexedResizableTypedArrayInt32Store:
-    case AccessCase::IndexedResizableTypedArrayUint32Store:
-    case AccessCase::IndexedResizableTypedArrayFloat32Store:
-    case AccessCase::IndexedResizableTypedArrayFloat64Store:
-    case AccessCase::IndexedStringLoad:
-    case AccessCase::IndexedInt32InHit:
-    case AccessCase::IndexedDoubleInHit:
-    case AccessCase::IndexedContiguousInHit:
-    case AccessCase::IndexedArrayStorageInHit:
-    case AccessCase::IndexedScopedArgumentsInHit:
-    case AccessCase::IndexedDirectArgumentsInHit:
-    case AccessCase::IndexedTypedArrayInt8InHit:
-    case AccessCase::IndexedTypedArrayUint8InHit:
-    case AccessCase::IndexedTypedArrayUint8ClampedInHit:
-    case AccessCase::IndexedTypedArrayInt16InHit:
-    case AccessCase::IndexedTypedArrayUint16InHit:
-    case AccessCase::IndexedTypedArrayInt32InHit:
-    case AccessCase::IndexedTypedArrayUint32InHit:
-    case AccessCase::IndexedTypedArrayFloat32InHit:
-    case AccessCase::IndexedTypedArrayFloat64InHit:
-    case AccessCase::IndexedResizableTypedArrayInt8InHit:
-    case AccessCase::IndexedResizableTypedArrayUint8InHit:
-    case AccessCase::IndexedResizableTypedArrayUint8ClampedInHit:
-    case AccessCase::IndexedResizableTypedArrayInt16InHit:
-    case AccessCase::IndexedResizableTypedArrayUint16InHit:
-    case AccessCase::IndexedResizableTypedArrayInt32InHit:
-    case AccessCase::IndexedResizableTypedArrayUint32InHit:
-    case AccessCase::IndexedResizableTypedArrayFloat32InHit:
-    case AccessCase::IndexedResizableTypedArrayFloat64InHit:
-    case AccessCase::IndexedStringInHit:
-    case AccessCase::IndexedMegamorphicIn:
-    case AccessCase::InstanceOfGeneric:
-        return false;
-    }
-
-    return false;
-}
-
 static bool doesJSCalls(AccessCase::AccessType type)
 {
     switch (type) {
@@ -2799,7 +2677,10 @@ void InlineCacheCompiler::generateImpl(AccessCase& accessCase)
     case AccessCase::IntrinsicGetter: {
         GPRReg valueRegsPayloadGPR = valueRegs.payloadGPR();
 
-        Structure* currStructure = accessCase.hasAlternateBase() ? accessCase.alternateBase()->structure() : accessCase.structure();
+        Structure* currStructure = accessCase.structure();
+        if (auto* object = accessCase.tryGetAlternateBase())
+            currStructure = object->structure();
+
         if (isValidOffset(accessCase.m_offset))
             currStructure->startWatchingPropertyForReplacements(vm, accessCase.offset());
 
@@ -2819,9 +2700,8 @@ void InlineCacheCompiler::generateImpl(AccessCase& accessCase)
             // and it left the baseForAccess inside scratchGPR. We could re-derive the base,
             // but it'd require emitting the same code to load the base twice.
             propertyOwnerGPR = scratchGPR;
-        } else if (accessCase.hasAlternateBase()) {
-            jit.move(
-                CCallHelpers::TrustedImmPtr(accessCase.alternateBase()), scratchGPR);
+        } else if (auto* object = accessCase.tryGetAlternateBase()) {
+            jit.move(CCallHelpers::TrustedImmPtr(object), scratchGPR);
             propertyOwnerGPR = scratchGPR;
         } else if (accessCase.viaGlobalProxy() && doesPropertyStorageLoads) {
             // We only need this when loading an inline or out of line property. For customs accessors,
@@ -4037,11 +3917,6 @@ static inline ASCIILiteral categoryName(AccessType type)
     return nullptr;
 }
 
-enum class HandlerICType : uint8_t {
-    Stateless,
-    MegamorphicById,
-};
-
 static Vector<WatchpointSet*, 3> collectAdditionalWatchpoints(VM& vm, AccessCase& accessCase)
 {
     // It's fine to commit something that is already committed. That arises when we switch to using
@@ -4084,7 +3959,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
     // to be unmutated. For sure, we want it to hang onto any data structures that may be referenced
     // from the code of the current stub (aka previous).
     Vector<WatchpointSet*, 8> additionalWatchpointSets;
-    PolymorphicAccess::ListType cases;
+    Vector<RefPtr<AccessCase>, 16> cases;
     cases.reserveInitialCapacity(poly.m_list.size());
     unsigned srcIndex = 0;
     for (auto& someCase : poly.m_list) {
@@ -4357,11 +4232,11 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
             watchpoint = makeUnique<StructureStubInfoClearingWatchpoint>(codeBlock, m_stubInfo);
             stub->watchpointSet().add(watchpoint.get());
         }
+
+        poly.m_list.shrink(0);
+        poly.m_list.append(stub->cases().span());
         auto handler = InlineCacheHandler::create(WTFMove(stub), WTFMove(watchpoint));
         dataLogLnIf(InlineCacheCompilerInternal::verbose, "Returning: ", handler->callTarget());
-
-        poly.m_list = WTFMove(cases);
-        poly.m_list.shrinkToFit();
 
         AccessGenerationResult::Kind resultKind;
         if (generatedMegamorphicCode)
@@ -4375,30 +4250,37 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
     };
 
     std::optional<SharedJITStubSet::StatelessCacheKey> statelessType;
-    std::optional<HandlerICType> handlerICType;
-    if (cases.size() == 1) {
-        auto& accessCase = cases.first();
-        if (useHandlerIC()) {
-            ASSERT(codeBlock->useDataIC());
-            if (isStateless(accessCase->m_type)) {
-                handlerICType = HandlerICType::Stateless;
-                statelessType = std::tuple { SharedJITStubSet::stubInfoKey(*m_stubInfo), accessCase->m_type };
-                if (auto stub = vm().m_sharedJITStubs->getStatelessStub(statelessType.value())) {
-                    dataLogLnIf(InlineCacheCompilerInternal::verbose, "Using ", m_stubInfo->accessType, " / ", stub->cases().first()->m_type);
+    if (useHandlerIC()) {
+        ASSERT(codeBlock->useDataIC());
+        if (cases.size() == 1 && isStateless(cases.first()->m_type)) {
+            auto& accessCase = cases.first();
+            statelessType = std::tuple { SharedJITStubSet::stubInfoKey(*m_stubInfo), accessCase->m_type };
+            if (auto stub = vm().m_sharedJITStubs->getStatelessStub(statelessType.value())) {
+                dataLogLnIf(InlineCacheCompilerInternal::verbose, "Using ", m_stubInfo->accessType, " / ", stub->cases().first()->m_type);
+                return finishCodeGeneration(stub.releaseNonNull());
+            }
+        }
+
+        std::sort(cases.begin(), cases.end(), [](auto& lhs, auto& rhs) {
+            if (lhs->type() == rhs->type()) {
+                if (lhs->structure()->id() == rhs->structure()->id())
+                    return bitwise_cast<uintptr_t>(lhs->uid()) < bitwise_cast<uintptr_t>(rhs->uid());
+                return lhs->structure()->id() < rhs->structure()->id();
+            }
+            return lhs->type() < rhs->type();
+        });
+
+        if (!statelessType) {
+            SharedJITStubSet::Searcher searcher {
+                SharedJITStubSet::stubInfoKey(*m_stubInfo),
+                cases.span(),
+            };
+            if (auto stub = vm().m_sharedJITStubs->find(searcher)) {
+                if (stub->isStillValid()) {
+                    dataLogLnIf(InlineCacheCompilerInternal::verbose, "Using ", m_stubInfo->accessType, " / ", listDump(stub->cases()));
                     return finishCodeGeneration(stub.releaseNonNull());
                 }
-            } else if (isMegamorphicById(accessCase->m_type)) {
-                handlerICType = HandlerICType::MegamorphicById;
-                FixedVector<RefPtr<AccessCase>> keys(cases.size());
-                keys[0] = accessCase;
-                SharedJITStubSet::Searcher searcher {
-                    SharedJITStubSet::stubInfoKey(*m_stubInfo),
-                    keys,
-                };
-                if (auto stub = vm().m_sharedJITStubs->find(searcher)) {
-                    dataLogLnIf(InlineCacheCompilerInternal::verbose, "Using ", m_stubInfo->accessType, " / ", stub->cases().first()->m_type);
-                    return finishCodeGeneration(stub.releaseNonNull());
-                }
+                vm().m_sharedJITStubs->remove(stub.get());
             }
         }
     }
@@ -4412,7 +4294,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
     std::optional<FPRReg> scratchFPR;
     bool doesCalls = false;
     bool doesJSCalls = false;
-    bool canBeShared = Options::useDataICSharing();
+    bool canBeShared = useHandlerIC();
     bool needsInt32PropertyCheck = false;
     bool needsStringPropertyCheck = false;
     bool needsSymbolPropertyCheck = false;
@@ -4420,29 +4302,14 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
     bool allGuardedByStructureCheck = true;
     if (!m_stubInfo->hasConstantIdentifier)
         allGuardedByStructureCheck = false;
+    FixedVector<RefPtr<AccessCase>> keys(WTFMove(cases));
     Vector<JSCell*> cellsToMark;
-    FixedVector<RefPtr<AccessCase>> keys(cases.size());
-    unsigned index = 0;
-    for (auto& entry : cases) {
+    for (auto& entry : keys) {
         if (!scratchFPR && needsScratchFPR(entry->m_type))
             scratchFPR = allocator.allocateScratchFPR();
 
         doesCalls |= entry->doesCalls(vm(), &cellsToMark);
         doesJSCalls |= JSC::doesJSCalls(entry->type());
-        switch (entry->type()) {
-        case AccessCase::CustomValueGetter:
-        case AccessCase::CustomAccessorGetter:
-        case AccessCase::CustomValueSetter:
-        case AccessCase::CustomAccessorSetter:
-            // Custom getter / setter emits JSGlobalObject pointer, which is tied to the linked CodeBlock.
-            canBeShared = false;
-            break;
-        default:
-            break;
-        }
-
-        if (entry->usesPolyProto())
-            canBeShared = false;
 
         if (!m_stubInfo->hasConstantIdentifier) {
             if (entry->requiresIdentifierNameMatch()) {
@@ -4456,14 +4323,11 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
                 acceptValueProperty = true;
         } else
             allGuardedByStructureCheck &= entry->guardedByStructureCheckSkippingConstantIdentifierCheck();
-
-        keys[index] = entry;
-        ++index;
     }
     m_scratchFPR = scratchFPR.value_or(InvalidFPRReg);
     m_doesCalls = doesCalls;
     m_doesJSCalls = doesJSCalls;
-    if (needsSymbolPropertyCheck || needsStringPropertyCheck || needsInt32PropertyCheck || doesJSCalls)
+    if (doesJSCalls)
         canBeShared = false;
 
     CCallHelpers jit(codeBlock);
@@ -4487,10 +4351,10 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
 
     m_preservedReusedRegisterState = allocator.preserveReusedRegistersByPushing(jit, ScratchRegisterAllocator::ExtraStackSpace::NoExtraSpace);
 
-    if (cases.isEmpty()) {
+    if (keys.isEmpty()) {
         // This is super unlikely, but we make it legal anyway.
         m_failAndRepatch.append(jit.jump());
-    } else if (!allGuardedByStructureCheck || cases.size() == 1) {
+    } else if (!allGuardedByStructureCheck || keys.size() == 1) {
         // If there are any proxies in the list, we cannot just use a binary switch over the structure.
         // We need to resort to a cascade. A cascade also happens to be optimal if we only have just
         // one case.
@@ -4507,11 +4371,11 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
 #endif
                 }
                 JIT_COMMENT(jit, "Cases start (needsInt32PropertyCheck)");
-                for (unsigned i = cases.size(); i--;) {
+                for (unsigned i = keys.size(); i--;) {
                     fallThrough.link(&jit);
                     fallThrough.clear();
-                    if (cases[i]->requiresInt32PropertyCheck())
-                        generateWithGuard(*cases[i], fallThrough);
+                    if (keys[i]->requiresInt32PropertyCheck())
+                        generateWithGuard(*keys[i], fallThrough);
                 }
 
                 if (needsStringPropertyCheck || needsSymbolPropertyCheck || acceptValueProperty) {
@@ -4540,11 +4404,11 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
                 m_failAndRepatch.append(jit.branchIfRopeStringImpl(m_scratchGPR));
 
                 JIT_COMMENT(jit, "Cases start (needsStringPropertyCheck)");
-                for (unsigned i = cases.size(); i--;) {
+                for (unsigned i = keys.size(); i--;) {
                     fallThrough.link(&jit);
                     fallThrough.clear();
-                    if (cases[i]->requiresIdentifierNameMatch() && !cases[i]->uid()->isSymbol())
-                        generateWithGuard(*cases[i], fallThrough);
+                    if (keys[i]->requiresIdentifierNameMatch() && !keys[i]->uid()->isSymbol())
+                        generateWithGuard(*keys[i], fallThrough);
                 }
 
                 if (needsSymbolPropertyCheck || acceptValueProperty) {
@@ -4569,11 +4433,11 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
                 }
 
                 JIT_COMMENT(jit, "Cases start (needsSymbolPropertyCheck)");
-                for (unsigned i = cases.size(); i--;) {
+                for (unsigned i = keys.size(); i--;) {
                     fallThrough.link(&jit);
                     fallThrough.clear();
-                    if (cases[i]->requiresIdentifierNameMatch() && cases[i]->uid()->isSymbol())
-                        generateWithGuard(*cases[i], fallThrough);
+                    if (keys[i]->requiresIdentifierNameMatch() && keys[i]->uid()->isSymbol())
+                        generateWithGuard(*keys[i], fallThrough);
                 }
 
                 if (acceptValueProperty) {
@@ -4586,20 +4450,20 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
 
             if (acceptValueProperty) {
                 JIT_COMMENT(jit, "Cases start (remaining)");
-                for (unsigned i = cases.size(); i--;) {
+                for (unsigned i = keys.size(); i--;) {
                     fallThrough.link(&jit);
                     fallThrough.clear();
-                    if (!cases[i]->requiresIdentifierNameMatch() && !cases[i]->requiresInt32PropertyCheck())
-                        generateWithGuard(*cases[i], fallThrough);
+                    if (!keys[i]->requiresIdentifierNameMatch() && !keys[i]->requiresInt32PropertyCheck())
+                        generateWithGuard(*keys[i], fallThrough);
                 }
             }
         } else {
             // Cascade through the list, preferring newer entries.
             JIT_COMMENT(jit, "Cases start !(needsInt32PropertyCheck || needsStringPropertyCheck || needsSymbolPropertyCheck)");
-            for (unsigned i = cases.size(); i--;) {
+            for (unsigned i = keys.size(); i--;) {
                 fallThrough.link(&jit);
                 fallThrough.clear();
-                generateWithGuard(*cases[i], fallThrough);
+                generateWithGuard(*keys[i], fallThrough);
             }
         }
 
@@ -4611,13 +4475,13 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
             CCallHelpers::Address(m_stubInfo->m_baseGPR, JSCell::structureIDOffset()),
             m_scratchGPR);
 
-        Vector<int64_t, 16> caseValues(cases.size());
-        for (unsigned i = 0; i < cases.size(); ++i)
-            caseValues[i] = bitwise_cast<int32_t>(cases[i]->structure()->id());
+        Vector<int64_t, 16> caseValues(keys.size());
+        for (unsigned i = 0; i < keys.size(); ++i)
+            caseValues[i] = bitwise_cast<int32_t>(keys[i]->structure()->id());
 
         BinarySwitch binarySwitch(m_scratchGPR, caseValues.span(), BinarySwitch::Int32);
         while (binarySwitch.advance(jit))
-            generate(*cases[binarySwitch.caseIndex()]);
+            generate(*keys[binarySwitch.caseIndex()]);
         m_failAndRepatch.append(binarySwitch.fallThrough());
     }
 
@@ -4715,19 +4579,6 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
         failure.linkThunk(m_stubInfo->slowPathStartLocation, &jit);
     }
 
-    RefPtr<PolymorphicAccessJITStubRoutine> stub;
-    if (codeBlock->useDataIC() && canBeShared) {
-        SharedJITStubSet::Searcher searcher {
-            SharedJITStubSet::stubInfoKey(*m_stubInfo),
-            keys,
-        };
-        stub = vm().m_sharedJITStubs->find(searcher);
-        if (stub) {
-            dataLogLnIf(InlineCacheCompilerInternal::verbose, "Found existing code stub ", stub->code());
-            return finishCodeGeneration(stub.releaseNonNull());
-        }
-    }
-
     LinkBuffer linkBuffer(jit, codeBlock, LinkBuffer::Profile::InlineCache, JITCompilationCanFail);
     if (linkBuffer.didFailToAllocate()) {
         dataLogLnIf(InlineCacheCompilerInternal::verbose, "Did fail to allocate.");
@@ -4738,24 +4589,24 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
     if (codeBlock->useDataIC())
         ASSERT(m_success.empty());
 
-    dataLogLnIf(InlineCacheCompilerInternal::verbose, FullCodeOrigin(codeBlock, m_stubInfo->codeOrigin), ": Generating polymorphic access stub for ", listDump(cases));
+    dataLogLnIf(InlineCacheCompilerInternal::verbose, FullCodeOrigin(codeBlock, m_stubInfo->codeOrigin), ": Generating polymorphic access stub for ", listDump(keys));
 
-    MacroAssemblerCodeRef<JITStubRoutinePtrTag> code = FINALIZE_CODE_FOR(codeBlock, linkBuffer, JITStubRoutinePtrTag, categoryName(m_stubInfo->accessType), "%s", toCString("Access stub for ", *codeBlock, " ", m_stubInfo->codeOrigin, "with start: ", m_stubInfo->startLocation, " with return point ", successLabel, ": ", listDump(cases)).data());
+    MacroAssemblerCodeRef<JITStubRoutinePtrTag> code = FINALIZE_CODE_FOR(codeBlock, linkBuffer, JITStubRoutinePtrTag, categoryName(m_stubInfo->accessType), "%s", toCString("Access stub for ", *codeBlock, " ", m_stubInfo->codeOrigin, "with start: ", m_stubInfo->startLocation, " with return point ", successLabel, ": ", listDump(keys)).data());
 
     CodeBlock* owner = codeBlock;
-    if (handlerICType) {
+    if (canBeShared) {
         ASSERT(codeBlock->useDataIC());
         owner = nullptr;
     }
 
     FixedVector<StructureID> weakStructures(WTFMove(m_weakStructures));
-    stub = createICJITStubRoutine(code, WTFMove(keys), WTFMove(weakStructures), vm(), owner, doesCalls, cellsToMark, WTFMove(m_callLinkInfos), codeBlockThatOwnsExceptionHandlers, callSiteIndexForExceptionHandling);
+    auto stub = createICJITStubRoutine(code, WTFMove(keys), WTFMove(weakStructures), vm(), owner, doesCalls, cellsToMark, WTFMove(m_callLinkInfos), codeBlockThatOwnsExceptionHandlers, callSiteIndexForExceptionHandling);
 
     {
         std::unique_ptr<WatchpointsOnStructureStubInfo> watchpoints;
 
         for (auto& condition : m_conditions)
-            WatchpointsOnStructureStubInfo::ensureReferenceAndInstallWatchpoint(vm(), watchpoints, stub.get(), condition);
+            WatchpointsOnStructureStubInfo::ensureReferenceAndInstallWatchpoint(vm(), watchpoints, stub.ptr(), condition);
 
         // NOTE: We currently assume that this is relatively rare. It mainly arises for accesses to
         // properties on DOM nodes. For sure we cache many DOM node accesses, but even in
@@ -4763,25 +4614,26 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
         // vanilla objects or exotic objects from within JSC (like Arguments, those are super popular).
         // Those common kinds of JSC object accesses don't hit this case.
         for (WatchpointSet* set : additionalWatchpointSets) {
-            Watchpoint* watchpoint = WatchpointsOnStructureStubInfo::ensureReferenceAndAddWatchpoint(vm(), watchpoints, stub.get());
+            Watchpoint* watchpoint = WatchpointsOnStructureStubInfo::ensureReferenceAndAddWatchpoint(vm(), watchpoints, stub.ptr());
             set->add(watchpoint);
         }
 
         stub->setWatchpoints(WTFMove(watchpoints));
     }
 
-    if (handlerICType) {
+    if (canBeShared) {
         ASSERT(codeBlock->useDataIC());
-        dataLogLnIf(InlineCacheCompilerInternal::verbose, "Installing ", m_stubInfo->accessType, " / ", stub->cases().first()->m_type);
-        if (statelessType)
-            vm().m_sharedJITStubs->setStatelessStub(statelessType.value(), *stub);
-        else {
-            vm().m_sharedJITStubs->add(SharedJITStubSet::Hash::Key(SharedJITStubSet::stubInfoKey(*m_stubInfo), stub.get()));
+        if (statelessType) {
+            dataLogLnIf(InlineCacheCompilerInternal::verbose, "Installing ", m_stubInfo->accessType, " / ", stub->cases().first()->m_type);
+            vm().m_sharedJITStubs->setStatelessStub(statelessType.value(), Ref { stub });
+        } else {
+            dataLogLnIf(InlineCacheCompilerInternal::verbose, "Installing ", m_stubInfo->accessType, " / ", listDump(stub->cases()));
+            vm().m_sharedJITStubs->add(SharedJITStubSet::Hash::Key(SharedJITStubSet::stubInfoKey(*m_stubInfo), stub.ptr()));
             stub->addedToSharedJITStubSet();
         }
     }
 
-    return finishCodeGeneration(stub.releaseNonNull());
+    return finishCodeGeneration(WTFMove(stub));
 }
 
 PolymorphicAccess::PolymorphicAccess() = default;
@@ -4941,6 +4793,20 @@ bool InlineCacheHandler::visitWeak(VM& vm) const
     }
 
     return true;
+}
+
+void InlineCacheHandler::addOwner(CodeBlock* codeBlock)
+{
+    if (!m_stubRoutine)
+        return;
+    m_stubRoutine->addOwner(codeBlock);
+}
+
+void InlineCacheHandler::removeOwner(CodeBlock* codeBlock)
+{
+    if (!m_stubRoutine)
+        return;
+    m_stubRoutine->removeOwner(codeBlock);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -191,6 +191,9 @@ public:
 
     static Ref<InlineCacheHandler> createNonHandlerSlowPath(CodePtr<JITStubRoutinePtrTag>);
 
+    void addOwner(CodeBlock*);
+    void removeOwner(CodeBlock*);
+
 private:
     InlineCacheHandler() = default;
     InlineCacheHandler(Ref<PolymorphicAccessJITStubRoutine>&&, std::unique_ptr<StructureStubInfoClearingWatchpoint>&&);
@@ -344,8 +347,6 @@ private:
     ScratchRegisterAllocator::PreservedState m_preservedReusedRegisterState;
     GPRReg m_scratchGPR { InvalidGPRReg };
     FPRReg m_scratchFPR { InvalidFPRReg };
-    Vector<StructureID> m_weakStructures;
-    Vector<ObjectPropertyCondition> m_conditions;
     Bag<OptimizingCallLinkInfo> m_callLinkInfos;
     ScalarRegisterSet m_liveRegistersToPreserveAtExceptionHandlingCallSite;
     ScalarRegisterSet m_liveRegistersForCall;
@@ -356,6 +357,8 @@ private:
     bool m_calculatedCallSiteIndex : 1 { false };
     bool m_doesJSCalls : 1 { false };
     bool m_doesCalls : 1 { false };
+    Vector<StructureID, 4> m_weakStructures;
+    Vector<ObjectPropertyCondition, 64> m_conditions;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/PutByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/PutByStatus.cpp
@@ -258,7 +258,10 @@ PutByStatus PutByStatus::computeForStubInfo(const ConcurrentJSLocker& locker, Co
                 if (!conditionSet.isStillValid())
                     continue;
 
-                Structure* currStructure = access.hasAlternateBase() ? access.alternateBase()->structure() : access.structure();
+                Structure* currStructure = access.structure();
+                if (auto* object = access.tryGetAlternateBase())
+                    currStructure = object->structure();
+
                 // For now, we only support cases which JSGlobalObject is the same to the currently profiledBlock.
                 if (currStructure->globalObject() != profiledBlock->globalObject())
                     return PutByStatus(JSC::slowVersion(summary), *stubInfo);

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -517,10 +517,8 @@ static InlineCacheAction tryCacheGetBy(JSGlobalObject* globalObject, CodeBlock* 
 
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), propertyName, WTFMove(newCase));
 
-        if (result.generatedSomeCode()) {
+        if (result.generatedSomeCode())
             LOG_IC((ICEvent::GetByReplaceWithJump, baseValue.classInfoOrNull(), Identifier::fromUid(vm, propertyName.uid()), slot.slotBase() == baseValue));
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
-        }
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -686,10 +684,8 @@ static InlineCacheAction tryCacheArrayGetByVal(JSGlobalObject* globalObject, Cod
 
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), nullptr, newCase.releaseNonNull());
 
-        if (result.generatedSomeCode()) {
+        if (result.generatedSomeCode())
             LOG_IC((ICEvent::GetByReplaceWithJump, baseValue.classInfoOrNull(), Identifier()));
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
-        }
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -1022,10 +1018,8 @@ static InlineCacheAction tryCachePutBy(JSGlobalObject* globalObject, CodeBlock* 
         
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, slot.isStrictMode() ? ECMAMode::strict() : ECMAMode::sloppy(), propertyName, WTFMove(newCase));
 
-        if (result.generatedSomeCode()) {
+        if (result.generatedSomeCode())
             LOG_IC((ICEvent::PutByReplaceWithJump, oldStructure->classInfoForCells(), ident, slot.base() == baseValue));
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
-        }
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -1150,10 +1144,8 @@ static InlineCacheAction tryCacheArrayPutByVal(JSGlobalObject* globalObject, Cod
         GCSafeConcurrentJSLocker locker(codeBlock->m_lock, globalObject->vm());
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, ecmaModeFor(putByKind), nullptr, AccessCase::create(vm, codeBlock, accessType, nullptr));
 
-        if (result.generatedSomeCode()) {
+        if (result.generatedSomeCode())
             LOG_IC((ICEvent::PutByReplaceWithJump, baseValue.classInfoOrNull(), Identifier()));
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
-        }
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -1225,10 +1217,8 @@ static InlineCacheAction tryCacheDeleteBy(JSGlobalObject* globalObject, CodeBloc
 
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, ecmaMode, propertyName, WTFMove(newCase));
 
-        if (result.generatedSomeCode()) {
+        if (result.generatedSomeCode())
             LOG_IC((ICEvent::DelByReplaceWithJump, oldStructure->classInfoForCells(), Identifier::fromUid(vm, propertyName.uid())));
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
-        }
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -1389,10 +1379,8 @@ static InlineCacheAction tryCacheInBy(
 
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), propertyName, WTFMove(newCase));
 
-        if (result.generatedSomeCode()) {
+        if (result.generatedSomeCode())
             LOG_IC((ICEvent::InReplaceWithJump, structure->classInfoForCells(), ident, slot.slotBase() == base));
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
-        }
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -1456,10 +1444,8 @@ static InlineCacheAction tryCacheHasPrivateBrand(JSGlobalObject* globalObject, C
 
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), brandID, WTFMove(newCase));
 
-        if (result.generatedSomeCode()) {
+        if (result.generatedSomeCode())
             LOG_IC((ICEvent::InReplaceWithJump, structure->classInfoForCells(), ident, isBaseProperty));
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
-        }
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -1501,10 +1487,8 @@ static InlineCacheAction tryCacheCheckPrivateBrand(
 
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), brandID, WTFMove(newCase));
 
-        if (result.generatedSomeCode()) {
+        if (result.generatedSomeCode())
             LOG_IC((ICEvent::CheckPrivateBrandReplaceWithJump, structure->classInfoForCells(), ident, isBaseProperty));
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
-        }
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -1558,10 +1542,8 @@ static InlineCacheAction tryCacheSetPrivateBrand(
 
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), brandID, WTFMove(newCase));
 
-        if (result.generatedSomeCode()) {
+        if (result.generatedSomeCode())
             LOG_IC((ICEvent::SetPrivateBrandReplaceWithJump, oldStructure->classInfoForCells(), ident, isBaseProperty));
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
-        }
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -1623,11 +1605,9 @@ static InlineCacheAction tryCacheInstanceOf(
         LOG_IC((ICEvent::InstanceOfAddAccessCase, structure->classInfoForCells(), Identifier()));
         
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), nullptr, WTFMove(newCase));
-        
-        if (result.generatedSomeCode()) {
+
+        if (result.generatedSomeCode())
             LOG_IC((ICEvent::InstanceOfReplaceWithJump, structure->classInfoForCells(), Identifier()));
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
-        }
     }
     
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -1748,9 +1728,6 @@ static InlineCacheAction tryCacheArrayInByVal(JSGlobalObject* globalObject, Code
             newCase = AccessCase::create(vm, codeBlock, accessType, nullptr);
 
         result = stubInfo.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), nullptr, newCase.releaseNonNull());
-
-        if (result.generatedSomeCode())
-            InlineAccess::rewireStubAsJumpInAccess(codeBlock, stubInfo, *result.handler());
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, stubInfo, codeBlock, result);
@@ -2050,7 +2027,7 @@ void linkPolymorphicCall(VM& vm, JSCell* owner, CallFrame* callFrame, CallLinkIn
 void resetGetBy(CodeBlock* codeBlock, StructureStubInfo& stubInfo, GetByKind kind)
 {
     repatchSlowPathCall(codeBlock, stubInfo, appropriateGetByOptimizeFunction(kind));
-    InlineAccess::resetStubAsJumpInAccess(codeBlock, stubInfo);
+    stubInfo.resetStubAsJumpInAccess(codeBlock);
 }
 
 void resetPutBy(CodeBlock* codeBlock, StructureStubInfo& stubInfo, PutByKind kind)
@@ -2096,7 +2073,7 @@ void resetPutBy(CodeBlock* codeBlock, StructureStubInfo& stubInfo, PutByKind kin
     }
 
     repatchSlowPathCall(codeBlock, stubInfo, optimizedFunction);
-    InlineAccess::resetStubAsJumpInAccess(codeBlock, stubInfo);
+    stubInfo.resetStubAsJumpInAccess(codeBlock);
 }
 
 void resetDelBy(CodeBlock* codeBlock, StructureStubInfo& stubInfo, DelByKind kind)
@@ -2115,37 +2092,37 @@ void resetDelBy(CodeBlock* codeBlock, StructureStubInfo& stubInfo, DelByKind kin
         repatchSlowPathCall(codeBlock, stubInfo, operationDeleteByValSloppyOptimize);
         break;
     }
-    InlineAccess::resetStubAsJumpInAccess(codeBlock, stubInfo);
+    stubInfo.resetStubAsJumpInAccess(codeBlock);
 }
 
 void resetInBy(CodeBlock* codeBlock, StructureStubInfo& stubInfo, InByKind kind)
 {
     repatchSlowPathCall(codeBlock, stubInfo, appropriateInByOptimizeFunction(kind));
-    InlineAccess::resetStubAsJumpInAccess(codeBlock, stubInfo);
+    stubInfo.resetStubAsJumpInAccess(codeBlock);
 }
 
 void resetHasPrivateBrand(CodeBlock* codeBlock, StructureStubInfo& stubInfo)
 {
     repatchSlowPathCall(codeBlock, stubInfo, operationHasPrivateBrandOptimize);
-    InlineAccess::resetStubAsJumpInAccess(codeBlock, stubInfo);
+    stubInfo.resetStubAsJumpInAccess(codeBlock);
 }
 
 void resetInstanceOf(CodeBlock* codeBlock, StructureStubInfo& stubInfo)
 {
     repatchSlowPathCall(codeBlock, stubInfo, operationInstanceOfOptimize);
-    InlineAccess::resetStubAsJumpInAccess(codeBlock, stubInfo);
+    stubInfo.resetStubAsJumpInAccess(codeBlock);
 }
 
 void resetCheckPrivateBrand(CodeBlock* codeBlock, StructureStubInfo& stubInfo)
 {
     repatchSlowPathCall(codeBlock, stubInfo, operationCheckPrivateBrandOptimize);
-    InlineAccess::resetStubAsJumpInAccess(codeBlock, stubInfo);
+    stubInfo.resetStubAsJumpInAccess(codeBlock);
 }
 
 void resetSetPrivateBrand(CodeBlock* codeBlock, StructureStubInfo& stubInfo)
 {
     repatchSlowPathCall(codeBlock, stubInfo, operationSetPrivateBrandOptimize);
-    InlineAccess::resetStubAsJumpInAccess(codeBlock, stubInfo);
+    stubInfo.resetStubAsJumpInAccess(codeBlock);
 }
 
 #endif

--- a/Source/JavaScriptCore/bytecode/SharedJITStubSet.h
+++ b/Source/JavaScriptCore/bytecode/SharedJITStubSet.h
@@ -109,7 +109,7 @@ public:
         };
 
         StructureStubInfoKey m_stubInfoKey;
-        const FixedVector<RefPtr<AccessCase>>& m_cases;
+        std::span<const RefPtr<AccessCase>> m_cases;
     };
 
     struct PointerTranslator {

--- a/Source/JavaScriptCore/bytecode/StructureStubInfo.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubInfo.h
@@ -141,8 +141,8 @@ public:
     void deref();
     void aboutToDie();
 
-    void initializeFromUnlinkedStructureStubInfo(VM&, const BaselineUnlinkedStructureStubInfo&);
-    void initializeFromDFGUnlinkedStructureStubInfo(const DFG::UnlinkedStructureStubInfo&);
+    void initializeFromUnlinkedStructureStubInfo(VM&, CodeBlock*, const BaselineUnlinkedStructureStubInfo&);
+    void initializeFromDFGUnlinkedStructureStubInfo(CodeBlock*, const DFG::UnlinkedStructureStubInfo&);
 
     DECLARE_VISIT_AGGREGATE;
 
@@ -365,6 +365,9 @@ private:
         CacheableIdentifier m_byValId;
     };
 
+    void replaceHandler(CodeBlock*, Ref<InlineCacheHandler>&&);
+    void rewireStubAsJumpInAccess(CodeBlock*, InlineCacheHandler&);
+
 public:
     static ptrdiff_t offsetOfByIdSelfOffset() { return OBJECT_OFFSETOF(StructureStubInfo, byIdSelfOffset); }
     static ptrdiff_t offsetOfInlineAccessBaseStructureID() { return OBJECT_OFFSETOF(StructureStubInfo, m_inlineAccessBaseStructureID); }
@@ -375,6 +378,8 @@ public:
     static ptrdiff_t offsetOfCountdown() { return OBJECT_OFFSETOF(StructureStubInfo, countdown); }
     static ptrdiff_t offsetOfCallSiteIndex() { return OBJECT_OFFSETOF(StructureStubInfo, callSiteIndex); }
     static ptrdiff_t offsetOfHandler() { return OBJECT_OFFSETOF(StructureStubInfo, m_handler); }
+
+    void resetStubAsJumpInAccess(CodeBlock*);
 
     GPRReg thisGPR() const { return m_extraGPR; }
     GPRReg prototypeGPR() const { return m_extraGPR; }
@@ -420,8 +425,8 @@ public:
 
     CodePtr<JITStubRoutinePtrTag> m_codePtr;
     std::unique_ptr<PolymorphicAccess> m_stub;
-    RefPtr<InlineCacheHandler> m_handler;
 private:
+    RefPtr<InlineCacheHandler> m_handler;
     // Represents those structures that already have buffered AccessCases in the PolymorphicAccess.
     // Note that it's always safe to clear this. If we clear it prematurely, then if we see the same
     // structure again during this buffering countdown, we will create an AccessCase object for it.

--- a/Source/JavaScriptCore/dfg/DFGJITCode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.cpp
@@ -94,7 +94,7 @@ bool JITData::tryInitialize(VM& vm, CodeBlock* codeBlock, const JITCode& jitCode
 
     for (unsigned index = 0; index < jitCode.m_unlinkedStubInfos.size(); ++index) {
         const UnlinkedStructureStubInfo& unlinkedStubInfo = jitCode.m_unlinkedStubInfos[index];
-        stubInfo(index).initializeFromDFGUnlinkedStructureStubInfo(unlinkedStubInfo);
+        stubInfo(index).initializeFromDFGUnlinkedStructureStubInfo(codeBlock, unlinkedStubInfo);
     }
 
     unsigned indexOfWatchpoints = 0;

--- a/Source/JavaScriptCore/heap/JITStubRoutineSet.cpp
+++ b/Source/JavaScriptCore/heap/JITStubRoutineSet.cpp
@@ -126,8 +126,8 @@ void JITStubRoutineSet::deleteUnmarkedJettisonedStubRoutines(VM& vm)
     while (srcIndex < m_routines.size()) {
         Routine routine = m_routines[srcIndex++];
         auto* stub = routine.routine;
-        if (!stub->m_ownerIsDead && stub->owner())
-            stub->m_ownerIsDead = !vm.heap.isMarked(stub->owner());
+        if (!stub->m_ownerIsDead)
+            stub->m_ownerIsDead = stub->removeDeadOwners(vm);
 
         // If the stub is running right now, we should keep it alive regardless of whether owner CodeBlock gets dead.
         // It is OK since we already marked all the related cells.

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
@@ -84,6 +84,28 @@ IGNORE_GCC_WARNINGS_BEGIN("sequence-point")
 IGNORE_GCC_WARNINGS_END
 }
 
+bool GCAwareJITStubRoutine::removeDeadOwners(VM& vm)
+{
+    ASSERT(vm.heap.isInPhase(CollectorPhase::End));
+    if (m_owner)
+        return !vm.heap.isMarked(m_owner);
+
+    if (m_isInSharedJITStubSet) {
+        auto& owners = static_cast<PolymorphicAccessJITStubRoutine*>(this)->m_owners;
+        owners.removeAllIf([&](auto pair) {
+            return !vm.heap.isMarked(pair.key);
+        });
+        if (owners.isEmpty()) {
+            // All owners are dead. Unregistering itself from m_vm.m_sharedJITStubs since it is no longer valid.
+            vm.m_sharedJITStubs->remove(static_cast<PolymorphicAccessJITStubRoutine*>(this));
+            return true;
+        }
+        return false;
+    }
+
+    return false;
+}
+
 PolymorphicAccessJITStubRoutine::PolymorphicAccessJITStubRoutine(Type type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, VM& vm, FixedVector<RefPtr<AccessCase>>&& cases, FixedVector<StructureID>&& weakStructures, JSCell* owner)
     : GCAwareJITStubRoutine(type, code, owner)
     , m_vm(vm)
@@ -122,7 +144,7 @@ void PolymorphicAccessJITStubRoutine::invalidate()
     }
 }
 
-unsigned PolymorphicAccessJITStubRoutine::computeHash(const FixedVector<RefPtr<AccessCase>>& cases)
+unsigned PolymorphicAccessJITStubRoutine::computeHash(std::span<const RefPtr<AccessCase>> cases)
 {
     Hasher hasher;
     for (auto& key : cases)
@@ -215,7 +237,10 @@ Ref<PolymorphicAccessJITStubRoutine> createICJITStubRoutine(
     if (!makesCalls) {
         // Allocating CallLinkInfos means we should have calls.
         ASSERT(callLinkInfos.isEmpty());
-        return adoptRef(*new PolymorphicAccessJITStubRoutine(JITStubRoutine::Type::PolymorphicAccessJITStubRoutineType, code, vm, WTFMove(cases), WTFMove(weakStructures), owner));
+        auto stub = adoptRef(*new PolymorphicAccessJITStubRoutine(JITStubRoutine::Type::PolymorphicAccessJITStubRoutineType, code, vm, WTFMove(cases), WTFMove(weakStructures), owner));
+        constexpr bool isCodeImmutable = false;
+        stub->makeGCAware(vm, isCodeImmutable);
+        return stub;
     }
     
     if (codeBlockForExceptionHandlers) {

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
@@ -73,6 +73,8 @@ public:
     void makeGCAware(VM&, bool isCodeImmutable);
 
     JSCell* owner() const { return m_owner; }
+
+    bool removeDeadOwners(VM&);
     
 protected:
     void observeZeroRefCountImpl();
@@ -92,6 +94,7 @@ class PolymorphicAccessJITStubRoutine : public GCAwareJITStubRoutine {
 public:
     using Base = GCAwareJITStubRoutine;
     friend class JITStubRoutine;
+    friend class GCAwareJITStubRoutine;
 
     PolymorphicAccessJITStubRoutine(Type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&, FixedVector<RefPtr<AccessCase>>&&, FixedVector<StructureID>&&, JSCell* owner);
     ~PolymorphicAccessJITStubRoutine();
@@ -106,14 +109,36 @@ public:
         return m_hash;
     }
 
-    static unsigned computeHash(const FixedVector<RefPtr<AccessCase>>&);
+    static unsigned computeHash(std::span<const RefPtr<AccessCase>>);
 
     void addedToSharedJITStubSet();
+
 
     const WatchpointsOnStructureStubInfo* watchpoints() const { return m_watchpoints.get(); }
     void setWatchpoints(std::unique_ptr<WatchpointsOnStructureStubInfo>&&);
     WatchpointSet& watchpointSet() { return *m_watchpointSet.get(); }
     void invalidate();
+
+    bool isStillValid() const
+    {
+        if (!m_watchpointSet)
+            return false;
+        if (!m_watchpointSet->isStillValid())
+            return false;
+        return !m_ownerIsDead;
+    }
+
+    void addOwner(CodeBlock* codeBlock)
+    {
+        if (m_isInSharedJITStubSet)
+            m_owners.add(codeBlock);
+    }
+
+    void removeOwner(CodeBlock* codeBlock)
+    {
+        if (m_isInSharedJITStubSet)
+            m_owners.remove(codeBlock);
+    }
 
 protected:
     void observeZeroRefCountImpl();
@@ -123,6 +148,7 @@ private:
     FixedVector<RefPtr<AccessCase>> m_cases;
     FixedVector<StructureID> m_weakStructures;
     RefPtr<WatchpointSet> m_watchpointSet;
+    HashCountedSet<CodeBlock*> m_owners;
     std::unique_ptr<WatchpointsOnStructureStubInfo> m_watchpoints;
 };
 

--- a/Source/JavaScriptCore/runtime/StructureID.h
+++ b/Source/JavaScriptCore/runtime/StructureID.h
@@ -85,7 +85,7 @@ public:
     static StructureID encode(const Structure*);
 
     explicit operator bool() const { return !!m_bits; }
-    friend bool operator==(const StructureID&, const StructureID&) = default;
+    friend auto operator<=>(const StructureID&, const StructureID&) = default;
     constexpr uint32_t bits() const { return m_bits; }
 
     StructureID(WTF::HashTableDeletedValueType) : m_bits(nukedStructureIDBit) { }

--- a/Source/WTF/wtf/FixedVector.h
+++ b/Source/WTF/wtf/FixedVector.h
@@ -192,6 +192,19 @@ public:
 
     Storage* storage() { return m_storage.get(); }
 
+    std::span<const T> span() const { return { data(), size() }; }
+    std::span<T> mutableSpan() { return { data(), size() }; }
+
+    Vector<T> subvector(size_t offset, size_t length = std::dynamic_extent) const
+    {
+        return { span().subspan(offset, length) };
+    }
+
+    std::span<const T> subspan(size_t offset, size_t length = std::dynamic_extent) const
+    {
+        return span().subspan(offset, length);
+    }
+
 private:
     friend class JSC::LLIntOffsetsExtractor;
 

--- a/Source/WTF/wtf/HashCountedSet.h
+++ b/Source/WTF/wtf/HashCountedSet.h
@@ -100,6 +100,9 @@ public:
     bool removeAll(iterator);
     bool removeAll(const ValueType&);
 
+    template<typename Functor>
+    bool removeAllIf(const Functor&);
+
     // Clears the whole set.
     void clear();
 
@@ -278,6 +281,12 @@ inline bool HashCountedSet<Value, HashFunctions, Traits>::removeAll(iterator it)
 
     m_impl.remove(it);
     return true;
+}
+
+template<typename Value, typename HashFunctions, typename Traits>
+inline bool HashCountedSet<Value, HashFunctions, Traits>::removeAllIf(const auto& functor)
+{
+    return m_impl.removeIf(functor);
 }
 
 template<typename Value, typename HashFunctions, typename Traits>


### PR DESCRIPTION
#### 13455c7affe3713294333e8fa829a3089f36f2e4
<pre>
[JSC] Reland Handler IC
<a href="https://bugs.webkit.org/show_bug.cgi?id=273693">https://bugs.webkit.org/show_bug.cgi?id=273693</a>
<a href="https://rdar.apple.com/127496851">rdar://127496851</a>

Reviewed by Keith Miller.

This patch enables limited variant of Handler IC. The limitation means,

1. Only enabled for Baseline JIT.
2. Getter and Setter are not supported yet.
3. We are caching entire code as an one handler. This is not the final form we would like to have.
   Next step is splitting them into one per AccessCase and chain them.
4. After (3) gets done, we would like to put more data into InlineCacheHandler itself so that code
   can be more and more sharable.

But even with this limited form, we are already observing good cache hit rate. So we take an approach starting with this,
and further extending Handler IC based on the above milestones.

We enable Handler IC, which is only enabled for Baseline JIT right now.
The IC is hash-consed via SharedJITStubSet. And InlineCacheCompiler first search for an already compiled stub, if it finds it,
we register watchpoint to this stub and use it without new compilation. If it is not found, we compile a new stub and register it to this table if possible.
When nobody uses this stub, then refCount becomes zero, and it automatically unregister itself from the table.
Each StructureStubInfo site&apos;s access cases is always subsumes stub&apos;s access cases. So GC will check validity via this StructureStubInfo&apos;s access cases, and
drop stub when it is no longer valid (as the same to the current IC).

The major difference from the last patch is adding multiple owners to the shared JIT IC.
Stubs are unregistering themselves from SharedJITStubSet when it reaches to zero-ref-count.
But this does not work well since CodeBlock can be destroyed lazily: if CodeBlock is dead, during that,
no GC scanning happens to this stub while ref-count is still non-zero.
For normal JIT stubs, we have owner concept for JIT stub. At GC end phase, we iterate stubs and check whether the owner is already dead.
And if it is dead, we mark it m_ownerIsDead. But shared JIT stub does not have this concept.
Instead, we have HashCountedSet for shared JIT stub, and register multiple owners for shared JIT stub. And at GC end phase, we scan owners
to wipe dead owners, and when live owners become zero, we mark the stub as m_ownerIsDead too.

* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::tryGetAlternateBaseImpl const):
(JSC::AccessCase::canBeShared):
(JSC::AccessCase::tryGetAlternateBase const):
(JSC::AccessCase::hasAlternateBaseImpl const): Deleted.
(JSC::AccessCase::alternateBaseImpl const): Deleted.
(JSC::AccessCase::hasAlternateBase const): Deleted.
(JSC::AccessCase::alternateBase const): Deleted.
* Source/JavaScriptCore/bytecode/AccessCase.h:
(JSC::AccessCase::identifier const):
(JSC::AccessCase::dumpImpl const):
(JSC::AccessCase::updateIdentifier): Deleted.
* Source/JavaScriptCore/bytecode/GetByStatus.cpp:
(JSC::GetByStatus::computeForStubInfoWithoutExitSiteFeedback):
* Source/JavaScriptCore/bytecode/GetterSetterAccessCase.cpp:
(JSC::GetterSetterAccessCase::tryGetAlternateBaseImpl const):
(JSC::GetterSetterAccessCase::hasAlternateBaseImpl const): Deleted.
(JSC::GetterSetterAccessCase::alternateBaseImpl const): Deleted.
* Source/JavaScriptCore/bytecode/GetterSetterAccessCase.h:
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::generateImpl):
(JSC::InlineCacheCompiler::regenerate):
(JSC::isMegamorphicById): Deleted.
* Source/JavaScriptCore/bytecode/PutByStatus.cpp:
(JSC::PutByStatus::computeForStubInfo):
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h:
(JSC::PolymorphicAccessJITStubRoutine::isStillValid const):
* Source/JavaScriptCore/runtime/StructureID.h:

Canonical link: <a href="https://commits.webkit.org/278369@main">https://commits.webkit.org/278369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6b984258872f95a3b28d1253315c97acccfe72a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50256 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29549 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53515 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/946 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/584 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41010 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27216 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43258 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22109 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24633 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/510 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8634 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43636 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46619 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55100 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49755 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25352 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/507 "Found 1 new test failure: fast/webgpu/texture-supports-blending.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48411 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26615 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43442 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47435 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27477 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57233 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7277 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26345 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11763 "Passed tests") | 
<!--EWS-Status-Bubble-End-->