### PR TITLE
[WebAuthn] Set user presence flag to false when performing conditional create with the platform authenticator

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-local.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-local.https-expected.txt
@@ -9,4 +9,5 @@ PASS PublicKeyCredential's [[create]] with direct attestation in a mock local au
 PASS PublicKeyCredential's [[create]] with duplicate credential in a mock local authenticator.
 PASS PublicKeyCredential's [[create]] with duplicate credential in a mock local authenticator. 2
 PASS PublicKeyCredential's [[create]] with user presence in a mock local authenticator.
+PASS PublicKeyCredential's [[create]] with conditional mediation mock local authenticator.
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-local.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-local.https.html
@@ -5,7 +5,7 @@
 <script src="./resources/util.js"></script>
 <script src="./resources/cbor.js"></script>
 <script>
-    function checkResult(credential, credentialID, isUV = true)
+    function checkResult(credential, credentialID, isUV = true, isUP = true)
     {
         // Check keychain
         if (window.testRunner) {
@@ -26,10 +26,12 @@
         // Check authData
         const authData = decodeAuthData(attestationObject.authData);
         assert_equals(bytesToHexString(authData.rpIdHash), "49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d9763");
+        let expectedFlags = 64;
+        if (isUP)
+            expectedFlags |= 1;
         if (isUV)
-            assert_equals(authData.flags, 69);
-        else
-            assert_equals(authData.flags, 65);
+            expectedFlags |= 4;
+        assert_equals(expectedFlags, authData.flags);
         assert_equals(authData.counter, 0);
         assert_equals("fbfc3007154e4ecc8c0b6e020557d7bd", bytesToHexString(authData.aaguid));
         assert_array_equals(authData.credentialID, credentialID);
@@ -401,4 +403,38 @@
             checkResult(credential, credentialID, false);
         });
     }, "PublicKeyCredential's [[create]] with user presence in a mock local authenticator.");
