### PR TITLE
LockFairnessTest in ToyLocks benchmark should have a low priority thread.

### DIFF
--- a/Source/WTF/benchmarks/LockFairnessTest.cpp
+++ b/Source/WTF/benchmarks/LockFairnessTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,7 +24,8 @@
  */
 
 // On Mac, you can build this like so:
-// xcrun clang++ -o LockFairnessTest Source/WTF/benchmarks/LockFairnessTest.cpp -O3 -W -ISource/WTF -ISource/WTF/icu -ISource/WTF/benchmarks -LWebKitBuild/Release -lWTF -framework Foundation -licucore -std=c++14 -fvisibility=hidden
+// build WebKit until you have WTF.a
+// xcrun clang++ -o LockFairnessTest Source/WTF/benchmarks/LockFairnessTest.cpp -W -ISource/WTF -ISource/WTF/icu -ISource/WTF/benchmarks -LWebKitBuild/Release -lWTF -lbmalloc -lpas -framework Foundation -licucore -std=c++20 -fvisibility=hidden -DNDEBUG -O3 <-arch arm64e if internal>
 
 #include "config.h"
 
@@ -88,7 +89,9 @@ struct Benchmark {
                         usleep(microsecondsInCriticalSection);
                         lock.unlock();
                     }
-                });
+                },
+                ThreadType::Unknown,
+                threadIndex ? Thread::QOS::UserInitiated : Thread::QOS::Background);
         }
     
         sleep(100_ms);

--- a/Source/WTF/benchmarks/ToyLocks.h
+++ b/Source/WTF/benchmarks/ToyLocks.h
@@ -85,8 +85,16 @@ public:
 
     void lock()
     {
-        while (!m_lock.compareExchangeWeak(0, 1, std::memory_order_acquire))
+        while (!m_lock.compareExchangeWeak(0, 1, std::memory_order_acquire)) {
+#if CPU(X86_64)
             asm volatile ("pause");
+#elif CPU(ARM64)
+            asm volatile ("yield");
+#else
+#error "unsupported arch"
+#endif
+        }
+
     }
 
     void unlock()


### PR DESCRIPTION
#### 70c5dd96eb645d4bab0b9919cbdcdecf635fb9df
<pre>
LockFairnessTest in ToyLocks benchmark should have a low priority thread.
<a href="https://bugs.webkit.org/show_bug.cgi?id=273713">https://bugs.webkit.org/show_bug.cgi?id=273713</a>
<a href="https://rdar.apple.com/127513197">rdar://127513197</a>

Reviewed by NOBODY (OOPS!).

With this change our &quot;eventually fair&quot; locks don&apos;t seem so fair:

% ./LockFairnessTest lock 50 20 50
WTFLock: 4107, 3932, 4233, 4235, 3732, 4258, 4033, 4086, 4210, 3965, 3979, 4020, 4020, 4090, 4254, 3854, 3824, 4177, 4116, 4208, 4111, 4085, 4298, 4005, 4101, 4169, 4169, 3872, 4184, 4242, 4165, 4382, 3998, 4218, 4110, 4408, 4423, 3873, 4132, 3956, 4593, 4198, 3895, 4395, 4217, 4024, 4284, 4292, 4015, 567

The reason is that every time WTF::Lock barges it throws away the queuing order of ParkingLot. Since
the low priority thread tends to get scheduled last it will go to the end of the queue most times.

Explanation of why this fixes the bug (OOPS!).

* Source/WTF/benchmarks/LockFairnessTest.cpp:
* Source/WTF/benchmarks/ToyLocks.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70c5dd96eb645d4bab0b9919cbdcdecf635fb9df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50279 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53538 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/969 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41024 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52378 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27233 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43277 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22124 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24648 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/530 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8657 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43608 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46633 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/594 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55124 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49778 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25375 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/531 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48428 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26638 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43460 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47464 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27500 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57256 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26368 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11767 "Passed tests") | 
<!--EWS-Status-Bubble-End-->