### PR TITLE
REGRESSION (277924@main): nullptr deref crash calling XSLTProcessor.transformToFragment() before parsing XML

### DIFF
--- a/LayoutTests/fast/xsl/xslt-transform-to-fragment-no-xml-parsing-crash-expected.txt
+++ b/LayoutTests/fast/xsl/xslt-transform-to-fragment-no-xml-parsing-crash-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: Did not parse external entity resource at '' because cross-origin loads are not allowed.
+CONSOLE MESSAGE: Start tag expected, '<' not found
+
+PASS if no crash

--- a/LayoutTests/fast/xsl/xslt-transform-to-fragment-no-xml-parsing-crash.html
+++ b/LayoutTests/fast/xsl/xslt-transform-to-fragment-no-xml-parsing-crash.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html><!-- webkit-test-runner [ runSingly=true ] -->
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+function test()
+{
+    processor = new XSLTProcessor();
+    docType = document.implementation.createDocumentType("xml:test", "-//test//Test 1.0//EN", "M/");
+    processor.importStylesheet(docType);
+    processor.transformToFragment(node1, document);
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+</head>
+<body onload="test()">
+<span id="node1">PASS if no crash</span>
+</body>
+</html>

--- a/LayoutTests/platform/glib/fast/xsl/xslt-transform-to-fragment-no-xml-parsing-crash-expected.txt
+++ b/LayoutTests/platform/glib/fast/xsl/xslt-transform-to-fragment-no-xml-parsing-crash-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: Document is empty
+
+CONSOLE MESSAGE: Did not parse external entity resource at '' because cross-origin loads are not allowed.
+CONSOLE MESSAGE: Start tag expected, '<' not found
+
+PASS if no crash

--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -193,6 +193,7 @@ xmlDocPtr xmlDocPtrForString(CachedResourceLoader&, const String& source, const 
 #endif
 
 xmlParserInputPtr externalEntityLoader(const char* url, const char* id, xmlParserCtxtPtr);
+void initializeXMLParser();
 
 std::optional<HashMap<String, String>> parseAttributes(CachedResourceLoader&, const String&);
 

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -553,10 +553,11 @@ xmlParserInputPtr externalEntityLoader(const char* url, const char* id, xmlParse
 {
     if (!shouldAllowExternalLoad(URL(String::fromUTF8(url))))
         return nullptr;
+    RELEASE_ASSERT_WITH_MESSAGE(!!defaultEntityLoader, "Missing call to initializeXMLParser()");
     return defaultEntityLoader(url, id, context);
 }
 
-static void initializeXMLParser()
+void initializeXMLParser()
 {
     static std::once_flag flag;
     std::call_once(flag, [&] {

--- a/Source/WebCore/xml/parser/XMLDocumentParserScope.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserScope.cpp
@@ -45,8 +45,9 @@ XMLDocumentParserScope::XMLDocumentParserScope(CachedResourceLoader* cachedResou
 #else
 XMLDocumentParserScope::XMLDocumentParserScope(CachedResourceLoader* cachedResourceLoader)
     : m_oldCachedResourceLoader(currentCachedResourceLoader())
-    , m_oldEntityLoader(xmlGetExternalEntityLoader())
 {
+    initializeXMLParser();
+    m_oldEntityLoader = xmlGetExternalEntityLoader();
     currentCachedResourceLoader() = cachedResourceLoader;
     xmlSetExternalEntityLoader(WebCore::externalEntityLoader);
 }
@@ -55,11 +56,12 @@ XMLDocumentParserScope::XMLDocumentParserScope(CachedResourceLoader* cachedResou
 #if ENABLE(XSLT)
 XMLDocumentParserScope::XMLDocumentParserScope(CachedResourceLoader* cachedResourceLoader, xmlGenericErrorFunc genericErrorFunc, xmlStructuredErrorFunc structuredErrorFunc, void* errorContext)
     : m_oldCachedResourceLoader(currentCachedResourceLoader())
-    , m_oldEntityLoader(xmlGetExternalEntityLoader())
     , m_oldGenericErrorFunc(xmlGenericError)
     , m_oldStructuredErrorFunc(xmlStructuredError)
     , m_oldErrorContext(xmlGenericErrorContext)
 {
+    initializeXMLParser();
+    m_oldEntityLoader = xmlGetExternalEntityLoader();
     currentCachedResourceLoader() = cachedResourceLoader;
     xmlSetExternalEntityLoader(WebCore::externalEntityLoader);
     if (genericErrorFunc)


### PR DESCRIPTION
#### cbbffdafe0a9f188e1f87fdb4d528b0f153b2aa3
<pre>
REGRESSION (277924@main): nullptr deref crash calling XSLTProcessor.transformToFragment() before parsing XML
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=273735">https://bugs.webkit.org/show_bug.cgi?id=273735</a>&gt;
&lt;<a href="https://rdar.apple.com/127496002">rdar://127496002</a>&gt;

Reviewed by Alex Christensen.

If docLoaderFunc() in XSLTProcessorLibxslt.cpp was called before an XML
document was parsed, the WebCore::defaultEntityLoader global would not
be initialized, which could result in a nullptr dereference crash.

The fix is to call initializeXMLParser() in XMLDocumentParserScope()
constructors since there are cases where XMLDocumentParserScope is used
but XMLParserContext (the only place where initializeXMLParser() was
called previously) is not.

Test:  fast/xsl/xslt-transform-to-fragment-no-xml-parsing-crash.html

* LayoutTests/fast/xsl/xslt-transform-to-fragment-no-xml-parsing-crash-expected.txt: Add.
* LayoutTests/fast/xsl/xslt-transform-to-fragment-no-xml-parsing-crash.html: Add.
- Test is marked &quot;runSingly=true&quot; since parsing any XML content before
  running the test avoids the crash.
* LayoutTests/platform/glib/fast/xsl/xslt-transform-to-fragment-no-xml-parsing-crash-expected.txt: Add.
- Platform-specific results for GTK and WPE ports.

* Source/WebCore/xml/parser/XMLDocumentParser.h:
(WebCore::initializeXMLParser): Add declaration.
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::externalEntityLoader):
- Add RELEASE_ASSERT() for the cause of the original crash.
(WebCore::initializeXMLParser):
- Remove static keyword so this can be called from
  XMLDocumentParserScope() constructors.
* Source/WebCore/xml/parser/XMLDocumentParserScope.cpp:
(WebCore::XMLDocumentParserScope::XMLDocumentParserScope):
- Call initializeXMLParser() from constructors before setting
  m_oldEntityLoader.

Canonical link: <a href="https://commits.webkit.org/278419@main">https://commits.webkit.org/278419@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37eccf4acffd8ad842b6f3456c6f996c80fbd67a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53736 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1167 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52780 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/817 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41175 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52576 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/27432 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43459 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22280 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/24841 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/718 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8855 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46822 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/779 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55325 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25575 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/701 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48578 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26836 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47623 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27700 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7306 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26568 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | 
<!--EWS-Status-Bubble-End-->