### PR TITLE
[JSC] Profile String ArrayIndex access

### DIFF
--- a/JSTests/microbenchmarks/array-index-access-string.js
+++ b/JSTests/microbenchmarks/array-index-access-string.js
@@ -1,0 +1,11 @@
+function test(array, index) {
+    return array[index];
+}
+noInline(test);
+
+var array = [0, 1, 2, 3, 4, 5, 6, 7];
+
+for (var i = 0; i < 1e6; ++i) {
+    test(array, i & 7);
+    test(array, "0");
+}

--- a/Source/JavaScriptCore/bytecode/ArrayProfile.h
+++ b/Source/JavaScriptCore/bytecode/ArrayProfile.h
@@ -203,6 +203,8 @@ enum class ArrayProfileFlag : uint32_t {
     UsesNonOriginalArrayStructures = 1 << 4,
     MayBeResizableOrGrowableSharedTypedArray = 1 << 5,
     DidPerformFirstRunPruning = 1 << 6,
+    MayUseStringArrayIndex = 1 << 7,
+    MayUseStringNonArrayIndex = 1 << 8,
 };
 
 class ArrayProfile {
@@ -213,7 +215,13 @@ public:
 
     static constexpr uint64_t s_smallTypedArrayMaxLength = std::numeric_limits<int32_t>::max();
     void setMayBeLargeTypedArray() { m_arrayProfileFlags.add(ArrayProfileFlag::MayBeLargeTypedArray); }
-    bool mayBeLargeTypedArray(const ConcurrentJSLocker&) const { return m_arrayProfileFlags.contains(ArrayProfileFlag::MayBeLargeTypedArray); }
+    bool mayBeLargeTypedArray() const { return m_arrayProfileFlags.contains(ArrayProfileFlag::MayBeLargeTypedArray); }
+
+    void setMayUseStringArrayIndex() { m_arrayProfileFlags.add(ArrayProfileFlag::MayUseStringArrayIndex); }
+    bool mayUseStringArrayIndex() const { return m_arrayProfileFlags.contains(ArrayProfileFlag::MayUseStringArrayIndex); }
+
+    void setMayUseStringNonArrayIndex() { m_arrayProfileFlags.add(ArrayProfileFlag::MayUseStringNonArrayIndex); }
+    bool mayUseStringNonArrayIndex() const { return m_arrayProfileFlags.contains(ArrayProfileFlag::MayUseStringNonArrayIndex); }
 
     bool mayBeResizableOrGrowableSharedTypedArray(const ConcurrentJSLocker&) const { return m_arrayProfileFlags.contains(ArrayProfileFlag::MayBeResizableOrGrowableSharedTypedArray); }
 

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3007,6 +3007,28 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
     }
 
+    case StringToArrayIndex: {
+        JSValue childConst = forNode(node->child1()).value();
+        if (childConst) {
+            if (childConst.isString()) {
+                if (const StringImpl* string = asString(childConst)->tryGetValueImpl()) {
+                    if (auto index = parseIndex(*string)) {
+                        setConstant(node, jsNumber(*index));
+                        break;
+                    }
+                }
+            }
+            setConstant(node, childConst);
+            break;
+        }
+
+        if (forNode(node->child1()).m_type & SpecString)
+            setTypeForNode(node, forNode(node->child1()).m_type | SpecBytecodeNumber);
+        else
+            setForNode(node, forNode(node->child1()));
+        break;
+    }
+
     case ToNumber: {
         if (node->child1().useKind() == StringUse) {
             setNonCellTypeForNode(node, SpecBytecodeNumber);

--- a/Source/JavaScriptCore/dfg/DFGArrayMode.h
+++ b/Source/JavaScriptCore/dfg/DFGArrayMode.h
@@ -253,7 +253,7 @@ public:
 
         Array::Speculation speculation = speculationFromProfile(locker, profile, makeSafe);
 
-        bool mayBeLargeTypedArray = profile->mayBeLargeTypedArray(locker);
+        bool mayBeLargeTypedArray = profile->mayBeLargeTypedArray();
         bool mayBeResizableOrGrowableSharedTypedArray = profile->mayBeResizableOrGrowableSharedTypedArray(locker);
         return withArrayClassAndSpeculation(myArrayClass, speculation, mayBeLargeTypedArray, mayBeResizableOrGrowableSharedTypedArray);
     }

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -260,6 +260,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case GetExecutable:
     case BottomValue:
     case TypeOf:
+    case StringToArrayIndex:
         def(PureValue(node));
         return;
 

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -405,6 +405,7 @@ bool doesGC(Graph& graph, Node* node)
     case NewSymbol:
     case MakeRope:
     case MakeAtomString:
+    case StringToArrayIndex:
     case NewFunction:
     case NewGeneratorFunction:
     case NewAsyncGeneratorFunction:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1786,6 +1786,20 @@ private:
             break;
         }
 
