### PR TITLE
Content Script CSS overriding style attributes inconsistent.

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -961,6 +961,9 @@
 /* WKWebExtensionErrorInvalidContentScripts description for missing matches entry */
 "Manifest `content_scripts` entry has no specified `matches` entry." = "Manifest `content_scripts` entry has no specified `matches` entry.";
 
+/* WKWebExtensionErrorInvalidContentScripts description for unknown 'css_origin' value */
+"Manifest `content_scripts` entry has unknown `css_origin` value." = "Manifest `content_scripts` entry has unknown `css_origin` value.";
+
 /* WKWebExtensionErrorInvalidContentScripts description for unknown 'run_at' value */
 "Manifest `content_scripts` entry has unknown `run_at` value." = "Manifest `content_scripts` entry has unknown `run_at` value.";
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionDynamicScripts.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionDynamicScripts.serialization.in
@@ -36,6 +36,7 @@ struct WebKit::WebExtensionScriptInjectionParameters {
     std::optional<String> function;
 
     WebKit::WebExtensionContentWorldType world;
+    WebCore::UserStyleLevel styleLevel;
 }
 
 struct WebKit::WebExtensionScriptInjectionResultParameters {
@@ -59,6 +60,7 @@ struct WebKit::WebExtensionRegisteredScriptParameters {
     std::optional<bool> persistent;
 
     std::optional<WebKit::WebExtensionContentWorldType> world;
+    std::optional<WebCore::UserStyleLevel> styleLevel;
 }
 
 [Nested] enum class WebKit::WebExtension::InjectionTime : uint8_t {

--- a/Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptParameters.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#include <WebCore/UserStyleSheetTypes.h>
 #include <wtf/Forward.h>
 
 namespace WebKit {
@@ -46,6 +47,7 @@ struct WebExtensionRegisteredScriptParameters {
     std::optional<bool> persistent;
 
     std::optional<WebExtensionContentWorldType> world;
+    std::optional<WebCore::UserStyleLevel> styleLevel;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Extensions/WebExtensionScriptInjectionParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionScriptInjectionParameters.h
@@ -28,6 +28,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include "APIData.h"
+#include <WebCore/UserStyleSheetTypes.h>
 #include <wtf/Forward.h>
 
 namespace WebKit {
@@ -44,6 +45,7 @@ struct WebExtensionScriptInjectionParameters {
     std::optional<String> function;
 
     WebExtensionContentWorldType world { WebExtensionContentWorldType::ContentScript };
+    WebCore::UserStyleLevel styleLevel { WebCore::UserStyleLevel::Author };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
@@ -117,7 +117,7 @@ void WebExtensionContext::scriptingInsertCSS(const WebExtensionScriptInjectionPa
         auto injectedFrames = parameters.frameIDs ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames;
 
         auto styleSheetPairs = getSourcePairsForParameters(parameters, m_extension);
-        injectStyleSheets(styleSheetPairs, webView, *m_contentScriptWorld, injectedFrames, *this);
+        injectStyleSheets(styleSheetPairs, webView, *m_contentScriptWorld, parameters.styleLevel, injectedFrames, *this);
 
         completionHandler({ });
     });
@@ -418,6 +418,7 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
         injectedContentData.injectionTime = parameters.injectionTime.value_or(WebExtension::InjectionTime::DocumentIdle);
         injectedContentData.injectsIntoAllFrames = parameters.allFrames.value_or(false);
         injectedContentData.contentWorldType = parameters.world.value_or(WebExtensionContentWorldType::ContentScript);
+        injectedContentData.styleLevel = parameters.styleLevel.value_or(WebCore::UserStyleLevel::Author);
         injectedContentData.scriptPaths = scriptPaths;
         injectedContentData.styleSheetPaths = styleSheetPaths;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -649,7 +649,7 @@ void WebExtensionContext::tabsInsertCSS(WebPageProxyIdentifier webPageProxyIdent
         auto injectedFrames = parameters.frameIDs ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames;
 
         auto styleSheetPairs = getSourcePairsForParameters(parameters, m_extension);
-        injectStyleSheets(styleSheetPairs, webView, *m_contentScriptWorld, injectedFrames, *this);
+        injectStyleSheets(styleSheetPairs, webView, *m_contentScriptWorld, parameters.styleLevel, injectedFrames, *this);
 
         completionHandler({ });
     });

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -118,6 +118,9 @@ static NSString * const contentScriptsCSSManifestKey = @"css";
 static NSString * const contentScriptsWorldManifestKey = @"world";
 static NSString * const contentScriptsIsolatedManifestKey = @"ISOLATED";
 static NSString * const contentScriptsMainManifestKey = @"MAIN";
+static NSString * const contentScriptsCSSOriginManifestKey = @"css_origin";
+static NSString * const contentScriptsAuthorManifestKey = @"author";
+static NSString * const contentScriptsUserManifestKey = @"user";
 
 static NSString * const permissionsManifestKey = @"permissions";
 static NSString * const optionalPermissionsManifestKey = @"optional_permissions";
@@ -2057,6 +2060,15 @@ void WebExtension::populateContentScriptPropertiesIfNeeded()
         else
             recordError(createError(Error::InvalidContentScripts, WEB_UI_STRING("Manifest `content_scripts` entry has unknown `world` value.", "WKWebExtensionErrorInvalidContentScripts description for unknown 'world' value")));
 
+        auto styleLevel = WebCore::UserStyleLevel::Author;
+        auto *cssOriginString = objectForKey<NSString>(dictionary, contentScriptsCSSOriginManifestKey).lowercaseString;
+        if (!cssOriginString || [cssOriginString isEqualToString:contentScriptsAuthorManifestKey])
+            styleLevel = WebCore::UserStyleLevel::Author;
+        else if ([cssOriginString isEqualToString:contentScriptsUserManifestKey])
+            styleLevel = WebCore::UserStyleLevel::User;
+        else
+            recordError(createError(Error::InvalidContentScripts, WEB_UI_STRING("Manifest `content_scripts` entry has unknown `css_origin` value.", "WKWebExtensionErrorInvalidContentScripts description for unknown 'css_origin' value")));
+
         InjectedContentData injectedContentData;
         injectedContentData.includeMatchPatterns = WTFMove(includeMatchPatterns);
         injectedContentData.excludeMatchPatterns = WTFMove(excludeMatchPatterns);
@@ -2064,6 +2076,7 @@ void WebExtension::populateContentScriptPropertiesIfNeeded()
         injectedContentData.matchesAboutBlank = matchesAboutBlank;
         injectedContentData.injectsIntoAllFrames = injectsIntoAllFrames;
         injectedContentData.contentWorldType = contentWorldType;
+        injectedContentData.styleLevel = styleLevel;
         injectedContentData.scriptPaths = scriptPaths;
         injectedContentData.styleSheetPaths = styleSheetPaths;
         injectedContentData.includeGlobPatternStrings = includeGlobPatternStrings;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -4015,6 +4015,7 @@ void WebExtensionContext::addInjectedContent(const InjectedContentVector& inject
         auto injectionTime = toImpl(injectedContentData.injectionTime);
         auto waitForNotification = WebCore::WaitForNotificationBeforeInjecting::No;
         Ref executionWorld = toContentWorld(injectedContentData.contentWorldType);
+        auto styleLevel = injectedContentData.styleLevel;
 
         auto scriptID = injectedContentData.identifier;
         bool isRegisteredScript = !scriptID.isEmpty();
@@ -4045,7 +4046,7 @@ void WebExtensionContext::addInjectedContent(const InjectedContentVector& inject
             if (!styleSheetString)
                 continue;
 
-            auto userStyleSheet = API::UserStyleSheet::create(WebCore::UserStyleSheet { styleSheetString, URL { m_baseURL, styleSheetPath }, makeVector<String>(includeMatchPatterns), makeVector<String>(excludeMatchPatterns), injectedFrames, WebCore::UserStyleLevel::User, std::nullopt }, executionWorld);
+            auto userStyleSheet = API::UserStyleSheet::create(WebCore::UserStyleSheet { styleSheetString, URL { m_baseURL, styleSheetPath }, makeVector<String>(includeMatchPatterns), makeVector<String>(excludeMatchPatterns), injectedFrames, styleLevel, std::nullopt }, executionWorld);
             originInjectedStyleSheets.append(userStyleSheet);
 
             for (auto& userContentController : userContentControllers)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -156,7 +156,7 @@ void executeScript(std::optional<SourcePairs> scriptPairs, WKWebView *webView, A
     }).get()];
 }
 
-void injectStyleSheets(SourcePairs styleSheetPairs, WKWebView *webView, API::ContentWorld& executionWorld, WebCore::UserContentInjectedFrames injectedFrames, WebExtensionContext& context)
+void injectStyleSheets(SourcePairs styleSheetPairs, WKWebView *webView, API::ContentWorld& executionWorld, WebCore::UserStyleLevel styleLevel, WebCore::UserContentInjectedFrames injectedFrames, WebExtensionContext& context)
 {
     auto page = webView._page;
     auto pageID = page->webPageID();
@@ -165,7 +165,7 @@ void injectStyleSheets(SourcePairs styleSheetPairs, WKWebView *webView, API::Con
         if (!styleSheet)
             continue;
 
-        auto userStyleSheet = API::UserStyleSheet::create(WebCore::UserStyleSheet { styleSheet.value().first, styleSheet.value().second.value_or(URL { }), Vector<String> { }, Vector<String> { }, injectedFrames, WebCore::UserStyleLevel::User, pageID }, executionWorld);
+        auto userStyleSheet = API::UserStyleSheet::create(WebCore::UserStyleSheet { styleSheet.value().first, styleSheet.value().second.value_or(URL { }), Vector<String> { }, Vector<String> { }, injectedFrames, styleLevel, pageID }, executionWorld);
 
         auto& controller = page.get()->userContentController();
         controller.addUserStyleSheet(userStyleSheet);

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -31,6 +31,7 @@
 #include "CocoaImage.h"
 #include "WebExtensionContentWorldType.h"
 #include "WebExtensionMatchPattern.h"
+#include <WebCore/UserStyleSheetTypes.h>
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
 #include <wtf/RetainPtr.h>
@@ -158,6 +159,7 @@ public:
         bool matchesAboutBlank { false };
         bool injectsIntoAllFrames { false };
         WebExtensionContentWorldType contentWorldType { WebExtensionContentWorldType::ContentScript };
+        WebCore::UserStyleLevel styleLevel { WebCore::UserStyleLevel::Author };
 
         RetainPtr<NSArray> scriptPaths;
         RetainPtr<NSArray> styleSheetPaths;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
@@ -109,7 +109,7 @@ SourcePairs getSourcePairsForParameters(const WebExtensionScriptInjectionParamet
 Vector<RetainPtr<_WKFrameTreeNode>> getFrames(_WKFrameTreeNode *, std::optional<Vector<WebExtensionFrameIdentifier>>);
 
 void executeScript(std::optional<SourcePairs>, WKWebView *, API::ContentWorld&, WebExtensionTab*, const WebExtensionScriptInjectionParameters&, WebExtensionContext&, CompletionHandler<void(InjectionResults&&)>&&);
-void injectStyleSheets(SourcePairs, WKWebView *, API::ContentWorld&, WebCore::UserContentInjectedFrames, WebExtensionContext&);
+void injectStyleSheets(SourcePairs, WKWebView *, API::ContentWorld&, WebCore::UserStyleLevel, WebCore::UserContentInjectedFrames, WebExtensionContext&);
 void removeStyleSheets(SourcePairs, WKWebView *, WebCore::UserContentInjectedFrames, WebExtensionContext&);
 
 WebExtensionScriptInjectionResultParameters toInjectionResultParameters(id resultOfExecution, WKFrameInfo *, NSString *errorMessage);

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
@@ -54,10 +54,12 @@ static NSString * const allFramesKey = @"allFrames";
 static NSString * const argsKey = @"args";
 static NSString * const argumentsKey = @"arguments";
 static NSString * const cssKey = @"css";
+static NSString * const cssOriginKey = @"cssOrigin";
 static NSString * const filesKey = @"files";
 static NSString * const frameIDsKey = @"frameIds";
 static NSString * const funcKey = @"func";
 static NSString * const functionKey = @"function";
+static NSString * const originKey = @"origin";
 static NSString * const tabIDKey = @"tabId";
 static NSString * const targetKey = @"target";
 static NSString * const worldKey = @"world";
@@ -73,11 +75,13 @@ static NSString * const runAtKey = @"runAt";
 static NSString * const mainWorld = @"MAIN";
 static NSString * const isolatedWorld = @"ISOLATED";
 
+static NSString * const authorValue = @"author";
+static NSString * const userValue = @"user";
+
 static NSString * const documentEnd = @"document_end";
 static NSString * const documentIdle = @"document_idle";
 static NSString * const documentStart = @"document_start";
 
-// FIXME: <https://webkit.org/b/261765> Consider adding support for cssOrigin.
 // FIXME: <https://webkit.org/b/261765> Consider adding support for injectImmediately.
 // FIXME: <https://webkit.org/b/264829> Add support for matchOriginAsFallback.
 
@@ -144,6 +148,9 @@ NSDictionary *toWebAPI(const WebExtensionRegisteredScriptParameters& parameters)
     if (parameters.excludeMatchPatterns)
         result[excludeMatchesKey] = createNSArray(parameters.excludeMatchPatterns.value()).get();
 
+    if (parameters.styleLevel)
+        result[cssOriginKey] = parameters.styleLevel.value() == WebCore::UserStyleLevel::User ? userValue : authorValue;
+
     return [result copy];
 }
 
@@ -180,6 +187,9 @@ void WebExtensionAPIScripting::executeScript(NSDictionary *script, Ref<WebExtens
     parseTargetInjectionOptions(script[targetKey], parameters, outExceptionString);
     parseScriptInjectionOptions(script, parameters, outExceptionString);
 
+    if (*outExceptionString)
+        return;
+
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ScriptingExecuteScript(WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Vector<WebKit::WebExtensionScriptInjectionResultParameters>, WebExtensionError>&& result) {
         if (!result)
             callback->reportError(result.error());
@@ -199,6 +209,9 @@ void WebExtensionAPIScripting::insertCSS(NSDictionary *cssInfo, Ref<WebExtension
     parseTargetInjectionOptions(cssInfo[targetKey], parameters, outExceptionString);
     parseCSSInjectionOptions(cssInfo, parameters);
 
+    if (*outExceptionString)
+        return;
+
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ScriptingInsertCSS(WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result)
             callback->reportError(result.error());
@@ -217,6 +230,9 @@ void WebExtensionAPIScripting::removeCSS(NSDictionary *cssInfo, Ref<WebExtension
     WebExtensionScriptInjectionParameters parameters;
     parseTargetInjectionOptions(cssInfo[targetKey], parameters, outExceptionString);
     parseCSSInjectionOptions(cssInfo, parameters);
+
+    if (*outExceptionString)
+        return;
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ScriptingRemoveCSS(WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result)
@@ -410,6 +426,7 @@ bool WebExtensionAPIScripting::validateCSS(NSDictionary *cssInfo, NSString **out
     static NSDictionary<NSString *, id> *keyTypes = @{
         cssKey: NSString.class,
         filesKey: @[ NSString.class ],
+        originKey: NSString.class,
         targetKey: NSDictionary.class,
     };
 
@@ -427,6 +444,13 @@ bool WebExtensionAPIScripting::validateCSS(NSDictionary *cssInfo, NSString **out
     if (!cssInfo[filesKey] && !cssInfo[cssKey]) {
         *outExceptionString = toErrorString(nil, @"details", @"it must specify either 'css' or 'files'");
         return false;
+    }
+
+    if (NSString *origin = objectForKey<NSString>(cssInfo, originKey).lowercaseString) {
+        if (![origin isEqualToString:userValue] && ![origin isEqualToString:authorValue]) {
+            *outExceptionString = toErrorString(nil, originKey, @"it must specify either 'AUTHOR' or 'USER'");
+            return false;
+        }
     }
 
     return true;
@@ -448,6 +472,7 @@ bool WebExtensionAPIScripting::validateRegisteredScripts(NSArray *scripts, First
         persistAcrossSessionsKey: @YES.class,
         runAtKey: NSString.class,
         worldKey: NSString.class,
+        cssOriginKey: NSString.class,
     };
 
     if (![scripts isKindOfClass:NSArray.class]) {
@@ -490,7 +515,14 @@ bool WebExtensionAPIScripting::validateRegisteredScripts(NSArray *scripts, First
 
         if (NSString *injectionTime = script[runAtKey]) {
             if (![injectionTime isEqualToString:documentIdle] && ![injectionTime isEqualToString:documentStart] && ![injectionTime isEqualToString:documentEnd]) {
-                *outExceptionString = toErrorString(nil, runAtKey, @"it must be one of the following: 'document_end', 'document_idle', or 'document_start'");
+                *outExceptionString = toErrorString(nil, runAtKey, @"it must specify either 'document_start', 'document_end', or 'document_idle'");
+                return false;
+            }
+        }
+
+        if (NSString *cssOrigin = objectForKey<NSString>(script, cssOriginKey).lowercaseString) {
+            if (![cssOrigin isEqualToString:userValue] && ![cssOrigin isEqualToString:authorValue]) {
+                *outExceptionString = toErrorString(nil, cssOriginKey, @"it must specify either 'author' or 'user'");
                 return false;
             }
         }
@@ -572,6 +604,9 @@ void WebExtensionAPIScripting::parseCSSInjectionOptions(NSDictionary *cssInfo, W
 
     if (NSArray *files = cssInfo[filesKey])
         parameters.files = makeVector<String>(files);
+
+    if (NSString *origin = objectForKey<NSString>(cssInfo, originKey).lowercaseString)
+        parameters.styleLevel = [origin isEqualToString:userValue] ? WebCore::UserStyleLevel::User : WebCore::UserStyleLevel::Author;
 }
 
 void WebExtensionAPIScripting::parseRegisteredContentScripts(NSArray *scripts, FirstTimeRegistration firstTimeRegistration, Vector<WebExtensionRegisteredScriptParameters>& parametersVector)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -115,6 +115,10 @@ static NSString * const nameKey = @"name";
 static NSString * const allFramesKey = @"allFrames";
 static NSString * const codeKey = @"code";
 static NSString * const fileKey = @"file";
+static NSString * const cssOriginKey = @"cssOrigin";
+
+static NSString * const authorValue = @"author";
+static NSString * const userValue = @"user";
 
 static NSString * const emptyURLValue = @"";
 static NSString * const emptyTitleValue = @"";
@@ -525,6 +529,17 @@ bool WebExtensionAPITabs::parseScriptOptions(NSDictionary *options, WebExtension
 
     if (!boolForKey(options, allFramesKey, false))
         parameters.frameIDs = { WebExtensionFrameConstants::MainFrameIdentifier };
+
+    if (NSString *origin = options[cssOriginKey]) {
+        if ([origin isEqualToString:userValue])
+            parameters.styleLevel = WebCore::UserStyleLevel::User;
+        else if ([origin isEqualToString:authorValue])
+            parameters.styleLevel = WebCore::UserStyleLevel::Author;
+        else {
+            *outExceptionString = toErrorString(nil, cssOriginKey, @"it must specify either 'author' or 'user'");
+            return false;
+        }
+    }
 
     return true;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
@@ -235,6 +235,18 @@ TEST(WKWebExtension, ContentScriptsParsing)
     EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_TRUE(testExtension.hasInjectedContent);
 
+    testManifestDictionary[@"content_scripts"] = @[ @{ @"css": @[ @NO, @"test.css", @"" ], @"css_origin": @"user", @"matches": @[ @"*://*.example.com/" ] } ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+    EXPECT_TRUE(testExtension.hasInjectedContent);
+
+    testManifestDictionary[@"content_scripts"] = @[ @{ @"css": @[ @NO, @"test.css", @"" ], @"css_origin": @"author", @"matches": @[ @"*://*.example.com/" ] } ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+    EXPECT_TRUE(testExtension.hasInjectedContent);
+
     // Invalid cases
 
     testManifestDictionary[@"content_scripts"] = @[ ];
@@ -266,6 +278,13 @@ TEST(WKWebExtension, ContentScriptsParsing)
     EXPECT_TRUE(testExtension.hasInjectedContent);
 
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js" ], @"matches": @[ @"*://*.example.com/" ], @"world": @"INVALID" } ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+
+    EXPECT_NE(testExtension.errors.count, 0ul);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
+    EXPECT_TRUE(testExtension.hasInjectedContent);
+
+    testManifestDictionary[@"content_scripts"] = @[ @{ @"css": @[ @NO, @"test.css", @"" ], @"css_origin": @"bad", @"matches": @[ @"*://*.example.com/" ] } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NE(testExtension.errors.count, 0ul);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm
@@ -436,6 +436,24 @@ TEST(WKWebExtensionContext, ContentScriptsParsing)
     EXPECT_FALSE([testContext hasInjectedContentForURL:webkitURL]);
     EXPECT_TRUE([testContext hasInjectedContentForURL:exampleURL]);
 
+    testManifestDictionary[@"content_scripts"] = @[ @{ @"css": @[ @NO, @"test.css", @"" ], @"css_origin": @"user", @"matches": @[ @"*://*.example.com/" ] } ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
+
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+    EXPECT_TRUE(testContext.hasInjectedContent);
+    EXPECT_FALSE([testContext hasInjectedContentForURL:webkitURL]);
+    EXPECT_TRUE([testContext hasInjectedContentForURL:exampleURL]);
+
+    testManifestDictionary[@"content_scripts"] = @[ @{ @"css": @[ @NO, @"test.css", @"" ], @"css_origin": @"author", @"matches": @[ @"*://*.example.com/" ] } ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
+
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+    EXPECT_TRUE(testContext.hasInjectedContent);
+    EXPECT_FALSE([testContext hasInjectedContentForURL:webkitURL]);
+    EXPECT_TRUE([testContext hasInjectedContentForURL:exampleURL]);
+
     // Invalid cases
 
     testManifestDictionary[@"content_scripts"] = @[ ];
@@ -475,6 +493,15 @@ TEST(WKWebExtensionContext, ContentScriptsParsing)
     EXPECT_TRUE([testContext hasInjectedContentForURL:exampleURL]);
 
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js" ], @"matches": @[ @"*://*.example.com/" ], @"world": @"INVALID" } ];
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
+
+    EXPECT_NE(testExtension.errors.count, 0ul);
+    EXPECT_TRUE(testContext.hasInjectedContent);
+    EXPECT_FALSE([testContext hasInjectedContentForURL:webkitURL]);
+    EXPECT_TRUE([testContext hasInjectedContentForURL:exampleURL]);
+
+    testManifestDictionary[@"content_scripts"] = @[ @{ @"css": @[ @NO, @"test.css", @"" ], @"css_origin": @"bad", @"matches": @[ @"*://*.example.com/" ] } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
     testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
 


### PR DESCRIPTION
#### f4d3ac245e7d24d2d7702b884c10f29527be307a
<pre>
Content Script CSS overriding style attributes inconsistent.
<a href="https://webkit.org/b/273122">https://webkit.org/b/273122</a>
<a href="https://rdar.apple.com/problem/126916972">rdar://problem/126916972</a>

Reviewed by Antti Koivisto.

Change web extension content styles to be author level instead of user level by default.

To allow extensions to still use user level, added support for `cssOrigin` in the
`tabs.insertCSS()` options, as well as `origin` in the `scripting.insertCSS` options.
Accepted values are `user` and `author`.

In addition, this introduces `cssOrigin` in `scripting.registerContentScripts()` and
`css_origin` for the `content_scripts` entry in the manifest. These are new options
and are being discussed in the WECG at <a href="https://github.com/w3c/webextensions/issues/414.">https://github.com/w3c/webextensions/issues/414.</a>

* Source/WebCore/en.lproj/Localizable.strings: Updated.
* Source/WebKit/Shared/Extensions/WebExtensionDynamicScripts.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptParameters.h:
* Source/WebKit/Shared/Extensions/WebExtensionScriptInjectionParameters.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::scriptingInsertCSS):
(WebKit::WebExtensionContext::createInjectedContentForScripts):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsInsertCSS):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::populateContentScriptPropertiesIfNeeded):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::addInjectedContent):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::injectStyleSheets):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm:
(WebKit::toWebAPI): Added origin.
(WebKit::WebExtensionAPIScripting::executeScript): Return early if outExceptionString is set.
(WebKit::WebExtensionAPIScripting::insertCSS): Ditto.
(WebKit::WebExtensionAPIScripting::removeCSS): Ditto.
(WebKit::WebExtensionAPIScripting::validateCSS): Added origin.
(WebKit::WebExtensionAPIScripting::validateRegisteredScripts): Ditto.
(WebKit::WebExtensionAPIScripting::parseCSSInjectionOptions): Ditto.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::parseScriptOptions):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
(TestWebKitAPI::TEST(WKWebExtension, ContentScriptsParsing)): Added new cases.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, ErrorsCSS)): Added new error case.
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, ErrorsRegisteredContentScript)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, CSSUserOrigin)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, CSSAuthorOrigin)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, World)): Fixed test that was always passing.
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, RegisterContentScriptsWithCSSUserOrigin)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, RegisterContentScriptsWithCSSAuthorOrigin)): Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, Errors)): Added new error case.
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, CSSUserOrigin)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, CSSAuthorOrigin)): Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm:
(TestWebKitAPI::TEST(WKWebExtensionContext, ContentScriptsParsing)): Added new cases.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm:
(TestWebKitAPI::TEST(WKWebExtensionController, CSSUserOrigin)): Added.
(TestWebKitAPI::TEST(WKWebExtensionController, CSSAuthorOrigin)): Added.

Canonical link: <a href="https://commits.webkit.org/278387@main">https://commits.webkit.org/278387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae7d95b0deb21478c1072656fc4e9c3542507f06

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53586 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1017 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52630 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41053 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52426 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43318 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22157 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24686 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/572 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8705 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46671 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/636 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55172 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25423 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48458 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26686 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43501 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47492 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27548 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7284 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26416 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->