### PR TITLE
[JSC] Reland JavaScript BigInt Public C API

### DIFF
--- a/Source/JavaScriptCore/API/JSBase.h
+++ b/Source/JavaScriptCore/API/JSBase.h
@@ -152,4 +152,34 @@ JS_EXPORT void JSGarbageCollect(JSContextRef ctx);
 #endif
 #endif
 
+#if JSC_OBJC_API_ENABLED
+#define JSC_CF_ENUM(enumName, ...)       \
+    typedef CF_ENUM(uint32_t, enumName) { \
+        __VA_ARGS__                       \
+    }
+#else
+#define JSC_CF_ENUM(enumName, ...) \
+    typedef enum {                  \
+        __VA_ARGS__                 \
+    } enumName
+#endif
+
+#if JSC_OBJC_API_ENABLED
+#define JSC_ASSUME_NONNULL_BEGIN _Pragma("clang assume_nonnull begin")
+#define JSC_ASSUME_NONNULL_END _Pragma("clang assume_nonnull end")
+#else
+#define JSC_ASSUME_NONNULL_BEGIN
+#define JSC_ASSUME_NONNULL_END
+#endif
+
+#if JSC_OBJC_API_ENABLED
+#define JSC_NULL_UNSPECIFIED _Null_unspecified
+#define JSC_NULLABLE _Nullable
+#define JSC_NONNULL _Nonnull
+#else
+#define JSC_NULL_UNSPECIFIED
+#define JSC_NULLABLE
+#define JSC_NONNULL
+#endif
+
 #endif /* JSBase_h */

--- a/Source/JavaScriptCore/API/JSValue.h
+++ b/Source/JavaScriptCore/API/JSValue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,7 +51,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @property
 @abstract The JSContext that this value originates from.
 */
-@property (readonly, strong) JSContext *context;
+@property (readonly, strong) JSContext * _Null_unspecified context;
 
 /*!
 @methodgroup Creating JavaScript Values
@@ -63,7 +63,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @param value The Objective-C object to be converted.
 @result The new JSValue.
 */
-+ (JSValue *)valueWithObject:(id)value inContext:(JSContext *)context;
++ (JSValue * _Null_unspecified)valueWithObject:(id _Null_unspecified)value inContext:(JSContext * _Null_unspecified)context;
 
 /*!
 @method
@@ -71,7 +71,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @param context The JSContext in which the resulting JSValue will be created.
 @result The new JSValue representing the equivalent boolean value.
 */
-+ (JSValue *)valueWithBool:(BOOL)value inContext:(JSContext *)context;
++ (JSValue * _Null_unspecified)valueWithBool:(BOOL)value inContext:(JSContext * _Null_unspecified)context;
 
 /*!
 @method
@@ -79,7 +79,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @param context The JSContext in which the resulting JSValue will be created.
 @result The new JSValue representing the equivalent boolean value.
 */
-+ (JSValue *)valueWithDouble:(double)value inContext:(JSContext *)context;
++ (JSValue * _Null_unspecified)valueWithDouble:(double)value inContext:(JSContext * _Null_unspecified)context;
 
 /*!
 @method
@@ -87,7 +87,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @param context The JSContext in which the resulting JSValue will be created.
 @result The new JSValue representing the equivalent boolean value.
 */
-+ (JSValue *)valueWithInt32:(int32_t)value inContext:(JSContext *)context;
++ (JSValue * _Null_unspecified)valueWithInt32:(int32_t)value inContext:(JSContext * _Null_unspecified)context;
 
 /*!
 @method
@@ -95,7 +95,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @param context The JSContext in which the resulting JSValue will be created.
 @result The new JSValue representing the equivalent boolean value.
 */
-+ (JSValue *)valueWithUInt32:(uint32_t)value inContext:(JSContext *)context;
++ (JSValue * _Null_unspecified)valueWithUInt32:(uint32_t)value inContext:(JSContext * _Null_unspecified)context;
 
 /*!
 @method
@@ -103,7 +103,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @param context The JSContext in which the resulting object will be created.
 @result The new JavaScript object.
 */
-+ (JSValue *)valueWithNewObjectInContext:(JSContext *)context;
++ (JSValue * _Null_unspecified)valueWithNewObjectInContext:(JSContext * _Null_unspecified)context;
 
 /*!
 @method
@@ -111,7 +111,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @param context The JSContext in which the resulting array will be created.
 @result The new JavaScript array.
 */
-+ (JSValue *)valueWithNewArrayInContext:(JSContext *)context;
++ (JSValue * _Null_unspecified)valueWithNewArrayInContext:(JSContext * _Null_unspecified)context;
 
 /*!
 @method
@@ -121,7 +121,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @param context The JSContext in which the resulting regular expression object will be created.
 @result The new JavaScript regular expression object.
 */
-+ (JSValue *)valueWithNewRegularExpressionFromPattern:(NSString *)pattern flags:(NSString *)flags inContext:(JSContext *)context;
++ (JSValue * _Null_unspecified)valueWithNewRegularExpressionFromPattern:(NSString * _Null_unspecified)pattern flags:(NSString * _Null_unspecified)flags inContext:(JSContext * _Null_unspecified)context;
 
 /*!
 @method
@@ -130,7 +130,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @param context The JSContext in which the resulting error object will be created.
 @result The new JavaScript error object.
 */
-+ (JSValue *)valueWithNewErrorFromMessage:(NSString *)message inContext:(JSContext *)context;
++ (JSValue * _Null_unspecified)valueWithNewErrorFromMessage:(NSString * _Null_unspecified)message inContext:(JSContext * _Null_unspecified)context;
 
 /*!
 @method
@@ -140,7 +140,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @result The JSValue representing a new promise JavaScript object.
 @discussion This method is equivalent to calling the Promise constructor in JavaScript. the resolve and reject callbacks each normally take a single value, which they forward to all relevent pending reactions. While inside the executor callback context will act as if it were in any other callback, except calleeFunction will be <code>nil</code>. This also means means the new promise object may be accessed via <code>[context thisValue]</code>.
 */
-+ (JSValue *)valueWithNewPromiseInContext:(JSContext *)context fromExecutor:(void (^)(JSValue *resolve, JSValue *reject))callback JSC_API_AVAILABLE(macos(10.15), ios(13.0));
++ (JSValue * _Null_unspecified)valueWithNewPromiseInContext:(JSContext * _Null_unspecified)context fromExecutor:(void (^ _Null_unspecified)(JSValue * _Null_unspecified resolve, JSValue * _Null_unspecified reject))callback JSC_API_AVAILABLE(macos(10.15), ios(13.0));
 
 /*!
 @method
@@ -150,7 +150,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @result The JSValue representing a new promise JavaScript object.
 @discussion This method is equivalent to calling <code>[JSValue valueWithNewPromiseFromExecutor:^(JSValue *resolve, JSValue *reject) { [resolve callWithArguments:@[result]]; } inContext:context]</code>
 */
-+ (JSValue *)valueWithNewPromiseResolvedWithResult:(id)result inContext:(JSContext *)context JSC_API_AVAILABLE(macos(10.15), ios(13.0));
++ (JSValue * _Null_unspecified)valueWithNewPromiseResolvedWithResult:(id _Null_unspecified)result inContext:(JSContext * _Null_unspecified)context JSC_API_AVAILABLE(macos(10.15), ios(13.0));
 
 /*!
 @method
@@ -160,7 +160,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @result The JSValue representing a new promise JavaScript object.
 @discussion This method is equivalent to calling <code>[JSValue valueWithNewPromiseFromExecutor:^(JSValue *resolve, JSValue *reject) { [reject callWithArguments:@[reason]]; } inContext:context]</code>
 */
-+ (JSValue *)valueWithNewPromiseRejectedWithReason:(id)reason inContext:(JSContext *)context JSC_API_AVAILABLE(macos(10.15), ios(13.0));
++ (JSValue * _Null_unspecified)valueWithNewPromiseRejectedWithReason:(id _Null_unspecified)reason inContext:(JSContext * _Null_unspecified)context JSC_API_AVAILABLE(macos(10.15), ios(13.0));
 
 /*!
 @method
@@ -169,7 +169,45 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @param context The JSContext to which the resulting JSValue belongs.
 @result The JSValue representing a unique JavaScript value with type symbol.
 */
-+ (JSValue *)valueWithNewSymbolFromDescription:(NSString *)description inContext:(JSContext *)context JSC_API_AVAILABLE(macos(10.15), ios(13.0));
++ (JSValue * _Null_unspecified)valueWithNewSymbolFromDescription:(NSString * _Null_unspecified)description inContext:(JSContext * _Null_unspecified)context JSC_API_AVAILABLE(macos(10.15), ios(13.0));
+
+/*!
+@method
+@abstract Create a new BigInt value from a numeric string.
+@param string The string representation of the BigInt JavaScript value being created.
+@param context The JSContext to which the resulting JSValue belongs.
+@result The JSValue representing a JavaScript value with type BigInt.
+@discussion This is equivalent to calling the <code>BigInt</code> constructor from JavaScript with a string argument.
+*/
++ (nullable JSValue *)valueWithNewBigIntFromString:(nonnull NSString *)string inContext:(nonnull JSContext *)context JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+@method
+@abstract Create a new BigInt value from a <code>int64_t</code>.
+@param int64 The signed 64-bit integer of the BigInt JavaScript value being created.
+@param context The JSContext to which the resulting JSValue belongs.
+@result The JSValue representing a JavaScript value with type BigInt.
+*/
++ (nullable JSValue *)valueWithNewBigIntFromInt64:(int64_t)int64 inContext:(nonnull JSContext *)context JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+@method
+@abstract Create a new BigInt value from a <code>uint64_t</code>.
+@param uint64 The unsigned 64-bit integer of the BigInt JavaScript value being created.
+@param context The JSContext to which the resulting JSValue belongs.
+@result The JSValue representing a JavaScript value with type BigInt.
+*/
++ (nullable JSValue *)valueWithNewBigIntFromUInt64:(uint64_t)uint64 inContext:(nonnull JSContext *)context JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+@method
+@abstract Create a new BigInt value from a double.
+@param value The value of the BigInt JavaScript value being created.
+@param context The JSContext to which the resulting JSValue belongs.
+@result The JSValue representing a JavaScript value with type BigInt.
+@discussion If the value is not an integer, an exception is thrown.
+*/
++ (nullable JSValue *)valueWithNewBigIntFromDouble:(double)value inContext:(nonnull JSContext *)context JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
 
 /*!
 @method
@@ -177,7 +215,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @param context The JSContext to which the resulting JSValue belongs.
 @result The JSValue representing the JavaScript value <code>null</code>.
 */
