### PR TITLE
Letters disappear randomly while typing in Stash when writing suggestions are enabled

### DIFF
--- a/LayoutTests/editing/input/mac/do-not-allow-inline-predictions-if-text-changes-expected-mismatch.html
+++ b/LayoutTests/editing/input/mac/do-not-allow-inline-predictions-if-text-changes-expected-mismatch.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+[contenteditable] {
+    font-size: 16px;
+    width: 300px;
+    height: 100px;
+    caret-color: transparent;
+}
+</style>
+</head>
+<body>
+<div contenteditable></div>
+<script>
+let editor = document.querySelector("[contenteditable]");
+if (window.testRunner)
+    testRunner.waitUntilDone();
+addEventListener("load", async () => {
+    editor.focus();
+    if (!window.testRunner)
+        return;
+
+    for (let character of [..."I want to celeb"]) {
+        await UIHelper.typeCharacter(character);
+        await UIHelper.ensurePresentationUpdate();
+    }
+    await UIHelper.setInlinePrediction("celebrate", 5);
+    await UIHelper.ensurePresentationUpdate();
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/input/mac/do-not-allow-inline-predictions-if-text-changes.html
+++ b/LayoutTests/editing/input/mac/do-not-allow-inline-predictions-if-text-changes.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+[contenteditable] {
+    font-size: 16px;
+    width: 300px;
+    height: 100px;
+    caret-color: transparent;
+}
+</style>
+</head>
+<body>
+<div contenteditable></div>
+<script>
+let editor = document.querySelector("[contenteditable]");
+if (window.testRunner)
+    testRunner.waitUntilDone();
+addEventListener("load", async () => {
+    editor.focus();
+    if (!window.testRunner)
+        return;
+
+    for (let character of [..."I want to celeb"]) {
+        await UIHelper.typeCharacter(character);
+        await UIHelper.ensurePresentationUpdate();
+    }
+    await UIHelper.setInlinePrediction("celebrate", 5);
+    await UIHelper.ensurePresentationUpdate();
+    testRunner.notifyDone();
+});
+
+let typedText = "";
+editor.addEventListener("keydown", event => {
+    if (event.key.length > 1)
+        return;
+
+    typedText += event.key === " " ? "\xa0" : event.key;
+    setTimeout(() => {
+        for (let childNode of [...editor.childNodes])
+            childNode.remove();
+        const newText = document.createTextNode(typedText);
+        editor.appendChild(newText);
+        getSelection().setPosition(newText, newText.length);
+    });
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1909,6 +1909,7 @@ webkit.org/b/272685 [ Ventura+ x86_64 ] imported/w3c/web-platform-tests/svg/pain
 # Inline predictions are only supported on Sonoma and later.
 [ Monterey Ventura ] editing/input/mac/show-inline-prediction-with-adjacent-text.html [ Skip ]
 [ Monterey Ventura ] editing/input/mac/writing-suggestions-textarea-multiple-lines.html [ Skip ]
+[ Monterey Ventura ] editing/input/mac/do-not-allow-inline-predictions-if-text-changes.html [ Skip ]
 
 webkit.org/b/273012 [ Ventura+ x86_64 ] imported/w3c/web-platform-tests/svg/painting/reftests/percentage.svg [ ImageOnlyFailure ]
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3098,19 +3098,6 @@ InlineMediaPlaybackRequiresPlaysInlineAttribute:
     WebCore:
       default: false
 
-InlinePredictionsInAllEditableElementsEnabled:
-  type: bool
-  status: internal
-  humanReadableName: "Inline Text Predictions"
-  humanReadableDescription: "Enable Inline Text Predictions in all editable elements"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
-
 InputTypeColorEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -611,7 +611,7 @@ public:
     bool isPastingFromMenuOrKeyBinding() const { return m_pastingFromMenuOrKeyBinding; }
     bool isCopyingFromMenuOrKeyBinding() const { return m_copyingFromMenuOrKeyBinding; }
 
-    Node* nodeBeforeWritingSuggestions() const;
+    WEBCORE_EXPORT Node* nodeBeforeWritingSuggestions() const;
     Element* writingSuggestionsContainerElement() const;
     WritingSuggestionData* writingSuggestionData() const { return m_writingSuggestionData.get(); }
     bool isInsertingTextForWritingSuggestion() const { return m_isInsertingTextForWritingSuggestion; }

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -696,6 +696,9 @@ bool VisibleSelection::isInPasswordField() const
 
 bool VisibleSelection::canEnableWritingSuggestions() const
 {
+    if (RefPtr formControl = enclosingTextFormControl(start()))
+        return formControl->isWritingSuggestionsEnabled();
+
     RefPtr containerNode = start().containerNode();
     if (!containerNode)
         return false;

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h
@@ -34,6 +34,7 @@
 
 @property (nonatomic, readonly) BOOL _hasActiveVideoForControlsManager;
 @property (nonatomic, readonly) BOOL _shouldRequestCandidates;
+@property (nonatomic, readonly) BOOL _allowsInlinePredictions;
 @property (nonatomic, readonly) NSMenu *_activeMenu;
 
 - (void)_requestControlledElementID;

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm
@@ -75,6 +75,15 @@
     return _impl->shouldRequestCandidates();
 }
 
+- (BOOL)_allowsInlinePredictions
+{
+#if HAVE(INLINE_PREDICTIONS)
+    return _impl->allowsInlinePredictions();
+#else
+    return NO;
+#endif
+}
+
 - (void)_insertText:(id)string replacementRange:(NSRange)replacementRange
 {
     [self insertText:string replacementRange:replacementRange];

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -746,6 +746,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     void removeTextIndicatorStyleForID(WTF::UUID);
 #endif
 
+#if HAVE(INLINE_PREDICTIONS)
+    bool allowsInlinePredictions() const;
+#endif
+
 private:
 #if HAVE(TOUCH_BAR)
     void setUpTextTouchBar(NSTouchBar *);
@@ -818,7 +822,6 @@ private:
     void handleRequestedCandidates(NSInteger sequenceNumber, NSArray<NSTextCheckingResult *> *candidates);
 
 #if HAVE(INLINE_PREDICTIONS)
-    bool allowsInlinePredictions() const;
     void showInlinePredictionsForCandidates(NSArray<NSTextCheckingResult *> *);
     void showInlinePredictionsForCandidate(NSTextCheckingResult *, NSRange, NSRange);
 #endif

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -5291,18 +5291,12 @@ void WebViewImpl::setMarkedText(id string, NSRange selectedRange, NSRange replac
 #if HAVE(INLINE_PREDICTIONS)
 bool WebViewImpl::allowsInlinePredictions() const
 {
-    const EditorState& editorState = m_page->editorState();
+    auto& editorState = m_page->editorState();
 
     if (editorState.hasPostLayoutData() && editorState.postLayoutData->canEnableWritingSuggestions)
         return NSSpellChecker.isAutomaticInlineCompletionEnabled;
 
-    if (!editorState.isContentEditable)
-        return false;
-
-    if (!inlinePredictionsEnabled() && !m_page->preferences().inlinePredictionsInAllEditableElementsEnabled())
-        return false;
-
-    return NSSpellChecker.isAutomaticInlineCompletionEnabled;
+    return editorState.isContentEditable && inlinePredictionsEnabled() && NSSpellChecker.isAutomaticInlineCompletionEnabled;
 }
 
 void WebViewImpl::showInlinePredictionsForCandidate(NSTextCheckingResult *candidate, NSRange absoluteSelectedRange, NSRange oldRelativeSelectedRange)

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -783,8 +783,16 @@ void WebPage::getPlatformEditorStateCommon(const LocalFrame& frame, EditorState&
         }
 
         postLayoutData.baseWritingDirection = frame.editor().baseWritingDirectionForSelectionStart();
+        postLayoutData.canEnableWritingSuggestions = [&] {
+            if (!selection.canEnableWritingSuggestions())
+                return false;
 
-        postLayoutData.canEnableWritingSuggestions = selection.canEnableWritingSuggestions();
+            if (!m_lastNodeBeforeWritingSuggestions)
+                return true;
+
+            RefPtr currentNode = frame.editor().nodeBeforeWritingSuggestions();
+            return !currentNode || m_lastNodeBeforeWritingSuggestions == currentNode.get();
+        }();
     }
 
     if (RefPtr editableRootOrFormControl = enclosingTextFormControl(selection.start()) ?: selection.rootEditableElement()) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7599,6 +7599,8 @@ void WebPage::didCommitLoad(WebFrame* frame)
 
     themeColorChanged();
 
+    m_lastNodeBeforeWritingSuggestions = { };
+
     WebProcess::singleton().updateActivePages(m_processDisplayName);
 
     updateMainFrameScrollOffsetPinning();
@@ -9607,6 +9609,15 @@ void WebPage::frameNameWasChangedInAnotherProcess(FrameIdentifier frameID, const
         return;
     if (RefPtr coreFrame = webFrame->coreFrame())
         coreFrame->tree().setSpecifiedName(AtomString(frameName));
+}
+
+void WebPage::updateLastNodeBeforeWritingSuggestions(const KeyboardEvent& event)
+{
+    if (event.type() != eventNames().keydownEvent)
+        return;
+
+    if (RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame())
+        m_lastNodeBeforeWritingSuggestions = frame->editor().nodeBeforeWritingSuggestions();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2023,6 +2023,8 @@ private:
     void reapplyEditCommand(WebUndoStepID commandID);
     void didRemoveEditCommand(WebUndoStepID commandID);
 
+    void updateLastNodeBeforeWritingSuggestions(const WebCore::KeyboardEvent&);
+
     void findString(const String&, OptionSet<FindOptions>, uint32_t maxMatchCount, CompletionHandler<void(std::optional<WebCore::FrameIdentifier>, Vector<WebCore::IntRect>&&, uint32_t, int32_t, bool)>&&);
 #if ENABLE(IMAGE_ANALYSIS)
     void findStringIncludingImages(const String&, OptionSet<FindOptions>, uint32_t maxMatchCount, CompletionHandler<void(std::optional<WebCore::FrameIdentifier>, Vector<WebCore::IntRect>&&, uint32_t, int32_t, bool)>&&);
@@ -2745,6 +2747,8 @@ private:
 #if HAVE(APP_ACCENT_COLORS)
     bool m_appUsesCustomAccentColor { false };
 #endif
+
+    WeakPtr<WebCore::Node, WebCore::WeakPtrImplWithEventTargetData> m_lastNodeBeforeWritingSuggestions;
 
     bool m_textManipulationIncludesSubframes { false };
     std::optional<Vector<WebCore::TextManipulationController::ExclusionRule>> m_textManipulationExclusionRules;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -605,6 +605,8 @@ bool WebPage::handleEditingKeyboardEvent(KeyboardEvent& event)
     if (handleKeyEventByRelinquishingFocusToChrome(event))
         return true;
 
+    updateLastNodeBeforeWritingSuggestions(event);
+
     // FIXME: Interpret the event immediately upon receiving it in UI process, without sending to WebProcess first.
     auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::InterpretKeyEvent(editorState(ShouldPerformLayout::Yes), platformEvent->type() == PlatformKeyboardEvent::Type::Char), m_identifier);
     auto [eventWasHandled] = sendResult.takeReplyOr(false);

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -324,6 +324,8 @@ bool WebPage::handleEditingKeyboardEvent(KeyboardEvent& event)
     if (handleKeyEventByRelinquishingFocusToChrome(event))
         return true;
 
+    updateLastNodeBeforeWritingSuggestions(event);
+
     bool eventWasHandled = false;
 
     // Are there commands that could just cause text insertion if executed via Editor?

--- a/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
@@ -458,6 +458,9 @@ void UIScriptControllerMac::setWebViewAllowsMagnification(bool allowsMagnificati
 void UIScriptControllerMac::setInlinePrediction(JSStringRef jsText, unsigned startIndex)
 {
 #if HAVE(INLINE_PREDICTIONS)
+    if (!webView()._allowsInlinePredictions)
+        return;
+
     auto fullText = jsText->string();
     RetainPtr markedText = adoptNS([[NSMutableAttributedString alloc] initWithString:fullText.left(startIndex)]);
     [markedText appendAttributedString:adoptNS([[NSAttributedString alloc] initWithString:fullText.substring(startIndex) attributes:@{


### PR DESCRIPTION
#### 6cd1f4e75e31195246920f7fba52d3003fe08e9d
<pre>
Letters disappear randomly while typing in Stash when writing suggestions are enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=273748">https://bugs.webkit.org/show_bug.cgi?id=273748</a>
<a href="https://rdar.apple.com/127392270">rdar://127392270</a>

Reviewed by Richard Robinson.

Stash&apos;s JavaScript listens for `keydown` events and, in response, replaces text nodes right before
the selection in the editable container when writing comments. This interferes with both current
implementations of writing suggestions (i.e. inline predictions), which depend on the text node
before the user&apos;s selection being the same, as the user types.

We can detect this case by computing and remembering the last node before the user&apos;s selection after
each editing keyboard event (where writing suggestions would normally be inserted). If this text
node changes in between the last key event and when sending the next editor state after changing the
selection, then don&apos;t allow writing suggestions.

* LayoutTests/editing/input/mac/do-not-allow-inline-predictions-if-text-changes-expected-mismatch.html: Added.
* LayoutTests/editing/input/mac/do-not-allow-inline-predictions-if-text-changes.html: Added.

Add a layout test to exercise the new heuristic.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Remove the internal `InlinePredictionsInAllEditableElementsEnabled` setting. This was only used to
test writing suggestions on the web, before enabling it by default.

* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::canEnableWritingSuggestions const):

Make the `writingsuggestions` state in editable elements follow the enclosing text form control, if
applicable. This is needed to keep `WritingSuggestionsWebAPI.DefaultStateWithDisabledAutocomplete`
passing after the change to consult `EditorState` in `-[WKContentView _updateTextInputTraits:]`, now
that we don&apos;t solely depend on the initial focused element information.

* Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm:
(-[WKWebView _allowsInlinePredictions]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _updateTextInputTraits:]):

Make the iOS codepath honor editor state&apos;s writing suggestions enablement flag (which may change on
the fly, unlike focused element information).

* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::allowsInlinePredictions const):

Remove logic to honor the (now-removed) internal feature flag, and simplify the logic a bit.

* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::getPlatformEditorStateCommon const):

Consult `m_lastNodeBeforeWritingSuggestions` when computing `canEnableWritingSuggestions` on the
`EditorState`&apos;s post-layout data. If the current node has changed since the last key event, avoid
trying to compute and inject writing suggestions.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didCommitLoad):

Reset `m_lastNodeBeforeWritingSuggestions`.

(WebKit::WebPage::updateLastNodeBeforeWritingSuggestions):

Add a helper method to update `m_lastNodeBeforeWritingSuggestions` after a `keydown`.

* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::handleEditingKeyboardEvent):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::handleEditingKeyboardEvent):

Call the helper method above when handling keyboard editing.

* Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm:
(WTR::UIScriptControllerMac::setInlinePrediction):

Make this a no-op when `-_allowsInlinePredictions` is `NO`, so that we can (somewhat indirectly)
test the new logic to avoid writing suggestions in the case where the text node before the selection
keeps changing after each key event.

Canonical link: <a href="https://commits.webkit.org/278407@main">https://commits.webkit.org/278407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f391d83981d789290dffa4391368a6e22ddb840

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53711 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1142 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52755 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/792 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41154 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43439 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22258 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/24822 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/697 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8830 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43785 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46801 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55300 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49952 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25550 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/680 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48562 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26811 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/43598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47603 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11060 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27675 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57430 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26543 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11804 "Found unexpected failure with change (failure)") | 
<!--EWS-Status-Bubble-End-->