### PR TITLE
[webkitcorepy] Add mutually exclusive groups to TaskPool

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py
@@ -23,6 +23,7 @@
 import io
 import os
 import logging
+import math
 import multiprocessing
 import signal
 import sys
@@ -100,16 +101,18 @@ class _State(_Message):
     STARTING, STOPPING = 1, 0
     STATES = [STARTING, STOPPING]
 
-    def __init__(self, state):
+    def __init__(self, state, mutually_exclusive_groups=None):
         super(_State, self).__init__()
         self.state = state
+        self.mutually_exclusive_groups = mutually_exclusive_groups or []
 
     def __call__(self, caller):
-        log.info('{} {}'.format(
+        log.info('{} {}{}'.format(
             self.who, {
                 self.STARTING: 'starting',
                 self.STOPPING: 'stopping',
             }.get(self.state, self.state),
+            ' ({})'.format(', '.join(self.mutually_exclusive_groups)) if self.mutually_exclusive_groups else '',
         ))
         if caller:
             caller._started += {
@@ -164,6 +167,35 @@ class _BiDirectionalQueue(object):
             self.incoming.close()
             self.outgoing.join_thread()
             self.incoming.join_thread()
+
+
+class _Queue(object):
+    def __init__(self, queue=None):
+        self.queue = queue or multiprocessing.Queue()
+
+    def send(self, object):
+        if self.queue._closed:
+            sys.stderr.write('Cannot send message to closed queue\n')
+            return False
+        return self.queue.put(object)
+
+    def receive(self, blocking=True):
+        with Timeout.DisableAlarm():
+            try:
+                if not blocking:
+                    return self.queue.get(block=False)
+
+                difference = Timeout.difference()
+                if difference is not None:
+                    return self.queue.get(timeout=difference)
+                return self.queue.get()
+            except Queue.Empty:
+                pass
+
+    def close(self):
+        with OutputCapture():
+            self.queue.close()
+            self.queue.join_thread()
 
 
 class _DummyQueue(object):
@@ -264,7 +296,7 @@ class _Process(object):
             cls.working = False
 
     @classmethod
-    def main(cls, name, loglevel, setup, setupargs, setupkwargs, queue, teardown, teardownargs, teardownkwargs):
+    def main(cls, name, loglevel, setup, setupargs, setupkwargs, queue, teardown, teardownargs, teardownkwargs, mutually_exclusive_group_queues):
         from tblib import pickling_support
 
         cls.name = name
@@ -288,7 +320,8 @@ class _Process(object):
         logger.setLevel(loglevel)
 
         cls.queue = queue
-        queue.send(_State(_State.STARTING))
+        group_queues = list(mutually_exclusive_group_queues.values())
+        queue.send(_State(_State.STARTING, list(mutually_exclusive_group_queues.keys())))
 
         with OutputCapture.ReplaceSysStream('stderr', cls.Stream(_Print.stderr, queue)), OutputCapture.ReplaceSysStream('stdout', cls.Stream(_Print.stdout, queue)):
             try:
@@ -297,7 +330,22 @@ class _Process(object):
                     setup(*setupargs, **setupkwargs)
 
                 while cls.working:
-                    task = queue.receive()
+                    task = None
+                    for i in range(len(group_queues)):
+                        group_queue = group_queues[i]
+                        task = group_queue.receive(blocking=False)
+                        if task:
+                            del group_queues[i]
+                            group_queues.append(group_queue)
+                            break
+                    if not task:
+                        task = queue.receive()
+                    # Since queue.receive is blocking, we should check group_queues one final time before breaking the work loop
+                    if not task:
+                        for group_queue in group_queues:
+                            task = group_queue.receive(blocking=False)
+                            if task:
+                                break
                     if not task:
                         break
                     queue.send(_Result(value=task(None), id=task.id))
@@ -313,7 +361,7 @@ class _Process(object):
                     teardown(*teardownargs, **teardownkwargs)
                 sys.stdout.flush()
                 sys.stderr.flush()
-                queue.send(_State(_State.STOPPING))
+                queue.send(_State(_State.STOPPING, list(mutually_exclusive_group_queues.keys())))
                 cls.queue.close()
                 cls.queue = None
 
@@ -327,6 +375,7 @@ class TaskPool(object):
     State = _State
     ChildException = _ChildException
     BiDirectionalQueue = _BiDirectionalQueue
+    Queue = _Queue
     Process = _Process
 
 
@@ -338,6 +387,7 @@ class TaskPool(object):
         setupargs=None, setupkwargs=None,
         teardownargs=None, teardownkwargs=None,
         force_fork=False,
+        mutually_exclusive_groups=None,
     ):
         # Ensure tblib is installed before creating child processes
         import tblib
@@ -351,6 +401,8 @@ class TaskPool(object):
             raise ValueError('TaskPool requires positive number of workers')
 
         self.queue = None
+        self.mutually_exclusive_groups = set(mutually_exclusive_groups or [])
+        self._group_queues = dict()
         self.workers = []
 
         self._setup_args = (setup, setupargs or [], setupkwargs or {})
@@ -382,15 +434,25 @@ class TaskPool(object):
         from mock import patch
 
         self.queue = self.BiDirectionalQueue()
-        self.workers = [multiprocessing.Process(
-            target=self.Process.main,
-            args=(
-                '{}/{}'.format(self.name, count), logging.getLogger().getEffectiveLevel(),
-                self._setup_args[0], self._setup_args[1], self._setup_args[2],
-                self.BiDirectionalQueue(outgoing=self.queue.incoming, incoming=self.queue.outgoing),
-                self._teardown_args[0], self._teardown_args[1], self._teardown_args[2],
-            ),
-        ) for count in range(self._num_workers)]
+        self._group_queues = {
+            name: self.Queue() for name in self.mutually_exclusive_groups
+        }
+
+        mutually_exclusive_groups = sorted(self.mutually_exclusive_groups)
+        self.workers = []
+        for count in range(self._num_workers):
+            groups_for_worker = mutually_exclusive_groups[:int(math.ceil(float(len(mutually_exclusive_groups)) / (self._num_workers - count)))]
+            mutually_exclusive_groups = mutually_exclusive_groups[len(groups_for_worker):]
+            self.workers.append(multiprocessing.Process(
+                target=self.Process.main,
+                args=(
+                    '{}/{}'.format(self.name, count), logging.getLogger().getEffectiveLevel(),
+                    self._setup_args[0], self._setup_args[1], self._setup_args[2],
+                    self.BiDirectionalQueue(outgoing=self.queue.incoming, incoming=self.queue.outgoing),
+                    self._teardown_args[0], self._teardown_args[1], self._teardown_args[2],
+                    {group: self._group_queues[group] for group in groups_for_worker},
+                ),
+            ))
 
         with Timeout(seconds=self.enter_grace_period, patch=False, handler=self.Exception('Failed to start all workers')):
             for worker in self.workers:
@@ -402,16 +464,22 @@ class TaskPool(object):
 
     def do(self, function, *args, **kwargs):
         callback = kwargs.pop('callback', None)
+        group = kwargs.pop('group', None)
+        if group and group not in self._group_queues:
+            raise ValueError("'{}' is not a recognized group".format(group))
+
         if not self.queue:
             result = function(*args, **kwargs)
             if callback:
                 callback(result)
             return
 
+        queue = self._group_queues.get(group, self.queue)
+
         if callback:
             self.callbacks[self._id_count] = callback
         self.pending_count += 1
-        self.queue.send(self.Task(function, self._id_count, *args, **kwargs))
+        queue.send(self.Task(function, self._id_count, *args, **kwargs))
         self._id_count += 1
 
         # For every block of tasks passed to our workers, we need consume messages so we don't get deadlocked

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/task_pool_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/task_pool_unittest.py
@@ -36,8 +36,11 @@ def teardown(arg='Tearing down'):
     logger.warning(arg)
 
 
-def action(argument):
-    print('action({})'.format(argument))
+def action(argument, include_worker=False):
+    print('{}action({})'.format(
+        '{} '.format(TaskPool.Process.name) if include_worker else '',
+        argument,
+    ))
     return argument
 
 
@@ -170,3 +173,92 @@ class TaskPoolUnittest(unittest.TestCase):
                 sorted(captured.webkitcorepy.log.getvalue().splitlines()),
                 ['worker/{} Teardown argument'.format(x) for x in range(4)],
             )
+
+        def test_mutually_exclusive_group(self):
+            with OutputCapture(level=logging.INFO) as captured:
+                with TaskPool(workers=4, mutually_exclusive_groups=['group']) as pool:
+                    for character in self.alphabet:
+                        pool.do(
+                            action, character,
+                            include_worker=True,
+                            group='group' if character in ('a', 'b', 'c', 'd') else None,
+                        )
+                    pool.wait()
+
+            self.assertEqual(
+                sorted(captured.webkitcorepy.log.getvalue().splitlines()), [
+                    'worker/0 starting (group)', 'worker/0 stopping (group)',
+                    'worker/1 starting', 'worker/1 stopping',
+                    'worker/2 starting', 'worker/2 stopping',
+                    'worker/3 starting', 'worker/3 stopping',
+                ],
+            )
+            self.assertEqual(
+                sorted(captured.stdout.getvalue().splitlines())[:4], [
+                    'worker/0 action(a)',
+                    'worker/0 action(b)',
+                    'worker/0 action(c)',
+                    'worker/0 action(d)',
+                ]
+            )
+
+        def test_mutually_exclusive_groups(self):
+            with OutputCapture(level=logging.INFO) as captured:
+                with TaskPool(workers=4, mutually_exclusive_groups=[
+                    'alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot',
+                ]) as pool:
+                    for character in self.alphabet:
+                        pool.do(
+                            action,
+                            character,
+                            include_worker=True,
+                            group=dict(
+                                a='alpha',
+                                b='bravo',
+                                c='charlie',
+                                d='delta',
+                                e='echo',
+                                f='foxtrot',
+                            ).get(character, None)
+                        )
+                    pool.wait()
+
+            self.assertEqual(
+                sorted(captured.webkitcorepy.log.getvalue().splitlines()), [
+                    'worker/0 starting (alpha, bravo)', 'worker/0 stopping (alpha, bravo)',
+                    'worker/1 starting (charlie, delta)', 'worker/1 stopping (charlie, delta)',
+                    'worker/2 starting (echo)', 'worker/2 stopping (echo)',
+                    'worker/3 starting (foxtrot)', 'worker/3 stopping (foxtrot)',
+                ],
+            )
+
+            logging_by_worker = {}
+            for line in captured.stdout.getvalue().splitlines():
+                worker = line.split(' ')[0]
+                if worker not in logging_by_worker:
+                    logging_by_worker[worker] = []
+                logging_by_worker[worker].append(line)
+
+            self.assertEqual(
+                sorted(logging_by_worker['worker/0'])[:2],
+                ['worker/0 action(a)', 'worker/0 action(b)'],
+            )
+            self.assertEqual(
+                sorted(logging_by_worker['worker/1'])[:2],
+                ['worker/1 action(c)', 'worker/1 action(d)'],
+            )
+            self.assertEqual(
+                sorted(logging_by_worker['worker/2'])[0],
+                'worker/2 action(e)',
+            )
+            self.assertEqual(
+                sorted(logging_by_worker['worker/3'])[0],
+                'worker/3 action(f)',
+            )
+
+        def test_invalid_group(self):
+            with OutputCapture(level=logging.INFO) as captured:
+                with TaskPool(workers=1) as pool:
+                    with self.assertRaises(ValueError):
+                        pool.do(action, 'a', group='invalid')
+                    pool.wait()


### PR DESCRIPTION
#### 03d9366f146b13e52b370ee15d905a7da16b6c01
<pre>
[webkitcorepy] Add mutually exclusive groups to TaskPool
<a href="https://bugs.webkit.org/show_bug.cgi?id=273695">https://bugs.webkit.org/show_bug.cgi?id=273695</a>
<a href="https://rdar.apple.com/127503729">rdar://127503729</a>

Reviewed by Sam Sneddon.

Add the concept of mutually exclusive groups to TaskPool, which will
allow for types of tests to be grouped in a single processes with other
tests of their own type.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py:
(_State.__init__): Include mutually exclusive groups supported by worker.
(_State.__call__): Print names of mutually exclusive groups supported by worker.
(_Queue): Added.
(_Process.main): Attempt to fetch tasks from any groups registered to this worker
before fetching tasks from the shared queue.
(TaskPool.__init__): Allow caller to define mutually exclusive groups.
(TaskPool.__enter__): Distribute mutually exclusive groups amongst workers, with each
worker taking ownership over an equal number of groups.
(TaskPool.do): Allow caller to specify a group send task to.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/task_pool_unittest.py:
(action): Add option to log which worker a task was run on.
(TaskPoolUnittest.test_mutually_exclusive_group):
(TaskPoolUnittest.test_mutually_exclusive_groups):
(TaskPoolUnittest.test_invalid_group):

Canonical link: <a href="https://commits.webkit.org/278787@main">https://commits.webkit.org/278787@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1d8dee537f0a8cbddbb89ef594bfea2ca8e66cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51571 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3924 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/54838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2264 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1945 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/54838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/53670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/28518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44481 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/54838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/51420 "Found 1 webkitpy python3 test failure: webkit.messages_unittest.GeneratedFileContentsTest.test_message_argument_description") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/1742 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1832 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56430 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/26691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/51590 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/27930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44549 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/28824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7518 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/27665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->