-+ (JSValue *)valueWithNullInContext:(JSContext *)context;
++ (JSValue * _Null_unspecified)valueWithNullInContext:(JSContext * _Null_unspecified)context;
 
 /*!
 @method
@@ -185,7 +223,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @param context The JSContext to which the resulting JSValue belongs.
 @result The JSValue representing the JavaScript value <code>undefined</code>.
 */
-+ (JSValue *)valueWithUndefinedInContext:(JSContext *)context;
++ (JSValue * _Null_unspecified)valueWithUndefinedInContext:(JSContext * _Null_unspecified)context;
 
 /*!
 @methodgroup Converting to Objective-C Types
@@ -240,7 +278,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
  to the conversion rules specified above.
 @result The Objective-C representation of this JSValue.
 */
-- (id)toObject;
+- (id _Null_unspecified)toObject;
 
 /*!
 @method
@@ -249,7 +287,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
  If the result is not of the specified Class then <code>nil</code> will be returned.
 @result An Objective-C object of the specified Class or <code>nil</code>.
 */
-- (id)toObjectOfClass:(Class)expectedClass;
+- (id _Null_unspecified)toObjectOfClass:(Class _Null_unspecified)expectedClass;
 
 /*!
 @method
@@ -263,17 +301,15 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 /*!
 @method
 @abstract Convert a JSValue to a double.
-@discussion The JSValue is converted to a number according to the rules specified 
- by the JavaScript language.
 @result The double result of the conversion.
+@discussion Convert the JSValue to a number according to the rules specified by the JavaScript language. Unless the JSValue is a BigInt then this is equivalent to <code>Number(value)</code> in JavaScript.
 */
 - (double)toDouble;
 
 /*!
 @method
 @abstract Convert a JSValue to an <code>int32_t</code>.
-@discussion The JSValue is converted to an integer according to the rules specified 
- by the JavaScript language.
+@discussion The JSValue is converted to an integer according to the rules specified by the JavaScript language. If the JSValue is a BigInt, then the value is truncated to an <code>int32_t</code>.
 @result The <code>int32_t</code> result of the conversion.
 */
 - (int32_t)toInt32;
@@ -281,21 +317,33 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 /*!
 @method
 @abstract Convert a JSValue to a <code>uint32_t</code>.
-@discussion The JSValue is converted to an integer according to the rules specified 
- by the JavaScript language.
+@discussion The JSValue is converted to an integer according to the rules specified by the JavaScript language. If the JSValue is a BigInt, then the value is truncated to a <code>uint32_t</code>.
 @result The <code>uint32_t</code> result of the conversion.
 */
 - (uint32_t)toUInt32;
 
 /*!
 @method
+@abstract Convert a JSValue to a <code>int64_t</code>.
+@discussion The JSValue is converted to an integer according to the rules specified by the JavaScript language. If the value is a BigInt, then the value is truncated to an <code>int64_t</code>.
+*/
+- (int64_t)toInt64 JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+@method
+@abstract Convert a JSValue to a <code>uint64_t</code>.
+@discussion The JSValue is converted to an integer according to the rules specified by the JavaScript language. If the value is a BigInt, then the value is truncated to a <code>uint64_t</code>.
+*/
+- (uint64_t)toUInt64 JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+@method
 @abstract Convert a JSValue to a NSNumber.
-@discussion If the JSValue represents a boolean, a NSNumber value of YES or NO 
- will be returned. For all other types the value will be converted to a number according 
- to the rules specified by the JavaScript language.
+@discussion If the JSValue represents a boolean, a NSNumber value of YES or NO
+ will be returned. For all other types, the result is equivalent to <code>Number(value)</code> in JavaScript.
 @result The NSNumber result of the conversion.
 */
-- (NSNumber *)toNumber;
+- (NSNumber * _Null_unspecified)toNumber;
 
 /*!
 @method
@@ -304,7 +352,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
  by the JavaScript language.
 @result The NSString containing the result of the conversion.
 */
-- (NSString *)toString;
+- (NSString * _Null_unspecified)toString;
 
 /*!
 @method
@@ -313,7 +361,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
  since 1970 which is then used to create a new NSDate instance.
 @result The NSDate created using the converted time interval.
 */
-- (NSDate *)toDate;
+- (NSDate * _Null_unspecified)toDate;
 
 /*!
 @method
@@ -327,7 +375,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @result The NSArray containing the recursively converted contents of the 
  converted JavaScript array.
 */
-- (NSArray *)toArray;
+- (NSArray * _Null_unspecified)toArray;
 
 /*!
 @method
@@ -339,10 +387,10 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @result The NSDictionary containing the recursively converted contents of
  the converted JavaScript object.
 */
-- (NSDictionary *)toDictionary;
+- (NSDictionary * _Null_unspecified)toDictionary;
 
 /*!
-@functiongroup Checking JavaScript Types
+@methodgroup Checking JavaScript Types
 */
 
 /*!
@@ -403,16 +451,10 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @property (readonly) BOOL isSymbol JSC_API_AVAILABLE(macos(10.15), ios(13.0));
 
 /*!
-@method
-@abstract Compare two JSValues using JavaScript's <code>===</code> operator.
+@property
+@abstract Check if a JSValue is a BigInt.
 */
-- (BOOL)isEqualToObject:(id)value;
-
-/*!
-@method
-@abstract Compare two JSValues using JavaScript's <code>==</code> operator.
-*/
-- (BOOL)isEqualWithTypeCoercionToObject:(id)value;
+@property (readonly) BOOL isBigInt JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
 
 /*!
 @method
@@ -421,7 +463,59 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
  If an object other than a JSValue is passed, it will first be converted according to
  the aforementioned rules.
 */
-- (BOOL)isInstanceOf:(id)value;
+- (BOOL)isInstanceOf:(id _Null_unspecified)value;
+
+/*!
+@methodgroup Compare JavaScript values
+*/
+
+/*!
+@method
+@abstract Compare two JSValues using JavaScript's <code>===</code> operator.
+*/
+- (BOOL)isEqualToObject:(id _Null_unspecified)value;
+
+/*!
+@method
+@abstract Compare two JSValues using JavaScript's <code>==</code> operator.
+*/
+- (BOOL)isEqualWithTypeCoercionToObject:(id _Null_unspecified)value;
+
+/*!
+@method
+@abstract Compare two JSValues.
+@other The JSValue to compare with.
+@result A value of JSRelationCondition, a kJSRelationConditionUndefined is returned if an exception is thrown.
+@discussion The result is computed by comparing the results of JavaScript's <code>==</code>, <code><</code>, and <code>></code> operators. If either <code>self</code> or <code>other</code> is (or would coerce to) <code>NaN</code> in JavaScript, then the result is kJSRelationConditionUndefined.
+*/
+- (JSRelationCondition)compareJSValue:(nonnull JSValue *)other JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+@method
+@abstract Compare a JSValue with a <code>int64_t</code>.
+@other The <code>int64_t</code> to compare with.
+@result A value of JSRelationCondition, a kJSRelationConditionUndefined is returned if an exception is thrown.
+@discussion The JSValue is converted to an integer according to the rules specified by the JavaScript language then compared with <code>other</code>.
+*/
+- (JSRelationCondition)compareInt64:(int64_t)other JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+@method
+@abstract Compare a JSValue with a <code>uint64_t</code>.
+@other The <code>uint64_t</code> to compare with.
+@result A value of JSRelationCondition, a kJSRelationConditionUndefined is returned if an exception is thrown.
+@discussion The JSValue is converted to an integer according to the rules specified by the JavaScript language then compared with <code>other</code>.
+*/
+- (JSRelationCondition)compareUInt64:(uint64_t)other JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+@method
+@abstract Compare a JSValue with a double.
+@other The double to compare with.
+@result A value of JSRelationCondition, a kJSRelationConditionUndefined is returned if an exception is thrown.
+@discussion The JSValue is converted to a double according to the rules specified by the JavaScript language then compared with <code>other</code>.
+*/
+- (JSRelationCondition)compareDouble:(double)other JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
 
 /*!
 @methodgroup Calling Functions and Constructors
@@ -434,7 +528,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @param arguments The arguments to pass to the function.
 @result The return value of the function call. 
 */
-- (JSValue *)callWithArguments:(NSArray *)arguments;
+- (JSValue * _Null_unspecified)callWithArguments:(NSArray * _Null_unspecified)arguments;
 
 /*!
 @method
@@ -443,7 +537,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @param arguments The arguments to pass to the constructor.
 @result The return value of the constructor call.
 */
-- (JSValue *)constructWithArguments:(NSArray *)arguments;
+- (JSValue * _Null_unspecified)constructWithArguments:(NSArray * _Null_unspecified)arguments;
 
 /*!
 @method
@@ -455,7 +549,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @param arguments The arguments to pass to the method.
 @result The return value of the method call.
 */
-- (JSValue *)invokeMethod:(NSString *)method withArguments:(NSArray *)arguments;
+- (JSValue * _Null_unspecified)invokeMethod:(NSString * _Null_unspecified)method withArguments:(NSArray * _Null_unspecified)arguments;
 
 @end
 
@@ -478,7 +572,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @result A newly allocated JavaScript object containing properties
  named <code>x</code> and <code>y</code>, with values from the CGPoint.
 */
-+ (JSValue *)valueWithPoint:(CGPoint)point inContext:(JSContext *)context;
++ (JSValue * _Null_unspecified)valueWithPoint:(CGPoint)point inContext:(JSContext * _Null_unspecified)context;
 
 /*!
 @method
@@ -486,7 +580,7 @@ NS_CLASS_AVAILABLE(10_9, 7_0)
 @result A newly allocated JavaScript object containing properties
  named <code>location</code> and <code>length</code>, with values from the NSRange.
 */
