### PR TITLE
[WPE][WebDriver] Implement automation keyboard and mouse input handlers for new WPE API

### DIFF
--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -212,6 +212,7 @@ UIProcess/API/wpe/WebKitWebViewWPE.cpp @no-unify
 UIProcess/API/wpe/WPEWebView.cpp @no-unify
 
 UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.cpp
+UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp
 
 UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
 

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -1794,7 +1794,7 @@ void WebAutomationSession::simulateMouseInteraction(WebPageProxy& page, MouseInt
             callbackInMap(AUTOMATION_COMMAND_ERROR_WITH_NAME(Timeout));
         callbackInMap = WTFMove(mouseEventsFlushedCallback);
 
-        platformSimulateMouseInteraction(page, interaction, mouseButton, locationInViewport, platformWebModifiersFromRaw(m_currentModifiers), pointerType);
+        platformSimulateMouseInteraction(page, interaction, mouseButton, locationInViewport, platformWebModifiersFromRaw(page, m_currentModifiers), pointerType);
 
         // If the event does not hit test anything in the window, then it may not have been delivered.
         if (callbackInMap && !page->isProcessingMouseEvents()) {

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -266,7 +266,7 @@ private:
     void updateClickCount(MouseButton, const WebCore::IntPoint&, Seconds maxTime = 1_s, int maxDistance = 0);
     void resetClickCount();
     void platformSimulateMouseInteraction(WebPageProxy&, MouseInteraction, MouseButton, const WebCore::IntPoint& locationInViewport, OptionSet<WebEventModifier>, const String& pointerType);
-    static OptionSet<WebEventModifier> platformWebModifiersFromRaw(unsigned modifiers);
+    static OptionSet<WebEventModifier> platformWebModifiersFromRaw(WebPageProxy&, unsigned modifiers);
 #endif
 #if ENABLE(WEBDRIVER_TOUCH_INTERACTIONS)
     // Simulates a single touch point being pressed, moved, and released.

--- a/Source/WebKit/UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp
+++ b/Source/WebKit/UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp
@@ -103,7 +103,7 @@ void WebAutomationSession::platformSimulateMouseInteraction(WebPageProxy& page, 
     }
 }
 
-OptionSet<WebEventModifier> WebAutomationSession::platformWebModifiersFromRaw(unsigned modifiers)
+OptionSet<WebEventModifier> WebAutomationSession::platformWebModifiersFromRaw(WebPageProxy&, unsigned modifiers)
 {
     OptionSet<WebEventModifier> webModifiers;
 

--- a/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.h
+++ b/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WebAutomationSession.h"
+#include "WebAutomationSessionMacros.h"
+#include "WebPageProxy.h"
+
+namespace WebKit {
+
+#if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
+void platformSimulateMouseInteractionLibWPE(WebPageProxy&, MouseInteraction, MouseButton, const WebCore::IntPoint& locationInView, OptionSet<WebEventModifier> keyModifiers, const String& pointerType, unsigned& currentModifiers);
+#endif
+#if ENABLE(WEBDRIVER_KEYBOARD_INTERACTIONS)
+void platformSimulateKeyboardInteractionLibWPE(WebPageProxy&, KeyboardInteraction, std::variant<VirtualKey, CharKey>&&, unsigned& currentModifiers);
+void platformSimulateKeySequenceLibWPE(WebPageProxy&, const String& keySequence, unsigned& currentModifiers);
+#endif
+#if ENABLE(WEBDRIVER_WHEEL_INTERACTIONS)
+void platformSimulateWheelInteractionLibWPE(WebPageProxy&, const WebCore::IntPoint& location, const WebCore::IntSize& delta);
+#endif
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
+++ b/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
@@ -281,7 +281,7 @@ void WebAutomationSession::platformSimulateMouseInteraction(WebPageProxy& page, 
     sendSynthesizedEventsToPage(page, eventsToBeSent.get());
 }
 
-OptionSet<WebEventModifier> WebAutomationSession::platformWebModifiersFromRaw(unsigned modifiers)
+OptionSet<WebEventModifier> WebAutomationSession::platformWebModifiersFromRaw(WebPageProxy&, unsigned modifiers)
 {
     return WebEventFactory::webEventModifiersForNSEventModifierFlags(modifiers);
 }

--- a/Source/WebKit/UIProcess/Automation/win/WebAutomationSessionWin.cpp
+++ b/Source/WebKit/UIProcess/Automation/win/WebAutomationSessionWin.cpp
@@ -332,7 +332,7 @@ void WebAutomationSession::platformSimulateKeyboardInteraction(WebPageProxy& pag
     page.handleKeyboardEvent(event);
 }
 
-OptionSet<WebEventModifier> WebAutomationSession::platformWebModifiersFromRaw(unsigned modifiers)
+OptionSet<WebEventModifier> WebAutomationSession::platformWebModifiersFromRaw(WebPageProxy&, unsigned modifiers)
 {
     OptionSet<WebEventModifier> webModifiers;
 

--- a/Source/WebKit/WPEPlatform/wpe/WPEKeymapXKB.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEKeymapXKB.cpp
@@ -168,7 +168,7 @@ static void wpe_keymap_xkb_class_init(WPEKeymapXKBClass* keymapXKBClass)
 /**
  * wpe_keymap_xkb_new: (skip)
  *
- * Crerate a new #WPEKeymapXKB
+ * Create a new #WPEKeymapXKB
  *
  * Returns: (transfer full): a #WPEKeymapXKB
  */


### PR DESCRIPTION
#### 4a97b2ece9b549de56c9e960f11009ecc00967da
<pre>
[WPE][WebDriver] Implement automation keyboard and mouse input handlers for new WPE API
<a href="https://bugs.webkit.org/show_bug.cgi?id=273750">https://bugs.webkit.org/show_bug.cgi?id=273750</a>

Reviewed by Carlos Garcia Campos.

Using new WPEEvent class when we&apos;re under the new WPE API.

This commit also moves the WPE-related WebAutomationSession platformSimulate* methods
implementation to the new API file, calling the older libwpe-based API in the `LibWPE.cpp`
file if required.

* Source/WebKit/SourcesWPE.txt: Add new file
* Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.cpp:
* Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.h: Added
* Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEKeymapXKB.cpp: Fix typo

Canonical link: <a href="https://commits.webkit.org/279376@main">https://commits.webkit.org/279376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/398d7ce4aee56f7be26452534dae3f66f4ff3ea1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53243 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56522 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3969 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43160 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2583 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55341 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30736 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45970 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24291 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27666 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2125 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49432 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58118 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28388 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3429 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50561 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29605 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46190 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49879 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11622 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30526 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29366 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->