### PR TITLE
Tweak InlineItemsBuilder more

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/InlineItem.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItem.h
@@ -118,3 +118,13 @@ SPECIALIZE_TYPE_TRAITS_END()
 
 }
 }
+
+namespace WTF {
+
+template<>
+struct VectorTraits<WebCore::Layout::InlineItem> : public VectorTraitsBase<false, void> {
+    static constexpr bool canCopyWithMemcpy = true;
+    static constexpr bool canMoveWithMemcpy = true;
+};
+
+}

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.h
@@ -47,7 +47,7 @@ public:
 
 private:
     void collectInlineItems(InlineItemList&, InlineItemPosition startPosition);
-    using LayoutQueue = Vector<CheckedRef<const Box>>;
+    using LayoutQueue = Vector<CheckedRef<const Box>, 8>;
     LayoutQueue initializeLayoutQueue(InlineItemPosition startPosition);
     LayoutQueue traverseUntilDamaged(const Box& firstDamagedLayoutBox);
     void breakAndComputeBidiLevels(InlineItemList&);

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -437,9 +438,29 @@ TextBreakIterator::ContentAnalysis TextUtil::contentAnalysis(WordBreak wordBreak
     return TextBreakIterator::ContentAnalysis::Mechanical;
 }
 
+// True if the character may need the Bidi reordering. If false, the
+// `Bidi_Class` of `ch` isn't `R`, `AL`, nor Bidi controls.
+// https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%5B%3Abc%3DR%3A%5D%5B%3Abc%3DAL%3A%5D%5D&g=bc
+// https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=[:Bidi_C:]
+static ALWAYS_INLINE bool mayBeBidiRTL(char32_t ch)
+{
+    if (ch < 0x0590)
+        return false;
+    // General Punctuation such as curly quotes.
+    if (ch >= 0x2010 && ch <= 0x2029)
+        return false;
+    // CJK etc., up to Surrogate Pairs.
+    if (ch >= 0x206A && ch <= 0xD7FF)
+        return false;
+    // Common in CJK.
+    if (ch >= 0xFF00 && ch <= 0xFFFF)
+        return false;
+    return true;
+}
+
 bool TextUtil::isStrongDirectionalityCharacter(char32_t character)
 {
-    if (isLatin1(character))
+    if (!mayBeBidiRTL(character))
         return false;
 
     auto bidiCategory = u_charDirection(character);
@@ -455,6 +476,9 @@ bool TextUtil::isStrongDirectionalityCharacter(char32_t character)
 bool TextUtil::containsStrongDirectionalityText(StringView text)
 {
     if (text.is8Bit())
+        return false;
+
+    if (text.containsOnly<[](UChar character) ALWAYS_INLINE_LAMBDA { return !mayBeBidiRTL(character); }>())
         return false;
 
     for (char32_t character : text.codePoints()) {


### PR DESCRIPTION
#### 59eb1ee2b4c65f256049f5a0afc651bb25d3c962
<pre>
Tweak InlineItemsBuilder more
<a href="https://bugs.webkit.org/show_bug.cgi?id=273744">https://bugs.webkit.org/show_bug.cgi?id=273744</a>
<a href="https://rdar.apple.com/127564214">rdar://127564214</a>

Reviewed by Alan Baradlay.

Optimize InlineItemsBuilder further.

1. Integrage blink&apos;s mayBeBidiRTL for isStrongDirectionalityCharacter, which returns false-positive answer about Bidi quickly.
2. Attach inline capacity to LayoutQueue.
3. Define VectorTraits for Layout::InlineItem.
4. Clean up buildInlineItemListForTextFromBreakingPositionsCache&apos;s frequent vector access. We can just use std::span and iteration.
5. Clean up populateBreakingPositionCache. TextBreakingPositionCache::List should have reserveInitialCapacity with the quickly scanned std::span.

* Source/WebCore/layout/formattingContexts/inline/InlineItem.h:
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::buildInlineItemListForTextFromBreakingPositionsCache):
(WebCore::Layout::InlineItemsBuilder::populateBreakingPositionCache):
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.h:
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::containsStrongDirectionalityText):

Canonical link: <a href="https://commits.webkit.org/278396@main">https://commits.webkit.org/278396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e439a6922aa14c2ef4d637443681d492f360486

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53666 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1097 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35943 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/747 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41114 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43392 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22218 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24777 "4 new passes 4 flakes") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/649 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8785 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46756 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/711 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55255 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25505 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/639 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48518 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26766 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43560 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47556 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27628 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7287 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26498 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->