### PR TITLE
Optimize some usage of StringBuilder

### DIFF
--- a/Source/JavaScriptCore/runtime/FileBasedFuzzerAgentBase.cpp
+++ b/Source/JavaScriptCore/runtime/FileBasedFuzzerAgentBase.cpp
@@ -38,15 +38,9 @@ FileBasedFuzzerAgentBase::FileBasedFuzzerAgentBase(VM&)
 
 String FileBasedFuzzerAgentBase::createLookupKey(const String& sourceFilename, OpcodeID opcodeId, int startLocation, int endLocation)
 {
-    StringBuilder lookupKey;
-    lookupKey.append(sourceFilename);
-    lookupKey.append('|');
-    lookupKey.append(opcodeNames[opcodeAliasForLookupKey(opcodeId)]);
-    lookupKey.append('|');
-    lookupKey.append(startLocation);
-    lookupKey.append('|');
-    lookupKey.append(endLocation);
-    return lookupKey.toString();
+    return makeString(sourceFilename, '|',
+        opcodeNames[opcodeAliasForLookupKey(opcodeId)],
+        '|', startLocation, '|', endLocation);
 }
 
 OpcodeID FileBasedFuzzerAgentBase::opcodeAliasForLookupKey(const OpcodeID& opcodeId)

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -592,11 +592,9 @@ static String percentEncodeCharacters(const StringType& input, bool(*shouldEncod
             StringBuilder builder;
             for (unsigned j = 0; j < span.size(); j++) {
                 auto c = span[j];
-                if (shouldEncode(c)) {
-                    builder.append('%');
-                    builder.append(upperNibbleToASCIIHexDigit(c));
-                    builder.append(lowerNibbleToASCIIHexDigit(c));
-                } else
+                if (shouldEncode(c))
+                    builder.append('%', upperNibbleToASCIIHexDigit(c), lowerNibbleToASCIIHexDigit(c));
+                else
                     builder.append(c);
             }
             return builder.toString();

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -622,9 +622,7 @@ Vector<char> asciiDebug(StringImpl* impl)
                 buffer.append(ch);
             buffer.append(ch);
         } else {
-            buffer.append('\\');
-            buffer.append('u');
-            buffer.append(hex(ch, 4));
+            buffer.append('\\', 'u', hex(ch, 4));
         }
     }
     CString narrowString = buffer.toString().ascii();

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -720,7 +720,7 @@ void MediaKeySession::updateKeyStatuses(CDMInstanceSession::KeyStatusVector&& in
             continue;
         if (!statusString.isEmpty())
             statusString.append(", "_s);
-        statusString.append(makeString(convertEnumerationToString(statusCount.key), ": "_s, statusCount.value));
+        statusString.append(convertEnumerationToString(statusCount.key), ": "_s, statusCount.value);
     }
     ALWAYS_LOG(LOGIDENTIFIER, "statuses: {", statusString.toString(), "}");
 #endif

--- a/Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp
+++ b/Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp
@@ -207,10 +207,8 @@ static String resolveRelativeVirtualPath(StringView baseVirtualPath, StringView 
         return "/"_s;
 
     StringBuilder builder;
-    for (auto& segment : virtualPathSegments) {
-        builder.append('/');
-        builder.append(segment);
-    }
+    for (auto& segment : virtualPathSegments)
+        builder.append('/', segment);
     return builder.toString();
 }
 

--- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
+++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
@@ -334,19 +334,13 @@ int Geolocation::watchPosition(Ref<PositionCallback>&& successCallback, RefPtr<P
 
 static void logError(const String& target, const bool isSecure, const bool isMixedContent, Document* document)
 {
-    StringBuilder message;
-    message.append("[blocked] Access to geolocation was blocked over"_s);
-    
-    if (!isSecure)
-        message.append(" insecure connection to "_s);
-    else if (isMixedContent)
-        message.append(" secure connection with mixed content to "_s);
-    else
+    if (isSecure && !isMixedContent)
         return;
-    
-    message.append(target);
-    message.append(".\n"_s);
-    document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, message.toString());
+
+    auto message = makeString("[blocked] Access to geolocation was blocked over"_s,
+        isSecure ? " secure connection with mixed content to "_s : " insecure connection to "_s,
+        target, ".\n"_s);
+    document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, WTFMove(message));
 }
     
 bool Geolocation::shouldBlockGeolocationRequests()

--- a/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
@@ -347,8 +347,8 @@ String IDBKeyData::loggingString() const
         size_t i = 0;
         for (; i < 8 && i < data->size(); ++i) {
             uint8_t byte = data->at(i);
-            builder.append(upperNibbleToLowercaseASCIIHexDigit(byte));
-            builder.append(lowerNibbleToLowercaseASCIIHexDigit(byte));
+            builder.append(upperNibbleToLowercaseASCIIHexDigit(byte),
+                lowerNibbleToLowercaseASCIIHexDigit(byte));
         }
 
         if (data->size() > 8)

--- a/Source/WebCore/Modules/indexeddb/IDBKeyPath.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyPath.cpp
@@ -217,12 +217,9 @@ String loggingString(const IDBKeyPath& path)
 
         StringBuilder builder;
         builder.append("< "_s);
-        for (size_t i = 0; i < strings.size() - 1; ++i) {
-            builder.append(strings[i]);
-            builder.append(", "_s);
-        }
-        builder.append(strings.last());
-        builder.append(" >"_s);
+        for (size_t i = 0; i < strings.size() - 1; ++i)
+            builder.append(strings[i], ", "_s);
+        builder.append(strings.last(), " >"_s);
 
         return builder.toString();
     });

--- a/Source/WebCore/Modules/push-api/PushSubscriptionIdentifier.cpp
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionIdentifier.cpp
@@ -55,12 +55,12 @@ String PushSubscriptionSetIdentifier::debugDescription() const
         1 + bundleIdentifier.length() +
         (!pushPartition.isEmpty() ? 6 + pushPartition.length() : 0) +
         (dataStoreIdentifier ? 12 : 0) + 1);
-    builder.append("["_s, bundleIdentifier);
+    builder.append('[', bundleIdentifier);
     if (!pushPartition.isEmpty())
         builder.append(" part:"_s, pushPartition);
     if (dataStoreIdentifier)
         builder.append(" ds:"_s, dataStoreIdentifier->toString(), 0, 8);
-    builder.append("]"_s);
+    builder.append(']');
     return builder.toString();
 }
 

--- a/Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h
+++ b/Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h
@@ -146,8 +146,7 @@ String decodeEscapeSequences(StringView string, const TextEncoding& encoding)
         if (decoded.isEmpty())
             continue;
 
-        result.append(string.substring(decodedPosition, encodedRunPosition - decodedPosition));
-        result.append(decoded);
+        result.append(string.substring(decodedPosition, encodedRunPosition - decodedPosition), decoded);
         decodedPosition = encodedRunEnd;
     }
     result.append(string.substring(decodedPosition, length - decodedPosition));

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
@@ -510,7 +510,7 @@ String CSSCounterStyleDescriptors::symbolsCSSText() const
     StringBuilder builder;
     for (size_t i = 0; i < m_symbols.size(); ++i) {
         if (i)
-            builder.append(" "_s);
+            builder.append(' ');
         builder.append(m_symbols[i].cssText());
     }
     return builder.toString();
