### PR TITLE
[GCC] Unreviewed, build fix for Debian 11 after 278358@main

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMConvertUnion.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertUnion.h
@@ -217,7 +217,7 @@ template<typename... T> struct Converter<IDLUnion<T...>> : DefaultConverter<IDLU
         //         (FIXME: Add support for object and step 4.2)
         if (brigand::any<TypeList, IsIDLInterface<brigand::_1>>::value) {
             std::optional<ReturnType> returnValue;
-            forEach<InterfaceTypeList>([&]<typename Type> {
+            forEach<InterfaceTypeList>([&]<typename Type>() {
                 if (returnValue)
                     return;
                 
@@ -289,7 +289,7 @@ template<typename... T> struct Converter<IDLUnion<T...>> : DefaultConverter<IDLU
         constexpr bool hasTypedArrayType = brigand::any<TypeList, IsIDLTypedArray<brigand::_1>>::value;
         if (hasTypedArrayType) {
             std::optional<ReturnType> returnValue;
-            forEach<TypedArrayTypeList>([&]<typename Type> {
+            forEach<TypedArrayTypeList>([&]<typename Type>() {
                 if (returnValue)
                     return;
 
@@ -415,7 +415,7 @@ template<typename... T> struct JSConverter<IDLUnion<T...>> {
         auto index = variant.index();
 
         std::optional<JSC::JSValue> returnValue;
-        forEach<Sequence>([&]<typename I> {
+        forEach<Sequence>([&]<typename I>() {
             if (I::value == index) {
                 ASSERT(!returnValue);
                 returnValue = toJS<brigand::at<TypeList, I>>(lexicalGlobalObject, globalObject, std::get<I::value>(variant));

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp
@@ -614,7 +614,7 @@ static Color parseColorFunctionParametersRaw(CSSParserTokenRange& range, ColorPa
         if (!originColor.isValid())
             return { };
 
-        return callWithColorFunction(args.peek().id(), [&]<typename Descriptor> {
+        return callWithColorFunction(args.peek().id(), [&]<typename Descriptor>() {
             consumeIdentRaw(args);
 
             return parseGenericRelativeFunctionParametersRaw<Descriptor>(args, state, WTFMove(originColor));

--- a/Source/WebCore/platform/graphics/ColorConversion.cpp
+++ b/Source/WebCore/platform/graphics/ColorConversion.cpp
@@ -365,9 +365,9 @@ OKLab<float> ColorConversion<OKLab<float>, OKLCHA<float>>::convert(const OKLCHA<
 
 ColorComponents<float, 4> convertAndResolveColorComponents(ColorSpace inputColorSpace, ColorComponents<float, 4> inputColorComponents, ColorSpace outputColorSpace)
 {
-    return callWithColorType<float>(inputColorSpace, [&]<typename InputColorType> {
+    return callWithColorType<float>(inputColorSpace, [&]<typename InputColorType>() {
         auto inputColor = makeFromComponents<InputColorType>(inputColorComponents);
-        return callWithColorType<float>(outputColorSpace, [&]<typename OutputColorType> {
+        return callWithColorType<float>(outputColorSpace, [&]<typename OutputColorType>() {
             return asColorComponents(convertColor<OutputColorType>(inputColor).resolved());
         });
     });

--- a/Source/WebCore/platform/graphics/ColorSpace.h
+++ b/Source/WebCore/platform/graphics/ColorSpace.h
@@ -133,7 +133,7 @@ template<typename T, typename Functor> constexpr decltype(auto) callWithColorTyp
 
 template<typename T, typename Functor> constexpr decltype(auto) callWithColorType(const ColorComponents<T, 4>& components, ColorSpace colorSpace, Functor&& functor)
 {
-    return callWithColorType<T>(colorSpace, [&]<typename ColorType> {
+    return callWithColorType<T>(colorSpace, [&]<typename ColorType>() {
         return std::invoke(std::forward<Functor>(functor), makeFromComponents<ColorType>(components));
     });
 }


### PR DESCRIPTION
#### ab7b68fdc2666ed2d2b77c62fbd0de85cf3591db
<pre>
[GCC] Unreviewed, build fix for Debian 11 after 278358@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=273694">https://bugs.webkit.org/show_bug.cgi?id=273694</a>

In GCC10, templated lambdas require empty arguments.

* Source/WebCore/bindings/js/JSDOMConvertUnion.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp:
(WebCore::CSSPropertyParserHelpers::parseColorFunctionParametersRaw):
* Source/WebCore/platform/graphics/ColorConversion.cpp:
(WebCore::convertAndResolveColorComponents):
* Source/WebCore/platform/graphics/ColorSpace.h:
(WebCore::callWithColorType):

Canonical link: <a href="https://commits.webkit.org/278386@main">https://commits.webkit.org/278386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d59cc3105b278131395714b7deed0c709fe7b18

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53625 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1056 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52669 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/706 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41084 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27326 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43357 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22188 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24739 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/613 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8744 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46720 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/676 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55213 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25464 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/601 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48490 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26725 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43536 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47528 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27587 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7283 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26457 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->