-+ (JSValue *)valueWithRange:(NSRange)range inContext:(JSContext *)context;
++ (JSValue * _Null_unspecified)valueWithRange:(NSRange)range inContext:(JSContext * _Null_unspecified)context;
 
 /*!
 @method
@@ -495,7 +589,7 @@ Create a JSValue from a CGRect.
 @result A newly allocated JavaScript object containing properties
  named <code>x</code>, <code>y</code>, <code>width</code>, and <code>height</code>, with values from the CGRect.
 */
-+ (JSValue *)valueWithRect:(CGRect)rect inContext:(JSContext *)context;
++ (JSValue * _Null_unspecified)valueWithRect:(CGRect)rect inContext:(JSContext * _Null_unspecified)context;
 
 /*!
 @method
@@ -503,7 +597,7 @@ Create a JSValue from a CGRect.
 @result A newly allocated JavaScript object containing properties
  named <code>width</code> and <code>height</code>, with values from the CGSize.
 */
-+ (JSValue *)valueWithSize:(CGSize)size inContext:(JSContext *)context;
++ (JSValue * _Null_unspecified)valueWithSize:(CGSize)size inContext:(JSContext * _Null_unspecified)context;
 
 /*!
 @method
@@ -550,9 +644,9 @@ Create a JSValue from a CGRect.
 @interface JSValue (PropertyAccess)
 
 #if (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED < 101500) || (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED < 130000)
-typedef NSString *JSValueProperty;
+typedef NSString * _Null_unspecified JSValueProperty;
 #else
-typedef id JSValueProperty;
+typedef id _Null_unspecified JSValueProperty;
 #endif
 
 /*!
@@ -562,14 +656,14 @@ typedef id JSValueProperty;
  if the property does not exist.
  @discussion Corresponds to the JavaScript operation <code>object[property]</code>. Starting with macOS 10.15 and iOS 13, 'property' can be any 'id' and will be converted to a JSValue using the conversion rules of <code>valueWithObject:inContext:</code>. Prior to macOS 10.15 and iOS 13, 'property' was expected to be an NSString *.
  */
-- (JSValue *)valueForProperty:(JSValueProperty)property;
+- (JSValue * _Null_unspecified)valueForProperty:(JSValueProperty)property;
 
 /*!
  @method
  @abstract Set a property on a JSValue.
  @discussion Corresponds to the JavaScript operation <code>object[property] = value</code>. Starting with macOS 10.15 and iOS 13, 'property' can be any 'id' and will be converted to a JSValue using the conversion rules of <code>valueWithObject:inContext:</code>. Prior to macOS 10.15 and iOS 13, 'property' was expected to be an NSString *.
  */
-- (void)setValue:(id)value forProperty:(JSValueProperty)property;
+- (void)setValue:(id _Null_unspecified)value forProperty:(JSValueProperty)property;
 
 /*!
  @method
@@ -594,7 +688,7 @@ typedef id JSValueProperty;
  @discussion This method may be used to create a data or accessor property on an object.
  This method operates in accordance with the Object.defineProperty method in the JavaScript language. Starting with macOS 10.15 and iOS 13, 'property' can be any 'id' and will be converted to a JSValue using the conversion rules of <code>valueWithObject:inContext:</code>. Prior to macOS 10.15 and iOS 13, 'property' was expected to be an NSString *.
  */
-- (void)defineProperty:(JSValueProperty)property descriptor:(id)descriptor;
+- (void)defineProperty:(JSValueProperty)property descriptor:(id _Null_unspecified)descriptor;
 
 /*!
  @method
@@ -602,7 +696,7 @@ typedef id JSValueProperty;
  @result The JSValue for the property at the specified index.
  Returns the JavaScript value <code>undefined</code> if no property exists at that index.
  */
-- (JSValue *)valueAtIndex:(NSUInteger)index;
+- (JSValue * _Null_unspecified)valueAtIndex:(NSUInteger)index;
 
 /*!
  @method
@@ -610,7 +704,7 @@ typedef id JSValueProperty;
  @discussion For JSValues that are JavaScript arrays, indices greater than
  UINT_MAX - 1 will not affect the length of the array.
  */
-- (void)setValue:(id)value atIndex:(NSUInteger)index;
+- (void)setValue:(id _Null_unspecified)value atIndex:(NSUInteger)index;
 
 @end
 
@@ -635,10 +729,10 @@ typedef id JSValueProperty;
 */
 @interface JSValue (SubscriptSupport)
 
-- (JSValue *)objectForKeyedSubscript:(id)key;
-- (JSValue *)objectAtIndexedSubscript:(NSUInteger)index;
-- (void)setObject:(id)object forKeyedSubscript:(id)key;
-- (void)setObject:(id)object atIndexedSubscript:(NSUInteger)index;
+- (JSValue * _Null_unspecified)objectForKeyedSubscript:(id _Null_unspecified)key;
+- (JSValue * _Null_unspecified)objectAtIndexedSubscript:(NSUInteger)index;
+- (void)setObject:(id _Null_unspecified)object forKeyedSubscript:(id _Null_unspecified)key;
+- (void)setObject:(id _Null_unspecified)object atIndexedSubscript:(NSUInteger)index;
 
 @end
 
@@ -653,14 +747,14 @@ typedef id JSValueProperty;
 @abstract Creates a JSValue, wrapping its C API counterpart.
 @result The Objective-C API equivalent of the specified JSValueRef.
 */
-+ (JSValue *)valueWithJSValueRef:(JSValueRef)value inContext:(JSContext *)context;
++ (JSValue * _Null_unspecified)valueWithJSValueRef:(JSValueRef _Null_unspecified)value inContext:(JSContext * _Null_unspecified)context;
 
 /*!
 @property
 @abstract Returns the C API counterpart wrapped by a JSContext.
 @result The C API equivalent of this JSValue.
 */
-@property (readonly) JSValueRef JSValueRef;
+@property (readonly) JSValueRef _Null_unspecified JSValueRef;
 @end
 
 #ifdef __cplusplus
@@ -699,27 +793,27 @@ extern "C" {
 /*!
 @const 
 */
-JS_EXPORT extern NSString * const JSPropertyDescriptorWritableKey;
+JS_EXPORT extern NSString * _Null_unspecified const JSPropertyDescriptorWritableKey;
 /*!
 @const 
 */
-JS_EXPORT extern NSString * const JSPropertyDescriptorEnumerableKey;
+JS_EXPORT extern NSString * _Null_unspecified const JSPropertyDescriptorEnumerableKey;
 /*!
 @const 
 */
-JS_EXPORT extern NSString * const JSPropertyDescriptorConfigurableKey;
+JS_EXPORT extern NSString * _Null_unspecified const JSPropertyDescriptorConfigurableKey;
 /*!
 @const 
 */
-JS_EXPORT extern NSString * const JSPropertyDescriptorValueKey;
+JS_EXPORT extern NSString * _Null_unspecified const JSPropertyDescriptorValueKey;
 /*!
 @const 
 */
-JS_EXPORT extern NSString * const JSPropertyDescriptorGetKey;
+JS_EXPORT extern NSString * _Null_unspecified const JSPropertyDescriptorGetKey;
 /*!
 @const 
 */
-JS_EXPORT extern NSString * const JSPropertyDescriptorSetKey;
+JS_EXPORT extern NSString * _Null_unspecified const JSPropertyDescriptorSetKey;
 
 #ifdef __cplusplus
 } // extern "C"

--- a/Source/JavaScriptCore/API/JSValueRef.cpp
+++ b/Source/JavaScriptCore/API/JSValueRef.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -74,6 +74,8 @@ using namespace JSC;
         return kJSTypeString;
     if (jsValue.isSymbol())
         return kJSTypeSymbol;
+    if (jsValue.isBigInt())
+        return kJSTypeBigInt;
     ASSERT(jsValue.isObject());
     return kJSTypeObject;
 }
@@ -181,6 +183,21 @@ bool JSValueIsSymbol(JSContextRef ctx, JSValueRef value)
     return toJS(globalObject, value).isSymbol();
 #else
     return value && toJS(value).isSymbol();
+#endif
+}
+
+bool JSValueIsBigInt(JSContextRef ctx, JSValueRef value)
+{
+    if (!ctx) {
+        ASSERT_NOT_REACHED();
+        return false;
+    }
+#if !CPU(ADDRESS64)
+    JSGlobalObject* globalObject = toJS(ctx);
+    JSLockHolder locker(globalObject);
+    return toJS(globalObject, value).isBigInt();
+#else
+    return value && toJS(value).isBigInt();
 #endif
 }
 
@@ -368,6 +385,295 @@ JSValueRef JSValueMakeSymbol(JSContextRef ctx, JSStringRef description)
     return toRef(globalObject, Symbol::createWithDescription(vm, description->string()));
 }
 