@@ -524,9 +524,7 @@ String CSSCounterStyleDescriptors::additiveSymbolsCSSText() const
     for (size_t i = 0; i < m_additiveSymbols.size(); ++i) {
         if (i)
             builder.append(", "_s);
-        builder.append(m_additiveSymbols[i].second);
-        builder.append(" "_s);
-        builder.append(m_additiveSymbols[i].first.cssText());
+        builder.append(m_additiveSymbols[i].second, ' ', m_additiveSymbols[i].first.cssText());
     }
     return builder.toString();
 }

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -187,8 +187,7 @@ void CSSStyleRule::cssTextForRulesWithReplacementURLs(StringBuilder& rules, cons
 String CSSStyleRule::cssTextInternal(StringBuilder& declarations, StringBuilder& rules) const
 {
     StringBuilder builder;
-    builder.append(selectorText());
-    builder.append(" {"_s);
+    builder.append(selectorText(), " {"_s);
 
     if (declarations.isEmpty() && rules.isEmpty()) {
         builder.append(" }"_s);

--- a/Source/WebCore/css/query/GenericMediaQuerySerialization.cpp
+++ b/Source/WebCore/css/query/GenericMediaQuerySerialization.cpp
@@ -108,8 +108,7 @@ void serialize(StringBuilder& builder, const Feature& feature)
         }
         serializeIdentifier(feature.name, builder);
 
-        builder.append(": "_s);
-        builder.append(feature.rightComparison->value->cssText());
+        builder.append(": "_s, feature.rightComparison->value->cssText());
         break;
 
     case Syntax::Range:

--- a/Source/WebCore/css/typedom/CSSOMVariableReferenceValue.cpp
+++ b/Source/WebCore/css/typedom/CSSOMVariableReferenceValue.cpp
@@ -65,8 +65,7 @@ String CSSOMVariableReferenceValue::toString() const
 
 void CSSOMVariableReferenceValue::serialize(StringBuilder& builder, OptionSet<SerializationArguments> arguments) const
 {
-    builder.append("var("_s);
-    builder.append(m_variable);
+    builder.append("var("_s, m_variable);
     if (m_fallback) {
         builder.append(',');
         m_fallback->serialize(builder, arguments);

--- a/Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp
@@ -39,6 +39,7 @@
 #include "DOMMatrixInit.h"
 #include "ExceptionOr.h"
 #include <wtf/IsoMallocInlines.h>
+#include <wtf/text/StringConcatenateNumbers.h>
 
 namespace WebCore {
 
@@ -103,53 +104,20 @@ CSSMatrixComponent::CSSMatrixComponent(Ref<DOMMatrixReadOnly>&& matrix, Is2D is2
 void CSSMatrixComponent::serialize(StringBuilder& builder) const
 {
     if (is2D()) {
-        builder.append("matrix("_s);
-        builder.append(String::number(m_matrix->a()));
-        builder.append(", "_s);
-        builder.append(String::number(m_matrix->b()));
-        builder.append(", "_s);
-        builder.append(String::number(m_matrix->c()));
-        builder.append(", "_s);
-        builder.append(String::number(m_matrix->d()));
-        builder.append(", "_s);
-        builder.append(String::number(m_matrix->e()));
-        builder.append(", "_s);
-        builder.append(String::number(m_matrix->f()));
-        builder.append(')');
+        builder.append("matrix("_s, m_matrix->a(), ", "_s,
+        m_matrix->b(), ", "_s, m_matrix->c(), ", "_s,
+        m_matrix->d(), ", "_s, m_matrix->e(), ", "_s,
+        m_matrix->f(), ')');
     } else {
-        builder.append("matrix3d("_s);
-        builder.append(String::number(m_matrix->m11()));
-        builder.append(", "_s);
-        builder.append(String::number(m_matrix->m12()));
-        builder.append(", "_s);
-        builder.append(String::number(m_matrix->m13()));
-        builder.append(", "_s);
-        builder.append(String::number(m_matrix->m14()));
-        builder.append(", "_s);
-        builder.append(String::number(m_matrix->m21()));
-        builder.append(", "_s);
-        builder.append(String::number(m_matrix->m22()));
-        builder.append(", "_s);
-        builder.append(String::number(m_matrix->m23()));
-        builder.append(", "_s);
-        builder.append(String::number(m_matrix->m24()));
-        builder.append(", "_s);
-        builder.append(String::number(m_matrix->m31()));
-        builder.append(", "_s);
-        builder.append(String::number(m_matrix->m32()));
-        builder.append(", "_s);
-        builder.append(String::number(m_matrix->m33()));
-        builder.append(", "_s);
-        builder.append(String::number(m_matrix->m34()));
-        builder.append(", "_s);
-        builder.append(String::number(m_matrix->m41()));
-        builder.append(", "_s);
-        builder.append(String::number(m_matrix->m42()));
-        builder.append(", "_s);
-        builder.append(String::number(m_matrix->m43()));
-        builder.append(", "_s);
-        builder.append(String::number(m_matrix->m44()));
-        builder.append(')');
+        builder.append("matrix3d("_s, m_matrix->m11(), ", "_s,
+        m_matrix->m12(), ", "_s, m_matrix->m13(), ", "_s,
+        m_matrix->m14(), ", "_s, m_matrix->m21(), ", "_s,
+        m_matrix->m22(), ", "_s, m_matrix->m23(), ", "_s,
+        m_matrix->m24(), ", "_s, m_matrix->m31(), ", "_s,
+        m_matrix->m32(), ", "_s, m_matrix->m33(), ", "_s,
+        m_matrix->m34(), ", "_s, m_matrix->m41(), ", "_s,
+        m_matrix->m42(), ", "_s, m_matrix->m43(), ", "_s,
+        m_matrix->m44(), ')');
     }
 }
 

--- a/Source/WebCore/dom/FragmentDirectiveGenerator.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveGenerator.cpp
@@ -112,12 +112,7 @@ void FragmentDirectiveGenerator::generateFragmentDirective(const SimpleRange& te
         String startText = percentEncodeFragmentDirectiveSpecialCharacters(nextWordsFromPosition(3, visibleStartPosition));
         String endText = percentEncodeFragmentDirectiveSpecialCharacters(previousWordsFromPosition(3, visibleEndPosition));
 
-        StringBuilder textDirectiveBuilder;
-        textDirectiveBuilder.append(textDirectivePrefix);
-        textDirectiveBuilder.append(startText);
-        textDirectiveBuilder.append(',');
-        textDirectiveBuilder.append(endText);
-        url.setFragmentIdentifier(StringView(textDirectiveBuilder));
+        url.setFragmentIdentifier(makeString(textDirectivePrefix, startText, ',', endText));
     }
     if (textFromRange.length() < maxCharacters && textFromRange.length() > minCharacter) {
         StringBuilder textDirectiveBuilder;
@@ -129,14 +124,10 @@ void FragmentDirectiveGenerator::generateFragmentDirective(const SimpleRange& te
         String prefix = percentEncodeFragmentDirectiveSpecialCharacters(previousWordsFromPosition(3, visibleStartPosition));
         String suffix = percentEncodeFragmentDirectiveSpecialCharacters(nextWordsFromPosition(3, visibleEndPosition));
 
-        StringBuilder textDirectiveBuilder;
-        textDirectiveBuilder.append(textDirectivePrefix);
-        textDirectiveBuilder.append(percentEncodeFragmentDirectiveSpecialCharacters(prefix));
-        textDirectiveBuilder.append("-,"_s);
-        textDirectiveBuilder.append(percentEncodeFragmentDirectiveSpecialCharacters(textFromRange));
-        textDirectiveBuilder.append(",-"_s);
-        textDirectiveBuilder.append(percentEncodeFragmentDirectiveSpecialCharacters(suffix));
-        url.setFragmentIdentifier(StringView(textDirectiveBuilder));
+        url.setFragmentIdentifier(makeString(textDirectivePrefix,
+            percentEncodeFragmentDirectiveSpecialCharacters(prefix), "-,"_s,
+            percentEncodeFragmentDirectiveSpecialCharacters(textFromRange), ",-"_s,
+            percentEncodeFragmentDirectiveSpecialCharacters(suffix)));
     }
 
     m_urlWithFragment = url;

--- a/Source/WebCore/editing/FontShadow.cpp
+++ b/Source/WebCore/editing/FontShadow.cpp
@@ -41,9 +41,9 @@ String serializationForCSS(const FontShadow& shadow)
         return noneAtom();
 
     StringBuilder builder;
-    builder.append(shadow.offset.width(), "px "_s);
-    builder.append(shadow.offset.height(), "px "_s);
-    builder.append(serializationForCSS(shadow.color));
+    builder.append(shadow.offset.width(), "px "_s,
+        shadow.offset.height(), "px "_s,
+        serializationForCSS(shadow.color));
     if (shadow.blurRadius)
         builder.append(' ', shadow.blurRadius, "px"_s);
     return builder.toString();

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -2046,16 +2046,13 @@ std::optional<InspectorOverlay::Highlight::FlexHighlightOverlay> InspectorOverla
             if (flexOverlay.config.showOrderNumbers) {
                 StringBuilder orderNumbers;
 
-                if (auto index = renderChildrenInDOMOrder.find(renderChild); index != notFound) {
-                    orderNumbers.append("Item #"_s);
-                    orderNumbers.append(index + 1);
-                }
+                if (auto index = renderChildrenInDOMOrder.find(renderChild); index != notFound)
+                    orderNumbers.append("Item #"_s, index + 1);
 
                 if (auto order = renderChild->style().order(); order || hasCustomOrder) {
                     if (!orderNumbers.isEmpty())
                         orderNumbers.append('\n');
-                    orderNumbers.append("order: "_s);
-                    orderNumbers.append(order);
+                    orderNumbers.append("order: "_s, order);
                 }
 
                 if (!orderNumbers.isEmpty())

--- a/Source/WebCore/loader/ResourceLoadStatistics.cpp
+++ b/Source/WebCore/loader/ResourceLoadStatistics.cpp
@@ -447,9 +447,7 @@ String ResourceLoadStatistics::toString() const
 
     // User interaction
     appendBoolean(builder, "hadUserInteraction"_s, hadUserInteraction);
-    builder.append('\n');
-    builder.append("    mostRecentUserInteraction: "_s, hasHadRecentUserInteraction(mostRecentUserInteractionTime.secondsSinceEpoch()) ? "within 24 hours" : "-1");
-    builder.append('\n');
+    builder.append("\n    mostRecentUserInteraction: "_s, hasHadRecentUserInteraction(mostRecentUserInteractionTime.secondsSinceEpoch()) ? "within 24 hours\n"_s : "-1\n"_s);
     appendBoolean(builder, "grandfathered"_s, grandfathered);
     builder.append('\n');
 
@@ -476,9 +474,7 @@ String ResourceLoadStatistics::toString() const
     appendBoolean(builder, "isPrevalentResource"_s, isPrevalentResource);
     builder.append('\n');
     appendBoolean(builder, "isVeryPrevalentResource"_s, isVeryPrevalentResource);
-    builder.append('\n');
-    builder.append("    dataRecordsRemoved: "_s, dataRecordsRemoved);
-    builder.append('\n');
+    builder.append("\n    dataRecordsRemoved: "_s, dataRecordsRemoved, '\n');
 
 #if ENABLE(WEB_API_STATISTICS)
     appendHashSet(builder, "fontsFailedToLoad"_s, fontsFailedToLoad);
@@ -488,8 +484,7 @@ String ResourceLoadStatistics::toString() const
     appendScreenAPIOptionSet(builder, screenFunctionsAccessed);
     appendHashSet(builder, "canvasTextWritten"_s, canvasActivityRecord.textWritten);
     appendBoolean(builder, "canvasReadData"_s, canvasActivityRecord.wasDataRead);
-    builder.append('\n');
-    builder.append('\n');
+    builder.append("\n\n"_s);
 #endif
 
     return builder.toString();

--- a/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
+++ b/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
@@ -151,20 +151,12 @@ Ref<FragmentedSharedBuffer> MHTMLArchive::generateMHTMLData(Page* page)
         // We replace non ASCII characters with '?' characters to match IE's behavior.
         stringBuilder.append(replaceNonPrintableCharacters(localMainFrame->document()->title()));
     }
-    stringBuilder.append("\r\nDate: "_s);
-    stringBuilder.append(dateString);
-    stringBuilder.append("\r\nMIME-Version: 1.0\r\n"_s);
-    stringBuilder.append("Content-Type: multipart/related;\r\n"_s);
-    if (localMainFrame) {
-        stringBuilder.append("\ttype=\""_s);
-        stringBuilder.append(localMainFrame->document()->suggestedMIMEType());
-    }
-    stringBuilder.append("\";\r\n"_s);
-    stringBuilder.append("\tboundary=\""_s);
-    stringBuilder.append(boundary);
-    stringBuilder.append("\"\r\n\r\n"_s);
+    stringBuilder.append("\r\nDate: "_s, dateString,
+        "\r\nMIME-Version: 1.0\r\nContent-Type: multipart/related;\r\n"_s);
+    if (localMainFrame)
+        stringBuilder.append("\ttype=\""_s, localMainFrame->document()->suggestedMIMEType());
+    stringBuilder.append("\";\r\n\tboundary=\""_s, boundary, "\"\r\n\r\n"_s);
 
-    // We use utf8() below instead of ascii() as ascii() replaces CRLFs with ?? (we still only have put ASCII characters in it).
     ASSERT(stringBuilder.toString().containsOnlyASCII());
     CString asciiString = stringBuilder.toString().utf8();
     SharedBufferBuilder mhtmlData;

--- a/Source/WebCore/platform/graphics/CodecUtilities.cpp
+++ b/Source/WebCore/platform/graphics/CodecUtilities.cpp
@@ -49,44 +49,35 @@ String humanReadableStringFromCodecString(const String& codecString)
         uint8_t levelMajor = parameters->level / 10;
         uint8_t levelMinor = parameters->level % 10;
         auto levelString = levelMinor ? WEB_UI_FORMAT_STRING("%d.%d", "Codec Level (Codec Strings)", levelMajor, levelMinor) : String::number(levelMajor);
-        builder.append(WEB_UI_FORMAT_STRING("Profile %d, Level %s", "VP8/9 Codec Level & Profile (Codec Strings)", parameters->profile, levelString.utf8().data()));
-        builder.append(')');
+        builder.append(WEB_UI_FORMAT_STRING("Profile %d, Level %s", "VP8/9 Codec Level & Profile (Codec Strings)", parameters->profile, levelString.utf8().data()), ')');
 
         return builder.toString();
     }
 
     if (auto parameters = parseAVCCodecParameters(codecString)) {
         StringBuilder builder;
-        builder.append(WEB_UI_STRING_KEY("AVC", "AVC (Codec String)", "Codec Strings"));
-        builder.append(" ("_s);
+        builder.append(WEB_UI_STRING_KEY("AVC", "AVC (Codec String)", "Codec Strings"), " ("_s);
         switch (parameters->profileIDC) {
         case 66:
-            builder.append(WEB_UI_STRING_KEY("Baseline Profile", "Baseline Profile (AVC Codec Profile)", "Codec Strings"));
-            builder.append(", "_s);
+            builder.append(WEB_UI_STRING_KEY("Baseline Profile", "Baseline Profile (AVC Codec Profile)", "Codec Strings"), ", "_s);
             break;
         case 77:
-            builder.append(WEB_UI_STRING_KEY("Main Profile", "Main Profile (AVC Codec Profile)", "Codec Strings"));
-            builder.append(", "_s);
+            builder.append(WEB_UI_STRING_KEY("Main Profile", "Main Profile (AVC Codec Profile)", "Codec Strings"), ", "_s);
             break;
         case 88:
-            builder.append(WEB_UI_STRING_KEY("Extended Profile", "Extended Profile (AVC Codec Profile)", "Codec Strings"));
-            builder.append(", "_s);
+            builder.append(WEB_UI_STRING_KEY("Extended Profile", "Extended Profile (AVC Codec Profile)", "Codec Strings"), ", "_s);
             break;
         case 100:
-            builder.append(WEB_UI_STRING_KEY("High Profile", "High Profile (AVC Codec Profile)", "Codec Strings"));
-            builder.append(", "_s);
+            builder.append(WEB_UI_STRING_KEY("High Profile", "High Profile (AVC Codec Profile)", "Codec Strings"), ", "_s);
             break;
         case 110:
-            builder.append(WEB_UI_STRING_KEY("High 10 Profile", "High 10 Profile (AVC Codec Profile)", "Codec Strings"));
-            builder.append(", "_s);
+            builder.append(WEB_UI_STRING_KEY("High 10 Profile", "High 10 Profile (AVC Codec Profile)", "Codec Strings"), ", "_s);
             break;
         case 122:
-            builder.append(WEB_UI_STRING_KEY("High 422 Profile", "High 422 Profile (AVC Codec Profile)", "Codec Strings"));
-            builder.append(", "_s);
+            builder.append(WEB_UI_STRING_KEY("High 422 Profile", "High 422 Profile (AVC Codec Profile)", "Codec Strings"), ", "_s);
             break;
         case 244:
-            builder.append(WEB_UI_STRING_KEY("High 444 Predictive Profile", "High 444 Predictive Profile (AVC Codec Profile)", "Codec Strings"));
-            builder.append(", "_s);
+            builder.append(WEB_UI_STRING_KEY("High 444 Predictive Profile", "High 444 Predictive Profile (AVC Codec Profile)", "Codec Strings"), ", "_s);
             break;
         }
         if (parameters->levelIDC == 11)
@@ -103,16 +94,13 @@ String humanReadableStringFromCodecString(const String& codecString)
 
     if (auto parameters = parseHEVCCodecParameters(codecString)) {
         StringBuilder builder;
-        builder.append(WEB_UI_STRING_KEY("HEVC", "HEVC (Codec String)", "Codec Strings"));
-        builder.append(" ("_s);
+        builder.append(WEB_UI_STRING_KEY("HEVC", "HEVC (Codec String)", "Codec Strings"), " ("_s);
         switch (parameters->generalProfileIDC) {
         case 1:
-            builder.append(WEB_UI_STRING_KEY("Main Profile", "Main Profile (HEVC Codec Profile)", "Codec Strings"));
-            builder.append(", "_s);
+            builder.append(WEB_UI_STRING_KEY("Main Profile", "Main Profile (HEVC Codec Profile)", "Codec Strings"), ", "_s);
             break;
         case 2:
-            builder.append(WEB_UI_STRING_KEY("Main 10 Profile", "Main 10 Profile (HEVC Codec Profile)", "Codec Strings"));
-            builder.append(", "_s);
+            builder.append(WEB_UI_STRING_KEY("Main 10 Profile", "Main 10 Profile (HEVC Codec Profile)", "Codec Strings"), ", "_s);
             break;
         }
         if (parameters->generalTierFlag)
@@ -125,20 +113,16 @@ String humanReadableStringFromCodecString(const String& codecString)
 
     if (auto parameters = parseAV1CodecParameters(codecString)) {
         StringBuilder builder;
-        builder.append(WEB_UI_STRING_KEY("AV1", "AV1 (Codec String)", "Codec Strings"));
-        builder.append(" ("_s);
+        builder.append(WEB_UI_STRING_KEY("AV1", "AV1 (Codec String)", "Codec Strings"), " ("_s);
         switch (parameters->profile) {
         case AV1ConfigurationProfile::Main:
-            builder.append(WEB_UI_STRING_KEY("Main Profile, ", "Main Profile (AV1 Codec Profile)", "Codec Strings"));
-            builder.append(", "_s);
+            builder.append(WEB_UI_STRING_KEY("Main Profile, ", "Main Profile (AV1 Codec Profile)", "Codec Strings"), ", "_s);
             break;
         case AV1ConfigurationProfile::High:
-            builder.append(WEB_UI_STRING_KEY("High Profile, ", "High Profile (AV1 Codec Profile)", "Codec Strings"));
-            builder.append(", "_s);
+            builder.append(WEB_UI_STRING_KEY("High Profile, ", "High Profile (AV1 Codec Profile)", "Codec Strings"), ", "_s);
             break;
         case AV1ConfigurationProfile::Professional:
-            builder.append(WEB_UI_STRING_KEY("Professional Profile, ", "Professional Profile (AV1 Codec Profile)", "Codec Strings"));
-            builder.append(", "_s);
+            builder.append(WEB_UI_STRING_KEY("Professional Profile, ", "Professional Profile (AV1 Codec Profile)", "Codec Strings"), ", "_s);
             break;
         };
 

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -2098,13 +2098,9 @@ String MediaPlayer::lastErrorMessage() const
 
 String SeekTarget::toString() const
 {
-    StringBuilder builder;
-    builder.append('[');
-    builder.append(WTF::LogArgument<MediaTime>::toString(time));
-    builder.append(WTF::LogArgument<MediaTime>::toString(negativeThreshold));
-    builder.append(WTF::LogArgument<MediaTime>::toString(positiveThreshold));
-    builder.append(']');
-    return builder.toString();
+    return makeString('[', WTF::LogArgument<MediaTime>::toString(time),
+        WTF::LogArgument<MediaTime>::toString(negativeThreshold),
+        WTF::LogArgument<MediaTime>::toString(positiveThreshold), ']');
 }
 
 }

--- a/Source/WebCore/platform/graphics/VP9Utilities.cpp
+++ b/Source/WebCore/platform/graphics/VP9Utilities.cpp
@@ -29,6 +29,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/IntegerToStringConversion.h>
 #include <wtf/text/StringBuilder.h>
+#include <wtf/text/StringConcatenateNumbers.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebCore {
@@ -296,13 +297,7 @@ String createVPCodecParametersString(const VPCodecConfigurationRecord& configura
         || !isValidRange(configuration.videoFullRangeFlag))
         return resultBuilder.toString();
 
-    resultBuilder.append(".0"_s);
-    resultBuilder.append(numberToStringUnsigned<String>(configuration.profile));
-
-    resultBuilder.append('.');
-    resultBuilder.append(numberToStringUnsigned<String>(configuration.level));
-
-    resultBuilder.append('.');
+    resultBuilder.append(".0"_s, numberToStringUnsigned<String>(configuration.profile), '.', numberToStringUnsigned<String>(configuration.level), '.');
     if (configuration.transferCharacteristics < 10)
         resultBuilder.append('0');
     resultBuilder.append(numberToStringUnsigned<String>(configuration.bitDepth));
@@ -319,26 +314,16 @@ String createVPCodecParametersString(const VPCodecConfigurationRecord& configura
         && configuration.matrixCoefficients == defaultConfiguration->matrixCoefficients)
         return resultBuilder.toString();
 
-    resultBuilder.append(".0"_s);
-    resultBuilder.append(numberToStringUnsigned<String>(configuration.chromaSubsampling));
-
-    resultBuilder.append('.');
+    resultBuilder.append(".0"_s, numberToStringUnsigned<String>(configuration.chromaSubsampling), '.');
     if (configuration.colorPrimaries < 10)
         resultBuilder.append('0');
-    resultBuilder.append(numberToStringUnsigned<String>(configuration.colorPrimaries));
-
-    resultBuilder.append('.');
+    resultBuilder.append(numberToStringUnsigned<String>(configuration.colorPrimaries), '.');
     if (configuration.transferCharacteristics < 10)
         resultBuilder.append('0');
-    resultBuilder.append(numberToStringUnsigned<String>(configuration.transferCharacteristics));
-
-    resultBuilder.append('.');
+    resultBuilder.append(numberToStringUnsigned<String>(configuration.transferCharacteristics), '.');
     if (configuration.matrixCoefficients < 10)
         resultBuilder.append('0');
-    resultBuilder.append(numberToStringUnsigned<String>(configuration.matrixCoefficients));
-
-    resultBuilder.append(".0"_s);
-    resultBuilder.append(numberToStringUnsigned<String>(configuration.videoFullRangeFlag));
+    resultBuilder.append(numberToStringUnsigned<String>(configuration.matrixCoefficients), ".0"_s, numberToStringUnsigned<String>(configuration.videoFullRangeFlag));
 
     return resultBuilder.toString();
 }

--- a/Source/WebCore/platform/gtk/SelectionData.cpp
+++ b/Source/WebCore/platform/gtk/SelectionData.cpp
@@ -104,18 +104,11 @@ void SelectionData::setURL(const URL& url, const String& label)
     if (hasMarkup())
         return;
 
-    String actualLabel(label);
-    if (actualLabel.isEmpty())
-        actualLabel = url.string();
-
-    StringBuilder markup;
-    markup.append("<a href=\""_s);
-    markup.append(url.string());
-    markup.append("\">"_s);
+    String actualLabel = label.isEmpty() ? url.string() : label;
     GUniquePtr<gchar> escaped(g_markup_escape_text(actualLabel.utf8().data(), -1));
-    markup.append(String::fromUTF8(escaped.get()));
-    markup.append("</a>"_s);
-    setMarkup(markup.toString());
+
+    setMarkup(makeString("<a href=\""_s, url.string(), "\">"_s,
+        String::fromUTF8(escaped.get()), "</a>"_s));
 }
 
 const String& SelectionData::urlLabel() const

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.cpp
@@ -71,8 +71,7 @@ void MediaRecorderPrivateMock::resumeRecording(CompletionHandler<void()>&& compl
 void MediaRecorderPrivateMock::videoFrameAvailable(VideoFrame&, VideoFrameTimeMetadata)
 {
     Locker locker { m_bufferLock };
-    m_buffer.append("Video Track ID: "_s);
-    m_buffer.append(m_videoTrackID);
+    m_buffer.append("Video Track ID: "_s, m_videoTrackID);
     generateMockCounterString();
 }
 
@@ -82,8 +81,7 @@ void MediaRecorderPrivateMock::audioSamplesAvailable(const MediaTime&, const Pla
     // explicitly allow the following allocation(s).
     DisableMallocRestrictionsForCurrentThreadScope disableMallocRestrictions;
     Locker locker { m_bufferLock };
-    m_buffer.append("Audio Track ID: "_s);
-    m_buffer.append(m_audioTrackID);
+    m_buffer.append("Audio Track ID: "_s, m_audioTrackID);
     generateMockCounterString();
 }
 

--- a/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp
+++ b/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp
@@ -75,10 +75,8 @@ static std::pair<String, bool> cookiesForSession(const NetworkStorageSession& se
         for (const auto& cookie : *result) {
             if (!cookies.isEmpty())
                 cookies.append("; "_s);
-            if (!cookie.name.isEmpty()) {
-                cookies.append(cookie.name);
-                cookies.append('=');
-            }
+            if (!cookie.name.isEmpty())
+                cookies.append(cookie.name, '=');
             if (cookie.secure)
                 didAccessSecureCookies = true;
             cookies.append(cookie.value);

--- a/Source/WebCore/platform/text/win/LocaleWin.cpp
+++ b/Source/WebCore/platform/text/win/LocaleWin.cpp
@@ -321,11 +321,8 @@ String LocaleWin::shortTimeFormat()
     // Vista or older Windows doesn't support LOCALE_SSHORTTIME.
     if (format.isEmpty()) {
         format = getLocaleInfoString(LOCALE_STIMEFORMAT);
-        StringBuilder builder;
-        builder.append(getLocaleInfoString(LOCALE_STIME));
-        builder.append("ss"_s);
-        size_t pos = format.reverseFind(builder.toString());
-        if (pos != notFound)
+        auto locale = makeString(getLocaleInfoString(LOCALE_STIME), "ss"_s);
+        if (format.reverseFind(builder) != notFound)
             format = makeStringByRemoving(format, pos, builder.length());
     }
     m_timeFormatWithoutSeconds = convertWindowsDateTimeFormat(format);
@@ -334,25 +331,15 @@ String LocaleWin::shortTimeFormat()
 
 String LocaleWin::dateTimeFormatWithSeconds()
 {
-    if (!m_dateTimeFormatWithSeconds.isNull())
-        return m_dateTimeFormatWithSeconds;
-    StringBuilder builder;
-    builder.append(dateFormat());
-    builder.append(' ');
-    builder.append(timeFormat());
-    m_dateTimeFormatWithSeconds = builder.toString();
+    if (m_dateTimeFormatWithSeconds.isNull())
+        m_dateTimeFormatWithSeconds = makeString(dateFormat(), ' ', timeFormat());
     return m_dateTimeFormatWithSeconds;
 }
 
 String LocaleWin::dateTimeFormatWithoutSeconds()
 {
-    if (!m_dateTimeFormatWithoutSeconds.isNull())
-        return m_dateTimeFormatWithoutSeconds;
-    StringBuilder builder;
-    builder.append(dateFormat());
-    builder.append(' ');
-    builder.append(shortTimeFormat());
-    m_dateTimeFormatWithoutSeconds = builder.toString();
+    if (m_dateTimeFormatWithoutSeconds.isNull())
+        m_dateTimeFormatWithoutSeconds = makeString(dateFormat(), ' ', shortTimeFormat());
     return m_dateTimeFormatWithoutSeconds;
 }
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1183,14 +1183,11 @@ AtomString Internals::imageLastDecodingOptions(HTMLImageElement& element)
 
     auto options = bitmapImage->currentFrameDecodingOptions();
     StringBuilder builder;
-    builder.append("{ decodingMode : "_s);
-    builder.append(options.decodingMode() == DecodingMode::Asynchronous ? "Asynchronous"_s : "Synchronous"_s);
+    builder.append("{ decodingMode : "_s,
+        options.decodingMode() == DecodingMode::Asynchronous ? "Asynchronous"_s : "Synchronous"_s);
     if (auto sizeForDrawing = options.sizeForDrawing()) {
-        builder.append(", sizeForDrawing : { "_s);
-        builder.append(sizeForDrawing->width());
-        builder.append(", "_s);
-        builder.append(sizeForDrawing->height());
-        builder.append(" }"_s);
+        builder.append(", sizeForDrawing : { "_s, sizeForDrawing->width(),
+            ", "_s, sizeForDrawing->height(), " }"_s);
     }
     builder.append(" }"_s);
     return builder.toAtomString();
@@ -7220,10 +7217,8 @@ String Internals::dumpStyleResolvers()
             return currentIdentifier++;
         }).iterator->value;
 
-        result.append('(', name, ' ');
-        result.append("(identifier="_s, identifier, ") "_s);
-        result.append("(author rule count="_s, resolver.ruleSets().authorStyle().ruleCount(), ')');
-        result.append(")\n"_s);
+        result.append('(', name, ' ', "(identifier="_s, identifier, ") (author rule count="_s,
+            resolver.ruleSets().authorStyle().ruleCount(), "))\n"_s);
     };
 
     dumpResolver("document resolver"_s, document->styleScope().resolver());

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -40,6 +40,7 @@
 #include <wtf/SetForScope.h>
 #include <wtf/SortedArrayMap.h>
 #include <wtf/text/StringBuilder.h>
+#include <wtf/text/StringConcatenateNumbers.h>
 
 namespace WGSL {
 
@@ -190,25 +191,25 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
         m_stringBuilder.append("struct texture_external {\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "texture2d<float> FirstPlane;\n"_s);
-            m_stringBuilder.append(m_indent, "texture2d<float> SecondPlane;\n"_s);
-            m_stringBuilder.append(m_indent, "float3x2 UVRemapMatrix;\n"_s);
-            m_stringBuilder.append(m_indent, "float4x3 ColorSpaceConversionMatrix;\n"_s);
-            m_stringBuilder.append(m_indent, "uint get_width(uint lod = 0) const { return FirstPlane.get_width(lod); }\n"_s);
-            m_stringBuilder.append(m_indent, "uint get_height(uint lod = 0) const { return FirstPlane.get_height(lod); }\n"_s);
+            m_stringBuilder.append(m_indent, "texture2d<float> FirstPlane;\n"_s,
+                m_indent, "texture2d<float> SecondPlane;\n"_s,
+                m_indent, "float3x2 UVRemapMatrix;\n"_s,
+                m_indent, "float4x3 ColorSpaceConversionMatrix;\n"_s,
+                m_indent, "uint get_width(uint lod = 0) const { return FirstPlane.get_width(lod); }\n"_s,
+                m_indent, "uint get_height(uint lod = 0) const { return FirstPlane.get_height(lod); }\n"_s);
         }
         m_stringBuilder.append("};\n\n"_s);
     }
 
     if (m_shaderModule.usesPackArray()) {
         m_shaderModule.clearUsesPackArray();
-        m_stringBuilder.append(m_indent, "template<typename T, size_t N>\n"_s);
-        m_stringBuilder.append(m_indent, "array<typename T::PackedType, N> __pack(array<T, N> unpacked)\n"_s);
-        m_stringBuilder.append(m_indent, "{\n"_s);
+        m_stringBuilder.append(m_indent, "template<typename T, size_t N>\n"_s,
+            m_indent, "array<typename T::PackedType, N> __pack(array<T, N> unpacked)\n"_s,
+            m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "array<typename T::PackedType, N> packed;\n"_s);
-            m_stringBuilder.append(m_indent, "for (size_t i = 0; i < N; ++i)\n"_s);
+            m_stringBuilder.append(m_indent, "array<typename T::PackedType, N> packed;\n"_s,
+                m_indent, "for (size_t i = 0; i < N; ++i)\n"_s);
             {
                 IndentationScope scope(m_indent);
                 m_stringBuilder.append(m_indent, "packed[i] = __pack(unpacked[i]);\n"_s);
@@ -220,13 +221,13 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
 
     if (m_shaderModule.usesUnpackArray()) {
         m_shaderModule.clearUsesUnpackArray();
-        m_stringBuilder.append(m_indent, "template<typename T, size_t N>\n"_s);
-        m_stringBuilder.append(m_indent, "array<typename T::UnpackedType, N> __unpack(array<T, N> packed)\n"_s);
-        m_stringBuilder.append(m_indent, "{\n"_s);
+        m_stringBuilder.append(m_indent, "template<typename T, size_t N>\n"_s,
+            m_indent, "array<typename T::UnpackedType, N> __unpack(array<T, N> packed)\n"_s,
+            m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "array<typename T::UnpackedType, N> unpacked;\n"_s);
-            m_stringBuilder.append(m_indent, "for (size_t i = 0; i < N; ++i)\n"_s);
+            m_stringBuilder.append(m_indent, "array<typename T::UnpackedType, N> unpacked;\n"_s,
+                m_indent, "for (size_t i = 0; i < N; ++i)\n"_s);
             {
                 IndentationScope scope(m_indent);
                 m_stringBuilder.append(m_indent, "unpacked[i] = __unpack(packed[i]);\n"_s);
@@ -237,27 +238,27 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
     }
 
     if (m_shaderModule.usesWorkgroupUniformLoad()) {
-        m_stringBuilder.append(m_indent, "template<typename T>\n"_s);
-        m_stringBuilder.append(m_indent, "T __workgroup_uniform_load(threadgroup T* const ptr)\n"_s);
-        m_stringBuilder.append(m_indent, "{\n"_s);
+        m_stringBuilder.append(m_indent, "template<typename T>\n"_s,
+            m_indent, "T __workgroup_uniform_load(threadgroup T* const ptr)\n"_s,
+            m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "threadgroup_barrier(mem_flags::mem_threadgroup);\n"_s);
-            m_stringBuilder.append(m_indent, "auto result = *ptr;\n"_s);
-            m_stringBuilder.append(m_indent, "threadgroup_barrier(mem_flags::mem_threadgroup);\n"_s);
-            m_stringBuilder.append(m_indent, "return result;\n"_s);
+            m_stringBuilder.append(m_indent, "threadgroup_barrier(mem_flags::mem_threadgroup);\n"_s,
+                m_indent, "auto result = *ptr;\n"_s,
+                m_indent, "threadgroup_barrier(mem_flags::mem_threadgroup);\n"_s,
+                m_indent, "return result;\n"_s);
         }
         m_stringBuilder.append(m_indent, "}\n\n"_s);
     }
 
     if (m_shaderModule.usesDivision()) {
-        m_stringBuilder.append(m_indent, "template<typename T, typename U, typename V = conditional_t<is_scalar_v<U>, T, U>>\n"_s);
-        m_stringBuilder.append(m_indent, "V __wgslDiv(T lhs, U rhs)\n"_s);
-        m_stringBuilder.append(m_indent, "{\n"_s);
+        m_stringBuilder.append(m_indent, "template<typename T, typename U, typename V = conditional_t<is_scalar_v<U>, T, U>>\n"_s,
+            m_indent, "V __wgslDiv(T lhs, U rhs)\n"_s,
+            m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "auto predicate = V(rhs) == V(0);\n"_s);
-            m_stringBuilder.append(m_indent, "if constexpr (is_signed_v<U>)\n"_s);
+            m_stringBuilder.append(m_indent, "auto predicate = V(rhs) == V(0);\n"_s,
+                m_indent, "if constexpr (is_signed_v<U>)\n"_s);
             {
                 IndentationScope scope(m_indent);
                 m_stringBuilder.append(m_indent, "predicate = predicate || (V(lhs) == V(numeric_limits<T>::lowest()) && V(rhs) == V(-1));\n"_s);
@@ -268,13 +269,13 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
     }
 
     if (m_shaderModule.usesModulo()) {
-        m_stringBuilder.append(m_indent, "template<typename T, typename U, typename V = conditional_t<is_scalar_v<U>, T, U>>\n"_s);
-        m_stringBuilder.append(m_indent, "V __wgslMod(T lhs, U rhs)\n"_s);
-        m_stringBuilder.append(m_indent, "{\n"_s);
+        m_stringBuilder.append(m_indent, "template<typename T, typename U, typename V = conditional_t<is_scalar_v<U>, T, U>>\n"_s,
+            m_indent, "V __wgslMod(T lhs, U rhs)\n"_s,
+            m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "auto predicate = V(rhs) == V(0);\n"_s);
-            m_stringBuilder.append(m_indent, "if constexpr (is_signed_v<U>)\n"_s);
+            m_stringBuilder.append(m_indent, "auto predicate = V(rhs) == V(0);\n"_s,
+                m_indent, "if constexpr (is_signed_v<U>)\n"_s);
             {
                 IndentationScope scope(m_indent);
                 m_stringBuilder.append(m_indent, "predicate = predicate || (V(lhs) == V(numeric_limits<T>::lowest()) && V(rhs) == V(-1));\n"_s);
@@ -286,125 +287,122 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
 
 
     if (m_shaderModule.usesFrexp()) {
-        m_stringBuilder.append(m_indent, "template<typename T, typename U>\n"_s);
-        m_stringBuilder.append(m_indent, "struct __frexp_result {\n"_s);
+        m_stringBuilder.append(m_indent, "template<typename T, typename U>\n"_s,
+            m_indent, "struct __frexp_result {\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "T fract;\n"_s);
-            m_stringBuilder.append(m_indent, "U exp;\n"_s);
+            m_stringBuilder.append(m_indent, "T fract;\n"_s,
+                m_indent, "U exp;\n"_s);
         }
-        m_stringBuilder.append(m_indent, "};\n\n"_s);
-
-        m_stringBuilder.append(m_indent, "template<typename T, typename U = conditional_t<is_vector_v<T>, vec<int, vec_elements<T>::value ?: 2>, int>>\n"_s);
-        m_stringBuilder.append(m_indent, "__frexp_result<T, U> __wgslFrexp(T value)\n"_s);
-        m_stringBuilder.append(m_indent, "{\n"_s);
+        m_stringBuilder.append(m_indent, "};\n\n"_s,
+            m_indent, "template<typename T, typename U = conditional_t<is_vector_v<T>, vec<int, vec_elements<T>::value ?: 2>, int>>\n"_s,
+            m_indent, "__frexp_result<T, U> __wgslFrexp(T value)\n"_s,
+            m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "__frexp_result<T, U> result;\n"_s);
-            m_stringBuilder.append(m_indent, "result.fract = frexp(value, result.exp);\n"_s);
-            m_stringBuilder.append(m_indent, "return result;\n"_s);
+            m_stringBuilder.append(m_indent, "__frexp_result<T, U> result;\n"_s,
+                m_indent, "result.fract = frexp(value, result.exp);\n"_s,
+                m_indent, "return result;\n"_s);
         }
         m_stringBuilder.append(m_indent, "}\n\n"_s);
     }
 
     if (m_shaderModule.usesModf()) {
-        m_stringBuilder.append(m_indent, "template<typename T, typename U>\n"_s);
-        m_stringBuilder.append(m_indent, "struct __modf_result {\n"_s);
+        m_stringBuilder.append(m_indent, "template<typename T, typename U>\n"_s,
+            m_indent, "struct __modf_result {\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "T fract;\n"_s);
-            m_stringBuilder.append(m_indent, "U whole;\n"_s);
+            m_stringBuilder.append(m_indent, "T fract;\n"_s,
+                m_indent, "U whole;\n"_s);
         }
-        m_stringBuilder.append(m_indent, "};\n\n"_s);
-
-        m_stringBuilder.append(m_indent, "template<typename T>\n"_s);
-        m_stringBuilder.append(m_indent, "__modf_result<T, T> __wgslModf(T value)\n"_s);
-        m_stringBuilder.append(m_indent, "{\n"_s);
+        m_stringBuilder.append(m_indent, "};\n\n"_s,
+            m_indent, "template<typename T>\n"_s,
+            m_indent, "__modf_result<T, T> __wgslModf(T value)\n"_s,
+            m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "__modf_result<T, T> result;\n"_s);
-            m_stringBuilder.append(m_indent, "result.fract = modf(value, result.whole);\n"_s);
-            m_stringBuilder.append(m_indent, "return result;\n"_s);
+            m_stringBuilder.append(m_indent, "__modf_result<T, T> result;\n"_s,
+                m_indent, "result.fract = modf(value, result.whole);\n"_s,
+                m_indent, "return result;\n"_s);
         }
         m_stringBuilder.append(m_indent, "}\n\n"_s);
     }
 
     if (m_shaderModule.usesAtomicCompareExchange()) {
-        m_stringBuilder.append(m_indent, "template<typename T, typename U = bool>\n"_s);
-        m_stringBuilder.append(m_indent, "struct __atomic_compare_exchange_result {\n"_s);
+        m_stringBuilder.append(m_indent, "template<typename T, typename U = bool>\n"_s,
+            m_indent, "struct __atomic_compare_exchange_result {\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "T old_value;\n"_s);
-            m_stringBuilder.append(m_indent, "U exchanged;\n"_s);
+            m_stringBuilder.append(m_indent, "T old_value;\n"_s,
+                m_indent, "U exchanged;\n"_s);
         }
-        m_stringBuilder.append(m_indent, "};\n\n"_s);
-
-        m_stringBuilder.append(m_indent, "#define __wgslAtomicCompareExchangeWeak(atomic, compare, value) \\\n"_s);
+        m_stringBuilder.append(m_indent, "};\n\n"_s,
+            m_indent, "#define __wgslAtomicCompareExchangeWeak(atomic, compare, value) \\\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "({ auto innerCompare = compare; \\\n"_s);
-            m_stringBuilder.append(m_indent, "bool exchanged = atomic_compare_exchange_weak_explicit((atomic), &innerCompare, value, memory_order_relaxed, memory_order_relaxed); \\\n"_s);
-            m_stringBuilder.append(m_indent, "__atomic_compare_exchange_result<decltype(compare)> { innerCompare, exchanged }; \\\n"_s);
-            m_stringBuilder.append(m_indent, "})\n"_s);
+            m_stringBuilder.append(m_indent, "({ auto innerCompare = compare; \\\n"_s,
+                m_indent, "bool exchanged = atomic_compare_exchange_weak_explicit((atomic), &innerCompare, value, memory_order_relaxed, memory_order_relaxed); \\\n"_s,
+                m_indent, "__atomic_compare_exchange_result<decltype(compare)> { innerCompare, exchanged }; \\\n"_s,
+                m_indent, "})\n"_s);
         }
     }
 
     if (m_shaderModule.usesDot()) {
-        m_stringBuilder.append(m_indent, "template<typename T, unsigned N>\n"_s);
-        m_stringBuilder.append(m_indent, "T __wgslDot(vec<T, N> lhs, vec<T, N> rhs)\n"_s);
-        m_stringBuilder.append(m_indent, "{\n"_s);
+        m_stringBuilder.append(m_indent, "template<typename T, unsigned N>\n"_s,
+            m_indent, "T __wgslDot(vec<T, N> lhs, vec<T, N> rhs)\n"_s,
+            m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "auto result = lhs[0] * rhs[0] + lhs[1] * rhs[1];\n"_s);
-            m_stringBuilder.append(m_indent, "if constexpr (N > 2) result += lhs[2] * rhs[2];\n"_s);
-            m_stringBuilder.append(m_indent, "if constexpr (N > 3) result += lhs[3] * rhs[3];\n"_s);
-            m_stringBuilder.append(m_indent, "return result;\n"_s);
+            m_stringBuilder.append(m_indent, "auto result = lhs[0] * rhs[0] + lhs[1] * rhs[1];\n"_s,
+                m_indent, "if constexpr (N > 2) result += lhs[2] * rhs[2];\n"_s,
+                m_indent, "if constexpr (N > 3) result += lhs[3] * rhs[3];\n"_s,
+                m_indent, "return result;\n"_s);
         }
         m_stringBuilder.append(m_indent, "}\n"_s);
     }
 
     if (m_shaderModule.usesDot4I8Packed()) {
-        m_stringBuilder.append(m_indent, "int __wgslDot4I8Packed(uint lhs, uint rhs)\n"_s);
-        m_stringBuilder.append(m_indent, "{\n"_s);
+        m_stringBuilder.append(m_indent, "int __wgslDot4I8Packed(uint lhs, uint rhs)\n"_s,
+            m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "auto vec1 = as_type<packed_char4>(lhs);"_s);
-            m_stringBuilder.append(m_indent, "auto vec2 = as_type<packed_char4>(rhs);"_s);
-            m_stringBuilder.append(m_indent, "return vec1[0] * vec2[0] + vec1[1] * vec2[1] + vec1[2] * vec2[2] + vec1[3] * vec2[3];"_s);
+            m_stringBuilder.append(m_indent, "auto vec1 = as_type<packed_char4>(lhs);"_s,
+                m_indent, "auto vec2 = as_type<packed_char4>(rhs);"_s,
+                m_indent, "return vec1[0] * vec2[0] + vec1[1] * vec2[1] + vec1[2] * vec2[2] + vec1[3] * vec2[3];"_s);
         }
         m_stringBuilder.append(m_indent, "}\n"_s);
     }
 
     if (m_shaderModule.usesDot4U8Packed()) {
-        m_stringBuilder.append(m_indent, "uint __wgslDot4U8Packed(uint lhs, uint rhs)\n"_s);
-        m_stringBuilder.append(m_indent, "{\n"_s);
+        m_stringBuilder.append(m_indent, "uint __wgslDot4U8Packed(uint lhs, uint rhs)\n"_s,
+            m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "auto vec1 = as_type<packed_uchar4>(lhs);"_s);
-            m_stringBuilder.append(m_indent, "auto vec2 = as_type<packed_uchar4>(rhs);"_s);
-            m_stringBuilder.append(m_indent, "return vec1[0] * vec2[0] + vec1[1] * vec2[1] + vec1[2] * vec2[2] + vec1[3] * vec2[3];"_s);
+            m_stringBuilder.append(m_indent, "auto vec1 = as_type<packed_uchar4>(lhs);"_s,
+                m_indent, "auto vec2 = as_type<packed_uchar4>(rhs);"_s,
+                m_indent, "return vec1[0] * vec2[0] + vec1[1] * vec2[1] + vec1[2] * vec2[2] + vec1[3] * vec2[3];"_s);
         }
         m_stringBuilder.append(m_indent, "}\n"_s);
     }
 
     if (m_shaderModule.usesFirstLeadingBit()) {
-        m_stringBuilder.append(m_indent, "template<typename T>\n"_s);
-        m_stringBuilder.append(m_indent, "T __wgslFirstLeadingBit(T e)\n"_s);
-        m_stringBuilder.append(m_indent, "{\n"_s);
+        m_stringBuilder.append(m_indent, "template<typename T>\n"_s,
+            m_indent, "T __wgslFirstLeadingBit(T e)\n"_s,
+            m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "if constexpr (is_signed_v<T>)\n"_s);
-            m_stringBuilder.append(m_indent, "    return select(T(31 - select(clz(e), clz(~e), e < T(0))), T(-1), e == T(0) || e == T(-1));\n"_s);
-            m_stringBuilder.append(m_indent, "else\n"_s);
-            m_stringBuilder.append(m_indent, "    return select(T(31 - clz(e)), T(-1), e == T(0));\n"_s);
+            m_stringBuilder.append(m_indent, "if constexpr (is_signed_v<T>)\n"_s,
+                m_indent, "    return select(T(31 - select(clz(e), clz(~e), e < T(0))), T(-1), e == T(0) || e == T(-1));\n"_s,
+                m_indent, "else\n"_s,
+                m_indent, "    return select(T(31 - clz(e)), T(-1), e == T(0));\n"_s);
         }
         m_stringBuilder.append(m_indent, "}\n"_s);
     }
 
     if (m_shaderModule.usesFirstTrailingBit()) {
-        m_stringBuilder.append(m_indent, "template<typename T>\n"_s);
-        m_stringBuilder.append(m_indent, "T __wgslFirstTrailingBit(T e)\n"_s);
-        m_stringBuilder.append(m_indent, "{\n"_s);
+        m_stringBuilder.append(m_indent, "template<typename T>\n"_s,
+            m_indent, "T __wgslFirstTrailingBit(T e)\n"_s,
+            m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
             m_stringBuilder.append(m_indent, "return select(ctz(e), T(-1), e == T(0));\n"_s);
@@ -413,9 +411,9 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
     }
 
     if (m_shaderModule.usesSign()) {
-        m_stringBuilder.append(m_indent, "template<typename T>\n"_s);
-        m_stringBuilder.append(m_indent, "T __wgslSign(T e)\n"_s);
-        m_stringBuilder.append(m_indent, "{\n"_s);
+        m_stringBuilder.append(m_indent, "template<typename T>\n"_s,
+            m_indent, "T __wgslSign(T e)\n"_s,
+            m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
             m_stringBuilder.append(m_indent, "return select(select(T(-1), T(1), e > 0), T(0), e == 0);\n"_s);
@@ -424,14 +422,14 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
     }
 
     if (m_shaderModule.usesExtractBits()) {
-        m_stringBuilder.append(m_indent, "template<typename T>\n"_s);
-        m_stringBuilder.append(m_indent, "T __wgslExtractBits(T e, uint offset, uint count)\n"_s);
-        m_stringBuilder.append(m_indent, "{\n"_s);
+        m_stringBuilder.append(m_indent, "template<typename T>\n"_s,
+            m_indent, "T __wgslExtractBits(T e, uint offset, uint count)\n"_s,
+            m_indent, "{\n"_s);
         {
             IndentationScope scope(m_indent);
-            m_stringBuilder.append(m_indent, "auto o = min(offset, 32u);\n"_s);
-            m_stringBuilder.append(m_indent, "auto c = min(count, 32u - o);\n"_s);
-            m_stringBuilder.append(m_indent, "return extract_bits(e, o, c);\n"_s);
+            m_stringBuilder.append(m_indent, "auto o = min(offset, 32u);\n"_s,
+                m_indent, "auto c = min(count, 32u - o);\n"_s,
+                m_indent, "return extract_bits(e, o, c);\n"_s);
         }
         m_stringBuilder.append(m_indent, "}\n"_s);
     }
@@ -510,10 +508,10 @@ void FunctionDefinitionWriter::visit(AST::Structure& structDecl)
             auto& name = member.name();
             auto* type = member.type().inferredType();
             if (isPrimitiveReference(type, Types::Primitive::TextureExternal)) {
-                m_stringBuilder.append(m_indent, "texture2d<float> __"_s, name, "_FirstPlane;\n"_s);
-                m_stringBuilder.append(m_indent, "texture2d<float> __"_s, name, "_SecondPlane;\n"_s);
-                m_stringBuilder.append(m_indent, "float3x2 __"_s, name, "_UVRemapMatrix;\n"_s);
-                m_stringBuilder.append(m_indent, "float4x3 __"_s, name, "_ColorSpaceConversionMatrix;\n"_s);
+                m_stringBuilder.append(m_indent, "texture2d<float> __"_s, name, "_FirstPlane;\n"_s,
+                    m_indent, "texture2d<float> __"_s, name, "_SecondPlane;\n"_s,
+                    m_indent, "float3x2 __"_s, name, "_UVRemapMatrix;\n"_s,
+                    m_indent, "float4x3 __"_s, name, "_ColorSpaceConversionMatrix;\n"_s);
                 continue;
             }
 
@@ -531,9 +529,8 @@ void FunctionDefinitionWriter::visit(AST::Structure& structDecl)
         }
 
         if (structDecl.role() == AST::StructureRole::VertexOutput || structDecl.role() == AST::StructureRole::FragmentOutput) {
-            m_stringBuilder.append('\n');
-            m_stringBuilder.append(m_indent, "template<typename T>\n"_s);
-            m_stringBuilder.append(m_indent, structDecl.name(), "(const thread T& other)\n"_s);
+            m_stringBuilder.append('\n', m_indent, "template<typename T>\n"_s,
+                m_indent, structDecl.name(), "(const thread T& other)\n"_s);
             {
                 IndentationScope scope(m_indent);
                 char prefix = ':';
@@ -548,9 +545,8 @@ void FunctionDefinitionWriter::visit(AST::Structure& structDecl)
             ASSERT(structDecl.members().size() == 1);
             auto& member = structDecl.members()[0];
 
-            m_stringBuilder.append('\n');
-            m_stringBuilder.append(m_indent, "template<typename T>\n"_s);
-            m_stringBuilder.append(m_indent, structDecl.name(), "(T value)\n"_s);
+            m_stringBuilder.append('\n', m_indent, "template<typename T>\n"_s,
+                m_indent, structDecl.name(), "(T value)\n"_s);
             {
                 IndentationScope scope(m_indent);
                 m_stringBuilder.append(m_indent, ": "_s, member.name(), "(value)\n"_s);
@@ -570,8 +566,8 @@ void FunctionDefinitionWriter::generatePackingHelpers(AST::Structure& structure)
     const String& packedName = structure.name();
     auto unpackedName = structure.original()->name();
 
-    m_stringBuilder.append(m_indent, packedName, " __pack("_s, unpackedName, " unpacked)\n"_s);
-    m_stringBuilder.append(m_indent, "{\n"_s);
+    m_stringBuilder.append(m_indent, packedName, " __pack("_s, unpackedName, " unpacked)\n"_s,
+        m_indent, "{\n"_s);
     {
         IndentationScope scope(m_indent);
         m_stringBuilder.append(m_indent, packedName, " packed;\n"_s);
@@ -584,10 +580,9 @@ void FunctionDefinitionWriter::generatePackingHelpers(AST::Structure& structure)
         }
         m_stringBuilder.append(m_indent, "return packed;\n"_s);
     }
-    m_stringBuilder.append(m_indent, "}\n\n"_s);
-
-    m_stringBuilder.append(m_indent, unpackedName, " __unpack("_s, packedName, " packed)\n"_s);
-    m_stringBuilder.append(m_indent, "{\n"_s);
+    m_stringBuilder.append(m_indent, "}\n\n"_s,
+        m_indent, unpackedName, " __unpack("_s, packedName, " packed)\n"_s,
+        m_indent, "{\n"_s);
     {
         IndentationScope scope(m_indent);
         m_stringBuilder.append(m_indent, unpackedName, " unpacked;\n"_s);
@@ -618,17 +613,17 @@ bool FunctionDefinitionWriter::emitPackedVector(const Types::Vector& vector)
     switch (primitive.kind) {
     case Types::Primitive::AbstractInt:
     case Types::Primitive::I32:
-        m_stringBuilder.append("packed_int"_s, String::number(vector.size));
+        m_stringBuilder.append("packed_int"_s, vector.size);
         break;
     case Types::Primitive::U32:
-        m_stringBuilder.append("packed_uint"_s, String::number(vector.size));
+        m_stringBuilder.append("packed_uint"_s, vector.size);
         break;
     case Types::Primitive::AbstractFloat:
     case Types::Primitive::F32:
-        m_stringBuilder.append("packed_float"_s, String::number(vector.size));
+        m_stringBuilder.append("packed_float"_s, vector.size);
         break;
     case Types::Primitive::F16:
-        m_stringBuilder.append("packed_half"_s, String::number(vector.size));
+        m_stringBuilder.append("packed_half"_s, vector.size);
         break;
     case Types::Primitive::Bool:
     case Types::Primitive::Void:
@@ -2356,15 +2351,12 @@ void FunctionDefinitionWriter::visit(AST::SwitchStatement& statement)
 {
     const auto& visitClause = [&](AST::SwitchClause& clause, bool isDefault = false) {
         for (auto& selector : clause.selectors) {
-            m_stringBuilder.append('\n');
-            m_stringBuilder.append(m_indent, "case "_s);
+            m_stringBuilder.append('\n', m_indent, "case "_s);
             visit(selector);
             m_stringBuilder.append(':');
         }
-        if (isDefault) {
-            m_stringBuilder.append('\n');
-            m_stringBuilder.append(m_indent, "default:"_s);
-        }
+        if (isDefault)
+            m_stringBuilder.append('\n', m_indent, "default:"_s);
         m_stringBuilder.append(' ');
         visit(clause.body);
 

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -100,12 +100,11 @@ struct TemplateTypes<TT> {
 #define CONSUME_TYPE_NAMED(name, type) \
     auto name##Expected = consumeType(TokenType::type); \
     if (!name##Expected) { \
-        StringBuilder builder; \
-        builder.append("Expected a "_s); \
-        builder.append(toString(TokenType::type)); \
-        builder.append(", but got a "_s); \
-        builder.append(toString(name##Expected.error())); \
-        FAIL(builder.toString()); \
+        auto error = makeString("Expected a "_s, \
+            toString(TokenType::type), \
+            ", but got a "_s, \
+            toString(name##Expected.error())); \
+        FAIL(WTFMove(error)); \
     } \
     auto& name = *name##Expected;
 
@@ -113,12 +112,11 @@ struct TemplateTypes<TT> {
     do { \
         auto expectedToken = consumeType(TokenType::type); \
         if (!expectedToken) { \
-            StringBuilder builder; \
-            builder.append("Expected a "_s); \
-            builder.append(toString(TokenType::type)); \
-            builder.append(", but got a "_s); \
-            builder.append(toString(expectedToken.error())); \
-            FAIL(builder.toString()); \
+            auto error = makeString("Expected a "_s, \
+                toString(TokenType::type), \
+                ", but got a "_s, \
+                toString(expectedToken.error())); \
+            FAIL(WTFMove(error)); \
         } \
     } while (false)
 
@@ -128,8 +126,7 @@ struct TemplateTypes<TT> {
         StringBuilder builder; \
         builder.append("Expected one of ["_s); \
         TemplateTypes<__VA_ARGS__>::appendNameTo(builder); \
-        builder.append("], but got a "_s); \
-        builder.append(toString(name##Expected.error())); \
+        builder.append("], but got a "_s, toString(name##Expected.error())); \
         FAIL(builder.toString()); \
     } \
     auto& name = *name##Expected;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -2097,17 +2097,16 @@ void NetworkSessionCocoa::donateToSKAdNetwork(WebCore::PrivateClickMeasurement&&
     if (!m_privateClickMeasurementDebugModeEnabled)
         return;
 
-    StringBuilder debugString;
-    debugString.append("Submitting potential install attribution for AdamId: "_s);
-    debugString.append(makeString(*pcm.adamID()));
-    debugString.append(", adNetworkRegistrableDomain: "_s);
-    debugString.append(pcm.destinationSite().registrableDomain.string());
-    debugString.append(", impressionId: "_s);
-    debugString.append(pcm.ephemeralSourceNonce()->nonce);
-    debugString.append(", sourceWebRegistrableDomain: "_s);
-    debugString.append(pcm.sourceSite().registrableDomain.string());
-    debugString.append(", version: 3"_s);
-    networkProcess().broadcastConsoleMessage(sessionID(), MessageSource::PrivateClickMeasurement, MessageLevel::Debug, debugString.toString());
+    auto debugString = makeString("Submitting potential install attribution for AdamId: "_s,
+        *pcm.adamID(),
+        ", adNetworkRegistrableDomain: "_s,
+        pcm.destinationSite().registrableDomain.string(),
+        ", impressionId: "_s,
+        pcm.ephemeralSourceNonce()->nonce,
+        ", sourceWebRegistrableDomain: "_s,
+        pcm.sourceSite().registrableDomain.string(),
+        ", version: 3"_s);
+    networkProcess().broadcastConsoleMessage(sessionID(), MessageSource::PrivateClickMeasurement, MessageLevel::Debug, debugString);
 }
 
 void NetworkSessionCocoa::deleteAlternativeServicesForHostNames(const Vector<String>& hosts)

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -526,9 +526,7 @@ String CacheStorageManager::representationString()
         if (!isFirst)
             builder.append(", "_s);
         isFirst = false;
-        builder.append("\""_s);
-        builder.append(cache->name());
-        builder.append("\""_s);
+        builder.append('"', cache->name(), '"');
     }
 
     builder.append("], \"removed\": ["_s);
@@ -537,9 +535,7 @@ String CacheStorageManager::representationString()
         if (!isFirst)
             builder.append(", "_s);
         isFirst = false;
-        builder.append("\""_s);
-        builder.append(cache->name());
-        builder.append("\""_s);
+        builder.append('"', cache->name(), '"');
     }
     builder.append("]}\n"_s);
     return builder.toString();

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1827,11 +1827,12 @@ void NetworkStorageManager::cacheStorageRepresentation(CompletionHandler<void(St
     for (auto& origin : getAllOrigins()) {
         auto fetchedTypes = originStorageManager(origin).fetchDataTypesInList(targetTypes, false);
         if (!fetchedTypes.isEmpty()) {
-            StringBuilder originBuilder;
-            originBuilder.append("\n{ \"origin\" : { \"topOrigin\" : \""_s, origin.topOrigin.toString(), "\", \"clientOrigin\": \""_s, origin.clientOrigin.toString(), "\" }, \"caches\" : "_s);
-            originBuilder.append(originStorageManager(origin).cacheStorageManager(*m_cacheStorageRegistry, origin, m_queue.copyRef()).representationString());
-            originBuilder.append('}');
-            originStrings.append(originBuilder.toString());
+            originStrings.append(makeString("\n{ \"origin\" : { \"topOrigin\" : \""_s,
+                origin.topOrigin.toString(), "\", \"clientOrigin\": \""_s,
+                origin.clientOrigin.toString(), "\" }, \"caches\" : "_s,
+                originStorageManager(origin).cacheStorageManager(*m_cacheStorageRegistry, origin, m_queue.copyRef()).representationString(),
+                '}'
+            ));
         }
         removeOriginStorageManagerIfPossible(origin);
     }


### PR DESCRIPTION
#### 9e40c12adba07ed27e7bd52bb32cfedcb1eef2aa
<pre>
Optimize some usage of StringBuilder
<a href="https://bugs.webkit.org/show_bug.cgi?id=273728">https://bugs.webkit.org/show_bug.cgi?id=273728</a>

Reviewed by Tim Nguyen.

Optimize some usage of StringBuilder. This is a follow-up to 278348@main
to address Darin&apos;s comments.

* Source/JavaScriptCore/runtime/FileBasedFuzzerAgentBase.cpp:
(JSC::FileBasedFuzzerAgentBase::createLookupKey):
* Source/WTF/wtf/URL.cpp:
(WTF::percentEncodeCharacters):
* Source/WTF/wtf/text/WTFString.cpp:
(asciiDebug):
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
(WebCore::MediaKeySession::updateKeyStatuses):
* Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp:
(WebCore::resolveRelativeVirtualPath):
* Source/WebCore/Modules/geolocation/Geolocation.cpp:
(WebCore::logError):
* Source/WebCore/Modules/indexeddb/IDBKeyData.cpp:
(WebCore::IDBKeyData::loggingString const):
* Source/WebCore/Modules/indexeddb/IDBKeyPath.cpp:
(WebCore::loggingString):
* Source/WebCore/Modules/push-api/PushSubscriptionIdentifier.cpp:
(WebCore::PushSubscriptionSetIdentifier::debugDescription const):
* Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h:
(PAL::decodeEscapeSequences):
* Source/WebCore/css/CSSCounterStyleDescriptors.cpp:
(WebCore::CSSCounterStyleDescriptors::symbolsCSSText const):
(WebCore::CSSCounterStyleDescriptors::additiveSymbolsCSSText const):
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::cssTextInternal const):
* Source/WebCore/css/query/GenericMediaQuerySerialization.cpp:
(WebCore::MQ::serialize):
* Source/WebCore/css/typedom/CSSOMVariableReferenceValue.cpp:
(WebCore::CSSOMVariableReferenceValue::serialize const):
* Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp:
(WebCore::CSSMatrixComponent::serialize const):
* Source/WebCore/dom/FragmentDirectiveGenerator.cpp:
(WebCore::FragmentDirectiveGenerator::generateFragmentDirective):
* Source/WebCore/editing/FontShadow.cpp:
(WebCore::serializationForCSS):
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::InspectorOverlay::buildFlexOverlay):
* Source/WebCore/loader/ResourceLoadStatistics.cpp:
(WebCore::ResourceLoadStatistics::toString const):
* Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp:
(WebCore::MHTMLArchive::generateMHTMLData):
* Source/WebCore/platform/graphics/CodecUtilities.cpp:
(WebCore::humanReadableStringFromCodecString):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::SeekTarget::toString const):
* Source/WebCore/platform/graphics/VP9Utilities.cpp:
(WebCore::createVPCodecParametersString):
* Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp:
(WebCore::TextureMapperShaderProgram::create):
* Source/WebCore/platform/gtk/SelectionData.cpp:
(WebCore::SelectionData::setURL):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.cpp:
(WebCore::MediaRecorderPrivateMock::videoFrameAvailable):
(WebCore::MediaRecorderPrivateMock::audioSamplesAvailable):
* Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp:
(WebCore::cookiesForSession):
* Source/WebCore/platform/text/win/LocaleWin.cpp:
(WebCore::LocaleWin::shortTimeFormat):
(WebCore::LocaleWin::dateTimeFormatWithSeconds):
(WebCore::LocaleWin::dateTimeFormatWithoutSeconds):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::imageLastDecodingOptions):
(WebCore::Internals::dumpStyleResolvers):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):
(WGSL::Metal::FunctionDefinitionWriter::visit):
(WGSL::Metal::FunctionDefinitionWriter::generatePackingHelpers):
(WGSL::Metal::FunctionDefinitionWriter::emitPackedVector):
* Source/WebGPU/WGSL/Parser.cpp:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::donateToSKAdNetwork):
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
(WebKit::CacheStorageManager::representationString):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::cacheStorageRepresentation):

Canonical link: <a href="https://commits.webkit.org/278383@main">https://commits.webkit.org/278383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf28462686daf690c77f184735a446b27ef4ad25

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53615 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1046 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52659 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/694 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41074 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27313 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43346 "Found 1 new API test failure: TestWebKitAPI.HSTS.Preconnect (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22178 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24725 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/602 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8734 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43687 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46707 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55203 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49855 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25452 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/590 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48481 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-visibility-hidden-child.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26715 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/43527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47516 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27577 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57334 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7281 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26446 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11779 "Passed tests") | 
<!--EWS-Status-Bubble-End-->