### PR TITLE
[UnifiedPDF] Text jiggles between the low-res page snapshots and high-resolution tiles

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
@@ -460,6 +460,9 @@ void AsyncPDFRenderer::paintPDFPageIntoBuffer(RetainPtr<PDFDocument>&& pdfDocume
     context.translate(destinationRect.minXMaxYCorner());
     context.scale({ 1, -1 });
 
+    CGContextSetShouldSubpixelQuantizeFonts(context.platformContext(), false);
+    CGContextSetAllowsFontSubpixelPositioning(context.platformContext(), true);
+
     LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::paintPDFPageIntoBuffer - painting page " << pageIndex);
     [pdfPage drawWithBox:kPDFDisplayBoxCropBox toContext:context.platformContext()];
 }
@@ -585,7 +588,7 @@ void AsyncPDFRenderer::paintPagePreview(GraphicsContext& context, const FloatRec
     LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::paintPagePreview for page " << pageIndex  << " - buffer " << imageBuffer);
 
     if (imageBuffer)
-        context.drawImageBuffer(*imageBuffer, pageBoundsInPaintingCoordinates);
+        context.drawImageBuffer(*imageBuffer, pageBoundsInPaintingCoordinates, pageBoundsInPaintingCoordinates);
 }
 
 void AsyncPDFRenderer::invalidateTilesForPaintingRect(float pageScaleFactor, const FloatRect& paintingRect)


### PR DESCRIPTION
#### 7754d9bf5ef54b9c4c58bdace2e3cd25da11df2c
<pre>
[UnifiedPDF] Text jiggles between the low-res page snapshots and high-resolution tiles
<a href="https://bugs.webkit.org/show_bug.cgi?id=273727">https://bugs.webkit.org/show_bug.cgi?id=273727</a>
<a href="https://rdar.apple.com/127523619">rdar://127523619</a>

Reviewed by Tim Horton.

Fix two issues that caused text and other content to not be perfectly aligned between
page previews and high-resolution tiles.

First, the scale are always non-integral, so there was some slight scaling of the
page preview buffers in `AsyncPDFRenderer::paintPagePreview()` since the image buffer size
is an expanded integral value, and when painting without a sourceRect, it scales the whole
buffer to fit the destination rect. We can use the same rect for source and destination
to avoid this.

Second, turn off CG font subpixel quantization and positioning, both of which can cause
glyphs to snap when drawing into the scaled-down context used for page previews.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::paintPDFPageIntoBuffer):
(WebKit::AsyncPDFRenderer::paintPagePreview):

Canonical link: <a href="https://commits.webkit.org/278378@main">https://commits.webkit.org/278378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a136671e103f7c7ac558815cd44b622d759c3d7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53585 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1016 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/664 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41052 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52425 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43317 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22156 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24685 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8704 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46670 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/635 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55171 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25422 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/563 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48459 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26685 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43500 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47496 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/table/basic (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11047 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27547 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26415 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->