### PR TITLE
[JSC] Remove tests for Symbols as WeakMap keys from test262 skipped files

### DIFF
--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -884,14 +884,5 @@ skip:
     - test/built-ins/Temporal/PlainTime/prototype/until/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-out-of-range.js
     - test/built-ins/Temporal/PlainTime/prototype/until/argument-zoneddatetime-timezone-getoffsetnanosecondsfor-wrong-type.js
 
-    # Symbols as WeakMap keys proposal breaks existing tests https://github.com/tc39/proposal-symbols-as-weakmap-keys
-    - test/built-ins/WeakMap/prototype/set/key-not-object-throw.js
-    - test/built-ins/WeakSet/symbol-disallowed-as-weakset-key.js
-    - test/built-ins/WeakSet/prototype/add/value-not-object-throw.js
-    - test/built-ins/WeakRef/target-not-object-throws.js
-    - test/built-ins/FinalizationRegistry/prototype/unregister/unregisterToken-not-object-throws.js
-    - test/built-ins/FinalizationRegistry/prototype/register/target-not-object-throws.js
-    - test/built-ins/FinalizationRegistry/prototype/register/unregisterToken-not-object-or-undefined-throws.js
-
     # Skip while https://bugs.webkit.org/show_bug.cgi?id=249330 is being investigated
     - test/built-ins/RegExp/named-groups/lookbehind.js


### PR DESCRIPTION
#### efd0a42fa49fc049175471e9241dcd23390877b0
<pre>
[JSC] Remove tests for Symbols as WeakMap keys from test262 skipped files
<a href="https://bugs.webkit.org/show_bug.cgi?id=273746">https://bugs.webkit.org/show_bug.cgi?id=273746</a>

Reviewed by Yusuke Suzuki.

We had been skipping several test262 test cases that were broken due to the implementation of the
Symbols as WeakMap keys proposal[1]. However, those tests have been fixed or removed in
tc39/test262#3678[2].

This patch removes those tests from the skipped files.

[1]: <a href="https://github.com/tc39/proposal-symbols-as-weakmap-keys">https://github.com/tc39/proposal-symbols-as-weakmap-keys</a>
[2]: <a href="https://github.com/tc39/test262/pull/3678">https://github.com/tc39/test262/pull/3678</a>

* JSTests/test262/config.yaml:

Canonical link: <a href="https://commits.webkit.org/278395@main">https://commits.webkit.org/278395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b2aef61f932dcd24ae16146873e9e23faee9468

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53632 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1063 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/713 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41089 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43363 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22193 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24746 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8751 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43705 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46726 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55220 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49872 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25471 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/608 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48496 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26732 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43542 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47534 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27594 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57351 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7286 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26464 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11781 "Passed tests") | 
<!--EWS-Status-Bubble-End-->