### PR TITLE
[Unified Text Replacement] When a "rich text" text replacement session ends, the session should be undone if it is not accepted

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm
@@ -213,15 +213,10 @@ void UnifiedTextReplacementController::textReplacementSessionDidUpdateStateForRe
     }
 }
 
-void UnifiedTextReplacementController::didEndTextReplacementSession(const WTF::UUID& uuid, bool accepted)
+template<>
+void UnifiedTextReplacementController::didEndTextReplacementSession<WebUnifiedTextReplacementType::PlainText>(const WTF::UUID& uuid, bool accepted)
 {
-    RELEASE_LOG(UnifiedTextReplacement, "UnifiedTextReplacementController::didEndTextReplacementSession (%s) [accepted: %d]", uuid.toString().utf8().data(), accepted);
-
     RefPtr document = this->document();
-    if (!document) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
 
     auto sessionRange = contextRangeForSessionWithUUID(uuid);
     if (!sessionRange) {
@@ -244,8 +239,46 @@ void UnifiedTextReplacementController::didEndTextReplacementSession(const WTF::U
 
         return false;
     });
+}
+
+template<>
+void UnifiedTextReplacementController::didEndTextReplacementSession<WebUnifiedTextReplacementType::RichText>(const WTF::UUID& uuid, bool accepted)
+{
+    if (accepted)
+        return;
+
+    RefPtr document = this->document();
+
+    textReplacementSessionPerformEditActionForRichText(*document, uuid, WebTextReplacementData::EditAction::Undo);
+}
+
+void UnifiedTextReplacementController::didEndTextReplacementSession(const WTF::UUID& uuid, bool accepted)
+{
+    RELEASE_LOG(UnifiedTextReplacement, "UnifiedTextReplacementController::didEndTextReplacementSession (%s) [accepted: %d]", uuid.toString().utf8().data(), accepted);
+
+    RefPtr document = this->document();
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    auto replacementType = m_replacementTypes.get(uuid);
+    switch (replacementType) {
+    case WebUnifiedTextReplacementType::PlainText:
+        didEndTextReplacementSession<WebUnifiedTextReplacementType::PlainText>(uuid, accepted);
+        break;
+    case WebUnifiedTextReplacementType::RichText:
+        didEndTextReplacementSession<WebUnifiedTextReplacementType::RichText>(uuid, accepted);
+        break;
+    }
 
     m_webPage->removeTextIndicatorStyleForID(uuid);
+
+    auto sessionRange = contextRangeForSessionWithUUID(uuid);
+    if (!sessionRange) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
 
     document->selection().setSelection({ *sessionRange });
 

--- a/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
+++ b/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
@@ -88,6 +88,9 @@ private:
     void textReplacementSessionPerformEditActionForPlainText(WebCore::Document&, const WTF::UUID&, WebTextReplacementData::EditAction);
     void textReplacementSessionPerformEditActionForRichText(WebCore::Document&, const WTF::UUID&, WebTextReplacementData::EditAction);
 
+    template<WebUnifiedTextReplacementType Type>
+    void didEndTextReplacementSession(const WTF::UUID&, bool accepted);
+
     RefPtr<WebCore::Document> document() const;
 
     WeakPtr<WebPage> m_webPage;


### PR DESCRIPTION
#### c53d438a8fed8e5c2a8ca63d7e5c900ee9d24967
<pre>
[Unified Text Replacement] When a &quot;rich text&quot; text replacement session ends, the session should be undone if it is not accepted
<a href="https://bugs.webkit.org/show_bug.cgi?id=273709">https://bugs.webkit.org/show_bug.cgi?id=273709</a>
<a href="https://rdar.apple.com/127390343">rdar://127390343</a>

Reviewed by Abrar Rahman Protyasha.

Ensure that `didEndTextReplacementSession` handles both plain text and rich text replacements properly.

* Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm:
(WebKit::UnifiedTextReplacementController::didEndTextReplacementSession&lt;WebUnifiedTextReplacementType::PlainText&gt;):
(WebKit::UnifiedTextReplacementController::didEndTextReplacementSession&lt;WebUnifiedTextReplacementType::RichText&gt;):
(WebKit::UnifiedTextReplacementController::didEndTextReplacementSession):
* Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h:

Canonical link: <a href="https://commits.webkit.org/278345@main">https://commits.webkit.org/278345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd072ecadac7bab0a38496664007e13f3b97b3ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50272 "Failed to checkout and rebase branch from PR 28122") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2569 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/53531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35793 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/609 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/53531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52371 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/27234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/43271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/53531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/24649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8650 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55117 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/25368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/26631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/43455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/27493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7264 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/26361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->