### PR TITLE
Add a few rules about spaces around lambdas and templates to the style guide

### DIFF
--- a/Websites/webkit.org/code-style.md
+++ b/Websites/webkit.org/code-style.md
@@ -246,28 +246,52 @@ if(condition)
     doIt();
 ```
 
-[](#spacing-function-paren) Do not place spaces between a function and its parentheses, or between a parenthesis and its content.
+[](#spacing-function-paren-prior) Do not place spaces between the name, angle brackets and parentheses of a function declaration or invocation.
 
 ###### Right:
 
 ```cpp
-f(a, b);
+f();
+void g() { ... }
+h<int>();
 ```
 
 ###### Wrong:
 
 ```cpp
-f (a, b);
-f( a, b );
+f ();
+void g () { ... }
+h <int> ();
 ```
 
-[](#spacing-lambda-paren) Do not place spaces between square brackets and parentheses of a lambda function but do place a space before braces.
+[](#spacing-function-paren-inside) Do not place spaces between the parenthesis and its parameters, or angle brackets and its parameters of a function declaration or invocation.
+
+###### Right:
+
+```cpp
+f(a, b);
+void g(int a) { ... }
+h<int>();
+```
+
+###### Wrong:
+
+```cpp
+f( a, b );
+void g( int a ) { ... }
+h< int >();
+```
+
+
+[](#spacing-lambda-paren) Do not place spaces between square brackets, angle brackets and parentheses of a lambda function but do place a space before braces.
 
 ###### Right:
 
 ```cpp
 [](int x) { return x; }
 [this] { return m_member; }
+[=]<typename T> { return T(); }
+[&]<typename X>(X parameter) { return parameter; }
 ```
 
 ###### Wrong:
@@ -275,7 +299,24 @@ f( a, b );
 ```cpp
 [] (int x) { return x; }
 [this]{ return m_member; }
+[=] <typename T> { return T(); }
+[&]<typename X> (X parameter) { return parameter; }
 ```
+
+[](#spacing-template) Do not place spaces between the identifier `template` and its angle brackets.
+
+###### Right:
+
+```cpp
+template<typename T> T foo();
+template<typename U> struct Bar { };
+```
+
+###### Wrong:
+
+```cpp
+template <typename T> T foo();
+template <typename U> struct Bar { };
 
 [](#spacing-braced-init) When initializing an object, place a space before the leading brace as well as between the braces and their content.
 


### PR DESCRIPTION
#### e96d0ed0cc8243f4e80b8b44e8bbbe2c9365856a
<pre>
Add a few rules about spaces around lambdas and templates to the style guide
<a href="https://bugs.webkit.org/show_bug.cgi?id=273724">https://bugs.webkit.org/show_bug.cgi?id=273724</a>

Reviewed by Chris Dumez and Darin Adler.

Fleshes out the rules spaces in and around lambdas and templates.

* Websites/webkit.org/code-style.md:

Canonical link: <a href="https://commits.webkit.org/278374@main">https://commits.webkit.org/278374@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75ae30bdc165130d3af4b32e372efacccd743098

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53580 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1011 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35843 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/659 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41047 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52420 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43305 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22151 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8699 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55166 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25417 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/557 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48451 "Found 2 new test failures: http/tests/inspector/network/har/har-page.html, imported/w3c/web-platform-tests/css/css-view-transitions/content-with-transparent-background.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26680 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47483 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11046 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27542 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26410 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->