+JSValueRef JSBigIntCreateWithDouble(JSContextRef ctx, double value, JSValueRef* exception)
+{
+    if (!ctx) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    JSGlobalObject* globalObject = toJS(ctx);
+    VM& vm = globalObject->vm();
+    JSLockHolder locker(vm);
+    auto scope = DECLARE_CATCH_SCOPE(vm);
+
+    if (!isInteger(value)) {
+        setException(ctx, exception, createRangeError(globalObject, "Not an integer"_s));
+        return nullptr;
+    }
+
+    JSValue result = JSBigInt::makeHeapBigIntOrBigInt32(globalObject, value);
+    if (handleExceptionIfNeeded(scope, ctx, exception) == ExceptionStatus::DidThrow)
+        return nullptr;
+
+    return toRef(globalObject, result);
+}
+
+JSValueRef JSBigIntCreateWithUInt64(JSContextRef ctx, uint64_t integer, JSValueRef* exception)
+{
+    if (!ctx) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    JSGlobalObject* globalObject = toJS(ctx);
+    VM& vm = globalObject->vm();
+    JSLockHolder locker(vm);
+    auto scope = DECLARE_CATCH_SCOPE(vm);
+
+    JSValue result = JSBigInt::makeHeapBigIntOrBigInt32(globalObject, integer);
+    if (handleExceptionIfNeeded(scope, ctx, exception) == ExceptionStatus::DidThrow)
+        return nullptr;
+
+    return toRef(globalObject, result);
+}
+
+JSValueRef JSBigIntCreateWithInt64(JSContextRef ctx, int64_t integer, JSValueRef* exception)
+{
+    if (!ctx) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    JSGlobalObject* globalObject = toJS(ctx);
+    VM& vm = globalObject->vm();
+    JSLockHolder locker(vm);
+    auto scope = DECLARE_CATCH_SCOPE(vm);
+
+    JSValue result = JSBigInt::makeHeapBigIntOrBigInt32(globalObject, integer);
+    if (handleExceptionIfNeeded(scope, ctx, exception) == ExceptionStatus::DidThrow)
+        return nullptr;
+
+    return toRef(globalObject, result);
+}
+
+JSValueRef JSBigIntCreateWithString(JSContextRef ctx, JSStringRef string, JSValueRef* exception)
+{
+    if (!ctx) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    JSGlobalObject* globalObject = toJS(ctx);
+    VM& vm = globalObject->vm();
+    JSLockHolder locker(vm);
+    auto scope = DECLARE_CATCH_SCOPE(vm);
+
+    JSValue result = JSBigInt::parseInt(globalObject, string->string(), JSBigInt::ErrorParseMode::ThrowExceptions);
+    if (handleExceptionIfNeeded(scope, ctx, exception) == ExceptionStatus::DidThrow)
+        return nullptr;
+
+    return toRef(globalObject, result);
+}
+
+uint64_t JSValueToUInt64(JSContextRef ctx, JSValueRef value, JSValueRef* exception)
+{
+    if (!ctx) {
+        ASSERT_NOT_REACHED();
+        return 0;
+    }
+
+    JSGlobalObject* globalObject = toJS(ctx);
+    JSLockHolder locker(globalObject);
+    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+    JSValue numeric = toJS(globalObject, value).toNumeric(globalObject);
+    if (handleExceptionIfNeeded(scope, ctx, exception) == ExceptionStatus::DidThrow)
+        return 0;
+
+    if (numeric.isBigInt())
+        return JSBigInt::toBigUInt64(numeric);
+
+    ASSERT(numeric.isNumber());
+    return JSC::toUInt64(numeric.asNumber());
+}
+
+int64_t JSValueToInt64(JSContextRef ctx, JSValueRef value, JSValueRef* exception)
+{
+    if (!ctx) {
+        ASSERT_NOT_REACHED();
+        return 0;
+    }
+
+    JSGlobalObject* globalObject = toJS(ctx);
+    JSLockHolder locker(globalObject);
+    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+    JSValue numeric = toJS(globalObject, value).toNumeric(globalObject);
+    if (handleExceptionIfNeeded(scope, ctx, exception) == ExceptionStatus::DidThrow)
+        return 0;
+
+    if (numeric.isBigInt())
+        return JSBigInt::toBigInt64(numeric);
+
+    ASSERT(numeric.isNumber());
+    return JSC::toInt64(numeric.asNumber());
+}
+
+uint32_t JSValueToUInt32(JSContextRef ctx, JSValueRef value, JSValueRef* exception)
+{
+    if (!ctx) {
+        ASSERT_NOT_REACHED();
+        return 0;
+    }
+
+    JSGlobalObject* globalObject = toJS(ctx);
+    JSLockHolder locker(globalObject);
+    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+    JSValue numeric = toJS(globalObject, value).toNumeric(globalObject);
+    if (handleExceptionIfNeeded(scope, ctx, exception) == ExceptionStatus::DidThrow)
+        return 0;
+
+    if (numeric.isBigInt())
+        return static_cast<uint32_t>(JSBigInt::toBigUInt64(numeric));
+
+    ASSERT(numeric.isNumber());
+    return JSC::toUInt32(numeric.asNumber());
+}
+
+int32_t JSValueToInt32(JSContextRef ctx, JSValueRef value, JSValueRef* exception)
+{
+    if (!ctx) {
+        ASSERT_NOT_REACHED();
+        return 0;
+    }
+
+    JSGlobalObject* globalObject = toJS(ctx);
+    JSLockHolder locker(globalObject);
+    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+    JSValue numeric = toJS(globalObject, value).toNumeric(globalObject);
+    if (handleExceptionIfNeeded(scope, ctx, exception) == ExceptionStatus::DidThrow)
+        return 0;
+
+    if (numeric.isBigInt())
+        return static_cast<int32_t>(JSBigInt::toBigInt64(numeric));
+
+    ASSERT(numeric.isNumber());
+    return JSC::toInt32(numeric.asNumber());
+}
+
+ALWAYS_INLINE JSRelationCondition toJSRelationCondition(JSC::JSBigInt::ComparisonResult);
+JSRelationCondition toJSRelationCondition(JSC::JSBigInt::ComparisonResult result)
+{
+    switch (result) {
+    case JSC::JSBigInt::ComparisonResult::Equal:
+        return JSRelationCondition::kJSRelationConditionEqual;
+    case JSC::JSBigInt::ComparisonResult::Undefined:
+        return JSRelationCondition::kJSRelationConditionUndefined;
+    case JSC::JSBigInt::ComparisonResult::GreaterThan:
+        return JSRelationCondition::kJSRelationConditionGreaterThan;
+    case JSC::JSBigInt::ComparisonResult::LessThan:
+        return JSRelationCondition::kJSRelationConditionLessThan;
+    default:
+        ASSERT_NOT_REACHED();
+        return JSRelationCondition::kJSRelationConditionUndefined;
+    }
+}
+
+JSRelationCondition JSValueCompareUInt64(JSContextRef ctx, JSValueRef left, uint64_t right, JSValueRef* exception)
+{
+    if (!ctx) {
+        ASSERT_NOT_REACHED();
+        return kJSRelationConditionUndefined;
+    }
+
+    JSGlobalObject* globalObject = toJS(ctx);
+    JSLockHolder locker(globalObject);
+    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+    JSValue leftNumeric = toJS(globalObject, left).toNumeric(globalObject);
+    if (handleExceptionIfNeeded(scope, ctx, exception) == ExceptionStatus::DidThrow)
+        return kJSRelationConditionUndefined;
+
+    if (leftNumeric.isBigInt())
+        return toJSRelationCondition(JSBigInt::compare(leftNumeric, right));
+    ASSERT(leftNumeric.isNumber());
+    return toJSRelationCondition(JSBigInt::compareToDouble(leftNumeric.asNumber(), right));
+}
+
+JSRelationCondition JSValueCompareInt64(JSContextRef ctx, JSValueRef left, int64_t right, JSValueRef* exception)
+{
+    if (!ctx) {
+        ASSERT_NOT_REACHED();
+        return kJSRelationConditionUndefined;
+    }
+
+    JSGlobalObject* globalObject = toJS(ctx);
+    JSLockHolder locker(globalObject);
+    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+    JSValue leftNumeric = toJS(globalObject, left).toNumeric(globalObject);
+    if (handleExceptionIfNeeded(scope, ctx, exception) == ExceptionStatus::DidThrow)
+        return kJSRelationConditionUndefined;
+
+    if (leftNumeric.isBigInt())
+        return toJSRelationCondition(JSBigInt::compare(leftNumeric, right));
+    ASSERT(leftNumeric.isNumber());
+    return toJSRelationCondition(JSBigInt::compareToDouble(leftNumeric.asNumber(), right));
+}
+
+JSRelationCondition JSValueCompareDouble(JSContextRef ctx, JSValueRef left, double right, JSValueRef* exception)
+{
+    if (!ctx) {
+        ASSERT_NOT_REACHED();
+        return kJSRelationConditionUndefined;
+    }
+
+    JSGlobalObject* globalObject = toJS(ctx);
+    JSLockHolder locker(globalObject);
+    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+    JSValue leftNumeric = toJS(globalObject, left).toNumeric(globalObject);
+    if (handleExceptionIfNeeded(scope, ctx, exception) == ExceptionStatus::DidThrow)
+        return kJSRelationConditionUndefined;
+
+    if (leftNumeric.isBigInt())
+        return toJSRelationCondition(JSBigInt::compareToDouble(leftNumeric, right));
+
+    ASSERT(leftNumeric.isNumber());
+    double leftDouble = leftNumeric.asNumber();
+    if (std::isnan(leftDouble) || std::isnan(right))
+        return kJSRelationConditionUndefined;
+    if (leftDouble == right)
+        return kJSRelationConditionEqual;
+    if (leftDouble < right)
+        return kJSRelationConditionLessThan;
+    return kJSRelationConditionGreaterThan;
+}
+
+JSRelationCondition JSValueCompare(JSContextRef ctx, JSValueRef left, JSValueRef right, JSValueRef* exception)
+{
+    if (!ctx) {
+        ASSERT_NOT_REACHED();
+        return kJSRelationConditionUndefined;
+    }
+
+    JSGlobalObject* globalObject = toJS(ctx);
+    JSLockHolder locker(globalObject);
+    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+    JSValue leftValue = toJS(globalObject, left);
+    JSValue rightValue = toJS(globalObject, right);
+
+    bool isEqual = JSValue::equal(globalObject, leftValue, rightValue);
+    if (handleExceptionIfNeeded(scope, ctx, exception) == ExceptionStatus::DidThrow)
+        return kJSRelationConditionUndefined;
+    if (isEqual)
+        return kJSRelationConditionEqual;
+
+    bool isLessThan = jsLess<true>(globalObject, leftValue, rightValue);
+    if (handleExceptionIfNeeded(scope, ctx, exception) == ExceptionStatus::DidThrow)
+        return kJSRelationConditionUndefined;
+
+    bool isGreaterThan = jsLess<true>(globalObject, rightValue, leftValue);
+    if (handleExceptionIfNeeded(scope, ctx, exception) == ExceptionStatus::DidThrow)
+        return kJSRelationConditionUndefined;
+
+    ASSERT(!isLessThan || !isGreaterThan);
+
+    // This means either the left or right has a NaN result of toPrimitiveNumeric.
+    if (!isLessThan && !isGreaterThan)
+        return kJSRelationConditionUndefined;
+
+    if (isLessThan)
+        return kJSRelationConditionLessThan;
+    return kJSRelationConditionGreaterThan;
+}
+
 JSValueRef JSValueMakeString(JSContextRef ctx, JSStringRef string)
 {
     if (!ctx) {
@@ -441,13 +747,15 @@ double JSValueToNumber(JSContextRef ctx, JSValueRef value, JSValueRef* exception
     VM& vm = globalObject->vm();
     JSLockHolder locker(vm);
     auto scope = DECLARE_CATCH_SCOPE(vm);
-
-    JSValue jsValue = toJS(globalObject, value);
-
-    double number = jsValue.toNumber(globalObject);
+    JSValue numeric = toJS(globalObject, value).toNumeric(globalObject);
     if (handleExceptionIfNeeded(scope, ctx, exception) == ExceptionStatus::DidThrow)
-        number = PNaN;
-    return number;
+        return PNaN;
+
+    if (numeric.isBigInt())
+        return JSBigInt::toNumber(numeric).asNumber();
+
+    ASSERT(numeric.isNumber());
+    return numeric.asNumber();
 }
 
 JSStringRef JSValueToStringCopy(JSContextRef ctx, JSValueRef value, JSValueRef* exception)

--- a/Source/JavaScriptCore/API/JSValueRef.h
+++ b/Source/JavaScriptCore/API/JSValueRef.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2019 Apple Inc.  All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,8 @@
 #ifndef __cplusplus
 #include <stdbool.h>
 #endif
+#include <stddef.h> /* for size_t */
+#include <stdint.h> /* for int64_t and uint64_t */
 
 /*!
 @enum JSType
@@ -43,6 +45,7 @@
 @constant     kJSTypeString     A primitive string value.
 @constant     kJSTypeObject     An object value (meaning that this JSValueRef is a JSObjectRef).
 @constant     kJSTypeSymbol     A primitive symbol value.
+@constant     kJSTypeBigInt     A primitive BigInt value.
 */
 typedef enum {
     kJSTypeUndefined,
@@ -51,7 +54,8 @@ typedef enum {
     kJSTypeNumber,
     kJSTypeString,
     kJSTypeObject,
-    kJSTypeSymbol JSC_API_AVAILABLE(macos(10.15), ios(13.0))
+    kJSTypeSymbol JSC_API_AVAILABLE(macos(10.15), ios(13.0)),
+    kJSTypeBigInt JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA))
 } JSType;
 
 /*!
@@ -88,6 +92,21 @@ typedef enum {
     kJSTypedArrayTypeBigUint64Array,
 } JSTypedArrayType JSC_API_AVAILABLE(macos(10.12), ios(10.0));
 
+/*!
+@enum JSRelationCondition
+@abstract     A constant identifying the type of JavaScript relation condition.
+@constant     kJSRelationConditionUndefined    Fail to compare two operands.
+@constant     kJSRelationConditionEqual        Two operands have equivalent values.
+@constant     kJSRelationConditionGreaterThan  The left operand is greater than the right operand.
+@constant     kJSRelationConditionLessThan     The left operand is less than the right operand.
+*/
+JSC_CF_ENUM(JSRelationCondition,
+    kJSRelationConditionUndefined,
+    kJSRelationConditionEqual,
+    kJSRelationConditionGreaterThan,
+    kJSRelationConditionLessThan
+) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -99,7 +118,7 @@ extern "C" {
 @param value    The JSValue whose type you want to obtain.
 @result         A value of type JSType that identifies value's type.
 */
-JS_EXPORT JSType JSValueGetType(JSContextRef ctx, JSValueRef value);
+JS_EXPORT JSType JSValueGetType(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef value);
 
 /*!
 @function
@@ -108,7 +127,7 @@ JS_EXPORT JSType JSValueGetType(JSContextRef ctx, JSValueRef value);
 @param value    The JSValue to test.
 @result         true if value's type is the undefined type, otherwise false.
 */
-JS_EXPORT bool JSValueIsUndefined(JSContextRef ctx, JSValueRef value);
+JS_EXPORT bool JSValueIsUndefined(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef value);
 
 /*!
 @function
@@ -117,7 +136,7 @@ JS_EXPORT bool JSValueIsUndefined(JSContextRef ctx, JSValueRef value);
 @param value    The JSValue to test.
 @result         true if value's type is the null type, otherwise false.
 */
-JS_EXPORT bool JSValueIsNull(JSContextRef ctx, JSValueRef value);
+JS_EXPORT bool JSValueIsNull(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef value);
 
 /*!
 @function
@@ -126,7 +145,7 @@ JS_EXPORT bool JSValueIsNull(JSContextRef ctx, JSValueRef value);
 @param value    The JSValue to test.
 @result         true if value's type is the boolean type, otherwise false.
 */
-JS_EXPORT bool JSValueIsBoolean(JSContextRef ctx, JSValueRef value);
+JS_EXPORT bool JSValueIsBoolean(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef value);
 
 /*!
 @function
@@ -135,7 +154,7 @@ JS_EXPORT bool JSValueIsBoolean(JSContextRef ctx, JSValueRef value);
 @param value    The JSValue to test.
 @result         true if value's type is the number type, otherwise false.
 */
-JS_EXPORT bool JSValueIsNumber(JSContextRef ctx, JSValueRef value);
+JS_EXPORT bool JSValueIsNumber(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef value);
 
 /*!
 @function
@@ -144,7 +163,7 @@ JS_EXPORT bool JSValueIsNumber(JSContextRef ctx, JSValueRef value);
 @param value    The JSValue to test.
 @result         true if value's type is the string type, otherwise false.
 */
-JS_EXPORT bool JSValueIsString(JSContextRef ctx, JSValueRef value);
+JS_EXPORT bool JSValueIsString(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef value);
 
 /*!
 @function
@@ -153,7 +172,18 @@ JS_EXPORT bool JSValueIsString(JSContextRef ctx, JSValueRef value);
 @param value    The JSValue to test.
 @result         true if value's type is the symbol type, otherwise false.
 */
-JS_EXPORT bool JSValueIsSymbol(JSContextRef ctx, JSValueRef value) JSC_API_AVAILABLE(macos(10.15), ios(13.0));
+JS_EXPORT bool JSValueIsSymbol(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef value) JSC_API_AVAILABLE(macos(10.15), ios(13.0));
+
+JSC_ASSUME_NONNULL_BEGIN
+/*!
+@function
+@abstract       Tests whether a JavaScript value's type is the BigInt type.
+@param ctx      The execution context to use.
+@param value    The JSValue to test.
+@result         true if value's type is the BigInt type, otherwise false.
+*/
+JS_EXPORT bool JSValueIsBigInt(JSContextRef ctx, JSValueRef value) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+JSC_ASSUME_NONNULL_END
 
 /*!
 @function
@@ -162,7 +192,7 @@ JS_EXPORT bool JSValueIsSymbol(JSContextRef ctx, JSValueRef value) JSC_API_AVAIL
 @param value    The JSValue to test.
 @result         true if value's type is the object type, otherwise false.
 */
-JS_EXPORT bool JSValueIsObject(JSContextRef ctx, JSValueRef value);
+JS_EXPORT bool JSValueIsObject(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef value);
 
 
 /*!
@@ -173,7 +203,7 @@ JS_EXPORT bool JSValueIsObject(JSContextRef ctx, JSValueRef value);
 @param jsClass The JSClass to test against.
 @result true if value is an object and has jsClass in its class chain, otherwise false.
 */
-JS_EXPORT bool JSValueIsObjectOfClass(JSContextRef ctx, JSValueRef value, JSClassRef jsClass);
+JS_EXPORT bool JSValueIsObjectOfClass(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef value, JSC_NULL_UNSPECIFIED JSClassRef jsClass);
 
 /*!
 @function
@@ -182,7 +212,7 @@ JS_EXPORT bool JSValueIsObjectOfClass(JSContextRef ctx, JSValueRef value, JSClas
 @param value    The JSValue to test.
 @result         true if value is an array, otherwise false.
 */
-JS_EXPORT bool JSValueIsArray(JSContextRef ctx, JSValueRef value) JSC_API_AVAILABLE(macos(10.11), ios(9.0));
+JS_EXPORT bool JSValueIsArray(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef value) JSC_API_AVAILABLE(macos(10.11), ios(9.0));
 
 /*!
 @function
@@ -191,17 +221,17 @@ JS_EXPORT bool JSValueIsArray(JSContextRef ctx, JSValueRef value) JSC_API_AVAILA
 @param value    The JSValue to test.
 @result         true if value is a date, otherwise false.
 */
-JS_EXPORT bool JSValueIsDate(JSContextRef ctx, JSValueRef value) JSC_API_AVAILABLE(macos(10.11), ios(9.0));
+JS_EXPORT bool JSValueIsDate(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef value) JSC_API_AVAILABLE(macos(10.11), ios(9.0));
 
 /*!
 @function
 @abstract           Returns a JavaScript value's Typed Array type.
 @param ctx          The execution context to use.
 @param value        The JSValue whose Typed Array type to return.
-@param exception    A pointer to a JSValueRef in which to store an exception, if any. Pass NULL if you do not care to store an exception.
+@param exception    A pointer to a JSValueRef in which to store an exception, if any. To reliable detect exception, initialize this to null before the call. Pass NULL if you do not care to store an exception.
 @result             A value of type JSTypedArrayType that identifies value's Typed Array type, or kJSTypedArrayTypeNone if the value is not a Typed Array object.
  */
-JS_EXPORT JSTypedArrayType JSValueGetTypedArrayType(JSContextRef ctx, JSValueRef value, JSValueRef* exception) JSC_API_AVAILABLE(macos(10.12), ios(10.0));
+JS_EXPORT JSTypedArrayType JSValueGetTypedArrayType(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef value, JSC_NULL_UNSPECIFIED JSValueRef* JSC_NULL_UNSPECIFIED exception) JSC_API_AVAILABLE(macos(10.12), ios(10.0));
 
 /* Comparing values */
 
@@ -211,10 +241,10 @@ JS_EXPORT JSTypedArrayType JSValueGetTypedArrayType(JSContextRef ctx, JSValueRef
 @param ctx The execution context to use.
 @param a The first value to test.
 @param b The second value to test.
-@param exception A pointer to a JSValueRef in which to store an exception, if any. Pass NULL if you do not care to store an exception.
+@param exception A pointer to a JSValueRef in which to store an exception, if any. To reliable detect exception, initialize this to null before the call. Pass NULL if you do not care to store an exception.
 @result true if the two values are equal, false if they are not equal or an exception is thrown.
 */
-JS_EXPORT bool JSValueIsEqual(JSContextRef ctx, JSValueRef a, JSValueRef b, JSValueRef* exception);
+JS_EXPORT bool JSValueIsEqual(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef a, JSC_NULL_UNSPECIFIED JSValueRef b, JSC_NULL_UNSPECIFIED JSValueRef* JSC_NULL_UNSPECIFIED exception);
 
 /*!
 @function
@@ -224,7 +254,7 @@ JS_EXPORT bool JSValueIsEqual(JSContextRef ctx, JSValueRef a, JSValueRef b, JSVa
 @param b        The second value to test.
 @result         true if the two values are strict equal, otherwise false.
 */
-JS_EXPORT bool JSValueIsStrictEqual(JSContextRef ctx, JSValueRef a, JSValueRef b);
+JS_EXPORT bool JSValueIsStrictEqual(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef a, JSC_NULL_UNSPECIFIED JSValueRef b);
 
 /*!
 @function
@@ -232,10 +262,60 @@ JS_EXPORT bool JSValueIsStrictEqual(JSContextRef ctx, JSValueRef a, JSValueRef b
 @param ctx The execution context to use.
 @param value The JSValue to test.
 @param constructor The constructor to test against.
-@param exception A pointer to a JSValueRef in which to store an exception, if any. Pass NULL if you do not care to store an exception.
+@param exception A pointer to a JSValueRef in which to store an exception, if any. To reliable detect exception, initialize this to null before the call. Pass NULL if you do not care to store an exception.
 @result true if value is an object constructed by constructor, as compared by the JS instanceof operator, otherwise false.
 */
-JS_EXPORT bool JSValueIsInstanceOfConstructor(JSContextRef ctx, JSValueRef value, JSObjectRef constructor, JSValueRef* exception);
+JS_EXPORT bool JSValueIsInstanceOfConstructor(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef value, JSC_NULL_UNSPECIFIED JSObjectRef constructor, JSC_NULL_UNSPECIFIED JSValueRef* JSC_NULL_UNSPECIFIED exception);
+
+JSC_ASSUME_NONNULL_BEGIN
+/*!
+    @function
+    @abstract         Compares two JSValues.
+    @param ctx        The execution context to use.
+    @param left       The JSValue as the left operand.
+    @param right      The JSValue as the right operand.
+    @param exception  A pointer to a JSValueRef in which to store an exception, if any. To reliable detect exception, initialize this to null before the call. Pass NULL if you do not care to store an exception.
+    @result           A value of JSRelationCondition, a kJSRelationConditionUndefined is returned if an exception is thrown.
+    @discussion       The result is computed by comparing the results of JavaScript's `==`, `<`, and `>` operators. If either `left` or `right` is (or would coerce to) `NaN` in JavaScript, then the result is kJSRelationConditionUndefined.
+*/
+JS_EXPORT JSRelationCondition JSValueCompare(JSContextRef ctx, JSValueRef left, JSValueRef right, JSC_NULLABLE JSValueRef* JSC_NULLABLE exception) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+    @function
+    @abstract         Compares a JSValue with a signed 64-bit integer.
+    @param ctx        The execution context to use.
+    @param left       The JSValue as the left operand.
+    @param right      The int64_t as the right operand.
+    @param exception  A pointer to a JSValueRef in which to store an exception, if any. To reliable detect exception, initialize this to null before the call. Pass NULL if you do not care to store an exception.
+    @result           A value of JSRelationCondition, a kJSRelationConditionUndefined is returned if an exception is thrown.
+    @discussion       `left` is converted to an integer according to the rules specified by the JavaScript language then compared with `right`.
+*/
+JS_EXPORT JSRelationCondition JSValueCompareInt64(JSContextRef ctx, JSValueRef left, int64_t right, JSC_NULLABLE JSValueRef* JSC_NULLABLE exception) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+    @function
+    @abstract         Compares a JSValue with an unsigned 64-bit integer.
+    @param ctx        The execution context to use.
+    @param left       The JSValue as the left operand.
+    @param right      The uint64_t as the right operand.
+    @param exception  A pointer to a JSValueRef in which to store an exception, if any. To reliable detect exception, initialize this to null before the call. Pass NULL if you do not care to store an exception.
+    @result           A value of JSRelationCondition, a kJSRelationConditionUndefined is returned if an exception is thrown.
+    @discussion       `left` is converted to an integer according to the rules specified by the JavaScript language then compared with `right`.
+*/
+JS_EXPORT JSRelationCondition JSValueCompareUInt64(JSContextRef ctx, JSValueRef left, uint64_t right, JSC_NULLABLE JSValueRef* JSC_NULLABLE exception) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+    @function
+    @abstract         Compares a JSValue with a double.
+    @param ctx        The execution context to use.
+    @param left       The JSValue as the left operand.
+    @param right      The double as the right operand.
+    @param exception  A pointer to a JSValueRef in which to store an exception, if any. To reliable detect exception, initialize this to null before the call. Pass NULL if you do not care to store an exception.
+    @result           A value of JSRelationCondition, a kJSRelationConditionUndefined is returned if an exception is thrown.
+    @discussion       `left` is converted to a double according to the rules specified by the JavaScript language then compared with `right`.
+*/
+JS_EXPORT JSRelationCondition JSValueCompareDouble(JSContextRef ctx, JSValueRef left, double right, JSC_NULLABLE JSValueRef* JSC_NULLABLE exception) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+JSC_ASSUME_NONNULL_END
 
 /* Creating values */
 
@@ -245,7 +325,7 @@ JS_EXPORT bool JSValueIsInstanceOfConstructor(JSContextRef ctx, JSValueRef value
 @param ctx  The execution context to use.
 @result         The unique undefined value.
 */
-JS_EXPORT JSValueRef JSValueMakeUndefined(JSContextRef ctx);
+JS_EXPORT JSC_NULL_UNSPECIFIED JSValueRef JSValueMakeUndefined(JSC_NULL_UNSPECIFIED JSContextRef ctx);
 
 /*!
 @function
@@ -253,7 +333,7 @@ JS_EXPORT JSValueRef JSValueMakeUndefined(JSContextRef ctx);
 @param ctx  The execution context to use.
 @result         The unique null value.
 */
-JS_EXPORT JSValueRef JSValueMakeNull(JSContextRef ctx);
+JS_EXPORT JSC_NULL_UNSPECIFIED JSValueRef JSValueMakeNull(JSC_NULL_UNSPECIFIED JSContextRef ctx);
 
 /*!
 @function
@@ -262,7 +342,7 @@ JS_EXPORT JSValueRef JSValueMakeNull(JSContextRef ctx);
 @param boolean  The bool to assign to the newly created JSValue.
 @result         A JSValue of the boolean type, representing the value of boolean.
 */
-JS_EXPORT JSValueRef JSValueMakeBoolean(JSContextRef ctx, bool boolean);
+JS_EXPORT JSC_NULL_UNSPECIFIED JSValueRef JSValueMakeBoolean(JSC_NULL_UNSPECIFIED JSContextRef ctx, bool boolean);
 
 /*!
 @function
@@ -271,7 +351,7 @@ JS_EXPORT JSValueRef JSValueMakeBoolean(JSContextRef ctx, bool boolean);
 @param number   The double to assign to the newly created JSValue.
 @result         A JSValue of the number type, representing the value of number.
 */
-JS_EXPORT JSValueRef JSValueMakeNumber(JSContextRef ctx, double number);
+JS_EXPORT JSC_NULL_UNSPECIFIED JSValueRef JSValueMakeNumber(JSC_NULL_UNSPECIFIED JSContextRef ctx, double number);
 
 /*!
 @function
@@ -281,7 +361,7 @@ JS_EXPORT JSValueRef JSValueMakeNumber(JSContextRef ctx, double number);
  newly created JSValue retains string, and releases it upon garbage collection.
 @result         A JSValue of the string type, representing the value of string.
 */
-JS_EXPORT JSValueRef JSValueMakeString(JSContextRef ctx, JSStringRef string);
+JS_EXPORT JSC_NULL_UNSPECIFIED JSValueRef JSValueMakeString(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSStringRef string);
 
 /*!
  @function
@@ -290,7 +370,51 @@ JS_EXPORT JSValueRef JSValueMakeString(JSContextRef ctx, JSStringRef string);
  @param description   A description of the newly created symbol value.
  @result              A unique JSValue of the symbol type, whose description matches the one provided.
  */
-JS_EXPORT JSValueRef JSValueMakeSymbol(JSContextRef ctx, JSStringRef description) JSC_API_AVAILABLE(macos(10.15), ios(13.0));
+JS_EXPORT JSC_NULL_UNSPECIFIED JSValueRef JSValueMakeSymbol(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSStringRef description) JSC_API_AVAILABLE(macos(10.15), ios(13.0));
+
+JSC_ASSUME_NONNULL_BEGIN
+/*!
+    @function
+    @abstract         Creates a JavaScript BigInt with a double.
+    @param ctx        The execution context to use.
+    @param value      The value to copy into the new BigInt JSValue.
+    @param exception  A pointer to a JSValueRef in which to store an exception, if any. To reliable detect exception, initialize this to null before the call. Pass NULL if you do not care to store an exception.
+    @result           A BigInt JSValue of the value, or NULL if an exception is thrown.
+    @discussion       If the value is not an integer, an exception is thrown.
+*/
+JS_EXPORT JSValueRef JSBigIntCreateWithDouble(JSContextRef ctx, double value, JSC_NULLABLE JSValueRef* JSC_NULLABLE exception) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+    @function
+    @abstract         Creates a JavaScript BigInt with a 64-bit signed integer.
+    @param ctx        The execution context to use.
+    @param integer    The 64-bit signed integer to copy into the new BigInt JSValue.
+    @param exception  A pointer to a JSValueRef in which to store an exception, if any. To reliable detect exception, initialize this to null before the call. Pass NULL if you do not care to store an exception.
+    @result           A BigInt JSValue of the integer, or NULL if an exception is thrown.
+*/
+JS_EXPORT JSValueRef JSBigIntCreateWithInt64(JSContextRef ctx, int64_t integer, JSC_NULLABLE JSValueRef* JSC_NULLABLE exception) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+    @function
+    @abstract         Creates a JavaScript BigInt with a 64-bit unsigned integer.
+    @param ctx        The execution context to use.
+    @param integer    The 64-bit unsigned integer to copy into the new BigInt JSValue.
+    @param exception  A pointer to a JSValueRef in which to store an exception, if any. To reliable detect exception, initialize this to null before the call. Pass NULL if you do not care to store an exception.
+    @result           A BigInt JSValue of the integer, or NULL if an exception is thrown.
+*/
+JS_EXPORT JSValueRef JSBigIntCreateWithUInt64(JSContextRef ctx, uint64_t integer, JSC_NULLABLE JSValueRef* JSC_NULLABLE exception) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+    @function
+    @abstract         Creates a JavaScript BigInt with an integer represented in string.
+    @param ctx        The execution context to use.
+    @param string     The JSStringRef representation of an integer.
+    @param exception  A pointer to a JSValueRef in which to store an exception, if any. To reliable detect exception, initialize this to null before the call. Pass NULL if you do not care to store an exception.
+    @result           A BigInt JSValue of the string, or NULL if an exception is thrown.
+    @discussion       This is equivalent to calling the `BigInt` constructor from JavaScript with a string argument.
+*/
+JS_EXPORT JSValueRef JSBigIntCreateWithString(JSContextRef ctx, JSStringRef string, JSC_NULLABLE JSValueRef* JSC_NULLABLE exception) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+JSC_ASSUME_NONNULL_END
 
 /* Converting to and from JSON formatted strings */
 
@@ -301,7 +425,7 @@ JS_EXPORT JSValueRef JSValueMakeSymbol(JSContextRef ctx, JSStringRef description
  @param string   The JSString containing the JSON string to be parsed.
  @result         A JSValue containing the parsed value, or NULL if the input is invalid.
  */
-JS_EXPORT JSValueRef JSValueMakeFromJSONString(JSContextRef ctx, JSStringRef string) JSC_API_AVAILABLE(macos(10.7), ios(7.0));
+JS_EXPORT JSC_NULL_UNSPECIFIED JSValueRef JSValueMakeFromJSONString(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSStringRef string) JSC_API_AVAILABLE(macos(10.7), ios(7.0));
 
 /*!
  @function
@@ -309,10 +433,10 @@ JS_EXPORT JSValueRef JSValueMakeFromJSONString(JSContextRef ctx, JSStringRef str
  @param ctx      The execution context to use.
  @param value    The value to serialize.
  @param indent   The number of spaces to indent when nesting.  If 0, the resulting JSON will not contains newlines.  The size of the indent is clamped to 10 spaces.
- @param exception A pointer to a JSValueRef in which to store an exception, if any. Pass NULL if you do not care to store an exception.
+ @param exception A pointer to a JSValueRef in which to store an exception, if any. To reliable detect exception, initialize this to null before the call. Pass NULL if you do not care to store an exception.
  @result         A JSString with the result of serialization, or NULL if an exception is thrown.
  */
-JS_EXPORT JSStringRef JSValueCreateJSONString(JSContextRef ctx, JSValueRef value, unsigned indent, JSValueRef* exception) JSC_API_AVAILABLE(macos(10.7), ios(7.0));
+JS_EXPORT JSC_NULL_UNSPECIFIED JSStringRef JSValueCreateJSONString(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef value, unsigned indent, JSC_NULL_UNSPECIFIED JSValueRef* JSC_NULL_UNSPECIFIED exception) JSC_API_AVAILABLE(macos(10.7), ios(7.0));
 
 /* Converting to primitive values */
 
@@ -323,37 +447,84 @@ JS_EXPORT JSStringRef JSValueCreateJSONString(JSContextRef ctx, JSValueRef value
 @param value    The JSValue to convert.
 @result         The boolean result of conversion.
 */
-JS_EXPORT bool JSValueToBoolean(JSContextRef ctx, JSValueRef value);
+JS_EXPORT bool JSValueToBoolean(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef value);
 
 /*!
 @function
 @abstract       Converts a JavaScript value to number and returns the resulting number.
 @param ctx  The execution context to use.
 @param value    The JSValue to convert.
-@param exception A pointer to a JSValueRef in which to store an exception, if any. Pass NULL if you do not care to store an exception.
+@param exception A pointer to a JSValueRef in which to store an exception, if any. To reliable detect exception, initialize this to null before the call. Pass NULL if you do not care to store an exception.
 @result         The numeric result of conversion, or NaN if an exception is thrown.
+@discussion     The result is equivalent to `Number(value)` in JavaScript.
 */
-JS_EXPORT double JSValueToNumber(JSContextRef ctx, JSValueRef value, JSValueRef* exception);
+JS_EXPORT double JSValueToNumber(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef value, JSC_NULL_UNSPECIFIED JSValueRef* JSC_NULL_UNSPECIFIED exception);
+
+JSC_ASSUME_NONNULL_BEGIN
+/*!
+    @function
+    @abstract         Converts a JSValue to a singed 32-bit integer and returns the resulting integer.
+    @param ctx        The execution context to use.
+    @param value      The JSValue to convert.
+    @param exception  A pointer to a JSValueRef in which to store an exception, if any. To reliable detect exception, initialize this to null before the call. Pass NULL if you do not care to store an exception.
+    @result           An int32_t with the result of conversion, or 0 if an exception is thrown. Since 0 is valid value, `exception` must be checked after the call.
+    @discussion       The JSValue is converted to an integer according to the rules specified by the JavaScript language. If the value is a BigInt, then the JSValue is truncated to an int32_t.
+*/
+JS_EXPORT int32_t JSValueToInt32(JSContextRef ctx, JSValueRef value, JSC_NULLABLE JSValueRef* JSC_NULLABLE exception) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+    @function
+    @abstract         Converts a JSValue to an unsigned 32-bit integer and returns the resulting integer.
+    @param ctx        The execution context to use.
+    @param value      The JSValue to convert.
+    @param exception  A pointer to a JSValueRef in which to store an exception, if any. To reliable detect exception, initialize this to null before the call. Pass NULL if you do not care to store an exception.
+    @result           A uint32_t with the result of conversion, or 0 if an exception is thrown. Since 0 is valid value, `exception` must be checked after the call.
+    @discussion       The JSValue is converted to an integer according to the rules specified by the JavaScript language. If the value is a BigInt, then the JSValue is truncated to a uint32_t.
+*/
+JS_EXPORT uint32_t JSValueToUInt32(JSContextRef ctx, JSValueRef value, JSC_NULLABLE JSValueRef* JSC_NULLABLE exception) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+    @function
+    @abstract         Converts a JSValue to a singed 64-bit integer and returns the resulting integer.
+    @param ctx        The execution context to use.
+    @param value      The JSValue to convert.
+    @param exception  A pointer to a JSValueRef in which to store an exception, if any. To reliable detect exception, initialize this to null before the call. Pass NULL if you do not care to store an exception.
+    @result           An int64_t with the result of conversion, or 0 if an exception is thrown. Since 0 is valid value, `exception` must be checked after the call.
+    @discussion       The JSValue is converted to an integer according to the rules specified by the JavaScript language. If the value is a BigInt, then the JSValue is truncated to an int64_t.
+*/
+JS_EXPORT int64_t JSValueToInt64(JSContextRef ctx, JSValueRef value, JSC_NULLABLE JSValueRef* JSC_NULLABLE exception) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+    @function
+    @abstract         Converts a JSValue to an unsigned 64-bit integer and returns the resulting integer.
+    @param ctx        The execution context to use.
+    @param value      The JSValue to convert.
+    @param exception  A pointer to a JSValueRef in which to store an exception, if any. To reliable detect exception, initialize this to null before the call. Pass NULL if you do not care to store an exception.
+    @result           A uint64_t with the result of conversion, or 0 if an exception is thrown. Since 0 is valid value, `exception` must be checked after the call.
+    @discussion       The JSValue is converted to an integer according to the rules specified by the JavaScript language. If the value is a BigInt, then the JSValue is truncated to a uint64_t.
+*/
+JS_EXPORT uint64_t JSValueToUInt64(JSContextRef ctx, JSValueRef value, JSC_NULLABLE JSValueRef* JSC_NULLABLE exception) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+JSC_ASSUME_NONNULL_END
 
 /*!
 @function
 @abstract       Converts a JavaScript value to string and copies the result into a JavaScript string.
 @param ctx  The execution context to use.
 @param value    The JSValue to convert.
-@param exception A pointer to a JSValueRef in which to store an exception, if any. Pass NULL if you do not care to store an exception.
+@param exception A pointer to a JSValueRef in which to store an exception, if any. To reliable detect exception, initialize this to null before the call. Pass NULL if you do not care to store an exception.
 @result         A JSString with the result of conversion, or NULL if an exception is thrown. Ownership follows the Create Rule.
 */
-JS_EXPORT JSStringRef JSValueToStringCopy(JSContextRef ctx, JSValueRef value, JSValueRef* exception);
+JS_EXPORT JSC_NULL_UNSPECIFIED JSStringRef JSValueToStringCopy(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef value, JSC_NULL_UNSPECIFIED JSValueRef* JSC_NULL_UNSPECIFIED exception);
 
 /*!
 @function
 @abstract Converts a JavaScript value to object and returns the resulting object.
 @param ctx  The execution context to use.
 @param value    The JSValue to convert.
-@param exception A pointer to a JSValueRef in which to store an exception, if any. Pass NULL if you do not care to store an exception.
+@param exception A pointer to a JSValueRef in which to store an exception, if any. To reliable detect exception, initialize this to null before the call. Pass NULL if you do not care to store an exception.
 @result         The JSObject result of conversion, or NULL if an exception is thrown.
 */
-JS_EXPORT JSObjectRef JSValueToObject(JSContextRef ctx, JSValueRef value, JSValueRef* exception);
+JS_EXPORT JSC_NULL_UNSPECIFIED JSObjectRef JSValueToObject(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef value, JSC_NULL_UNSPECIFIED JSValueRef* JSC_NULL_UNSPECIFIED exception);
 
 /* Garbage collection */
 /*!
@@ -365,7 +536,7 @@ JS_EXPORT JSObjectRef JSValueToObject(JSContextRef ctx, JSValueRef value, JSValu
  
 A value may be protected multiple times and must be unprotected an equal number of times before becoming eligible for garbage collection.
 */
-JS_EXPORT void JSValueProtect(JSContextRef ctx, JSValueRef value);
+JS_EXPORT void JSValueProtect(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef value);
 
 /*!
 @function
@@ -375,7 +546,7 @@ JS_EXPORT void JSValueProtect(JSContextRef ctx, JSValueRef value);
 @discussion     A value may be protected multiple times and must be unprotected an 
  equal number of times before becoming eligible for garbage collection.
 */
-JS_EXPORT void JSValueUnprotect(JSContextRef ctx, JSValueRef value);
+JS_EXPORT void JSValueUnprotect(JSC_NULL_UNSPECIFIED JSContextRef ctx, JSC_NULL_UNSPECIFIED JSValueRef value);
 
 #ifdef __cplusplus
 }

--- a/Source/JavaScriptCore/API/tests/testapi.mm
+++ b/Source/JavaScriptCore/API/tests/testapi.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -2829,6 +2829,101 @@ static void testToString()
     }
 }
 
+static void testBigIntAPI()
+{
+    @autoreleasepool {
+        JSContext *context = [[JSContext alloc] init];
+        JSValue *posInfinity = [context evaluateScript:@"Infinity;"];
+        checkResult(@"Should be a bigint value", !posInfinity.toInt32);
+        checkResult(@"Should be a bigint value", !posInfinity.toUInt32);
+
+        JSValue *negInfinity = [context evaluateScript:@"-Infinity;"];
+        checkResult(@"Should be a bigint value", !negInfinity.toInt32);
+        checkResult(@"Should be a bigint value", !negInfinity.toUInt32);
+    }
+
+    @autoreleasepool {
+        JSContext *context = [[JSContext alloc] init];
+        JSValue *bigInt = [context evaluateScript:@"BigInt('42');"];
+        JSValue *notBigInt = [context evaluateScript:@"'42'"];
+        checkResult(@"Should be a bigint value", bigInt.isBigInt);
+        checkResult(@"Should not be a bigint value", !notBigInt.isBigInt);
+        checkResult(@"Should equal to 42", [[bigInt toNumber] doubleValue] == 42.0);
+    }
+
+    @autoreleasepool {
+        JSContext *context = [[JSContext alloc] init];
+        JSValue *bigInt = [JSValue valueWithNewBigIntFromString:@"42" inContext:context];
+        checkResult(@"Should be a created from Obj-C", bigInt.isBigInt);
+    }
+
+    @autoreleasepool {
+        JSContext *context = [[JSContext alloc] init];
+        JSValue *bigInt = [JSValue valueWithNewBigIntFromInt64:(int64_t)42 inContext:context];
+        checkResult(@"Should be a created from Obj-C", bigInt.isBigInt);
+
+        JSRelationCondition condition = [bigInt compareInt64:(int64_t)42];
+        checkResult(@"Should be kJSRelationConditionEqual", condition == kJSRelationConditionEqual);
+    }
+
+    @autoreleasepool {
+        JSContext *context = [[JSContext alloc] init];
+        JSValue *bigInt = [JSValue valueWithNewBigIntFromUInt64:(uint64_t)42 inContext:context];
+        checkResult(@"Should be a created from Obj-C", bigInt.isBigInt);
+
+        JSRelationCondition condition = [bigInt compareUInt64:(uint64_t)42];
+        checkResult(@"Should be kJSRelationConditionEqual", condition == kJSRelationConditionEqual);
+    }
+
+    @autoreleasepool {
+        JSContext *context = [[JSContext alloc] init];
+        double value = 42.0;
+        JSValue *bigInt = [JSValue valueWithNewBigIntFromDouble:(double)value inContext:context];
+        checkResult(@"Should be a created from Obj-C", bigInt.isBigInt);
+
+        double toDoubleResult = [bigInt toDouble];
+        checkResult(@"Should equal to value", toDoubleResult == value);
+
+        JSRelationCondition condition = [bigInt compareDouble:(double)value];
+        checkResult(@"Should be kJSRelationConditionEqual", condition == kJSRelationConditionEqual);
+
+        bigInt = [JSValue valueWithNewBigIntFromDouble:(double)42.1 inContext:context];
+        checkResult(@"Should be a nullptr", !bigInt);
+        checkResult(@"Should throw an exception", [context exception]);
+    }
+
+    @autoreleasepool {
+        JSContext *context = [[JSContext alloc] init];
+        JSValue *array = [JSValue valueWithNewArrayInContext:context];
+        checkResult(@"Should be 0", ![array toUInt64]);
+
+        JSValue *bigInt = [JSValue valueWithNewBigIntFromUInt64:(uint64_t)42 inContext:context];
+        checkResult(@"Should be a 42", [bigInt toUInt64] == 42);
+    }
+
+    @autoreleasepool {
+        JSContext *context = [[JSContext alloc] init];
+        JSValue *array = [JSValue valueWithNewArrayInContext:context];
+        checkResult(@"Should be 0", ![array toInt64]);
+
+        JSValue *bigInt = [JSValue valueWithNewBigIntFromInt64:(int64_t)42 inContext:context];
+        checkResult(@"Should be a 42", [bigInt toInt64] == 42);
+    }
+
+    @autoreleasepool {
+        JSContext *context = [[JSContext alloc] init];
+        JSValue *bigInt = [JSValue valueWithNewBigIntFromInt64:(int64_t)42 inContext:context];
+        checkResult(@"Should be a string `42`", [[bigInt toString] isEqualToString:@"42"]);
+    }
+
+    @autoreleasepool {
+        JSContext *context = [[JSContext alloc] init];
+        JSValue *bigInt42 = [JSValue valueWithNewBigIntFromInt64:(int64_t)42 inContext:context];
+        JSValue *bigInt43 = [JSValue valueWithNewBigIntFromInt64:(int64_t)43 inContext:context];
+        checkResult(@"Should be kJSRelationConditionLessThan", [bigInt42 compareJSValue:bigInt43] == kJSRelationConditionLessThan);
+    }
+}
+
 #define RUN(test) do { \
         if (!shouldRun(#test)) \
             break; \
@@ -2850,6 +2945,7 @@ void testObjectiveCAPI(const char* filter)
     RUN(checkNegativeNSIntegers());
     RUN(runJITThreadLimitTests());
     RUN(testToString());
+    RUN(testBigIntAPI());
 
     RUN(testLoaderResolvesAbsoluteScriptURL());
     RUN(testFetch());


### PR DESCRIPTION
#### e8e34401087195314e5831bf97523f1813a49516
<pre>
[JSC] Reland JavaScript BigInt Public C API
<a href="https://bugs.webkit.org/show_bug.cgi?id=250511">https://bugs.webkit.org/show_bug.cgi?id=250511</a>
<a href="https://rdar.apple.com/104194532">rdar://104194532</a>

Reviewed by Keith Miller.

JavaScriptCore framework provides the ability to evaluate JavaScript programs
within applications developed using Swift and Object-C. While JavaScriptCore
APIs support all JavaScript primitive types except for BigInt type. This patch
introduces BigInt public C APIs for type verification, type access, value
creation, value conversion, and value comparison.

* Source/JavaScriptCore/API/JSBase.h:
* Source/JavaScriptCore/API/JSValue.h:
* Source/JavaScriptCore/API/JSValue.mm:
(+[JSValue valueWithNewBigIntFromString:inContext:]):
(+[JSValue valueWithNewBigIntFromInt64:inContext:]):
(+[JSValue valueWithNewBigIntFromUInt64:inContext:]):
(+[JSValue valueWithNewBigIntFromDouble:inContext:]):
(-[JSValue compareUInt64:]):
(-[JSValue compareInt64:]):
(-[JSValue compareDouble:]):
(-[JSValue compare:]):
(+[JSValue valueWithNewPromiseInContext:fromExecutor:]):
(-[JSValue toInt32]):
(-[JSValue toUInt32]):
(-[JSValue toInt64]):
(-[JSValue toUInt64]):
(-[JSValue isBigInt]):
* Source/JavaScriptCore/API/JSValueRef.cpp:
(JSValueGetType):
(JSValueIsBigInt):
(JSBigIntCreateWithDouble):
(JSBigIntCreateWithUInt64):
(JSBigIntCreateWithInt64):
(JSBigIntCreateWithString):
(JSValueToUInt64):
(JSValueToInt64):
(JSValueToUInt32):
(JSValueToInt32):
(toJSRelationCondition):
(JSValueCompareUInt64):
(JSValueCompareInt64):
(JSValueCompareDouble):
(JSValueCompare):
(JSValueToNumber):
* Source/JavaScriptCore/API/JSValueRef.h:
* Source/JavaScriptCore/API/tests/testapi.cpp:
(TestAPI::checkIsBigIntType):
(TestAPI::checkThrownException):
(TestAPI::testBigInt):
* Source/JavaScriptCore/API/tests/testapi.mm:
(testBigIntAPI):
(testObjectiveCAPI):

Canonical link: <a href="https://commits.webkit.org/278588@main">https://commits.webkit.org/278588@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5fd48ed4f277bc5f99693b860af6c4bd19c3090

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50468 "34 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53727 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1158 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/808 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41167 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52567 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43449 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22272 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24833 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/707 "Found 1 new test failure: imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-works-on-frame-src.https.sub.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8846 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43801 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46813 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55316 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49968 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25566 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/694 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48573 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26827 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43607 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47618 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27691 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57446 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7408 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26559 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11808 "Passed tests") | 
<!--EWS-Status-Bubble-End-->