### PR TITLE
HTMLMediaElement::ensureMediaControls() should handle its own exceptions.

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2014-2015 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -5217,8 +5217,19 @@ bool HTMLMediaElement::setupAndCallJS(const JSSetupFunction& task)
     auto* globalObject = JSC::jsCast<JSDOMGlobalObject*>(scriptController.globalObject(world));
     auto& vm = globalObject->vm();
     JSC::JSLockHolder lock(vm);
+    auto scope = DECLARE_CATCH_SCOPE(vm);
     auto* lexicalGlobalObject = globalObject;
-    return task(*globalObject, *lexicalGlobalObject, scriptController, world);
+
+    auto reportExceptionAndReturnFalse = [&] () -> bool {
+        auto* exception = scope.exception();
+        scope.clearException();
+        reportException(globalObject, exception);
+        return false;
+    };
+
+    auto result = task(*globalObject, *lexicalGlobalObject, scriptController, world);
+    RETURN_IF_EXCEPTION(scope, reportExceptionAndReturnFalse());
+    return result;
 }
 
 void HTMLMediaElement::updateCaptionContainer()
@@ -5231,17 +5242,10 @@ void HTMLMediaElement::updateCaptionContainer()
 
     setupAndCallJS([this](JSDOMGlobalObject& globalObject, JSC::JSGlobalObject& lexicalGlobalObject, ScriptController&, DOMWrapperWorld&) {
         auto& vm = globalObject.vm();
-        auto scope = DECLARE_CATCH_SCOPE(vm);
-
-        auto reportExceptionAndReturnFalse = [&] () -> bool {
-            auto* exception = scope.exception();
-            scope.clearException();
-            reportException(&globalObject, exception);
-            return false;
-        };
+        auto scope = DECLARE_THROW_SCOPE(vm);
 
         auto controllerValue = controllerJSValue(lexicalGlobalObject, globalObject, *this);
-        RETURN_IF_EXCEPTION(scope, reportExceptionAndReturnFalse());
+        RETURN_IF_EXCEPTION(scope, false);
 
         auto* controllerObject = JSC::jsDynamicCast<JSC::JSObject*>(controllerValue);
         if (!controllerObject)
@@ -5254,7 +5258,7 @@ void HTMLMediaElement::updateCaptionContainer()
         // Return value:
         //     None
         auto methodValue = controllerObject->get(&lexicalGlobalObject, JSC::Identifier::fromString(vm, "updateCaptionContainer"_s));
-        RETURN_IF_EXCEPTION(scope, reportExceptionAndReturnFalse());
+        RETURN_IF_EXCEPTION(scope, false);
 
         auto* methodObject = JSC::jsDynamicCast<JSC::JSObject*>(methodValue);
         if (!methodObject)
@@ -5267,7 +5271,7 @@ void HTMLMediaElement::updateCaptionContainer()
         JSC::MarkedArgumentBuffer noArguments;
         ASSERT(!noArguments.hasOverflowed());
         JSC::call(&lexicalGlobalObject, methodObject, callData, controllerObject, noArguments);
-        RETURN_IF_EXCEPTION(scope, reportExceptionAndReturnFalse());
+        RETURN_IF_EXCEPTION(scope, false);
 
         m_haveSetUpCaptionContainer = true;
 
@@ -8356,20 +8360,13 @@ bool HTMLMediaElement::ensureMediaControls()
     if (oldControlsState == ControlsState::None) {
         controlsReady = setupAndCallJS([this, mediaControlsScripts = WTFMove(mediaControlsScripts)](JSDOMGlobalObject& globalObject, JSC::JSGlobalObject& lexicalGlobalObject, ScriptController& scriptController, DOMWrapperWorld& world) {
             auto& vm = globalObject.vm();
-            auto scope = DECLARE_CATCH_SCOPE(vm);
-
-            auto reportExceptionAndReturnFalse = [&] {
-                auto* exception = scope.exception();
-                scope.clearException();
-                reportException(&globalObject, exception);
-                return false;
-            };
+            auto scope = DECLARE_THROW_SCOPE(vm);
 
             for (auto& mediaControlsScript : mediaControlsScripts) {
                 if (mediaControlsScript.isEmpty())
                     continue;
                 scriptController.evaluateInWorldIgnoringException(ScriptSourceCode(mediaControlsScript, JSC::SourceTaintedOrigin::Untainted), world);
-                RETURN_IF_EXCEPTION(scope, reportExceptionAndReturnFalse());
+                RETURN_IF_EXCEPTION(scope, false);
             }
 
             // The media controls script must provide a method with the following details.
@@ -8398,13 +8395,13 @@ bool HTMLMediaElement::ensureMediaControls()
             ASSERT(!argList.hasOverflowed());
 
             auto* function = functionValue.toObject(&lexicalGlobalObject);
-            RETURN_IF_EXCEPTION(scope, reportExceptionAndReturnFalse());
+            RETURN_IF_EXCEPTION(scope, false);
             auto callData = JSC::getCallData(function);
             if (callData.type == JSC::CallData::Type::None)
                 return false;
 
             auto controllerValue = JSC::call(&lexicalGlobalObject, function, callData, &globalObject, argList);
-            RETURN_IF_EXCEPTION(scope, reportExceptionAndReturnFalse());
+            RETURN_IF_EXCEPTION(scope, false);
 
             auto* controllerObject = JSC::jsDynamicCast<JSC::JSObject*>(controllerValue);
             if (!controllerObject)
@@ -8412,7 +8409,7 @@ bool HTMLMediaElement::ensureMediaControls()
 
             // Connect the Media, MediaControllerHost, and Controller so the GC knows about their relationship
             auto* mediaJSWrapperObject = mediaJSWrapper.toObject(&lexicalGlobalObject);
-            RETURN_IF_EXCEPTION(scope, reportExceptionAndReturnFalse());
+            RETURN_IF_EXCEPTION(scope, false);
             auto controlsHost = JSC::Identifier::fromString(vm, "controlsHost"_s);
 
             ASSERT(!mediaJSWrapperObject->hasProperty(&lexicalGlobalObject, controlsHost));
@@ -8432,10 +8429,10 @@ bool HTMLMediaElement::ensureMediaControls()
             if (m_mediaControlsDependOnPageScaleFactor)
                 updatePageScaleFactorJSProperty();
 
-            RETURN_IF_EXCEPTION(scope, reportExceptionAndReturnFalse());
+            RETURN_IF_EXCEPTION(scope, false);
 
             updateUsesLTRUserInterfaceLayoutDirectionJSProperty();
-            RETURN_IF_EXCEPTION(scope, reportExceptionAndReturnFalse());
+            RETURN_IF_EXCEPTION(scope, false);
 
             return true;
         });


### PR DESCRIPTION
#### 91285f2f6800e5031c656e2ccad4352fe88b1d3b
<pre>
HTMLMediaElement::ensureMediaControls() should handle its own exceptions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=273706">https://bugs.webkit.org/show_bug.cgi?id=273706</a>
<a href="https://rdar.apple.com/126757731">rdar://126757731</a>

Reviewed by Yusuke Suzuki and Jer Noble.

Ensure that setupAndCallJS() handles any uncaught exceptions before returning.  This makes
it such that the tasks that it calls do not needs to deal with this.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::ensureMediaControls):

Canonical link: <a href="https://commits.webkit.org/278381@main">https://commits.webkit.org/278381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/755b02c71949e5d77a76326bb430ab3a45699d6a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50346 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53605 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1036 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52649 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/684 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41066 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52445 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43334 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22170 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24714 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/589 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8724 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46697 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55193 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25442 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/580 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48474 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43517 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47509 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27567 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7279 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26435 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->