### PR TITLE
[WebGPU] Remove unsupported timestamp query functionality from WebGPU.framework

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -129,7 +129,6 @@ private:
         Ref<QuerySet> querySet;
         uint32_t queryIndex;
     };
-    Vector<PendingTimestampWrites> m_pendingTimestampWrites;
     uint64_t m_debugGroupStackSize { 0 };
     WeakPtr<CommandBuffer> m_cachedCommandBuffer;
     NSString* m_lastErrorString { nil };

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.h
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.h
@@ -93,7 +93,6 @@ private:
         Ref<QuerySet> querySet;
         uint32_t queryIndex;
     };
-    Vector<PendingTimestampWrites> m_pendingTimestampWrites;
     uint64_t m_debugGroupStackSize { 0 };
 
     const Ref<Device> m_device;

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -48,20 +48,12 @@ if (!m_computeCommandEncoder || !m_parentEncoder->isValid() || !m_parentEncoder-
     return; \
 }
 
-ComputePassEncoder::ComputePassEncoder(id<MTLComputeCommandEncoder> computeCommandEncoder, const WGPUComputePassDescriptor& descriptor, CommandEncoder& parentEncoder, Device& device)
+ComputePassEncoder::ComputePassEncoder(id<MTLComputeCommandEncoder> computeCommandEncoder, const WGPUComputePassDescriptor&, CommandEncoder& parentEncoder, Device& device)
     : m_computeCommandEncoder(computeCommandEncoder)
     , m_device(device)
     , m_parentEncoder(parentEncoder)
 {
     m_parentEncoder->lock(true);
-
-    if (m_device->baseCapabilities().counterSamplingAPI == HardwareCapabilities::BaseCapabilities::CounterSamplingAPI::CommandBoundary) {
-        if (descriptor.timestampWrites) {
-            const auto& timestampWrite = *descriptor.timestampWrites;
-            [m_computeCommandEncoder sampleCountersInBuffer:fromAPI(timestampWrite.querySet).counterSampleBuffer() atSampleIndex:timestampWrite.beginningOfPassWriteIndex withBarrier:NO];
-            m_pendingTimestampWrites.append({ fromAPI(timestampWrite.querySet), timestampWrite.endOfPassWriteIndex });
-        }
-    }
 }
 
 ComputePassEncoder::ComputePassEncoder(CommandEncoder& parentEncoder, Device& device, NSString* errorString)
@@ -329,10 +321,6 @@ void ComputePassEncoder::endPass()
         return;
     }
 
-    ASSERT(m_pendingTimestampWrites.isEmpty() || m_device->baseCapabilities().counterSamplingAPI == HardwareCapabilities::BaseCapabilities::CounterSamplingAPI::CommandBoundary);
-    for (const auto& pendingTimestampWrite : m_pendingTimestampWrites)
-        [m_computeCommandEncoder sampleCountersInBuffer:pendingTimestampWrite.querySet->counterSampleBuffer() atSampleIndex:pendingTimestampWrite.queryIndex withBarrier:NO];
-    m_pendingTimestampWrites.clear();
     m_parentEncoder->endEncoding(m_computeCommandEncoder);
     m_computeCommandEncoder = nil;
     m_parentEncoder->lock(false);

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.h
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.h
@@ -43,11 +43,6 @@ struct HardwareCapabilities {
         // as all hardware can render to this format. It's unclear whether this should
         // apply to _all_ PresentationContexts or just PresentationContextCoreAnimation.
         bool canPresentRGB10A2PixelFormats { false };
-        enum class CounterSamplingAPI : uint8_t {
-            StageBoundary,
-            CommandBoundary,
-        };
-        CounterSamplingAPI counterSamplingAPI { CounterSamplingAPI::StageBoundary }; // only meaningful if timestampCounterSet is non-nil
     } baseCapabilities;
 };
 

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -79,15 +79,7 @@ static HardwareCapabilities::BaseCapabilities baseCapabilities(id<MTLDevice> dev
             statisticCounterSet = counterSet;
     }
 
-    auto counterSamplingAPI = HardwareCapabilities::BaseCapabilities::CounterSamplingAPI::StageBoundary;
-    if ([device supportsCounterSampling:MTLCounterSamplingPointAtBlitBoundary]
-        && [device supportsCounterSampling:MTLCounterSamplingPointAtDispatchBoundary]
-        && [device supportsCounterSampling:MTLCounterSamplingPointAtDrawBoundary])
-        counterSamplingAPI = HardwareCapabilities::BaseCapabilities::CounterSamplingAPI::CommandBoundary;
-    else if ([device supportsCounterSampling:MTLCounterSamplingPointAtStageBoundary])
-        counterSamplingAPI = HardwareCapabilities::BaseCapabilities::CounterSamplingAPI::StageBoundary;
-    else
-        timestampCounterSet = nil;
+    timestampCounterSet = nil;
 
     return {
         .argumentBuffersTier = [device argumentBuffersSupport],
@@ -95,7 +87,6 @@ static HardwareCapabilities::BaseCapabilities baseCapabilities(id<MTLDevice> dev
         .timestampCounterSet = timestampCounterSet,
         .statisticCounterSet = statisticCounterSet,
         .canPresentRGB10A2PixelFormats = false, // To be filled in by the caller.
-        .counterSamplingAPI = counterSamplingAPI,
     };
 }
 