+        case StringToArrayIndex: {
+            if (node->child1()->shouldSpeculateInt32()) {
+                fixEdge<Int32Use>(node->child1());
+                node->convertToIdentity();
+                break;
+            }
+            if (node->child1()->shouldSpeculateSymbol()) {
+                fixEdge<SymbolUse>(node->child1());
+                node->convertToIdentity();
+                break;
+            }
+            break;
+        }
+
         case ToNumber:
         case ToNumeric:
         case CallNumberConstructor: {

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -2026,6 +2026,28 @@ public:
         m_opInfo2 = prediction;
     }
 
+    bool hasAdditionalPrediction()
+    {
+        switch (op()) {
+        case StringToArrayIndex:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    SpeculatedType getAdditionalPrediction()
+    {
+        ASSERT(hasAdditionalPrediction());
+        return m_opInfo2.as<SpeculatedType>();
+    }
+
+    void setAdditionalPrediction(SpeculatedType prediction)
+    {
+        ASSERT(hasAdditionalPrediction());
+        m_opInfo2 = prediction;
+    }
+
     SpeculatedType getForcedPrediction()
     {
         ASSERT(op() == IdentityWithProfile);

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -469,6 +469,7 @@ namespace JSC { namespace DFG {
     macro(FunctionBind, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \
     macro(MakeRope, NodeResultJS) \
     macro(MakeAtomString, NodeResultJS) \
+    macro(StringToArrayIndex, NodeResultJS) \
     macro(InByVal, NodeResultBoolean | NodeMustGenerate) \
     macro(InByValMegamorphic, NodeResultBoolean | NodeMustGenerate) \
     macro(InById, NodeResultBoolean | NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -740,6 +740,13 @@ private:
             break;
         }
 
+        case StringToArrayIndex: {
+            SpeculatedType child = node->child1()->prediction();
+            if (child)
+                changed |= mergePrediction(resultOfToStringToArrayIndex(child, node->getAdditionalPrediction()));
+            break;
+        }
+
         case NormalizeMapKey: {
             SpeculatedType prediction = node->child1()->prediction();
             if (prediction)
@@ -1494,9 +1501,10 @@ private:
         case ArithAbs:
         case GetByVal:
         case ToThis:
-        case ToPrimitive: 
+        case ToPrimitive:
         case ToPropertyKey:
         case ToPropertyKeyOrNumber:
+        case StringToArrayIndex:
         case NormalizeMapKey:
         case AtomicsAdd:
         case AtomicsAnd:
@@ -1742,6 +1750,17 @@ private:
             return mergeSpeculations(type & SpecSymbol, SpecString);
 
         return SpecFullNumber | SpecString | SpecSymbol;
+    }
+
+    SpeculatedType resultOfToStringToArrayIndex(SpeculatedType type, SpeculatedType additionalPrediction)
+    {
+        if (additionalPrediction)
+            return additionalPrediction;
+
+        if (type & SpecString)
+            return type | SpecBytecodeNumber;
+
+        return type;
     }
 
     Vector<Node*> m_dependentNodes;

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -329,6 +329,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case GetWebAssemblyInstanceExports:
     case NumberIsNaN:
     case StringIndexOf:
+    case StringToArrayIndex:
         return true;
 
     case GlobalIsNaN:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1625,6 +1625,7 @@ public:
     void compileToPrimitive(Node*);
     void compileToPropertyKey(Node*);
     void compileToPropertyKeyOrNumber(Node*);
+    void compileStringToArrayIndex(Node*);
     void compileToNumeric(Node*);
     void compileCallNumberConstructor(Node*);
     void compileLogShadowChickenPrologue(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3073,6 +3073,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case StringToArrayIndex: {
+        compileStringToArrayIndex(node);
+        break;
+    }
+
     case ToNumber: {
         switch (node->child1().useKind()) {
         case StringUse: {

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -4222,6 +4222,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case StringToArrayIndex: {
+        compileStringToArrayIndex(node);
+        break;
+    }
+
     case ToNumber: {
         switch (node->child1().useKind()) {
         case StringUse: {

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -260,6 +260,7 @@ inline CapabilityLevel canCompile(Node* node)
     case ToPrimitive:
     case ToPropertyKey:
     case ToPropertyKeyOrNumber:
+    case StringToArrayIndex:
     case Throw:
     case ThrowStaticError:
     case Unreachable:

--- a/Source/JavaScriptCore/jit/JITOperations.h
+++ b/Source/JavaScriptCore/jit/JITOperations.h
@@ -384,6 +384,8 @@ JSC_DECLARE_JIT_OPERATION(operationResolveScopeForBaseline, EncodedJSValue, (JSG
 JSC_DECLARE_JIT_OPERATION(operationGetFromScope, EncodedJSValue, (JSGlobalObject*, const JSInstruction* bytecodePC));
 JSC_DECLARE_JIT_OPERATION(operationPutToScope, void, (JSGlobalObject*, const JSInstruction* bytecodePC));
 
+JSC_DECLARE_JIT_OPERATION(operationStringToArrayIndex, EncodedJSValue, (JSGlobalObject*, EncodedJSValue, ArrayProfile*));
+
 JSC_DECLARE_JIT_OPERATION(operationReallocateButterflyToHavePropertyStorageWithInitialCapacity, char*, (VM*, JSObject*));
 JSC_DECLARE_JIT_OPERATION(operationReallocateButterflyToGrowPropertyStorage, char*, (VM*, JSObject*, size_t newSize));
 

--- a/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
+++ b/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
@@ -60,8 +60,22 @@ void JIT::emit_op_get_by_val(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::GetByVal::profileGPR;
     using BaselineJITRegisters::GetByVal::scratch1GPR;
 
+    if (bytecode.metadata(m_profiledCodeBlock).m_arrayProfile.mayUseStringArrayIndex()) {
+        emitGetVirtualRegister(property, propertyJSR);
+        JumpList skipCases;
+        skipCases.append(branchIfNotCell(propertyJSR));
+        skipCases.append(branchIfNotString(propertyJSR.payloadGPR()));
+        constexpr GPRReg globalObjectGPR = preferredArgumentGPR<decltype(operationStringToArrayIndex), 0>();
+        constexpr GPRReg arrayProfileGPR = preferredArgumentGPR<decltype(operationStringToArrayIndex), 2>();
+        static_assert(noOverlap(globalObjectGPR, arrayProfileGPR, propertyJSR));
+        loadGlobalObject(globalObjectGPR);
+        materializePointerIntoMetadata(bytecode, OpGetByVal::Metadata::offsetOfArrayProfile(), arrayProfileGPR);
+        callOperation(operationStringToArrayIndex, globalObjectGPR, propertyJSR, arrayProfileGPR);
+        moveValueRegs(JSRInfo::returnValueJSR, propertyJSR);
+        skipCases.link(this);
+    } else
+        emitGetVirtualRegister(property, propertyJSR);
     emitGetVirtualRegister(base, baseJSR);
-    emitGetVirtualRegister(property, propertyJSR);
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadStructureStubInfo(stubInfoIndex, stubInfoGPR);
@@ -241,8 +255,22 @@ void JIT::emit_op_put_by_val(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::PutByVal::stubInfoGPR;
     using BaselineJITRegisters::PutByVal::scratch1GPR;
 
+    if (bytecode.metadata(m_profiledCodeBlock).m_arrayProfile.mayUseStringArrayIndex()) {
+        emitGetVirtualRegister(property, propertyJSR);
+        JumpList skipCases;
+        skipCases.append(branchIfNotCell(propertyJSR));
+        skipCases.append(branchIfNotString(propertyJSR.payloadGPR()));
+        constexpr GPRReg globalObjectGPR = preferredArgumentGPR<decltype(operationStringToArrayIndex), 0>();
+        constexpr GPRReg arrayProfileGPR = preferredArgumentGPR<decltype(operationStringToArrayIndex), 2>();
+        static_assert(noOverlap(globalObjectGPR, arrayProfileGPR, propertyJSR));
+        loadGlobalObject(globalObjectGPR);
+        materializePointerIntoMetadata(bytecode, OpGetByVal::Metadata::offsetOfArrayProfile(), arrayProfileGPR);
+        callOperation(operationStringToArrayIndex, globalObjectGPR, propertyJSR, arrayProfileGPR);
+        moveValueRegs(JSRInfo::returnValueJSR, propertyJSR);
+        skipCases.link(this);
+    } else
+        emitGetVirtualRegister(property, propertyJSR);
     emitGetVirtualRegister(base, baseJSR);
-    emitGetVirtualRegister(property, propertyJSR);
     emitGetVirtualRegister(value, valueJSR);
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
@@ -832,8 +860,22 @@ void JIT::emit_op_in_by_val(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::InByVal::profileGPR;
     using BaselineJITRegisters::InByVal::scratch1GPR;
 
+    if (bytecode.metadata(m_profiledCodeBlock).m_arrayProfile.mayUseStringArrayIndex()) {
+        emitGetVirtualRegister(property, propertyJSR);
+        JumpList skipCases;
+        skipCases.append(branchIfNotCell(propertyJSR));
+        skipCases.append(branchIfNotString(propertyJSR.payloadGPR()));
+        constexpr GPRReg globalObjectGPR = preferredArgumentGPR<decltype(operationStringToArrayIndex), 0>();
+        constexpr GPRReg arrayProfileGPR = preferredArgumentGPR<decltype(operationStringToArrayIndex), 2>();
+        static_assert(noOverlap(globalObjectGPR, arrayProfileGPR, propertyJSR));
+        loadGlobalObject(globalObjectGPR);
+        materializePointerIntoMetadata(bytecode, OpGetByVal::Metadata::offsetOfArrayProfile(), arrayProfileGPR);
+        callOperation(operationStringToArrayIndex, globalObjectGPR, propertyJSR, arrayProfileGPR);
+        moveValueRegs(JSRInfo::returnValueJSR, propertyJSR);
+        skipCases.link(this);
+    } else
+        emitGetVirtualRegister(property, propertyJSR);
     emitGetVirtualRegister(base, baseJSR);
-    emitGetVirtualRegister(property, propertyJSR);
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadStructureStubInfo(stubInfoIndex, stubInfoGPR);
@@ -1645,8 +1687,22 @@ void JIT::emit_op_get_by_val_with_this(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::GetByValWithThis::profileGPR;
     using BaselineJITRegisters::GetByValWithThis::scratch1GPR;
 
+    if (bytecode.metadata(m_profiledCodeBlock).m_arrayProfile.mayUseStringArrayIndex()) {
+        emitGetVirtualRegister(property, propertyJSR);
+        JumpList skipCases;
+        skipCases.append(branchIfNotCell(propertyJSR));
+        skipCases.append(branchIfNotString(propertyJSR.payloadGPR()));
+        constexpr GPRReg globalObjectGPR = preferredArgumentGPR<decltype(operationStringToArrayIndex), 0>();
+        constexpr GPRReg arrayProfileGPR = preferredArgumentGPR<decltype(operationStringToArrayIndex), 2>();
+        static_assert(noOverlap(globalObjectGPR, arrayProfileGPR, propertyJSR));
+        loadGlobalObject(globalObjectGPR);
+        materializePointerIntoMetadata(bytecode, OpGetByVal::Metadata::offsetOfArrayProfile(), arrayProfileGPR);
+        callOperation(operationStringToArrayIndex, globalObjectGPR, propertyJSR, arrayProfileGPR);
+        moveValueRegs(JSRInfo::returnValueJSR, propertyJSR);
+        skipCases.link(this);
+    } else
+        emitGetVirtualRegister(property, propertyJSR);
     emitGetVirtualRegister(base, baseJSR);
-    emitGetVirtualRegister(property, propertyJSR);
     emitGetVirtualRegister(thisValue, thisJSR);
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
@@ -1146,6 +1146,7 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_get_by_val_with_this)
     BEGIN();
 
     auto bytecode = pc->as<OpGetByValWithThis>();
+    auto& metadata = bytecode.metadata(codeBlock);
     JSValue baseValue = GET_C(bytecode.m_base).jsValue();
     JSValue thisValue = GET_C(bytecode.m_thisValue).jsValue();
     JSValue subscript = GET_C(bytecode.m_property).jsValue();
@@ -1174,6 +1175,12 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_get_by_val_with_this)
     baseValue.requireObjectCoercible(globalObject);
     CHECK_EXCEPTION();
     auto property = subscript.toPropertyKey(globalObject);
+
+    if (subscript.isString()) {
+        if (auto index = parseIndex(property))
+            metadata.m_arrayProfile.setMayUseStringArrayIndex();
+    }
+
     CHECK_EXCEPTION();
     RETURN_PROFILED(baseValue.get(globalObject, property, slot));
 }

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.h
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.h
@@ -117,6 +117,16 @@ inline bool opInByVal(JSGlobalObject* globalObject, JSValue baseVal, JSValue pro
 
     auto property = propName.toPropertyKey(globalObject);
     RETURN_IF_EXCEPTION(scope, false);
+
+    if (propName.isString()) {
+        if (auto index = parseIndex(property)) {
+            if (arrayProfile)
+                arrayProfile->setMayUseStringArrayIndex();
+            RELEASE_AND_RETURN(scope, baseObj->hasProperty(globalObject, *index));
+        }
+    }
+
+
     RELEASE_AND_RETURN(scope, baseObj->hasProperty(globalObject, property));
 }
 

--- a/Source/JavaScriptCore/runtime/Identifier.h
+++ b/Source/JavaScriptCore/runtime/Identifier.h
@@ -78,7 +78,7 @@ ALWAYS_INLINE std::optional<uint32_t> parseIndex(std::span<const CharType> chara
     return value;
 }
 
-ALWAYS_INLINE std::optional<uint32_t> parseIndex(StringImpl& impl)
+ALWAYS_INLINE std::optional<uint32_t> parseIndex(const StringImpl& impl)
 {
     return impl.is8Bit() ? parseIndex(impl.span8()) : parseIndex(impl.span16());
 }


### PR DESCRIPTION
#### fdd6b03d048362674aa32ed53d3d46433091e738
<pre>
[JSC] Profile String ArrayIndex access
<a href="https://bugs.webkit.org/show_bug.cgi?id=273730">https://bugs.webkit.org/show_bug.cgi?id=273730</a>
<a href="https://rdar.apple.com/127534769">rdar://127534769</a>

Reviewed by NOBODY (OOPS!).

WIP

* JSTests/microbenchmarks/array-index-access-string.js: Added.
(test):
* Source/JavaScriptCore/bytecode/ArrayProfile.h:
(JSC::ArrayProfile::mayBeLargeTypedArray const):
(JSC::ArrayProfile::setMayUseStringArrayIndex):
(JSC::ArrayProfile::mayUseStringArrayIndex const):
* Source/JavaScriptCore/dfg/DFGArrayMode.h:
(JSC::DFG::ArrayMode::withProfile const):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::JSC_DEFINE_JIT_OPERATION):
(JSC::putByValOptimize):
(JSC::directPutByValOptimize):
(JSC::deleteByValOptimize):
* Source/JavaScriptCore/jit/JITOperations.h:
* Source/JavaScriptCore/jit/JITPropertyAccess.cpp:
(JSC::JIT::emit_op_get_by_val):
(JSC::JIT::emit_op_put_by_val):
(JSC::JIT::emit_op_in_by_val):
(JSC::JIT::emit_op_get_by_val_with_this):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::getByVal):
(JSC::LLInt::LLINT_SLOW_PATH_DECL):
* Source/JavaScriptCore/runtime/CommonSlowPaths.cpp:
(JSC::JSC_DEFINE_COMMON_SLOW_PATH):
* Source/JavaScriptCore/runtime/CommonSlowPaths.h:
(JSC::CommonSlowPaths::opInByVal):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a48b9423ba406bcffe90648dd13863bed7e9192

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2661 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53621 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1052 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/700 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41080 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43353 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22184 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24732 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/608 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8740 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43694 "Found 19 new JSC stress test failures: stress/array-concat-spread-proxy-exception-check.js.bytecode-cache, stress/array-concat-spread-proxy-exception-check.js.default, stress/array-concat-spread-proxy-exception-check.js.ftl-eager, stress/array-concat-spread-proxy-exception-check.js.ftl-no-cjit-b3o0, stress/array-concat-spread-proxy-exception-check.js.ftl-no-cjit-no-put-stack-validate, stress/array-concat-spread-proxy-exception-check.js.ftl-no-cjit-small-pool, stress/array-concat-spread-proxy-exception-check.js.ftl-no-cjit-validate-sampling-profiler, stress/array-concat-spread-proxy.js.bytecode-cache, stress/array-concat-spread-proxy.js.default, stress/array-concat-spread-proxy.js.ftl-eager ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46714 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/671 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55209 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49861 "Found 18 new JSC stress test failures: stress/array-concat-spread-proxy-exception-check.js.bytecode-cache, stress/array-concat-spread-proxy-exception-check.js.default, stress/array-concat-spread-proxy-exception-check.js.ftl-no-cjit-b3o0, stress/array-concat-spread-proxy-exception-check.js.ftl-no-cjit-no-put-stack-validate, stress/array-concat-spread-proxy-exception-check.js.ftl-no-cjit-small-pool, stress/array-concat-spread-proxy-exception-check.js.ftl-no-cjit-validate-sampling-profiler, stress/array-concat-spread-proxy.js.bytecode-cache, stress/array-concat-spread-proxy.js.default, stress/array-concat-spread-proxy.js.ftl-eager, stress/array-concat-spread-proxy.js.ftl-no-cjit-b3o0 ... (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25459 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/597 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48487 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26721 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47523 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27583 "Built successfully") | | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57340 "Hash 8a48b942 for PR 28143 does not build (failure)") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26453 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/57340 "Hash 8a48b942 for PR 28143 does not build (failure)") | 
<!--EWS-Status-Bubble-End-->