+
+    promise_test(async t => {
+        const privateKeyBase64 = await generatePrivateKeyBase64();
+        const credentialID = await calculateCredentialID(privateKeyBase64);
+        const userhandleBase64 = generateUserhandleBase64();
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration({
+                local: {
+                    userVerification: "presence",
+                    acceptAttestation: false,
+                    privateKeyBase64: privateKeyBase64,
+                }
+            });
+
+        const options = {
+            publicKey: {
+                rp: {
+                    name: "localhost",
+                },
+                user: {
+                    name: userhandleBase64,
+                    id: Base64URL.parse(userhandleBase64),
+                    displayName: "Appleseed",
+                },
+                challenge: Base64URL.parse("MTIzNDU2"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+            },
+            mediation: "conditional",
+        };
+
+        return navigator.credentials.create(options).then(credential => {
+            checkResult(credential, credentialID, false, false);
+        });
+    }, "PublicKeyCredential's [[create]] with conditional mediation mock local authenticator.");
 </script>

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.h
@@ -83,6 +83,8 @@ private:
     std::optional<WebCore::ExceptionData> processLargeBlobExtension(const WebCore::PublicKeyCredentialCreationOptions&, WebCore::AuthenticationExtensionsClientOutputs& extensionOutputs);
     std::optional<WebCore::ExceptionData> processLargeBlobExtension(const WebCore::PublicKeyCredentialRequestOptions&, WebCore::AuthenticationExtensionsClientOutputs& extensionOutputs, const Ref<WebCore::AuthenticatorAssertionResponse>&);
 
+    std::optional<Vector<Ref<WebCore::AuthenticatorAssertionResponse>>> getExistingCredentials(const String& rpId);
+
     State m_state { State::Init };
     UniqueRef<LocalConnection> m_connection;
     Vector<Ref<WebCore::AuthenticatorAssertionResponse>> m_existingCredentials;

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.h
@@ -66,6 +66,7 @@ public:
     virtual ~LocalConnection();
 
     // Overrided by MockLocalConnection.
+    virtual RetainPtr<NSArray> getExistingCredentials(const String& rpId);
     virtual void verifyUser(const String& rpId, WebCore::ClientDataType, SecAccessControlRef, WebCore::UserVerificationRequirement, UserVerificationCallback&&);
     virtual void verifyUser(SecAccessControlRef, LAContext *, CompletionHandler<void(UserVerification)>&&);
     virtual RetainPtr<SecKeyRef> createCredentialPrivateKey(LAContext *, SecAccessControlRef, const String& secAttrLabel, NSData *secAttrApplicationTag) const;

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h
@@ -38,6 +38,7 @@ public:
     explicit MockLocalConnection(const WebCore::MockWebAuthenticationConfiguration&);
 
 private:
+    RetainPtr<NSArray> getExistingCredentials(const String& rpId) final;
     void verifyUser(const String&, WebCore::ClientDataType, SecAccessControlRef, WebCore::UserVerificationRequirement,  UserVerificationCallback&&) final;
     void verifyUser(SecAccessControlRef, LAContext *, CompletionHandler<void(UserVerification)>&&) final;
     RetainPtr<SecKeyRef> createCredentialPrivateKey(LAContext *, SecAccessControlRef, const String& secAttrLabel, NSData *secAttrApplicationTag) const final;

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.mm
@@ -152,6 +152,30 @@ void MockLocalConnection::filterResponses(Vector<Ref<AuthenticatorAssertionRespo
     responses.append(WTFMove(response));
 }
 
+RetainPtr<NSArray> MockLocalConnection::getExistingCredentials(const String& rpId)
+{
+    // Search Keychain for existing credential matched the RP ID.
+    NSDictionary *query = @{
+        (id)kSecClass: (id)kSecClassKey,
+        (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate,
+        (id)kSecAttrSynchronizable: (id)kSecAttrSynchronizableAny,
+        (id)kSecAttrLabel: rpId,
+        (id)kSecReturnAttributes: @YES,
+        (id)kSecMatchLimit: (id)kSecMatchLimitAll,
+        (id)kSecUseDataProtectionKeychain: @YES
+    };
+
+    CFTypeRef attributesArrayRef = nullptr;
+    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &attributesArrayRef);
+    if (status && status != errSecItemNotFound)
+        return nullptr;
+    auto retainAttributesArray = adoptCF(attributesArrayRef);
+    NSArray *sortedAttributesArray = [(NSArray *)attributesArrayRef sortedArrayUsingComparator:^(NSDictionary *a, NSDictionary *b) {
+        return [b[(id)kSecAttrModificationDate] compare:a[(id)kSecAttrModificationDate]];
+    }];
+    return retainPtr(sortedAttributesArray);
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalService.mm
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEB_AUTHN)
 
+#import "LocalAuthenticator.h"
 #import "MockLocalConnection.h"
 #import <wtf/RunLoop.h>
 

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp
@@ -133,7 +133,8 @@ void WebAuthenticatorCoordinatorProxy::handleRequest(WebAuthenticationRequestDat
         }
     };
 
-    if (shouldRequestConditionalRegistration) {
+    auto& authenticatorManager = m_webPageProxy.websiteDataStore().authenticatorManager();
+    if (shouldRequestConditionalRegistration && !authenticatorManager.isMock() && !authenticatorManager.isVirtual()) {
         m_webPageProxy.uiClient().requestWebAuthenticationConditonalMediationRegistration(WTFMove(username), WTFMove(afterConsent));
         return;
     }


### PR DESCRIPTION
#### d004f0ceeda366e05550e3de119408b4faceac26
<pre>
[WebAuthn] Set user presence flag to false when performing conditional create with the platform authenticator
<a href="https://bugs.webkit.org/show_bug.cgi?id=273714">https://bugs.webkit.org/show_bug.cgi?id=273714</a>
<a href="https://rdar.apple.com/125862933">rdar://125862933</a>

Reviewed by Brent Fulgham.

Because a test of user prescence isn&apos;t explicitly collected during the authentication ceremony
that creates a credential during a conditional create, we set the user presence flag to false
to conform with the spec.

* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticatorInternal::authDataFlags):
(WebKit::LocalAuthenticator::continueMakeCredentialAfterUserVerification):
(WebKit::LocalAuthenticator::continueGetAssertionAfterUserVerification):

Canonical link: <a href="https://commits.webkit.org/278531@main">https://commits.webkit.org/278531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/389eee41cbbcc108b83bfbf7c9413d9932bfc922

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54099 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1531 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36413 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1182 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41420 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27784 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43798 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22548 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25127 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1054 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9281 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47109 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1116 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55693 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1000 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48830 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27199 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43873 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11143 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28067 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26931 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->