### PR TITLE
Replace potentially more confusing decltype() usage with template lambdas where possible

### DIFF
--- a/Source/WebCore/Modules/cache/DOMCache.cpp
+++ b/Source/WebCore/Modules/cache/DOMCache.cpp
@@ -153,8 +153,8 @@ void DOMCache::matchAll(std::optional<RequestInfo>&& info, CacheQueryOptions&& o
     }
 
     auto requestStart = MonotonicTime::now();
-    queryCache(WTFMove(resourceRequest), options, ShouldRetrieveResponses::Yes, [this, promise = WTFMove(promise), requestStart](auto&& result) mutable {
-        queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [this, promise = WTFMove(promise), result = std::forward<decltype(result)>(result), requestStart]() mutable {
+    queryCache(WTFMove(resourceRequest), options, ShouldRetrieveResponses::Yes, [this, promise = WTFMove(promise), requestStart]<typename Result> (Result&& result) mutable {
+        queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [this, promise = WTFMove(promise), result = std::forward<Result>(result), requestStart]() mutable {
             if (result.hasException()) {
                 promise.reject(result.releaseException());
                 return;

--- a/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.cpp
+++ b/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.cpp
@@ -151,8 +151,8 @@ void WorkerCacheStorageConnection::retrieveRecords(DOMCacheIdentifier cacheIdent
     m_retrieveRecordsPendingRequests.add(requestIdentifier, WTFMove(callback));
 
     callOnMainThread([workerThread = Ref { m_scope.thread() }, mainThreadConnection = m_mainThreadConnection, requestIdentifier, cacheIdentifier, options = WTFMove(options).isolatedCopy()]() mutable {
-        mainThreadConnection->retrieveRecords(cacheIdentifier, WTFMove(options), [workerThread = WTFMove(workerThread), requestIdentifier](auto&& result) mutable {
-            workerThread->runLoop().postTaskForMode([result = isolatedCopyCrossThreadRecordsOrError(std::forward<decltype(result)>(result)), requestIdentifier] (auto& scope) mutable {
+        mainThreadConnection->retrieveRecords(cacheIdentifier, WTFMove(options), [workerThread = WTFMove(workerThread), requestIdentifier]<typename Result> (Result&& result) mutable {
+            workerThread->runLoop().postTaskForMode([result = isolatedCopyCrossThreadRecordsOrError(std::forward<Result>(result)), requestIdentifier] (auto& scope) mutable {
                 downcast<WorkerGlobalScope>(scope).cacheStorageConnection().retrieveRecordsCompleted(requestIdentifier, WTFMove(result));
             }, WorkerRunLoop::defaultMode());
         });

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp
@@ -66,12 +66,12 @@ void FileSystemEntry::getParent(ScriptExecutionContext& context, RefPtr<FileSyst
     if (!successCallback && !errorCallback)
         return;
 
-    filesystem().getParent(context, *this, [this, pendingActivity = makePendingActivity(*this), successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback)](auto&& result) mutable {
+    filesystem().getParent(context, *this, [this, pendingActivity = makePendingActivity(*this), successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback)]<typename Result> (Result&& result) mutable {
         RefPtr document = this->document();
         if (!document)
             return;
 
-        document->eventLoop().queueTask(TaskSource::Networking, [successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback), result = std::forward<decltype(result)>(result), pendingActivity = WTFMove(pendingActivity)]() mutable {
+        document->eventLoop().queueTask(TaskSource::Networking, [successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback), result = std::forward<Result>(result), pendingActivity = WTFMove(pendingActivity)] () mutable {
             if (result.hasException()) {
                 if (errorCallback)
                     errorCallback->handleEvent(DOMException::create(result.releaseException()));

--- a/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp
+++ b/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp
@@ -60,8 +60,8 @@ static void doFetch(ScriptExecutionContext& scope, FetchRequest::Info&& input, F
         return;
     }
 
-    FetchResponse::fetch(scope, request.get(), [promise = WTFMove(promise), scope = Ref { scope }, userGestureToken = UserGestureIndicator::currentUserGesture()](auto&& result) mutable {
-        scope->eventLoop().queueTask(TaskSource::Networking, [promise = WTFMove(promise), userGestureToken = WTFMove(userGestureToken), result = std::forward<decltype(result)>(result)]() mutable {
+    FetchResponse::fetch(scope, request.get(), [promise = WTFMove(promise), scope = Ref { scope }, userGestureToken = UserGestureIndicator::currentUserGesture()]<typename Result> (Result&& result) mutable {
+        scope->eventLoop().queueTask(TaskSource::Networking, [promise = WTFMove(promise), userGestureToken = WTFMove(userGestureToken), result = std::forward<Result>(result)] () mutable {
             if (!userGestureToken || userGestureToken->hasExpired(UserGestureToken::maximumIntervalForUserGestureForwardingForFetch()) || !userGestureToken->processingUserGesture()) {
                 promise.settle(WTFMove(result));
                 return;

--- a/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
@@ -68,27 +68,29 @@ IDBKeyData::IDBKeyData(const IDBKey* key)
 }
 
 IDBKeyData::IDBKeyData(const IDBKeyData& data, IsolatedCopyTag)
-    : m_value(crossThreadCopy(data.m_value)) { }
+    : m_value(crossThreadCopy(data.m_value))
+{
+}
 
 IndexedDB::KeyType IDBKeyData::type() const
 {
     switch (m_value.index()) {
-    case WTF::alternativeIndexV<std::nullptr_t, decltype(m_value)>:
-    case WTF::alternativeIndexV<Invalid, decltype(m_value)>:
+    case WTF::alternativeIndexV<std::nullptr_t, ValueVariant>:
+    case WTF::alternativeIndexV<Invalid, ValueVariant>:
         return IndexedDB::KeyType::Invalid;
-    case WTF::alternativeIndexV<Vector<IDBKeyData>, decltype(m_value)>:
+    case WTF::alternativeIndexV<Vector<IDBKeyData>, ValueVariant>:
         return IndexedDB::KeyType::Array;
-    case WTF::alternativeIndexV<String, decltype(m_value)>:
+    case WTF::alternativeIndexV<String, ValueVariant>:
         return IndexedDB::KeyType::String;
-    case WTF::alternativeIndexV<double, decltype(m_value)>:
+    case WTF::alternativeIndexV<double, ValueVariant>:
         return IndexedDB::KeyType::Number;
-    case WTF::alternativeIndexV<Date, decltype(m_value)>:
+    case WTF::alternativeIndexV<Date, ValueVariant>:
         return IndexedDB::KeyType::Date;
-    case WTF::alternativeIndexV<ThreadSafeDataBuffer, decltype(m_value)>:
+    case WTF::alternativeIndexV<ThreadSafeDataBuffer, ValueVariant>:
         return IndexedDB::KeyType::Binary;
-    case WTF::alternativeIndexV<Min, decltype(m_value)>:
+    case WTF::alternativeIndexV<Min, ValueVariant>:
         return IndexedDB::KeyType::Min;
-    case WTF::alternativeIndexV<Max, decltype(m_value)>:
+    case WTF::alternativeIndexV<Max, ValueVariant>:
         return IndexedDB::KeyType::Max;
     }
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -496,12 +496,12 @@ void PeerConnectionBackend::addIceCandidate(RTCIceCandidate* iceCandidate, Funct
         return;
     }
 
-    doAddIceCandidate(*iceCandidate, [weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto&& result) mutable {
+    doAddIceCandidate(*iceCandidate, [weakThis = WeakPtr { *this }, callback = WTFMove(callback)]<typename Result> (Result&& result) mutable {
         if (!weakThis)
             return;
 
         auto& peerConnection = weakThis->m_peerConnection;
-        peerConnection.queueTaskKeepingObjectAlive(peerConnection, TaskSource::Networking, [&peerConnection, callback = WTFMove(callback), result = std::forward<decltype(result)>(result)]() mutable {
+        peerConnection.queueTaskKeepingObjectAlive(peerConnection, TaskSource::Networking, [&peerConnection, callback = WTFMove(callback), result = std::forward<Result>(result)] () mutable {
             if (peerConnection.isClosed())
                 return;
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
@@ -595,8 +595,8 @@ static std::optional<PeerConnectionBackend::DescriptionStates> descriptionsFromP
 
 void LibWebRTCMediaEndpoint::addIceCandidate(std::unique_ptr<webrtc::IceCandidateInterface>&& candidate, PeerConnectionBackend::AddIceCandidateCallback&& callback)
 {
-    m_backend->AddIceCandidate(WTFMove(candidate), [task = createSharedTask<PeerConnectionBackend::AddIceCandidateCallbackFunction>(WTFMove(callback)), backend = m_backend](auto&& error) mutable {
-        callOnMainThread([task = WTFMove(task), descriptions = crossThreadCopy(descriptionsFromPeerConnection(backend.get())), error = std::forward<decltype(error)>(error)]() mutable {
+    m_backend->AddIceCandidate(WTFMove(candidate), [task = createSharedTask<PeerConnectionBackend::AddIceCandidateCallbackFunction>(WTFMove(callback)), backend = m_backend]<typename Error> (Error&& error) mutable {
+        callOnMainThread([task = WTFMove(task), descriptions = crossThreadCopy(descriptionsFromPeerConnection(backend.get())), error = std::forward<Error>(error)] () mutable {
             if (!error.ok()) {
                 task->run(toException(error));
                 return;

--- a/Source/WebCore/bindings/js/JSDOMConvertUnion.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertUnion.h
@@ -111,10 +111,34 @@ struct ConditionalFront<List, false> {
     using type = void;
 };
 
+template<class F, class...Ts> F forEachArgs(F f)
+{
+    return (void)std::initializer_list<int> {
+        (
+            (void)f.template operator()<Ts>(),
+            0
+        )...
+    }, f;
+}
+
+template<template<class...> class List, typename... Elements, typename Functor>
+Functor forEachImpl(List<Elements...>&&, Functor f)
+{
+    return forEachArgs<Functor, Elements...>(f);
+}
+
+}
+
+/// Version of `brigand::for_each` that utilizes template lambdas to avoid the need to pass a dummy parameter.
+template<typename List, typename Functor> Functor forEach(Functor f)
+{
+    return Detail::forEachImpl(List { }, f);
 }
 
 template<typename List, bool condition>
 using ConditionalFront = typename Detail::ConditionalFront<List, condition>::type;
+
+
 
 template<typename... T> struct Converter<IDLUnion<T...>> : DefaultConverter<IDLUnion<T...>> {
     using Type = IDLUnion<T...>;
@@ -193,11 +217,10 @@ template<typename... T> struct Converter<IDLUnion<T...>> : DefaultConverter<IDLU
         //         (FIXME: Add support for object and step 4.2)
         if (brigand::any<TypeList, IsIDLInterface<brigand::_1>>::value) {
             std::optional<ReturnType> returnValue;
-            brigand::for_each<InterfaceTypeList>([&](auto&& type) {
+            forEach<InterfaceTypeList>([&]<typename Type> {
                 if (returnValue)
                     return;
                 
-                using Type = typename std::remove_cvref_t<decltype(type)>::type;
                 using ImplementationType = typename Type::ImplementationType;
                 using RawType = typename Type::RawType;
 
@@ -266,11 +289,10 @@ template<typename... T> struct Converter<IDLUnion<T...>> : DefaultConverter<IDLU
         constexpr bool hasTypedArrayType = brigand::any<TypeList, IsIDLTypedArray<brigand::_1>>::value;
         if (hasTypedArrayType) {
             std::optional<ReturnType> returnValue;
-            brigand::for_each<TypedArrayTypeList>([&](auto&& type) {
+            forEach<TypedArrayTypeList>([&]<typename Type> {
                 if (returnValue)
                     return;
 
-                using Type = typename std::remove_cvref_t<decltype(type)>::type;
                 using ImplementationType = typename Type::ImplementationType;
                 using WrapperType = typename Converter<Type>::WrapperType;
 
@@ -393,8 +415,7 @@ template<typename... T> struct JSConverter<IDLUnion<T...>> {
         auto index = variant.index();
 
         std::optional<JSC::JSValue> returnValue;
-        brigand::for_each<Sequence>([&](auto&& type) {
-            using I = typename std::remove_cvref_t<decltype(type)>::type;
+        forEach<Sequence>([&]<typename I> {
             if (I::value == index) {
                 ASSERT(!returnValue);
                 returnValue = toJS<brigand::at<TypeList, I>>(lexicalGlobalObject, globalObject, std::get<I::value>(variant));

--- a/Source/WebCore/css/CSSGradientValue.cpp
+++ b/Source/WebCore/css/CSSGradientValue.cpp
@@ -196,10 +196,10 @@ static bool appendColorInterpolationMethod(StringBuilder& builder, CSSGradientCo
             }
             return false;
         },
-        [&] (const auto& method) {
-            builder.append(needsLeadingSpace ? " " : "", "in ", serializationForCSS(method.interpolationColorSpace));
-            if constexpr (hasHueInterpolationMethod<decltype(method)>)
-                serializationForCSS(builder, method.hueInterpolationMethod);
+        [&]<typename MethodColorSpace> (const MethodColorSpace& methodColorSpace) {
+            builder.append(needsLeadingSpace ? " " : "", "in ", serializationForCSS(methodColorSpace.interpolationColorSpace));
+            if constexpr (hasHueInterpolationMethod<MethodColorSpace>)
+                serializationForCSS(builder, methodColorSpace.hueInterpolationMethod);
             return true;
         }
     );

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -306,8 +306,7 @@ void CSSValue::collectComputedStyleDependencies(ComputedStyleDependencies& depen
 bool CSSValue::equals(const CSSValue& other) const
 {
     if (classType() == other.classType()) {
-        return visitDerived([&](auto& typedThis) {
-            using ValueType = std::remove_reference_t<decltype(typedThis)>;
+        return visitDerived([&]<typename ValueType> (ValueType& typedThis) {
             static_assert(!std::is_same_v<decltype(&ValueType::equals), decltype(&CSSValue::equals)>);
             return typedThis.equals(uncheckedDowncast<ValueType>(other));
         });
@@ -366,9 +365,9 @@ ASCIILiteral CSSValue::separatorCSSText(ValueSeparator separator)
 
 void CSSValue::operator delete(CSSValue* value, std::destroying_delete_t)
 {
-    value->visitDerived([](auto& value) {
+    value->visitDerived([]<typename ValueType> (ValueType& value) {
         std::destroy_at(&value);
-        std::decay_t<decltype(value)>::freeAfterDestruction(&value);
+        ValueType::freeAfterDestruction(&value);
     });
 }
 

--- a/Source/WebCore/css/DeprecatedCSSOMValue.cpp
+++ b/Source/WebCore/css/DeprecatedCSSOMValue.cpp
@@ -33,9 +33,9 @@ namespace WebCore {
 
 void DeprecatedCSSOMValue::operator delete(DeprecatedCSSOMValue* value, std::destroying_delete_t)
 {
-    auto destroyAndFree = [&](auto& value) {
+    auto destroyAndFree = [&]<typename ValueType> (ValueType& value) {
         std::destroy_at(&value);
-        std::decay_t<decltype(value)>::freeAfterDestruction(&value);
+        ValueType::freeAfterDestruction(&value);
     };
 
     switch (value->classType()) {

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -141,18 +141,18 @@ template<typename Visitor> constexpr decltype(auto) StyleRuleBase::visitDerived(
 
 void StyleRuleBase::operator delete(StyleRuleBase* rule, std::destroying_delete_t)
 {
-    rule->visitDerived([](auto& rule) {
+    rule->visitDerived([]<typename RuleType> (RuleType& rule) {
         std::destroy_at(&rule);
-        std::decay_t<decltype(rule)>::freeAfterDestruction(&rule);
+        RuleType::freeAfterDestruction(&rule);
     });
 }
 
 Ref<StyleRuleBase> StyleRuleBase::copy() const
 {
-    return visitDerived([](auto& rule) -> Ref<StyleRuleBase> {
+    return visitDerived([]<typename RuleType> (RuleType& rule) -> Ref<StyleRuleBase> {
         // Check at compile time for a mistake where this function would call itself, leading to infinite recursion.
         // We can do this with the types of pointers to member functions because they includes the type of the class.
-        static_assert(!std::is_same_v<decltype(&std::decay_t<decltype(rule)>::copy), decltype(&StyleRuleBase::copy)>);
+        static_assert(!std::is_same_v<decltype(&RuleType::copy), decltype(&StyleRuleBase::copy)>);
         return rule.copy();
     });
 }

--- a/Source/WebCore/css/color/CSSResolvedColorMix.cpp
+++ b/Source/WebCore/css/color/CSSResolvedColorMix.cpp
@@ -114,9 +114,9 @@ Color mix(const CSSResolvedColorMix& colorMix)
         return { };
 
     return WTF::switchOn(colorMix.colorInterpolationMethod.colorSpace,
-        [&] (auto colorSpace) {
-            return mixColorComponentsUsingColorInterpolationMethod<decltype(colorSpace)>(
-                colorSpace,
+        [&] (const auto& methodColorSpace) {
+            return mixColorComponentsUsingColorInterpolationMethod(
+                methodColorSpace,
                 *mixPercentages,
                 colorMix.mixComponents1.color,
                 colorMix.mixComponents2.color

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -382,9 +382,9 @@ void Node::trackForDebugging()
 
 inline void NodeRareData::operator delete(NodeRareData* nodeRareData, std::destroying_delete_t)
 {
-    auto destroyAndFree = [&](auto& value) {
+    auto destroyAndFree = [&]<typename RareDataType> (RareDataType& value) {
         std::destroy_at(&value);
-        std::decay_t<decltype(value)>::freeAfterDestruction(&value);
+        RareDataType::freeAfterDestruction(&value);
     };
 
     if (nodeRareData->m_isElementRareData)

--- a/Source/WebCore/loader/SubresourceIntegrity.cpp
+++ b/Source/WebCore/loader/SubresourceIntegrity.cpp
@@ -102,8 +102,7 @@ std::optional<Vector<EncodedResourceCryptographicDigest>> parseIntegrityMetadata
 
     std::optional<Vector<EncodedResourceCryptographicDigest>> result;
     
-    readCharactersForParsing(integrityMetadata, [&result] (auto buffer) {
-        using CharacterType = typename decltype(buffer)::CharacterType;
+    readCharactersForParsing(integrityMetadata, [&result]<typename CharacterType> (StringParsingBuffer<CharacterType> buffer) {
         splitOnSpaces(buffer, IntegrityMetadataParser<CharacterType> { result });
     });
 

--- a/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp
@@ -80,9 +80,7 @@ std::optional<ApplicationCacheManifest> parseApplicationCacheManifest(const URL&
 
     auto manifestString = TextResourceDecoder::create(cacheManifestMIMEType, "UTF-8")->decodeAndFlush(data);
 
-    return readCharactersForParsing(manifestString, [&](auto buffer) -> std::optional<ApplicationCacheManifest> {
-        using CharacterType = typename decltype(buffer)::CharacterType;
-    
+    return readCharactersForParsing(manifestString, [&]<typename CharacterType> (StringParsingBuffer<CharacterType> buffer) -> std::optional<ApplicationCacheManifest> {
         ApplicationCacheManifest manifest;
         auto mode = ApplicationCacheParserMode::Explicit;
 

--- a/Source/WebCore/platform/Length.cpp
+++ b/Source/WebCore/platform/Length.cpp
@@ -271,16 +271,22 @@ LengthType Length::typeFromIndex(const IPCData& data)
 Length::Length(IPCData&& data)
     : m_type(typeFromIndex(data))
 {
-    WTF::switchOn(data, [&] (auto data) {
-        WTF::switchOn(data.value, [&] (float value) {
-            m_isFloat = true;
-            m_floatValue = value;
-        }, [&] (int value) {
-            m_isFloat = false;
-            m_intValue = value;
-        });
-        m_hasQuirk = data.hasQuirk;
-    }, [] (auto emptyData) requires std::is_empty_v<decltype(emptyData)> { });
+    WTF::switchOn(data,
+        [&] (auto data) {
+            WTF::switchOn(data.value,
+                [&] (float value) {
+                    m_isFloat = true;
+                    m_floatValue = value;
+                },
+                [&] (int value) {
+                    m_isFloat = false;
+                    m_intValue = value;
+                }
+            );
+            m_hasQuirk = data.hasQuirk;
+        },
+        []<typename EmptyData> (EmptyData) requires std::is_empty_v<EmptyData> { }
+    );
 }
 
 auto Length::ipcData() const -> IPCData

--- a/Source/WebCore/platform/graphics/Color.cpp
+++ b/Source/WebCore/platform/graphics/Color.cpp
@@ -177,9 +177,7 @@ double Color::luminance() const
 
 bool Color::anyComponentIsNone() const
 {
-    return callOnUnderlyingType([&] (const auto& underlyingColor) {
-        using ColorType = std::decay_t<decltype(underlyingColor)>;
-
+    return callOnUnderlyingType([&]<typename ColorType> (const ColorType& underlyingColor) {
         if constexpr (std::is_same_v<ColorType, SRGBA<uint8_t>>)
             return false;
         else
@@ -202,9 +200,7 @@ Color Color::colorWithAlpha(float alpha) const
 
 Color Color::invertedColorWithAlpha(float alpha) const
 {
-    return callOnUnderlyingType([&] (const auto& underlyingColor) -> Color {
-        using ColorType = std::decay_t<decltype(underlyingColor)>;
-
+    return callOnUnderlyingType([&]<typename ColorType> (const ColorType& underlyingColor) -> Color {
         // FIXME: Determine if there is a meaningful understanding of inversion that works
         // better for non-invertible color types like Lab or consider removing this in favor
         // of alternatives.

--- a/Source/WebCore/platform/graphics/ColorBlending.cpp
+++ b/Source/WebCore/platform/graphics/ColorBlending.cpp
@@ -99,9 +99,7 @@ Color blendWithWhite(const Color& color)
 
 static bool requiresLegacyInterpolationRules(const Color& color)
 {
-    return color.callOnUnderlyingType([&] (const auto& underlyingColor) {
-        using ColorType = std::decay_t<decltype(underlyingColor)>;
-
+    return color.callOnUnderlyingType([&]<typename ColorType> (const ColorType&) {
         if constexpr (std::is_same_v<ColorType, SRGBA<uint8_t>>)
             return true;
         else if constexpr (std::is_same_v<ColorType, SRGBA<float>>)

--- a/Source/WebCore/platform/graphics/ColorConversion.cpp
+++ b/Source/WebCore/platform/graphics/ColorConversion.cpp
@@ -365,52 +365,11 @@ OKLab<float> ColorConversion<OKLab<float>, OKLCHA<float>>::convert(const OKLCHA<
 
 ColorComponents<float, 4> convertAndResolveColorComponents(ColorSpace inputColorSpace, ColorComponents<float, 4> inputColorComponents, ColorSpace outputColorSpace)
 {
-    return callWithColorType(inputColorComponents, inputColorSpace, [outputColorSpace] (const auto& inputColor) {
-        switch (outputColorSpace) {
-        case ColorSpace::A98RGB:
-            return asColorComponents(convertColor<A98RGB<float>>(inputColor).resolved());
-        case ColorSpace::DisplayP3:
-            return asColorComponents(convertColor<DisplayP3<float>>(inputColor).resolved());
-        case ColorSpace::ExtendedA98RGB:
-            return asColorComponents(convertColor<ExtendedA98RGB<float>>(inputColor).resolved());
-        case ColorSpace::ExtendedDisplayP3:
-            return asColorComponents(convertColor<ExtendedDisplayP3<float>>(inputColor).resolved());
-        case ColorSpace::ExtendedLinearSRGB:
-            return asColorComponents(convertColor<ExtendedLinearSRGBA<float>>(inputColor).resolved());
-        case ColorSpace::ExtendedProPhotoRGB:
-            return asColorComponents(convertColor<ExtendedProPhotoRGB<float>>(inputColor).resolved());
-        case ColorSpace::ExtendedRec2020:
-            return asColorComponents(convertColor<ExtendedRec2020<float>>(inputColor).resolved());
-        case ColorSpace::ExtendedSRGB:
-            return asColorComponents(convertColor<ExtendedSRGBA<float>>(inputColor).resolved());
-        case ColorSpace::HSL:
-            return asColorComponents(convertColor<HSLA<float>>(inputColor).resolved());
-        case ColorSpace::HWB:
-            return asColorComponents(convertColor<HWBA<float>>(inputColor).resolved());
-        case ColorSpace::LCH:
-            return asColorComponents(convertColor<LCHA<float>>(inputColor).resolved());
-        case ColorSpace::Lab:
-            return asColorComponents(convertColor<Lab<float>>(inputColor).resolved());
-        case ColorSpace::LinearSRGB:
-            return asColorComponents(convertColor<LinearSRGBA<float>>(inputColor).resolved());
-        case ColorSpace::OKLCH:
-            return asColorComponents(convertColor<OKLCHA<float>>(inputColor).resolved());
-        case ColorSpace::OKLab:
-            return asColorComponents(convertColor<OKLab<float>>(inputColor).resolved());
-        case ColorSpace::ProPhotoRGB:
-            return asColorComponents(convertColor<ProPhotoRGB<float>>(inputColor).resolved());
-        case ColorSpace::Rec2020:
-            return asColorComponents(convertColor<Rec2020<float>>(inputColor).resolved());
-        case ColorSpace::SRGB:
-            return asColorComponents(convertColor<SRGBA<float>>(inputColor).resolved());
-        case ColorSpace::XYZ_D50:
-            return asColorComponents(convertColor<XYZA<float, WhitePoint::D50>>(inputColor).resolved());
-        case ColorSpace::XYZ_D65:
-            return asColorComponents(convertColor<XYZA<float, WhitePoint::D65>>(inputColor).resolved());
-        }
-
-        ASSERT_NOT_REACHED();
-        return asColorComponents(convertColor<SRGBA<float>>(inputColor).resolved());
+    return callWithColorType<float>(inputColorSpace, [&]<typename InputColorType> {
+        auto inputColor = makeFromComponents<InputColorType>(inputColorComponents);
+        return callWithColorType<float>(outputColorSpace, [&]<typename OutputColorType> {
+            return asColorComponents(convertColor<OutputColorType>(inputColor).resolved());
+        });
     });
 }
 

--- a/Source/WebCore/platform/graphics/ColorInterpolation.cpp
+++ b/Source/WebCore/platform/graphics/ColorInterpolation.cpp
@@ -86,8 +86,8 @@ std::pair<float, float> fixupHueComponentsPriorToInterpolation(HueInterpolationM
 Color interpolateColors(ColorInterpolationMethod colorInterpolationMethod, Color color1, double color1Multiplier, Color color2, double color2Multiplier)
 {
     return WTF::switchOn(colorInterpolationMethod.colorSpace,
-        [&] (auto& colorSpace) -> Color {
-            using ColorType = typename std::remove_reference_t<decltype(colorSpace)>::ColorType;
+        [&]<typename MethodColorSpace> (const MethodColorSpace& colorSpace) -> Color {
+            using ColorType = typename MethodColorSpace::ColorType;
             switch (colorInterpolationMethod.alphaPremultiplication) {
             case AlphaPremultiplication::Premultiplied:
                 return interpolateColorComponents<AlphaPremultiplication::Premultiplied>(colorSpace, color1.toColorTypeLossy<ColorType>(), color1Multiplier, color2.toColorTypeLossy<ColorType>(), color2Multiplier);

--- a/Source/WebCore/platform/graphics/ColorInterpolationMethod.cpp
+++ b/Source/WebCore/platform/graphics/ColorInterpolationMethod.cpp
@@ -56,9 +56,9 @@ void serializationForCSS(StringBuilder& builder, HueInterpolationMethod hueInter
 void serializationForCSS(StringBuilder& builder, const ColorInterpolationMethod& method)
 {
     WTF::switchOn(method.colorSpace,
-        [&] (auto& type) {
+        [&]<typename MethodColorSpace> (const MethodColorSpace& type) {
             serializationForCSS(builder, type.interpolationColorSpace);
-            if constexpr (hasHueInterpolationMethod<decltype(type)>)
+            if constexpr (hasHueInterpolationMethod<MethodColorSpace>)
                 serializationForCSS(builder, type.hueInterpolationMethod);
         }
     );
@@ -142,9 +142,9 @@ TextStream& operator<<(TextStream& ts, HueInterpolationMethod hueInterpolationMe
 TextStream& operator<<(TextStream& ts, const ColorInterpolationMethod& method)
 {
     WTF::switchOn(method.colorSpace,
-        [&] (auto& type) {
+        [&]<typename ColorSpace> (const ColorSpace& type) {
             ts << type.interpolationColorSpace;
-            if constexpr (hasHueInterpolationMethod<decltype(type)>)
+            if constexpr (hasHueInterpolationMethod<ColorSpace>)
                 ts << ' ' << type.hueInterpolationMethod;
             ts << ' ' << method.alphaPremultiplication;
         }

--- a/Source/WebCore/platform/graphics/ColorInterpolationMethod.h
+++ b/Source/WebCore/platform/graphics/ColorInterpolationMethod.h
@@ -174,10 +174,10 @@ inline void add(Hasher& hasher, const ColorInterpolationMethod& colorInterpolati
 {
     add(hasher, colorInterpolationMethod.alphaPremultiplication);
     WTF::switchOn(colorInterpolationMethod.colorSpace,
-        [&] (auto& type) {
-            add(hasher, type.interpolationColorSpace);
-            if constexpr (std::remove_reference_t<decltype(type)>::ColorType::Model::coordinateSystem == ColorSpaceCoordinateSystem::CylindricalPolar) {
-                add(hasher, type.hueInterpolationMethod);
+        [&]<typename MethodColorSpace> (const MethodColorSpace& mothodColorSpace) {
+            add(hasher, mothodColorSpace.interpolationColorSpace);
+            if constexpr (MethodColorSpace::ColorType::Model::coordinateSystem == ColorSpaceCoordinateSystem::CylindricalPolar) {
+                add(hasher, mothodColorSpace.hueInterpolationMethod);
             }
         }
     );

--- a/Source/WebCore/platform/graphics/ColorSpace.h
+++ b/Source/WebCore/platform/graphics/ColorSpace.h
@@ -82,55 +82,60 @@ template<typename T> struct ColorSpaceMapping<XYZA<T, WhitePoint::D65>> { static
 
 template<typename ColorType> constexpr ColorSpace ColorSpaceFor = ColorSpaceMapping<CanonicalColorType<ColorType>>::colorSpace;
 
-
-template<typename T, typename Functor> constexpr decltype(auto) callWithColorType(const ColorComponents<T, 4>& components, ColorSpace colorSpace, Functor&& functor)
+template<typename T, typename Functor> constexpr decltype(auto) callWithColorType(ColorSpace colorSpace, Functor&& functor)
 {
     switch (colorSpace) {
     case ColorSpace::A98RGB:
-        return std::invoke(std::forward<Functor>(functor), makeFromComponents<A98RGB<T>>(components));
+        return functor.template operator()<A98RGB<T>>();
     case ColorSpace::DisplayP3:
-        return std::invoke(std::forward<Functor>(functor), makeFromComponents<DisplayP3<T>>(components));
+        return functor.template operator()<DisplayP3<T>>();
     case ColorSpace::ExtendedA98RGB:
-        return std::invoke(std::forward<Functor>(functor), makeFromComponents<ExtendedA98RGB<T>>(components));
+        return functor.template operator()<ExtendedA98RGB<T>>();
     case ColorSpace::ExtendedDisplayP3:
-        return std::invoke(std::forward<Functor>(functor), makeFromComponents<ExtendedDisplayP3<T>>(components));
+        return functor.template operator()<ExtendedDisplayP3<T>>();
     case ColorSpace::ExtendedLinearSRGB:
-        return std::invoke(std::forward<Functor>(functor), makeFromComponents<ExtendedLinearSRGBA<T>>(components));
+        return functor.template operator()<ExtendedLinearSRGBA<T>>();
     case ColorSpace::ExtendedProPhotoRGB:
-        return std::invoke(std::forward<Functor>(functor), makeFromComponents<ExtendedProPhotoRGB<T>>(components));
+        return functor.template operator()<ExtendedProPhotoRGB<T>>();
     case ColorSpace::ExtendedRec2020:
-        return std::invoke(std::forward<Functor>(functor), makeFromComponents<ExtendedRec2020<T>>(components));
+        return functor.template operator()<ExtendedRec2020<T>>();
     case ColorSpace::ExtendedSRGB:
-        return std::invoke(std::forward<Functor>(functor), makeFromComponents<ExtendedSRGBA<T>>(components));
+        return functor.template operator()<ExtendedSRGBA<T>>();
     case ColorSpace::HSL:
-        return std::invoke(std::forward<Functor>(functor), makeFromComponents<HSLA<T>>(components));
+        return functor.template operator()<HSLA<T>>();
     case ColorSpace::HWB:
-        return std::invoke(std::forward<Functor>(functor), makeFromComponents<HWBA<T>>(components));
+        return functor.template operator()<HWBA<T>>();
     case ColorSpace::LCH:
-        return std::invoke(std::forward<Functor>(functor), makeFromComponents<LCHA<T>>(components));
+        return functor.template operator()<LCHA<T>>();
     case ColorSpace::Lab:
-        return std::invoke(std::forward<Functor>(functor), makeFromComponents<Lab<T>>(components));
+        return functor.template operator()<Lab<T>>();
     case ColorSpace::LinearSRGB:
-        return std::invoke(std::forward<Functor>(functor), makeFromComponents<LinearSRGBA<T>>(components));
+        return functor.template operator()<LinearSRGBA<T>>();
     case ColorSpace::OKLCH:
-        return std::invoke(std::forward<Functor>(functor), makeFromComponents<OKLCHA<T>>(components));
+        return functor.template operator()<OKLCHA<T>>();
     case ColorSpace::OKLab:
-        return std::invoke(std::forward<Functor>(functor), makeFromComponents<OKLab<T>>(components));
+        return functor.template operator()<OKLab<T>>();
     case ColorSpace::ProPhotoRGB:
-        return std::invoke(std::forward<Functor>(functor), makeFromComponents<ProPhotoRGB<T>>(components));
+        return functor.template operator()<ProPhotoRGB<T>>();
     case ColorSpace::Rec2020:
-        return std::invoke(std::forward<Functor>(functor), makeFromComponents<Rec2020<T>>(components));
+        return functor.template operator()<Rec2020<T>>();
     case ColorSpace::SRGB:
-        return std::invoke(std::forward<Functor>(functor), makeFromComponents<SRGBA<T>>(components));
+        return functor.template operator()<SRGBA<T>>();
     case ColorSpace::XYZ_D50:
-        return std::invoke(std::forward<Functor>(functor), makeFromComponents<XYZA<T, WhitePoint::D50>>(components));
+        return functor.template operator()<XYZA<T, WhitePoint::D50>>();
     case ColorSpace::XYZ_D65:
-        return std::invoke(std::forward<Functor>(functor), makeFromComponents<XYZA<T, WhitePoint::D65>>(components));
+        return functor.template operator()<XYZA<T, WhitePoint::D65>>();
     }
 
     ASSERT_NOT_REACHED();
-    return std::invoke(std::forward<Functor>(functor), makeFromComponents<SRGBA<T>>(components));
+    return functor.template operator()<SRGBA<T>>();
 }
 
+template<typename T, typename Functor> constexpr decltype(auto) callWithColorType(const ColorComponents<T, 4>& components, ColorSpace colorSpace, Functor&& functor)
+{
+    return callWithColorType<T>(colorSpace, [&]<typename ColorType> {
+        return std::invoke(std::forward<Functor>(functor), makeFromComponents<ColorType>(components));
+    });
+}
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/PathSegment.cpp
+++ b/Source/WebCore/platform/graphics/PathSegment.cpp
@@ -74,8 +74,8 @@ bool PathSegment::canApplyElements() const
 
 bool PathSegment::applyElements(const PathElementApplier& applier) const
 {
-    return WTF::switchOn(m_data, [&](auto& data) -> bool {
-        if constexpr (std::decay_t<decltype(data)>::canApplyElements) {
+    return WTF::switchOn(m_data, [&]<typename DataType>(DataType& data) -> bool {
+        if constexpr (DataType::canApplyElements) {
             data.applyElements(applier);
             return true;
         }
@@ -92,8 +92,8 @@ bool PathSegment::canTransform() const
 
 bool PathSegment::transform(const AffineTransform& transform)
 {
-    return WTF::switchOn(m_data, [&](auto& data) {
-        if constexpr (std::decay_t<decltype(data)>::canTransform) {
+    return WTF::switchOn(m_data, [&]<typename DataType>(DataType& data) {
+        if constexpr (DataType::canTransform) {
             data.transform(transform);
             return true;
         }

--- a/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
@@ -558,8 +558,8 @@ GradientRendererCG::Strategy GradientRendererCG::makeShading(ColorInterpolationM
     auto makeData = [&] (auto colorInterpolationMethod, auto& stops) {
         auto convertColorToColorInterpolationSpace = [&] (const Color& color, auto colorInterpolationMethod) -> ColorComponents<float, 4> {
             return WTF::switchOn(colorInterpolationMethod.colorSpace,
-                [&] (auto& colorSpace) -> ColorComponents<float, 4> {
-                    using ColorType = typename std::remove_reference_t<decltype(colorSpace)>::ColorType;
+                [&]<typename MethodColorSpace> (const MethodColorSpace&) -> ColorComponents<float, 4> {
+                    using ColorType = typename MethodColorSpace::ColorType;
                     return asColorComponents(color.template toColorTypeLossy<ColorType>().unresolved());
                 }
             );
@@ -611,14 +611,12 @@ GradientRendererCG::Strategy GradientRendererCG::makeShading(ColorInterpolationM
     auto makeFunction = [&] (auto colorInterpolationMethod, auto& data) {
         auto makeEvaluateCallback = [&] (auto colorInterpolationMethod) -> CGFunctionEvaluateCallback {
             return WTF::switchOn(colorInterpolationMethod.colorSpace,
-                [&] (auto& colorSpace) -> CGFunctionEvaluateCallback {
-                    using InterpolationMethodColorSpace = typename std::remove_reference_t<decltype(colorSpace)>;
-                    
+                [&]<typename MethodColorSpace> (const MethodColorSpace&) -> CGFunctionEvaluateCallback {
                     switch (colorInterpolationMethod.alphaPremultiplication) {
                     case AlphaPremultiplication::Unpremultiplied:
-                        return &Shading::shadingFunction<InterpolationMethodColorSpace, AlphaPremultiplication::Unpremultiplied>;
+                        return &Shading::shadingFunction<MethodColorSpace, AlphaPremultiplication::Unpremultiplied>;
                     case AlphaPremultiplication::Premultiplied:
-                        return &Shading::shadingFunction<InterpolationMethodColorSpace, AlphaPremultiplication::Premultiplied>;
+                        return &Shading::shadingFunction<MethodColorSpace, AlphaPremultiplication::Premultiplied>;
                     }
                 }
             );

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
@@ -40,8 +40,7 @@ template<typename T> inline constexpr bool HasIsValid<T, std::void_t<decltype(st
 
 bool isValid(const Item& item)
 {
-    return WTF::switchOn(item, [&](const auto& item) {
-        using T = std::decay_t<decltype(item)>;
+    return WTF::switchOn(item, [&]<typename T> (const T& item) {
         if constexpr (HasIsValid<T>)
             return item.isValid();
         else {
@@ -218,8 +217,8 @@ bool shouldDumpItem(const Item& item, OptionSet<AsTextFlag> flags)
 
 void dumpItem(TextStream& ts, const Item& item, OptionSet<AsTextFlag> flags)
 {
-    WTF::switchOn(item, [&](const auto& item) {
-        ts << std::decay_t<decltype(item)>::name;
+    WTF::switchOn(item, [&]<typename ItemType> (const ItemType& item) {
+        ts << ItemType::name;
         item.dump(ts, flags);
     });
 }

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -524,7 +524,7 @@ public:
     RenderLayer* enclosingFloatPaintingLayer() const;
     
     virtual std::optional<LayoutUnit> firstLineBaseline() const { return std::optional<LayoutUnit>(); }
-    virtual std::optional<LayoutUnit> lastLineBaseline() const { return std::optional<LayoutUnit> (); }
+    virtual std::optional<LayoutUnit> lastLineBaseline() const { return std::optional<LayoutUnit>(); }
     virtual std::optional<LayoutUnit> inlineBlockBaseline(LineDirectionMode) const { return std::optional<LayoutUnit>(); } // Returns empty if we should skip this box when computing the baseline of an inline-block.
     LayoutUnit synthesizeBaseline(FontBaseline baselineType, BaselineSynthesisEdge) const;
 

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -522,12 +522,10 @@ void SVGRenderSupport::updateMaskedAncestorShouldIsolateBlending(const RenderEle
 
 FloatRect SVGRenderSupport::calculateApproximateStrokeBoundingBox(const RenderElement& renderer)
 {
-    auto calculateApproximateScalingStrokeBoundingBox = [&](const auto& renderer, FloatRect fillBoundingBox) -> FloatRect {
+    auto calculateApproximateScalingStrokeBoundingBox = [&]<typename Renderer>(const Renderer& renderer, FloatRect fillBoundingBox) -> FloatRect {
         // Implementation of
         // https://drafts.fxtf.org/css-masking/#compute-stroke-bounding-box
         // except that we ignore whether the stroke is none.
-
-        using Renderer = std::decay_t<decltype(renderer)>;
 
         ASSERT(renderer.style().svgStyle().hasStroke());
 

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -409,7 +409,7 @@ void RuleFeatureSet::collectFeatures(const RuleData& ruleData, const Vector<Ref<
     if (ruleData.containsUncommonAttributeSelector())
         uncommonAttributeRules.append({ ruleData });
 
-    auto addToMap = [&](auto& map, auto& entries, auto hostAffectingNames) {
+    auto addToMap = [&]<typename HostAffectingNames>(auto& map, auto& entries, HostAffectingNames hostAffectingNames) {
         for (auto& entry : entries) {
             auto& [selector, matchElement, isNegation] = entry;
             auto& name = selector->value();
@@ -420,7 +420,7 @@ void RuleFeatureSet::collectFeatures(const RuleData& ruleData, const Vector<Ref<
 
             setUsesMatchElement(matchElement);
 
-            if constexpr (!std::is_same_v<std::nullptr_t, decltype(hostAffectingNames)>) {
+            if constexpr (!std::is_same_v<std::nullptr_t, HostAffectingNames>) {
                 if (matchElement == MatchElement::Host)
                     hostAffectingNames->add(name);
             }

--- a/Source/WebCore/svg/SVGViewSpec.cpp
+++ b/Source/WebCore/svg/SVGViewSpec.cpp
@@ -73,9 +73,7 @@ template<typename CharacterType> static constexpr CharacterType viewTargetSpec[]
 
 bool SVGViewSpec::parseViewSpec(StringView string)
 {
-    return readCharactersForParsing(string, [&](auto buffer) -> bool {
-        using CharacterType = typename decltype(buffer)::CharacterType;
-
+    return readCharactersForParsing(string, [&]<typename CharacterType> (StringParsingBuffer<CharacterType> buffer) -> bool {
         if (buffer.atEnd() || !m_contextElement)
             return false;
 

--- a/Source/WebCore/workers/service/ServiceWorkerClients.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerClients.cpp
@@ -54,8 +54,8 @@ void ServiceWorkerClients::get(ScriptExecutionContext& context, const String& id
 
     callOnMainThread([promiseIdentifier = addPendingPromise(WTFMove(promise)), serviceWorkerIdentifier, id = id.isolatedCopy()] () {
         auto connection = SWContextManager::singleton().connection();
-        connection->findClientByVisibleIdentifier(serviceWorkerIdentifier, id, [promiseIdentifier, serviceWorkerIdentifier] (auto&& clientData) {
-            SWContextManager::singleton().postTaskToServiceWorker(serviceWorkerIdentifier, [promiseIdentifier, data = crossThreadCopy(std::forward<decltype(clientData)>(clientData))] (auto& context) mutable {
+        connection->findClientByVisibleIdentifier(serviceWorkerIdentifier, id, [promiseIdentifier, serviceWorkerIdentifier]<typename ClientData> (ClientData&& clientData) {
+            SWContextManager::singleton().postTaskToServiceWorker(serviceWorkerIdentifier, [promiseIdentifier, data = crossThreadCopy(std::forward<ClientData>(clientData))] (auto& context) mutable {
                 if (auto promise = context.clients().takePendingPromise(promiseIdentifier))
                     didFinishGetRequest(context, *promise, WTFMove(data));
             });
@@ -113,8 +113,8 @@ void ServiceWorkerClients::openWindow(ScriptExecutionContext& context, const Str
     auto serviceWorkerIdentifier = downcast<ServiceWorkerGlobalScope>(context).thread().identifier();
     callOnMainThread([promiseIdentifier = addPendingPromise(WTFMove(promise)), serviceWorkerIdentifier, url = url.isolatedCopy()] () mutable {
         auto connection = SWContextManager::singleton().connection();
-        connection->openWindow(serviceWorkerIdentifier, url, [promiseIdentifier, serviceWorkerIdentifier] (auto&& result) mutable {
-            SWContextManager::singleton().postTaskToServiceWorker(serviceWorkerIdentifier, [promiseIdentifier, result = crossThreadCopy(std::forward<decltype(result)>(result))] (ServiceWorkerGlobalScope& scope) mutable {
+        connection->openWindow(serviceWorkerIdentifier, url, [promiseIdentifier, serviceWorkerIdentifier]<typename Result> (Result&& result) mutable {
+            SWContextManager::singleton().postTaskToServiceWorker(serviceWorkerIdentifier, [promiseIdentifier, result = crossThreadCopy(std::forward<Result>(result))] (ServiceWorkerGlobalScope& scope) mutable {
                 LOG(ServiceWorker, "WebProcess %i finished ServiceWorkerClients::openWindow call result is %d.", getpid(), !result.hasException());
 
                 auto promise = scope.clients().takePendingPromise(promiseIdentifier);

--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
@@ -218,8 +218,8 @@ void dispatchFetchEvent(Ref<Client>&& client, ServiceWorkerGlobalScope& globalSc
 
     CertificateInfo certificateInfo = globalScope.certificateInfo();
 
-    event->onResponse([client, mode, redirect, requestURL, certificateInfo = WTFMove(certificateInfo), deferredPromise] (auto&& result) mutable {
-        processResponse(WTFMove(client), std::forward<decltype(result)>(result), mode, redirect, requestURL, WTFMove(certificateInfo), deferredPromise.get());
+    event->onResponse([client, mode, redirect, requestURL, certificateInfo = WTFMove(certificateInfo), deferredPromise]<typename Result> (Result&& result) mutable {
+        processResponse(WTFMove(client), std::forward<Result>(result), mode, redirect, requestURL, WTFMove(certificateInfo), deferredPromise.get());
     });
 
     globalScope.dispatchEvent(event);


### PR DESCRIPTION
#### 5fe8dd6a3b46ad9e11f397ea324c5615cb7680bf
<pre>
Replace potentially more confusing decltype() usage with template lambdas where possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=273694">https://bugs.webkit.org/show_bug.cgi?id=273694</a>

Reviewed by Darin Adler.

A somewhat common patter in WebCore is for a call site to use a generic lambda but still
want to know what the type of the generic argument was. Something like:

    function([](auto parameter) {
        using Type = std::decay_t&lt;decltype(parameter)&gt;;

        ...
    });

This was necessary in the past due to the lack of template lambdas, but now we have them
and this can be come:

    function([]&lt;typename Type&gt;(Type parameter) {
        ...
    });

Additionally, this now lets us provide a template parameter without the need for passing
an argument. For example, if the actual value of the parameter was not needed in the
example above, we could instead write:

    function([]&lt;typename Type&gt;() {
        ...
    });

This allows us to generalize a few places that needed a mapping of color space to color
type, allowing us to remove some duplicate copies of the big switch.

* Source/WebCore/Modules/cache/DOMCache.cpp:
(WebCore::DOMCache::matchAll):
* Source/WebCore/Modules/cache/WorkerCacheStorageConnection.cpp:
(WebCore::WorkerCacheStorageConnection::retrieveRecords):
* Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp:
(WebCore::FileSystemEntry::getParent):
* Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp:
(WebCore::doFetch):
* Source/WebCore/Modules/indexeddb/IDBKeyData.cpp:
(WebCore::IDBKeyData::IDBKeyData):
(WebCore::IDBKeyData::type const):
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::PeerConnectionBackend::addIceCandidate):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp:
(WebCore::LibWebRTCMediaEndpoint::addIceCandidate):
* Source/WebCore/bindings/js/JSDOMConvertUnion.h:
(WebCore::Detail::forEachArgs):
(WebCore::forEach):
* Source/WebCore/css/CSSGradientValue.cpp:
(WebCore::appendColorInterpolationMethod):
* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::equals const):
(WebCore::CSSValue::operator delete):
* Source/WebCore/css/DeprecatedCSSOMValue.cpp:
(WebCore::DeprecatedCSSOMValue::operator delete):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleBase::operator delete):
(WebCore::StyleRuleBase::copy const):
* Source/WebCore/css/color/CSSResolvedColorMix.cpp:
(WebCore::mix):
* Source/WebCore/dom/Node.cpp:
(WebCore::NodeRareData::operator delete):
* Source/WebCore/loader/SubresourceIntegrity.cpp:
(WebCore::parseIntegrityMetadata):
* Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp:
(WebCore::parseApplicationCacheManifest):
* Source/WebCore/platform/Length.cpp:
(WebCore::Length::Length):
* Source/WebCore/platform/graphics/Color.cpp:
(WebCore::Color::anyComponentIsNone const):
(WebCore::Color::invertedColorWithAlpha const):
* Source/WebCore/platform/graphics/ColorBlending.cpp:
(WebCore::requiresLegacyInterpolationRules):
* Source/WebCore/platform/graphics/ColorConversion.cpp:
(WebCore::convertAndResolveColorComponents):
* Source/WebCore/platform/graphics/ColorInterpolation.cpp:
(WebCore::interpolateColors):
* Source/WebCore/platform/graphics/ColorInterpolationMethod.cpp:
(WebCore::serializationForCSS):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/ColorInterpolationMethod.h:
(WebCore::add):
(WebCore::serializationForCSS):
* Source/WebCore/platform/graphics/ColorSpace.h:
(WebCore::callWithColorType):
* Source/WebCore/platform/graphics/PathSegment.cpp:
(WebCore::PathSegment::applyElements const):
(WebCore::PathSegment::transform):
* Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp:
(WebCore::GradientRendererCG::makeShading const):
* Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp:
(WebCore::DisplayList::isValid):
(WebCore::DisplayList::dumpItem):
* Source/WebCore/rendering/RenderBox.h:
(WebCore::RenderBox::lastLineBaseline const):
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::calculateApproximateStrokeBoundingBox):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::collectFeatures):
* Source/WebCore/svg/SVGViewSpec.cpp:
(WebCore::SVGViewSpec::parseViewSpec):
* Source/WebCore/workers/service/ServiceWorkerClients.cpp:
(WebCore::ServiceWorkerClients::get):
(WebCore::ServiceWorkerClients::openWindow):
* Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp:
(WebCore::ServiceWorkerFetch::dispatchFetchEvent):

Canonical link: <a href="https://commits.webkit.org/278358@main">https://commits.webkit.org/278358@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34396ed8844c9ca8949a1b216936026c4506d5b4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50233 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53492 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/923 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/548 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40988 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52332 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27196 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43237 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22086 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24616 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/489 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8611 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46603 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/551 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55077 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25329 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/484 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48400 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26590 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43424 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47423 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11034 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27454 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26322 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->