### PR TITLE
[JSC] Do not frequently clear fallthrough vector in InlineCacheCompiler

### DIFF
--- a/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
@@ -775,10 +775,10 @@ public:
     // All jumps in the set will be linked to the same destination.
     class JumpList {
     public:
-        typedef Vector<Jump, 2> JumpVector;
-        
-        JumpList() { }
-        
+        using JumpVector = Vector<Jump, 2>;
+
+        JumpList() = default;
+
         JumpList(Jump jump)
         {
             if (jump.isSet())
@@ -825,7 +825,12 @@ public:
         {
             m_jumps.clear();
         }
-        
+
+        void shrink(size_t size)
+        {
+            m_jumps.shrink(size);
+        }
+
         const JumpVector& jumps() const { return m_jumps; }
 
     private:

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -4373,7 +4373,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
                 JIT_COMMENT(jit, "Cases start (needsInt32PropertyCheck)");
                 for (unsigned i = keys.size(); i--;) {
                     fallThrough.link(&jit);
-                    fallThrough.clear();
+                    fallThrough.shrink(0);
                     if (keys[i]->requiresInt32PropertyCheck())
                         generateWithGuard(*keys[i], fallThrough);
                 }
@@ -4381,7 +4381,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
                 if (needsStringPropertyCheck || needsSymbolPropertyCheck || acceptValueProperty) {
                     notInt32.link(&jit);
                     fallThrough.link(&jit);
-                    fallThrough.clear();
+                    fallThrough.shrink(0);
                 } else
                     m_failAndRepatch.append(notInt32);
             }
@@ -4406,7 +4406,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
                 JIT_COMMENT(jit, "Cases start (needsStringPropertyCheck)");
                 for (unsigned i = keys.size(); i--;) {
                     fallThrough.link(&jit);
-                    fallThrough.clear();
+                    fallThrough.shrink(0);
                     if (keys[i]->requiresIdentifierNameMatch() && !keys[i]->uid()->isSymbol())
                         generateWithGuard(*keys[i], fallThrough);
                 }
@@ -4414,7 +4414,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
                 if (needsSymbolPropertyCheck || acceptValueProperty) {
                     notString.link(&jit);
                     fallThrough.link(&jit);
-                    fallThrough.clear();
+                    fallThrough.shrink(0);
                 } else
                     m_failAndRepatch.append(notString);
             }
@@ -4435,7 +4435,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
                 JIT_COMMENT(jit, "Cases start (needsSymbolPropertyCheck)");
                 for (unsigned i = keys.size(); i--;) {
                     fallThrough.link(&jit);
-                    fallThrough.clear();
+                    fallThrough.shrink(0);
                     if (keys[i]->requiresIdentifierNameMatch() && keys[i]->uid()->isSymbol())
                         generateWithGuard(*keys[i], fallThrough);
                 }
@@ -4443,7 +4443,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
                 if (acceptValueProperty) {
                     notSymbol.link(&jit);
                     fallThrough.link(&jit);
-                    fallThrough.clear();
+                    fallThrough.shrink(0);
                 } else
                     m_failAndRepatch.append(notSymbol);
             }
@@ -4452,7 +4452,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
                 JIT_COMMENT(jit, "Cases start (remaining)");
                 for (unsigned i = keys.size(); i--;) {
                     fallThrough.link(&jit);
-                    fallThrough.clear();
+                    fallThrough.shrink(0);
                     if (!keys[i]->requiresIdentifierNameMatch() && !keys[i]->requiresInt32PropertyCheck())
                         generateWithGuard(*keys[i], fallThrough);
                 }
@@ -4462,7 +4462,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
             JIT_COMMENT(jit, "Cases start !(needsInt32PropertyCheck || needsStringPropertyCheck || needsSymbolPropertyCheck)");
             for (unsigned i = keys.size(); i--;) {
                 fallThrough.link(&jit);
-                fallThrough.clear();
+                fallThrough.shrink(0);
                 generateWithGuard(*keys[i], fallThrough);
             }
         }


### PR DESCRIPTION
#### ef888b0bd895fd56a4411fda5a405a7f0842ebcb
<pre>
[JSC] Do not frequently clear fallthrough vector in InlineCacheCompiler
<a href="https://bugs.webkit.org/show_bug.cgi?id=273752">https://bugs.webkit.org/show_bug.cgi?id=273752</a>
<a href="https://rdar.apple.com/127584639">rdar://127584639</a>

Reviewed by Mark Lam.

Let&apos;s reuse already allocated Vector storage.

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::regenerate):

Canonical link: <a href="https://commits.webkit.org/278409@main">https://commits.webkit.org/278409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37d2045a75390ee377845e34a28bf3f8d2d0d5f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53667 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1098 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/748 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41115 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52507 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27364 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43394 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22219 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24779 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/651 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8786 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43740 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46758 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/713 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55256 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49907 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25506 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/640 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48522 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26767 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43561 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47560 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27629 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57386 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7295 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26499 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11788 "Passed tests") | 
<!--EWS-Status-Bubble-End-->