@@ -521,14 +512,12 @@ static HardwareCapabilities::BaseCapabilities mergeBaseCapabilities(const Hardwa
     ASSERT(previous.argumentBuffersTier == next.argumentBuffersTier);
     ASSERT((!previous.timestampCounterSet && !next.timestampCounterSet) || [previous.timestampCounterSet isEqual:next.timestampCounterSet]);
     ASSERT(!previous.statisticCounterSet || [previous.statisticCounterSet isEqual:next.statisticCounterSet]);
-    ASSERT(previous.counterSamplingAPI == next.counterSamplingAPI);
     return {
         previous.argumentBuffersTier,
         previous.supportsNonPrivateDepthStencilTextures || next.supportsNonPrivateDepthStencilTextures,
         previous.timestampCounterSet,
         previous.statisticCounterSet,
         previous.canPresentRGB10A2PixelFormats || next.canPresentRGB10A2PixelFormats,
-        previous.counterSamplingAPI,
     };
 }
 

--- a/Source/WebGPU/WebGPU/QuerySet.h
+++ b/Source/WebGPU/WebGPU/QuerySet.h
@@ -66,7 +66,6 @@ public:
     bool isValid() const;
 
     void setOverrideLocation(QuerySet& otherQuerySet, uint32_t beginningOfPassIndex, uint32_t endOfPassIndex);
-    void encodeResolveCommands(id<MTLBlitCommandEncoder>, uint32_t firstQuery, uint32_t queryCount, const Buffer& destination, uint64_t destinationOffset) const;
 
     Device& device() const { return m_device; }
     uint32_t count() const { return m_count; }
@@ -97,7 +96,6 @@ private:
         Ref<QuerySet> other;
         uint32_t otherIndex;
     };
-    Vector<std::optional<OverrideLocation>> m_overrideLocations;
     mutable WeakPtr<CommandEncoder> m_cachedCommandEncoder;
     bool m_destroyed { false };
 };

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -129,7 +129,6 @@ private:
         Ref<QuerySet> querySet;
         uint32_t queryIndex;
     };
-    Vector<PendingTimestampWrites> m_pendingTimestampWrites;
 
     const Ref<Device> m_device;
     WeakPtr<Buffer> m_indexBuffer;


### PR DESCRIPTION
#### 9d74d3a31e3c2b02159e947c82d021c8630c1754
<pre>
[WebGPU] Remove unsupported timestamp query functionality from WebGPU.framework
<a href="https://bugs.webkit.org/show_bug.cgi?id=273702">https://bugs.webkit.org/show_bug.cgi?id=273702</a>
&lt;radar://126912548&gt;

Reviewed by Tadeu Zagallo.

Timestamp queries are an optional WebGPU feature which are
not so useful on Apple Silicon chips, remove support from
WebGPU.framework as we don&apos;t support them from the API layer.

* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::ensureBlitCommandEncoder):
(WebGPU::CommandEncoder::finalizeBlitCommandEncoder):
(WebGPU::CommandEncoder::beginComputePass):
(WebGPU::CommandEncoder::beginRenderPass):
(WebGPU::CommandEncoder::resolveQuerySet):
(WebGPU::CommandEncoder::writeTimestamp):
* Source/WebGPU/WebGPU/ComputePassEncoder.h:
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::ComputePassEncoder):
(WebGPU::ComputePassEncoder::endPass):
* Source/WebGPU/WebGPU/HardwareCapabilities.h:
* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::baseCapabilities):
(WebGPU::mergeBaseCapabilities):
* Source/WebGPU/WebGPU/QuerySet.h:
* Source/WebGPU/WebGPU/QuerySet.mm:
(WebGPU::Device::createQuerySet):
(WebGPU::QuerySet::QuerySet):
(WebGPU::QuerySet::destroy):
(WebGPU::QuerySet::setOverrideLocation):
(WebGPU::QuerySet::encodeResolveCommands const): Deleted.
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::m_maxDrawCount):
(WebGPU::RenderPassEncoder::endPass):

Canonical link: <a href="https://commits.webkit.org/278468@main">https://commits.webkit.org/278468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a980a1a533cc7cc3c807fb48a054ebbe83483b1c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2547 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53509 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/940 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41001 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27252 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43248 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22100 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24662 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8628 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46647 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/562 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55094 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25346 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48403 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26608 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43432 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47434 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11097 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27471 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26339 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->