### PR TITLE
Stop using `const char*` in string concatenation in JSC

### DIFF
--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
@@ -214,7 +214,7 @@ JSInternalPromise* JSAPIGlobalObject::moduleLoaderFetch(JSGlobalObject* globalOb
         NSURL *sourceURL = [jsScript sourceURL];
         String oldModuleKey { [sourceURL absoluteString] };
         if (UNLIKELY(Identifier::fromString(vm, oldModuleKey) != moduleKey))
-            return rejectPromise(makeString("The same JSScript was provided for two different identifiers, previously: ", oldModuleKey, " and now: ", moduleKey.string()));
+            return rejectPromise(makeString("The same JSScript was provided for two different identifiers, previously: "_s, oldModuleKey, " and now: "_s, moduleKey.string()));
 
         strongPromise.get()->resolve(globalObject, source);
         return encodedJSUndefined();

--- a/Source/JavaScriptCore/API/JSContextRef.cpp
+++ b/Source/JavaScriptCore/API/JSContextRef.cpp
@@ -331,7 +331,7 @@ public:
             StringBuilder& builder = m_builder;
             if (!builder.isEmpty())
                 builder.append('\n');
-            builder.append('#', visitor->index(), ' ', visitor->functionName(), "() at ", visitor->sourceURL());
+            builder.append('#', visitor->index(), ' ', visitor->functionName(), "() at "_s, visitor->sourceURL());
             if (visitor->hasLineAndColumnInfo()) {
                 auto lineColumn = visitor->computeLineAndColumn();
                 builder.append(':', lineColumn.line);

--- a/Source/JavaScriptCore/API/JSScript.mm
+++ b/Source/JavaScriptCore/API/JSScript.mm
@@ -307,7 +307,7 @@ static bool validateBytecodeCachePath(NSURL* cachePath, NSError** error)
     const char* tempFileName = [cachePathString stringByAppendingString:@".tmp"].UTF8String;
     int fd = open(cacheFileName, O_CREAT | O_WRONLY | O_EXLOCK | O_NONBLOCK, 0600);
     if (fd == -1) {
-        error = makeString("Could not open or lock the bytecode cache file. It's likely another VM or process is already using it. Error: ", safeStrerror(errno).data());
+        error = makeString("Could not open or lock the bytecode cache file. It's likely another VM or process is already using it. Error: "_s, safeStrerror(errno).span());
         return NO;
     }
 
@@ -317,7 +317,7 @@ static bool validateBytecodeCachePath(NSURL* cachePath, NSError** error)
 
     int tempFD = open(tempFileName, O_CREAT | O_RDWR | O_EXLOCK | O_NONBLOCK, 0600);
     if (tempFD == -1) {
-        error = makeString("Could not open or lock the bytecode cache temp file. Error: ", safeStrerror(errno).data());
+        error = makeString("Could not open or lock the bytecode cache temp file. Error: "_s, safeStrerror(errno).span());
         return NO;
     }
 
@@ -340,7 +340,7 @@ static bool validateBytecodeCachePath(NSURL* cachePath, NSError** error)
     if (cacheError.isValid()) {
         m_cachedBytecode = JSC::CachedBytecode::create();
         FileSystem::truncateFile(fd, 0);
-        error = makeString("Unable to generate bytecode for this JSScript because: ", cacheError.message());
+        error = makeString("Unable to generate bytecode for this JSScript because: "_s, cacheError.message());
         return NO;
     }
 

--- a/Source/JavaScriptCore/API/tests/ExecutionTimeLimitTest.cpp
+++ b/Source/JavaScriptCore/API/tests/ExecutionTimeLimitTest.cpp
@@ -501,10 +501,10 @@ int testExecutionTimeLimit()
                     "var startTime = currentCPUTime();"
                     "while (true) {"
                         "for (var i = 0; i < 1000; i++);"
-                            "if (currentCPUTime() - startTime > ", timeAfterWatchdogShouldHaveFired.seconds(), ") break;"
+                            "if (currentCPUTime() - startTime > "_s, timeAfterWatchdogShouldHaveFired.seconds(), ") break;"
                     "}"
                 "}"
-                "foo();"
+                "foo();"_s
             ).utf8();
 
             JSStringRef script = JSStringCreateWithUTF8CString(scriptText.data());

--- a/Source/JavaScriptCore/dfg/DFGCFAPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCFAPhase.cpp
@@ -220,7 +220,7 @@ private:
         for (unsigned i = 0; i < block->size(); ++i) {
             Node* node = block->at(i);
             if (m_verbose) {
-                dataLogF("      %s @%u: ", Graph::opName(node->op()), node->index());
+                dataLogF("      %s @%u: ", Graph::opName(node->op()).characters(), node->index());
                 
                 if (!safeToExecute(m_state, m_graph, node))
                     dataLog("(UNSAFE) ");

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -63,8 +63,8 @@ namespace JSC { namespace DFG {
 static constexpr bool dumpOSRAvailabilityData = false;
 
 // Creates an array of stringized names.
-static const char* const dfgOpNames[] = {
-#define STRINGIZE_DFG_OP_ENUM(opcode, flags) #opcode ,
+static constexpr ASCIILiteral dfgOpNames[] = {
+#define STRINGIZE_DFG_OP_ENUM(opcode, flags) #opcode ## _s ,
     FOR_EACH_DFG_OP(STRINGIZE_DFG_OP_ENUM)
 #undef STRINGIZE_DFG_OP_ENUM
 };
@@ -98,7 +98,7 @@ Graph::~Graph()
 {
 }
 
-const char *Graph::opName(NodeType op)
+ASCIILiteral Graph::opName(NodeType op)
 {
     return dfgOpNames[op];
 }

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -460,7 +460,7 @@ public:
         return arithRound->canSpeculateInt32(pass) && !hasExitSite(arithRound->origin.semantic, Overflow) && !hasExitSite(arithRound->origin.semantic, NegativeZero);
     }
     
-    static const char* opName(NodeType);
+    static ASCIILiteral opName(NodeType);
     
     RegisteredStructureSet* addStructureSet(const StructureSet& structureSet)
     {

--- a/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
+++ b/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
@@ -280,32 +280,32 @@ static uint8_t edgeTypeToNumber(EdgeType type)
     return static_cast<uint8_t>(type);
 }
 
-static const char* edgeTypeToString(EdgeType type)
+static ASCIILiteral edgeTypeToString(EdgeType type)
 {
     switch (type) {
     case EdgeType::Internal:
-        return "Internal";
+        return "Internal"_s;
     case EdgeType::Property:
-        return "Property";
+        return "Property"_s;
     case EdgeType::Index:
-        return "Index";
+        return "Index"_s;
     case EdgeType::Variable:
-        return "Variable";
+        return "Variable"_s;
     }
     ASSERT_NOT_REACHED();
-    return "Internal";
+    return "Internal"_s;
 }
 
-static const char* snapshotTypeToString(HeapSnapshotBuilder::SnapshotType type)
+static ASCIILiteral snapshotTypeToString(HeapSnapshotBuilder::SnapshotType type)
 {
     switch (type) {
     case HeapSnapshotBuilder::SnapshotType::InspectorSnapshot:
-        return "Inspector";
+        return "Inspector"_s;
     case HeapSnapshotBuilder::SnapshotType::GCDebuggingSnapshot:
-        return "GCDebugging";
+        return "GCDebugging"_s;
     }
     ASSERT_NOT_REACHED();
-    return "Inspector";
+    return "Inspector"_s;
 }
 
 String HeapSnapshotBuilder::json()
@@ -427,7 +427,7 @@ String HeapSnapshotBuilder::json(Function<bool (const HeapSnapshotNode&)> allowN
         // <nodeId>, <sizeInBytes>, <nodeClassNameIndex>, <flags>, [<labelIndex>, <cellAddress>, <wrappedAddress>]
         json.append(',', node.identifier, ',', node.cell->estimatedSizeInBytes(vm), ',', classNameIndex, ',', flags);
         if (m_snapshotType == SnapshotType::GCDebuggingSnapshot)
-            json.append(',', labelIndex, ",\"0x", hex(reinterpret_cast<uintptr_t>(node.cell), Lowercase), "\",\"0x", hex(reinterpret_cast<uintptr_t>(wrappedAddress), Lowercase), '"');
+            json.append(',', labelIndex, ",\"0x"_s, hex(reinterpret_cast<uintptr_t>(node.cell), Lowercase), "\",\"0x"_s, hex(reinterpret_cast<uintptr_t>(wrappedAddress), Lowercase), '"');
     };
 
     bool firstEdge = true;

--- a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
+++ b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
@@ -288,7 +288,7 @@ void BackendDispatcher::reportProtocolError(std::optional<long> relatedRequestId
 }
 
 template<typename T>
-T BackendDispatcher::getPropertyValue(JSON::Object* params, const String& name, bool required, std::function<T(JSON::Value&)> converter, const char* typeName)
+T BackendDispatcher::getPropertyValue(JSON::Object* params, const String& name, bool required, std::function<T(JSON::Value&)> converter, ASCIILiteral typeName)
 {
     T result;
 
@@ -315,45 +315,45 @@ T BackendDispatcher::getPropertyValue(JSON::Object* params, const String& name, 
 
 std::optional<bool> BackendDispatcher::getBoolean(JSON::Object* params, const String& name, bool required)
 {
-    return getPropertyValue<std::optional<bool>>(params, name, required, &JSON::Value::asBoolean, "Boolean");
+    return getPropertyValue<std::optional<bool>>(params, name, required, &JSON::Value::asBoolean, "Boolean"_s);
 }
 
 std::optional<int> BackendDispatcher::getInteger(JSON::Object* params, const String& name, bool required)
 {
     // FIXME: <http://webkit.org/b/179847> simplify this when legacy InspectorObject symbols are no longer needed.
     std::optional<int> (JSON::Value::*asInteger)() const = &JSON::Value::asInteger;
-    return getPropertyValue<std::optional<int>>(params, name, required, asInteger, "Integer");
+    return getPropertyValue<std::optional<int>>(params, name, required, asInteger, "Integer"_s);
 }
 
 std::optional<double> BackendDispatcher::getDouble(JSON::Object* params, const String& name, bool required)
 {
     // FIXME: <http://webkit.org/b/179847> simplify this when legacy InspectorObject symbols are no longer needed.
     std::optional<double> (JSON::Value::*asDouble)() const = &JSON::Value::asDouble;
-    return getPropertyValue<std::optional<double>>(params, name, required, asDouble, "Number");
+    return getPropertyValue<std::optional<double>>(params, name, required, asDouble, "Number"_s);
 }
 
 String BackendDispatcher::getString(JSON::Object* params, const String& name, bool required)
 {
     // FIXME: <http://webkit.org/b/179847> simplify this when legacy InspectorObject symbols are no longer needed.
     String (JSON::Value::*asString)() const = &JSON::Value::asString;
-    return getPropertyValue<String>(params, name, required, asString, "String");
+    return getPropertyValue<String>(params, name, required, asString, "String"_s);
 }
 
 RefPtr<JSON::Value> BackendDispatcher::getValue(JSON::Object* params, const String& name, bool required)
 {
-    return getPropertyValue<RefPtr<JSON::Value>>(params, name, required, &JSON::Value::asValue, "Value");
+    return getPropertyValue<RefPtr<JSON::Value>>(params, name, required, &JSON::Value::asValue, "Value"_s);
 }
 
 RefPtr<JSON::Object> BackendDispatcher::getObject(JSON::Object* params, const String& name, bool required)
 {
     return getPropertyValue<RefPtr<JSON::Object>>(params, name, required, [](JSON::Value& value) {
         return value.asObject();
-    }, "Object");
+    }, "Object"_s);
 }
 
 RefPtr<JSON::Array> BackendDispatcher::getArray(JSON::Object* params, const String& name, bool required)
 {
-    return getPropertyValue<RefPtr<JSON::Array>>(params, name, required, &JSON::Value::asArray, "Array");
+    return getPropertyValue<RefPtr<JSON::Array>>(params, name, required, &JSON::Value::asArray, "Array"_s);
 }
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h
+++ b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h
@@ -109,7 +109,7 @@ private:
     BackendDispatcher(Ref<FrontendRouter>&&);
 
     template<typename T>
-    WTF_INTERNAL T getPropertyValue(JSON::Object*, const String& name, bool required, std::function<T(JSON::Value&)> converter, const char* typeName);
+    WTF_INTERNAL T getPropertyValue(JSON::Object*, const String& name, bool required, std::function<T(JSON::Value&)> converter, ASCIILiteral typeName);
 
     Ref<FrontendRouter> m_frontendRouter;
     HashMap<String, SupplementalBackendDispatcher*> m_dispatchers;

--- a/Source/JavaScriptCore/interpreter/StackVisitor.cpp
+++ b/Source/JavaScriptCore/interpreter/StackVisitor.cpp
@@ -431,7 +431,7 @@ String StackVisitor::Frame::toString() const
 {
     String functionName = this->functionName();
     String sourceURL = this->sourceURL();
-    const char* separator = !sourceURL.isEmpty() && !functionName.isEmpty() ? "@" : "";
+    auto separator = !sourceURL.isEmpty() && !functionName.isEmpty() ? "@"_s : ""_s;
 
     if (sourceURL.isEmpty() || !hasLineAndColumnInfo())
         return makeString(functionName, separator, sourceURL);

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -2211,7 +2211,7 @@ JSC_DEFINE_HOST_FUNCTION(functionOpenFile, (JSGlobalObject* globalObject, CallFr
 
     FILE* descriptor = fopen(filePath.fileSystemPath().ascii().data(), "r");
     if (!descriptor)
-        return throwVMException(globalObject, scope, createURIError(globalObject, makeString("Could not open file at "_s, filePath.string(), " fopen had error: "_s, safeStrerror(errno).data())));
+        return throwVMException(globalObject, scope, createURIError(globalObject, makeString("Could not open file at "_s, filePath.string(), " fopen had error: "_s, safeStrerror(errno).span())));
 
     RELEASE_AND_RETURN(scope, JSValue::encode(JSFileDescriptor::create(vm, globalObject, WTFMove(descriptor))));
 }

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -1696,7 +1696,7 @@ private:
     template <typename... Args>
     NEVER_INLINE void logError(bool, Args&&...);
     
-    NEVER_INLINE void updateErrorWithNameAndMessage(const char* beforeMessage, const String& name, const char* afterMessage)
+    NEVER_INLINE void updateErrorWithNameAndMessage(ASCIILiteral beforeMessage, const String& name, ASCIILiteral afterMessage)
     {
         m_errorMessage = makeString(beforeMessage, " '"_s, name, "' "_s, afterMessage);
     }

--- a/Source/JavaScriptCore/runtime/AtomicsObject.cpp
+++ b/Source/JavaScriptCore/runtime/AtomicsObject.cpp
@@ -124,7 +124,7 @@ static unsigned validateAtomicAccess(JSGlobalObject* globalObject, VM& vm, JSArr
     if (LIKELY(accessIndexValue.isUInt32()))
         accessIndex = accessIndexValue.asUInt32();
     else {
-        accessIndex = accessIndexValue.toIndex(globalObject, "accessIndex");
+        accessIndex = accessIndexValue.toIndex(globalObject, "accessIndex"_s);
         RETURN_IF_EXCEPTION(scope, 0);
     }
 

--- a/Source/JavaScriptCore/runtime/BigIntConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/BigIntConstructor.cpp
@@ -111,7 +111,7 @@ JSC_DEFINE_HOST_FUNCTION(bigIntConstructorFuncAsUintN, (JSGlobalObject* globalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto numberOfBits = callFrame->argument(0).toIndex(globalObject, "number of bits");
+    auto numberOfBits = callFrame->argument(0).toIndex(globalObject, "number of bits"_s);
     RETURN_IF_EXCEPTION(scope, { });
 
     JSValue bigInt = callFrame->argument(1).toBigInt(globalObject);
@@ -131,7 +131,7 @@ JSC_DEFINE_HOST_FUNCTION(bigIntConstructorFuncAsIntN, (JSGlobalObject* globalObj
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto numberOfBits = callFrame->argument(0).toIndex(globalObject, "number of bits");
+    auto numberOfBits = callFrame->argument(0).toIndex(globalObject, "number of bits"_s);
     RETURN_IF_EXCEPTION(scope, { });
 
     JSValue bigInt = callFrame->argument(1).toBigInt(globalObject);

--- a/Source/JavaScriptCore/runtime/ConsoleClient.cpp
+++ b/Source/JavaScriptCore/runtime/ConsoleClient.cpp
@@ -239,7 +239,7 @@ void ConsoleClient::printConsoleMessageWithArguments(MessageSource source, Messa
                 functionName = "(unknown)"_s;
 
             StringBuilder callFrameBuilder;
-            callFrameBuilder.append(i, ": ", functionName, '(');
+            callFrameBuilder.append(i, ": "_s, functionName, '(');
             appendURLAndPosition(callFrameBuilder, callFrame.sourceURL(), callFrame.lineNumber(), callFrame.columnNumber());
             callFrameBuilder.append(')');
 

--- a/Source/JavaScriptCore/runtime/Error.cpp
+++ b/Source/JavaScriptCore/runtime/Error.cpp
@@ -290,15 +290,17 @@ JSObject* createTypeErrorCopy(JSGlobalObject* globalObject, JSValue error)
 
 String makeDOMAttributeGetterTypeErrorMessage(const char* interfaceName, const String& attributeName)
 {
-    return makeString("The "_s, interfaceName, '.', attributeName, " getter can only be used on instances of "_s, interfaceName);
+    auto interfaceNameSpan = span(interfaceName);
+    return makeString("The "_s, interfaceNameSpan, '.', attributeName, " getter can only be used on instances of "_s, interfaceNameSpan);
 }
 
 String makeDOMAttributeSetterTypeErrorMessage(const char* interfaceName, const String& attributeName)
 {
-    return makeString("The "_s, interfaceName, '.', attributeName, " setter can only be used on instances of "_s, interfaceName);
+    auto interfaceNameSpan = span(interfaceName);
+    return makeString("The "_s, interfaceNameSpan, '.', attributeName, " setter can only be used on instances of "_s, interfaceNameSpan);
 }
 
-Exception* throwConstructorCannotBeCalledAsFunctionTypeError(JSGlobalObject* globalObject, ThrowScope& scope, const char* constructorName)
+Exception* throwConstructorCannotBeCalledAsFunctionTypeError(JSGlobalObject* globalObject, ThrowScope& scope, ASCIILiteral constructorName)
 {
     return throwTypeError(globalObject, scope, makeString("calling "_s, constructorName, " constructor without new is invalid"_s));
 }

--- a/Source/JavaScriptCore/runtime/Error.h
+++ b/Source/JavaScriptCore/runtime/Error.h
@@ -84,7 +84,7 @@ JSObject* createTypeErrorCopy(JSGlobalObject*, JSValue error);
 // Methods to throw Errors.
 
 // Convenience wrappers, create an throw an exception with a default message.
-JS_EXPORT_PRIVATE Exception* throwConstructorCannotBeCalledAsFunctionTypeError(JSGlobalObject*, ThrowScope&, const char* constructorName);
+JS_EXPORT_PRIVATE Exception* throwConstructorCannotBeCalledAsFunctionTypeError(JSGlobalObject*, ThrowScope&, ASCIILiteral constructorName);
 JS_EXPORT_PRIVATE Exception* throwTypeError(JSGlobalObject*, ThrowScope&);
 JS_EXPORT_PRIVATE Exception* throwTypeError(JSGlobalObject*, ThrowScope&, ASCIILiteral errorMessage);
 JS_EXPORT_PRIVATE Exception* throwTypeError(JSGlobalObject*, ThrowScope&, const String& errorMessage);

--- a/Source/JavaScriptCore/runtime/ErrorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorPrototype.cpp
@@ -124,7 +124,7 @@ JSC_DEFINE_HOST_FUNCTION(errorProtoFuncToString, (JSGlobalObject* globalObject, 
         return JSValue::encode(name.isString() ? name : jsString(vm, WTFMove(nameString)));
 
     // 10. Return the result of concatenating name, ":", a single space character, and msg.
-    RELEASE_AND_RETURN(scope, JSValue::encode(jsMakeNontrivialString(globalObject, nameString, ": ", messageString)));
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsMakeNontrivialString(globalObject, nameString, ": "_s, messageString)));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
@@ -174,7 +174,7 @@ String notAFunctionSourceAppender(const String& originalMessage, StringView sour
     if (!base)
         return defaultApproximateSourceError(originalMessage, sourceText);
     StringBuilder builder(StringBuilder::OverflowHandler::RecordOverflow);
-    builder.append(base, " is not a function. (In '", sourceText, "', '", base, "' is ");
+    builder.append(base, " is not a function. (In '"_s, sourceText, "', '"_s, base, "' is "_s);
     if (type == TypeSymbol)
         builder.append("a Symbol"_s);
     else {
@@ -331,12 +331,12 @@ JSObject* createErrorForDuplicateGlobalVariableDeclaration(JSGlobalObject* globa
 
 JSObject* createErrorForInvalidGlobalFunctionDeclaration(JSGlobalObject* globalObject, const Identifier& ident)
 {
-    return createTypeError(globalObject, makeString("Can't declare global function '", ident.string(), "': property must be either configurable or both writable and enumerable"));
+    return createTypeError(globalObject, makeString("Can't declare global function '"_s, ident.string(), "': property must be either configurable or both writable and enumerable"_s));
 }
 
 JSObject* createErrorForInvalidGlobalVarDeclaration(JSGlobalObject* globalObject, const Identifier& ident)
 {
-    return createTypeError(globalObject, makeString("Can't declare global variable '", ident.string(), "': global object must be extensible"));
+    return createTypeError(globalObject, makeString("Can't declare global variable '"_s, ident.string(), "': global object must be extensible"_s));
 }
 
 JSObject* createTDZError(JSGlobalObject* globalObject)

--- a/Source/JavaScriptCore/runtime/FinalizationRegistryConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/FinalizationRegistryConstructor.cpp
@@ -57,7 +57,7 @@ JSC_DEFINE_HOST_FUNCTION(callFinalizationRegistry, (JSGlobalObject* globalObject
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "FinalizationRegistry"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "FinalizationRegistry"_s));
 }
 
 JSC_DEFINE_HOST_FUNCTION(constructFinalizationRegistry, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/FunctionConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionConstructor.cpp
@@ -67,19 +67,19 @@ void FunctionConstructor::finishCreation(VM& vm, FunctionPrototype* functionProt
 
 static String stringifyFunction(JSGlobalObject* globalObject, const ArgList& args, const Identifier& functionName, FunctionConstructionMode functionConstructionMode, ThrowScope& scope, std::optional<int>& functionConstructorParametersEndPosition)
 {
-    const char* prefix = nullptr;
+    ASCIILiteral prefix;
     switch (functionConstructionMode) {
     case FunctionConstructionMode::Function:
-        prefix = "function ";
+        prefix = "function "_s;
         break;
     case FunctionConstructionMode::Generator:
-        prefix = "function* ";
+        prefix = "function* "_s;
         break;
     case FunctionConstructionMode::Async:
-        prefix = "async function ";
+        prefix = "async function "_s;
         break;
     case FunctionConstructionMode::AsyncGenerator:
-        prefix = "async function* ";
+        prefix = "async function* "_s;
         break;
     }
 

--- a/Source/JavaScriptCore/runtime/FunctionExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionExecutable.cpp
@@ -173,7 +173,7 @@ JSString* FunctionExecutable::toStringSlow(JSGlobalObject* globalObject)
     };
 
     if (isBuiltinFunction())
-        return cacheIfNoException(jsMakeNontrivialString(globalObject, "function ", name().string(), "() {\n    [native code]\n}"));
+        return cacheIfNoException(jsMakeNontrivialString(globalObject, "function "_s, name().string(), "() {\n    [native code]\n}"_s));
 
     if (isClass())
         return cache(jsString(vm, classSource().view()));

--- a/Source/JavaScriptCore/runtime/FunctionPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionPrototype.cpp
@@ -90,14 +90,14 @@ JSC_DEFINE_HOST_FUNCTION(functionProtoFuncToString, (JSGlobalObject* globalObjec
     if (thisValue.inherits<InternalFunction>()) {
         InternalFunction* function = jsCast<InternalFunction*>(thisValue);
         Integrity::auditStructureID(function->structureID());
-        RELEASE_AND_RETURN(scope, JSValue::encode(jsMakeNontrivialString(globalObject, "function ", function->name(), "() {\n    [native code]\n}")));
+        RELEASE_AND_RETURN(scope, JSValue::encode(jsMakeNontrivialString(globalObject, "function "_s, function->name(), "() {\n    [native code]\n}"_s)));
     }
 
     if (thisValue.isObject()) {
         JSObject* object = asObject(thisValue);
         Integrity::auditStructureID(object->structureID());
         if (object->isCallable())
-            RELEASE_AND_RETURN(scope, JSValue::encode(jsMakeNontrivialString(globalObject, "function ", object->classInfo()->className, "() {\n    [native code]\n}")));
+            RELEASE_AND_RETURN(scope, JSValue::encode(jsMakeNontrivialString(globalObject, "function "_s, object->classInfo()->className, "() {\n    [native code]\n}"_s)));
     }
 
     return throwVMTypeError(globalObject, scope);

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -743,7 +743,7 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
             int64_t minutes = minutesValue.value();
             int64_t absMinutes = std::abs(minutes);
             tz = makeString(minutes < 0 ? '-' : '+', pad('0', 2, absMinutes / 60), ':', pad('0', 2, absMinutes % 60));
-            timeZoneForICU = makeString("GMT", minutes < 0 ? '-' : '+', pad('0', 2, absMinutes / 60), pad('0', 2, absMinutes % 60));
+            timeZoneForICU = makeString("GMT"_s, minutes < 0 ? '-' : '+', pad('0', 2, absMinutes / 60), pad('0', 2, absMinutes % 60));
         } else {
             tz = canonicalizeTimeZoneName(originalTz);
             if (tz.isNull()) {
@@ -1429,7 +1429,7 @@ UDateIntervalFormat* IntlDateTimeFormat::createDateIntervalFormatIfNecessary(JSG
     // While the pattern is including right HourCycle patterns, UDateIntervalFormat does not follow.
     // We need to enforce HourCycle by setting "hc" extension if it is specified.
     StringBuilder localeBuilder;
-    localeBuilder.append(m_dataLocale, "-u-ca-", m_calendar, "-nu-", m_numberingSystem);
+    localeBuilder.append(m_dataLocale, "-u-ca-"_s, m_calendar, "-nu-"_s, m_numberingSystem);
     if (m_hourCycle != HourCycle::None)
         localeBuilder.append("-hc-"_s, hourCycleString(m_hourCycle));
     CString dataLocaleWithExtensions = localeBuilder.toString().utf8();

--- a/Source/JavaScriptCore/runtime/IntlDisplayNamesConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDisplayNamesConstructor.cpp
@@ -101,7 +101,7 @@ JSC_DEFINE_HOST_FUNCTION(callIntlDisplayNames, (JSGlobalObject* globalObject, Ca
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "DisplayNames"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "DisplayNames"_s));
 }
 
 JSC_DEFINE_HOST_FUNCTION(intlDisplayNamesConstructorSupportedLocalesOf, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/IntlDurationFormatConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormatConstructor.cpp
@@ -101,7 +101,7 @@ JSC_DEFINE_HOST_FUNCTION(callIntlDurationFormat, (JSGlobalObject* globalObject, 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "DurationFormat"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "DurationFormat"_s));
 }
 
 JSC_DEFINE_HOST_FUNCTION(intlDurationFormatConstructorSupportedLocalesOf, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/IntlListFormatConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/IntlListFormatConstructor.cpp
@@ -101,7 +101,7 @@ JSC_DEFINE_HOST_FUNCTION(callIntlListFormat, (JSGlobalObject* globalObject, Call
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "ListFormat"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "ListFormat"_s));
 }
 
 JSC_DEFINE_HOST_FUNCTION(intlListFormatConstructorSupportedLocalesOf, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/IntlLocaleConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocaleConstructor.cpp
@@ -92,7 +92,7 @@ JSC_DEFINE_HOST_FUNCTION(callIntlLocale, (JSGlobalObject* globalObject, CallFram
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "Locale"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "Locale"_s));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/IntlPluralRulesConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/IntlPluralRulesConstructor.cpp
@@ -105,7 +105,7 @@ JSC_DEFINE_HOST_FUNCTION(callIntlPluralRules, (JSGlobalObject* globalObject, Cal
 
     // 13.2.1 Intl.PluralRules ([ locales [ , options ] ])
     // https://tc39.github.io/ecma402/#sec-intl.pluralrules
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "PluralRules"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "PluralRules"_s));
 }
 
 JSC_DEFINE_HOST_FUNCTION(intlPluralRulesConstructorFuncSupportedLocalesOf, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/IntlRelativeTimeFormatConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/IntlRelativeTimeFormatConstructor.cpp
@@ -103,7 +103,7 @@ JSC_DEFINE_HOST_FUNCTION(callIntlRelativeTimeFormat, (JSGlobalObject* globalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "RelativeTimeFormat"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "RelativeTimeFormat"_s));
 }
 
 // https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.supportedLocalesOf

--- a/Source/JavaScriptCore/runtime/IntlSegmenterConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/IntlSegmenterConstructor.cpp
@@ -101,7 +101,7 @@ JSC_DEFINE_HOST_FUNCTION(callIntlSegmenter, (JSGlobalObject* globalObject, CallF
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "Segmenter"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "Segmenter"_s));
 }
 
 JSC_DEFINE_HOST_FUNCTION(intlSegmenterConstructorSupportedLocalesOf, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/JSArrayBufferConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferConstructor.cpp
@@ -142,7 +142,7 @@ JSC_DEFINE_HOST_FUNCTION(callArrayBuffer, (JSGlobalObject* globalObject, CallFra
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "ArrayBuffer"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "ArrayBuffer"_s));
 }
 
 JSC_DEFINE_HOST_FUNCTION(constructArrayBuffer, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/JSCJSValue.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.h
@@ -315,7 +315,7 @@ public:
     double toIntegerOrInfinity(JSGlobalObject*) const;
     int32_t toInt32(JSGlobalObject*) const;
     uint32_t toUInt32(JSGlobalObject*) const;
-    uint32_t toIndex(JSGlobalObject*, const char* errorName) const;
+    uint32_t toIndex(JSGlobalObject*, ASCIILiteral errorName) const;
     size_t toTypedArrayIndex(JSGlobalObject*, ASCIILiteral) const;
     uint64_t toLength(JSGlobalObject*) const;
 

--- a/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
@@ -58,7 +58,7 @@ inline uint32_t JSValue::toUInt32(JSGlobalObject* globalObject) const
     return toInt32(globalObject);
 }
 
-inline uint32_t JSValue::toIndex(JSGlobalObject* globalObject, const char* errorName) const
+inline uint32_t JSValue::toIndex(JSGlobalObject* globalObject, ASCIILiteral errorName) const
 {
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/Source/JavaScriptCore/runtime/JSDataViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSDataViewPrototype.cpp
@@ -136,7 +136,7 @@ EncodedJSValue getData(JSGlobalObject* globalObject, CallFrame* callFrame)
     if (!dataView)
         return throwVMTypeError(globalObject, scope, "Receiver of DataView method must be a DataView"_s);
     
-    size_t byteOffset = callFrame->argument(0).toIndex(globalObject, "byteOffset");
+    size_t byteOffset = callFrame->argument(0).toIndex(globalObject, "byteOffset"_s);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
     
     bool littleEndian = false;
@@ -184,7 +184,7 @@ EncodedJSValue setData(JSGlobalObject* globalObject, CallFrame* callFrame)
     if (!dataView)
         return throwVMTypeError(globalObject, scope, "Receiver of DataView method must be a DataView"_s);
     
-    size_t byteOffset = callFrame->argument(0).toIndex(globalObject, "byteOffset");
+    size_t byteOffset = callFrame->argument(0).toIndex(globalObject, "byteOffset"_s);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     const unsigned dataSize = sizeof(typename Adaptor::Type);

--- a/Source/JavaScriptCore/runtime/JSFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSFunction.cpp
@@ -266,13 +266,13 @@ JSString* JSFunction::toString(JSGlobalObject* globalObject)
     if (inherits<JSBoundFunction>()) {
         JSBoundFunction* function = jsCast<JSBoundFunction*>(this);
         auto scope = DECLARE_THROW_SCOPE(vm);
-        JSValue string = jsMakeNontrivialString(globalObject, "function ", function->nameString(), "() {\n    [native code]\n}");
+        JSValue string = jsMakeNontrivialString(globalObject, "function "_s, function->nameString(), "() {\n    [native code]\n}"_s);
         RETURN_IF_EXCEPTION(scope, nullptr);
         return asString(string);
     } else if (inherits<JSRemoteFunction>()) {
         JSRemoteFunction* function = jsCast<JSRemoteFunction*>(this);
         auto scope = DECLARE_THROW_SCOPE(vm);
-        JSValue string = jsMakeNontrivialString(globalObject, "function ", function->nameString(), "() {\n    [native code]\n}");
+        JSValue string = jsMakeNontrivialString(globalObject, "function "_s, function->nameString(), "() {\n    [native code]\n}"_s);
         RETURN_IF_EXCEPTION(scope, nullptr);
         return asString(string);
     }
@@ -528,7 +528,7 @@ void JSFunction::setFunctionName(JSGlobalObject* globalObject, JSValue value)
         if (uid.isNullSymbol())
             name = emptyString();
         else {
-            name = makeNameWithOutOfMemoryCheck(globalObject, scope, "Function ", '[', String(&uid), ']');
+            name = makeNameWithOutOfMemoryCheck(globalObject, scope, "Function "_s, '[', String(&uid), ']');
             RETURN_IF_EXCEPTION(scope, void());
         }
     } else {
@@ -577,9 +577,9 @@ JSFunction::PropertyStatus JSFunction::reifyName(VM& vm, JSGlobalObject* globalO
     const Identifier& propID = vm.propertyNames->name;
 
     if (jsExecutable()->isGetter())
-        name = makeNameWithOutOfMemoryCheck(globalObject, throwScope, "Getter ", "get ", name);
+        name = makeNameWithOutOfMemoryCheck(globalObject, throwScope, "Getter "_s, "get "_s, name);
     else if (jsExecutable()->isSetter())
-        name = makeNameWithOutOfMemoryCheck(globalObject, throwScope, "Setter ", "set ", name);
+        name = makeNameWithOutOfMemoryCheck(globalObject, throwScope, "Setter "_s, "set "_s, name);
     RETURN_IF_EXCEPTION(throwScope, PropertyStatus::Lazy);
 
     rareData->setHasReifiedName();

--- a/Source/JavaScriptCore/runtime/JSFunctionInlines.h
+++ b/Source/JavaScriptCore/runtime/JSFunctionInlines.h
@@ -156,7 +156,7 @@ inline double JSFunction::originalLength(VM& vm)
 }
 
 template<typename... StringTypes>
-ALWAYS_INLINE String makeNameWithOutOfMemoryCheck(JSGlobalObject* globalObject, ThrowScope& throwScope, const char* messagePrefix, StringTypes... strings)
+ALWAYS_INLINE String makeNameWithOutOfMemoryCheck(JSGlobalObject* globalObject, ThrowScope& throwScope, ASCIILiteral messagePrefix, StringTypes... strings)
 {
     String name = tryMakeString(strings...);
     if (UNLIKELY(!name)) {
@@ -197,10 +197,10 @@ inline JSString* JSFunction::originalName(JSGlobalObject* globalObject)
         name = ecmaName.string();
 
     if (jsExecutable()->isGetter()) {
-        name = makeNameWithOutOfMemoryCheck(globalObject, scope, "Getter ", "get ", name);
+        name = makeNameWithOutOfMemoryCheck(globalObject, scope, "Getter "_s, "get "_s, name);
         RETURN_IF_EXCEPTION(scope, { });
     } else if (jsExecutable()->isSetter()) {
-        name = makeNameWithOutOfMemoryCheck(globalObject, scope, "Setter ", "set ", name);
+        name = makeNameWithOutOfMemoryCheck(globalObject, scope, "Setter "_s, "set "_s, name);
         RETURN_IF_EXCEPTION(scope, { });
     }
     return jsString(vm, WTFMove(name));

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -579,7 +579,7 @@ bool JSGenericTypedArrayView<Adaptor>::defineOwnProperty(
     JSGenericTypedArrayView* thisObject = jsCast<JSGenericTypedArrayView*>(object);
 
     if (std::optional<uint32_t> index = parseIndex(propertyName)) {
-        auto throwTypeErrorIfNeeded = [&] (const char* errorMessage) -> bool {
+        auto throwTypeErrorIfNeeded = [&] (ASCIILiteral errorMessage) -> bool {
             if (shouldThrow)
                 throwTypeError(globalObject, scope, makeString(errorMessage, *index));
             return false;
@@ -589,19 +589,19 @@ bool JSGenericTypedArrayView<Adaptor>::defineOwnProperty(
             return typeError(globalObject, scope, shouldThrow, typedArrayBufferHasBeenDetachedErrorMessage);
 
         if (!thisObject->inBounds(index.value()))
-            return throwTypeErrorIfNeeded("Attempting to store out-of-bounds property on a typed array at index: ");
+            return throwTypeErrorIfNeeded("Attempting to store out-of-bounds property on a typed array at index: "_s);
 
         if (descriptor.isAccessorDescriptor())
-            return throwTypeErrorIfNeeded("Attempting to store accessor property on a typed array at index: ");
+            return throwTypeErrorIfNeeded("Attempting to store accessor property on a typed array at index: "_s);
 
         if (descriptor.configurablePresent() && !descriptor.configurable())
-            return throwTypeErrorIfNeeded("Attempting to store non-configurable property on a typed array at index: ");
+            return throwTypeErrorIfNeeded("Attempting to store non-configurable property on a typed array at index: "_s);
 
         if (descriptor.enumerablePresent() && !descriptor.enumerable())
-            return throwTypeErrorIfNeeded("Attempting to store non-enumerable property on a typed array at index: ");
+            return throwTypeErrorIfNeeded("Attempting to store non-enumerable property on a typed array at index: "_s);
 
         if (descriptor.writablePresent() && !descriptor.writable())
-            return throwTypeErrorIfNeeded("Attempting to store non-writable property on a typed array at index: ");
+            return throwTypeErrorIfNeeded("Attempting to store non-writable property on a typed array at index: "_s);
 
         scope.release();
         if (descriptor.value())

--- a/Source/JavaScriptCore/runtime/JSModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleRecord.cpp
@@ -158,7 +158,7 @@ void JSModuleRecord::instantiateDeclarations(JSGlobalObject* globalObject, Modul
             RELEASE_ASSERT(vm.exceptionForInspection(), vm.traps().maybeNeedHandling(), vm.exceptionForInspection(), importedModule);
             RELEASE_ASSERT(vm.traps().maybeNeedHandling(), vm.traps().maybeNeedHandling(), vm.exceptionForInspection(), importedModule);
             if (!vm.exceptionForInspection() || !vm.traps().maybeNeedHandling()) {
-                throwSyntaxError(globalObject, scope, makeString("Importing module '", String(importEntry.moduleRequest.impl()), "' is not found."));
+                throwSyntaxError(globalObject, scope, makeString("Importing module '"_s, String(importEntry.moduleRequest.impl()), "' is not found."_s));
                 return;
             }
         }

--- a/Source/JavaScriptCore/runtime/MapConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/MapConstructor.cpp
@@ -64,7 +64,7 @@ JSC_DEFINE_HOST_FUNCTION(callMap, (JSGlobalObject* globalObject, CallFrame*))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "Map"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "Map"_s));
 }
 
 JSC_DEFINE_HOST_FUNCTION(constructMap, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/NativeExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/NativeExecutable.cpp
@@ -107,7 +107,7 @@ JSString* NativeExecutable::toStringSlow(JSGlobalObject *globalObject)
 
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    JSValue value = jsMakeNontrivialString(globalObject, "function ", name(), "() {\n    [native code]\n}");
+    JSValue value = jsMakeNontrivialString(globalObject, "function "_s, name(), "() {\n    [native code]\n}"_s);
 
     RETURN_IF_EXCEPTION(throwScope, nullptr);
 

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -81,27 +81,27 @@ bool hasCapacityToUseLargeGigacage();
 // and cannot be modified thereafter.
 
 #define FOR_EACH_JSC_OPTION(v)                                          \
-    v(Bool, useKernTCSM, defaultTCSMValue(), Normal, "Note: this needs to go before other options since they depend on this value.") \
-    v(Bool, validateOptions, false, Normal, "crashes if mis-typed JSC options were passed to the VM") \
-    v(Unsigned, dumpOptions, 0, Normal, "dumps JSC options (0 = None, 1 = Overridden only, 2 = All, 3 = Verbose)") \
-    v(OptionString, configFile, nullptr, Normal, "file to configure JSC options and logging location") \
+    v(Bool, useKernTCSM, defaultTCSMValue(), Normal, "Note: this needs to go before other options since they depend on this value."_s) \
+    v(Bool, validateOptions, false, Normal, "crashes if mis-typed JSC options were passed to the VM"_s) \
+    v(Unsigned, dumpOptions, 0, Normal, "dumps JSC options (0 = None, 1 = Overridden only, 2 = All, 3 = Verbose)"_s) \
+    v(OptionString, configFile, nullptr, Normal, "file to configure JSC options and logging location"_s) \
     \
-    v(Bool, useLLInt,  true, Normal, "allows the LLINT to be used if true") \
-    v(Bool, useJIT, jitEnabledByDefault(), Normal, "allows the executable pages to be allocated for JIT and thunks if true") \
-    v(Bool, useBaselineJIT, true, Normal, "allows the baseline JIT to be used if true") \
-    v(Bool, useDFGJIT, true, Normal, "allows the DFG JIT to be used if true") \
-    v(Bool, useRegExpJIT, jitEnabledByDefault(), Normal, "allows the RegExp JIT to be used if true") \
-    v(Bool, useDOMJIT, is64Bit(), Normal, "allows the DOMJIT to be used if true") \
+    v(Bool, useLLInt,  true, Normal, "allows the LLINT to be used if true"_s) \
+    v(Bool, useJIT, jitEnabledByDefault(), Normal, "allows the executable pages to be allocated for JIT and thunks if true"_s) \
+    v(Bool, useBaselineJIT, true, Normal, "allows the baseline JIT to be used if true"_s) \
+    v(Bool, useDFGJIT, true, Normal, "allows the DFG JIT to be used if true"_s) \
+    v(Bool, useRegExpJIT, jitEnabledByDefault(), Normal, "allows the RegExp JIT to be used if true"_s) \
+    v(Bool, useDOMJIT, is64Bit(), Normal, "allows the DOMJIT to be used if true"_s) \
     \
     v(Bool, reportMustSucceedExecutableAllocations, false, Normal, nullptr) \
     \
-    v(Unsigned, maxPerThreadStackUsage, 5 * MB, Normal, "Max allowed stack usage by the VM") \
-    v(Unsigned, softReservedZoneSize, 128 * KB, Normal, "A buffer greater than reservedZoneSize that reserves space for stringifying exceptions.") \
-    v(Unsigned, reservedZoneSize, 64 * KB, Normal, "The amount of stack space we guarantee to our clients (and to interal VM code that does not call out to clients).") \
+    v(Unsigned, maxPerThreadStackUsage, 5 * MB, Normal, "Max allowed stack usage by the VM"_s) \
+    v(Unsigned, softReservedZoneSize, 128 * KB, Normal, "A buffer greater than reservedZoneSize that reserves space for stringifying exceptions."_s) \
+    v(Unsigned, reservedZoneSize, 64 * KB, Normal, "The amount of stack space we guarantee to our clients (and to interal VM code that does not call out to clients)."_s) \
     \
-    v(Bool, crashOnDisallowedVMEntry, ASSERT_ENABLED, Normal, "Forces a crash if we attempt to enter the VM when disallowed") \
+    v(Bool, crashOnDisallowedVMEntry, ASSERT_ENABLED, Normal, "Forces a crash if we attempt to enter the VM when disallowed"_s) \
     v(Bool, crashIfCantAllocateJITMemory, false, Normal, nullptr) \
-    v(Unsigned, jitMemoryReservationSize, 0, Normal, "Set this number to change the executable allocation size in ExecutableAllocatorFixedVMPool. (In bytes.)") \
+    v(Unsigned, jitMemoryReservationSize, 0, Normal, "Set this number to change the executable allocation size in ExecutableAllocatorFixedVMPool. (In bytes.)"_s) \
     \
     v(Bool, forceCodeBlockLiveness, false, Normal, nullptr) \
     v(Bool, forceICFailure, false, Normal, nullptr) \
@@ -117,7 +117,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, dumpBytecodeLivenessResults, false, Normal, nullptr) \
     v(Bool, validateBytecode, false, Normal, nullptr) \
     v(Bool, forceDebuggerBytecodeGeneration, false, Normal, nullptr) \
-    v(Bool, debuggerTriggersBreakpointException, false, Normal, "Using the debugger statement will trigger an breakpoint exception (Useful when lldbing)") \
+    v(Bool, debuggerTriggersBreakpointException, false, Normal, "Using the debugger statement will trigger an breakpoint exception (Useful when lldbing)"_s) \
     v(Bool, dumpBytecodesBeforeGeneratorification, false, Normal, nullptr) \
     \
     v(Bool, useFunctionDotArguments, true, Normal, nullptr) \
@@ -129,39 +129,39 @@ bool hasCapacityToUseLargeGigacage();
     \
     v(Bool, useIterationIntrinsics, true, Normal, nullptr) \
     \
-    v(OSLogType, useOSLog, OSLogType::None, Normal, "Log dataLog()s to os_log instead of stderr") \
+    v(OSLogType, useOSLog, OSLogType::None, Normal, "Log dataLog()s to os_log instead of stderr"_s) \
     /* dumpDisassembly implies dumpDFGDisassembly. */ \
     v(Bool, needDisassemblySupport, false, Normal, nullptr) \
-    v(Bool, dumpDisassembly, false, Normal, "dumps disassembly of all JIT compiled code upon compilation") \
+    v(Bool, dumpDisassembly, false, Normal, "dumps disassembly of all JIT compiled code upon compilation"_s) \
     v(Bool, asyncDisassembly, false, Normal, nullptr) \
     v(Bool, logJIT, false, Normal, nullptr) \
-    v(Bool, dumpBaselineDisassembly, false, Normal, "dumps disassembly of Baseline function upon compilation") \
-    v(Bool, dumpDFGDisassembly, false, Normal, "dumps disassembly of DFG function upon compilation") \
-    v(Bool, dumpFTLDisassembly, false, Normal, "dumps disassembly of FTL function upon compilation") \
-    v(Bool, dumpRegExpDisassembly, false, Normal, "dumps disassembly of RegExp upon compilation") \
-    v(Bool, dumpWasmDisassembly, false, Normal, "dumps disassembly of all Wasm code upon compilation") \
-    v(OptionString, dumpWasmSourceFileName, nullptr, Normal, "log every wasm module validation, and dump source bytes to <filename>.0.wasm, <filename>.1.wasm, etc...") \
-    v(OptionString, wasmOMGFunctionsToDump, nullptr, Normal, "file with newline separated list of function indices to dump IR/disassembly for, if no such file exists, the function index itself") \
-    v(Bool, dumpBBQDisassembly, false, Normal, "dumps disassembly of BBQ Wasm code upon compilation") \
-    v(Bool, dumpOMGDisassembly, false, Normal, "dumps disassembly of OMG Wasm code upon compilation") \
+    v(Bool, dumpBaselineDisassembly, false, Normal, "dumps disassembly of Baseline function upon compilation"_s) \
+    v(Bool, dumpDFGDisassembly, false, Normal, "dumps disassembly of DFG function upon compilation"_s) \
+    v(Bool, dumpFTLDisassembly, false, Normal, "dumps disassembly of FTL function upon compilation"_s) \
+    v(Bool, dumpRegExpDisassembly, false, Normal, "dumps disassembly of RegExp upon compilation"_s) \
+    v(Bool, dumpWasmDisassembly, false, Normal, "dumps disassembly of all Wasm code upon compilation"_s) \
+    v(OptionString, dumpWasmSourceFileName, nullptr, Normal, "log every wasm module validation, and dump source bytes to <filename>.0.wasm, <filename>.1.wasm, etc..."_s) \
+    v(OptionString, wasmOMGFunctionsToDump, nullptr, Normal, "file with newline separated list of function indices to dump IR/disassembly for, if no such file exists, the function index itself"_s) \
+    v(Bool, dumpBBQDisassembly, false, Normal, "dumps disassembly of BBQ Wasm code upon compilation"_s) \
+    v(Bool, dumpOMGDisassembly, false, Normal, "dumps disassembly of OMG Wasm code upon compilation"_s) \
     v(Bool, logJITCodeForPerf, false, Configurable, nullptr) \
-    v(OptionString, jitDumpDirectory, nullptr, Normal, "Directory to place JITDump") \
-    v(OptionRange, bytecodeRangeToJITCompile, nullptr, Normal, "bytecode size range to allow compilation on, e.g. 1:100") \
-    v(OptionRange, bytecodeRangeToDFGCompile, nullptr, Normal, "bytecode size range to allow DFG compilation on, e.g. 1:100") \
-    v(OptionRange, bytecodeRangeToFTLCompile, nullptr, Normal, "bytecode size range to allow FTL compilation on, e.g. 1:100") \
-    v(OptionString, jitAllowlist, nullptr, Normal, "file with newline separated list of function signatures to allow compilation on or, if no such file exists, the function signature to allow") \
-    v(OptionString, dfgAllowlist, nullptr, Normal, "file with newline separated list of function signatures to allow DFG compilation on or, if no such file exists, the function signature to allow") \
-    v(OptionString, ftlAllowlist, nullptr, Normal, "file with newline separated list of function signatures to allow FTL compilation on or, if no such file exists, the function signature to allow") \
-    v(OptionString, bbqAllowlist, nullptr, Normal, "file with newline separated list of function indices to allow BBQ compilation on or, if no such file exists, the function index to allow") \
-    v(OptionString, omgAllowlist, nullptr, Normal, "file with newline separated list of function indices to allow OMG compilation on or, if no such file exists, the function index to allow") \
-    v(Bool, dumpSourceAtDFGTime, false, Normal, "dumps source code of JS function being DFG compiled") \
-    v(Bool, dumpBytecodeAtDFGTime, false, Normal, "dumps bytecode of JS function being DFG compiled") \
+    v(OptionString, jitDumpDirectory, nullptr, Normal, "Directory to place JITDump"_s) \
+    v(OptionRange, bytecodeRangeToJITCompile, nullptr, Normal, "bytecode size range to allow compilation on, e.g. 1:100"_s) \
+    v(OptionRange, bytecodeRangeToDFGCompile, nullptr, Normal, "bytecode size range to allow DFG compilation on, e.g. 1:100"_s) \
+    v(OptionRange, bytecodeRangeToFTLCompile, nullptr, Normal, "bytecode size range to allow FTL compilation on, e.g. 1:100"_s) \
+    v(OptionString, jitAllowlist, nullptr, Normal, "file with newline separated list of function signatures to allow compilation on or, if no such file exists, the function signature to allow"_s) \
+    v(OptionString, dfgAllowlist, nullptr, Normal, "file with newline separated list of function signatures to allow DFG compilation on or, if no such file exists, the function signature to allow"_s) \
+    v(OptionString, ftlAllowlist, nullptr, Normal, "file with newline separated list of function signatures to allow FTL compilation on or, if no such file exists, the function signature to allow"_s) \
+    v(OptionString, bbqAllowlist, nullptr, Normal, "file with newline separated list of function indices to allow BBQ compilation on or, if no such file exists, the function index to allow"_s) \
+    v(OptionString, omgAllowlist, nullptr, Normal, "file with newline separated list of function indices to allow OMG compilation on or, if no such file exists, the function index to allow"_s) \
+    v(Bool, dumpSourceAtDFGTime, false, Normal, "dumps source code of JS function being DFG compiled"_s) \
+    v(Bool, dumpBytecodeAtDFGTime, false, Normal, "dumps bytecode of JS function being DFG compiled"_s) \
     v(Bool, dumpGraphAfterParsing, false, Normal, nullptr) \
     v(Bool, dumpGraphAtEachPhase, false, Normal, nullptr) \
-    v(Bool, dumpDFGGraphAtEachPhase, false, Normal, "dumps the DFG graph at each phase of DFG compilation (note this excludes DFG graphs during FTL compilation)") \
-    v(Bool, dumpDFGFTLGraphAtEachPhase, false, Normal, "dumps the DFG graph at each phase of DFG compilation when compiling FTL code") \
-    v(Bool, dumpB3GraphAtEachPhase, false, Normal, "dumps the B3 graph at each phase of compilation") \
-    v(Bool, dumpAirGraphAtEachPhase, false, Normal, "dumps the Air graph at each phase of compilation") \
+    v(Bool, dumpDFGGraphAtEachPhase, false, Normal, "dumps the DFG graph at each phase of DFG compilation (note this excludes DFG graphs during FTL compilation)"_s) \
+    v(Bool, dumpDFGFTLGraphAtEachPhase, false, Normal, "dumps the DFG graph at each phase of DFG compilation when compiling FTL code"_s) \
+    v(Bool, dumpB3GraphAtEachPhase, false, Normal, "dumps the B3 graph at each phase of compilation"_s) \
+    v(Bool, dumpAirGraphAtEachPhase, false, Normal, "dumps the Air graph at each phase of compilation"_s) \
     v(Bool, verboseDFGBytecodeParsing, false, Normal, nullptr) \
     v(Bool, safepointBeforeEachPhase, true, Normal, nullptr) \
     v(Bool, verboseCompilation, false, Normal, nullptr) \
@@ -178,15 +178,15 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, verboseFTLOSRExit, false, Normal, nullptr) \
     v(Bool, verboseCallLink, false, Normal, nullptr) \
     v(Bool, verboseCompilationQueue, false, Normal, nullptr) \
-    v(Bool, reportCompileTimes, false, Normal, "dumps JS function signature and the time it took to compile in all tiers") \
-    v(Bool, reportBaselineCompileTimes, false, Normal, "dumps JS function signature and the time it took to BaselineJIT compile") \
-    v(Bool, reportDFGCompileTimes, false, Normal, "dumps JS function signature and the time it took to DFG and FTL compile") \
-    v(Bool, reportFTLCompileTimes, false, Normal, "dumps JS function signature and the time it took to FTL compile") \
+    v(Bool, reportCompileTimes, false, Normal, "dumps JS function signature and the time it took to compile in all tiers"_s) \
+    v(Bool, reportBaselineCompileTimes, false, Normal, "dumps JS function signature and the time it took to BaselineJIT compile"_s) \
+    v(Bool, reportDFGCompileTimes, false, Normal, "dumps JS function signature and the time it took to DFG and FTL compile"_s) \
+    v(Bool, reportFTLCompileTimes, false, Normal, "dumps JS function signature and the time it took to FTL compile"_s) \
     v(Bool, reportTotalCompileTimes, false, Normal, nullptr) \
-    v(Bool, reportTotalPhaseTimes, false, Normal, "This prints phase times at the end of running script inside jsc.cpp") \
-    v(Bool, reportParseTimes, false, Normal, "dumps JS function signature and the time it took to parse") \
-    v(Bool, reportBytecodeCompileTimes, false, Normal, "dumps JS function signature and the time it took to bytecode compile") \
-    v(Bool, countParseTimes, false, Normal, "counts parse times") \
+    v(Bool, reportTotalPhaseTimes, false, Normal, "This prints phase times at the end of running script inside jsc.cpp"_s) \
+    v(Bool, reportParseTimes, false, Normal, "dumps JS function signature and the time it took to parse"_s) \
+    v(Bool, reportBytecodeCompileTimes, false, Normal, "dumps JS function signature and the time it took to bytecode compile"_s) \
+    v(Bool, countParseTimes, false, Normal, "counts parse times"_s) \
     v(Bool, verboseExitProfile, false, Normal, nullptr) \
     v(Bool, verboseCFA, false, Normal, nullptr) \
     v(Bool, verboseDFGFailure, false, Normal, nullptr) \
@@ -211,8 +211,8 @@ bool hasCapacityToUseLargeGigacage();
     v(Double, mediumHeapGrowthFactor, 1.5, Normal, nullptr) \
     v(Double, largeHeapGrowthFactor, 1.24, Normal, nullptr) \
     v(Double, miniVMHeapGrowthFactor, 1.20, Normal, nullptr) \
-    v(Double, criticalGCMemoryThreshold, 0.80, Normal, "percent memory in use the GC considers critical.  The collector is much more aggressive above this threshold") \
-    v(Double, customFullGCCallbackBailThreshold, -1.0, Normal, "percent of memory paged out before we bail out of timer based Full GCs. -1.0 means use (maxHeapGrowthFactor - 1)") \
+    v(Double, criticalGCMemoryThreshold, 0.80, Normal, "percent memory in use the GC considers critical.  The collector is much more aggressive above this threshold"_s) \
+    v(Double, customFullGCCallbackBailThreshold, -1.0, Normal, "percent of memory paged out before we bail out of timer based Full GCs. -1.0 means use (maxHeapGrowthFactor - 1)"_s) \
     v(Double, minimumMutatorUtilization, 0, Normal, nullptr) \
     v(Double, maximumMutatorUtilization, 0.7, Normal, nullptr) \
     v(Double, epsilonMutatorUtilization, 0.01, Normal, nullptr) \
@@ -236,7 +236,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useOSREntryToDFG, true, Normal, nullptr) \
     v(Bool, useOSREntryToFTL, true, Normal, nullptr) \
     \
-    v(Bool, useFTLJIT, true, Normal, "allows the FTL JIT to be used if true") \
+    v(Bool, useFTLJIT, true, Normal, "allows the FTL JIT to be used if true"_s) \
     v(Bool, validateFTLOSRExitLiveness, false, Normal, nullptr) \
     v(Unsigned, defaultB3OptLevel, 2, Normal, nullptr) \
     v(Bool, b3AlwaysFailsBeforeCompile, false, Normal, nullptr) \
@@ -265,9 +265,9 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useValueRepElimination, true, Normal, nullptr) \
     v(Bool, useArityFixupInlining, true, Normal, nullptr) \
     v(Bool, logExecutableAllocation, false, Normal, nullptr) \
-    v(Unsigned, maxDFGNodesInBasicBlockForPreciseAnalysis, 20000, Normal, "Disable precise but costly analysis and give conservative results if the number of DFG nodes in a block exceeds this threshold") \
+    v(Unsigned, maxDFGNodesInBasicBlockForPreciseAnalysis, 20000, Normal, "Disable precise but costly analysis and give conservative results if the number of DFG nodes in a block exceeds this threshold"_s) \
     \
-    v(Bool, useConcurrentJIT, true, Normal, "allows the DFG / FTL compilation in threads other than the executing JS thread") \
+    v(Bool, useConcurrentJIT, true, Normal, "allows the DFG / FTL compilation in threads other than the executing JS thread"_s) \
     v(Unsigned, numberOfWorklistThreads, computeNumberOfWorkerThreads(3, 2), Normal, nullptr) \
     v(Unsigned, numberOfDFGCompilerThreads, computeNumberOfWorkerThreads(3, 2) - 1, Normal, nullptr) \
     v(Unsigned, numberOfFTLCompilerThreads, computeNumberOfWorkerThreads(MAXIMUM_NUMBER_OF_FTL_COMPILER_THREADS, 2) - 1, Normal, nullptr) \
@@ -297,7 +297,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, maximumFTLCandidateBytecodeCost, 20000, Normal, nullptr) \
     \
     /* Depth of inline stack, so 1 = no inlining, 2 = one level, etc. */ \
-    v(Unsigned, maximumInliningDepth, 5, Normal, "maximum allowed inlining depth.  Depth of 1 means no inlining") \
+    v(Unsigned, maximumInliningDepth, 5, Normal, "maximum allowed inlining depth.  Depth of 1 means no inlining"_s) \
     v(Unsigned, maximumInliningRecursion, 2, Normal, nullptr) \
     \
     /* Maximum size of a caller for enabling inlining. This is purely to protect us */\
@@ -308,13 +308,13 @@ bool hasCapacityToUseLargeGigacage();
     \
     v(Unsigned, maximumBinaryStringSwitchCaseLength, 50, Normal, nullptr) \
     v(Unsigned, maximumBinaryStringSwitchTotalLength, 2000, Normal, nullptr) \
-    v(Unsigned, maximumRegExpTestInlineCodesize, 500, Normal, "Maximum code size in bytes for inlined RegExp.test JIT code.") \
+    v(Unsigned, maximumRegExpTestInlineCodesize, 500, Normal, "Maximum code size in bytes for inlined RegExp.test JIT code."_s) \
     \
-    v(Unsigned, maximumWasmDepthForInlining, isIOS() ? 2 : 8, Normal, "Maximum inlining depth to consider inlining a wasm function.") \
-    v(Unsigned, maximumWasmCalleeSizeForInlining, 200, Normal, "Maximum wasm size in bytes to consider inlining a wasm function.") \
-    v(Unsigned, maximumWasmCallerSizeForInlining, 10000, Normal, "Maximum wasm size in bytes for the caller of an inlined function.") \
+    v(Unsigned, maximumWasmDepthForInlining, isIOS() ? 2 : 8, Normal, "Maximum inlining depth to consider inlining a wasm function."_s) \
+    v(Unsigned, maximumWasmCalleeSizeForInlining, 200, Normal, "Maximum wasm size in bytes to consider inlining a wasm function."_s) \
+    v(Unsigned, maximumWasmCallerSizeForInlining, 10000, Normal, "Maximum wasm size in bytes for the caller of an inlined function."_s) \
     \
-    v(Double, jitPolicyScale, 1.0, Normal, "scale JIT thresholds to this specified ratio between 0.0 (compile ASAP) and 1.0 (compile like normal).") \
+    v(Double, jitPolicyScale, 1.0, Normal, "scale JIT thresholds to this specified ratio between 0.0 (compile ASAP) and 1.0 (compile like normal)."_s) \
     v(Bool, forceEagerCompilation, false, Normal, nullptr) \
     v(Int32, thresholdForJITAfterWarmUp, 500, Normal, nullptr) \
     v(Int32, thresholdForJITSoon, 100, Normal, nullptr) \
@@ -365,7 +365,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, maxHeapSizeAsRAMSizeMultiple, 0, Normal, nullptr) \
     v(Double, minHeapUtilization, 0.8, Normal, nullptr) \
     v(Double, minMarkedBlockUtilization, 0.9, Normal, nullptr) \
-    v(Unsigned, slowPathAllocsBetweenGCs, 0, Normal, "force a GC on every Nth slow path alloc, where N is specified by this option") \
+    v(Unsigned, slowPathAllocsBetweenGCs, 0, Normal, "force a GC on every Nth slow path alloc, where N is specified by this option"_s) \
     \
     v(Double, percentCPUPerMBForFullTimer, 0.0003125, Normal, nullptr) \
     v(Double, percentCPUPerMBForEdenTimer, 0.0025, Normal, nullptr) \
@@ -374,58 +374,58 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, forceWeakRandomSeed, false, Normal, nullptr) \
     v(Unsigned, forcedWeakRandomSeed, 0, Normal, nullptr) \
     \
-    v(Bool, alwaysHaveABadTime, false, Normal, "debugging option to test HaveABadTime mode") \
-    v(Bool, allowDoubleShape, true, Normal, "debugging option to test disabling use of DoubleShape") \
-    v(Bool, useZombieMode, false, Normal, "debugging option to scribble over dead objects with 0xbadbeef0") \
-    v(Bool, useImmortalObjects, false, Normal, "debugging option to keep all objects alive forever") \
-    v(Bool, sweepSynchronously, false, Normal, "debugging option to sweep all dead objects synchronously at GC end before resuming mutator") \
-    v(Unsigned, maxSingleAllocationSize, 0, Configurable, "debugging option to limit individual allocations to a max size (0 = limit not set, N = limit size in bytes)") \
+    v(Bool, alwaysHaveABadTime, false, Normal, "debugging option to test HaveABadTime mode"_s) \
+    v(Bool, allowDoubleShape, true, Normal, "debugging option to test disabling use of DoubleShape"_s) \
+    v(Bool, useZombieMode, false, Normal, "debugging option to scribble over dead objects with 0xbadbeef0"_s) \
+    v(Bool, useImmortalObjects, false, Normal, "debugging option to keep all objects alive forever"_s) \
+    v(Bool, sweepSynchronously, false, Normal, "debugging option to sweep all dead objects synchronously at GC end before resuming mutator"_s) \
+    v(Unsigned, maxSingleAllocationSize, 0, Configurable, "debugging option to limit individual allocations to a max size (0 = limit not set, N = limit size in bytes)"_s) \
     \
-    v(GCLogLevel, logGC, GCLogging::None, Normal, "debugging option to log GC activity (0 = None, 1 = Basic, 2 = Verbose)") \
+    v(GCLogLevel, logGC, GCLogging::None, Normal, "debugging option to log GC activity (0 = None, 1 = Basic, 2 = Verbose)"_s) \
     v(Bool, useGC, true, Normal, nullptr) \
     v(Bool, useGlobalGC, false, Normal, nullptr) \
-    v(Bool, gcAtEnd, false, Normal, "If true, the jsc CLI will do a GC before exiting") \
-    v(Bool, forceGCSlowPaths, false, Normal, "If true, we will force all JIT fast allocations down their slow paths.") \
-    v(Bool, forceDidDeferGCWork, false, Normal, "If true, we will force all DeferGC destructions to perform a GC.") \
+    v(Bool, gcAtEnd, false, Normal, "If true, the jsc CLI will do a GC before exiting"_s) \
+    v(Bool, forceGCSlowPaths, false, Normal, "If true, we will force all JIT fast allocations down their slow paths."_s) \
+    v(Bool, forceDidDeferGCWork, false, Normal, "If true, we will force all DeferGC destructions to perform a GC."_s) \
     v(Unsigned, gcMaxHeapSize, 0, Normal, nullptr) \
     v(Unsigned, forceRAMSize, 0, Normal, nullptr) \
     v(Bool, recordGCPauseTimes, false, Normal, nullptr) \
     v(Bool, dumpHeapStatisticsAtVMDestruction, false, Normal, nullptr) \
-    v(Bool, forceCodeBlockToJettisonDueToOldAge, false, Normal, "If true, this means that anytime we can jettison a CodeBlock due to old age, we do.") \
-    v(Bool, useEagerCodeBlockJettisonTiming, false, Normal, "If true, the time slices for jettisoning a CodeBlock due to old age are shrunk significantly.") \
+    v(Bool, forceCodeBlockToJettisonDueToOldAge, false, Normal, "If true, this means that anytime we can jettison a CodeBlock due to old age, we do."_s) \
+    v(Bool, useEagerCodeBlockJettisonTiming, false, Normal, "If true, the time slices for jettisoning a CodeBlock due to old age are shrunk significantly."_s) \
     \
     v(Bool, useTypeProfiler, false, Normal, nullptr) \
     v(Bool, useControlFlowProfiler, false, Normal, nullptr) \
     \
     v(Bool, useSamplingProfiler, false, Normal, nullptr) \
-    v(Unsigned, sampleInterval, 1000, Normal, "Time between stack traces in microseconds.") \
-    v(Bool, collectExtraSamplingProfilerData, false, Normal, "This corresponds to the JSC shell's --sample option, or if we're wanting to use the sampling profiler via the Debug menu in the browser.") \
-    v(Unsigned, samplingProfilerTopFunctionsCount, 12, Normal, "Number of top functions to report when using the command line interface.") \
-    v(Unsigned, samplingProfilerTopBytecodesCount, 40, Normal, "Number of top bytecodes to report when using the command line interface.") \
-    v(Bool, samplingProfilerIgnoreExternalSourceID, false, Normal, "Ignore external source ID when aggregating results from sampling profiler") \
-    v(OptionString, samplingProfilerPath, nullptr, Normal, "The path to the directory to write sampiling profiler output to. This probably will not work with WK2 unless the path is in the sandbox.") \
-    v(Bool, sampleCCode, false, Normal, "Causes the sampling profiler to record profiling data for C frames.") \
+    v(Unsigned, sampleInterval, 1000, Normal, "Time between stack traces in microseconds."_s) \
+    v(Bool, collectExtraSamplingProfilerData, false, Normal, "This corresponds to the JSC shell's --sample option, or if we're wanting to use the sampling profiler via the Debug menu in the browser."_s) \
+    v(Unsigned, samplingProfilerTopFunctionsCount, 12, Normal, "Number of top functions to report when using the command line interface."_s) \
+    v(Unsigned, samplingProfilerTopBytecodesCount, 40, Normal, "Number of top bytecodes to report when using the command line interface."_s) \
+    v(Bool, samplingProfilerIgnoreExternalSourceID, false, Normal, "Ignore external source ID when aggregating results from sampling profiler"_s) \
+    v(OptionString, samplingProfilerPath, nullptr, Normal, "The path to the directory to write sampiling profiler output to. This probably will not work with WK2 unless the path is in the sandbox."_s) \
+    v(Bool, sampleCCode, false, Normal, "Causes the sampling profiler to record profiling data for C frames."_s) \
     \
-    v(Bool, alwaysGeneratePCToCodeOriginMap, false, Normal, "This will make sure we always generate a PCToCodeOriginMap for JITed code.") \
+    v(Bool, alwaysGeneratePCToCodeOriginMap, false, Normal, "This will make sure we always generate a PCToCodeOriginMap for JITed code."_s) \
     \
-    v(Double, randomIntegrityAuditRate, 0.05, Normal, "Probability of random integrity audits [0.0 - 1.0]") \
+    v(Double, randomIntegrityAuditRate, 0.05, Normal, "Probability of random integrity audits [0.0 - 1.0]"_s) \
     v(Bool, verifyGC, false, Normal, nullptr) \
     v(Bool, verboseVerifyGC, false, Normal, nullptr) \
     v(Bool, verifyHeap, false, Normal, nullptr) \
     v(Unsigned, numberOfGCCyclesToRecordForVerification, 3, Normal, nullptr) \
     \
-    v(Unsigned, exceptionStackTraceLimit, 100, Normal, "Stack trace limit for internal Exception object") \
-    v(Unsigned, defaultErrorStackTraceLimit, 100, Normal, "The default value for Error.stackTraceLimit") \
+    v(Unsigned, exceptionStackTraceLimit, 100, Normal, "Stack trace limit for internal Exception object"_s) \
+    v(Unsigned, defaultErrorStackTraceLimit, 100, Normal, "The default value for Error.stackTraceLimit"_s) \
     v(Bool, exitOnResourceExhaustion, false, Normal, nullptr) \
     v(Bool, useExceptionFuzz, false, Normal, nullptr) \
     v(Unsigned, fireExceptionFuzzAt, 0, Normal, nullptr) \
-    v(Bool, validateDFGExceptionHandling, ASSERT_ENABLED, Normal, "Causes the DFG to emit code validating exception handling for each node that can exit") \
-    v(Bool, dumpSimulatedThrows, false, Normal, "Dumps the call stack of the last simulated throw if exception scope verification fails") \
-    v(Bool, validateExceptionChecks, false, Normal, "Verifies that needed exception checks are performed.") \
-    v(Unsigned, unexpectedExceptionStackTraceLimit, 100, Normal, "Stack trace limit for debugging unexpected exceptions observed in the VM") \
+    v(Bool, validateDFGExceptionHandling, ASSERT_ENABLED, Normal, "Causes the DFG to emit code validating exception handling for each node that can exit"_s) \
+    v(Bool, dumpSimulatedThrows, false, Normal, "Dumps the call stack of the last simulated throw if exception scope verification fails"_s) \
+    v(Bool, validateExceptionChecks, false, Normal, "Verifies that needed exception checks are performed."_s) \
+    v(Unsigned, unexpectedExceptionStackTraceLimit, 100, Normal, "Stack trace limit for debugging unexpected exceptions observed in the VM"_s) \
     \
-    v(Bool, validateDFGClobberize, false, Normal, "Emits code in the DFG/FTL to validate the Clobberize phase")\
-    v(Bool, validateBoundsCheckElimination, false, Normal, "Emits code in the DFG/FTL to validate bounds check elimination")\
+    v(Bool, validateDFGClobberize, false, Normal, "Emits code in the DFG/FTL to validate the Clobberize phase"_s) \
+    v(Bool, validateBoundsCheckElimination, false, Normal, "Emits code in the DFG/FTL to validate bounds check elimination"_s) \
     \
     v(Bool, useExecutableAllocationFuzz, false, Normal, nullptr) \
     v(Unsigned, fireExecutableAllocationFuzzAt, 0, Normal, nullptr) \
@@ -440,7 +440,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, fireOSRExitFuzzAtOrAfter, 0, Normal, nullptr) \
     v(Bool, verboseOSRExitFuzz, true, Normal, nullptr) \
     \
-    v(Unsigned, seedOfVMRandomForFuzzer, 0, Normal, "0 means not fuzzing this; use a cryptographically random seed") \
+    v(Unsigned, seedOfVMRandomForFuzzer, 0, Normal, "0 means not fuzzing this; use a cryptographically random seed"_s) \
     v(Bool, useRandomizingFuzzerAgent, false, Normal, nullptr) \
     v(Unsigned, seedOfRandomizingFuzzerAgent, 1, Normal, nullptr) \
     v(Bool, dumpFuzzerAgentPredictions, false, Normal, nullptr) \
@@ -448,13 +448,13 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useFileBasedFuzzerAgent, false, Normal, nullptr) \
     v(Bool, usePredictionFileCreatingFuzzerAgent, false, Normal, nullptr) \
     v(Bool, requirePredictionForFileBasedFuzzerAgent, false, Normal, nullptr) \
-    v(OptionString, fuzzerPredictionsFile, nullptr, Normal, "file with list of predictions for FileBasedFuzzerAgent") \
+    v(OptionString, fuzzerPredictionsFile, nullptr, Normal, "file with list of predictions for FileBasedFuzzerAgent"_s) \
     v(Bool, useNarrowingNumberPredictionFuzzerAgent, false, Normal, nullptr) \
     v(Bool, useWideningNumberPredictionFuzzerAgent, false, Normal, nullptr) \
     \
     v(Bool, logPhaseTimes, false, Normal, nullptr) \
     v(Double, rareBlockPenalty, 0.001, Normal, nullptr) \
-    v(Unsigned, maximumTmpsForGraphColoring, 60000, Normal, "The maximum number of tmps an Air program can have before always register allocating with Linear Scan") \
+    v(Unsigned, maximumTmpsForGraphColoring, 60000, Normal, "The maximum number of tmps an Air program can have before always register allocating with Linear Scan"_s) \
     v(Bool, airLinearScanVerbose, false, Normal, nullptr) \
     v(Bool, airLinearScanSpillsEverything, false, Normal, nullptr) \
     v(Bool, airForceBriggsAllocator, false, Normal, nullptr) \
@@ -470,100 +470,100 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useB3CanonicalizePrePostIncrements, false, Normal, nullptr) \
     v(Bool, useAirOptimizePairedLoadStore, true, Normal, nullptr) \
     \
-    v(Bool, useDollarVM, false, Restricted, "installs the $vm debugging tool in global objects") \
-    v(OptionString, functionOverrides, nullptr, Restricted, "file with debugging overrides for function bodies") \
+    v(Bool, useDollarVM, false, Restricted, "installs the $vm debugging tool in global objects"_s) \
+    v(OptionString, functionOverrides, nullptr, Restricted, "file with debugging overrides for function bodies"_s) \
     \
-    v(Unsigned, watchdog, 0, Normal, "watchdog timeout (0 = Disabled, N = a timeout period of N milliseconds)") \
-    v(Bool, usePollingTraps, false, Normal, "use polling (instead of signalling) VM traps") \
+    v(Unsigned, watchdog, 0, Normal, "watchdog timeout (0 = Disabled, N = a timeout period of N milliseconds)"_s) \
+    v(Bool, usePollingTraps, false, Normal, "use polling (instead of signalling) VM traps"_s) \
     \
-    v(Bool, useMachForExceptions, true, Normal, "Use mach exceptions rather than signals to handle faults and pass thread messages. (This does nothing on platforms without mach)") \
+    v(Bool, useMachForExceptions, true, Normal, "Use mach exceptions rather than signals to handle faults and pass thread messages. (This does nothing on platforms without mach)"_s) \
     \
     v(Bool, useICStats, false, Normal, nullptr) \
     \
-    v(Unsigned, prototypeHitCountForLLIntCaching, 2, Normal, "Number of prototype property hits before caching a prototype in the LLInt. A count of 0 means never cache.") \
+    v(Unsigned, prototypeHitCountForLLIntCaching, 2, Normal, "Number of prototype property hits before caching a prototype in the LLInt. A count of 0 means never cache."_s) \
     \
     v(Bool, dumpCompiledRegExpPatterns, false, Normal, nullptr) \
     v(Bool, verboseRegExpCompilation, false, Normal, nullptr) \
     \
     v(Bool, dumpModuleRecord, false, Normal, nullptr) \
     v(Bool, dumpModuleLoadingState, false, Normal, nullptr) \
-    v(Bool, exposeInternalModuleLoader, false, Normal, "expose the internal module loader object to the global space for debugging") \
+    v(Bool, exposeInternalModuleLoader, false, Normal, "expose the internal module loader object to the global space for debugging"_s) \
     \
-    v(Bool, exposePrivateIdentifiers, false, Normal, "Allow non-builtin scripts to use private identifiers. Mostly useful to expose @superSamplerBegin/End intrinsics for profiling") \
+    v(Bool, exposePrivateIdentifiers, false, Normal, "Allow non-builtin scripts to use private identifiers. Mostly useful to expose @superSamplerBegin/End intrinsics for profiling"_s) \
     \
     v(Bool, useSuperSampler, false, Normal, nullptr) \
     \
-    v(Bool, useSourceProviderCache, true, Normal, "If false, the parser will not use the source provider cache. It's good to verify everything works when this is false. Because the cache is so successful, it can mask bugs.") \
-    v(Bool, useCodeCache, true, Normal, "If false, the unlinked byte code cache will not be used.") \
+    v(Bool, useSourceProviderCache, true, Normal, "If false, the parser will not use the source provider cache. It's good to verify everything works when this is false. Because the cache is so successful, it can mask bugs."_s) \
+    v(Bool, useCodeCache, true, Normal, "If false, the unlinked byte code cache will not be used."_s) \
     \
-    v(Bool, useWebAssembly, true, Normal, "Expose the WebAssembly global object.") \
+    v(Bool, useWebAssembly, true, Normal, "Expose the WebAssembly global object."_s) \
     \
-    v(Bool, failToCompileWebAssemblyCode, false, Normal, "If true, no Wasm::Plan will sucessfully compile a function.") \
-    v(Size, webAssemblyPartialCompileLimit, 5000, Normal, "Limit on the number of bytes a Wasm::Plan::compile should attempt before checking for other work.") \
-    v(Unsigned, webAssemblyBBQB3OptimizationLevel, 1, Normal, "B3 Optimization level for BBQ Web Assembly module compilations.") \
-    v(Unsigned, webAssemblyOMGOptimizationLevel, Options::defaultB3OptLevel(), Normal, "B3 Optimization level for OMG Web Assembly module compilations.") \
+    v(Bool, failToCompileWebAssemblyCode, false, Normal, "If true, no Wasm::Plan will sucessfully compile a function."_s) \
+    v(Size, webAssemblyPartialCompileLimit, 5000, Normal, "Limit on the number of bytes a Wasm::Plan::compile should attempt before checking for other work."_s) \
+    v(Unsigned, webAssemblyBBQB3OptimizationLevel, 1, Normal, "B3 Optimization level for BBQ Web Assembly module compilations."_s) \
+    v(Unsigned, webAssemblyOMGOptimizationLevel, Options::defaultB3OptLevel(), Normal, "B3 Optimization level for OMG Web Assembly module compilations."_s) \
     \
-    v(Bool, useBBQTierUpChecks, true, Normal, "Enables tier up checks for our BBQ code.") \
+    v(Bool, useBBQTierUpChecks, true, Normal, "Enables tier up checks for our BBQ code."_s) \
     v(Bool, useWebAssemblyOSR, true, Normal, nullptr) \
-    v(Int32, thresholdForBBQOptimizeAfterWarmUp, 150, Normal, "The count before we tier up a function to BBQ.") \
+    v(Int32, thresholdForBBQOptimizeAfterWarmUp, 150, Normal, "The count before we tier up a function to BBQ."_s) \
     v(Int32, thresholdForBBQOptimizeSoon, 50, Normal, nullptr) \
-    v(Int32, thresholdForOMGOptimizeAfterWarmUp, 50000, Normal, "The count before we tier up a function to OMG.") \
+    v(Int32, thresholdForOMGOptimizeAfterWarmUp, 50000, Normal, "The count before we tier up a function to OMG."_s) \
     v(Int32, thresholdForOMGOptimizeSoon, 500, Normal, nullptr) \
-    v(Int32, omgTierUpCounterIncrementForLoop, 1, Normal, "The amount the tier up counter is incremented on each loop backedge.") \
-    v(Int32, omgTierUpCounterIncrementForEntry, 15, Normal, "The amount the tier up counter is incremented on each function entry.") \
-    v(Bool, useWebAssemblyFastMemory, true, Normal, "If true, we will try to use a 32-bit address space with a signal handler to bounds check wasm memory.") \
+    v(Int32, omgTierUpCounterIncrementForLoop, 1, Normal, "The amount the tier up counter is incremented on each loop backedge."_s) \
+    v(Int32, omgTierUpCounterIncrementForEntry, 15, Normal, "The amount the tier up counter is incremented on each function entry."_s) \
+    v(Bool, useWebAssemblyFastMemory, true, Normal, "If true, we will try to use a 32-bit address space with a signal handler to bounds check wasm memory."_s) \
     v(Bool, logWebAssemblyMemory, false, Normal, nullptr) \
-    v(Unsigned, webAssemblyFastMemoryRedzonePages, 128, Normal, "WebAssembly fast memories use 4GiB virtual allocations, plus a redzone (counted as multiple of 64KiB WebAssembly pages) at the end to catch reg+imm accesses which exceed 32-bit, anything beyond the redzone is explicitly bounds-checked") \
-    v(Bool, crashIfWebAssemblyCantFastMemory, false, Normal, "If true, we will crash if we can't obtain fast memory for wasm.") \
-    v(Bool, crashOnFailedWebAssemblyValidate, false, Normal, "If true, we will crash if we can't validate a wasm module instead of throwing an exception.") \
+    v(Unsigned, webAssemblyFastMemoryRedzonePages, 128, Normal, "WebAssembly fast memories use 4GiB virtual allocations, plus a redzone (counted as multiple of 64KiB WebAssembly pages) at the end to catch reg+imm accesses which exceed 32-bit, anything beyond the redzone is explicitly bounds-checked"_s) \
+    v(Bool, crashIfWebAssemblyCantFastMemory, false, Normal, "If true, we will crash if we can't obtain fast memory for wasm."_s) \
+    v(Bool, crashOnFailedWebAssemblyValidate, false, Normal, "If true, we will crash if we can't validate a wasm module instead of throwing an exception."_s) \
     v(Unsigned, maxNumWebAssemblyFastMemories, hasCapacityToUseLargeGigacage() ? 8 : 3, Normal, nullptr) \
-    v(Bool, verboseBBQJITAllocation, false, Normal, "Logs extra information about register allocation during BBQ JIT") \
-    v(Bool, verboseBBQJITInstructions, false, Normal, "Logs instruction information during BBQ JIT") \
+    v(Bool, verboseBBQJITAllocation, false, Normal, "Logs extra information about register allocation during BBQ JIT"_s) \
+    v(Bool, verboseBBQJITInstructions, false, Normal, "Logs instruction information during BBQ JIT"_s) \
     v(Bool, useWasmLLInt, true, Normal, nullptr) \
-    v(Bool, useBBQJIT, true, Normal, "allows the BBQ JIT to be used if true") \
-    v(Bool, useOMGJIT, true, Normal, "allows the OMG JIT to be used if true") \
-    v(Bool, useWasmLLIntPrologueOSR, true, Normal, "allows prologue OSR from Wasm LLInt if true") \
-    v(Bool, useWasmLLIntLoopOSR, true, Normal, "allows loop OSR from Wasm LLInt if true") \
-    v(Bool, useWasmLLIntEpilogueOSR, true, Normal, "allows epilogue OSR from Wasm LLInt if true") \
-    v(OptionRange, wasmFunctionIndexRangeToCompile, nullptr, Normal, "wasm function index range to allow compilation on, e.g. 1:100") \
+    v(Bool, useBBQJIT, true, Normal, "allows the BBQ JIT to be used if true"_s) \
+    v(Bool, useOMGJIT, true, Normal, "allows the OMG JIT to be used if true"_s) \
+    v(Bool, useWasmLLIntPrologueOSR, true, Normal, "allows prologue OSR from Wasm LLInt if true"_s) \
+    v(Bool, useWasmLLIntLoopOSR, true, Normal, "allows loop OSR from Wasm LLInt if true"_s) \
+    v(Bool, useWasmLLIntEpilogueOSR, true, Normal, "allows epilogue OSR from Wasm LLInt if true"_s) \
+    v(OptionRange, wasmFunctionIndexRangeToCompile, nullptr, Normal, "wasm function index range to allow compilation on, e.g. 1:100"_s) \
     v(Bool, wasmLLIntTiersUpToBBQ, true, Normal, nullptr) \
-    v(Bool, useEagerWebAssemblyModuleHashing, false, Normal, "Unnamed WebAssembly modules are identified in backtraces through their hash, if available.") \
-    v(Bool, useArrayAllocationProfiling, true, Normal, "If true, we will use our normal array allocation profiling. If false, the allocation profile will always claim to be undecided.") \
-    v(Bool, forcePolyProto, false, Normal, "If true, create_this will always create an object with a poly proto structure.") \
-    v(Bool, forceMiniVMMode, false, Normal, "If true, it will force mini VM mode on.") \
+    v(Bool, useEagerWebAssemblyModuleHashing, false, Normal, "Unnamed WebAssembly modules are identified in backtraces through their hash, if available."_s) \
+    v(Bool, useArrayAllocationProfiling, true, Normal, "If true, we will use our normal array allocation profiling. If false, the allocation profile will always claim to be undecided."_s) \
+    v(Bool, forcePolyProto, false, Normal, "If true, create_this will always create an object with a poly proto structure."_s) \
+    v(Bool, forceMiniVMMode, false, Normal, "If true, it will force mini VM mode on."_s) \
     v(Bool, useTracePoints, false, Normal, nullptr) \
     v(Bool, useCompilerSignpost, false, Normal, nullptr) \
     v(Bool, traceLLIntExecution, false, Configurable, nullptr) \
     v(Bool, traceLLIntSlowPath, false, Configurable, nullptr) \
     v(Bool, traceBaselineJITExecution, false, Normal, nullptr) \
-    v(Unsigned, thresholdForGlobalLexicalBindingEpoch, UINT_MAX, Normal, "Threshold for global lexical binding epoch. If the epoch reaches to this value, CodeBlock metadata for scope operations will be revised globally. It needs to be greater than 1.") \
+    v(Unsigned, thresholdForGlobalLexicalBindingEpoch, UINT_MAX, Normal, "Threshold for global lexical binding epoch. If the epoch reaches to this value, CodeBlock metadata for scope operations will be revised globally. It needs to be greater than 1."_s) \
     v(OptionString, diskCachePath, nullptr, Restricted, nullptr) \
     v(Bool, forceDiskCache, false, Restricted, nullptr) \
     v(Bool, validateAbstractInterpreterState, false, Restricted, nullptr) \
     v(Double, validateAbstractInterpreterStateProbability, 0.5, Normal, nullptr) \
     v(OptionString, dumpJITMemoryPath, nullptr, Restricted, nullptr) \
-    v(Double, dumpJITMemoryFlushInterval, 10, Restricted, "Maximum time in between flushes of the JIT memory dump in seconds.") \
-    v(Bool, useUnlinkedCodeBlockJettisoning, false, Normal, "If true, UnlinkedCodeBlock can be jettisoned.") \
-    v(Bool, forceOSRExitToLLInt, false, Normal, "If true, we always exit to the LLInt. If false, we exit to whatever is most convenient.") \
-    v(Unsigned, getByValICMaxNumberOfIdentifiers, 4, Normal, "Number of identifiers we see in the LLInt that could cause us to bail on generating an IC for get_by_val.") \
-    v(Bool, useRandomizingExecutableIslandAllocation, false, Normal, "For the arm64 ExecutableAllocator, if true, select which region to use randomly. This is useful for testing that jump islands work.") \
-    v(Bool, exposeProfilersOnGlobalObject, false, Normal, "If true, we will expose functions to enable/disable both the sampling profiler and the super sampler") \
-    v(Bool, allowUnsupportedTiers, false, Normal, "If true, we will not disable DFG or FTL when an experimental feature is enabled.") \
+    v(Double, dumpJITMemoryFlushInterval, 10, Restricted, "Maximum time in between flushes of the JIT memory dump in seconds."_s) \
+    v(Bool, useUnlinkedCodeBlockJettisoning, false, Normal, "If true, UnlinkedCodeBlock can be jettisoned."_s) \
+    v(Bool, forceOSRExitToLLInt, false, Normal, "If true, we always exit to the LLInt. If false, we exit to whatever is most convenient."_s) \
+    v(Unsigned, getByValICMaxNumberOfIdentifiers, 4, Normal, "Number of identifiers we see in the LLInt that could cause us to bail on generating an IC for get_by_val."_s) \
+    v(Bool, useRandomizingExecutableIslandAllocation, false, Normal, "For the arm64 ExecutableAllocator, if true, select which region to use randomly. This is useful for testing that jump islands work."_s) \
+    v(Bool, exposeProfilersOnGlobalObject, false, Normal, "If true, we will expose functions to enable/disable both the sampling profiler and the super sampler"_s) \
+    v(Bool, allowUnsupportedTiers, false, Normal, "If true, we will not disable DFG or FTL when an experimental feature is enabled."_s) \
     v(Bool, returnEarlyFromInfiniteLoopsForFuzzing, false, Normal, nullptr) \
-    v(Size, earlyReturnFromInfiniteLoopsLimit, 1300000000, Normal, "When returnEarlyFromInfiniteLoopsForFuzzing is true, this determines the number of executions a loop can run for before just returning. This is helpful for the fuzzer so it doesn't get stuck in infinite loops.") \
+    v(Size, earlyReturnFromInfiniteLoopsLimit, 1300000000, Normal, "When returnEarlyFromInfiniteLoopsForFuzzing is true, this determines the number of executions a loop can run for before just returning. This is helpful for the fuzzer so it doesn't get stuck in infinite loops."_s) \
     v(Bool, useLICMFuzzing, false, Normal, nullptr) \
     v(Unsigned, seedForLICMFuzzer, 424242, Normal, nullptr) \
     v(Double, allowHoistingLICMProbability, 0.5, Normal, nullptr) \
     v(Bool, exposeCustomSettersOnGlobalObjectForTesting, false, Normal, nullptr) \
     v(Bool, useJITCage, canUseJITCage(), Normal, nullptr) \
-    v(Bool, useAllocationProfiling, false, Normal, "Allows toggling of bmalloc/libPAS allocation profiling features at JSC launch.") \
+    v(Bool, useAllocationProfiling, false, Normal, "Allows toggling of bmalloc/libPAS allocation profiling features at JSC launch."_s) \
     v(Bool, dumpBaselineJITSizeStatistics, false, Normal, nullptr) \
     v(Bool, dumpDFGJITSizeStatistics, false, Normal, nullptr) \
     v(Bool, verboseExecutablePoolAllocation, false, Normal, nullptr) \
     v(Bool, useHandlerIC, canUseHandlerIC(), Normal, nullptr) \
     v(Bool, useDataICInFTL, false, Normal, nullptr) \
     v(Bool, useDataICSharing, false, Normal, nullptr) \
-    v(Bool, useLLIntICs, true, Normal, "Use property and call ICs in LLInt code.") \
+    v(Bool, useLLIntICs, true, Normal, "Use property and call ICs in LLInt code."_s) \
     v(Bool, useBaselineJITCodeSharing, is64Bit(), Normal, nullptr) \
     v(Bool, libpasScavengeContinuously, false, Normal, nullptr) \
     v(Bool, useWasmFaultSignalHandler, true, Normal, nullptr) \
@@ -572,39 +572,39 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, dumpWasmWarnings, false, Normal, nullptr) \
     v(Bool, useRecursiveJSONParse, true, Normal, nullptr) \
     v(Unsigned, thresholdForStringReplaceCache, 0x1000, Normal, nullptr) \
-    v(Bool, useWasmIPInt, false, Normal, "Use the in-place interpereter for WASM instead of LLInt.") \
-    v(Bool, useWasmIPIntPrologueOSR, true, Normal, "Allow IPInt to tier up during function prologues") \
-    v(Bool, useWasmIPIntLoopOSR, true, Normal, "Allow IPInt to tier up during loop iterations") \
-    v(Bool, useWasmIPIntEpilogueOSR, true, Normal, "Allow IPInt to tier up during function epilogues") \
-    v(Bool, wasmIPIntTiersUpToBBQ, true, Normal, "Allow IPInt to tier up to BBQ") \
-    v(Bool, wasmIPIntTiersUpToOMG, true, Normal, "Allow IPInt to tier up to OMG") \
-    v(Bool, useIPIntWrappers, false, Normal, "Allow IPInt to replace JIT wasm wrappers") \
-    v(Bool, forceAllFunctionsToUseSIMD, false, Normal, "Force all functions to act conservatively w.r.t fp/vector registers for testing.") \
+    v(Bool, useWasmIPInt, false, Normal, "Use the in-place interpereter for WASM instead of LLInt."_s) \
+    v(Bool, useWasmIPIntPrologueOSR, true, Normal, "Allow IPInt to tier up during function prologues"_s) \
+    v(Bool, useWasmIPIntLoopOSR, true, Normal, "Allow IPInt to tier up during loop iterations"_s) \
+    v(Bool, useWasmIPIntEpilogueOSR, true, Normal, "Allow IPInt to tier up during function epilogues"_s) \
+    v(Bool, wasmIPIntTiersUpToBBQ, true, Normal, "Allow IPInt to tier up to BBQ"_s) \
+    v(Bool, wasmIPIntTiersUpToOMG, true, Normal, "Allow IPInt to tier up to OMG"_s) \
+    v(Bool, useIPIntWrappers, false, Normal, "Allow IPInt to replace JIT wasm wrappers"_s) \
+    v(Bool, forceAllFunctionsToUseSIMD, false, Normal, "Force all functions to act conservatively w.r.t fp/vector registers for testing."_s) \
     \
     /* Feature Flags */\
     \
-    v(Bool, useArrayBufferTransfer, true, Normal, "Expose ArrayBuffer.transfer feature.") \
-    v(Bool, useArrayFromAsync, true, Normal, "Expose the Array.fromAsync.") \
-    v(Bool, useArrayGroupMethod, true, Normal, "Expose the Object.groupBy() and Map.groupBy() methods.") \
-    v(Bool, useAtomicsWaitAsync, true, Normal, "Expose the waitAsync() methods on Atomics.") \
-    v(Bool, useSetMethods, true, Normal, "Expose the various Set.prototype methods for handling combinations of sets") \
-    v(Bool, useImportAttributes, true, Normal, "Enable import attributes.") \
-    v(Bool, useIntlDurationFormat, true, Normal, "Expose the Intl DurationFormat.") \
-    v(Bool, usePromiseWithResolversMethod, true, Normal, "Expose the Promise.withResolvers() method.") \
-    v(Bool, usePromiseTryMethod, false, Normal, "Expose the Promise.try() method.") \
-    v(Bool, useRegExpEscape, false, Normal, "Expose RegExp.escape feature.") \
-    v(Bool, useResizableArrayBuffer, true, Normal, "Expose ResizableArrayBuffer feature.") \
+    v(Bool, useArrayBufferTransfer, true, Normal, "Expose ArrayBuffer.transfer feature."_s) \
+    v(Bool, useArrayFromAsync, true, Normal, "Expose the Array.fromAsync."_s) \
+    v(Bool, useArrayGroupMethod, true, Normal, "Expose the Object.groupBy() and Map.groupBy() methods."_s) \
+    v(Bool, useAtomicsWaitAsync, true, Normal, "Expose the waitAsync() methods on Atomics."_s) \
+    v(Bool, useSetMethods, true, Normal, "Expose the various Set.prototype methods for handling combinations of sets"_s) \
+    v(Bool, useImportAttributes, true, Normal, "Enable import attributes."_s) \
+    v(Bool, useIntlDurationFormat, true, Normal, "Expose the Intl DurationFormat."_s) \
+    v(Bool, usePromiseWithResolversMethod, true, Normal, "Expose the Promise.withResolvers() method."_s) \
+    v(Bool, usePromiseTryMethod, false, Normal, "Expose the Promise.try() method."_s) \
+    v(Bool, useRegExpEscape, false, Normal, "Expose RegExp.escape feature."_s) \
+    v(Bool, useResizableArrayBuffer, true, Normal, "Expose ResizableArrayBuffer feature."_s) \
     v(Bool, useSharedArrayBuffer, false, Normal, nullptr) \
-    v(Bool, useShadowRealm, false, Normal, "Expose the ShadowRealm object.") \
-    v(Bool, useStringWellFormed, true, Normal, "Expose the String well-formed methods.") \
-    v(Bool, useTemporal, false, Normal, "Expose the Temporal object.") \
-    v(Bool, useWebAssemblyThreading, true, Normal, "Allow instructions from the wasm threading spec.") \
-    v(Bool, useWebAssemblyTypedFunctionReferences, true, Normal, "Allow function types from the wasm typed function references spec.") \
-    v(Bool, useWebAssemblyGC, false, Normal, "Allow gc types from the wasm gc proposal.") \
-    v(Bool, useWebAssemblySIMD, true, Normal, "Allow the new simd instructions and types from the wasm simd spec.") \
-    v(Bool, useWebAssemblyRelaxedSIMD, false, Normal, "Allow the relaxed simd instructions and types from the wasm relaxed simd spec.") \
-    v(Bool, useWebAssemblyTailCalls, false, Normal, "Allow the new instructions from the wasm tail calls spec.") \
-    v(Bool, useWebAssemblyExtendedConstantExpressions, true, Normal, "Allow the use of global, element, and data init expressions from the extended constant expressions proposal.") \
+    v(Bool, useShadowRealm, false, Normal, "Expose the ShadowRealm object."_s) \
+    v(Bool, useStringWellFormed, true, Normal, "Expose the String well-formed methods."_s) \
+    v(Bool, useTemporal, false, Normal, "Expose the Temporal object."_s) \
+    v(Bool, useWebAssemblyThreading, true, Normal, "Allow instructions from the wasm threading spec."_s) \
+    v(Bool, useWebAssemblyTypedFunctionReferences, true, Normal, "Allow function types from the wasm typed function references spec."_s) \
+    v(Bool, useWebAssemblyGC, false, Normal, "Allow gc types from the wasm gc proposal."_s) \
+    v(Bool, useWebAssemblySIMD, true, Normal, "Allow the new simd instructions and types from the wasm simd spec."_s) \
+    v(Bool, useWebAssemblyRelaxedSIMD, false, Normal, "Allow the relaxed simd instructions and types from the wasm relaxed simd spec."_s) \
+    v(Bool, useWebAssemblyTailCalls, false, Normal, "Allow the new instructions from the wasm tail calls spec."_s) \
+    v(Bool, useWebAssemblyExtendedConstantExpressions, true, Normal, "Allow the use of global, element, and data init expressions from the extended constant expressions proposal."_s) \
 
 
 

--- a/Source/JavaScriptCore/runtime/ProxyConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ProxyConstructor.cpp
@@ -90,7 +90,7 @@ JSC_DEFINE_HOST_FUNCTION(constructProxyObject, (JSGlobalObject* globalObject, Ca
 JSC_DEFINE_HOST_FUNCTION(callProxy, (JSGlobalObject* globalObject, CallFrame*))
 {
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "Proxy"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "Proxy"_s));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/ProxyObject.cpp
+++ b/Source/JavaScriptCore/runtime/ProxyObject.cpp
@@ -97,7 +97,7 @@ JSObject* ProxyObject::getHandlerTrap(JSGlobalObject* globalObject, JSObject* ha
 
         callData = JSC::getCallData(value);
         if (callData.type == CallData::Type::None) {
-            throwTypeError(globalObject, scope, makeString("'", String(ident.impl()), "' property of a Proxy's handler should be callable"));
+            throwTypeError(globalObject, scope, makeString('\'', String(ident.impl()), "' property of a Proxy's handler should be callable"_s));
             return nullptr;
         }
 

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -674,7 +674,7 @@ String RegExp::escapedPattern() const
 
 String RegExp::toSourceString() const
 {
-    return makeString('/', escapedPattern(), '/', Yarr::flagsString(flags()).data());
+    return makeString('/', escapedPattern(), '/', span(Yarr::flagsString(flags()).data()));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -1279,7 +1279,7 @@ void SamplingProfiler::reportTopBytecodes(PrintStream& out)
         auto frameDescription = makeString(frame.displayName(m_vm), descriptionForLocation(frame.semanticLocation, frame.wasmCompilationMode, frame.wasmOffset));
         if (std::optional<std::pair<StackFrame::CodeLocation, CodeBlock*>> machineLocation = frame.machineLocation) {
             frameDescription = makeString(frameDescription, " <-- "_s,
-                machineLocation->second->inferredName().data(), descriptionForLocation(machineLocation->first, std::nullopt, BytecodeIndex()));
+                span(machineLocation->second->inferredName().data()), descriptionForLocation(machineLocation->first, std::nullopt, BytecodeIndex()));
         }
         bytecodeCounts.add(frameDescription, 0).iterator->value++;
 

--- a/Source/JavaScriptCore/runtime/SetConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/SetConstructor.cpp
@@ -57,7 +57,7 @@ JSC_DEFINE_HOST_FUNCTION(callSet, (JSGlobalObject* globalObject, CallFrame*))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "Set"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "Set"_s));
 }
 
 JSC_DEFINE_HOST_FUNCTION(constructSet, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/ShadowRealmConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ShadowRealmConstructor.cpp
@@ -60,7 +60,7 @@ JSC_DEFINE_HOST_FUNCTION(constructWithShadowRealmConstructor, (JSGlobalObject* g
 JSC_DEFINE_HOST_FUNCTION(callShadowRealm, (JSGlobalObject* globalObject, CallFrame*))
 {
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "ShadowRealm"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "ShadowRealm"_s));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalCalendarConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendarConstructor.cpp
@@ -102,7 +102,7 @@ JSC_DEFINE_HOST_FUNCTION(callTemporalCalendar, (JSGlobalObject* globalObject, Ca
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "Calendar"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "Calendar"_s));
 }
 
 JSC_DEFINE_HOST_FUNCTION(temporalCalendarConstructorFuncFrom, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/TemporalDurationConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDurationConstructor.cpp
@@ -111,7 +111,7 @@ JSC_DEFINE_HOST_FUNCTION(callTemporalDuration, (JSGlobalObject* globalObject, Ca
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "Duration"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "Duration"_s));
 }
 
 JSC_DEFINE_HOST_FUNCTION(temporalDurationConstructorFuncFrom, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/TemporalInstantConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstantConstructor.cpp
@@ -108,7 +108,7 @@ JSC_DEFINE_HOST_FUNCTION(callTemporalInstant, (JSGlobalObject* globalObject, Cal
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "Instant"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "Instant"_s));
 }
 
 JSC_DEFINE_HOST_FUNCTION(temporalInstantConstructorFuncFrom, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateConstructor.cpp
@@ -124,7 +124,7 @@ JSC_DEFINE_HOST_FUNCTION(callTemporalPlainDate, (JSGlobalObject* globalObject, C
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "PlainDate"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "PlainDate"_s));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindate.from

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimeConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimeConstructor.cpp
@@ -107,7 +107,7 @@ JSC_DEFINE_HOST_FUNCTION(callTemporalPlainDateTime, (JSGlobalObject* globalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "PlainDateTime"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "PlainDateTime"_s));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.from

--- a/Source/JavaScriptCore/runtime/TemporalPlainTimeConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTimeConstructor.cpp
@@ -106,7 +106,7 @@ JSC_DEFINE_HOST_FUNCTION(callTemporalPlainTime, (JSGlobalObject* globalObject, C
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "PlainTime"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "PlainTime"_s));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaintime.from

--- a/Source/JavaScriptCore/runtime/TemporalTimeZoneConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalTimeZoneConstructor.cpp
@@ -106,7 +106,7 @@ JSC_DEFINE_HOST_FUNCTION(callTemporalTimeZone, (JSGlobalObject* globalObject, Ca
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "TimeZone"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "TimeZone"_s));
 }
 
 JSC_DEFINE_HOST_FUNCTION(temporalTimeZoneConstructorFuncFrom, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/TypeSet.cpp
+++ b/Source/JavaScriptCore/runtime/TypeSet.cpp
@@ -401,7 +401,7 @@ String StructureShape::stringRepresentation()
     representation.append('{');
     while (curShape) {
         for (auto& field : curShape->m_fields)
-            representation.append(StringView { field.get() }, ", ");
+            representation.append(StringView { field.get() }, ", "_s);
         if (curShape->m_proto)
             representation.append("__proto__ ["_s, curShape->m_proto->m_constructorName, "], "_s);
         curShape = curShape->m_proto;

--- a/Source/JavaScriptCore/runtime/WeakMapConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapConstructor.cpp
@@ -53,7 +53,7 @@ JSC_DEFINE_HOST_FUNCTION(callWeakMap, (JSGlobalObject* globalObject, CallFrame*)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WeakMap"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WeakMap"_s));
 }
 
 JSC_DEFINE_HOST_FUNCTION(constructWeakMap, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/WeakObjectRefConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/WeakObjectRefConstructor.cpp
@@ -53,7 +53,7 @@ JSC_DEFINE_HOST_FUNCTION(callWeakRef, (JSGlobalObject* globalObject, CallFrame*)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WeakRef"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WeakRef"_s));
 }
 
 JSC_DEFINE_HOST_FUNCTION(constructWeakRef, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/WeakSetConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/WeakSetConstructor.cpp
@@ -54,7 +54,7 @@ JSC_DEFINE_HOST_FUNCTION(callWeakSet, (JSGlobalObject* globalObject, CallFrame*)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WeakSet"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WeakSet"_s));
 }
 
 JSC_DEFINE_HOST_FUNCTION(constructWeakSet, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/wasm/WasmBBQDisassembler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQDisassembler.cpp
@@ -80,7 +80,7 @@ Vector<BBQDisassembler::DumpedOp> BBQDisassembler::dumpVectorForInstructions(Lin
         auto offset = std::get<2>(labels[i]);
         result.append(DumpedOp { { } });
         out.print(prefix);
-        out.println("[", makeString(pad(' ', 8, makeString("0x", hex(offset, 0, Lowercase)))), "] ", makeString(opcode));
+        out.println("[", makeString(pad(' ', 8, makeString("0x"_s, hex(offset, 0, Lowercase)))), "] "_s, makeString(opcode));
         unsigned nextIndex = i + 1;
         if (nextIndex >= labels.size()) {
             dumpDisassembly(out, linkBuffer, std::get<0>(labels[i]), endLabel);

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -74,11 +74,11 @@ FunctionAllowlist& BBQPlan::ensureGlobalBBQAllowlist()
 bool BBQPlan::prepareImpl()
 {
     const auto& functions = m_moduleInformation->functions;
-    if (!tryReserveCapacity(m_wasmInternalFunctions, functions.size(), " WebAssembly functions")
-        || !tryReserveCapacity(m_wasmInternalFunctionLinkBuffers, functions.size(), " compilation contexts")
-        || !tryReserveCapacity(m_compilationContexts, functions.size(), " compilation contexts")
-        || !tryReserveCapacity(m_callees, functions.size(), " BBQ callees")
-        || !tryReserveCapacity(m_allLoopEntrypoints, functions.size(), " loop entrypoints"))
+    if (!tryReserveCapacity(m_wasmInternalFunctions, functions.size(), " WebAssembly functions"_s)
+        || !tryReserveCapacity(m_wasmInternalFunctionLinkBuffers, functions.size(), " compilation contexts"_s)
+        || !tryReserveCapacity(m_compilationContexts, functions.size(), " compilation contexts"_s)
+        || !tryReserveCapacity(m_callees, functions.size(), " BBQ callees"_s)
+        || !tryReserveCapacity(m_allLoopEntrypoints, functions.size(), " loop entrypoints"_s))
         return false;
 
     m_wasmInternalFunctions.resize(functions.size());

--- a/Source/JavaScriptCore/wasm/WasmBranchHintsSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBranchHintsSectionParser.cpp
@@ -36,17 +36,17 @@ auto BranchHintsSectionParser::parse() -> PartialResult
 {
     uint32_t functionCount;
     int64_t previousFunctionIndex = -1;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(functionCount), "can't get function count");
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(functionCount), "can't get function count"_s);
 
     for (uint32_t i = 0; i < functionCount; ++i) {
         uint32_t functionIndex;
         uint32_t hintCount;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(functionIndex), "can't get function index for function ", i);
-        WASM_PARSER_FAIL_IF(static_cast<int64_t>(functionIndex) < previousFunctionIndex, "invalid function index ", functionIndex, " for function ", i);
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(functionIndex), "can't get function index for function "_s, i);
+        WASM_PARSER_FAIL_IF(static_cast<int64_t>(functionIndex) < previousFunctionIndex, "invalid function index "_s, functionIndex, " for function "_s, i);
 
         previousFunctionIndex = functionIndex;
 
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(hintCount), "can't get number of hints for function ", i);
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(hintCount), "can't get number of hints for function "_s, i);
 
         if (!hintCount)
             continue;
@@ -55,18 +55,18 @@ auto BranchHintsSectionParser::parse() -> PartialResult
         BranchHintMap branchHintsForFunction;
         for (uint32_t j = 0; j < hintCount; ++j) {
             uint32_t branchOffset;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(branchOffset), "can't get branch offset for hint ", j);
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(branchOffset), "can't get branch offset for hint "_s, j);
             WASM_PARSER_FAIL_IF(static_cast<int64_t>(branchOffset) < previousBranchOffset
-                || !m_info->branchHints.isValidKey(branchOffset), "invalid branch offset ", branchOffset, " for hint ", j);
+                || !m_info->branchHints.isValidKey(branchOffset), "invalid branch offset "_s, branchOffset, " for hint "_s, j);
 
             previousBranchOffset = branchOffset;
 
             uint32_t payloadSize;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(payloadSize), "can't get payload size for hint ", j);
-            WASM_PARSER_FAIL_IF(payloadSize != 0x1, "invalid payload size for hint ", j);
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(payloadSize), "can't get payload size for hint "_s, j);
+            WASM_PARSER_FAIL_IF(payloadSize != 0x1, "invalid payload size for hint "_s, j);
 
             uint8_t parsedBranchHint;
-            WASM_PARSER_FAIL_IF(!parseVarUInt1(parsedBranchHint), "can't get or invalid branch hint value for hint ", j);
+            WASM_PARSER_FAIL_IF(!parseVarUInt1(parsedBranchHint), "can't get or invalid branch hint value for hint "_s, j);
 
             BranchHint branchHint = static_cast<BranchHint>(parsedBranchHint);
             ASSERT(isValidBranchHint(branchHint));

--- a/Source/JavaScriptCore/wasm/WasmCompilationMode.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCompilationMode.cpp
@@ -31,32 +31,32 @@
 
 namespace JSC { namespace Wasm {
 
-const char* makeString(CompilationMode mode)
+ASCIILiteral makeString(CompilationMode mode)
 {
     switch (mode) {
     case CompilationMode::IPIntMode:
-        return "IPInt";
+        return "IPInt"_s;
     case CompilationMode::LLIntMode:
-        return "LLInt";
+        return "LLInt"_s;
     case CompilationMode::BBQMode:
-        return "BBQ";
+        return "BBQ"_s;
     case CompilationMode::BBQForOSREntryMode:
-        return "BBQForOSREntry";
+        return "BBQForOSREntry"_s;
     case CompilationMode::OMGMode:
-        return "OMG";
+        return "OMG"_s;
     case CompilationMode::OMGForOSREntryMode:
-        return "OMGForOSREntry";
+        return "OMGForOSREntry"_s;
     case CompilationMode::JSEntrypointJITMode:
-        return "JSEntrypoint";
+        return "JSEntrypoint"_s;
     case CompilationMode::JSEntrypointInterpreterMode:
-        return "JSEntrypointInterpreter";
+        return "JSEntrypointInterpreter"_s;
     case CompilationMode::JSToWasmICMode:
-        return "JSToWasmIC";
+        return "JSToWasmIC"_s;
     case CompilationMode::WasmToJSMode:
-        return "WasmToJS";
+        return "WasmToJS"_s;
     }
     RELEASE_ASSERT_NOT_REACHED();
-    return "";
+    return ""_s;
 }
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmCompilationMode.h
+++ b/Source/JavaScriptCore/wasm/WasmCompilationMode.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Forward.h>
+
 namespace JSC { namespace Wasm {
 
 enum class CompilationMode : uint8_t {
@@ -40,7 +42,7 @@ enum class CompilationMode : uint8_t {
     WasmToJSMode,
 };
 
-const char* makeString(CompilationMode);
+ASCIILiteral makeString(CompilationMode);
 
 constexpr inline bool isOSREntry(CompilationMode compilationMode)
 {

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -314,11 +314,11 @@ public:
 
     PartialResult WARN_UNUSED_RETURN addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType value, ExpressionType& result)
     {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled");
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled"_s);
 
         if (m_mode == Mode::Evaluate) {
             result = createNewArray(typeIndex, static_cast<uint32_t>(size.getValue()), value);
-            WASM_PARSER_FAIL_IF(result.isInvalid(), "Failed to allocate new array");
+            WASM_PARSER_FAIL_IF(result.isInvalid(), "Failed to allocate new array"_s);
         }
 
         return { };
@@ -326,7 +326,7 @@ public:
 
     PartialResult WARN_UNUSED_RETURN addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result)
     {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled");
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled"_s);
 
         if (m_mode == Mode::Evaluate) {
             Ref<TypeDefinition> typeDef = m_info.typeSignatures[typeIndex];
@@ -338,7 +338,7 @@ public:
             if (elementType == Wasm::Types::V128)
                 initValue = { vectorAllZeros() };
             result = createNewArray(typeIndex, static_cast<uint32_t>(size.getValue()), initValue);
-            WASM_PARSER_FAIL_IF(result.isInvalid(), "Failed to allocate new array");
+            WASM_PARSER_FAIL_IF(result.isInvalid(), "Failed to allocate new array"_s);
         }
 
         return { };
@@ -346,19 +346,19 @@ public:
 
     PartialResult WARN_UNUSED_RETURN addArrayNewFixed(uint32_t typeIndex, Vector<ExpressionType>& args, ExpressionType& result)
     {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled");
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled"_s);
 
         if (m_mode == Mode::Evaluate) {
             auto* arrayType = m_info.typeSignatures[typeIndex]->expand().as<ArrayType>();
             if (arrayType->elementType().type.unpacked().isV128()) {
                 result = createNewArray(typeIndex, args.size(), { vectorAllZeros() });
-                WASM_PARSER_FAIL_IF(result.isInvalid(), "Failed to allocate new array");
+                WASM_PARSER_FAIL_IF(result.isInvalid(), "Failed to allocate new array"_s);
                 JSWebAssemblyArray* arrayObject = jsCast<JSWebAssemblyArray*>(JSValue::decode(result.getValue()));
                 for (size_t i = 0; i < args.size(); i++)
                     arrayObject->set(i, args[i].getVector());
             } else {
                 result = createNewArray(typeIndex, args.size(), { });
-                WASM_PARSER_FAIL_IF(result.isInvalid(), "Failed to allocate new array");
+                WASM_PARSER_FAIL_IF(result.isInvalid(), "Failed to allocate new array"_s);
                 JSWebAssemblyArray* arrayObject = jsCast<JSWebAssemblyArray*>(JSValue::decode(result.getValue()));
                 for (size_t i = 0; i < args.size(); i++)
                     arrayObject->set(i, args[i].getValue());
@@ -390,11 +390,11 @@ public:
 
     PartialResult WARN_UNUSED_RETURN addStructNewDefault(uint32_t typeIndex, ExpressionType& result)
     {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled");
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled"_s);
 
         if (m_mode == Mode::Evaluate) {
             result = createNewStruct(typeIndex);
-            WASM_PARSER_FAIL_IF(result.isInvalid(), "Failed to allocate new struct");
+            WASM_PARSER_FAIL_IF(result.isInvalid(), "Failed to allocate new struct"_s);
         }
 
         return { };
@@ -402,11 +402,11 @@ public:
 
     PartialResult WARN_UNUSED_RETURN addStructNew(uint32_t typeIndex, Vector<ExpressionType>& args, ExpressionType& result)
     {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled");
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled"_s);
 
         if (m_mode == Mode::Evaluate) {
             result = createNewStruct(typeIndex);
-            WASM_PARSER_FAIL_IF(result.isInvalid(), "Failed to allocate new struct");
+            WASM_PARSER_FAIL_IF(result.isInvalid(), "Failed to allocate new struct"_s);
             JSWebAssemblyStruct* structObject = jsCast<JSWebAssemblyStruct*>(JSValue::decode(result.getValue()));
             for (size_t i = 0; i < args.size(); i++) {
                 if (args[i].type() == ConstExprValue::Vector)
@@ -426,7 +426,7 @@ public:
 
     PartialResult WARN_UNUSED_RETURN addAnyConvertExtern(ExpressionType reference, ExpressionType& result)
     {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled");
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled"_s);
         if (m_mode == Mode::Evaluate) {
             if (reference.type() == ConstExprValue::Numeric)
                 result = ConstExprValue(externInternalize(reference.getValue()));
@@ -441,7 +441,7 @@ public:
 
     PartialResult WARN_UNUSED_RETURN addExternConvertAny(ExpressionType reference, ExpressionType& result)
     {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled");
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled"_s);
         result = reference;
         return { };
     }

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
@@ -111,12 +111,12 @@ bool EntryPlan::parseAndValidateModule(std::span<const uint8_t> source)
 void EntryPlan::prepare()
 {
     ASSERT(m_state == State::Validated);
-    dataLogLnIf(WasmEntryPlanInternal::verbose, "Starting preparation");
+    dataLogLnIf(WasmEntryPlanInternal::verbose, "Starting preparation"_s);
 
     const auto& functions = m_moduleInformation->functions;
     m_numberOfFunctions = functions.size();
-    if (!tryReserveCapacity(m_wasmToWasmExitStubs, m_moduleInformation->importFunctionTypeIndices.size(), " WebAssembly to JavaScript stubs")
-        || !tryReserveCapacity(m_unlinkedWasmToWasmCalls, functions.size(), " unlinked WebAssembly to WebAssembly calls"))
+    if (!tryReserveCapacity(m_wasmToWasmExitStubs, m_moduleInformation->importFunctionTypeIndices.size(), " WebAssembly to JavaScript stubs"_s)
+        || !tryReserveCapacity(m_unlinkedWasmToWasmCalls, functions.size(), " unlinked WebAssembly to WebAssembly calls"_s))
         return;
 
     m_unlinkedWasmToWasmCalls.resize(functions.size());
@@ -128,7 +128,7 @@ void EntryPlan::prepare()
         Import* import = &m_moduleInformation->imports[importIndex];
         if (import->kind != ExternalKind::Function)
             continue;
-        dataLogLnIf(WasmEntryPlanInternal::verbose, "Processing import function number ", importFunctionIndex, ": ", makeString(import->module), ": ", makeString(import->field));
+        dataLogLnIf(WasmEntryPlanInternal::verbose, "Processing import function number "_s, importFunctionIndex, ": "_s, makeString(import->module), ": "_s, makeString(import->field));
         auto binding = wasmToWasm(importFunctionIndex);
         if (UNLIKELY(!binding)) {
             switch (binding.error()) {

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.h
@@ -103,7 +103,7 @@ protected:
     virtual void didCompleteCompilation() WTF_REQUIRES_LOCK(m_lock) = 0;
 
     template<typename T>
-    bool tryReserveCapacity(Vector<T>& vector, size_t size, const char* what)
+    bool tryReserveCapacity(Vector<T>& vector, size_t size, ASCIILiteral what)
     {
         if (UNLIKELY(!vector.tryReserveCapacity(size))) {
             Locker locker { m_lock };

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -471,17 +471,17 @@ static_assert(static_cast<int>(ExternalKind::Memory)   == 2, "Wasm needs Memory 
 static_assert(static_cast<int>(ExternalKind::Global)   == 3, "Wasm needs Global to have the value 3");
 static_assert(static_cast<int>(ExternalKind::Exception)   == 4, "Wasm needs Exception to have the value 4");
 
-inline const char* makeString(ExternalKind kind)
+inline ASCIILiteral makeString(ExternalKind kind)
 {
     switch (kind) {
-    case ExternalKind::Function: return "function";
-    case ExternalKind::Table: return "table";
-    case ExternalKind::Memory: return "memory";
-    case ExternalKind::Global: return "global";
-    case ExternalKind::Exception: return "tag";
+    case ExternalKind::Function: return "function"_s;
+    case ExternalKind::Table: return "table"_s;
+    case ExternalKind::Memory: return "memory"_s;
+    case ExternalKind::Global: return "global"_s;
+    case ExternalKind::Exception: return "tag"_s;
     }
     RELEASE_ASSERT_NOT_REACHED();
-    return "?";
+    return "?"_s;
 }
 
 struct Import {

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -94,7 +94,7 @@ struct FunctionParserTypes {
 
         void dump(PrintStream& out) const
         {
-            out.print(m_value, ": ", m_type);
+            out.print(m_value, ": "_s, m_type);
         }
 
     private:
@@ -186,9 +186,9 @@ private:
     void switchToBlock(ControlType&&, Stack&&);
 
 #define WASM_TRY_POP_EXPRESSION_STACK_INTO(result, what) do {                               \
-        WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't pop empty stack in ", what); \
+        WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't pop empty stack in "_s, what); \
         result = m_expressionStack.takeLast();                                              \
-        m_context.didPopValueFromStack(result, WTF::makeString("WasmFunctionParser.h:", (__LINE__)));                                                   \
+        m_context.didPopValueFromStack(result, WTF::makeString("WasmFunctionParser.h:"_s, (__LINE__)));                                                   \
     } while (0)
 
     using UnaryOperationHandler = PartialResult (Context::*)(ExpressionType, ExpressionType&);
@@ -254,21 +254,21 @@ private:
     };
     PartialResult WARN_UNUSED_RETURN parseMemoryInitImmediates(MemoryInitImmediates&);
 
-    PartialResult WARN_UNUSED_RETURN parseStructTypeIndex(uint32_t& structTypeIndex, const char* operation);
-    PartialResult WARN_UNUSED_RETURN parseStructFieldIndex(uint32_t& structFieldIndex, const StructType&, const char* operation);
+    PartialResult WARN_UNUSED_RETURN parseStructTypeIndex(uint32_t& structTypeIndex, ASCIILiteral operation);
+    PartialResult WARN_UNUSED_RETURN parseStructFieldIndex(uint32_t& structFieldIndex, const StructType&, ASCIILiteral operation);
 
     struct StructTypeIndexAndFieldIndex {
         uint32_t structTypeIndex;
         uint32_t fieldIndex;
     };
-    PartialResult WARN_UNUSED_RETURN parseStructTypeIndexAndFieldIndex(StructTypeIndexAndFieldIndex& result, const char* operation);
+    PartialResult WARN_UNUSED_RETURN parseStructTypeIndexAndFieldIndex(StructTypeIndexAndFieldIndex& result, ASCIILiteral operation);
 
     struct StructFieldManipulation {
         StructTypeIndexAndFieldIndex indices;
         TypedExpression structReference;
         FieldType field;
     };
-    PartialResult WARN_UNUSED_RETURN parseStructFieldManipulation(StructFieldManipulation& result, const char* operation);
+    PartialResult WARN_UNUSED_RETURN parseStructFieldManipulation(StructFieldManipulation& result, ASCIILiteral operation);
 
 #define WASM_TRY_ADD_TO_CONTEXT(add_expression) WASM_FAIL_IF_HELPER_FAILS(m_context.add_expression)
 
@@ -297,9 +297,9 @@ private:
     {
         if (isRefType(type) && Options::useWebAssemblyTypedFunctionReferences()) {
             StringPrintStream out;
-            out.print("(ref ");
+            out.print("(ref "_s);
             if (type.isNullable())
-                out.print("null ");
+                out.print("null "_s);
             if (typeIndexIsType(type.index))
                 out.print(heapTypeKindAsString(static_cast<TypeKind>(type.index)));
             // FIXME: use name section if it exists to provide a nicer name.
@@ -307,20 +307,20 @@ private:
                 const auto& typeDefinition = TypeInformation::get(type.index);
                 const auto& expandedDefinition = typeDefinition.expand();
                 if (expandedDefinition.is<FunctionSignature>())
-                    out.print("<func:");
+                    out.print("<func:"_s);
                 else if (expandedDefinition.is<ArrayType>())
-                    out.print("<array:");
+                    out.print("<array:"_s);
                 else {
                     ASSERT(expandedDefinition.is<StructType>());
-                    out.print("<struct:");
+                    out.print("<struct:"_s);
                 }
                 ASSERT(m_info.typeSignatures.contains(Ref { typeDefinition }));
                 out.print(m_info.typeSignatures.findIf([&](auto& sig) {
                     return sig.get() == typeDefinition;
                 }));
-                out.print(">");
+                out.print(">"_s);
             }
-            out.print(")");
+            out.print(")"_s);
             return out.toString();
         }
         return FailureHelper::makeString(type);
@@ -335,7 +335,7 @@ private:
     // FIXME add a macro as above for WASM_TRY_APPEND_TO_CONTROL_STACK https://bugs.webkit.org/show_bug.cgi?id=165862
 
     void addReferencedFunctions(const Element&);
-    PartialResult WARN_UNUSED_RETURN parseArrayTypeDefinition(const char*, bool, uint32_t&, FieldType&, Type&);
+    PartialResult WARN_UNUSED_RETURN parseArrayTypeDefinition(ASCIILiteral, bool, uint32_t&, FieldType&, Type&);
 
     Context& m_context;
     Stack m_expressionStack;
@@ -377,17 +377,17 @@ auto FunctionParser<Context>::parse() -> Result
 {
     uint32_t localGroupsCount;
 
-    WASM_PARSER_FAIL_IF(!m_signature.is<FunctionSignature>(), "type signature was not a function signature");
+    WASM_PARSER_FAIL_IF(!m_signature.is<FunctionSignature>(), "type signature was not a function signature"_s);
     const auto& signature = *m_signature.as<FunctionSignature>();
     if (signature.numVectors() || signature.numReturnVectors()) {
         m_context.notifyFunctionUsesSIMD();
         if (!Context::tierSupportsSIMD)
             WASM_TRY_ADD_TO_CONTEXT(addCrash());
     }
-    WASM_PARSER_FAIL_IF(!m_context.addArguments(m_signature), "can't add ", signature.argumentCount(), " arguments to Function");
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(localGroupsCount), "can't get local groups count");
+    WASM_PARSER_FAIL_IF(!m_context.addArguments(m_signature), "can't add "_s, signature.argumentCount(), " arguments to Function"_s);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(localGroupsCount), "can't get local groups count"_s);
 
-    WASM_PARSER_FAIL_IF(!m_locals.tryReserveCapacity(signature.argumentCount()), "can't allocate enough memory for function's ", signature.argumentCount(), " arguments");
+    WASM_PARSER_FAIL_IF(!m_locals.tryReserveCapacity(signature.argumentCount()), "can't allocate enough memory for function's "_s, signature.argumentCount(), " arguments"_s);
     m_locals.appendUsingFunctor(signature.argumentCount(), [&](size_t i) {
         return signature.argumentType(i);
     });
@@ -398,13 +398,13 @@ auto FunctionParser<Context>::parse() -> Result
         uint32_t numberOfLocals;
         Type typeOfLocal;
 
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(numberOfLocals), "can't get Function's number of locals in group ", i);
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(numberOfLocals), "can't get Function's number of locals in group "_s, i);
         totalNumberOfLocals += numberOfLocals;
-        WASM_PARSER_FAIL_IF(totalNumberOfLocals > maxFunctionLocals, "Function's number of locals is too big ", totalNumberOfLocals, " maximum ", maxFunctionLocals);
-        WASM_PARSER_FAIL_IF(!parseValueType(m_info, typeOfLocal), "can't get Function local's type in group ", i);
+        WASM_PARSER_FAIL_IF(totalNumberOfLocals > maxFunctionLocals, "Function's number of locals is too big "_s, totalNumberOfLocals, " maximum "_s, maxFunctionLocals);
+        WASM_PARSER_FAIL_IF(!parseValueType(m_info, typeOfLocal), "can't get Function local's type in group "_s, i);
         if (UNLIKELY(!isDefaultableType(typeOfLocal))) {
             if (!Options::useWebAssemblyTypedFunctionReferences())
-                return fail("Function locals must have a defaultable type");
+                return fail("Function locals must have a defaultable type"_s);
             totalNonDefaultableLocals++;
         }
 
@@ -414,14 +414,14 @@ auto FunctionParser<Context>::parse() -> Result
                 WASM_TRY_ADD_TO_CONTEXT(addCrash());
         }
 
-        WASM_PARSER_FAIL_IF(!m_locals.tryReserveCapacity(totalNumberOfLocals), "can't allocate enough memory for function's ", totalNumberOfLocals, " locals");
+        WASM_PARSER_FAIL_IF(!m_locals.tryReserveCapacity(totalNumberOfLocals), "can't allocate enough memory for function's "_s, totalNumberOfLocals, " locals"_s);
         m_locals.appendUsingFunctor(numberOfLocals, [&](size_t) { return typeOfLocal; });
 
         WASM_TRY_ADD_TO_CONTEXT(addLocal(typeOfLocal, numberOfLocals));
     }
 
     if (Options::useWebAssemblyTypedFunctionReferences()) {
-        WASM_PARSER_FAIL_IF(!m_localInitStack.tryReserveCapacity(totalNonDefaultableLocals), "can't allocate enough memory for tracking function's local initialization");
+        WASM_PARSER_FAIL_IF(!m_localInitStack.tryReserveCapacity(totalNonDefaultableLocals), "can't allocate enough memory for tracking function's local initialization"_s);
         m_localInitFlags.ensureSize(totalNumberOfLocals);
         // Param locals are always considered initialized, so we need to pre-set them.
         for (uint32_t i = 0; i < signature.argumentCount(); ++i) {
@@ -440,7 +440,7 @@ auto FunctionParser<Context>::parse() -> Result
 template<typename Context>
 auto FunctionParser<Context>::parseConstantExpression() -> Result
 {
-    WASM_PARSER_FAIL_IF(!m_signature.is<FunctionSignature>(), "type signature was not a function signature");
+    WASM_PARSER_FAIL_IF(!m_signature.is<FunctionSignature>(), "type signature was not a function signature"_s);
     const auto& signature = *m_signature.as<FunctionSignature>();
     if (signature.numVectors() || signature.numReturnVectors()) {
         m_context.notifyFunctionUsesSIMD();
@@ -461,8 +461,8 @@ auto FunctionParser<Context>::parseBody() -> PartialResult
     uint8_t op = 0;
     while (m_controlStack.size()) {
         m_currentOpcodeStartingOffset = m_offset;
-        WASM_PARSER_FAIL_IF(!parseUInt8(op), "can't decode opcode");
-        WASM_PARSER_FAIL_IF(!isValidOpType(op), "invalid opcode ", op);
+        WASM_PARSER_FAIL_IF(!parseUInt8(op), "can't decode opcode"_s);
+        WASM_PARSER_FAIL_IF(!isValidOpType(op), "invalid opcode "_s, op);
 
         m_currentOpcode = static_cast<OpType>(op);
 #if ENABLE(WEBASSEMBLY_OMGJIT)
@@ -494,11 +494,11 @@ auto FunctionParser<Context>::binaryCase(OpType op, BinaryOperationHandler handl
     TypedExpression right;
     TypedExpression left;
 
-    WASM_TRY_POP_EXPRESSION_STACK_INTO(right, "binary right");
-    WASM_TRY_POP_EXPRESSION_STACK_INTO(left, "binary left");
+    WASM_TRY_POP_EXPRESSION_STACK_INTO(right, "binary right"_s);
+    WASM_TRY_POP_EXPRESSION_STACK_INTO(left, "binary left"_s);
 
-    WASM_VALIDATOR_FAIL_IF(left.type() != lhsType, op, " left value type mismatch");
-    WASM_VALIDATOR_FAIL_IF(right.type() != rhsType, op, " right value type mismatch");
+    WASM_VALIDATOR_FAIL_IF(left.type() != lhsType, op, " left value type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(right.type() != rhsType, op, " right value type mismatch"_s);
 
     ExpressionType result;
     WASM_FAIL_IF_HELPER_FAILS((m_context.*handler)(left, right, result));
@@ -510,9 +510,9 @@ template<typename Context>
 auto FunctionParser<Context>::unaryCase(OpType op, UnaryOperationHandler handler, Type returnType, Type operandType) -> PartialResult
 {
     TypedExpression value;
-    WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "unary");
+    WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "unary"_s);
 
-    WASM_VALIDATOR_FAIL_IF(value.type() != operandType, op, " value type mismatch");
+    WASM_VALIDATOR_FAIL_IF(value.type() != operandType, op, " value type mismatch"_s);
 
     ExpressionType result;
     WASM_FAIL_IF_HELPER_FAILS((m_context.*handler)(value, result));
@@ -523,17 +523,17 @@ auto FunctionParser<Context>::unaryCase(OpType op, UnaryOperationHandler handler
 template<typename Context>
 auto FunctionParser<Context>::load(Type memoryType) -> PartialResult
 {
-    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "load instruction without memory");
+    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "load instruction without memory"_s);
 
     uint32_t alignment;
     uint32_t offset;
     TypedExpression pointer;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment");
-    WASM_PARSER_FAIL_IF(alignment > memoryLog2Alignment(m_currentOpcode), "byte alignment ", 1ull << alignment, " exceeds load's natural alignment ", 1ull << memoryLog2Alignment(m_currentOpcode));
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset");
-    WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "load pointer");
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
+    WASM_PARSER_FAIL_IF(alignment > memoryLog2Alignment(m_currentOpcode), "byte alignment "_s, 1ull << alignment, " exceeds load's natural alignment "_s, 1ull << memoryLog2Alignment(m_currentOpcode));
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset"_s);
+    WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "load pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), m_currentOpcode, " pointer type mismatch");
+    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), m_currentOpcode, " pointer type mismatch"_s);
 
     ExpressionType result;
     WASM_TRY_ADD_TO_CONTEXT(load(static_cast<LoadOpType>(m_currentOpcode), pointer, result, offset));
@@ -544,20 +544,20 @@ auto FunctionParser<Context>::load(Type memoryType) -> PartialResult
 template<typename Context>
 auto FunctionParser<Context>::store(Type memoryType) -> PartialResult
 {
-    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "store instruction without memory");
+    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "store instruction without memory"_s);
 
     uint32_t alignment;
     uint32_t offset;
     TypedExpression value;
     TypedExpression pointer;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get store alignment");
-    WASM_PARSER_FAIL_IF(alignment > memoryLog2Alignment(m_currentOpcode), "byte alignment ", 1ull << alignment, " exceeds store's natural alignment ", 1ull << memoryLog2Alignment(m_currentOpcode));
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get store offset");
-    WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "store value");
-    WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "store pointer");
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get store alignment"_s);
+    WASM_PARSER_FAIL_IF(alignment > memoryLog2Alignment(m_currentOpcode), "byte alignment "_s, 1ull << alignment, " exceeds store's natural alignment "_s, 1ull << memoryLog2Alignment(m_currentOpcode));
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get store offset"_s);
+    WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "store value"_s);
+    WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "store pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), m_currentOpcode, " pointer type mismatch");
-    WASM_VALIDATOR_FAIL_IF(value.type() != memoryType, m_currentOpcode, " value type mismatch");
+    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), m_currentOpcode, " pointer type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(value.type() != memoryType, m_currentOpcode, " value type mismatch"_s);
 
     WASM_TRY_ADD_TO_CONTEXT(store(static_cast<StoreOpType>(m_currentOpcode), pointer, value, offset));
     return { };
@@ -567,9 +567,9 @@ template<typename Context>
 auto FunctionParser<Context>::truncSaturated(Ext1OpType op, Type returnType, Type operandType) -> PartialResult
 {
     TypedExpression value;
-    WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "unary");
+    WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "unary"_s);
 
-    WASM_VALIDATOR_FAIL_IF(value.type() != operandType, "trunc-saturated value type mismatch. Expected: ", operandType, " but expression stack has ", value.type());
+    WASM_VALIDATOR_FAIL_IF(value.type() != operandType, "trunc-saturated value type mismatch. Expected: "_s, operandType, " but expression stack has "_s, value.type());
 
     ExpressionType result;
     WASM_TRY_ADD_TO_CONTEXT(truncSaturated(op, value, result, returnType, operandType));
@@ -580,17 +580,17 @@ auto FunctionParser<Context>::truncSaturated(Ext1OpType op, Type returnType, Typ
 template<typename Context>
 auto FunctionParser<Context>::atomicLoad(ExtAtomicOpType op, Type memoryType) -> PartialResult
 {
-    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "atomic instruction without memory");
+    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "atomic instruction without memory"_s);
 
     uint32_t alignment;
     uint32_t offset;
     TypedExpression pointer;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment");
-    WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment ", 1ull << alignment, " does not match against atomic op's natural alignment ", 1ull << memoryLog2Alignment(op));
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset");
-    WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "load pointer");
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
+    WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset"_s);
+    WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "load pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), static_cast<unsigned>(op), " pointer type mismatch");
+    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), static_cast<unsigned>(op), " pointer type mismatch"_s);
 
     ExpressionType result;
     WASM_TRY_ADD_TO_CONTEXT(atomicLoad(op, memoryType, pointer, result, offset));
@@ -601,20 +601,20 @@ auto FunctionParser<Context>::atomicLoad(ExtAtomicOpType op, Type memoryType) ->
 template<typename Context>
 auto FunctionParser<Context>::atomicStore(ExtAtomicOpType op, Type memoryType) -> PartialResult
 {
-    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "atomic instruction without memory");
+    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "atomic instruction without memory"_s);
 
     uint32_t alignment;
     uint32_t offset;
     TypedExpression value;
     TypedExpression pointer;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get store alignment");
-    WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment ", 1ull << alignment, " does not match against atomic op's natural alignment ", 1ull << memoryLog2Alignment(op));
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get store offset");
-    WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "store value");
-    WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "store pointer");
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get store alignment"_s);
+    WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get store offset"_s);
+    WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "store value"_s);
+    WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "store pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), m_currentOpcode, " pointer type mismatch");
-    WASM_VALIDATOR_FAIL_IF(value.type() != memoryType, m_currentOpcode, " value type mismatch");
+    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), m_currentOpcode, " pointer type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(value.type() != memoryType, m_currentOpcode, " value type mismatch"_s);
 
     WASM_TRY_ADD_TO_CONTEXT(atomicStore(op, memoryType, pointer, value, offset));
     return { };
@@ -623,20 +623,20 @@ auto FunctionParser<Context>::atomicStore(ExtAtomicOpType op, Type memoryType) -
 template<typename Context>
 auto FunctionParser<Context>::atomicBinaryRMW(ExtAtomicOpType op, Type memoryType) -> PartialResult
 {
-    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "atomic instruction without memory");
+    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "atomic instruction without memory"_s);
 
     uint32_t alignment;
     uint32_t offset;
     TypedExpression pointer;
     TypedExpression value;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment");
-    WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment ", 1ull << alignment, " does not match against atomic op's natural alignment ", 1ull << memoryLog2Alignment(op));
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset");
-    WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "value");
-    WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer");
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
+    WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset"_s);
+    WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "value"_s);
+    WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), static_cast<unsigned>(op), " pointer type mismatch");
-    WASM_VALIDATOR_FAIL_IF(value.type() != memoryType, static_cast<unsigned>(op), " value type mismatch");
+    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), static_cast<unsigned>(op), " pointer type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(value.type() != memoryType, static_cast<unsigned>(op), " value type mismatch"_s);
 
     ExpressionType result;
     WASM_TRY_ADD_TO_CONTEXT(atomicBinaryRMW(op, memoryType, pointer, value, result, offset));
@@ -647,23 +647,23 @@ auto FunctionParser<Context>::atomicBinaryRMW(ExtAtomicOpType op, Type memoryTyp
 template<typename Context>
 auto FunctionParser<Context>::atomicCompareExchange(ExtAtomicOpType op, Type memoryType) -> PartialResult
 {
-    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "atomic instruction without memory");
+    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "atomic instruction without memory"_s);
 
     uint32_t alignment;
     uint32_t offset;
     TypedExpression pointer;
     TypedExpression expected;
     TypedExpression value;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment");
-    WASM_PARSER_FAIL_IF(alignment !=  memoryLog2Alignment(op), "byte alignment ", 1ull << alignment, " does not match against atomic op's natural alignment ", 1ull << memoryLog2Alignment(op));
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset");
-    WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "value");
-    WASM_TRY_POP_EXPRESSION_STACK_INTO(expected, "expected");
-    WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer");
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
+    WASM_PARSER_FAIL_IF(alignment !=  memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset"_s);
+    WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "value"_s);
+    WASM_TRY_POP_EXPRESSION_STACK_INTO(expected, "expected"_s);
+    WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), static_cast<unsigned>(op), " pointer type mismatch");
-    WASM_VALIDATOR_FAIL_IF(expected.type() != memoryType, static_cast<unsigned>(op), " expected type mismatch");
-    WASM_VALIDATOR_FAIL_IF(value.type() != memoryType, static_cast<unsigned>(op), " value type mismatch");
+    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), static_cast<unsigned>(op), " pointer type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(expected.type() != memoryType, static_cast<unsigned>(op), " expected type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(value.type() != memoryType, static_cast<unsigned>(op), " value type mismatch"_s);
 
     ExpressionType result;
     WASM_TRY_ADD_TO_CONTEXT(atomicCompareExchange(op, memoryType, pointer, expected, value, result, offset));
@@ -674,23 +674,23 @@ auto FunctionParser<Context>::atomicCompareExchange(ExtAtomicOpType op, Type mem
 template<typename Context>
 auto FunctionParser<Context>::atomicWait(ExtAtomicOpType op, Type memoryType) -> PartialResult
 {
-    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "atomic instruction without memory");
+    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "atomic instruction without memory"_s);
 
     uint32_t alignment;
     uint32_t offset;
     TypedExpression pointer;
     TypedExpression value;
     TypedExpression timeout;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment");
-    WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment ", 1ull << alignment, " does not match against atomic op's natural alignment ", 1ull << memoryLog2Alignment(op));
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset");
-    WASM_TRY_POP_EXPRESSION_STACK_INTO(timeout, "timeout");
-    WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "value");
-    WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer");
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
+    WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset"_s);
+    WASM_TRY_POP_EXPRESSION_STACK_INTO(timeout, "timeout"_s);
+    WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "value"_s);
+    WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), static_cast<unsigned>(op), " pointer type mismatch");
-    WASM_VALIDATOR_FAIL_IF(value.type() != memoryType, static_cast<unsigned>(op), " value type mismatch");
-    WASM_VALIDATOR_FAIL_IF(!timeout.type().isI64(), static_cast<unsigned>(op), " timeout type mismatch");
+    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), static_cast<unsigned>(op), " pointer type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(value.type() != memoryType, static_cast<unsigned>(op), " value type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(!timeout.type().isI64(), static_cast<unsigned>(op), " timeout type mismatch"_s);
 
     ExpressionType result;
     WASM_TRY_ADD_TO_CONTEXT(atomicWait(op, pointer, value, timeout, result, offset));
@@ -701,20 +701,20 @@ auto FunctionParser<Context>::atomicWait(ExtAtomicOpType op, Type memoryType) ->
 template<typename Context>
 auto FunctionParser<Context>::atomicNotify(ExtAtomicOpType op) -> PartialResult
 {
-    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "atomic instruction without memory");
+    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "atomic instruction without memory"_s);
 
     uint32_t alignment;
     uint32_t offset;
     TypedExpression pointer;
     TypedExpression count;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment");
-    WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment ", 1ull << alignment, " does not match against atomic op's natural alignment ", 1ull << memoryLog2Alignment(op));
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset");
-    WASM_TRY_POP_EXPRESSION_STACK_INTO(count, "count");
-    WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer");
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
+    WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get load offset"_s);
+    WASM_TRY_POP_EXPRESSION_STACK_INTO(count, "count"_s);
+    WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "pointer"_s);
 
-    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), static_cast<unsigned>(op), " pointer type mismatch");
-    WASM_VALIDATOR_FAIL_IF(!count.type().isI32(), static_cast<unsigned>(op), " count type mismatch"); // The spec's definition is saying i64, but all implementations (including tests) are using i32. So looks like the spec is wrong.
+    WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), static_cast<unsigned>(op), " pointer type mismatch"_s);
+    WASM_VALIDATOR_FAIL_IF(!count.type().isI32(), static_cast<unsigned>(op), " count type mismatch"_s); // The spec's definition is saying i64, but all implementations (including tests) are using i32. So looks like the spec is wrong.
 
     ExpressionType result;
     WASM_TRY_ADD_TO_CONTEXT(atomicNotify(op, pointer, count, result, offset));
@@ -726,8 +726,8 @@ template<typename Context>
 auto FunctionParser<Context>::atomicFence(ExtAtomicOpType op) -> PartialResult
 {
     uint8_t flags;
-    WASM_PARSER_FAIL_IF(!parseUInt8(flags), "can't get flags");
-    WASM_PARSER_FAIL_IF(flags != 0x0, "flags should be 0x0 but got ", flags);
+    WASM_PARSER_FAIL_IF(!parseUInt8(flags), "can't get flags"_s);
+    WASM_PARSER_FAIL_IF(flags != 0x0, "flags should be 0x0 but got "_s, flags);
     WASM_TRY_ADD_TO_CONTEXT(atomicFence(op, flags));
     return { };
 }
@@ -791,32 +791,32 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
         default: RELEASE_ASSERT_NOT_REACHED();
         }
 
-        WASM_VALIDATOR_FAIL_IF(!m_info.memory, "simd memory instructions need a memory defined in the module");
+        WASM_VALIDATOR_FAIL_IF(!m_info.memory, "simd memory instructions need a memory defined in the module"_s);
 
         uint32_t alignment;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get simd memory op alignment");
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get simd memory op offset");
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get simd memory op alignment"_s);
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get simd memory op offset"_s);
 
-        WASM_VALIDATOR_FAIL_IF(alignment > maxAlignment, "alignment: ", alignment, " can't be larger than max alignment for simd operation: ", maxAlignment);
+        WASM_VALIDATOR_FAIL_IF(alignment > maxAlignment, "alignment: "_s, alignment, " can't be larger than max alignment for simd operation: "_s, maxAlignment);
 
         if constexpr (!isReachable)
             return { };
 
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "simd memory op pointer");
-        WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), "pointer must be i32");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "simd memory op pointer"_s);
+        WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), "pointer must be i32"_s);
 
         return { };
     };
 
     if (isRelaxedSIMDOperation(op))
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyRelaxedSIMD(), "relaxed simd instructions not supported");
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyRelaxedSIMD(), "relaxed simd instructions not supported"_s);
 
     switch (op) {
     case SIMDLaneOperation::Const: {
         v128_t constant;
         ASSERT(lane == SIMDLane::v128);
         ASSERT(signMode == SIMDSignMode::None);
-        WASM_PARSER_FAIL_IF(!parseImmByteArray16(constant), "can't parse 128-bit vector constant");
+        WASM_PARSER_FAIL_IF(!parseImmByteArray16(constant), "can't parse 128-bit vector constant"_s);
 
         if constexpr (!isReachable)
             return { };
@@ -834,7 +834,7 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
             return { };
 
         TypedExpression scalar;
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(scalar, "select condition");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(scalar, "select condition"_s);
         bool okType;
         switch (lane) {
         case SIMDLane::i8x16:
@@ -854,7 +854,7 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
         default:
             RELEASE_ASSERT_NOT_REACHED();
         }
-        WASM_VALIDATOR_FAIL_IF(!okType, "Wrong type to SIMD splat");
+        WASM_VALIDATOR_FAIL_IF(!okType, "Wrong type to SIMD splat"_s);
 
         if constexpr (Context::tierSupportsSIMD) {
             ExpressionType result;
@@ -871,10 +871,10 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
 
         TypedExpression vector;
         TypedExpression shift;
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(shift, "shift i32");
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(vector, "shift vector");
-        WASM_VALIDATOR_FAIL_IF(!vector.type().isV128(), "Shift vector must be v128");
-        WASM_VALIDATOR_FAIL_IF(!shift.type().isI32(), "Shift amount must be i32");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(shift, "shift i32"_s);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(vector, "shift vector"_s);
+        WASM_VALIDATOR_FAIL_IF(!vector.type().isV128(), "Shift vector must be v128"_s);
+        WASM_VALIDATOR_FAIL_IF(!shift.type().isI32(), "Shift amount must be i32"_s);
 
         if constexpr (Context::tierSupportsSIMD) {
             ExpressionType result;
@@ -892,10 +892,10 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
 
         TypedExpression lhs;
         TypedExpression rhs;
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(rhs, "rhs");
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(lhs, "lhs");
-        WASM_VALIDATOR_FAIL_IF(!lhs.type().isV128(), "extmul lhs vector must be v128");
-        WASM_VALIDATOR_FAIL_IF(!rhs.type().isV128(), "extmul rhs vector must be v128");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(rhs, "rhs"_s);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(lhs, "lhs"_s);
+        WASM_VALIDATOR_FAIL_IF(!lhs.type().isV128(), "extmul lhs vector must be v128"_s);
+        WASM_VALIDATOR_FAIL_IF(!rhs.type().isV128(), "extmul rhs vector must be v128"_s);
 
         if constexpr (Context::tierSupportsSIMD) {
             ExpressionType result;
@@ -932,8 +932,8 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
         TypedExpression val;
 
         if (isReachable) {
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(val, "val");
-            WASM_VALIDATOR_FAIL_IF(!val.type().isV128(), "store vector must be v128");
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(val, "val"_s);
+            WASM_VALIDATOR_FAIL_IF(!val.type().isV128(), "store vector must be v128"_s);
         }
 
         uint32_t offset;
@@ -973,8 +973,8 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
         })();
 
         if (isReachable) {
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(vector, "vector");
-            WASM_VALIDATOR_FAIL_IF(!vector.type().isV128(), "load_lane input must be a vector");
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(vector, "vector"_s);
+            WASM_VALIDATOR_FAIL_IF(!vector.type().isV128(), "load_lane input must be a vector"_s);
         }
 
         WASM_FAIL_IF_HELPER_FAILS(parseMemOp(offset, pointer));
@@ -1015,8 +1015,8 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
         })();
 
         if (isReachable) {
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(vector, "vector");
-            WASM_VALIDATOR_FAIL_IF(!vector.type().isV128(), "store_lane input must be a vector");
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(vector, "vector"_s);
+            WASM_VALIDATOR_FAIL_IF(!vector.type().isV128(), "store_lane input must be a vector"_s);
         }
 
         WASM_FAIL_IF_HELPER_FAILS(parseMemOp(offset, pointer));
@@ -1076,17 +1076,17 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
         TypedExpression a;
         TypedExpression b;
 
-        WASM_PARSER_FAIL_IF(!parseImmByteArray16(imm), "can't parse 128-bit shuffle immediate");
+        WASM_PARSER_FAIL_IF(!parseImmByteArray16(imm), "can't parse 128-bit shuffle immediate"_s);
         for (auto i = 0; i < 16; ++i)
             WASM_PARSER_FAIL_IF(imm.u8x16[i] >= 2 * elementCount(lane));
 
         if constexpr (!isReachable)
             return { };
 
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(b, "vector argument");
-        WASM_VALIDATOR_FAIL_IF(!b.type().isV128(), "shuffle input must be a vector");
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(a, "vector argument");
-        WASM_VALIDATOR_FAIL_IF(!a.type().isV128(), "shuffle input must be a vector");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(b, "vector argument"_s);
+        WASM_VALIDATOR_FAIL_IF(!b.type().isV128(), "shuffle input must be a vector"_s);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(a, "vector argument"_s);
+        WASM_VALIDATOR_FAIL_IF(!a.type().isV128(), "shuffle input must be a vector"_s);
 
         if constexpr (Context::tierSupportsSIMD) {
             ExpressionType result;
@@ -1104,8 +1104,8 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
         if constexpr (!isReachable)
             return { };
 
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(v, "vector argument");
-        WASM_VALIDATOR_FAIL_IF(v.type() != Types::V128, "type mismatch for argument 0");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(v, "vector argument"_s);
+        WASM_VALIDATOR_FAIL_IF(v.type() != Types::V128, "type mismatch for argument 0"_s);
 
         if constexpr (Context::tierSupportsSIMD) {
             ExpressionType result;
@@ -1124,10 +1124,10 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
         if constexpr (!isReachable)
             return { };
 
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(s, "scalar argument");
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(v, "vector argument");
-        WASM_VALIDATOR_FAIL_IF(v.type() != Types::V128, "type mismatch for argument 1");
-        WASM_VALIDATOR_FAIL_IF(s.type() != simdScalarType(lane), "type mismatch for argument 0");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(s, "scalar argument"_s);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(v, "vector argument"_s);
+        WASM_VALIDATOR_FAIL_IF(v.type() != Types::V128, "type mismatch for argument 1"_s);
+        WASM_VALIDATOR_FAIL_IF(s.type() != simdScalarType(lane), "type mismatch for argument 0"_s);
 
         if constexpr (Context::tierSupportsSIMD) {
             ExpressionType result;
@@ -1144,8 +1144,8 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
             return { };
 
         TypedExpression v;
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(v, "vector argument");
-        WASM_VALIDATOR_FAIL_IF(v.type() != Types::V128, "type mismatch for argument 0");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(v, "vector argument"_s);
+        WASM_VALIDATOR_FAIL_IF(v.type() != Types::V128, "type mismatch for argument 0"_s);
 
         if constexpr (Context::tierSupportsSIMD) {
             ExpressionType result;
@@ -1177,8 +1177,8 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
             return { };
 
         TypedExpression v;
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(v, "vector argument");
-        WASM_VALIDATOR_FAIL_IF(v.type() != Types::V128, "type mismatch for argument 0");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(v, "vector argument"_s);
+        WASM_VALIDATOR_FAIL_IF(v.type() != Types::V128, "type mismatch for argument 0"_s);
 
         if constexpr (Context::tierSupportsSIMD) {
             ExpressionType result;
@@ -1195,12 +1195,12 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
         TypedExpression v1;
         TypedExpression v2;
         TypedExpression c;
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(c, "vector argument");
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(v2, "vector argument");
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(v1, "vector argument");
-        WASM_VALIDATOR_FAIL_IF(v1.type() != Types::V128, "type mismatch for argument 2");
-        WASM_VALIDATOR_FAIL_IF(v2.type() != Types::V128, "type mismatch for argument 1");
-        WASM_VALIDATOR_FAIL_IF(c.type() != Types::V128, "type mismatch for argument 0");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(c, "vector argument"_s);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(v2, "vector argument"_s);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(v1, "vector argument"_s);
+        WASM_VALIDATOR_FAIL_IF(v1.type() != Types::V128, "type mismatch for argument 2"_s);
+        WASM_VALIDATOR_FAIL_IF(v2.type() != Types::V128, "type mismatch for argument 1"_s);
+        WASM_VALIDATOR_FAIL_IF(c.type() != Types::V128, "type mismatch for argument 0"_s);
 
         if constexpr (Context::tierSupportsSIMD) {
             ExpressionType result;
@@ -1219,10 +1219,10 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
 
         TypedExpression rhs;
         TypedExpression lhs;
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(rhs, "vector argument");
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(lhs, "vector argument");
-        WASM_VALIDATOR_FAIL_IF(lhs.type() != Types::V128, "type mismatch for argument 1");
-        WASM_VALIDATOR_FAIL_IF(rhs.type() != Types::V128, "type mismatch for argument 0");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(rhs, "vector argument"_s);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(lhs, "vector argument"_s);
+        WASM_VALIDATOR_FAIL_IF(lhs.type() != Types::V128, "type mismatch for argument 1"_s);
+        WASM_VALIDATOR_FAIL_IF(rhs.type() != Types::V128, "type mismatch for argument 0"_s);
 
         if constexpr (Context::tierSupportsSIMD) {
             ExpressionType result;
@@ -1239,10 +1239,10 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
 
         TypedExpression rhs;
         TypedExpression lhs;
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(rhs, "vector argument");
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(lhs, "vector argument");
-        WASM_VALIDATOR_FAIL_IF(lhs.type() != Types::V128, "type mismatch for argument 1");
-        WASM_VALIDATOR_FAIL_IF(rhs.type() != Types::V128, "type mismatch for argument 0");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(rhs, "vector argument"_s);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(lhs, "vector argument"_s);
+        WASM_VALIDATOR_FAIL_IF(lhs.type() != Types::V128, "type mismatch for argument 1"_s);
+        WASM_VALIDATOR_FAIL_IF(rhs.type() != Types::V128, "type mismatch for argument 0"_s);
 
         if constexpr (Context::tierSupportsSIMD) {
             ExpressionType result;
@@ -1277,10 +1277,10 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
 
         TypedExpression a;
         TypedExpression b;
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(b, "vector argument");
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(a, "vector argument");
-        WASM_VALIDATOR_FAIL_IF(a.type() != Types::V128, "type mismatch for argument 1");
-        WASM_VALIDATOR_FAIL_IF(b.type() != Types::V128, "type mismatch for argument 0");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(b, "vector argument"_s);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(a, "vector argument"_s);
+        WASM_VALIDATOR_FAIL_IF(a.type() != Types::V128, "type mismatch for argument 1"_s);
+        WASM_VALIDATOR_FAIL_IF(b.type() != Types::V128, "type mismatch for argument 0"_s);
 
         if constexpr (Context::tierSupportsSIMD) {
             ExpressionType result;
@@ -1297,12 +1297,12 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
         TypedExpression a;
         TypedExpression b;
         TypedExpression c;
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(c, "vector argument");
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(b, "vector argument");
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(a, "vector argument");
-        WASM_VALIDATOR_FAIL_IF(a.type() != Types::V128, "type mismatch for argument 0");
-        WASM_VALIDATOR_FAIL_IF(b.type() != Types::V128, "type mismatch for argument 1");
-        WASM_VALIDATOR_FAIL_IF(c.type() != Types::V128, "type mismatch for argument 2");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(c, "vector argument"_s);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(b, "vector argument"_s);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(a, "vector argument"_s);
+        WASM_VALIDATOR_FAIL_IF(a.type() != Types::V128, "type mismatch for argument 0"_s);
+        WASM_VALIDATOR_FAIL_IF(b.type() != Types::V128, "type mismatch for argument 1"_s);
+        WASM_VALIDATOR_FAIL_IF(c.type() != Types::V128, "type mismatch for argument 2"_s);
 
         if constexpr (Context::tierSupportsSIMD) {
             ExpressionType result;
@@ -1314,7 +1314,7 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
     }
     default:
         ASSERT_NOT_REACHED();
-        WASM_PARSER_FAIL_IF(true, "invalid simd op ", SIMDLaneOperationDump(op));
+        WASM_PARSER_FAIL_IF(true, "invalid simd op "_s, SIMDLaneOperationDump(op));
         break;
     }
     return { };
@@ -1325,8 +1325,8 @@ template<typename Context>
 auto FunctionParser<Context>::parseTableIndex(unsigned& result) -> PartialResult
 {
     unsigned tableIndex;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't parse table index");
-    WASM_VALIDATOR_FAIL_IF(tableIndex >= m_info.tableCount(), "table index ", tableIndex, " is invalid, limit is ", m_info.tableCount());
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't parse table index"_s);
+    WASM_VALIDATOR_FAIL_IF(tableIndex >= m_info.tableCount(), "table index "_s, tableIndex, " is invalid, limit is "_s, m_info.tableCount());
     result = tableIndex;
     return { };
 }
@@ -1335,8 +1335,8 @@ template<typename Context>
 auto FunctionParser<Context>::parseIndexForLocal(uint32_t& resultIndex) -> PartialResult
 {
     uint32_t index;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(index), "can't get index for local");
-    WASM_VALIDATOR_FAIL_IF(index >= m_locals.size(), "attempt to use unknown local ", index, ", the number of locals is ", m_locals.size());
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(index), "can't get index for local"_s);
+    WASM_VALIDATOR_FAIL_IF(index >= m_locals.size(), "attempt to use unknown local "_s, index, ", the number of locals is "_s, m_locals.size());
     resultIndex = index;
     return { };
 }
@@ -1345,8 +1345,8 @@ template<typename Context>
 auto FunctionParser<Context>::parseIndexForGlobal(uint32_t& resultIndex) -> PartialResult
 {
     uint32_t index;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(index), "can't get global's index");
-    WASM_VALIDATOR_FAIL_IF(index >= m_info.globals.size(), index, " of unknown global, limit is ", m_info.globals.size());
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(index), "can't get global's index"_s);
+    WASM_VALIDATOR_FAIL_IF(index >= m_info.globals.size(), index, " of unknown global, limit is "_s, m_info.globals.size());
     resultIndex = index;
     return { };
 }
@@ -1355,8 +1355,8 @@ template<typename Context>
 auto FunctionParser<Context>::parseFunctionIndex(uint32_t& resultIndex) -> PartialResult
 {
     uint32_t functionIndex;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(functionIndex), "can't parse function index");
-    WASM_PARSER_FAIL_IF(functionIndex >= m_info.functionIndexSpaceSize(), "function index ", functionIndex, " exceeds function index space ", m_info.functionIndexSpaceSize());
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(functionIndex), "can't parse function index"_s);
+    WASM_PARSER_FAIL_IF(functionIndex >= m_info.functionIndexSpaceSize(), "function index "_s, functionIndex, " exceeds function index space "_s, m_info.functionIndexSpaceSize());
     resultIndex = functionIndex;
     return { };
 }
@@ -1365,8 +1365,8 @@ template<typename Context>
 auto FunctionParser<Context>::parseExceptionIndex(uint32_t& result) -> PartialResult
 {
     uint32_t exceptionIndex;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(exceptionIndex), "can't parse exception index");
-    WASM_VALIDATOR_FAIL_IF(exceptionIndex >= m_info.exceptionIndexSpaceSize(), "exception index ", exceptionIndex, " is invalid, limit is ", m_info.exceptionIndexSpaceSize());
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(exceptionIndex), "can't parse exception index"_s);
+    WASM_VALIDATOR_FAIL_IF(exceptionIndex >= m_info.exceptionIndexSpaceSize(), "exception index "_s, exceptionIndex, " is invalid, limit is "_s, m_info.exceptionIndexSpaceSize());
     result = exceptionIndex;
     return { };
 }
@@ -1375,8 +1375,8 @@ template<typename Context>
 auto FunctionParser<Context>::parseBranchTarget(uint32_t& resultTarget) -> PartialResult
 {
     uint32_t target;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(target), "can't get br / br_if's target");
-    WASM_PARSER_FAIL_IF(target >= m_controlStack.size(), "br / br_if's target ", target, " exceeds control stack size ", m_controlStack.size());
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(target), "can't get br / br_if's target"_s);
+    WASM_PARSER_FAIL_IF(target >= m_controlStack.size(), "br / br_if's target "_s, target, " exceeds control stack size "_s, m_controlStack.size());
     resultTarget = target;
     return { };
 }
@@ -1386,13 +1386,13 @@ auto FunctionParser<Context>::parseDelegateTarget(uint32_t& resultTarget, uint32
 {
     // Right now, control stack includes try-delegate block, and delegate needs to specify outer scope.
     uint32_t target;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(target), "can't get delegate target");
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(target), "can't get delegate target"_s);
     Checked<uint32_t, RecordOverflow> controlStackSize { m_controlStack.size() };
     if (unreachableBlocks)
         controlStackSize += (unreachableBlocks - 1); // The first block is in the control stack already.
     controlStackSize -= 1; // delegate target does not include the current block.
-    WASM_PARSER_FAIL_IF(controlStackSize.hasOverflowed(), "invalid control stack size");
-    WASM_PARSER_FAIL_IF(target >= controlStackSize.value(), "delegate target ", target, " exceeds control stack size ", controlStackSize.value());
+    WASM_PARSER_FAIL_IF(controlStackSize.hasOverflowed(), "invalid control stack size"_s);
+    WASM_PARSER_FAIL_IF(target >= controlStackSize.value(), "delegate target "_s, target, " exceeds control stack size "_s, controlStackSize.value());
     resultTarget = target;
     return { };
 }
@@ -1401,8 +1401,8 @@ template<typename Context>
 auto FunctionParser<Context>::parseElementIndex(unsigned& result) -> PartialResult
 {
     unsigned elementIndex;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(elementIndex), "can't parse element index");
-    WASM_VALIDATOR_FAIL_IF(elementIndex >= m_info.elementCount(), "element index ", elementIndex, " is invalid, limit is ", m_info.elementCount());
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(elementIndex), "can't parse element index"_s);
+    WASM_VALIDATOR_FAIL_IF(elementIndex >= m_info.elementCount(), "element index "_s, elementIndex, " is invalid, limit is "_s, m_info.elementCount());
     result = elementIndex;
     return { };
 }
@@ -1411,8 +1411,8 @@ template<typename Context>
 auto FunctionParser<Context>::parseDataSegmentIndex(unsigned& result) -> PartialResult
 {
     unsigned dataSegmentIndex;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(dataSegmentIndex), "can't parse data segment index");
-    WASM_VALIDATOR_FAIL_IF(dataSegmentIndex >= m_info.dataSegmentsCount(), "data segment index ", dataSegmentIndex, " is invalid, limit is ", m_info.dataSegmentsCount());
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(dataSegmentIndex), "can't parse data segment index"_s);
+    WASM_VALIDATOR_FAIL_IF(dataSegmentIndex >= m_info.dataSegmentsCount(), "data segment index "_s, dataSegmentIndex, " is invalid, limit is "_s, m_info.dataSegmentsCount());
     result = dataSegmentIndex;
     return { };
 }
@@ -1436,12 +1436,12 @@ template<typename Context>
 auto FunctionParser<Context>::parseTableCopyImmediates(TableCopyImmediates& result) -> PartialResult
 {
     unsigned dstTableIndex;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(dstTableIndex), "can't parse destination table index");
-    WASM_VALIDATOR_FAIL_IF(dstTableIndex >= m_info.tableCount(), "table index ", dstTableIndex, " is invalid, limit is ", m_info.tableCount());
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(dstTableIndex), "can't parse destination table index"_s);
+    WASM_VALIDATOR_FAIL_IF(dstTableIndex >= m_info.tableCount(), "table index "_s, dstTableIndex, " is invalid, limit is "_s, m_info.tableCount());
 
     unsigned srcTableIndex;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(srcTableIndex), "can't parse source table index");
-    WASM_VALIDATOR_FAIL_IF(srcTableIndex >= m_info.tableCount(), "table index ", srcTableIndex, " is invalid, limit is ", m_info.tableCount());
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(srcTableIndex), "can't parse source table index"_s);
+    WASM_VALIDATOR_FAIL_IF(srcTableIndex >= m_info.tableCount(), "table index "_s, srcTableIndex, " is invalid, limit is "_s, m_info.tableCount());
 
     result.dstTableIndex = dstTableIndex;
     result.srcTableIndex = srcTableIndex;
@@ -1453,11 +1453,11 @@ template<typename Context>
 auto FunctionParser<Context>::parseAnnotatedSelectImmediates(AnnotatedSelectImmediates& result) -> PartialResult
 {
     uint32_t sizeOfAnnotationVector;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(sizeOfAnnotationVector), "select can't parse the size of annotation vector");
-    WASM_PARSER_FAIL_IF(sizeOfAnnotationVector != 1, "select invalid result arity for");
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(sizeOfAnnotationVector), "select can't parse the size of annotation vector"_s);
+    WASM_PARSER_FAIL_IF(sizeOfAnnotationVector != 1, "select invalid result arity for"_s);
 
     Type targetType;
-    WASM_PARSER_FAIL_IF(!parseValueType(m_info, targetType), "select can't parse annotations");
+    WASM_PARSER_FAIL_IF(!parseValueType(m_info, targetType), "select can't parse annotations"_s);
 
     result.sizeOfAnnotationVector = sizeOfAnnotationVector;
     result.targetType = targetType;
@@ -1468,8 +1468,8 @@ template<typename Context>
 auto FunctionParser<Context>::parseMemoryFillImmediate() -> PartialResult
 {
     uint8_t auxiliaryByte;
-    WASM_PARSER_FAIL_IF(!parseUInt8(auxiliaryByte), "can't parse auxiliary byte");
-    WASM_PARSER_FAIL_IF(!!auxiliaryByte, "auxiliary byte for memory.fill should be zero, but got ", auxiliaryByte);
+    WASM_PARSER_FAIL_IF(!parseUInt8(auxiliaryByte), "can't parse auxiliary byte"_s);
+    WASM_PARSER_FAIL_IF(!!auxiliaryByte, "auxiliary byte for memory.fill should be zero, but got "_s, auxiliaryByte);
     return { };
 }
 
@@ -1477,12 +1477,12 @@ template<typename Context>
 auto FunctionParser<Context>::parseMemoryCopyImmediates() -> PartialResult
 {
     uint8_t firstAuxiliaryByte;
-    WASM_PARSER_FAIL_IF(!parseUInt8(firstAuxiliaryByte), "can't parse auxiliary byte");
-    WASM_PARSER_FAIL_IF(!!firstAuxiliaryByte, "auxiliary byte for memory.copy should be zero, but got ", firstAuxiliaryByte);
+    WASM_PARSER_FAIL_IF(!parseUInt8(firstAuxiliaryByte), "can't parse auxiliary byte"_s);
+    WASM_PARSER_FAIL_IF(!!firstAuxiliaryByte, "auxiliary byte for memory.copy should be zero, but got "_s, firstAuxiliaryByte);
 
     uint8_t secondAuxiliaryByte;
-    WASM_PARSER_FAIL_IF(!parseUInt8(secondAuxiliaryByte), "can't parse auxiliary byte");
-    WASM_PARSER_FAIL_IF(!!secondAuxiliaryByte, "auxiliary byte for memory.copy should be zero, but got ", secondAuxiliaryByte);
+    WASM_PARSER_FAIL_IF(!parseUInt8(secondAuxiliaryByte), "can't parse auxiliary byte"_s);
+    WASM_PARSER_FAIL_IF(!!secondAuxiliaryByte, "auxiliary byte for memory.copy should be zero, but got "_s, secondAuxiliaryByte);
     return { };
 }
 
@@ -1493,8 +1493,8 @@ auto FunctionParser<Context>::parseMemoryInitImmediates(MemoryInitImmediates& re
     WASM_FAIL_IF_HELPER_FAILS(parseDataSegmentIndex(dataSegmentIndex));
 
     unsigned unused;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't parse unused");
-    WASM_PARSER_FAIL_IF(!!unused, "memory.init invalid unsued byte");
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't parse unused"_s);
+    WASM_PARSER_FAIL_IF(!!unused, "memory.init invalid unsued byte"_s);
 
     result.unused = unused;
     result.dataSegmentIndex = dataSegmentIndex;
@@ -1502,31 +1502,31 @@ auto FunctionParser<Context>::parseMemoryInitImmediates(MemoryInitImmediates& re
 }
 
 template<typename Context>
-auto FunctionParser<Context>::parseStructTypeIndex(uint32_t& structTypeIndex, const char* operation) -> PartialResult
+auto FunctionParser<Context>::parseStructTypeIndex(uint32_t& structTypeIndex, ASCIILiteral operation) -> PartialResult
 {
     uint32_t typeIndex;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(typeIndex), "can't get type index for ", operation);
-    WASM_VALIDATOR_FAIL_IF(typeIndex >= m_info.typeCount(), operation, " index ", typeIndex, " is out of bound");
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(typeIndex), "can't get type index for "_s, operation);
+    WASM_VALIDATOR_FAIL_IF(typeIndex >= m_info.typeCount(), operation, " index "_s, typeIndex, " is out of bound"_s);
     const TypeDefinition& type = m_info.typeSignatures[typeIndex]->expand();
-    WASM_VALIDATOR_FAIL_IF(!type.is<StructType>(), operation, ": invalid type index ", typeIndex);
+    WASM_VALIDATOR_FAIL_IF(!type.is<StructType>(), operation, ": invalid type index "_s, typeIndex);
 
     structTypeIndex = typeIndex;
     return { };
 }
 
 template<typename Context>
-auto FunctionParser<Context>::parseStructFieldIndex(uint32_t& structFieldIndex, const StructType& structType, const char* operation) -> PartialResult
+auto FunctionParser<Context>::parseStructFieldIndex(uint32_t& structFieldIndex, const StructType& structType, ASCIILiteral operation) -> PartialResult
 {
     uint32_t fieldIndex;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(fieldIndex), "can't get type index for ", operation);
-    WASM_PARSER_FAIL_IF(fieldIndex >= structType.fieldCount(), operation, " field immediate ", fieldIndex, " is out of bounds");
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(fieldIndex), "can't get type index for "_s, operation);
+    WASM_PARSER_FAIL_IF(fieldIndex >= structType.fieldCount(), operation, " field immediate "_s, fieldIndex, " is out of bounds"_s);
 
     structFieldIndex = fieldIndex;
     return { };
 }
 
 template<typename Context>
-auto FunctionParser<Context>::parseStructTypeIndexAndFieldIndex(StructTypeIndexAndFieldIndex& result, const char* operation) -> PartialResult
+auto FunctionParser<Context>::parseStructTypeIndexAndFieldIndex(StructTypeIndexAndFieldIndex& result, ASCIILiteral operation) -> PartialResult
 {
     uint32_t structTypeIndex;
     WASM_FAIL_IF_HELPER_FAILS(parseStructTypeIndex(structTypeIndex, operation));
@@ -1541,19 +1541,19 @@ auto FunctionParser<Context>::parseStructTypeIndexAndFieldIndex(StructTypeIndexA
 }
 
 template<typename Context>
-auto FunctionParser<Context>::parseStructFieldManipulation(StructFieldManipulation& result, const char* operation) -> PartialResult
+auto FunctionParser<Context>::parseStructFieldManipulation(StructFieldManipulation& result, ASCIILiteral operation) -> PartialResult
 {
     StructTypeIndexAndFieldIndex typeIndexAndFieldIndex;
     WASM_FAIL_IF_HELPER_FAILS(parseStructTypeIndexAndFieldIndex(typeIndexAndFieldIndex, operation));
 
     TypedExpression structRef;
-    WASM_TRY_POP_EXPRESSION_STACK_INTO(structRef, "struct reference");
+    WASM_TRY_POP_EXPRESSION_STACK_INTO(structRef, "struct reference"_s);
     const auto& structSignature = m_info.typeSignatures[typeIndexAndFieldIndex.structTypeIndex];
     Type structRefType = Type { TypeKind::RefNull, structSignature->index() };
-    WASM_VALIDATOR_FAIL_IF(!isSubtype(structRef.type(), structRefType), operation, " structref to type ", structRef.type(), " expected ", structRefType);
+    WASM_VALIDATOR_FAIL_IF(!isSubtype(structRef.type(), structRefType), operation, " structref to type "_s, structRef.type(), " expected "_s, structRefType);
 
     const auto& expandedSignature = structSignature->expand();
-    WASM_VALIDATOR_FAIL_IF(!expandedSignature.template is<StructType>(), operation, " type index points into a non struct type");
+    WASM_VALIDATOR_FAIL_IF(!expandedSignature.template is<StructType>(), operation, " type index points into a non struct type"_s);
     const auto& structType = expandedSignature.template as<StructType>();
 
     result.structReference = structRef;
@@ -1569,12 +1569,12 @@ auto FunctionParser<Context>::checkBranchTarget(const ControlType& target) -> Pa
     if (!target.branchTargetArity())
         return { };
 
-    WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < target.branchTargetArity(), ControlType::isTopLevel(target) ? "branch out of function" : "branch to block", " on expression stack of size ", m_expressionStack.size(), ", but block, ", target.signature()->toString() , " expects ", target.branchTargetArity(), " values");
+    WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < target.branchTargetArity(), ControlType::isTopLevel(target) ? "branch out of function"_s : "branch to block"_s, " on expression stack of size "_s, m_expressionStack.size(), ", but block, "_s, target.signature()->toString() , " expects "_s, target.branchTargetArity(), " values"_s);
 
 
     unsigned offset = m_expressionStack.size() - target.branchTargetArity();
     for (unsigned i = 0; i < target.branchTargetArity(); ++i)
-        WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack[offset + i].type(), target.branchTargetType(i)), "branch's stack type is not a subtype of block's type branch target type. Stack value has type ", m_expressionStack[offset + i].type(), " but branch target expects a value of ", target.branchTargetType(i), " at index ", i);
+        WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack[offset + i].type(), target.branchTargetType(i)), "branch's stack type is not a subtype of block's type branch target type. Stack value has type "_s, m_expressionStack[offset + i].type(), " but branch target expects a value of "_s, target.branchTargetType(i), " at index "_s, i);
 
     return { };
 }
@@ -1586,7 +1586,7 @@ auto FunctionParser<Context>::checkLocalInitialized(uint32_t index) -> PartialRe
     if (!Options::useWebAssemblyTypedFunctionReferences() || isDefaultableType(typeOfLocal(index)))
         return { };
 
-    WASM_VALIDATOR_FAIL_IF(!localIsInitialized(index), "non-defaultable function local ", index, " is accessed before initialization");
+    WASM_VALIDATOR_FAIL_IF(!localIsInitialized(index), "non-defaultable function local "_s, index, " is accessed before initialization"_s);
     return { };
 }
 
@@ -1594,9 +1594,9 @@ template<typename Context>
 auto FunctionParser<Context>::unify(const ControlType& controlData) -> PartialResult
 {
     const FunctionSignature* signature = controlData.signature();
-    WASM_VALIDATOR_FAIL_IF(signature->returnCount() != m_expressionStack.size(), " block with type: ", signature->toString(), " returns: ", signature->returnCount(), " but stack has: ", m_expressionStack.size(), " values");
+    WASM_VALIDATOR_FAIL_IF(signature->returnCount() != m_expressionStack.size(), " block with type: "_s, signature->toString(), " returns: "_s, signature->returnCount(), " but stack has: "_s, m_expressionStack.size(), " values"_s);
     for (unsigned i = 0; i < signature->returnCount(); ++i)
-        WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack[i].type(), signature->returnType(i)), "control flow returns with unexpected type. ", m_expressionStack[i].type(), " is not a ", signature->returnType(i));
+        WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack[i].type(), signature->returnType(i)), "control flow returns with unexpected type. "_s, m_expressionStack[i].type(), " is not a "_s, signature->returnType(i));
 
     return { };
 }
@@ -1616,18 +1616,18 @@ void FunctionParser<Context>::addReferencedFunctions(const Element& segment)
 }
 
 template<typename Context>
-auto FunctionParser<Context>::parseArrayTypeDefinition(const char* operation, bool isNullable, uint32_t& typeIndex, FieldType& elementType, Type& arrayRefType) -> PartialResult
+auto FunctionParser<Context>::parseArrayTypeDefinition(ASCIILiteral operation, bool isNullable, uint32_t& typeIndex, FieldType& elementType, Type& arrayRefType) -> PartialResult
 {
     // Parse type index
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(typeIndex), "can't get type index for ", operation);
-    WASM_VALIDATOR_FAIL_IF(typeIndex >= m_info.typeCount(), operation, " index ", typeIndex, " is out of bounds");
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(typeIndex), "can't get type index for "_s, operation);
+    WASM_VALIDATOR_FAIL_IF(typeIndex >= m_info.typeCount(), operation, " index "_s, typeIndex, " is out of bounds"_s);
 
     // Get the corresponding type definition
     const TypeDefinition& typeDefinition = m_info.typeSignatures[typeIndex].get();
     const TypeDefinition& expanded = typeDefinition.expand();
 
     // Check that it's an array type
-    WASM_VALIDATOR_FAIL_IF(!expanded.is<ArrayType>(), operation, " index ", typeIndex, " does not reference an array definition");
+    WASM_VALIDATOR_FAIL_IF(!expanded.is<ArrayType>(), operation, " index "_s, typeIndex, " does not reference an array definition"_s);
 
     // Extract the field type
     elementType = expanded.as<ArrayType>()->elementType();
@@ -1714,14 +1714,14 @@ auto FunctionParser<Context>::parseExpression() -> PartialResult
         TypedExpression zero;
         TypedExpression nonZero;
 
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(condition, "select condition");
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(zero, "select zero");
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(nonZero, "select non-zero");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(condition, "select condition"_s);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(zero, "select zero"_s);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(nonZero, "select non-zero"_s);
 
-        WASM_PARSER_FAIL_IF(isRefType(nonZero.type()) || isRefType(nonZero.type()), "can't use ref-types with unannotated select");
+        WASM_PARSER_FAIL_IF(isRefType(nonZero.type()) || isRefType(nonZero.type()), "can't use ref-types with unannotated select"_s);
 
-        WASM_VALIDATOR_FAIL_IF(!condition.type().isI32(), "select condition must be i32, got ", condition.type());
-        WASM_VALIDATOR_FAIL_IF(nonZero.type() != zero.type(), "select result types must match, got ", nonZero.type(), " and ", zero.type());
+        WASM_VALIDATOR_FAIL_IF(!condition.type().isI32(), "select condition must be i32, got "_s, condition.type());
+        WASM_VALIDATOR_FAIL_IF(nonZero.type() != zero.type(), "select result types must match, got "_s, nonZero.type(), " and "_s, zero.type());
 
         ExpressionType result;
         WASM_TRY_ADD_TO_CONTEXT(addSelect(condition, nonZero, zero, result));
@@ -1738,13 +1738,13 @@ auto FunctionParser<Context>::parseExpression() -> PartialResult
         TypedExpression zero;
         TypedExpression nonZero;
 
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(condition, "select condition");
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(zero, "select zero");
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(nonZero, "select non-zero");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(condition, "select condition"_s);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(zero, "select zero"_s);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(nonZero, "select non-zero"_s);
 
-        WASM_VALIDATOR_FAIL_IF(!condition.type().isI32(), "select condition must be i32, got ", condition.type());
-        WASM_VALIDATOR_FAIL_IF(!isSubtype(nonZero.type(), immediates.targetType), "select result types must match, got ", nonZero.type(), " and ", immediates.targetType);
-        WASM_VALIDATOR_FAIL_IF(!isSubtype(zero.type(), immediates.targetType), "select result types must match, got ", zero.type(), " and ", immediates.targetType);
+        WASM_VALIDATOR_FAIL_IF(!condition.type().isI32(), "select condition must be i32, got "_s, condition.type());
+        WASM_VALIDATOR_FAIL_IF(!isSubtype(nonZero.type(), immediates.targetType), "select result types must match, got "_s, nonZero.type(), " and "_s, immediates.targetType);
+        WASM_VALIDATOR_FAIL_IF(!isSubtype(zero.type(), immediates.targetType), "select result types must match, got "_s, zero.type(), " and "_s, immediates.targetType);
 
         ExpressionType result;
         WASM_TRY_ADD_TO_CONTEXT(addSelect(condition, nonZero, zero, result));
@@ -1763,40 +1763,40 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
     case F32Const: {
         uint32_t constant;
-        WASM_PARSER_FAIL_IF(!parseUInt32(constant), "can't parse 32-bit floating-point constant");
+        WASM_PARSER_FAIL_IF(!parseUInt32(constant), "can't parse 32-bit floating-point constant"_s);
         m_expressionStack.constructAndAppend(Types::F32, m_context.addConstant(Types::F32, constant));
         return { };
     }
 
     case I32Const: {
         int32_t constant;
-        WASM_PARSER_FAIL_IF(!parseVarInt32(constant), "can't parse 32-bit constant");
+        WASM_PARSER_FAIL_IF(!parseVarInt32(constant), "can't parse 32-bit constant"_s);
         m_expressionStack.constructAndAppend(Types::I32, m_context.addConstant(Types::I32, constant));
         return { };
     }
 
     case F64Const: {
         uint64_t constant;
-        WASM_PARSER_FAIL_IF(!parseUInt64(constant), "can't parse 64-bit floating-point constant");
+        WASM_PARSER_FAIL_IF(!parseUInt64(constant), "can't parse 64-bit floating-point constant"_s);
         m_expressionStack.constructAndAppend(Types::F64, m_context.addConstant(Types::F64, constant));
         return { };
     }
 
     case I64Const: {
         int64_t constant;
-        WASM_PARSER_FAIL_IF(!parseVarInt64(constant), "can't parse 64-bit constant");
+        WASM_PARSER_FAIL_IF(!parseVarInt64(constant), "can't parse 64-bit constant"_s);
         m_expressionStack.constructAndAppend(Types::I64, m_context.addConstant(Types::I64, constant));
         return { };
     }
 
     case TableGet: {
         unsigned tableIndex;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't parse table index");
-        WASM_VALIDATOR_FAIL_IF(tableIndex >= m_info.tableCount(), "table index ", tableIndex, " is invalid, limit is ", m_info.tableCount());
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't parse table index"_s);
+        WASM_VALIDATOR_FAIL_IF(tableIndex >= m_info.tableCount(), "table index "_s, tableIndex, " is invalid, limit is "_s, m_info.tableCount());
 
         TypedExpression index;
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(index, "table.get");
-        WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != index.type().kind, "table.get index to type ", index.type(), " expected ", TypeKind::I32);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(index, "table.get"_s);
+        WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != index.type().kind, "table.get index to type "_s, index.type(), " expected "_s, TypeKind::I32);
 
         ExpressionType result;
         WASM_TRY_ADD_TO_CONTEXT(addTableGet(tableIndex, index, result));
@@ -1807,14 +1807,14 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
     case TableSet: {
         unsigned tableIndex;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't parse table index");
-        WASM_VALIDATOR_FAIL_IF(tableIndex >= m_info.tableCount(), "table index ", tableIndex, " is invalid, limit is ", m_info.tableCount());
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't parse table index"_s);
+        WASM_VALIDATOR_FAIL_IF(tableIndex >= m_info.tableCount(), "table index "_s, tableIndex, " is invalid, limit is "_s, m_info.tableCount());
         TypedExpression value, index;
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "table.set");
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(index, "table.set");
-        WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != index.type().kind, "table.set index to type ", index.type(), " expected ", TypeKind::I32);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "table.set"_s);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(index, "table.set"_s);
+        WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != index.type().kind, "table.set index to type "_s, index.type(), " expected "_s, TypeKind::I32);
         Type type = m_info.tables[tableIndex].wasmType();
-        WASM_VALIDATOR_FAIL_IF(!isSubtype(value.type(), type), "table.set value to type ", value.type(), " expected ", type);
+        WASM_VALIDATOR_FAIL_IF(!isSubtype(value.type(), type), "table.set value to type "_s, value.type(), " expected "_s, type);
         RELEASE_ASSERT(m_info.tables[tableIndex].type() == TableElementType::Externref || m_info.tables[tableIndex].type() == TableElementType::Funcref);
         WASM_TRY_ADD_TO_CONTEXT(addTableSet(tableIndex, index, value));
         return { };
@@ -1822,7 +1822,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
     case Ext1: {
         uint32_t extOp;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(extOp), "can't parse 0xfc extended opcode");
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(extOp), "can't parse 0xfc extended opcode"_s);
 
         Ext1OpType op = static_cast<Ext1OpType>(extOp);
         switch (op) {
@@ -1835,13 +1835,13 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             TypedExpression dstOffset;
             TypedExpression srcOffset;
             TypedExpression length;
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(length, "table.init");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(srcOffset, "table.init");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(dstOffset, "table.init");
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(length, "table.init"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(srcOffset, "table.init"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(dstOffset, "table.init"_s);
 
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstOffset.type().kind, "table.init dst_offset to type ", dstOffset.type(), " expected ", TypeKind::I32);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != srcOffset.type().kind, "table.init src_offset to type ", srcOffset.type(), " expected ", TypeKind::I32);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != length.type().kind, "table.init length to type ", length.type(), " expected ", TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstOffset.type().kind, "table.init dst_offset to type "_s, dstOffset.type(), " expected "_s, TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != srcOffset.type().kind, "table.init src_offset to type "_s, srcOffset.type(), " expected "_s, TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != length.type().kind, "table.init length to type "_s, length.type(), " expected "_s, TypeKind::I32);
 
             WASM_TRY_ADD_TO_CONTEXT(addTableInit(immediates.elementIndex, immediates.tableIndex, dstOffset, srcOffset, length));
             break;
@@ -1868,12 +1868,12 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
             TypedExpression fill;
             TypedExpression delta;
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(delta, "table.grow");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(fill, "table.grow");
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(delta, "table.grow"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(fill, "table.grow"_s);
 
             Type tableType = m_info.tables[tableIndex].wasmType();
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(fill.type(), tableType), "table.grow expects fill value of type ", tableType, " got ", fill.type());
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != delta.type().kind, "table.grow expects an i32 delta value, got ", delta.type());
+            WASM_VALIDATOR_FAIL_IF(!isSubtype(fill.type(), tableType), "table.grow expects fill value of type "_s, tableType, " got "_s, fill.type());
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != delta.type().kind, "table.grow expects an i32 delta value, got "_s, delta.type());
 
             ExpressionType result;
             WASM_TRY_ADD_TO_CONTEXT(addTableGrow(tableIndex, fill, delta, result));
@@ -1885,14 +1885,14 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_FAIL_IF_HELPER_FAILS(parseTableIndex(tableIndex));
 
             TypedExpression offset, fill, count;
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(count, "table.fill");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(fill, "table.fill");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(offset, "table.fill");
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(count, "table.fill"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(fill, "table.fill"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(offset, "table.fill"_s);
 
             Type tableType = m_info.tables[tableIndex].wasmType();
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(fill.type(), tableType), "table.fill expects fill value of type ", tableType, " got ", fill.type());
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != offset.type().kind, "table.fill expects an i32 offset value, got ", offset.type());
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != count.type().kind, "table.fill expects an i32 count value, got ", count.type());
+            WASM_VALIDATOR_FAIL_IF(!isSubtype(fill.type(), tableType), "table.fill expects fill value of type "_s, tableType, " got "_s, fill.type());
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != offset.type().kind, "table.fill expects an i32 offset value, got "_s, offset.type());
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != count.type().kind, "table.fill expects an i32 count value, got "_s, count.type());
 
             WASM_TRY_ADD_TO_CONTEXT(addTableFill(tableIndex, offset, fill, count));
             break;
@@ -1903,18 +1903,18 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
             const auto srcType = m_info.table(immediates.srcTableIndex).wasmType();
             const auto dstType = m_info.table(immediates.dstTableIndex).wasmType();
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(srcType, dstType), "type mismatch at table.copy. got ", srcType, " and ", dstType);
+            WASM_VALIDATOR_FAIL_IF(!isSubtype(srcType, dstType), "type mismatch at table.copy. got "_s, srcType, " and "_s, dstType);
 
             TypedExpression dstOffset;
             TypedExpression srcOffset;
             TypedExpression length;
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(length, "table.copy");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(srcOffset, "table.copy");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(dstOffset, "table.copy");
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(length, "table.copy"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(srcOffset, "table.copy"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(dstOffset, "table.copy"_s);
 
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstOffset.type().kind, "table.copy dst_offset to type ", dstOffset.type(), " expected ", TypeKind::I32);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != srcOffset.type().kind, "table.copy src_offset to type ", srcOffset.type(), " expected ", TypeKind::I32);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != length.type().kind, "table.copy length to type ", length.type(), " expected ", TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstOffset.type().kind, "table.copy dst_offset to type "_s, dstOffset.type(), " expected "_s, TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != srcOffset.type().kind, "table.copy src_offset to type "_s, srcOffset.type(), " expected "_s, TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != length.type().kind, "table.copy length to type "_s, length.type(), " expected "_s, TypeKind::I32);
 
             WASM_TRY_ADD_TO_CONTEXT(addTableCopy(immediates.dstTableIndex, immediates.srcTableIndex, dstOffset, srcOffset, length));
             break;
@@ -1990,17 +1990,17 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 #undef CREATE_CASE
 
         default:
-            WASM_PARSER_FAIL_IF(true, "invalid 0xfc extended op ", extOp);
+            WASM_PARSER_FAIL_IF(true, "invalid 0xfc extended op "_s, extOp);
             break;
         }
         return { };
     }
 
     case ExtGC: {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled");
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled"_s);
 
         uint32_t extOp;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(extOp), "can't parse extended GC opcode");
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(extOp), "can't parse extended GC opcode"_s);
 
         ExtGCOpType op = static_cast<ExtGCOpType>(extOp);
         switch (op) {
@@ -2041,7 +2041,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             uint32_t typeIndex;
             FieldType fieldType;
             Type arrayRefType;
-            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.new", false, typeIndex, fieldType, arrayRefType));
+            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.new"_s, false, typeIndex, fieldType, arrayRefType));
             Type unpackedElementType = fieldType.type.unpacked();
 
             TypedExpression value, size;
@@ -2067,7 +2067,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             uint32_t typeIndex;
             FieldType fieldType;
             Type arrayRefType;
-            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.new_default", false, typeIndex, fieldType, arrayRefType));
+            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.new_default"_s, false, typeIndex, fieldType, arrayRefType));
             WASM_VALIDATOR_FAIL_IF(!isDefaultableType(fieldType.type), "array.new_default index ", typeIndex, " does not reference an array definition with a defaultable type");
 
             TypedExpression size;
@@ -2085,14 +2085,14 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             uint32_t typeIndex;
             FieldType fieldType;
             Type arrayRefType;
-            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.new_fixed", false, typeIndex, fieldType, arrayRefType));
+            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.new_fixed"_s, false, typeIndex, fieldType, arrayRefType));
             const Type elementType = fieldType.type.unpacked();
 
             // Get number of arguments
             uint32_t argc;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(argc), "can't get argument count for array.new_fixed");
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(argc), "can't get argument count for array.new_fixed"_s);
 
-            WASM_VALIDATOR_FAIL_IF(argc > maxArrayNewFixedArgs, "array_new_fixed can take at most ", maxArrayNewFixedArgs, " operands. Got ", argc);
+            WASM_VALIDATOR_FAIL_IF(argc > maxArrayNewFixedArgs, "array_new_fixed can take at most "_s, maxArrayNewFixedArgs, " operands. Got "_s, argc);
 
             // If more arguments are expected than the current stack size, that's an error
             WASM_VALIDATOR_FAIL_IF(argc > m_expressionStack.size(), "array_new_fixed: found ", m_expressionStack.size(), " operands on stack; expected ", argc, " operands");
@@ -2100,7 +2100,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             // Allocate stack space for arguments
             Vector<ExpressionType> args;
             size_t firstArgumentIndex = m_expressionStack.size() - argc;
-            WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(argc), "can't allocate enough memory for array.new_fixed ", argc, " values");
+            WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(argc), "can't allocate enough memory for array.new_fixed "_s, argc, " values"_s);
             args.grow(argc);
 
             // Start parsing arguments; the expected type for each one is the unpacked version of the array element type
@@ -2129,13 +2129,13 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             uint32_t typeIndex;
             FieldType fieldType;
             Type arrayRefType;
-            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.new_data", false, typeIndex, fieldType, arrayRefType));
+            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.new_data"_s, false, typeIndex, fieldType, arrayRefType));
 
             const StorageType storageType = fieldType.type;
             WASM_VALIDATOR_FAIL_IF(storageType.is<Type>() && isRefType(storageType.as<Type>()), "array.new_data expected numeric, packed, or vector type; found ", storageType.as<Type>());
 
             uint32_t dataIndex;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(dataIndex), "can't get data segment index for array.new_data");
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(dataIndex), "can't get data segment index for array.new_data"_s);
             WASM_VALIDATOR_FAIL_IF(!(m_info.dataSegmentsCount()), "array.new_data in module with no data segments");
             WASM_VALIDATOR_FAIL_IF(dataIndex >= m_info.dataSegmentsCount(), "array.new_data segment index ",
                 dataIndex, " is out of bounds (maximum data segment index is ", *m_info.numberOfDataSegments -1, ")");
@@ -2159,11 +2159,11 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             uint32_t typeIndex;
             FieldType fieldType;
             Type arrayRefType;
-            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.new_elem", false, typeIndex, fieldType, arrayRefType));
+            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.new_elem"_s, false, typeIndex, fieldType, arrayRefType));
 
             // Get the element segment index
             uint32_t elemSegmentIndex;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(elemSegmentIndex), "can't get elements segment index for array.new_elem");
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(elemSegmentIndex), "can't get elements segment index for array.new_elem"_s);
             uint32_t numElementsSegments = m_info.elements.size();
             WASM_VALIDATOR_FAIL_IF(!(numElementsSegments), "array.new_elem in module with no elements segments");
             WASM_VALIDATOR_FAIL_IF(elemSegmentIndex >= numElementsSegments, "array.new_elem segment index ",
@@ -2200,7 +2200,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         case ExtGCOpType::ArrayGet:
         case ExtGCOpType::ArrayGetS:
         case ExtGCOpType::ArrayGetU: {
-            const char* opName = op == ExtGCOpType::ArrayGet ? "array.get" : op == ExtGCOpType::ArrayGetS ? "array.get_s" : "array.get_u";
+            auto opName = op == ExtGCOpType::ArrayGet ? "array.get"_s : op == ExtGCOpType::ArrayGetS ? "array.get_s"_s : "array.get_u"_s;
 
             uint32_t typeIndex;
             FieldType fieldType;
@@ -2210,17 +2210,17 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
             // array.get_s and array.get_u are only valid for packed arrays
             if (op == ExtGCOpType::ArrayGetS || op == ExtGCOpType::ArrayGetU)
-                WASM_PARSER_FAIL_IF(!elementType.is<PackedType>(), opName, " applied to wrong type of array -- expected: i8 or i16, found ", elementType.as<Type>().kind);
+                WASM_PARSER_FAIL_IF(!elementType.is<PackedType>(), opName, " applied to wrong type of array -- expected: i8 or i16, found "_s, elementType.as<Type>().kind);
 
             // array.get is not valid for packed arrays
             if (op == ExtGCOpType::ArrayGet)
-                WASM_PARSER_FAIL_IF(elementType.is<PackedType>(), opName, " applied to packed array of ", elementType.as<PackedType>(), " -- use array.get_s or array.get_u");
+                WASM_PARSER_FAIL_IF(elementType.is<PackedType>(), opName, " applied to packed array of "_s, elementType.as<PackedType>(), " -- use array.get_s or array.get_u"_s);
 
             // The type of the result will be unpacked if the array is packed.
             const Type resultType = elementType.unpacked();
             TypedExpression arrayref, index;
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(index, "array.get");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(arrayref, "array.get");
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(index, "array.get"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(arrayref, "array.get"_s);
             WASM_VALIDATOR_FAIL_IF(!isSubtype(arrayref.type(), arrayRefType), opName, " arrayref to type ", arrayref.type(), " expected ", arrayRefType);
             WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != index.type().kind, "array.get index to type ", index.type(), " expected ", TypeKind::I32);
 
@@ -2240,7 +2240,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             uint32_t typeIndex;
             FieldType fieldType;
             Type arrayRefType;
-            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.set", true, typeIndex, fieldType, arrayRefType));
+            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.set"_s, true, typeIndex, fieldType, arrayRefType));
 
             // The type of the result will be unpacked if the array is packed.
             const Type unpackedElementType = fieldType.type.unpacked();
@@ -2248,9 +2248,9 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_VALIDATOR_FAIL_IF(fieldType.mutability != Mutability::Mutable, "array.set index ", typeIndex, " does not reference a mutable array definition");
 
             TypedExpression arrayref, index, value;
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "array.set");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(index, "array.set");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(arrayref, "array.set");
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "array.set"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(index, "array.set"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(arrayref, "array.set"_s);
             WASM_VALIDATOR_FAIL_IF(!isSubtype(arrayref.type(), arrayRefType), "array.set arrayref to type ", arrayref.type(), " expected ", arrayRefType);
             WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != index.type().kind, "array.set index to type ", index.type(), " expected ", TypeKind::I32);
             WASM_VALIDATOR_FAIL_IF(!isSubtype(value.type(), unpackedElementType), "array.set value to type ", value.type(), " expected ", unpackedElementType);
@@ -2267,7 +2267,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         }
         case ExtGCOpType::ArrayLen: {
             TypedExpression arrayref;
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(arrayref, "array.len");
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(arrayref, "array.len"_s);
             WASM_VALIDATOR_FAIL_IF(!isSubtype(arrayref.type(), Type { TypeKind::RefNull, static_cast<TypeIndex>(TypeKind::Arrayref) }), "array.len value to type ", arrayref.type(), " expected arrayref");
 
             ExpressionType result;
@@ -2280,16 +2280,16 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             uint32_t typeIndex;
             FieldType fieldType;
             Type arrayRefType;
-            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.fill", true, typeIndex, fieldType, arrayRefType));
+            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.fill"_s, true, typeIndex, fieldType, arrayRefType));
 
             const Type unpackedElementType = fieldType.type.unpacked();
             WASM_VALIDATOR_FAIL_IF(fieldType.mutability != Mutability::Mutable, "array.fill index ", typeIndex, " does not reference a mutable array definition");
 
             TypedExpression arrayref, offset, value, size;
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(size, "array.fill");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "array.fill");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(offset, "array.fill");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(arrayref, "array.fill");
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(size, "array.fill"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "array.fill"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(offset, "array.fill"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(arrayref, "array.fill"_s);
             WASM_VALIDATOR_FAIL_IF(!isSubtype(arrayref.type(), arrayRefType), "array.fill arrayref to type ", arrayref.type(), " expected ", arrayRefType);
             WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != offset.type().kind, "array.fill offset to type ", offset.type(), " expected ", TypeKind::I32);
             WASM_VALIDATOR_FAIL_IF(!isSubtype(value.type(), unpackedElementType), "array.fill value to type ", value.type(), " expected ", unpackedElementType);
@@ -2308,21 +2308,21 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             uint32_t dstTypeIndex;
             FieldType dstFieldType;
             Type dstArrayRefType;
-            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.copy", true, dstTypeIndex, dstFieldType, dstArrayRefType));
+            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.copy"_s, true, dstTypeIndex, dstFieldType, dstArrayRefType));
             uint32_t srcTypeIndex;
             FieldType srcFieldType;
             Type srcArrayRefType;
-            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.copy", true, srcTypeIndex, srcFieldType, srcArrayRefType));
+            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.copy"_s, true, srcTypeIndex, srcFieldType, srcArrayRefType));
 
             WASM_VALIDATOR_FAIL_IF(dstFieldType.mutability != Mutability::Mutable, "array.copy index ", dstTypeIndex, " does not reference a mutable array definition");
             WASM_VALIDATOR_FAIL_IF(!isSubtype(srcFieldType.type, dstFieldType.type), "array.copy src index ", srcTypeIndex, " does not reference a subtype of dst index ", dstTypeIndex);
 
             TypedExpression dst, dstOffset, src, srcOffset, size;
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(size, "array.copy");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(srcOffset, "array.copy");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(src, "array.copy");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(dstOffset, "array.copy");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(dst, "array.copy");
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(size, "array.copy"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(srcOffset, "array.copy"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(src, "array.copy"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(dstOffset, "array.copy"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(dst, "array.copy"_s);
             WASM_VALIDATOR_FAIL_IF(!isSubtype(dst.type(), dstArrayRefType), "array.copy dst to type ", dst.type(), " expected ", dstArrayRefType);
             WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstOffset.type().kind, "array.copy dstOffset to type ", dstOffset.type(), " expected ", TypeKind::I32);
             WASM_VALIDATOR_FAIL_IF(!isSubtype(src.type(), srcArrayRefType), "array.copy src to type ", src.type(), " expected ", srcArrayRefType);
@@ -2336,7 +2336,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             uint32_t dstTypeIndex;
             FieldType dstFieldType;
             Type dstArrayRefType;
-            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.init_elem", true, dstTypeIndex, dstFieldType, dstArrayRefType));
+            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.init_elem"_s, true, dstTypeIndex, dstFieldType, dstArrayRefType));
 
             uint32_t elemSegmentIndex;
             WASM_FAIL_IF_HELPER_FAILS(parseElementIndex(elemSegmentIndex));
@@ -2351,10 +2351,10 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             addReferencedFunctions(elementsSegment);
 
             TypedExpression dst, dstOffset, srcOffset, size;
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(size, "array.init_elem");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(srcOffset, "array.init_elem");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(dstOffset, "array.init_elem");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(dst, "array.init_elem");
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(size, "array.init_elem"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(srcOffset, "array.init_elem"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(dstOffset, "array.init_elem"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(dst, "array.init_elem"_s);
             WASM_VALIDATOR_FAIL_IF(!isSubtype(dst.type(), dstArrayRefType), "array.init_elem dst to type ", dst.type(), " expected ", dstArrayRefType);
             WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstOffset.type().kind, "array.init_elem dstOffset to type ", dstOffset.type(), " expected ", TypeKind::I32);
             WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != srcOffset.type().kind, "array.init_elem srcOffset to type ", srcOffset.type(), " expected ", TypeKind::I32);
@@ -2367,7 +2367,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             uint32_t dstTypeIndex;
             FieldType dstFieldType;
             Type dstArrayRefType;
-            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.init_data", true, dstTypeIndex, dstFieldType, dstArrayRefType));
+            WASM_FAIL_IF_HELPER_FAILS(parseArrayTypeDefinition("array.init_data"_s, true, dstTypeIndex, dstFieldType, dstArrayRefType));
 
             uint32_t dataSegmentIndex;
             WASM_FAIL_IF_HELPER_FAILS(parseDataSegmentIndex(dataSegmentIndex));
@@ -2376,36 +2376,36 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_VALIDATOR_FAIL_IF(!dstFieldType.type.is<PackedType>() && isRefType(dstFieldType.type.unpacked()), "array.init_data index ", dstTypeIndex, " must refer to an array definition with numeric or vector type");
 
             TypedExpression dst, dstOffset, srcOffset, size;
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(size, "array.init_data");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(srcOffset, "array.init_data");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(dstOffset, "array.init_data");
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(dst, "array.init_data");
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(dst.type(), dstArrayRefType), "array.init_data dst to type ", dst.type(), " expected ", dstArrayRefType);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstOffset.type().kind, "array.init_data dstOffset to type ", dstOffset.type(), " expected ", TypeKind::I32);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != srcOffset.type().kind, "array.init_data srcOffset to type ", srcOffset.type(), " expected ", TypeKind::I32);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind, "array.init_data size to type ", size.type(), " expected ", TypeKind::I32);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(size, "array.init_data"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(srcOffset, "array.init_data"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(dstOffset, "array.init_data"_s);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(dst, "array.init_data"_s);
+            WASM_VALIDATOR_FAIL_IF(!isSubtype(dst.type(), dstArrayRefType), "array.init_data dst to type "_s, dst.type(), " expected "_s, dstArrayRefType);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstOffset.type().kind, "array.init_data dstOffset to type "_s, dstOffset.type(), " expected "_s, TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != srcOffset.type().kind, "array.init_data srcOffset to type "_s, srcOffset.type(), " expected "_s, TypeKind::I32);
+            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != size.type().kind, "array.init_data size to type "_s, size.type(), " expected "_s, TypeKind::I32);
 
             WASM_TRY_ADD_TO_CONTEXT(addArrayInitData(dstTypeIndex, dst, dstOffset, dataSegmentIndex, srcOffset, size));
             return { };
         }
         case ExtGCOpType::StructNew: {
             uint32_t typeIndex;
-            WASM_FAIL_IF_HELPER_FAILS(parseStructTypeIndex(typeIndex, "struct.new"));
+            WASM_FAIL_IF_HELPER_FAILS(parseStructTypeIndex(typeIndex, "struct.new"_s));
 
             const auto& typeDefinition = m_info.typeSignatures[typeIndex];
             const auto* structType = typeDefinition->expand().template as<StructType>();
-            WASM_PARSER_FAIL_IF(structType->fieldCount() > m_expressionStack.size(), "struct.new ", typeIndex, " requires ", structType->fieldCount(), " values, but the expression stack currently holds ", m_expressionStack.size(), " values");
+            WASM_PARSER_FAIL_IF(structType->fieldCount() > m_expressionStack.size(), "struct.new "_s, typeIndex, " requires "_s, structType->fieldCount(), " values, but the expression stack currently holds "_s, m_expressionStack.size(), " values"_s);
 
             Vector<ExpressionType> args;
             size_t firstArgumentIndex = m_expressionStack.size() - structType->fieldCount();
-            WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(structType->fieldCount()), "can't allocate enough memory for struct.new ", structType->fieldCount(), " values");
+            WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(structType->fieldCount()), "can't allocate enough memory for struct.new "_s, structType->fieldCount(), " values"_s);
             args.grow(structType->fieldCount());
 
             bool hasV128Args = false;
             for (size_t i = 0; i < structType->fieldCount(); ++i) {
                 TypedExpression arg = m_expressionStack.at(m_expressionStack.size() - i - 1);
                 const auto& fieldType = structType->field(StructFieldCount(structType->fieldCount() - i - 1)).type.unpacked();
-                WASM_VALIDATOR_FAIL_IF(!isSubtype(arg.type(), fieldType), "argument type mismatch in struct.new, got ", arg.type(), ", expected ", fieldType);
+                WASM_VALIDATOR_FAIL_IF(!isSubtype(arg.type(), fieldType), "argument type mismatch in struct.new, got "_s, arg.type(), ", expected "_s, fieldType);
                 if (fieldType.isV128())
                     hasV128Args = true;
                 args[args.size() - i - 1] = arg;
@@ -2427,13 +2427,13 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         }
         case ExtGCOpType::StructNewDefault: {
             uint32_t typeIndex;
-            WASM_FAIL_IF_HELPER_FAILS(parseStructTypeIndex(typeIndex, "struct.new_default"));
+            WASM_FAIL_IF_HELPER_FAILS(parseStructTypeIndex(typeIndex, "struct.new_default"_s));
 
             const auto& typeDefinition = m_info.typeSignatures[typeIndex];
             const auto* structType = typeDefinition->expand().template as<StructType>();
 
             for (StructFieldCount i = 0; i < structType->fieldCount(); i++)
-                WASM_PARSER_FAIL_IF(!isDefaultableType(structType->field(i).type), "struct.new_default ", typeIndex, " requires all fields to be defaultable, but field ", i, " has type ", structType->field(i).type);
+                WASM_PARSER_FAIL_IF(!isDefaultableType(structType->field(i).type), "struct.new_default "_s, typeIndex, " requires all fields to be defaultable, but field "_s, i, " has type "_s, structType->field(i).type);
 
             ExpressionType result;
             WASM_TRY_ADD_TO_CONTEXT(addStructNewDefault(typeIndex, result));
@@ -2443,16 +2443,16 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         case ExtGCOpType::StructGet:
         case ExtGCOpType::StructGetS:
         case ExtGCOpType::StructGetU: {
-            const char* opName = op == ExtGCOpType::StructGet ? "struct.get" : op == ExtGCOpType::StructGetS ? "struct.get_s" : "struct.get_u";
+            auto opName = op == ExtGCOpType::StructGet ? "struct.get"_s : op == ExtGCOpType::StructGetS ? "struct.get_s"_s : "struct.get_u"_s;
 
             StructFieldManipulation structGetInput;
             WASM_FAIL_IF_HELPER_FAILS(parseStructFieldManipulation(structGetInput, opName));
 
             if (op == ExtGCOpType::StructGetS || op == ExtGCOpType::StructGetU)
-                WASM_PARSER_FAIL_IF(!structGetInput.field.type.template is<PackedType>(), opName, " applied to wrong type of struct -- expected: i8 or i16, found ", structGetInput.field.type.template as<Type>().kind);
+                WASM_PARSER_FAIL_IF(!structGetInput.field.type.template is<PackedType>(), opName, " applied to wrong type of struct -- expected: i8 or i16, found "_s, structGetInput.field.type.template as<Type>().kind);
 
             if (op == ExtGCOpType::StructGet)
-                WASM_PARSER_FAIL_IF(structGetInput.field.type.template is<PackedType>(), opName, " applied to packed array of ", structGetInput.field.type.template as<PackedType>(), " -- use struct.get_s or struct.get_u");
+                WASM_PARSER_FAIL_IF(structGetInput.field.type.template is<PackedType>(), opName, " applied to packed array of "_s, structGetInput.field.type.template as<PackedType>(), " -- use struct.get_s or struct.get_u"_s);
 
             if (structGetInput.field.type.unpacked().isV128()) {
                 m_context.notifyFunctionUsesSIMD();
@@ -2469,14 +2469,14 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         }
         case ExtGCOpType::StructSet: {
             TypedExpression value;
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "struct.set value");
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "struct.set value"_s);
 
             StructFieldManipulation structSetInput;
-            WASM_FAIL_IF_HELPER_FAILS(parseStructFieldManipulation(structSetInput, "struct.set"));
+            WASM_FAIL_IF_HELPER_FAILS(parseStructFieldManipulation(structSetInput, "struct.set"_s));
 
             const auto& field = structSetInput.field;
-            WASM_PARSER_FAIL_IF(field.mutability != Mutability::Mutable, "the field ", structSetInput.indices.fieldIndex, " can't be set because it is immutable");
-            WASM_PARSER_FAIL_IF(!isSubtype(value.type(), field.type.unpacked()), "type mismatch in struct.set");
+            WASM_PARSER_FAIL_IF(field.mutability != Mutability::Mutable, "the field "_s, structSetInput.indices.fieldIndex, " can't be set because it is immutable"_s);
+            WASM_PARSER_FAIL_IF(!isSubtype(value.type(), field.type.unpacked()), "type mismatch in struct.set"_s);
 
             if (field.type.unpacked().isV128()) {
                 m_context.notifyFunctionUsesSIMD();
@@ -2492,24 +2492,24 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         case ExtGCOpType::RefTestNull:
         case ExtGCOpType::RefCast:
         case ExtGCOpType::RefCastNull: {
-            const char* opName = op == ExtGCOpType::RefCast || op == ExtGCOpType::RefCastNull ? "ref.cast" : "ref.test";
+            auto opName = op == ExtGCOpType::RefCast || op == ExtGCOpType::RefCastNull ? "ref.cast"_s : "ref.test"_s;
             int32_t heapType;
-            WASM_PARSER_FAIL_IF(!parseHeapType(m_info, heapType), "can't get heap type for ", opName);
+            WASM_PARSER_FAIL_IF(!parseHeapType(m_info, heapType), "can't get heap type for "_s, opName);
 
             TypedExpression ref;
             WASM_TRY_POP_EXPRESSION_STACK_INTO(ref, opName);
-            WASM_VALIDATOR_FAIL_IF(!isRefType(ref.type()), opName, " to type ", ref.type(), " expected a reference type");
+            WASM_VALIDATOR_FAIL_IF(!isRefType(ref.type()), opName, " to type "_s, ref.type(), " expected a reference type"_s);
 
             TypeIndex resultTypeIndex = static_cast<TypeIndex>(heapType);
             if (typeIndexIsType(resultTypeIndex)) {
                 switch (static_cast<TypeKind>(heapType)) {
                 case TypeKind::Funcref:
                 case TypeKind::Nullfuncref:
-                    WASM_VALIDATOR_FAIL_IF(!isSubtype(ref.type(), funcrefType()), opName, " to type ", ref.type(), " expected a funcref");
+                    WASM_VALIDATOR_FAIL_IF(!isSubtype(ref.type(), funcrefType()), opName, " to type "_s, ref.type(), " expected a funcref"_s);
                     break;
                 case TypeKind::Externref:
                 case TypeKind::Nullexternref:
-                    WASM_VALIDATOR_FAIL_IF(!isSubtype(ref.type(), externrefType()), opName, " to type ", ref.type(), " expected an externref");
+                    WASM_VALIDATOR_FAIL_IF(!isSubtype(ref.type(), externrefType()), opName, " to type "_s, ref.type(), " expected an externref"_s);
                     break;
                 case TypeKind::Eqref:
                 case TypeKind::Anyref:
@@ -2517,7 +2517,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
                 case TypeKind::I31ref:
                 case TypeKind::Arrayref:
                 case TypeKind::Structref:
-                    WASM_VALIDATOR_FAIL_IF(!isSubtype(ref.type(), anyrefType()), "ref.cast to type ", ref.type(), " expected a subtype of anyref");
+                    WASM_VALIDATOR_FAIL_IF(!isSubtype(ref.type(), anyrefType()), "ref.cast to type "_s, ref.type(), " expected a subtype of anyref"_s);
                     break;
                 default:
                     RELEASE_ASSERT_NOT_REACHED();
@@ -2525,9 +2525,9 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             } else {
                 const TypeDefinition& signature = m_info.typeSignatures[heapType];
                 if (signature.expand().is<FunctionSignature>())
-                    WASM_VALIDATOR_FAIL_IF(!isSubtype(ref.type(), funcrefType()), opName, " to type ", ref.type(), " expected a funcref");
+                    WASM_VALIDATOR_FAIL_IF(!isSubtype(ref.type(), funcrefType()), opName, " to type "_s, ref.type(), " expected a funcref"_s);
                 else
-                    WASM_VALIDATOR_FAIL_IF(!isSubtype(ref.type(), anyrefType()), opName, " to type ", ref.type(), " expected a subtype of anyref");
+                    WASM_VALIDATOR_FAIL_IF(!isSubtype(ref.type(), anyrefType()), opName, " to type "_s, ref.type(), " expected a subtype of anyref"_s);
                 resultTypeIndex = signature.index();
             }
 
@@ -2545,9 +2545,9 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         }
         case ExtGCOpType::BrOnCast:
         case ExtGCOpType::BrOnCastFail: {
-            const char* opName = op == ExtGCOpType::BrOnCast ? "br_on_cast" : "br_on_cast_fail";
+            auto opName = op == ExtGCOpType::BrOnCast ? "br_on_cast"_s : "br_on_cast_fail"_s;
             uint8_t flags;
-            WASM_VALIDATOR_FAIL_IF(!parseUInt8(flags), "can't get flags byte for ", opName);
+            WASM_VALIDATOR_FAIL_IF(!parseUInt8(flags), "can't get flags byte for "_s, opName);
             bool hasNull1 = flags & 0x1;
             bool hasNull2 = flags & 0x2;
 
@@ -2555,8 +2555,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_FAIL_IF_HELPER_FAILS(parseBranchTarget(target));
 
             int32_t heapType1, heapType2;
-            WASM_PARSER_FAIL_IF(!parseHeapType(m_info, heapType1), "can't get first heap type for ", opName);
-            WASM_PARSER_FAIL_IF(!parseHeapType(m_info, heapType2), "can't get second heap type for ", opName);
+            WASM_PARSER_FAIL_IF(!parseHeapType(m_info, heapType1), "can't get first heap type for "_s, opName);
+            WASM_PARSER_FAIL_IF(!parseHeapType(m_info, heapType2), "can't get second heap type for "_s, opName);
 
             TypeIndex typeIndex1, typeIndex2;
             if (isTypeIndexHeapType(heapType1))
@@ -2571,11 +2571,11 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
             // Manually pop the stack in order to avoid decreasing the stack size, as we will immediately put it back.
             TypedExpression ref;
-            WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't pop empty stack in ", opName);
+            WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't pop empty stack in "_s, opName);
             ref = m_expressionStack.takeLast();
 
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(ref.type(), Type { hasNull1 ? TypeKind::RefNull : TypeKind::Ref, typeIndex1 }), opName, " to type ", ref.type(), " expected a reference type with source heaptype");
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(Type { hasNull2 ? TypeKind::RefNull : TypeKind::Ref, typeIndex2 }, Type { hasNull1 ? TypeKind::RefNull : TypeKind::Ref, typeIndex1 }), "target heaptype was not a subtype of source heaptype for ", opName);
+            WASM_VALIDATOR_FAIL_IF(!isSubtype(ref.type(), Type { hasNull1 ? TypeKind::RefNull : TypeKind::Ref, typeIndex1 }), opName, " to type "_s, ref.type(), " expected a reference type with source heaptype"_s);
+            WASM_VALIDATOR_FAIL_IF(!isSubtype(Type { hasNull2 ? TypeKind::RefNull : TypeKind::Ref, typeIndex2 }, Type { hasNull1 ? TypeKind::RefNull : TypeKind::Ref, typeIndex1 }), "target heaptype was not a subtype of source heaptype for "_s, opName);
 
             Type branchTargetType;
             Type nonTakenType;
@@ -2602,8 +2602,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         }
         case ExtGCOpType::AnyConvertExtern: {
             TypedExpression reference;
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(reference, "any.convert_extern");
-            WASM_VALIDATOR_FAIL_IF(!isExternref(reference.type()), "any.convert_extern reference to type ", reference.type(), " expected ", TypeKind::Externref);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(reference, "any.convert_extern"_s);
+            WASM_VALIDATOR_FAIL_IF(!isExternref(reference.type()), "any.convert_extern reference to type "_s, reference.type(), " expected "_s, TypeKind::Externref);
 
             ExpressionType result;
             WASM_TRY_ADD_TO_CONTEXT(addAnyConvertExtern(reference, result));
@@ -2612,8 +2612,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         }
         case ExtGCOpType::ExternConvertAny: {
             TypedExpression reference;
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(reference, "extern.convert_any");
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(reference.type(), anyrefType()), "extern.convert_any reference to type ", reference.type(), " expected ", TypeKind::Anyref);
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(reference, "extern.convert_any"_s);
+            WASM_VALIDATOR_FAIL_IF(!isSubtype(reference.type(), anyrefType()), "extern.convert_any reference to type "_s, reference.type(), " expected "_s, TypeKind::Anyref);
 
             ExpressionType result;
             WASM_TRY_ADD_TO_CONTEXT(addExternConvertAny(reference, result));
@@ -2621,7 +2621,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             return { };
         }
         default:
-            WASM_PARSER_FAIL_IF(true, "invalid extended GC op ", extOp);
+            WASM_PARSER_FAIL_IF(true, "invalid extended GC op "_s, extOp);
             break;
         }
         return { };
@@ -2629,7 +2629,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
     case ExtAtomic: {
         uint32_t extOp;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(extOp), "can't parse atomic extended opcode");
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(extOp), "can't parse atomic extended opcode"_s);
 
         ExtAtomicOpType op = static_cast<ExtAtomicOpType>(extOp);
 #if ENABLE(WEBASSEMBLY_OMGJIT)
@@ -2665,7 +2665,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         case ExtAtomicOpType::I64AtomicRmwCmpxchg:
             return atomicCompareExchange(op, Types::I64);
         default:
-            WASM_PARSER_FAIL_IF(true, "invalid extended atomic op ", extOp);
+            WASM_PARSER_FAIL_IF(true, "invalid extended atomic op "_s, extOp);
             break;
         }
         return { };
@@ -2675,22 +2675,22 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         Type typeOfNull;
         if (Options::useWebAssemblyTypedFunctionReferences()) {
             int32_t heapType;
-            WASM_PARSER_FAIL_IF(!parseHeapType(m_info, heapType), "ref.null heaptype must be funcref, externref or type_idx");
+            WASM_PARSER_FAIL_IF(!parseHeapType(m_info, heapType), "ref.null heaptype must be funcref, externref or type_idx"_s);
             if (isTypeIndexHeapType(heapType)) {
                 TypeIndex typeIndex = TypeInformation::get(m_info.typeSignatures[heapType].get());
                 typeOfNull = Type { TypeKind::RefNull, typeIndex };
             } else
                 typeOfNull = Type { TypeKind::RefNull, static_cast<TypeIndex>(heapType) };
         } else
-            WASM_PARSER_FAIL_IF(!parseRefType(m_info, typeOfNull), "ref.null type must be a reference type");
+            WASM_PARSER_FAIL_IF(!parseRefType(m_info, typeOfNull), "ref.null type must be a reference type"_s);
         m_expressionStack.constructAndAppend(typeOfNull, m_context.addConstant(typeOfNull, JSValue::encode(jsNull())));
         return { };
     }
 
     case RefIsNull: {
         TypedExpression value;
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "ref.is_null");
-        WASM_VALIDATOR_FAIL_IF(!isRefType(value.type()), "ref.is_null to type ", value.type(), " expected a reference type");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "ref.is_null"_s);
+        WASM_VALIDATOR_FAIL_IF(!isRefType(value.type()), "ref.is_null to type "_s, value.type(), " expected a reference type"_s);
         ExpressionType result;
         WASM_TRY_ADD_TO_CONTEXT(addRefIsNull(value, result));
         m_expressionStack.constructAndAppend(Types::I32, result);
@@ -2699,11 +2699,11 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
     case RefFunc: {
         uint32_t index;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(index), "can't get index for ref.func");
-        WASM_VALIDATOR_FAIL_IF(index >= m_info.functionIndexSpaceSize(), "ref.func index ", index, " is too large, max is ", m_info.functionIndexSpaceSize());
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(index), "can't get index for ref.func"_s);
+        WASM_VALIDATOR_FAIL_IF(index >= m_info.functionIndexSpaceSize(), "ref.func index "_s, index, " is too large, max is "_s, m_info.functionIndexSpaceSize());
         // Function references don't need to be declared in constant expression contexts.
         if constexpr (!std::is_same<Context, ConstExprGenerator>())
-            WASM_VALIDATOR_FAIL_IF(!m_info.isDeclaredFunction(index), "ref.func index ", index, " isn't declared");
+            WASM_VALIDATOR_FAIL_IF(!m_info.isDeclaredFunction(index), "ref.func index "_s, index, " isn't declared"_s);
         m_info.addReferencedFunction(index);
 
         ExpressionType result;
@@ -2720,9 +2720,9 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     }
 
     case RefAsNonNull: {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyTypedFunctionReferences(), "function references are not enabled");
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyTypedFunctionReferences(), "function references are not enabled"_s);
         TypedExpression ref;
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(ref, "ref.as_non_null");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(ref, "ref.as_non_null"_s);
 
         ExpressionType result;
         WASM_TRY_ADD_TO_CONTEXT(addRefAsNonNull(ref, result));
@@ -2732,13 +2732,13 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     }
 
     case BrOnNull: {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyTypedFunctionReferences(), "function references are not enabled");
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyTypedFunctionReferences(), "function references are not enabled"_s);
         uint32_t target;
         WASM_FAIL_IF_HELPER_FAILS(parseBranchTarget(target));
 
         TypedExpression ref;
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(ref, "br_on_null");
-        WASM_VALIDATOR_FAIL_IF(!isRefType(ref.type()), "br_on_null ref to type ", ref.type(), " expected a reference type");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(ref, "br_on_null"_s);
+        WASM_VALIDATOR_FAIL_IF(!isRefType(ref.type()), "br_on_null ref to type "_s, ref.type(), " expected a reference type"_s);
 
         ControlType& data = m_controlStack[m_controlStack.size() - 1 - target].controlData;
 
@@ -2752,16 +2752,16 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     }
 
     case BrOnNonNull: {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyTypedFunctionReferences(), "function references are not enabled");
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyTypedFunctionReferences(), "function references are not enabled"_s);
         uint32_t target;
         WASM_FAIL_IF_HELPER_FAILS(parseBranchTarget(target));
 
         TypedExpression ref;
         // Pop the stack manually to avoid changing the stack size, because the branch needs the value with a different type.
-        WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't pop empty stack in br_on_non_null");
+        WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't pop empty stack in br_on_non_null"_s);
         ref = m_expressionStack.takeLast();
         m_expressionStack.constructAndAppend(Type { TypeKind::Ref, ref.type().index }, ref.value());
-        WASM_VALIDATOR_FAIL_IF(!isRefType(ref.type()), "br_on_non_null ref to type ", ref.type(), " expected a reference type");
+        WASM_VALIDATOR_FAIL_IF(!isRefType(ref.type()), "br_on_non_null ref to type "_s, ref.type(), " expected a reference type"_s);
 
         ControlType& data = m_controlStack[m_controlStack.size() - 1 - target].controlData;
         WASM_FAIL_IF_HELPER_FAILS(checkBranchTarget(data));
@@ -2770,20 +2770,20 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_TRY_ADD_TO_CONTEXT(addBranchNull(data, ref, m_expressionStack, true, unused));
 
         // On a non-taken branch, the value is null so it's not needed on the stack.
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(ref, "br_on_non_null");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(ref, "br_on_non_null"_s);
 
         return { };
     }
 
     case RefEq: {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled");
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled"_s);
 
         TypedExpression ref0;
         TypedExpression ref1;
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(ref0, "ref.eq");
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(ref1, "ref.eq");
-        WASM_VALIDATOR_FAIL_IF(!isSubtype(ref0.type(), eqrefType()), "ref.eq ref0 to type ", ref0.type().kind, " expected ", TypeKind::Eqref);
-        WASM_VALIDATOR_FAIL_IF(!isSubtype(ref1.type(), eqrefType()), "ref.eq ref1 to type ", ref1.type().kind, " expected ", TypeKind::Eqref);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(ref0, "ref.eq"_s);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(ref1, "ref.eq"_s);
+        WASM_VALIDATOR_FAIL_IF(!isSubtype(ref0.type(), eqrefType()), "ref.eq ref0 to type "_s, ref0.type().kind, " expected "_s, TypeKind::Eqref);
+        WASM_VALIDATOR_FAIL_IF(!isSubtype(ref1.type(), eqrefType()), "ref.eq ref1 to type "_s, ref1.type().kind, " expected "_s, TypeKind::Eqref);
 
         ExpressionType result;
         WASM_TRY_ADD_TO_CONTEXT(addRefEq(ref0, ref1, result));
@@ -2809,9 +2809,9 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         pushLocalInitialized(index);
 
         TypedExpression value;
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "set_local");
-        WASM_VALIDATOR_FAIL_IF(index >= m_locals.size(), "attempt to set unknown local ", index, ", the number of locals is ", m_locals.size());
-        WASM_VALIDATOR_FAIL_IF(!isSubtype(value.type(), m_locals[index]), "set_local to type ", value.type(), " expected ", m_locals[index]);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "set_local"_s);
+        WASM_VALIDATOR_FAIL_IF(index >= m_locals.size(), "attempt to set unknown local "_s, index, ", the number of locals is "_s, m_locals.size());
+        WASM_VALIDATOR_FAIL_IF(!isSubtype(value.type(), m_locals[index]), "set_local to type "_s, value.type(), " expected "_s, m_locals[index]);
         WASM_TRY_ADD_TO_CONTEXT(setLocal(index, value));
         return { };
     }
@@ -2821,11 +2821,11 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_FAIL_IF_HELPER_FAILS(parseIndexForLocal(index));
         pushLocalInitialized(index);
 
-        WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't tee_local on empty expression stack");
+        WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't tee_local on empty expression stack"_s);
         TypedExpression value;
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "tee_local");
-        WASM_VALIDATOR_FAIL_IF(index >= m_locals.size(), "attempt to tee unknown local ", index, ", the number of locals is ", m_locals.size());
-        WASM_VALIDATOR_FAIL_IF(!isSubtype(value.type(), m_locals[index]), "set_local to type ", value.type(), " expected ", m_locals[index]);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "tee_local"_s);
+        WASM_VALIDATOR_FAIL_IF(index >= m_locals.size(), "attempt to tee unknown local "_s, index, "_s, the number of locals is "_s, m_locals.size());
+        WASM_VALIDATOR_FAIL_IF(!isSubtype(value.type(), m_locals[index]), "set_local to type "_s, value.type(), " expected "_s, m_locals[index]);
         WASM_TRY_ADD_TO_CONTEXT(setLocal(index, value));
 
         ExpressionType result;
@@ -2855,16 +2855,16 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     case SetGlobal: {
         uint32_t index;
         WASM_FAIL_IF_HELPER_FAILS(parseIndexForGlobal(index));
-        WASM_VALIDATOR_FAIL_IF(index >= m_info.globals.size(), "set_global ", index, " of unknown global, limit is ", m_info.globals.size());
-        WASM_VALIDATOR_FAIL_IF(m_info.globals[index].mutability == Mutability::Immutable, "set_global ", index, " is immutable");
+        WASM_VALIDATOR_FAIL_IF(index >= m_info.globals.size(), "set_global "_s, index, " of unknown global, limit is "_s, m_info.globals.size());
+        WASM_VALIDATOR_FAIL_IF(m_info.globals[index].mutability == Mutability::Immutable, "set_global "_s, index, " is immutable"_s);
 
         TypedExpression value;
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "set_global value");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "set_global value"_s);
 
         Type globalType = m_info.globals[index].type;
         ASSERT(isValueType(globalType));
 
-        WASM_VALIDATOR_FAIL_IF(!isSubtype(value.type(), globalType), "set_global ", index, " with type ", globalType.kind, " with a variable of type ", value.type().kind);
+        WASM_VALIDATOR_FAIL_IF(!isSubtype(value.type(), globalType), "set_global "_s, index, " with type "_s, globalType.kind, " with a variable of type "_s, value.type().kind);
 
         if (globalType.isV128()) {
             m_context.notifyFunctionUsesSIMD();
@@ -2877,7 +2877,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     }
 
     case TailCall:
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyTailCalls(), "wasm tail calls are not enabled");
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyTailCalls(), "wasm tail calls are not enabled"_s);
         FALLTHROUGH;
     case Call: {
         uint32_t functionIndex;
@@ -2886,16 +2886,16 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         TypeIndex calleeTypeIndex = m_info.typeIndexFromFunctionIndexSpace(functionIndex);
         const TypeDefinition& typeDefinition = TypeInformation::get(calleeTypeIndex).expand();
         const auto& calleeSignature = *typeDefinition.as<FunctionSignature>();
-        WASM_PARSER_FAIL_IF(calleeSignature.argumentCount() > m_expressionStack.size(), "call function index ", functionIndex, " has ", calleeSignature.argumentCount(), " arguments, but the expression stack currently holds ", m_expressionStack.size(), " values");
+        WASM_PARSER_FAIL_IF(calleeSignature.argumentCount() > m_expressionStack.size(), "call function index "_s, functionIndex, " has "_s, calleeSignature.argumentCount(), " arguments, but the expression stack currently holds "_s, m_expressionStack.size(), " values"_s);
 
         size_t firstArgumentIndex = m_expressionStack.size() - calleeSignature.argumentCount();
         Vector<ExpressionType> args;
-        WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(calleeSignature.argumentCount()), "can't allocate enough memory for call's ", calleeSignature.argumentCount(), " arguments");
+        WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(calleeSignature.argumentCount()), "can't allocate enough memory for call's "_s, calleeSignature.argumentCount(), " arguments"_s);
         args.grow(calleeSignature.argumentCount());
         for (size_t i = 0; i < calleeSignature.argumentCount(); ++i) {
             size_t stackIndex = m_expressionStack.size() - i - 1;
             TypedExpression arg = m_expressionStack.at(stackIndex);
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(arg.type(), calleeSignature.argumentType(calleeSignature.argumentCount() - i - 1)), "argument type mismatch in call, got ", arg.type(), ", expected ", calleeSignature.argumentType(calleeSignature.argumentCount() - i - 1));
+            WASM_VALIDATOR_FAIL_IF(!isSubtype(arg.type(), calleeSignature.argumentType(calleeSignature.argumentCount() - i - 1)), "argument type mismatch in call, got "_s, arg.type(), ", expected "_s, calleeSignature.argumentType(calleeSignature.argumentCount() - i - 1));
             args[args.size() - i - 1] = arg;
             m_context.didPopValueFromStack(arg, "Call"_s);
         }
@@ -2909,10 +2909,10 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
             const auto& callerSignature = *m_signature.as<FunctionSignature>();
 
-            WASM_PARSER_FAIL_IF(calleeSignature.returnCount() != callerSignature.returnCount(), "tail call function index ", functionIndex, " with return count ", calleeSignature.returnCount(), ", but the caller's signature has ", callerSignature.returnCount(), " return values");
+            WASM_PARSER_FAIL_IF(calleeSignature.returnCount() != callerSignature.returnCount(), "tail call function index "_s, functionIndex, " with return count "_s, calleeSignature.returnCount(), ", but the caller's signature has "_s, callerSignature.returnCount(), " return values"_s);
 
             for (unsigned i = 0; i < calleeSignature.returnCount(); ++i)
-                WASM_VALIDATOR_FAIL_IF(calleeSignature.returnType(i) != callerSignature.returnType(i), "tail call function index ", functionIndex, " return type mismatch: " , "expected ", callerSignature.returnType(i), ", got ", calleeSignature.returnType(i));
+                WASM_VALIDATOR_FAIL_IF(calleeSignature.returnType(i) != callerSignature.returnType(i), "tail call function index "_s, functionIndex, " return type mismatch: "_s , "expected "_s, callerSignature.returnType(i), ", got "_s, calleeSignature.returnType(i));
 
             WASM_TRY_ADD_TO_CONTEXT(addCall(functionIndex, typeDefinition, args, results, CallType::TailCall));
 
@@ -2939,34 +2939,34 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     }
 
     case TailCallIndirect:
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyTailCalls(), "wasm tail calls are not enabled");
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyTailCalls(), "wasm tail calls are not enabled"_s);
         FALLTHROUGH;
     case CallIndirect: {
         uint32_t signatureIndex;
         uint32_t tableIndex;
-        WASM_PARSER_FAIL_IF(!m_info.tableCount(), "call_indirect is only valid when a table is defined or imported");
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(signatureIndex), "can't get call_indirect's signature index");
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't get call_indirect's table index");
-        WASM_PARSER_FAIL_IF(tableIndex >= m_info.tableCount(), "call_indirect's table index ", tableIndex, " invalid, limit is ", m_info.tableCount());
-        WASM_PARSER_FAIL_IF(m_info.typeCount() <= signatureIndex, "call_indirect's signature index ", signatureIndex, " exceeds known signatures ", m_info.typeCount());
-        WASM_PARSER_FAIL_IF(m_info.tables[tableIndex].type() != TableElementType::Funcref, "call_indirect is only valid when a table has type funcref");
+        WASM_PARSER_FAIL_IF(!m_info.tableCount(), "call_indirect is only valid when a table is defined or imported"_s);
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(signatureIndex), "can't get call_indirect's signature index"_s);
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't get call_indirect's table index"_s);
+        WASM_PARSER_FAIL_IF(tableIndex >= m_info.tableCount(), "call_indirect's table index "_s, tableIndex, " invalid, limit is "_s, m_info.tableCount());
+        WASM_PARSER_FAIL_IF(m_info.typeCount() <= signatureIndex, "call_indirect's signature index "_s, signatureIndex, " exceeds known signatures "_s, m_info.typeCount());
+        WASM_PARSER_FAIL_IF(m_info.tables[tableIndex].type() != TableElementType::Funcref, "call_indirect is only valid when a table has type funcref"_s);
 
         const TypeDefinition& typeDefinition = m_info.typeSignatures[signatureIndex].get();
         const auto& calleeSignature = *typeDefinition.expand().as<FunctionSignature>();
         size_t argumentCount = calleeSignature.argumentCount() + 1; // Add the callee's index.
-        WASM_PARSER_FAIL_IF(argumentCount > m_expressionStack.size(), "call_indirect expects ", argumentCount, " arguments, but the expression stack currently holds ", m_expressionStack.size(), " values");
+        WASM_PARSER_FAIL_IF(argumentCount > m_expressionStack.size(), "call_indirect expects "_s, argumentCount, " arguments, but the expression stack currently holds "_s, m_expressionStack.size(), " values"_s);
 
-        WASM_VALIDATOR_FAIL_IF(!m_expressionStack.last().type().isI32(), "non-i32 call_indirect index ", m_expressionStack.last().type());
+        WASM_VALIDATOR_FAIL_IF(!m_expressionStack.last().type().isI32(), "non-i32 call_indirect index "_s, m_expressionStack.last().type());
 
         Vector<ExpressionType> args;
-        WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(argumentCount), "can't allocate enough memory for ", argumentCount, " call_indirect arguments");
+        WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(argumentCount), "can't allocate enough memory for "_s, argumentCount, " call_indirect arguments"_s);
         args.grow(argumentCount);
         size_t firstArgumentIndex = m_expressionStack.size() - argumentCount;
         for (size_t i = 0; i < argumentCount; ++i) {
             size_t stackIndex = m_expressionStack.size() - i - 1;
             TypedExpression arg = m_expressionStack.at(stackIndex);
             if (i > 0)
-                WASM_VALIDATOR_FAIL_IF(!isSubtype(arg.type(), calleeSignature.argumentType(argumentCount - i - 1)), "argument type mismatch in call_indirect, got ", arg.type(), ", expected ", calleeSignature.argumentType(argumentCount - i - 1));
+                WASM_VALIDATOR_FAIL_IF(!isSubtype(arg.type(), calleeSignature.argumentType(argumentCount - i - 1)), "argument type mismatch in call_indirect, got "_s, arg.type(), ", expected "_s, calleeSignature.argumentType(argumentCount - i - 1));
             args[args.size() - i - 1] = arg;
             m_context.didPopValueFromStack(arg, "CallIndirect"_s);
         }
@@ -2978,10 +2978,10 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
             const auto& callerSignature = *m_signature.as<FunctionSignature>();
 
-            WASM_PARSER_FAIL_IF(calleeSignature.returnCount() != callerSignature.returnCount(), "tail call indirect function with return count ", calleeSignature.returnCount(), ", but the caller's signature has ", callerSignature.returnCount(), " return values");
+            WASM_PARSER_FAIL_IF(calleeSignature.returnCount() != callerSignature.returnCount(), "tail call indirect function with return count "_s, calleeSignature.returnCount(), "_s, but the caller's signature has "_s, callerSignature.returnCount(), " return values"_s);
 
             for (unsigned i = 0; i < calleeSignature.returnCount(); ++i)
-                WASM_VALIDATOR_FAIL_IF(calleeSignature.returnType(i) != callerSignature.returnType(i), "tail call indirect return type mismatch: " , "expected ", callerSignature.returnType(i), ", got ", calleeSignature.returnType(i));
+                WASM_VALIDATOR_FAIL_IF(calleeSignature.returnType(i) != callerSignature.returnType(i), "tail call indirect return type mismatch: "_s , "expected "_s, callerSignature.returnType(i), ", got "_s, calleeSignature.returnType(i));
 
             WASM_TRY_ADD_TO_CONTEXT(addCallIndirect(tableIndex, typeDefinition, args, results, CallType::TailCall));
 
@@ -3010,10 +3010,10 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_PARSER_FAIL_IF(!Options::useWebAssemblyTypedFunctionReferences(), "function references are not enabled");
 
         uint32_t typeIndex;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(typeIndex), "can't get call_ref's signature index");
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(typeIndex), "can't get call_ref's signature index"_s);
         WASM_VALIDATOR_FAIL_IF(typeIndex >= m_info.typeCount(), "call_ref index ", typeIndex, " is out of bounds");
 
-        WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't call_ref on empty expression stack");
+        WASM_PARSER_FAIL_IF(m_expressionStack.isEmpty(), "can't call_ref on empty expression stack"_s);
 
         const TypeDefinition& typeDefinition = m_info.typeSignatures[typeIndex];
         const TypeIndex calleeTypeIndex = typeDefinition.index();
@@ -3064,7 +3064,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             return { };
 
         BlockSignature inlineSignature;
-        WASM_PARSER_FAIL_IF(!parseBlockSignature(m_info, inlineSignature), "can't get block's signature");
+        WASM_PARSER_FAIL_IF(!parseBlockSignature(m_info, inlineSignature), "can't get block's signature"_s);
 
         WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < inlineSignature->argumentCount(), "Too few values on stack for block. Block expects ", inlineSignature->argumentCount(), ", but only ", m_expressionStack.size(), " were present. Block has inlineSignature: ", inlineSignature->toString());
         unsigned offset = m_expressionStack.size() - inlineSignature->argumentCount();
@@ -3086,7 +3086,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
     case Loop: {
         BlockSignature inlineSignature;
-        WASM_PARSER_FAIL_IF(!parseBlockSignature(m_info, inlineSignature), "can't get loop's signature");
+        WASM_PARSER_FAIL_IF(!parseBlockSignature(m_info, inlineSignature), "can't get loop's signature"_s);
 
         WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < inlineSignature->argumentCount(), "Too few values on stack for loop block. Loop expects ", inlineSignature->argumentCount(), ", but only ", m_expressionStack.size(), " were present. Loop has inlineSignature: ", inlineSignature->toString());
         unsigned offset = m_expressionStack.size() - inlineSignature->argumentCount();
@@ -3110,8 +3110,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     case If: {
         BlockSignature inlineSignature;
         TypedExpression condition;
-        WASM_PARSER_FAIL_IF(!parseBlockSignature(m_info, inlineSignature), "can't get if's signature");
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(condition, "if condition");
+        WASM_PARSER_FAIL_IF(!parseBlockSignature(m_info, inlineSignature), "can't get if's signature"_s);
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(condition, "if condition"_s);
 
         WASM_VALIDATOR_FAIL_IF(!condition.type().isI32(), "if condition must be i32, got ", condition.type());
         WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < inlineSignature->argumentCount(), "Too few arguments on stack for if block. If expects ", inlineSignature->argumentCount(), ", but only ", m_expressionStack.size(), " were present. If block has signature: ", inlineSignature->toString());
@@ -3132,7 +3132,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     }
 
     case Else: {
-        WASM_PARSER_FAIL_IF(m_controlStack.size() == 1, "can't use else block at the top-level of a function");
+        WASM_PARSER_FAIL_IF(m_controlStack.size() == 1, "can't use else block at the top-level of a function"_s);
 
         ControlEntry& controlEntry = m_controlStack.last();
 
@@ -3146,7 +3146,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
     case Try: {
         BlockSignature inlineSignature;
-        WASM_PARSER_FAIL_IF(!parseBlockSignature(m_info, inlineSignature), "can't get try's signature");
+        WASM_PARSER_FAIL_IF(!parseBlockSignature(m_info, inlineSignature), "can't get try's signature"_s);
 
         WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < inlineSignature->argumentCount(), "Too few arguments on stack for try block. Try expects ", inlineSignature->argumentCount(), ", but only ", m_expressionStack.size(), " were present. Try block has signature: ", inlineSignature->toString());
         unsigned offset = m_expressionStack.size() - inlineSignature->argumentCount();
@@ -3166,7 +3166,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     }
 
     case Catch: {
-        WASM_PARSER_FAIL_IF(m_controlStack.size() == 1, "can't use catch block at the top-level of a function");
+        WASM_PARSER_FAIL_IF(m_controlStack.size() == 1, "can't use catch block at the top-level of a function"_s);
 
         uint32_t exceptionIndex;
         WASM_FAIL_IF_HELPER_FAILS(parseExceptionIndex(exceptionIndex));
@@ -3197,7 +3197,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     }
 
     case CatchAll: {
-        WASM_PARSER_FAIL_IF(m_controlStack.size() == 1, "can't use catch block at the top-level of a function");
+        WASM_PARSER_FAIL_IF(m_controlStack.size() == 1, "can't use catch block at the top-level of a function"_s);
 
         ControlEntry& controlEntry = m_controlStack.last();
 
@@ -3213,7 +3213,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     }
 
     case Delegate: {
-        WASM_PARSER_FAIL_IF(m_controlStack.size() == 1, "can't use delegate at the top-level of a function");
+        WASM_PARSER_FAIL_IF(m_controlStack.size() == 1, "can't use delegate at the top-level of a function"_s);
 
         uint32_t target;
         WASM_FAIL_IF_HELPER_FAILS(parseDelegateTarget(target, /* unreachableBlocks */ 0));
@@ -3241,7 +3241,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_VALIDATOR_FAIL_IF(m_expressionStack.size() < exceptionSignature.argumentCount(), "Too few arguments on stack for the exception being thrown. The exception expects ", exceptionSignature.argumentCount(), ", but only ", m_expressionStack.size(), " were present. Exception has signature: ", exceptionSignature.toString());
         unsigned offset = m_expressionStack.size() - exceptionSignature.argumentCount();
         Vector<ExpressionType> args;
-        WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(exceptionSignature.argumentCount()), "can't allocate enough memory for throw's ", exceptionSignature.argumentCount(), " arguments");
+        WASM_PARSER_FAIL_IF(!args.tryReserveInitialCapacity(exceptionSignature.argumentCount()), "can't allocate enough memory for throw's "_s, exceptionSignature.argumentCount(), " arguments"_s);
         args.grow(exceptionSignature.argumentCount());
         for (unsigned i = 0; i < exceptionSignature.argumentCount(); ++i) {
             TypedExpression arg = m_expressionStack.at(m_expressionStack.size() - i - 1);
@@ -3275,7 +3275,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         TypedExpression condition;
         if (m_currentOpcode == BrIf) {
-            WASM_TRY_POP_EXPRESSION_STACK_INTO(condition, "br / br_if condition");
+            WASM_TRY_POP_EXPRESSION_STACK_INTO(condition, "br / br_if condition"_s);
             WASM_VALIDATOR_FAIL_IF(!condition.type().isI32(), "conditional branch with non-i32 condition ", condition.type());
         } else {
             m_unreachableBlocks = 1;
@@ -3294,32 +3294,32 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         TypedExpression condition;
         Vector<ControlType*> targets;
 
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(numberOfTargets), "can't get the number of targets for br_table");
-        WASM_PARSER_FAIL_IF(numberOfTargets == std::numeric_limits<uint32_t>::max(), "br_table's number of targets is too big ", numberOfTargets);
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(numberOfTargets), "can't get the number of targets for br_table"_s);
+        WASM_PARSER_FAIL_IF(numberOfTargets == std::numeric_limits<uint32_t>::max(), "br_table's number of targets is too big "_s, numberOfTargets);
 
-        WASM_PARSER_FAIL_IF(!targets.tryReserveCapacity(numberOfTargets), "can't allocate memory for ", numberOfTargets, " br_table targets");
+        WASM_PARSER_FAIL_IF(!targets.tryReserveCapacity(numberOfTargets), "can't allocate memory for "_s, numberOfTargets, " br_table targets"_s);
         String errorMessage;
         targets.appendUsingFunctor(numberOfTargets, [&](size_t i) -> ControlType* {
             uint32_t target;
             if (UNLIKELY(!parseVarUInt32(target))) {
                 if (errorMessage.isNull())
-                    errorMessage = WTF::makeString("can't get ", i, "th target for br_table");
+                    errorMessage = WTF::makeString("can't get "_s, i, "th target for br_table"_s);
                 return nullptr;
             }
             if (UNLIKELY(target >= m_controlStack.size())) {
                 if (errorMessage.isNull())
-                    errorMessage = WTF::makeString("br_table's ", i, "th target ", target, " exceeds control stack size ", m_controlStack.size());
+                    errorMessage = WTF::makeString("br_table's "_s, i, "th target "_s, target, " exceeds control stack size "_s, m_controlStack.size());
                 return nullptr;
             }
             return &m_controlStack[m_controlStack.size() - 1 - target].controlData;
         });
         WASM_PARSER_FAIL_IF(!errorMessage.isNull(), errorMessage);
 
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(defaultTargetIndex), "can't get default target for br_table");
-        WASM_PARSER_FAIL_IF(defaultTargetIndex >= m_controlStack.size(), "br_table's default target ", defaultTargetIndex, " exceeds control stack size ", m_controlStack.size());
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(defaultTargetIndex), "can't get default target for br_table"_s);
+        WASM_PARSER_FAIL_IF(defaultTargetIndex >= m_controlStack.size(), "br_table's default target "_s, defaultTargetIndex, " exceeds control stack size "_s, m_controlStack.size());
         ControlType& defaultTarget = m_controlStack[m_controlStack.size() - 1 - defaultTargetIndex].controlData;
 
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(condition, "br_table condition");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(condition, "br_table condition"_s);
         WASM_VALIDATOR_FAIL_IF(!condition.type().isI32(), "br_table with non-i32 condition ", condition.type());
 
         for (unsigned i = 0; i < targets.size(); ++i) {
@@ -3368,7 +3368,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     }
 
     case Drop: {
-        WASM_PARSER_FAIL_IF(!m_expressionStack.size(), "can't drop on empty stack");
+        WASM_PARSER_FAIL_IF(!m_expressionStack.size(), "can't drop on empty stack"_s);
         auto last = m_expressionStack.takeLast();
         WASM_TRY_ADD_TO_CONTEXT(addDrop(last));
         m_context.didPopValueFromStack(last, "Drop"_s);
@@ -3380,14 +3380,14 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     }
 
     case GrowMemory: {
-        WASM_PARSER_FAIL_IF(!m_info.memory, "grow_memory is only valid if a memory is defined or imported");
+        WASM_PARSER_FAIL_IF(!m_info.memory, "grow_memory is only valid if a memory is defined or imported"_s);
 
         uint8_t reserved;
-        WASM_PARSER_FAIL_IF(!parseUInt8(reserved), "can't parse reserved byte for grow_memory");
-        WASM_PARSER_FAIL_IF(reserved != 0, "reserved byte for grow_memory must be zero");
+        WASM_PARSER_FAIL_IF(!parseUInt8(reserved), "can't parse reserved byte for grow_memory"_s);
+        WASM_PARSER_FAIL_IF(reserved, "reserved byte for grow_memory must be zero"_s);
 
         TypedExpression delta;
-        WASM_TRY_POP_EXPRESSION_STACK_INTO(delta, "expect an i32 argument to grow_memory on the stack");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(delta, "expect an i32 argument to grow_memory on the stack"_s);
         WASM_VALIDATOR_FAIL_IF(!delta.type().isI32(), "grow_memory with non-i32 delta argument has type: ", delta.type());
 
         ExpressionType result;
@@ -3398,11 +3398,11 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     }
 
     case CurrentMemory: {
-        WASM_PARSER_FAIL_IF(!m_info.memory, "current_memory is only valid if a memory is defined or imported");
+        WASM_PARSER_FAIL_IF(!m_info.memory, "current_memory is only valid if a memory is defined or imported"_s);
 
         uint8_t reserved;
-        WASM_PARSER_FAIL_IF(!parseUInt8(reserved), "can't parse reserved byte for current_memory");
-        WASM_PARSER_FAIL_IF(reserved != 0, "reserved byte for current_memory must be zero");
+        WASM_PARSER_FAIL_IF(!parseUInt8(reserved), "can't parse reserved byte for current_memory"_s);
+        WASM_PARSER_FAIL_IF(reserved, "reserved byte for current_memory must be zero"_s);
 
         ExpressionType result;
         WASM_TRY_ADD_TO_CONTEXT(addCurrentMemory(result));
@@ -3412,10 +3412,10 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     }
 #if ENABLE(B3_JIT)
     case ExtSIMD: {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblySIMD(), "wasm-simd is not enabled");
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblySIMD(), "wasm-simd is not enabled"_s);
         m_context.notifyFunctionUsesSIMD();
         uint32_t extOp;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(extOp), "can't parse wasm extended opcode");
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(extOp), "can't parse wasm extended opcode"_s);
 
         constexpr bool isReachable = true;
 
@@ -3431,14 +3431,14 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         FOR_EACH_WASM_EXT_SIMD_REL_OP(CREATE_SIMD_CASE)
         #undef CREATE_SIMD_CASE
         default:
-            WASM_PARSER_FAIL_IF(true, "invalid extended simd op ", extOp);
+            WASM_PARSER_FAIL_IF(true, "invalid extended simd op "_s, extOp);
             break;
         }
         return { };
     }
 #else
     case ExtSIMD:
-        WASM_PARSER_FAIL_IF(true, "wasm-simd is not supported");
+        WASM_PARSER_FAIL_IF(true, "wasm-simd is not supported"_s);
         return { };
 #endif
     }
@@ -3509,7 +3509,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
     }
 
     case Delegate: {
-        WASM_PARSER_FAIL_IF(m_controlStack.size() == 1, "can't use delegate at the top-level of a function");
+        WASM_PARSER_FAIL_IF(m_controlStack.size() == 1, "can't use delegate at the top-level of a function"_s);
 
         uint32_t target;
         WASM_FAIL_IF_HELPER_FAILS(parseDelegateTarget(target, m_unreachableBlocks));
@@ -3555,50 +3555,50 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
     case Block: {
         m_unreachableBlocks++;
         BlockSignature unused;
-        WASM_PARSER_FAIL_IF(!parseBlockSignature(m_info, unused), "can't get inline type for ", m_currentOpcode, " in unreachable context");
+        WASM_PARSER_FAIL_IF(!parseBlockSignature(m_info, unused), "can't get inline type for "_s, m_currentOpcode, " in unreachable context"_s);
         return { };
     }
 
     case BrTable: {
         uint32_t numberOfTargets;
         uint32_t unused;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(numberOfTargets), "can't get the number of targets for br_table in unreachable context");
-        WASM_PARSER_FAIL_IF(numberOfTargets == std::numeric_limits<uint32_t>::max(), "br_table's number of targets is too big ", numberOfTargets);
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(numberOfTargets), "can't get the number of targets for br_table in unreachable context"_s);
+        WASM_PARSER_FAIL_IF(numberOfTargets == std::numeric_limits<uint32_t>::max(), "br_table's number of targets is too big "_s, numberOfTargets);
 
         for (uint32_t i = 0; i < numberOfTargets; ++i)
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get ", i, "th target for br_table in unreachable context");
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get "_s, i, "th target for br_table in unreachable context"_s);
 
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get default target for br_table in unreachable context");
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get default target for br_table in unreachable context"_s);
         return { };
     }
 
     case TailCallIndirect:
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyTailCalls(), "wasm tail calls are not enabled");
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyTailCalls(), "wasm tail calls are not enabled"_s);
         FALLTHROUGH;
     case CallIndirect: {
         uint32_t unused;
         uint32_t unused2;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get call_indirect's signature index in unreachable context");
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(unused2), "can't get call_indirect's reserved byte in unreachable context");
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get call_indirect's signature index in unreachable context"_s);
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(unused2), "can't get call_indirect's reserved byte in unreachable context"_s);
         return { };
     }
 
     case CallRef: {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyTypedFunctionReferences(), "function references are not enabled");
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyTypedFunctionReferences(), "function references are not enabled"_s);
         uint32_t unused;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't call_ref's signature index in unreachable context");
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't call_ref's signature index in unreachable context"_s);
         return { };
     }
 
     case F32Const: {
         uint32_t unused;
-        WASM_PARSER_FAIL_IF(!parseUInt32(unused), "can't parse 32-bit floating-point constant");
+        WASM_PARSER_FAIL_IF(!parseUInt32(unused), "can't parse 32-bit floating-point constant"_s);
         return { };
     }
 
     case F64Const: {
         uint64_t constant;
-        WASM_PARSER_FAIL_IF(!parseUInt64(constant), "can't parse 64-bit floating-point constant");
+        WASM_PARSER_FAIL_IF(!parseUInt64(constant), "can't parse 64-bit floating-point constant"_s);
         return { };
     }
 
@@ -3606,8 +3606,8 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
     FOR_EACH_WASM_MEMORY_LOAD_OP(CREATE_CASE)
     FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE) {
         uint32_t unused;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get first immediate for ", m_currentOpcode, " in unreachable context");
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get second immediate for ", m_currentOpcode, " in unreachable context");
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get first immediate for "_s, m_currentOpcode, " in unreachable context"_s);
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get second immediate for "_s, m_currentOpcode, " in unreachable context"_s);
         return { };
     }
 
@@ -3634,7 +3634,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
     }
 
     case TailCall:
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyTailCalls(), "wasm tail calls are not enabled");
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyTailCalls(), "wasm tail calls are not enabled"_s);
         FALLTHROUGH;
     case Call: {
         uint32_t functionIndex;
@@ -3647,7 +3647,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
         WASM_FAIL_IF_HELPER_FAILS(parseBranchTarget(target));
 
         ControlType& data = m_controlStack[m_controlStack.size() - 1 - target].controlData;
-        WASM_VALIDATOR_FAIL_IF(!ControlType::isAnyCatch(data), "rethrow doesn't refer to a catch block");
+        WASM_VALIDATOR_FAIL_IF(!ControlType::isAnyCatch(data), "rethrow doesn't refer to a catch block"_s);
         return { };
     }
 
@@ -3667,19 +3667,19 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
 
     case I32Const: {
         int32_t unused;
-        WASM_PARSER_FAIL_IF(!parseVarInt32(unused), "can't get immediate for ", m_currentOpcode, " in unreachable context");
+        WASM_PARSER_FAIL_IF(!parseVarInt32(unused), "can't get immediate for "_s, m_currentOpcode, " in unreachable context"_s);
         return { };
     }
 
     case I64Const: {
         int64_t unused;
-        WASM_PARSER_FAIL_IF(!parseVarInt64(unused), "can't get immediate for ", m_currentOpcode, " in unreachable context");
+        WASM_PARSER_FAIL_IF(!parseVarInt64(unused), "can't get immediate for "_s, m_currentOpcode, " in unreachable context"_s);
         return { };
     }
 
     case Ext1: {
         uint32_t extOp;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(extOp), "can't parse extended 0xfc opcode");
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(extOp), "can't parse extended 0xfc opcode"_s);
 
         switch (static_cast<Ext1OpType>(extOp)) {
         case Ext1OpType::TableInit: {
@@ -3727,7 +3727,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
             return { };
 #undef CREATE_EXT1_CASE
         default:
-            WASM_PARSER_FAIL_IF(true, "invalid extended 0xfc op ", extOp);
+            WASM_PARSER_FAIL_IF(true, "invalid extended 0xfc op "_s, extOp);
             break;
         }
 
@@ -3743,7 +3743,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
     case TableGet:
     case TableSet: {
         unsigned tableIndex;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't parse table index");
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't parse table index"_s);
         FALLTHROUGH;
     }
     case RefIsNull:
@@ -3753,7 +3753,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
 
     case RefFunc: {
         uint32_t unused;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get immediate for ", m_currentOpcode, " in unreachable context");
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get immediate for "_s, m_currentOpcode, " in unreachable context"_s);
         return { };
     }
 
@@ -3770,10 +3770,10 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
     }
 
     case ExtGC: {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled");
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled"_s);
 
         uint32_t extOp;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(extOp), "can't parse extended GC opcode");
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(extOp), "can't parse extended GC opcode"_s);
 
         ExtGCOpType op = static_cast<ExtGCOpType>(extOp);
 #if ENABLE(WEBASSEMBLY_OMGJIT)
@@ -3788,90 +3788,90 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
             return { };
         case ExtGCOpType::ArrayNew: {
             uint32_t unused;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get type index immediate for array.new in unreachable context");
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get type index immediate for array.new in unreachable context"_s);
             return { };
         }
         case ExtGCOpType::ArrayNewDefault: {
             uint32_t unused;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get type index immediate for array.new_default in unreachable context");
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get type index immediate for array.new_default in unreachable context"_s);
             return { };
         }
         case ExtGCOpType::ArrayGet: {
             uint32_t unused;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get type index immediate for array.get in unreachable context");
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get type index immediate for array.get in unreachable context"_s);
             return { };
         }
         case ExtGCOpType::ArrayGetS: {
             uint32_t unused;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get type index immediate for array.get_s in unreachable context");
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get type index immediate for array.get_s in unreachable context"_s);
             return { };
         }
         case ExtGCOpType::ArrayGetU: {
             uint32_t unused;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get type index immediate for array.get_u in unreachable context");
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get type index immediate for array.get_u in unreachable context"_s);
             return { };
         }
         case ExtGCOpType::ArraySet: {
             uint32_t unused;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get type index immediate for array.set in unreachable context");
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get type index immediate for array.set in unreachable context"_s);
             return { };
         }
         case ExtGCOpType::ArrayLen:
             return { };
         case ExtGCOpType::ArrayFill: {
             uint32_t unused;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get type index immediate for array.fill in unreachable context");
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get type index immediate for array.fill in unreachable context"_s);
             return { };
         }
         case ExtGCOpType::ArrayCopy: {
             uint32_t unused;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get first type index immediate for array.copy in unreachable context");
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get second type index immediate for array.copy in unreachable context");
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get first type index immediate for array.copy in unreachable context"_s);
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get second type index immediate for array.copy in unreachable context"_s);
             return { };
         }
         case ExtGCOpType::ArrayInitElem: {
             uint32_t unused;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get first type index immediate for array.init_elem in unreachable context");
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get second type index immediate for array.init_elem in unreachable context");
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get first type index immediate for array.init_elem in unreachable context"_s);
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get second type index immediate for array.init_elem in unreachable context"_s);
             return { };
         }
         case ExtGCOpType::ArrayInitData: {
             uint32_t unused;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get first type index immediate for array.init_data in unreachable context");
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get second type index immediate for array.init_data in unreachable context");
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get first type index immediate for array.init_data in unreachable context"_s);
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get second type index immediate for array.init_data in unreachable context"_s);
             return { };
         }
         case ExtGCOpType::StructNew: {
             uint32_t unused;
-            WASM_FAIL_IF_HELPER_FAILS(parseStructTypeIndex(unused, "struct.new"));
+            WASM_FAIL_IF_HELPER_FAILS(parseStructTypeIndex(unused, "struct.new"_s));
             return { };
         }
         case ExtGCOpType::StructNewDefault: {
             uint32_t unused;
-            WASM_FAIL_IF_HELPER_FAILS(parseStructTypeIndex(unused, "struct.new_default"));
+            WASM_FAIL_IF_HELPER_FAILS(parseStructTypeIndex(unused, "struct.new_default"_s));
             return { };
         }
         case ExtGCOpType::StructGet: {
             StructTypeIndexAndFieldIndex unused;
-            WASM_FAIL_IF_HELPER_FAILS(parseStructTypeIndexAndFieldIndex(unused, "struct.get"));
+            WASM_FAIL_IF_HELPER_FAILS(parseStructTypeIndexAndFieldIndex(unused, "struct.get"_s));
             return { };
         }
         case ExtGCOpType::StructSet: {
             StructTypeIndexAndFieldIndex unused;
-            WASM_FAIL_IF_HELPER_FAILS(parseStructTypeIndexAndFieldIndex(unused, "struct.set"));
+            WASM_FAIL_IF_HELPER_FAILS(parseStructTypeIndexAndFieldIndex(unused, "struct.set"_s));
             return { };
         }
         case ExtGCOpType::RefTest:
         case ExtGCOpType::RefTestNull:
         case ExtGCOpType::RefCast:
         case ExtGCOpType::RefCastNull: {
-            const char* opName = op == ExtGCOpType::RefCast || op == ExtGCOpType::RefCastNull ? "ref.cast" : "ref.test";
+            auto opName = op == ExtGCOpType::RefCast || op == ExtGCOpType::RefCastNull ? "ref.cast"_s : "ref.test"_s;
             int32_t unused;
-            WASM_PARSER_FAIL_IF(!parseHeapType(m_info, unused), "can't get heap type for ", opName);
+            WASM_PARSER_FAIL_IF(!parseHeapType(m_info, unused), "can't get heap type for "_s, opName);
             return { };
         }
         default:
-            WASM_PARSER_FAIL_IF(true, "invalid extended GC op ", extOp);
+            WASM_PARSER_FAIL_IF(true, "invalid extended GC op "_s, extOp);
             break;
         }
 
@@ -3881,15 +3881,15 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
     case GrowMemory:
     case CurrentMemory: {
         uint8_t reserved;
-        WASM_PARSER_FAIL_IF(!parseUInt8(reserved), "can't parse reserved byte for grow_memory/current_memory");
-        WASM_PARSER_FAIL_IF(reserved != 0, "reserved byte for grow_memory/current_memory must be zero");
+        WASM_PARSER_FAIL_IF(!parseUInt8(reserved), "can't parse reserved byte for grow_memory/current_memory"_s);
+        WASM_PARSER_FAIL_IF(reserved, "reserved byte for grow_memory/current_memory must be zero"_s);
         return { };
     }
 
 #define CREATE_ATOMIC_CASE(name, ...) case ExtAtomicOpType::name:
     case ExtAtomic: {
         uint32_t extOp;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(extOp), "can't parse atomic extended opcode");
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(extOp), "can't parse atomic extended opcode"_s);
         ExtAtomicOpType op = static_cast<ExtAtomicOpType>(extOp);
         switch (op) {
         FOR_EACH_WASM_EXT_ATOMIC_LOAD_OP(CREATE_ATOMIC_CASE)
@@ -3906,22 +3906,22 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
         case ExtAtomicOpType::I64AtomicRmw32CmpxchgU:
         case ExtAtomicOpType::I64AtomicRmwCmpxchg:
         {
-            WASM_VALIDATOR_FAIL_IF(!m_info.memory, "atomic instruction without memory");
+            WASM_VALIDATOR_FAIL_IF(!m_info.memory, "atomic instruction without memory"_s);
             uint32_t alignment;
             uint32_t unused;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment");
-            WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment ", 1ull << alignment, " does not match against atomic op's natural alignment ", 1ull << memoryLog2Alignment(op));
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get first immediate for atomic ", static_cast<unsigned>(op), " in unreachable context");
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
+            WASM_PARSER_FAIL_IF(alignment != memoryLog2Alignment(op), "byte alignment "_s, 1ull << alignment, " does not match against atomic op's natural alignment "_s, 1ull << memoryLog2Alignment(op));
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get first immediate for atomic "_s, static_cast<unsigned>(op), " in unreachable context"_s);
             break;
         }
         case ExtAtomicOpType::AtomicFence: {
             uint8_t flags;
-            WASM_PARSER_FAIL_IF(!parseUInt8(flags), "can't get flags");
-            WASM_PARSER_FAIL_IF(flags != 0x0, "flags should be 0x0 but got ", flags);
+            WASM_PARSER_FAIL_IF(!parseUInt8(flags), "can't get flags"_s);
+            WASM_PARSER_FAIL_IF(flags != 0x0, "flags should be 0x0 but got "_s, flags);
             break;
         }
         default:
-            WASM_PARSER_FAIL_IF(true, "invalid extended atomic op ", extOp);
+            WASM_PARSER_FAIL_IF(true, "invalid extended atomic op "_s, extOp);
             break;
         }
 
@@ -3931,10 +3931,10 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
 
 #if ENABLE(B3_JIT)
     case ExtSIMD: {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblySIMD(), "wasm-simd is not enabled");
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblySIMD(), "wasm-simd is not enabled"_s);
         m_context.notifyFunctionUsesSIMD();
         uint32_t extOp;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(extOp), "can't parse wasm extended opcode");
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(extOp), "can't parse wasm extended opcode"_s);
 
         constexpr bool isReachable = false;
 
@@ -3947,14 +3947,14 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
         FOR_EACH_WASM_EXT_SIMD_REL_OP(CREATE_SIMD_CASE)
         #undef CREATE_SIMD_CASE
         default:
-            WASM_PARSER_FAIL_IF(true, "invalid extended simd op ", extOp);
+            WASM_PARSER_FAIL_IF(true, "invalid extended simd op "_s, extOp);
             break;
         }
         return { };
     }
 #else
     case ExtSIMD:
-        WASM_PARSER_FAIL_IF(true, "wasm-simd is not supported");
+        WASM_PARSER_FAIL_IF(true, "wasm-simd is not supported"_s);
         return { };
 #endif
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -69,7 +69,7 @@ IPIntPlan::IPIntPlan(VM& vm, Ref<ModuleInformation> info, CompilerMode compilerM
 bool IPIntPlan::prepareImpl()
 {
     const auto& functions = m_moduleInformation->functions;
-    if (!tryReserveCapacity(m_wasmInternalFunctions, functions.size(), "WebAssembly functions"))
+    if (!tryReserveCapacity(m_wasmInternalFunctions, functions.size(), "WebAssembly functions"_s))
         return false;
 
     m_wasmInternalFunctions.resize(functions.size());

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
@@ -71,7 +71,7 @@ LLIntPlan::LLIntPlan(VM& vm, Ref<ModuleInformation> info, CompilerMode compilerM
 bool LLIntPlan::prepareImpl()
 {
     const auto& functions = m_moduleInformation->functions;
-    if (!tryReserveCapacity(m_wasmInternalFunctions, functions.size(), " WebAssembly functions"))
+    if (!tryReserveCapacity(m_wasmInternalFunctions, functions.size(), " WebAssembly functions"_s))
         return false;
 
     m_wasmInternalFunctions.resize(functions.size());

--- a/Source/JavaScriptCore/wasm/WasmNameSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmNameSectionParser.cpp
@@ -35,15 +35,15 @@ namespace JSC { namespace Wasm {
 auto NameSectionParser::parse() -> Result
 {
     Ref<NameSection> nameSection = NameSection::create();
-    WASM_PARSER_FAIL_IF(!nameSection->functionNames.tryReserveCapacity(m_info.functionIndexSpaceSize()), "can't allocate enough memory for function names");
+    WASM_PARSER_FAIL_IF(!nameSection->functionNames.tryReserveCapacity(m_info.functionIndexSpaceSize()), "can't allocate enough memory for function names"_s);
     nameSection->functionNames.resize(m_info.functionIndexSpaceSize());
 
     for (size_t payloadNumber = 0; m_offset < source().size(); ++payloadNumber) {
         uint8_t nameType;
         uint32_t payloadLength;
-        WASM_PARSER_FAIL_IF(!parseUInt7(nameType), "can't get name type for payload ", payloadNumber);
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(payloadLength), "can't get payload length for payload ", payloadNumber);
-        WASM_PARSER_FAIL_IF(payloadLength > source().size() - m_offset, "payload length is too big for payload ", payloadNumber);
+        WASM_PARSER_FAIL_IF(!parseUInt7(nameType), "can't get name type for payload "_s, payloadNumber);
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(payloadLength), "can't get payload length for payload "_s, payloadNumber);
+        WASM_PARSER_FAIL_IF(payloadLength > source().size() - m_offset, "payload length is too big for payload "_s, payloadNumber);
         const auto payloadStart = m_offset;
 
         if (!isValidNameType(nameType)) {
@@ -56,22 +56,22 @@ auto NameSectionParser::parse() -> Result
         case NameType::Module: {
             uint32_t nameLen;
             Name nameString;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(nameLen), "can't get module's name length for payload ", payloadNumber);
-            WASM_PARSER_FAIL_IF(!consumeUTF8String(nameString, nameLen), "can't get module's name of length ", nameLen, " for payload ", payloadNumber);
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(nameLen), "can't get module's name length for payload "_s, payloadNumber);
+            WASM_PARSER_FAIL_IF(!consumeUTF8String(nameString, nameLen), "can't get module's name of length "_s, nameLen, " for payload "_s, payloadNumber);
             nameSection->moduleName = WTFMove(nameString);
             break;
         }
         case NameType::Function: {
             uint32_t count;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(count), "can't get function count for payload ", payloadNumber);
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(count), "can't get function count for payload "_s, payloadNumber);
             for (uint32_t function = 0; function < count; ++function) {
                 uint32_t index;
                 uint32_t nameLen;
                 Name nameString;
-                WASM_PARSER_FAIL_IF(!parseVarUInt32(index), "can't get function ", function, " index for payload ", payloadNumber);
-                WASM_PARSER_FAIL_IF(m_info.functionIndexSpaceSize() <= index, "function ", function, " index ", index, " is larger than function index space ", m_info.functionIndexSpaceSize(), " for payload ", payloadNumber);
-                WASM_PARSER_FAIL_IF(!parseVarUInt32(nameLen), "can't get functions ", function, "'s name length for payload ", payloadNumber);
-                WASM_PARSER_FAIL_IF(!consumeUTF8String(nameString, nameLen), "can't get function ", function, "'s name of length ", nameLen, " for payload ", payloadNumber);
+                WASM_PARSER_FAIL_IF(!parseVarUInt32(index), "can't get function "_s, function, " index for payload "_s, payloadNumber);
+                WASM_PARSER_FAIL_IF(m_info.functionIndexSpaceSize() <= index, "function "_s, function, " index "_s, index, " is larger than function index space "_s, m_info.functionIndexSpaceSize(), " for payload "_s, payloadNumber);
+                WASM_PARSER_FAIL_IF(!parseVarUInt32(nameLen), "can't get functions "_s, function, "'s name length for payload "_s, payloadNumber);
+                WASM_PARSER_FAIL_IF(!consumeUTF8String(nameString, nameLen), "can't get function "_s, function, "'s name of length "_s, nameLen, " for payload "_s, payloadNumber);
                 nameSection->functionNames[index] = WTFMove(nameString);
             }
             break;
@@ -79,25 +79,25 @@ auto NameSectionParser::parse() -> Result
         case NameType::Local: {
             // Ignore local names for now, we don't do anything with them but we still need to parse them in order to properly ignore them.
             uint32_t functionCount;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(functionCount), "can't get function count for local name payload ", payloadNumber);
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(functionCount), "can't get function count for local name payload "_s, payloadNumber);
             for (uint32_t function = 0; function < functionCount; ++function) {
                 uint32_t functionIndex;
                 uint32_t count;
-                WASM_PARSER_FAIL_IF(!parseVarUInt32(functionIndex), "can't get local's function index for payload ", payloadNumber);
-                WASM_PARSER_FAIL_IF(!parseVarUInt32(count), "can't get local count for payload ", payloadNumber);
+                WASM_PARSER_FAIL_IF(!parseVarUInt32(functionIndex), "can't get local's function index for payload "_s, payloadNumber);
+                WASM_PARSER_FAIL_IF(!parseVarUInt32(count), "can't get local count for payload "_s, payloadNumber);
                 for (uint32_t local = 0; local < count; ++local) {
                     uint32_t index;
                     uint32_t nameLen;
                     Name nameString;
-                    WASM_PARSER_FAIL_IF(!parseVarUInt32(index), "can't get local ", local, " index for payload ", payloadNumber);
-                    WASM_PARSER_FAIL_IF(!parseVarUInt32(nameLen), "can't get local ", local, "'s name length for payload ", payloadNumber);
-                    WASM_PARSER_FAIL_IF(!consumeUTF8String(nameString, nameLen), "can't get local ", local, "'s name of length ", nameLen, " for payload ", payloadNumber);
+                    WASM_PARSER_FAIL_IF(!parseVarUInt32(index), "can't get local "_s, local, " index for payload "_s, payloadNumber);
+                    WASM_PARSER_FAIL_IF(!parseVarUInt32(nameLen), "can't get local "_s, local, "'s name length for payload "_s, payloadNumber);
+                    WASM_PARSER_FAIL_IF(!consumeUTF8String(nameString, nameLen), "can't get local "_s, local, "'s name of length "_s, nameLen, " for payload "_s, payloadNumber);
                 }
             }
             break;
         }
         }
-        WASM_PARSER_FAIL_IF(payloadStart + payloadLength != m_offset, "payload for name section is not correct size, expected ", payloadLength, " got ", m_offset - payloadStart);
+        WASM_PARSER_FAIL_IF(payloadStart + payloadLength != m_offset, "payload for name section is not correct size, expected "_s, payloadLength, " got "_s, m_offset - payloadStart);
     }
     return nameSection;
 }

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -1351,7 +1351,7 @@ auto OMGIRGenerator::addLocal(Type type, uint32_t count) -> PartialResult
     size_t newSize = m_locals.size() + count;
     ASSERT(!(CheckedUint32(count) + m_locals.size()).hasOverflowed());
     ASSERT(newSize <= maxFunctionLocals);
-    WASM_COMPILE_FAIL_IF(!m_locals.tryReserveCapacity(newSize), "can't allocate memory for ", newSize, " locals");
+    WASM_COMPILE_FAIL_IF(!m_locals.tryReserveCapacity(newSize), "can't allocate memory for "_s, newSize, " locals"_s);
 
     m_locals.appendUsingFunctor(count, [&](size_t) {
         Variable* local = m_proc.addVariable(toB3Type(type));
@@ -1392,7 +1392,7 @@ auto OMGIRGenerator::addInlinedArguments(const TypeDefinition& signature) -> Par
 auto OMGIRGenerator::addArguments(const TypeDefinition& signature) -> PartialResult
 {
     ASSERT(!m_locals.size());
-    WASM_COMPILE_FAIL_IF(!m_locals.tryReserveCapacity(signature.as<FunctionSignature>()->argumentCount()), "can't allocate memory for ", signature.as<FunctionSignature>()->argumentCount(), " arguments");
+    WASM_COMPILE_FAIL_IF(!m_locals.tryReserveCapacity(signature.as<FunctionSignature>()->argumentCount()), "can't allocate memory for "_s, signature.as<FunctionSignature>()->argumentCount(), " arguments"_s);
 
     m_locals.grow(signature.as<FunctionSignature>()->argumentCount());
 

--- a/Source/JavaScriptCore/wasm/WasmParser.h
+++ b/Source/JavaScriptCore/wasm/WasmParser.h
@@ -238,8 +238,8 @@ ALWAYS_INLINE bool ParserBase::parseImmByteArray16(v128_t& result)
 ALWAYS_INLINE typename ParserBase::PartialResult ParserBase::parseImmLaneIdx(uint8_t laneCount, uint8_t& result)
 {
     RELEASE_ASSERT(laneCount == 2 || laneCount == 4 || laneCount == 8 || laneCount == 16 || laneCount == 32);
-    WASM_PARSER_FAIL_IF(!parseUInt8(result), "Could not parse the lane index immediate byte.");
-    WASM_PARSER_FAIL_IF(result >= laneCount, "Lane index immediate is too large, saw ", laneCount, ", expected an ImmLaneIdx", laneCount);
+    WASM_PARSER_FAIL_IF(!parseUInt8(result), "Could not parse the lane index immediate byte."_s);
+    WASM_PARSER_FAIL_IF(result >= laneCount, "Lane index immediate is too large, saw "_s, laneCount, ", expected an ImmLaneIdx"_s, laneCount);
     return { };
 }
 
@@ -300,19 +300,19 @@ ALWAYS_INLINE typename ParserBase::PartialResult ParserBase::parseBlockSignature
         }
 
         Type type = { typeKind, TypeDefinition::invalidIndex };
-        WASM_PARSER_FAIL_IF(!(isValueType(type) || type.isVoid()), "result type of block: ", makeString(type.kind), " is not a value type or Void");
+        WASM_PARSER_FAIL_IF(!(isValueType(type) || type.isVoid()), "result type of block: "_s, makeString(type.kind), " is not a value type or Void"_s);
         result = m_typeInformation.thunkFor(type);
         m_offset++;
         return { };
     }
 
     int64_t index;
-    WASM_PARSER_FAIL_IF(!parseVarInt64(index), "Block-like instruction doesn't return value type but can't decode type section index");
-    WASM_PARSER_FAIL_IF(index < 0, "Block-like instruction signature index is negative");
-    WASM_PARSER_FAIL_IF(static_cast<size_t>(index) >= info.typeCount(), "Block-like instruction signature index is out of bounds. Index: ", index, " type index space: ", info.typeCount());
+    WASM_PARSER_FAIL_IF(!parseVarInt64(index), "Block-like instruction doesn't return value type but can't decode type section index"_s);
+    WASM_PARSER_FAIL_IF(index < 0, "Block-like instruction signature index is negative"_s);
+    WASM_PARSER_FAIL_IF(static_cast<size_t>(index) >= info.typeCount(), "Block-like instruction signature index is out of bounds. Index: "_s, index, " type index space: "_s, info.typeCount());
 
     const auto& signature = info.typeSignatures[index].get().expand();
-    WASM_PARSER_FAIL_IF(!signature.is<FunctionSignature>(), "Block-like instruction signature index does not refer to a function type definition");
+    WASM_PARSER_FAIL_IF(!signature.is<FunctionSignature>(), "Block-like instruction signature index does not refer to a function type definition"_s);
 
     result = signature.as<FunctionSignature>();
     return { };
@@ -321,7 +321,7 @@ ALWAYS_INLINE typename ParserBase::PartialResult ParserBase::parseBlockSignature
 inline typename ParserBase::PartialResult ParserBase::parseReftypeSignature(const ModuleInformation& info, BlockSignature& result)
 {
     Type resultType;
-    WASM_PARSER_FAIL_IF(!parseValueType(info, resultType), "result type of block is not a valid ref type");
+    WASM_PARSER_FAIL_IF(!parseValueType(info, resultType), "result type of block is not a valid ref type"_s);
     Vector<Type, 16> returnTypes { resultType };
     const auto& typeDefinition = TypeInformation::typeDefinitionForFunction(returnTypes, { }).get();
     result = &TypeInformation::getFunctionSignature(typeDefinition->index());

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -47,16 +47,16 @@ auto SectionParser::parseType() -> PartialResult
     uint32_t count;
     uint32_t recursionGroupCount = 0;
 
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(count), "can't get Type section's count");
-    WASM_PARSER_FAIL_IF(count > maxTypes, "Type section's count is too big ", count, " maximum ", maxTypes);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(count), "can't get Type section's count"_s);
+    WASM_PARSER_FAIL_IF(count > maxTypes, "Type section's count is too big "_s, count, " maximum "_s, maxTypes);
     RELEASE_ASSERT(!m_info->typeSignatures.capacity());
     RELEASE_ASSERT(!m_info->rtts.capacity());
-    WASM_PARSER_FAIL_IF(!m_info->typeSignatures.tryReserveInitialCapacity(count), "can't allocate enough memory for Type section's ", count, " entries");
-    WASM_PARSER_FAIL_IF(!m_info->rtts.tryReserveInitialCapacity(count), "can't allocate enough memory for Type section's ", count, " canonical RTT entries");
+    WASM_PARSER_FAIL_IF(!m_info->typeSignatures.tryReserveInitialCapacity(count), "can't allocate enough memory for Type section's "_s, count, " entries"_s);
+    WASM_PARSER_FAIL_IF(!m_info->rtts.tryReserveInitialCapacity(count), "can't allocate enough memory for Type section's "_s, count, " canonical RTT entries"_s);
 
     for (uint32_t i = 0; i < count; ++i) {
         int8_t typeKind;
-        WASM_PARSER_FAIL_IF(!parseInt7(typeKind), "can't get ", i, "th Type's type");
+        WASM_PARSER_FAIL_IF(!parseInt7(typeKind), "can't get "_s, i, "th Type's type"_s);
         RefPtr<TypeDefinition> signature;
 
         // When GC is enabled, recursive references can show up in any of these cases.
@@ -87,7 +87,7 @@ auto SectionParser::parseType() -> PartialResult
 
             WASM_FAIL_IF_HELPER_FAILS(parseRecursionGroup(i, signature));
             ++recursionGroupCount;
-            WASM_PARSER_FAIL_IF(recursionGroupCount > maxNumberOfRecursionGroups, "number of recursion groups exceeded the limit of ", maxNumberOfRecursionGroups);
+            WASM_PARSER_FAIL_IF(recursionGroupCount > maxNumberOfRecursionGroups, "number of recursion groups exceeded the limit of "_s, maxNumberOfRecursionGroups);
             break;
         }
         case TypeKind::Sub:
@@ -103,7 +103,7 @@ auto SectionParser::parseType() -> PartialResult
             return fail(i, "th Type is non-Func, non-Struct, and non-Array ", typeKind);
         }
 
-        WASM_PARSER_FAIL_IF(!signature, "can't allocate enough memory for Type section's ", i, "th signature");
+        WASM_PARSER_FAIL_IF(!signature, "can't allocate enough memory for Type section's "_s, i, "th signature"_s);
 
         // When GC is enabled, type definitions that appear on their own are shorthand
         // notations for recursion groups with one type. Here we ensure that if such a
@@ -117,13 +117,13 @@ auto SectionParser::parseType() -> PartialResult
                 if (signature->hasRecursiveReference()) {
                     Vector<TypeIndex> types;
                     bool result = types.tryAppend(signature->index());
-                    WASM_PARSER_FAIL_IF(!result, "can't allocate enough memory for Type section's ", i, "th signature");
+                    WASM_PARSER_FAIL_IF(!result, "can't allocate enough memory for Type section's "_s, i, "th signature"_s);
                     RefPtr<TypeDefinition> group = TypeInformation::typeDefinitionForRecursionGroup(types);
                     RefPtr<TypeDefinition> projection = TypeInformation::typeDefinitionForProjection(group->index(), 0);
                     TypeInformation::registerCanonicalRTTForType(projection->index());
                     m_info->rtts.append(TypeInformation::getCanonicalRTT(projection->index()));
                     if (signature->is<Subtype>()) {
-                        WASM_PARSER_FAIL_IF(m_info->rtts.last()->displaySize() > maxSubtypeDepth, "subtype depth for Type section's ", i, "th signature exceeded the limits of ", maxSubtypeDepth);
+                        WASM_PARSER_FAIL_IF(m_info->rtts.last()->displaySize() > maxSubtypeDepth, "subtype depth for Type section's "_s, i, "th signature exceeded the limits of "_s, maxSubtypeDepth);
                         WASM_FAIL_IF_HELPER_FAILS(checkSubtypeValidity(projection->unroll()));
                     }
                     m_info->typeSignatures.append(projection.releaseNonNull());
@@ -131,7 +131,7 @@ auto SectionParser::parseType() -> PartialResult
                     TypeInformation::registerCanonicalRTTForType(signature->index());
                     m_info->rtts.append(TypeInformation::getCanonicalRTT(signature->index()));
                     if (signature->is<Subtype>()) {
-                        WASM_PARSER_FAIL_IF(m_info->rtts.last()->displaySize() > maxSubtypeDepth, "subtype depth for Type section's ", i, "th signature exceeded the limits of ", maxSubtypeDepth);
+                        WASM_PARSER_FAIL_IF(m_info->rtts.last()->displaySize() > maxSubtypeDepth, "subtype depth for Type section's "_s, i, "th signature exceeded the limits of "_s, maxSubtypeDepth);
                         WASM_FAIL_IF_HELPER_FAILS(checkSubtypeValidity(signature->unroll()));
                     }
                     m_info->typeSignatures.append(signature.releaseNonNull());
@@ -146,16 +146,16 @@ auto SectionParser::parseType() -> PartialResult
 auto SectionParser::parseImport() -> PartialResult
 {
     uint32_t importCount;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(importCount), "can't get Import section's count");
-    WASM_PARSER_FAIL_IF(importCount > maxImports, "Import section's count is too big ", importCount, " maximum ", maxImports);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(importCount), "can't get Import section's count"_s);
+    WASM_PARSER_FAIL_IF(importCount > maxImports, "Import section's count is too big "_s, importCount, " maximum "_s, maxImports);
     RELEASE_ASSERT(!m_info->globals.capacity());
     RELEASE_ASSERT(!m_info->imports.capacity());
     RELEASE_ASSERT(!m_info->importFunctionTypeIndices.capacity());
     RELEASE_ASSERT(!m_info->importExceptionTypeIndices.capacity());
-    WASM_PARSER_FAIL_IF(!m_info->globals.tryReserveInitialCapacity(importCount), "can't allocate enough memory for ", importCount, " globals"); // FIXME this over-allocates when we fix the FIXMEs below.
-    WASM_PARSER_FAIL_IF(!m_info->imports.tryReserveInitialCapacity(importCount), "can't allocate enough memory for ", importCount, " imports"); // FIXME this over-allocates when we fix the FIXMEs below.
-    WASM_PARSER_FAIL_IF(!m_info->importFunctionTypeIndices.tryReserveInitialCapacity(importCount), "can't allocate enough memory for ", importCount, " import function signatures"); // FIXME this over-allocates when we fix the FIXMEs below.
-    WASM_PARSER_FAIL_IF(!m_info->importExceptionTypeIndices.tryReserveInitialCapacity(importCount), "can't allocate enough memory for ", importCount, " import exception signatures"); // FIXME this over-allocates when we fix the FIXMEs below.
+    WASM_PARSER_FAIL_IF(!m_info->globals.tryReserveInitialCapacity(importCount), "can't allocate enough memory for "_s, importCount, " globals"_s); // FIXME this over-allocates when we fix the FIXMEs below.
+    WASM_PARSER_FAIL_IF(!m_info->imports.tryReserveInitialCapacity(importCount), "can't allocate enough memory for "_s, importCount, " imports"_s); // FIXME this over-allocates when we fix the FIXMEs below.
+    WASM_PARSER_FAIL_IF(!m_info->importFunctionTypeIndices.tryReserveInitialCapacity(importCount), "can't allocate enough memory for "_s, importCount, " import function signatures"_s); // FIXME this over-allocates when we fix the FIXMEs below.
+    WASM_PARSER_FAIL_IF(!m_info->importExceptionTypeIndices.tryReserveInitialCapacity(importCount), "can't allocate enough memory for "_s, importCount, " import exception signatures"_s); // FIXME this over-allocates when we fix the FIXMEs below.
 
     for (uint32_t importNumber = 0; importNumber < importCount; ++importNumber) {
         uint32_t moduleLen;
@@ -165,18 +165,18 @@ auto SectionParser::parseImport() -> PartialResult
         ExternalKind kind;
         unsigned kindIndex { 0 };
 
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(moduleLen), "can't get ", importNumber, "th Import's module name length");
-        WASM_PARSER_FAIL_IF(!consumeUTF8String(moduleString, moduleLen), "can't get ", importNumber, "th Import's module name of length ", moduleLen);
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(moduleLen), "can't get "_s, importNumber, "th Import's module name length"_s);
+        WASM_PARSER_FAIL_IF(!consumeUTF8String(moduleString, moduleLen), "can't get "_s, importNumber, "th Import's module name of length "_s, moduleLen);
 
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(fieldLen), "can't get ", importNumber, "th Import's field name length in module '", moduleString, "'");
-        WASM_PARSER_FAIL_IF(!consumeUTF8String(fieldString, fieldLen), "can't get ", importNumber, "th Import's field name of length ", moduleLen, " in module '", moduleString, "'");
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(fieldLen), "can't get "_s, importNumber, "th Import's field name length in module '"_s, moduleString, "'"_s);
+        WASM_PARSER_FAIL_IF(!consumeUTF8String(fieldString, fieldLen), "can't get "_s, importNumber, "th Import's field name of length "_s, moduleLen, " in module '"_s, moduleString, "'"_s);
 
-        WASM_PARSER_FAIL_IF(!parseExternalKind(kind), "can't get ", importNumber, "th Import's kind in module '", moduleString, "' field '", fieldString, "'");
+        WASM_PARSER_FAIL_IF(!parseExternalKind(kind), "can't get "_s, importNumber, "th Import's kind in module '"_s, moduleString, "' field '"_s, fieldString, "'"_s);
         switch (kind) {
         case ExternalKind::Function: {
             uint32_t functionTypeIndex;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(functionTypeIndex), "can't get ", importNumber, "th Import's function signature in module '", moduleString, "' field '", fieldString, "'");
-            WASM_PARSER_FAIL_IF(functionTypeIndex >= m_info->typeCount(), "invalid function signature for ", importNumber, "th Import, ", functionTypeIndex, " is out of range of ", m_info->typeCount(), " in module '", moduleString, "' field '", fieldString, "'");
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(functionTypeIndex), "can't get "_s, importNumber, "th Import's function signature in module '"_s, moduleString, "' field '"_s, fieldString, "'"_s);
+            WASM_PARSER_FAIL_IF(functionTypeIndex >= m_info->typeCount(), "invalid function signature for "_s, importNumber, "th Import, "_s, functionTypeIndex, " is out of range of "_s, m_info->typeCount(), " in module '"_s, moduleString, "' field '"_s, fieldString, "'"_s);
             kindIndex = m_info->importFunctionTypeIndices.size();
             TypeIndex typeIndex = TypeInformation::get(m_info->typeSignatures[functionTypeIndex]);
             m_info->importFunctionTypeIndices.append(typeIndex);
@@ -209,12 +209,12 @@ auto SectionParser::parseImport() -> PartialResult
         }
         case ExternalKind::Exception: {
             uint8_t tagType;
-            WASM_PARSER_FAIL_IF(!parseUInt8(tagType), "can't get ", importNumber, "th Import exception's tag type");
-            WASM_PARSER_FAIL_IF(tagType, importNumber, "th Import exception has tag type ", tagType, " but the only supported tag type is 0");
+            WASM_PARSER_FAIL_IF(!parseUInt8(tagType), "can't get "_s, importNumber, "th Import exception's tag type"_s);
+            WASM_PARSER_FAIL_IF(tagType, importNumber, "th Import exception has tag type "_s, tagType, " but the only supported tag type is 0"_s);
 
             uint32_t exceptionSignatureIndex;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(exceptionSignatureIndex), "can't get ", importNumber, "th Import's exception signature in module '", moduleString, "' field '", fieldString, "'");
-            WASM_PARSER_FAIL_IF(exceptionSignatureIndex >= m_info->typeCount(), "invalid exception signature for ", importNumber, "th Import, ", exceptionSignatureIndex, " is out of range of ", m_info->typeCount(), " in module '", moduleString, "' field '", fieldString, "'");
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(exceptionSignatureIndex), "can't get "_s, importNumber, "th Import's exception signature in module '"_s, moduleString, "' field '"_s, fieldString, "'"_s);
+            WASM_PARSER_FAIL_IF(exceptionSignatureIndex >= m_info->typeCount(), "invalid exception signature for "_s, importNumber, "th Import, "_s, exceptionSignatureIndex, " is out of range of "_s, m_info->typeCount(), " in module '"_s, moduleString, "' field '"_s, fieldString, "'"_s);
             kindIndex = m_info->importExceptionTypeIndices.size();
             TypeIndex typeIndex = TypeInformation::get(m_info->typeSignatures[exceptionSignatureIndex]);
             m_info->importExceptionTypeIndices.append(typeIndex);
@@ -232,17 +232,17 @@ auto SectionParser::parseImport() -> PartialResult
 auto SectionParser::parseFunction() -> PartialResult
 {
     uint32_t count;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(count), "can't get Function section's count");
-    WASM_PARSER_FAIL_IF(count > maxFunctions, "Function section's count is too big ", count, " maximum ", maxFunctions);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(count), "can't get Function section's count"_s);
+    WASM_PARSER_FAIL_IF(count > maxFunctions, "Function section's count is too big "_s, count, " maximum "_s, maxFunctions);
     RELEASE_ASSERT(!m_info->internalFunctionTypeIndices.capacity());
     RELEASE_ASSERT(!m_info->functions.capacity());
-    WASM_PARSER_FAIL_IF(!m_info->internalFunctionTypeIndices.tryReserveInitialCapacity(count), "can't allocate enough memory for ", count, " Function signatures");
-    WASM_PARSER_FAIL_IF(!m_info->functions.tryReserveInitialCapacity(count), "can't allocate enough memory for ", count, "Function locations");
+    WASM_PARSER_FAIL_IF(!m_info->internalFunctionTypeIndices.tryReserveInitialCapacity(count), "can't allocate enough memory for "_s, count, " Function signatures"_s);
+    WASM_PARSER_FAIL_IF(!m_info->functions.tryReserveInitialCapacity(count), "can't allocate enough memory for "_s, count, "Function locations"_s);
 
     for (uint32_t i = 0; i < count; ++i) {
         uint32_t typeNumber;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(typeNumber), "can't get ", i, "th Function's type number");
-        WASM_PARSER_FAIL_IF(typeNumber >= m_info->typeCount(), i, "th Function type number is invalid ", typeNumber);
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(typeNumber), "can't get "_s, i, "th Function's type number"_s);
+        WASM_PARSER_FAIL_IF(typeNumber >= m_info->typeCount(), i, "th Function type number is invalid "_s, typeNumber);
 
         TypeIndex typeIndex = TypeInformation::get(m_info->typeSignatures[typeNumber]);
         // The Code section fixes up start and end.
@@ -263,18 +263,18 @@ auto SectionParser::parseResizableLimits(uint32_t& initial, std::optional<uint32
     ASSERT(!maximum);
 
     uint8_t flags;
-    WASM_PARSER_FAIL_IF(!parseUInt8(flags), "can't parse resizable limits flags");
-    WASM_PARSER_FAIL_IF(flags != 0x0 && flags != 0x1 && flags != 0x3, "resizable limits flag should be 0x00, 0x01, or 0x03 but 0x", hex(flags, 2, Lowercase));
-    WASM_PARSER_FAIL_IF(flags == 0x3 && limitsType != LimitsType::Memory, "can't use shared limits for non memory");
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(initial), "can't parse resizable limits initial page count");
+    WASM_PARSER_FAIL_IF(!parseUInt8(flags), "can't parse resizable limits flags"_s);
+    WASM_PARSER_FAIL_IF(flags != 0x0 && flags != 0x1 && flags != 0x3, "resizable limits flag should be 0x00, 0x01, or 0x03 but 0x"_s, hex(flags, 2, Lowercase));
+    WASM_PARSER_FAIL_IF(flags == 0x3 && limitsType != LimitsType::Memory, "can't use shared limits for non memory"_s);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(initial), "can't parse resizable limits initial page count"_s);
 
     isShared = flags == 0x3;
-    WASM_PARSER_FAIL_IF(isShared && !Options::useWasmFaultSignalHandler(), "shared memory is not enabled");
+    WASM_PARSER_FAIL_IF(isShared && !Options::useWasmFaultSignalHandler(), "shared memory is not enabled"_s);
 
     if (flags) {
         uint32_t maximumInt;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(maximumInt), "can't parse resizable limits maximum page count");
-        WASM_PARSER_FAIL_IF(initial > maximumInt, "resizable limits has an initial page count of ", initial, " which is greater than its maximum ", maximumInt);
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(maximumInt), "can't parse resizable limits maximum page count"_s);
+        WASM_PARSER_FAIL_IF(initial > maximumInt, "resizable limits has an initial page count of "_s, initial, " which is greater than its maximum "_s, maximumInt);
         maximum = maximumInt;
     }
 
@@ -283,7 +283,7 @@ auto SectionParser::parseResizableLimits(uint32_t& initial, std::optional<uint32
 
 auto SectionParser::parseTableHelper(bool isImport) -> PartialResult
 {
-    WASM_PARSER_FAIL_IF(m_info->tableCount() >= maxTables, "Table count of ", m_info->tableCount(), " is too big, maximum ", maxTables);
+    WASM_PARSER_FAIL_IF(m_info->tableCount() >= maxTables, "Table count of "_s, m_info->tableCount(), " is too big, maximum "_s, maxTables);
 
     Type type;
     bool hasInitExpr = false;
@@ -291,20 +291,20 @@ auto SectionParser::parseTableHelper(bool isImport) -> PartialResult
     uint64_t initialBitsOrImportNumber = 0;
 
     int8_t firstByte = 0;
-    WASM_PARSER_FAIL_IF(!peekInt7(firstByte), "can't parse Table information");
+    WASM_PARSER_FAIL_IF(!peekInt7(firstByte), "can't parse Table information"_s);
     if (!isImport && Options::useWebAssemblyTypedFunctionReferences() && static_cast<TypeKind>(firstByte) == TypeKind::Void) {
         hasInitExpr = true;
         m_offset++;
         uint8_t reservedByte;
-        WASM_PARSER_FAIL_IF(!parseUInt8(reservedByte) || reservedByte, "can't parse explicitly initialized Table's reserved byte");
+        WASM_PARSER_FAIL_IF(!parseUInt8(reservedByte) || reservedByte, "can't parse explicitly initialized Table's reserved byte"_s);
     }
 
-    WASM_PARSER_FAIL_IF(!parseValueType(m_info, type), "can't parse Table type");
-    WASM_PARSER_FAIL_IF(!isRefType(type), "Table type should be a ref type, got ", type);
+    WASM_PARSER_FAIL_IF(!parseValueType(m_info, type), "can't parse Table type"_s);
+    WASM_PARSER_FAIL_IF(!isRefType(type), "Table type should be a ref type, got "_s, type);
     if (!Options::useWebAssemblyTypedFunctionReferences())
-        WASM_PARSER_FAIL_IF(type.kind != TypeKind::Funcref && type.kind != TypeKind::Externref, "Table type should be funcref or anyref, got ", type);
+        WASM_PARSER_FAIL_IF(type.kind != TypeKind::Funcref && type.kind != TypeKind::Externref, "Table type should be funcref or anyref, got "_s, type);
     if (!hasInitExpr)
-        WASM_PARSER_FAIL_IF(!isDefaultableType(type), "Table's type must be defaultable");
+        WASM_PARSER_FAIL_IF(!isDefaultableType(type), "Table's type must be defaultable"_s);
 
     uint32_t initial;
     std::optional<uint32_t> maximum;
@@ -312,7 +312,7 @@ auto SectionParser::parseTableHelper(bool isImport) -> PartialResult
     PartialResult limits = parseResizableLimits(initial, maximum, isShared, LimitsType::Table);
     if (UNLIKELY(!limits))
         return makeUnexpected(WTFMove(limits.error()));
-    WASM_PARSER_FAIL_IF(initial > maxTableEntries, "Table's initial page count of ", initial, " is too big, maximum ", maxTableEntries);
+    WASM_PARSER_FAIL_IF(initial > maxTableEntries, "Table's initial page count of "_s, initial, " is too big, maximum "_s, maxTableEntries);
 
     ASSERT(!maximum || *maximum >= initial);
 
@@ -322,7 +322,7 @@ auto SectionParser::parseTableHelper(bool isImport) -> PartialResult
         bool isExtendedConstantExpression;
         v128_t unusedVector { };
         WASM_FAIL_IF_HELPER_FAILS(parseInitExpr(initOpcode, isExtendedConstantExpression, initialBitsOrImportNumber, unusedVector, type, typeForInitOpcode));
-        WASM_PARSER_FAIL_IF(!isSubtype(typeForInitOpcode, type), "Table init_expr opcode of type ", typeForInitOpcode.kind, " doesn't match table's type ", type.kind);
+        WASM_PARSER_FAIL_IF(!isSubtype(typeForInitOpcode, type), "Table init_expr opcode of type "_s, typeForInitOpcode.kind, " doesn't match table's type "_s, type.kind);
 
         if (isExtendedConstantExpression)
             tableInitType = TableInformation::FromExtendedExpression;
@@ -345,7 +345,7 @@ auto SectionParser::parseTableHelper(bool isImport) -> PartialResult
 auto SectionParser::parseTable() -> PartialResult
 {
     uint32_t count;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(count), "can't get Table's count");
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(count), "can't get Table's count"_s);
 
     for (unsigned i = 0; i < count; ++i) {
         bool isImport = false;
@@ -359,7 +359,7 @@ auto SectionParser::parseTable() -> PartialResult
 
 auto SectionParser::parseMemoryHelper(bool isImport) -> PartialResult
 {
-    WASM_PARSER_FAIL_IF(m_info->memoryCount(), "there can at most be one Memory section for now");
+    WASM_PARSER_FAIL_IF(m_info->memoryCount(), "there can at most be one Memory section for now"_s);
 
     PageCount initialPageCount;
     PageCount maximumPageCount;
@@ -371,12 +371,12 @@ auto SectionParser::parseMemoryHelper(bool isImport) -> PartialResult
         if (UNLIKELY(!limits))
             return makeUnexpected(WTFMove(limits.error()));
         ASSERT(!maximum || *maximum >= initial);
-        WASM_PARSER_FAIL_IF(!PageCount::isValid(initial), "Memory's initial page count of ", initial, " is invalid");
+        WASM_PARSER_FAIL_IF(!PageCount::isValid(initial), "Memory's initial page count of "_s, initial, " is invalid"_s);
 
         initialPageCount = PageCount(initial);
 
         if (maximum) {
-            WASM_PARSER_FAIL_IF(!PageCount::isValid(*maximum), "Memory's maximum page count of ", *maximum, " is invalid");
+            WASM_PARSER_FAIL_IF(!PageCount::isValid(*maximum), "Memory's maximum page count of "_s, *maximum, " is invalid"_s);
             maximumPageCount = PageCount(*maximum);
         }
     }
@@ -390,12 +390,12 @@ auto SectionParser::parseMemoryHelper(bool isImport) -> PartialResult
 auto SectionParser::parseMemory() -> PartialResult
 {
     uint32_t count;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(count), "can't parse Memory section's count");
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(count), "can't parse Memory section's count"_s);
 
     if (!count)
         return { };
 
-    WASM_PARSER_FAIL_IF(count != 1, "Memory section has more than one memory, WebAssembly currently only allows zero or one");
+    WASM_PARSER_FAIL_IF(count != 1, "Memory section has more than one memory, WebAssembly currently only allows zero or one"_s);
 
     bool isImport = false;
     return parseMemoryHelper(isImport);
@@ -404,11 +404,11 @@ auto SectionParser::parseMemory() -> PartialResult
 auto SectionParser::parseGlobal() -> PartialResult
 {
     uint32_t globalCount;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(globalCount), "can't get Global section's count");
-    WASM_PARSER_FAIL_IF(globalCount > maxGlobals, "Global section's count is too big ", globalCount, " maximum ", maxGlobals);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(globalCount), "can't get Global section's count"_s);
+    WASM_PARSER_FAIL_IF(globalCount > maxGlobals, "Global section's count is too big "_s, globalCount, " maximum "_s, maxGlobals);
     size_t totalGlobals = globalCount + m_info->firstInternalGlobal;
     ASSERT(m_info->firstInternalGlobal == m_info->globals.size());
-    WASM_PARSER_FAIL_IF(!m_info->globals.tryGrowCapacityBy(globalCount), "can't allocate memory for ", totalGlobals, " globals");
+    WASM_PARSER_FAIL_IF(!m_info->globals.tryGrowCapacityBy(globalCount), "can't allocate memory for "_s, totalGlobals, " globals"_s);
 
     for (uint32_t globalIndex = 0; globalIndex < globalCount; ++globalIndex) {
         GlobalInformation global;
@@ -433,7 +433,7 @@ auto SectionParser::parseGlobal() -> PartialResult
             global.initializationType = GlobalInformation::FromRefFunc;
         else
             global.initializationType = GlobalInformation::FromExpression;
-        WASM_PARSER_FAIL_IF(!isSubtype(typeForInitOpcode, global.type), "Global init_expr opcode of type ", typeForInitOpcode.kind, " doesn't match global's type ", global.type.kind);
+        WASM_PARSER_FAIL_IF(!isSubtype(typeForInitOpcode, global.type), "Global init_expr opcode of type "_s, typeForInitOpcode.kind, " doesn't match global's type "_s, global.type.kind);
 
         if (initOpcode == RefFunc) {
             ASSERT(global.initializationType != GlobalInformation::FromVector);
@@ -449,10 +449,10 @@ auto SectionParser::parseGlobal() -> PartialResult
 auto SectionParser::parseExport() -> PartialResult
 {
     uint32_t exportCount;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(exportCount), "can't get Export section's count");
-    WASM_PARSER_FAIL_IF(exportCount > maxExports, "Export section's count is too big ", exportCount, " maximum ", maxExports);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(exportCount), "can't get Export section's count"_s);
+    WASM_PARSER_FAIL_IF(exportCount > maxExports, "Export section's count is too big "_s, exportCount, " maximum "_s, maxExports);
     RELEASE_ASSERT(!m_info->exports.capacity());
-    WASM_PARSER_FAIL_IF(!m_info->exports.tryReserveInitialCapacity(exportCount), "can't allocate enough memory for ", exportCount, " exports");
+    WASM_PARSER_FAIL_IF(!m_info->exports.tryReserveInitialCapacity(exportCount), "can't allocate enough memory for "_s, exportCount, " exports"_s);
 
     HashSet<String> exportNames;
     for (uint32_t exportNumber = 0; exportNumber < exportCount; ++exportNumber) {
@@ -461,31 +461,31 @@ auto SectionParser::parseExport() -> PartialResult
         ExternalKind kind;
         unsigned kindIndex;
 
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(fieldLen), "can't get ", exportNumber, "th Export's field name length");
-        WASM_PARSER_FAIL_IF(!consumeUTF8String(fieldString, fieldLen), "can't get ", exportNumber, "th Export's field name of length ", fieldLen);
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(fieldLen), "can't get "_s, exportNumber, "th Export's field name length"_s);
+        WASM_PARSER_FAIL_IF(!consumeUTF8String(fieldString, fieldLen), "can't get "_s, exportNumber, "th Export's field name of length "_s, fieldLen);
         String fieldName = WTF::makeString(fieldString);
-        WASM_PARSER_FAIL_IF(exportNames.contains(fieldName), "duplicate export: '", fieldString, "'");
+        WASM_PARSER_FAIL_IF(exportNames.contains(fieldName), "duplicate export: '"_s, fieldString, "'"_s);
         exportNames.add(fieldName);
 
-        WASM_PARSER_FAIL_IF(!parseExternalKind(kind), "can't get ", exportNumber, "th Export's kind, named '", fieldString, "'");
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(kindIndex), "can't get ", exportNumber, "th Export's kind index, named '", fieldString, "'");
+        WASM_PARSER_FAIL_IF(!parseExternalKind(kind), "can't get "_s, exportNumber, "th Export's kind, named '"_s, fieldString, "'"_s);
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(kindIndex), "can't get "_s, exportNumber, "th Export's kind index, named '"_s, fieldString, "'"_s);
         switch (kind) {
         case ExternalKind::Function: {
-            WASM_PARSER_FAIL_IF(kindIndex >= m_info->functionIndexSpaceSize(), exportNumber, "th Export has invalid function number ", kindIndex, " it exceeds the function index space ", m_info->functionIndexSpaceSize(), ", named '", fieldString, "'");
+            WASM_PARSER_FAIL_IF(kindIndex >= m_info->functionIndexSpaceSize(), exportNumber, "th Export has invalid function number "_s, kindIndex, " it exceeds the function index space "_s, m_info->functionIndexSpaceSize(), ", named '"_s, fieldString, "'"_s);
             m_info->addDeclaredFunction(kindIndex);
             break;
         }
         case ExternalKind::Table: {
-            WASM_PARSER_FAIL_IF(kindIndex >= m_info->tableCount(), "can't export Table ", kindIndex, " there are ", m_info->tableCount(), " Tables");
+            WASM_PARSER_FAIL_IF(kindIndex >= m_info->tableCount(), "can't export Table "_s, kindIndex, " there are "_s, m_info->tableCount(), " Tables"_s);
             break;
         }
         case ExternalKind::Memory: {
-            WASM_PARSER_FAIL_IF(!m_info->memory, "can't export a non-existent Memory");
-            WASM_PARSER_FAIL_IF(kindIndex, "can't export Memory ", kindIndex, " only one Table is currently supported");
+            WASM_PARSER_FAIL_IF(!m_info->memory, "can't export a non-existent Memory"_s);
+            WASM_PARSER_FAIL_IF(kindIndex, "can't export Memory "_s, kindIndex, " only one Table is currently supported"_s);
             break;
         }
         case ExternalKind::Global: {
-            WASM_PARSER_FAIL_IF(kindIndex >= m_info->globals.size(), exportNumber, "th Export has invalid global number ", kindIndex, " it exceeds the globals count ", m_info->globals.size(), ", named '", fieldString, "'");
+            WASM_PARSER_FAIL_IF(kindIndex >= m_info->globals.size(), exportNumber, "th Export has invalid global number "_s, kindIndex, " it exceeds the globals count "_s, m_info->globals.size(), ", named '"_s, fieldString, "'"_s);
             // Only mutable globals need floating bindings.
             GlobalInformation& global = m_info->globals[kindIndex];
             if (global.mutability == Mutability::Mutable)
@@ -493,7 +493,7 @@ auto SectionParser::parseExport() -> PartialResult
             break;
         }
         case ExternalKind::Exception: {
-            WASM_PARSER_FAIL_IF(kindIndex >= m_info->exceptionIndexSpaceSize(), exportNumber, "th Export has invalid exception number ", kindIndex, " it exceeds the exception index space ", m_info->exceptionIndexSpaceSize(), ", named '", fieldString, "'");
+            WASM_PARSER_FAIL_IF(kindIndex >= m_info->exceptionIndexSpaceSize(), exportNumber, "th Export has invalid exception number "_s, kindIndex, " it exceeds the exception index space "_s, m_info->exceptionIndexSpaceSize(), ", named '"_s, fieldString, "'"_s);
             m_info->addDeclaredException(kindIndex);
             break;
         }
@@ -508,12 +508,12 @@ auto SectionParser::parseExport() -> PartialResult
 auto SectionParser::parseStart() -> PartialResult
 {
     uint32_t startFunctionIndex;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(startFunctionIndex), "can't get Start index");
-    WASM_PARSER_FAIL_IF(startFunctionIndex >= m_info->functionIndexSpaceSize(), "Start index ", startFunctionIndex, " exceeds function index space ", m_info->functionIndexSpaceSize());
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(startFunctionIndex), "can't get Start index"_s);
+    WASM_PARSER_FAIL_IF(startFunctionIndex >= m_info->functionIndexSpaceSize(), "Start index "_s, startFunctionIndex, " exceeds function index space "_s, m_info->functionIndexSpaceSize());
     TypeIndex typeIndex = m_info->typeIndexFromFunctionIndexSpace(startFunctionIndex);
     const auto& signature = TypeInformation::getFunctionSignature(typeIndex);
-    WASM_PARSER_FAIL_IF(signature.argumentCount(), "Start function can't have arguments");
-    WASM_PARSER_FAIL_IF(!signature.returnsVoid(), "Start function can't return a value");
+    WASM_PARSER_FAIL_IF(signature.argumentCount(), "Start function can't have arguments"_s);
+    WASM_PARSER_FAIL_IF(!signature.returnsVoid(), "Start function can't return a value"_s);
     m_info->startFunctionIndexSpace = startFunctionIndex;
     return { };
 }
@@ -521,13 +521,13 @@ auto SectionParser::parseStart() -> PartialResult
 auto SectionParser::parseElement() -> PartialResult
 {
     uint32_t elementCount;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(elementCount), "can't get Element section's count");
-    WASM_PARSER_FAIL_IF(elementCount > maxTableEntries, "Element section's count is too big ", elementCount, " maximum ", maxTableEntries);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(elementCount), "can't get Element section's count"_s);
+    WASM_PARSER_FAIL_IF(elementCount > maxTableEntries, "Element section's count is too big "_s, elementCount, " maximum "_s, maxTableEntries);
     RELEASE_ASSERT(!m_info->elements.capacity());
-    WASM_PARSER_FAIL_IF(!m_info->elements.tryReserveInitialCapacity(elementCount), "can't allocate memory for ", elementCount, " Elements");
+    WASM_PARSER_FAIL_IF(!m_info->elements.tryReserveInitialCapacity(elementCount), "can't allocate memory for "_s, elementCount, " Elements"_s);
     for (unsigned elementNum = 0; elementNum < elementCount; ++elementNum) {
         uint32_t elementFlags;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(elementFlags), "can't get ", elementNum, "th Element reserved byte, which should be element flags");
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(elementFlags), "can't get "_s, elementNum, "th Element reserved byte, which should be element flags"_s);
 
         switch (elementFlags) {
         case 0x00: {
@@ -542,8 +542,8 @@ auto SectionParser::parseElement() -> PartialResult
             ASSERT(!!m_info->tables[tableIndex]);
 
             Element element(Element::Kind::Active, funcrefType(), tableIndex, WTFMove(initExpr));
-            WASM_PARSER_FAIL_IF(!element.initTypes.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element init_exprs");
-            WASM_PARSER_FAIL_IF(!element.initialBitsOrIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element init_exprs");
+            WASM_PARSER_FAIL_IF(!element.initTypes.tryReserveInitialCapacity(indexCount), "can't allocate memory for "_s, indexCount, " Element init_exprs"_s);
+            WASM_PARSER_FAIL_IF(!element.initialBitsOrIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for "_s, indexCount, " Element init_exprs"_s);
 
             WASM_FAIL_IF_HELPER_FAILS(parseElementSegmentVectorOfIndexes(element.initTypes, element.initialBitsOrIndices, indexCount, elementNum));
             m_info->elements.append(WTFMove(element));
@@ -556,8 +556,8 @@ auto SectionParser::parseElement() -> PartialResult
             uint32_t indexCount;
             WASM_FAIL_IF_HELPER_FAILS(parseIndexCountForElementSection(indexCount, elementNum));
             Element element(Element::Kind::Passive, funcrefType());
-            WASM_PARSER_FAIL_IF(!element.initTypes.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element init_exprs");
-            WASM_PARSER_FAIL_IF(!element.initialBitsOrIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element init_exprs");
+            WASM_PARSER_FAIL_IF(!element.initTypes.tryReserveInitialCapacity(indexCount), "can't allocate memory for "_s, indexCount, " Element init_exprs"_s);
+            WASM_PARSER_FAIL_IF(!element.initialBitsOrIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for "_s, indexCount, " Element init_exprs"_s);
 
             WASM_FAIL_IF_HELPER_FAILS(parseElementSegmentVectorOfIndexes(element.initTypes, element.initialBitsOrIndices, indexCount, elementNum));
             m_info->elements.append(WTFMove(element));
@@ -565,7 +565,7 @@ auto SectionParser::parseElement() -> PartialResult
         }
         case 0x02: {
             uint32_t tableIndex;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't get ", elementNum, "th Element table index");
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't get "_s, elementNum, "th Element table index"_s);
             WASM_FAIL_IF_HELPER_FAILS(validateElementTableIdx(tableIndex, funcrefType()));
 
             std::optional<I32InitExpr> initExpr;
@@ -579,8 +579,8 @@ auto SectionParser::parseElement() -> PartialResult
             ASSERT(!!m_info->tables[tableIndex]);
 
             Element element(Element::Kind::Active, funcrefType(), tableIndex, WTFMove(initExpr));
-            WASM_PARSER_FAIL_IF(!element.initTypes.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element init_exprs");
-            WASM_PARSER_FAIL_IF(!element.initialBitsOrIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element init_exprs");
+            WASM_PARSER_FAIL_IF(!element.initTypes.tryReserveInitialCapacity(indexCount), "can't allocate memory for "_s, indexCount, " Element init_exprs"_s);
+            WASM_PARSER_FAIL_IF(!element.initialBitsOrIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for "_s, indexCount, " Element init_exprs"_s);
 
             WASM_FAIL_IF_HELPER_FAILS(parseElementSegmentVectorOfIndexes(element.initTypes, element.initialBitsOrIndices, indexCount, elementNum));
             m_info->elements.append(WTFMove(element));
@@ -593,8 +593,8 @@ auto SectionParser::parseElement() -> PartialResult
             uint32_t indexCount;
             WASM_FAIL_IF_HELPER_FAILS(parseIndexCountForElementSection(indexCount, elementNum));
             Element element(Element::Kind::Declared, funcrefType());
-            WASM_PARSER_FAIL_IF(!element.initTypes.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element init_exprs");
-            WASM_PARSER_FAIL_IF(!element.initialBitsOrIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element init_exprs");
+            WASM_PARSER_FAIL_IF(!element.initTypes.tryReserveInitialCapacity(indexCount), "can't allocate memory for "_s, indexCount, " Element init_exprs"_s);
+            WASM_PARSER_FAIL_IF(!element.initialBitsOrIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for "_s, indexCount, " Element init_exprs"_s);
 
             WASM_FAIL_IF_HELPER_FAILS(parseElementSegmentVectorOfIndexes(element.initTypes, element.initialBitsOrIndices, indexCount, elementNum));
             m_info->elements.append(WTFMove(element));
@@ -612,8 +612,8 @@ auto SectionParser::parseElement() -> PartialResult
             ASSERT(!!m_info->tables[tableIndex]);
 
             Element element(Element::Kind::Active, funcrefType(), tableIndex, WTFMove(initExpr));
-            WASM_PARSER_FAIL_IF(!element.initTypes.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element init_exprs");
-            WASM_PARSER_FAIL_IF(!element.initialBitsOrIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element init_exprs");
+            WASM_PARSER_FAIL_IF(!element.initTypes.tryReserveInitialCapacity(indexCount), "can't allocate memory for "_s, indexCount, " Element init_exprs"_s);
+            WASM_PARSER_FAIL_IF(!element.initialBitsOrIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for "_s, indexCount, " Element init_exprs"_s);
 
             WASM_FAIL_IF_HELPER_FAILS(parseElementSegmentVectorOfExpressions(funcrefType(), element.initTypes, element.initialBitsOrIndices, indexCount, elementNum));
             m_info->elements.append(WTFMove(element));
@@ -621,15 +621,15 @@ auto SectionParser::parseElement() -> PartialResult
         }
         case 0x05: {
             Type refType;
-            WASM_PARSER_FAIL_IF(!parseRefType(m_info, refType), "can't parse reftype in elem section");
+            WASM_PARSER_FAIL_IF(!parseRefType(m_info, refType), "can't parse reftype in elem section"_s);
             ASSERT_IMPLIES(!Options::useWebAssemblyTypedFunctionReferences(), isExternref(refType) || isFuncref(refType));
 
             uint32_t indexCount;
             WASM_FAIL_IF_HELPER_FAILS(parseIndexCountForElementSection(indexCount, elementNum));
 
             Element element(Element::Kind::Passive, refType);
-            WASM_PARSER_FAIL_IF(!element.initTypes.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element init_exprs");
-            WASM_PARSER_FAIL_IF(!element.initialBitsOrIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element init_exprs");
+            WASM_PARSER_FAIL_IF(!element.initTypes.tryReserveInitialCapacity(indexCount), "can't allocate memory for "_s, indexCount, " Element init_exprs"_s);
+            WASM_PARSER_FAIL_IF(!element.initialBitsOrIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for "_s, indexCount, " Element init_exprs"_s);
 
             WASM_FAIL_IF_HELPER_FAILS(parseElementSegmentVectorOfExpressions(refType, element.initTypes, element.initialBitsOrIndices, indexCount, elementNum));
             m_info->elements.append(WTFMove(element));
@@ -637,13 +637,13 @@ auto SectionParser::parseElement() -> PartialResult
         }
         case 0x06: {
             uint32_t tableIndex;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't get ", elementNum, "th Element table index");
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't get "_s, elementNum, "th Element table index"_s);
 
             std::optional<I32InitExpr> initExpr;
             WASM_FAIL_IF_HELPER_FAILS(parseI32InitExprForElementSection(initExpr));
 
             Type refType;
-            WASM_PARSER_FAIL_IF(!parseRefType(m_info, refType), "can't parse reftype in elem section");
+            WASM_PARSER_FAIL_IF(!parseRefType(m_info, refType), "can't parse reftype in elem section"_s);
             ASSERT_IMPLIES(!Options::useWebAssemblyTypedFunctionReferences(), isExternref(refType) || isFuncref(refType));
             WASM_FAIL_IF_HELPER_FAILS(validateElementTableIdx(tableIndex, refType));
 
@@ -652,8 +652,8 @@ auto SectionParser::parseElement() -> PartialResult
             ASSERT(!!m_info->tables[tableIndex]);
 
             Element element(Element::Kind::Active, refType, tableIndex, WTFMove(initExpr));
-            WASM_PARSER_FAIL_IF(!element.initTypes.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element init_exprs");
-            WASM_PARSER_FAIL_IF(!element.initialBitsOrIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element init_exprs");
+            WASM_PARSER_FAIL_IF(!element.initTypes.tryReserveInitialCapacity(indexCount), "can't allocate memory for "_s, indexCount, " Element init_exprs"_s);
+            WASM_PARSER_FAIL_IF(!element.initialBitsOrIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for "_s, indexCount, " Element init_exprs"_s);
 
             WASM_FAIL_IF_HELPER_FAILS(parseElementSegmentVectorOfExpressions(refType, element.initTypes, element.initialBitsOrIndices, indexCount, elementNum));
             m_info->elements.append(WTFMove(element));
@@ -661,22 +661,22 @@ auto SectionParser::parseElement() -> PartialResult
         }
         case 0x07: {
             Type refType;
-            WASM_PARSER_FAIL_IF(!parseRefType(m_info, refType), "can't parse reftype in elem section");
+            WASM_PARSER_FAIL_IF(!parseRefType(m_info, refType), "can't parse reftype in elem section"_s);
             ASSERT_IMPLIES(!Options::useWebAssemblyTypedFunctionReferences(), isExternref(refType) || isFuncref(refType));
 
             uint32_t indexCount;
             WASM_FAIL_IF_HELPER_FAILS(parseIndexCountForElementSection(indexCount, elementNum));
 
             Element element(Element::Kind::Declared, refType);
-            WASM_PARSER_FAIL_IF(!element.initTypes.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element init_exprs");
-            WASM_PARSER_FAIL_IF(!element.initialBitsOrIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for ", indexCount, " Element init_exprs");
+            WASM_PARSER_FAIL_IF(!element.initTypes.tryReserveInitialCapacity(indexCount), "can't allocate memory for "_s, indexCount, " Element init_exprs"_s);
+            WASM_PARSER_FAIL_IF(!element.initialBitsOrIndices.tryReserveInitialCapacity(indexCount), "can't allocate memory for "_s, indexCount, " Element init_exprs"_s);
 
             WASM_FAIL_IF_HELPER_FAILS(parseElementSegmentVectorOfExpressions(refType, element.initTypes, element.initialBitsOrIndices, indexCount, elementNum));
             m_info->elements.append(WTFMove(element));
             break;
         }
         default:
-            WASM_PARSER_FAIL_IF(true, "can't get ", elementNum, "th Element reserved byte");
+            WASM_PARSER_FAIL_IF(true, "can't get "_s, elementNum, "th Element reserved byte"_s);
         }
     }
 
@@ -693,12 +693,12 @@ auto SectionParser::parseCode() -> PartialResult
 auto SectionParser::parseInitExpr(uint8_t& opcode, bool& isExtendedConstantExpression, uint64_t& bitsOrImportNumber, v128_t& vectorBits, Type expectedType, Type& resultType) -> PartialResult
 {
     size_t initialOffset = m_offset;
-    WASM_PARSER_FAIL_IF(!parseUInt8(opcode), "can't get init_expr's opcode");
+    WASM_PARSER_FAIL_IF(!parseUInt8(opcode), "can't get init_expr's opcode"_s);
 
     switch (opcode) {
     case I32Const: {
         int32_t constant;
-        WASM_PARSER_FAIL_IF(!parseVarInt32(constant), "can't get constant value for init_expr's i32.const");
+        WASM_PARSER_FAIL_IF(!parseVarInt32(constant), "can't get constant value for init_expr's i32.const"_s);
         bitsOrImportNumber = static_cast<uint64_t>(constant);
         resultType = Types::I32;
         break;
@@ -706,7 +706,7 @@ auto SectionParser::parseInitExpr(uint8_t& opcode, bool& isExtendedConstantExpre
 
     case I64Const: {
         int64_t constant;
-        WASM_PARSER_FAIL_IF(!parseVarInt64(constant), "can't get constant value for init_expr's i64.const");
+        WASM_PARSER_FAIL_IF(!parseVarInt64(constant), "can't get constant value for init_expr's i64.const"_s);
         bitsOrImportNumber = constant;
         resultType = Types::I64;
         break;
@@ -714,7 +714,7 @@ auto SectionParser::parseInitExpr(uint8_t& opcode, bool& isExtendedConstantExpre
 
     case F32Const: {
         uint32_t constant;
-        WASM_PARSER_FAIL_IF(!parseUInt32(constant), "can't get constant value for init_expr's f32.const");
+        WASM_PARSER_FAIL_IF(!parseUInt32(constant), "can't get constant value for init_expr's f32.const"_s);
         bitsOrImportNumber = constant;
         resultType = Types::F32;
         break;
@@ -722,7 +722,7 @@ auto SectionParser::parseInitExpr(uint8_t& opcode, bool& isExtendedConstantExpre
 
     case F64Const: {
         uint64_t constant;
-        WASM_PARSER_FAIL_IF(!parseUInt64(constant), "can't get constant value for init_expr's f64.const");
+        WASM_PARSER_FAIL_IF(!parseUInt64(constant), "can't get constant value for init_expr's f64.const"_s);
         bitsOrImportNumber = constant;
         resultType = Types::F64;
         break;
@@ -730,11 +730,11 @@ auto SectionParser::parseInitExpr(uint8_t& opcode, bool& isExtendedConstantExpre
 
 #if ENABLE(B3_JIT)
     case ExtSIMD: {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblySIMD(), "SIMD must be enabled");
-        WASM_PARSER_FAIL_IF(!parseUInt8(opcode), "can't get init_expr's simd opcode");
-        WASM_PARSER_FAIL_IF(static_cast<ExtSIMDOpType>(opcode) != ExtSIMDOpType::V128Const, "unknown init_expr simd opcode ", opcode);
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblySIMD(), "SIMD must be enabled"_s);
+        WASM_PARSER_FAIL_IF(!parseUInt8(opcode), "can't get init_expr's simd opcode"_s);
+        WASM_PARSER_FAIL_IF(static_cast<ExtSIMDOpType>(opcode) != ExtSIMDOpType::V128Const, "unknown init_expr simd opcode "_s, opcode);
         v128_t constant;
-        WASM_PARSER_FAIL_IF(!parseImmByteArray16(constant), "get constant value for init_expr's v128.const");
+        WASM_PARSER_FAIL_IF(!parseImmByteArray16(constant), "get constant value for init_expr's v128.const"_s);
 
         vectorBits = constant;
         resultType = Types::V128;
@@ -742,19 +742,19 @@ auto SectionParser::parseInitExpr(uint8_t& opcode, bool& isExtendedConstantExpre
     }
 #else
     case ExtSIMD:
-        WASM_PARSER_FAIL_IF(true, "wasm-simd is not supported");
+        WASM_PARSER_FAIL_IF(true, "wasm-simd is not supported"_s);
         (void) vectorBits;
         break;
 #endif
 
     case GetGlobal: {
         uint32_t index;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(index), "can't get get_global's index");
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(index), "can't get get_global's index"_s);
 
-        WASM_PARSER_FAIL_IF(index >= m_info->globals.size(), "get_global's index ", index, " exceeds the number of globals ", m_info->globals.size());
+        WASM_PARSER_FAIL_IF(index >= m_info->globals.size(), "get_global's index "_s, index, " exceeds the number of globals "_s, m_info->globals.size());
         if (!Options::useWebAssemblyGC())
-            WASM_PARSER_FAIL_IF(index >= m_info->firstInternalGlobal, "get_global import kind index ", index, " exceeds the first internal global ", m_info->firstInternalGlobal);
-        WASM_PARSER_FAIL_IF(m_info->globals[index].mutability != Mutability::Immutable, "get_global import kind index ", index, " is mutable ");
+            WASM_PARSER_FAIL_IF(index >= m_info->firstInternalGlobal, "get_global import kind index "_s, index, " exceeds the first internal global "_s, m_info->firstInternalGlobal);
+        WASM_PARSER_FAIL_IF(m_info->globals[index].mutability != Mutability::Immutable, "get_global import kind index "_s, index, " is mutable "_s);
 
         resultType = m_info->globals[index].type;
         bitsOrImportNumber = index;
@@ -765,14 +765,14 @@ auto SectionParser::parseInitExpr(uint8_t& opcode, bool& isExtendedConstantExpre
         Type typeOfNull;
         if (Options::useWebAssemblyTypedFunctionReferences()) {
             int32_t heapType;
-            WASM_PARSER_FAIL_IF(!parseHeapType(m_info, heapType), "ref.null heaptype must be funcref, externref or type_idx");
+            WASM_PARSER_FAIL_IF(!parseHeapType(m_info, heapType), "ref.null heaptype must be funcref, externref or type_idx"_s);
             if (isTypeIndexHeapType(heapType)) {
                 TypeIndex typeIndex = TypeInformation::get(m_info->typeSignatures[heapType].get());
                 typeOfNull = Type { TypeKind::RefNull, typeIndex };
             } else
                 typeOfNull = Type { TypeKind::RefNull, static_cast<TypeIndex>(heapType) };
         } else
-            WASM_PARSER_FAIL_IF(!parseRefType(m_info, typeOfNull), "ref.null type must be a reference type");
+            WASM_PARSER_FAIL_IF(!parseRefType(m_info, typeOfNull), "ref.null type must be a reference type"_s);
 
         resultType = typeOfNull;
         bitsOrImportNumber = JSValue::encode(jsNull());
@@ -781,8 +781,8 @@ auto SectionParser::parseInitExpr(uint8_t& opcode, bool& isExtendedConstantExpre
 
     case RefFunc: {
         uint32_t index;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(index), "can't get ref.func index");
-        WASM_PARSER_FAIL_IF(index >= m_info->functionIndexSpaceSize(), "ref.func index ", index, " exceeds the number of functions ", m_info->functionIndexSpaceSize());
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(index), "can't get ref.func index"_s);
+        WASM_PARSER_FAIL_IF(index >= m_info->functionIndexSpaceSize(), "ref.func index "_s, index, " exceeds the number of functions "_s, m_info->functionIndexSpaceSize());
         m_info->addReferencedFunction(index);
 
         if (Options::useWebAssemblyTypedFunctionReferences()) {
@@ -796,18 +796,18 @@ auto SectionParser::parseInitExpr(uint8_t& opcode, bool& isExtendedConstantExpre
     }
 
     case ExtGC:
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled");
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyExtendedConstantExpressions(), "unknown init_expr opcode ", opcode);
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled"_s);
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyExtendedConstantExpressions(), "unknown init_expr opcode "_s, opcode);
         break;
 
     default:
-        WASM_PARSER_FAIL_IF(true, "unknown init_expr opcode ", opcode);
+        WASM_PARSER_FAIL_IF(true, "unknown init_expr opcode "_s, opcode);
     }
 
     uint8_t endOpcode;
     // Don't consume the opcode byte unless it's an End so that the extended
     // parsing mode below can consume it if needed.
-    WASM_PARSER_FAIL_IF(offset() >= source().size(), "can't get init_expr's end opcode");
+    WASM_PARSER_FAIL_IF(offset() >= source().size(), "can't get init_expr's end opcode"_s);
     endOpcode = source()[offset()];
 
     if (endOpcode == OpType::End && opcode != OpType::ExtGC) {
@@ -815,14 +815,14 @@ auto SectionParser::parseInitExpr(uint8_t& opcode, bool& isExtendedConstantExpre
         isExtendedConstantExpression = false;
         return { };
     }
-    WASM_PARSER_FAIL_IF(!Options::useWebAssemblyExtendedConstantExpressions(), "init_expr should end with end, ended with ", endOpcode);
+    WASM_PARSER_FAIL_IF(!Options::useWebAssemblyExtendedConstantExpressions(), "init_expr should end with end, ended with "_s, endOpcode);
 
     // If an End doesn't appear, we have to assume it's an extended constant expression
     // and use the full Wasm expression parser to validate.
     size_t initExprOffset;
     WASM_FAIL_IF_HELPER_FAILS(parseExtendedConstExpr(source().subspan(initialOffset), initialOffset + m_offsetInSource, initExprOffset, m_info, expectedType));
     m_offset += (initExprOffset - (m_offset - initialOffset));
-    WASM_PARSER_FAIL_IF(!m_info->constantExpressions.tryConstructAndAppend(source().subspan(initialOffset, initExprOffset)), "could not allocate memory for init expr");
+    WASM_PARSER_FAIL_IF(!m_info->constantExpressions.tryConstructAndAppend(source().subspan(initialOffset, initExprOffset)), "could not allocate memory for init expr"_s);
     bitsOrImportNumber = m_info->constantExpressions.size() - 1;
     isExtendedConstantExpression = true;
     resultType = expectedType;
@@ -832,8 +832,8 @@ auto SectionParser::parseInitExpr(uint8_t& opcode, bool& isExtendedConstantExpre
 
 auto SectionParser::validateElementTableIdx(uint32_t tableIndex, Type type) -> PartialResult
 {
-    WASM_PARSER_FAIL_IF(tableIndex >= m_info->tableCount(), "Element section for Table ", tableIndex, " exceeds available Table ", m_info->tableCount());
-    WASM_PARSER_FAIL_IF(!isSubtype(type, m_info->tables[tableIndex].wasmType()), "Table ", tableIndex, " must have type '", type, "' to have an element section");
+    WASM_PARSER_FAIL_IF(tableIndex >= m_info->tableCount(), "Element section for Table "_s, tableIndex, " exceeds available Table "_s, m_info->tableCount());
+    WASM_PARSER_FAIL_IF(!isSubtype(type, m_info->tables[tableIndex].wasmType()), "Table "_s, tableIndex, " must have type '"_s, type, "' to have an element section"_s);
 
     return { };
 }
@@ -855,28 +855,28 @@ auto SectionParser::parseI32InitExpr(std::optional<I32InitExpr>& initExpr, ASCII
 auto SectionParser::parseFunctionType(uint32_t position, RefPtr<TypeDefinition>& functionSignature) -> PartialResult
 {
     uint32_t argumentCount;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(argumentCount), "can't get Type's argument count at index ", position);
-    WASM_PARSER_FAIL_IF(argumentCount > maxFunctionParams, "argument count of Type at index ", position, " is too big ", argumentCount, " maximum ", maxFunctionParams);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(argumentCount), "can't get Type's argument count at index "_s, position);
+    WASM_PARSER_FAIL_IF(argumentCount > maxFunctionParams, "argument count of Type at index "_s, position, " is too big "_s, argumentCount, " maximum "_s, maxFunctionParams);
     Vector<Type, 16> argumentTypes;
-    WASM_PARSER_FAIL_IF(!argumentTypes.tryReserveInitialCapacity(argumentCount), "can't allocate enough memory for Type section's ", position, "th signature");
+    WASM_PARSER_FAIL_IF(!argumentTypes.tryReserveInitialCapacity(argumentCount), "can't allocate enough memory for Type section's "_s, position, "th signature"_s);
 
     argumentTypes.resize(argumentCount);
     for (unsigned i = 0; i < argumentCount; ++i) {
         Type argumentType;
-        WASM_PARSER_FAIL_IF(!parseValueType(m_info, argumentType), "can't get ", i, "th argument Type");
+        WASM_PARSER_FAIL_IF(!parseValueType(m_info, argumentType), "can't get "_s, i, "th argument Type"_s);
         argumentTypes[i] = argumentType;
     }
 
     uint32_t returnCount;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(returnCount), "can't get Type's return count at index ", position);
-    WASM_PARSER_FAIL_IF(returnCount > maxFunctionReturns, "return count of Type at index ", position, " is too big ", returnCount, " maximum ", maxFunctionReturns);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(returnCount), "can't get Type's return count at index "_s, position);
+    WASM_PARSER_FAIL_IF(returnCount > maxFunctionReturns, "return count of Type at index "_s, position, " is too big "_s, returnCount, " maximum "_s, maxFunctionReturns);
 
     Vector<Type, 16> returnTypes;
-    WASM_PARSER_FAIL_IF(!returnTypes.tryReserveInitialCapacity(returnCount), "can't allocate enough memory for Type section's ", position, "th signature");
+    WASM_PARSER_FAIL_IF(!returnTypes.tryReserveInitialCapacity(returnCount), "can't allocate enough memory for Type section's "_s, position, "th signature"_s);
     returnTypes.resize(returnCount);
     for (unsigned i = 0; i < returnCount; ++i) {
         Type value;
-        WASM_PARSER_FAIL_IF(!parseValueType(m_info, value), "can't get ", i, "th Type's return value");
+        WASM_PARSER_FAIL_IF(!parseValueType(m_info, value), "can't get "_s, i, "th Type's return value"_s);
         returnTypes[i] = value;
     }
 
@@ -887,12 +887,12 @@ auto SectionParser::parseFunctionType(uint32_t position, RefPtr<TypeDefinition>&
 auto SectionParser::parsePackedType(PackedType& packedType) -> PartialResult
 {
     int8_t kind;
-    WASM_PARSER_FAIL_IF(!parseInt7(kind), "invalid type in struct field or array element");
+    WASM_PARSER_FAIL_IF(!parseInt7(kind), "invalid type in struct field or array element"_s);
     if (isValidPackedType(kind)) {
         packedType = static_cast<PackedType>(kind);
         return { };
     }
-    return fail("expected a packed type but got ", kind);
+    return fail("expected a packed type but got "_s, kind);
 }
 
 auto SectionParser::parseStorageType(StorageType& storageType) -> PartialResult
@@ -900,16 +900,16 @@ auto SectionParser::parseStorageType(StorageType& storageType) -> PartialResult
     ASSERT(Options::useWebAssemblyGC());
 
     int8_t kind;
-    WASM_PARSER_FAIL_IF(!peekInt7(kind), "invalid type in struct field or array element");
+    WASM_PARSER_FAIL_IF(!peekInt7(kind), "invalid type in struct field or array element"_s);
     if (isValidTypeKind(kind)) {
         Type elementType;
-        WASM_PARSER_FAIL_IF(!parseValueType(m_info, elementType), "invalid type in struct field or array element");
+        WASM_PARSER_FAIL_IF(!parseValueType(m_info, elementType), "invalid type in struct field or array element"_s);
         storageType = StorageType { elementType };
         return { };
     }
 
     PackedType elementType;
-    WASM_PARSER_FAIL_IF(!parsePackedType(elementType), "invalid type in struct field or array element");
+    WASM_PARSER_FAIL_IF(!parsePackedType(elementType), "invalid type in struct field or array element"_s);
     storageType = StorageType { elementType };
     return { };
 }
@@ -919,24 +919,24 @@ auto SectionParser::parseStructType(uint32_t position, RefPtr<TypeDefinition>& s
     ASSERT(Options::useWebAssemblyGC());
 
     uint32_t fieldCount;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(fieldCount), "can't get ", position, "th struct type's field count");
-    WASM_PARSER_FAIL_IF(fieldCount > maxStructFieldCount, "number of fields for struct type at position ", position, " is too big ", fieldCount, " maximum ", maxStructFieldCount);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(fieldCount), "can't get "_s, position, "th struct type's field count"_s);
+    WASM_PARSER_FAIL_IF(fieldCount > maxStructFieldCount, "number of fields for struct type at position "_s, position, " is too big "_s, fieldCount, " maximum "_s, maxStructFieldCount);
     Vector<FieldType> fields;
-    WASM_PARSER_FAIL_IF(!fields.tryReserveInitialCapacity(fieldCount), "can't allocate enough memory for struct fields ", fieldCount, " entries");
+    WASM_PARSER_FAIL_IF(!fields.tryReserveInitialCapacity(fieldCount), "can't allocate enough memory for struct fields "_s, fieldCount, " entries"_s);
     fields.resize(fieldCount);
 
     Checked<unsigned, RecordOverflow> structInstancePayloadSize { 0 };
     for (uint32_t fieldIndex = 0; fieldIndex < fieldCount; ++fieldIndex) {
         StorageType fieldType;
-        WASM_PARSER_FAIL_IF(!parseStorageType(fieldType), "can't get ", fieldIndex, "th field Type");
+        WASM_PARSER_FAIL_IF(!parseStorageType(fieldType), "can't get "_s, fieldIndex, "th field Type"_s);
 
         uint8_t mutability;
-        WASM_PARSER_FAIL_IF(!parseUInt8(mutability), position, "can't get ", fieldIndex, "th field mutability");
-        WASM_PARSER_FAIL_IF(mutability != 0x0 && mutability != 0x1, "invalid Field's mutability: 0x", hex(mutability, 2, Lowercase));
+        WASM_PARSER_FAIL_IF(!parseUInt8(mutability), position, "can't get "_s, fieldIndex, "th field mutability"_s);
+        WASM_PARSER_FAIL_IF(mutability != 0x0 && mutability != 0x1, "invalid Field's mutability: 0x"_s, hex(mutability, 2, Lowercase));
 
         fields[fieldIndex] = FieldType { fieldType, static_cast<Mutability>(mutability) };
         structInstancePayloadSize += typeSizeInBytes(fieldType);
-        WASM_PARSER_FAIL_IF(structInstancePayloadSize.hasOverflowed(), "struct layout is too big");
+        WASM_PARSER_FAIL_IF(structInstancePayloadSize.hasOverflowed(), "struct layout is too big"_s);
     }
 
     structType = TypeInformation::typeDefinitionForStruct(fields);
@@ -948,11 +948,11 @@ auto SectionParser::parseArrayType(uint32_t position, RefPtr<TypeDefinition>& ar
     ASSERT(Options::useWebAssemblyGC());
 
     StorageType elementType;
-    WASM_PARSER_FAIL_IF(!parseStorageType(elementType), "can't get array's element Type");
+    WASM_PARSER_FAIL_IF(!parseStorageType(elementType), "can't get array's element Type"_s);
 
     uint8_t mutability;
-    WASM_PARSER_FAIL_IF(!parseUInt8(mutability), position, "can't get array's mutability");
-    WASM_PARSER_FAIL_IF(mutability != 0x0 && mutability != 0x1, "invalid array mutability: 0x", hex(mutability, 2, Lowercase));
+    WASM_PARSER_FAIL_IF(!parseUInt8(mutability), position, "can't get array's mutability"_s);
+    WASM_PARSER_FAIL_IF(mutability != 0x0 && mutability != 0x1, "invalid array mutability: 0x"_s, hex(mutability, 2, Lowercase));
 
     arrayType = TypeInformation::typeDefinitionForArray(FieldType { elementType, static_cast<Mutability>(mutability) });
     return { };
@@ -963,17 +963,17 @@ auto SectionParser::parseRecursionGroup(uint32_t position, RefPtr<TypeDefinition
     ASSERT(Options::useWebAssemblyGC());
 
     uint32_t typeCount;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(typeCount), "can't get ", position, "th recursion group's type count");
-    WASM_PARSER_FAIL_IF(typeCount > maxRecursionGroupCount, "number of types for recursion group at position ", position, " is too big ", typeCount, " maximum ", maxRecursionGroupCount);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(typeCount), "can't get "_s, position, "th recursion group's type count"_s);
+    WASM_PARSER_FAIL_IF(typeCount > maxRecursionGroupCount, "number of types for recursion group at position "_s, position, " is too big "_s, typeCount, " maximum "_s, maxRecursionGroupCount);
     Vector<TypeIndex> types;
-    WASM_PARSER_FAIL_IF(!types.tryReserveInitialCapacity(typeCount), "can't allocate enough memory for recursion group ", typeCount, " entries");
+    WASM_PARSER_FAIL_IF(!types.tryReserveInitialCapacity(typeCount), "can't allocate enough memory for recursion group "_s, typeCount, " entries"_s);
     RefPtr<TypeDefinition> firstSignature;
 
     SetForScope<RecursionGroupInformation> recursionGroupInfo(m_recursionGroupInformation, RecursionGroupInformation { true, m_info->typeCount(), m_info->typeCount() + typeCount });
 
     for (uint32_t i = 0; i < typeCount; ++i) {
         int8_t typeKind;
-        WASM_PARSER_FAIL_IF(!parseInt7(typeKind), "can't get recursion group's ", i, "th Type's type");
+        WASM_PARSER_FAIL_IF(!parseInt7(typeKind), "can't get recursion group's "_s, i, "th Type's type"_s);
         RefPtr<TypeDefinition> signature;
         switch (static_cast<TypeKind>(typeKind)) {
         case TypeKind::Func: {
@@ -994,10 +994,10 @@ auto SectionParser::parseRecursionGroup(uint32_t position, RefPtr<TypeDefinition
             break;
         }
         default:
-            return fail(i, "th Type is non-Func, non-Struct, and non-Array ", typeKind);
+            return fail(i, "th Type is non-Func, non-Struct, and non-Array "_s, typeKind);
         }
 
-        WASM_PARSER_FAIL_IF(!signature, "can't allocate enough memory for recursion group's ", i, "th signature");
+        WASM_PARSER_FAIL_IF(!signature, "can't allocate enough memory for recursion group's "_s, i, "th signature"_s);
         types.append(signature->index());
 
         if (!i)
@@ -1009,12 +1009,12 @@ auto SectionParser::parseRecursionGroup(uint32_t position, RefPtr<TypeDefinition
     // Type definitions are normalized such that non-recursive, singleton recursion groups
     // are stored as the underlying concrete type without a projection. Otherwise we will
     // store projections for each recursion group index in the type section.
-    WASM_PARSER_FAIL_IF(!m_info->typeSignatures.tryGrowCapacityBy(typeCount), "can't allocate enough memory for recursion group's ", typeCount, " type ", typeCount > 1 ? "indices" : "index");
-    WASM_PARSER_FAIL_IF(!m_info->rtts.tryGrowCapacityBy(typeCount), "can't allocate enough memory for recursion group's ", typeCount, " RTT", typeCount > 1 ? "s" : "");
+    WASM_PARSER_FAIL_IF(!m_info->typeSignatures.tryGrowCapacityBy(typeCount), "can't allocate enough memory for recursion group's "_s, typeCount, " type "_s, typeCount > 1 ? "indices"_s : "index"_s);
+    WASM_PARSER_FAIL_IF(!m_info->rtts.tryGrowCapacityBy(typeCount), "can't allocate enough memory for recursion group's "_s, typeCount, " RTT"_s, typeCount > 1 ? "s"_s : ""_s);
     if (typeCount > 1) {
         for (uint32_t i = 0; i < typeCount; ++i) {
             RefPtr<TypeDefinition> projection = TypeInformation::typeDefinitionForProjection(recursionGroup->index(), i);
-            WASM_PARSER_FAIL_IF(!projection, "can't allocate enough memory for recursion group's ", i, "th projection");
+            WASM_PARSER_FAIL_IF(!projection, "can't allocate enough memory for recursion group's "_s, i, "th projection"_s);
             TypeInformation::registerCanonicalRTTForType(projection->index());
             m_info->rtts.append(TypeInformation::getCanonicalRTT(projection->index()));
             m_info->typeSignatures.append(projection.releaseNonNull());
@@ -1034,7 +1034,7 @@ auto SectionParser::parseRecursionGroup(uint32_t position, RefPtr<TypeDefinition
             m_info->typeSignatures.append(firstSignature.releaseNonNull());
         } else {
             RefPtr<TypeDefinition> projection = TypeInformation::typeDefinitionForProjection(recursionGroup->index(), 0);
-            WASM_PARSER_FAIL_IF(!projection, "can't allocate enough memory for recursion group's 0th projection");
+            WASM_PARSER_FAIL_IF(!projection, "can't allocate enough memory for recursion group's 0th projection"_s);
             TypeInformation::registerCanonicalRTTForType(projection->index());
             m_info->rtts.append(TypeInformation::getCanonicalRTT(projection->index()));
             if (firstSignature->is<Subtype>())
@@ -1115,8 +1115,8 @@ auto SectionParser::checkSubtypeValidity(const TypeDefinition& subtype) -> Parti
     ASSERT(!superSignature.is<Projection>() || !superSignature.as<Projection>()->isPlaceholder());
 
     const TypeDefinition& supertype = superSignature.unroll();
-    WASM_PARSER_FAIL_IF(!supertype.is<Subtype>() || supertype.as<Subtype>()->isFinal(), "cannot declare subtype of final supertype");
-    WASM_PARSER_FAIL_IF(!checkStructuralSubtype(TypeInformation::get(subtype.as<Subtype>()->underlyingType()), supertype), "structural type is not a subtype of the specified supertype");
+    WASM_PARSER_FAIL_IF(!supertype.is<Subtype>() || supertype.as<Subtype>()->isFinal(), "cannot declare subtype of final supertype"_s);
+    WASM_PARSER_FAIL_IF(!checkStructuralSubtype(TypeInformation::get(subtype.as<Subtype>()->underlyingType()), supertype), "structural type is not a subtype of the specified supertype"_s);
 
     return { };
 }
@@ -1126,15 +1126,15 @@ auto SectionParser::parseSubtype(uint32_t position, RefPtr<TypeDefinition>& subt
     ASSERT(Options::useWebAssemblyGC());
 
     uint32_t supertypeCount;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(supertypeCount), "can't get ", position, "th subtype's supertype count");
-    WASM_PARSER_FAIL_IF(supertypeCount > maxSubtypeSupertypeCount, "number of supertypes for subtype at position ", position, " is too big ", supertypeCount, " maximum ", maxSubtypeSupertypeCount);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(supertypeCount), "can't get "_s, position, "th subtype's supertype count"_s);
+    WASM_PARSER_FAIL_IF(supertypeCount > maxSubtypeSupertypeCount, "number of supertypes for subtype at position "_s, position, " is too big "_s, supertypeCount, " maximum "_s, maxSubtypeSupertypeCount);
 
     // The following assumes the MVP restriction that only up to a single supertype is allowed.
     TypeIndex supertypeIndex = TypeDefinition::invalidIndex;
     if (supertypeCount > 0) {
         uint32_t typeIndex;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(typeIndex), "can't get subtype's supertype index");
-        WASM_PARSER_FAIL_IF(typeIndex >= m_info->typeCount() + recursionGroupTypes.size(), "supertype index is a forward reference");
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(typeIndex), "can't get subtype's supertype index"_s);
+        WASM_PARSER_FAIL_IF(typeIndex >= m_info->typeCount() + recursionGroupTypes.size(), "supertype index is a forward reference"_s);
         if (typeIndex < m_info->typeCount())
             supertypeIndex = TypeInformation::get(m_info->typeSignatures[typeIndex]);
         // If a parent type is in the same recursion group, the index needs to refer to the projection instead.
@@ -1145,7 +1145,7 @@ auto SectionParser::parseSubtype(uint32_t position, RefPtr<TypeDefinition>& subt
     }
 
     int8_t typeKind;
-    WASM_PARSER_FAIL_IF(!parseInt7(typeKind), "can't get subtype's underlying Type's type");
+    WASM_PARSER_FAIL_IF(!parseInt7(typeKind), "can't get subtype's underlying Type's type"_s);
     RefPtr<TypeDefinition> underlyingType;
     switch (static_cast<TypeKind>(typeKind)) {
     case TypeKind::Func: {
@@ -1161,7 +1161,7 @@ auto SectionParser::parseSubtype(uint32_t position, RefPtr<TypeDefinition>& subt
         break;
     }
     default:
-        return fail("invalid structural type definition for subtype ", typeKind);
+        return fail("invalid structural type definition for subtype "_s, typeKind);
     }
 
     // When no supertypes are specified and the type is final, we will normalize
@@ -1188,8 +1188,8 @@ auto SectionParser::parseI32InitExprForElementSection(std::optional<I32InitExpr>
 auto SectionParser::parseElementKind(uint8_t& resultElementKind) -> PartialResult
 {
     uint8_t elementKind;
-    WASM_PARSER_FAIL_IF(!parseUInt8(elementKind), "can't get element kind");
-    WASM_PARSER_FAIL_IF(!!elementKind, "element kind must be zero");
+    WASM_PARSER_FAIL_IF(!parseUInt8(elementKind), "can't get element kind"_s);
+    WASM_PARSER_FAIL_IF(!!elementKind, "element kind must be zero"_s);
     resultElementKind = elementKind;
 
     return { };
@@ -1198,8 +1198,8 @@ auto SectionParser::parseElementKind(uint8_t& resultElementKind) -> PartialResul
 auto SectionParser::parseIndexCountForElementSection(uint32_t& resultIndexCount, const unsigned elementNum) -> PartialResult
 {
     uint32_t indexCount;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(indexCount), "can't get ", elementNum, "th index count for Element section");
-    WASM_PARSER_FAIL_IF(indexCount == std::numeric_limits<uint32_t>::max(), "Element section's ", elementNum, "th index count is too big ", indexCount);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(indexCount), "can't get "_s, elementNum, "th index count for Element section"_s);
+    WASM_PARSER_FAIL_IF(indexCount == std::numeric_limits<uint32_t>::max(), "Element section's "_s, elementNum, "th index count is too big "_s, indexCount);
     resultIndexCount = indexCount;
 
     return { };
@@ -1216,7 +1216,7 @@ auto SectionParser::parseElementSegmentVectorOfExpressions(Type elementType, Vec
         bool isExtendedConstantExpression;
         v128_t unusedVector { };
         WASM_FAIL_IF_HELPER_FAILS(parseInitExpr(initOpcode, isExtendedConstantExpression, initialBitsOrIndex, unusedVector, elementType, typeForInitOpcode));
-        WASM_PARSER_FAIL_IF(!isSubtype(typeForInitOpcode, elementType), "Element section's ", elementNum, "th element's init_expr opcode of type ", typeForInitOpcode.kind, " doesn't match element's type ", elementType.kind);
+        WASM_PARSER_FAIL_IF(!isSubtype(typeForInitOpcode, elementType), "Element section's "_s, elementNum, "th element's init_expr opcode of type "_s, typeForInitOpcode.kind, " doesn't match element's type "_s, elementType.kind);
 
         if (isExtendedConstantExpression)
             initType = Element::InitializationType::FromExtendedExpression;
@@ -1241,8 +1241,8 @@ auto SectionParser::parseElementSegmentVectorOfIndexes(Vector<Element::Initializ
 {
     for (uint32_t index = 0; index < indexCount; ++index) {
         uint32_t functionIndex;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(functionIndex), "can't get Element section's ", elementNum, "th element's ", index, "th index");
-        WASM_PARSER_FAIL_IF(functionIndex >= m_info->functionIndexSpaceSize(), "Element section's ", elementNum, "th element's ", index, "th index is ", functionIndex, " which exceeds the function index space size of ", m_info->functionIndexSpaceSize());
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(functionIndex), "can't get Element section's "_s, elementNum, "th element's "_s, index, "th index"_s);
+        WASM_PARSER_FAIL_IF(functionIndex >= m_info->functionIndexSpaceSize(), "Element section's "_s, elementNum, "th element's "_s, index, "th index is "_s, functionIndex, " which exceeds the function index space size of "_s, m_info->functionIndexSpaceSize());
 
         m_info->addDeclaredFunction(functionIndex);
         initTypes.append(Element::InitializationType::FromRefFunc);
@@ -1260,9 +1260,9 @@ auto SectionParser::parseI32InitExprForDataSection(std::optional<I32InitExpr>& i
 auto SectionParser::parseGlobalType(GlobalInformation& global) -> PartialResult
 {
     uint8_t mutability;
-    WASM_PARSER_FAIL_IF(!parseValueType(m_info, global.type), "can't get Global's value type");
-    WASM_PARSER_FAIL_IF(!parseUInt8(mutability), "can't get Global type's mutability");
-    WASM_PARSER_FAIL_IF(mutability != 0x0 && mutability != 0x1, "invalid Global's mutability: 0x", hex(mutability, 2, Lowercase));
+    WASM_PARSER_FAIL_IF(!parseValueType(m_info, global.type), "can't get Global's value type"_s);
+    WASM_PARSER_FAIL_IF(!parseUInt8(mutability), "can't get Global type's mutability"_s);
+    WASM_PARSER_FAIL_IF(mutability != 0x0 && mutability != 0x1, "invalid Global's mutability: 0x"_s, hex(mutability, 2, Lowercase));
     global.mutability = static_cast<Mutability>(mutability);
     return { };
 }
@@ -1270,33 +1270,33 @@ auto SectionParser::parseGlobalType(GlobalInformation& global) -> PartialResult
 auto SectionParser::parseData() -> PartialResult
 {
     uint32_t segmentCount;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(segmentCount), "can't get Data section's count");
-    WASM_PARSER_FAIL_IF(segmentCount > maxDataSegments, "Data section's count is too big ", segmentCount, " maximum ", maxDataSegments);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(segmentCount), "can't get Data section's count"_s);
+    WASM_PARSER_FAIL_IF(segmentCount > maxDataSegments, "Data section's count is too big "_s, segmentCount, " maximum "_s, maxDataSegments);
     if (m_info->numberOfDataSegments)
-        WASM_PARSER_FAIL_IF(segmentCount != m_info->numberOfDataSegments.value(), "Data section's count ", segmentCount, " is different from Data Count section's count ", m_info->numberOfDataSegments.value());
+        WASM_PARSER_FAIL_IF(segmentCount != m_info->numberOfDataSegments.value(), "Data section's count "_s, segmentCount, " is different from Data Count section's count "_s, m_info->numberOfDataSegments.value());
     RELEASE_ASSERT(!m_info->data.capacity());
-    WASM_PARSER_FAIL_IF(!m_info->data.tryReserveInitialCapacity(segmentCount), "can't allocate enough memory for Data section's ", segmentCount, " segments");
+    WASM_PARSER_FAIL_IF(!m_info->data.tryReserveInitialCapacity(segmentCount), "can't allocate enough memory for Data section's "_s, segmentCount, " segments"_s);
 
     for (uint32_t segmentNumber = 0; segmentNumber < segmentCount; ++segmentNumber) {
         uint32_t memoryIndexOrDataFlag = UINT32_MAX;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(memoryIndexOrDataFlag), "can't get ", segmentNumber, "th Data segment's flag");
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(memoryIndexOrDataFlag), "can't get "_s, segmentNumber, "th Data segment's flag"_s);
 
         if (!memoryIndexOrDataFlag) {
             const uint32_t memoryIndex = memoryIndexOrDataFlag;
-            WASM_PARSER_FAIL_IF(memoryIndex >= m_info->memoryCount(), segmentNumber, "th Data segment has index ", memoryIndex, " which exceeds the number of Memories ", m_info->memoryCount());
+            WASM_PARSER_FAIL_IF(memoryIndex >= m_info->memoryCount(), segmentNumber, "th Data segment has index "_s, memoryIndex, " which exceeds the number of Memories "_s, m_info->memoryCount());
 
             std::optional<I32InitExpr> initExpr;
             WASM_FAIL_IF_HELPER_FAILS(parseI32InitExprForDataSection(initExpr));
 
             uint32_t dataByteLength;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(dataByteLength), "can't get ", segmentNumber, "th Data segment's data byte length");
-            WASM_PARSER_FAIL_IF(dataByteLength > maxModuleSize, segmentNumber, "th Data segment's data byte length is too big ", dataByteLength, " maximum ", maxModuleSize);
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(dataByteLength), "can't get "_s, segmentNumber, "th Data segment's data byte length"_s);
+            WASM_PARSER_FAIL_IF(dataByteLength > maxModuleSize, segmentNumber, "th Data segment's data byte length is too big "_s, dataByteLength, " maximum "_s, maxModuleSize);
 
             auto segment = Segment::create(*initExpr, dataByteLength, Segment::Kind::Active);
-            WASM_PARSER_FAIL_IF(!segment, "can't allocate enough memory for ", segmentNumber, "th Data segment of size ", dataByteLength);
+            WASM_PARSER_FAIL_IF(!segment, "can't allocate enough memory for "_s, segmentNumber, "th Data segment of size "_s, dataByteLength);
             for (uint32_t dataByte = 0; dataByte < dataByteLength; ++dataByte) {
                 uint8_t byte;
-                WASM_PARSER_FAIL_IF(!parseUInt8(byte), "can't get ", dataByte, "th data byte from ", segmentNumber, "th Data segment");
+                WASM_PARSER_FAIL_IF(!parseUInt8(byte), "can't get "_s, dataByte, "th data byte from "_s, segmentNumber, "th Data segment"_s);
                 segment->byte(dataByte) = byte;
             }
             m_info->data.append(WTFMove(segment));
@@ -1306,14 +1306,14 @@ auto SectionParser::parseData() -> PartialResult
         const uint32_t dataFlag = memoryIndexOrDataFlag;
         if (dataFlag == 0x01) {
             uint32_t dataByteLength;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(dataByteLength), "can't get ", segmentNumber, "th Data segment's data byte length");
-            WASM_PARSER_FAIL_IF(dataByteLength > maxModuleSize, segmentNumber, "th Data segment's data byte length is too big ", dataByteLength, " maximum ", maxModuleSize);
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(dataByteLength), "can't get "_s, segmentNumber, "th Data segment's data byte length"_s);
+            WASM_PARSER_FAIL_IF(dataByteLength > maxModuleSize, segmentNumber, "th Data segment's data byte length is too big "_s, dataByteLength, " maximum "_s, maxModuleSize);
 
             auto segment = Segment::create(std::nullopt, dataByteLength, Segment::Kind::Passive);
-            WASM_PARSER_FAIL_IF(!segment, "can't allocate enough memory for ", segmentNumber, "th Data segment of size ", dataByteLength);
+            WASM_PARSER_FAIL_IF(!segment, "can't allocate enough memory for "_s, segmentNumber, "th Data segment of size "_s, dataByteLength);
             for (uint32_t dataByte = 0; dataByte < dataByteLength; ++dataByte) {
                 uint8_t byte;
-                WASM_PARSER_FAIL_IF(!parseUInt8(byte), "can't get ", dataByte, "th data byte from ", segmentNumber, "th Data segment");
+                WASM_PARSER_FAIL_IF(!parseUInt8(byte), "can't get "_s, dataByte, "th data byte from "_s, segmentNumber, "th Data segment"_s);
                 segment->byte(dataByte) = byte;
             }
             m_info->data.append(WTFMove(segment));
@@ -1323,28 +1323,28 @@ auto SectionParser::parseData() -> PartialResult
 
         if (dataFlag == 0x02) {
             uint32_t memoryIndex;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(memoryIndex), "can't get ", segmentNumber, "th Data segment's index");
-            WASM_PARSER_FAIL_IF(memoryIndex >= m_info->memoryCount(), segmentNumber, "th Data segment has index ", memoryIndex, " which exceeds the number of Memories ", m_info->memoryCount());
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(memoryIndex), "can't get "_s, segmentNumber, "th Data segment's index"_s);
+            WASM_PARSER_FAIL_IF(memoryIndex >= m_info->memoryCount(), segmentNumber, "th Data segment has index "_s, memoryIndex, " which exceeds the number of Memories "_s, m_info->memoryCount());
 
             std::optional<I32InitExpr> initExpr;
             WASM_FAIL_IF_HELPER_FAILS(parseI32InitExprForDataSection(initExpr));
 
             uint32_t dataByteLength;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(dataByteLength), "can't get ", segmentNumber, "th Data segment's data byte length");
-            WASM_PARSER_FAIL_IF(dataByteLength > maxModuleSize, segmentNumber, "th Data segment's data byte length is too big ", dataByteLength, " maximum ", maxModuleSize);
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(dataByteLength), "can't get "_s, segmentNumber, "th Data segment's data byte length"_s);
+            WASM_PARSER_FAIL_IF(dataByteLength > maxModuleSize, segmentNumber, "th Data segment's data byte length is too big "_s, dataByteLength, " maximum "_s, maxModuleSize);
 
             auto segment = Segment::create(*initExpr, dataByteLength, Segment::Kind::Active);
-            WASM_PARSER_FAIL_IF(!segment, "can't allocate enough memory for ", segmentNumber, "th Data segment of size ", dataByteLength);
+            WASM_PARSER_FAIL_IF(!segment, "can't allocate enough memory for "_s, segmentNumber, "th Data segment of size "_s, dataByteLength);
             for (uint32_t dataByte = 0; dataByte < dataByteLength; ++dataByte) {
                 uint8_t byte;
-                WASM_PARSER_FAIL_IF(!parseUInt8(byte), "can't get ", dataByte, "th data byte from ", segmentNumber, "th Data segment");
+                WASM_PARSER_FAIL_IF(!parseUInt8(byte), "can't get "_s, dataByte, "th data byte from "_s, segmentNumber, "th Data segment"_s);
                 segment->byte(dataByte) = byte;
             }
             m_info->data.append(WTFMove(segment));
             continue;
         }
 
-        WASM_PARSER_FAIL_IF(true, "unknown ", segmentNumber, "th Data segment's flag");
+        WASM_PARSER_FAIL_IF(true, "unknown "_s, segmentNumber, "th Data segment's flag"_s);
     }
 
     return { };
@@ -1353,8 +1353,8 @@ auto SectionParser::parseData() -> PartialResult
 auto SectionParser::parseDataCount() -> PartialResult
 {
     uint32_t numberOfDataSegments;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(numberOfDataSegments), "can't get Data Count section's count");
-    WASM_PARSER_FAIL_IF(numberOfDataSegments > maxDataSegments, "Data Count section's count is too big ", numberOfDataSegments , " maximum ", maxDataSegments);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(numberOfDataSegments), "can't get Data Count section's count"_s);
+    WASM_PARSER_FAIL_IF(numberOfDataSegments > maxDataSegments, "Data Count section's count is too big "_s, numberOfDataSegments , " maximum "_s, maxDataSegments);
 
     m_info->numberOfDataSegments = numberOfDataSegments;
     return { };
@@ -1363,22 +1363,22 @@ auto SectionParser::parseDataCount() -> PartialResult
 auto SectionParser::parseException() -> PartialResult
 {
     uint32_t exceptionCount;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(exceptionCount), "can't get Exception section's count");
-    WASM_PARSER_FAIL_IF(exceptionCount > maxExceptions, "Export section's count is too big ", exceptionCount, " maximum ", maxExceptions);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(exceptionCount), "can't get Exception section's count"_s);
+    WASM_PARSER_FAIL_IF(exceptionCount > maxExceptions, "Export section's count is too big "_s, exceptionCount, " maximum "_s, maxExceptions);
     RELEASE_ASSERT(!m_info->internalExceptionTypeIndices.capacity());
-    WASM_PARSER_FAIL_IF(!m_info->internalExceptionTypeIndices.tryReserveInitialCapacity(exceptionCount), "can't allocate enough memory for ", exceptionCount, " exceptions");
+    WASM_PARSER_FAIL_IF(!m_info->internalExceptionTypeIndices.tryReserveInitialCapacity(exceptionCount), "can't allocate enough memory for "_s, exceptionCount, " exceptions"_s);
 
     for (uint32_t exceptionNumber = 0; exceptionNumber < exceptionCount; ++exceptionNumber) {
         uint8_t tagType;
-        WASM_PARSER_FAIL_IF(!parseUInt8(tagType), "can't get ", exceptionNumber, "th Exception tag type");
-        WASM_PARSER_FAIL_IF(tagType, exceptionNumber, "th Exception has tag type ", tagType, " but the only supported tag type is 0");
+        WASM_PARSER_FAIL_IF(!parseUInt8(tagType), "can't get "_s, exceptionNumber, "th Exception tag type"_s);
+        WASM_PARSER_FAIL_IF(tagType, exceptionNumber, "th Exception has tag type "_s, tagType, " but the only supported tag type is 0"_s);
 
         uint32_t typeNumber;
-        WASM_PARSER_FAIL_IF(!parseVarUInt32(typeNumber), "can't get ", exceptionNumber, "th Exception's type number");
-        WASM_PARSER_FAIL_IF(typeNumber >= m_info->typeCount(), exceptionNumber, "th Exception type number is invalid ", typeNumber);
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(typeNumber), "can't get "_s, exceptionNumber, "th Exception's type number"_s);
+        WASM_PARSER_FAIL_IF(typeNumber >= m_info->typeCount(), exceptionNumber, "th Exception type number is invalid "_s, typeNumber);
         TypeIndex typeIndex = TypeInformation::get(m_info->typeSignatures[typeNumber]);
         auto signature = TypeInformation::getFunctionSignature(typeIndex);
-        WASM_PARSER_FAIL_IF(!signature.returnsVoid(), exceptionNumber, "th Exception type cannot have a non-void return type ", typeNumber);
+        WASM_PARSER_FAIL_IF(!signature.returnsVoid(), exceptionNumber, "th Exception type cannot have a non-void return type "_s, typeNumber);
         m_info->internalExceptionTypeIndices.append(typeIndex);
     }
 
@@ -1389,16 +1389,16 @@ auto SectionParser::parseCustom() -> PartialResult
     CustomSection section;
     uint32_t customSectionNumber = m_info->customSections.size() + 1;
     uint32_t nameLen;
-    WASM_PARSER_FAIL_IF(!m_info->customSections.tryReserveCapacity(customSectionNumber), "can't allocate enough memory for ", customSectionNumber, "th custom section");
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(nameLen), "can't get ", customSectionNumber, "th custom section's name length");
-    WASM_PARSER_FAIL_IF(!consumeUTF8String(section.name, nameLen), "nameLen get ", customSectionNumber, "th custom section's name of length ", nameLen);
+    WASM_PARSER_FAIL_IF(!m_info->customSections.tryReserveCapacity(customSectionNumber), "can't allocate enough memory for "_s, customSectionNumber, "th custom section"_s);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(nameLen), "can't get "_s, customSectionNumber, "th custom section's name length"_s);
+    WASM_PARSER_FAIL_IF(!consumeUTF8String(section.name, nameLen), "nameLen get "_s, customSectionNumber, "th custom section's name of length "_s, nameLen);
 
     uint32_t payloadBytes = source().size() - m_offset;
-    WASM_PARSER_FAIL_IF(!section.payload.tryReserveInitialCapacity(payloadBytes), "can't allocate enough memory for ", customSectionNumber, "th custom section's ", payloadBytes, " bytes");
+    WASM_PARSER_FAIL_IF(!section.payload.tryReserveInitialCapacity(payloadBytes), "can't allocate enough memory for "_s, customSectionNumber, "th custom section's "_s, payloadBytes, " bytes"_s);
     section.payload.resize(payloadBytes);
     for (uint32_t byteNumber = 0; byteNumber < payloadBytes; ++byteNumber) {
         uint8_t byte;
-        WASM_PARSER_FAIL_IF(!parseUInt8(byte), "can't get ", byteNumber, "th data byte from ", customSectionNumber, "th custom section");
+        WASM_PARSER_FAIL_IF(!parseUInt8(byte), "can't get "_s, byteNumber, "th data byte from "_s, customSectionNumber, "th custom section"_s);
         section.payload[byteNumber] = byte;
     }
 

--- a/Source/JavaScriptCore/wasm/WasmSections.h
+++ b/Source/JavaScriptCore/wasm/WasmSections.h
@@ -31,6 +31,8 @@
 IGNORE_RETURN_TYPE_WARNINGS_BEGIN
 #endif
 
+#include <wtf/text/ASCIILiteral.h>
+
 namespace JSC { namespace Wasm {
 
 // macro(Name, ID, OrderingNumber, Description).
@@ -104,14 +106,14 @@ inline bool validateOrder(Section previousKnown, Section next)
     return orderingNumber(previousKnown) < orderingNumber(next);
 }
 
-inline const char* makeString(Section section)
+inline ASCIILiteral makeString(Section section)
 {
     switch (section) {
     case Section::Begin:
-        return "Begin";
+        return "Begin"_s;
     case Section::Custom:
-        return "Custom";
-#define STRINGIFY_SECTION_NAME(NAME, ID, ORDERING, DESCRIPTION) case Section::NAME: return #NAME;
+        return "Custom"_s;
+#define STRINGIFY_SECTION_NAME(NAME, ID, ORDERING, DESCRIPTION) case Section::NAME: return #NAME ## _s;
         FOR_EACH_KNOWN_WASM_SECTION(STRINGIFY_SECTION_NAME)
 #undef STRINGIFY_SECTION_NAME
     }

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -472,7 +472,7 @@ private:
 
 };
 
-inline const char* makeString(const StorageType& storageType)
+inline ASCIILiteral makeString(const StorageType& storageType)
 {
     return(storageType.is<Type>() ? makeString(storageType.as<Type>().kind) :
         makeString(storageType.as<PackedType>()));

--- a/Source/JavaScriptCore/wasm/generateWasmOpsHeader.py
+++ b/Source/JavaScriptCore/wasm/generateWasmOpsHeader.py
@@ -221,6 +221,7 @@ contents = wasm.header + """
 
 #include <cstdint>
 #include <wtf/PrintStream.h>
+#include <wtf/text/ASCIILiteral.h>
 
 namespace JSC {
 
@@ -331,25 +332,25 @@ inline bool isValidPackedType(Int i)
 }
 #undef CREATE_CASE
 
-#define CREATE_CASE(name, ...) case TypeKind::name: return #name;
-inline const char* makeString(TypeKind kind)
+#define CREATE_CASE(name, ...) case TypeKind::name: return #name ## _s;
+inline ASCIILiteral makeString(TypeKind kind)
 {
     switch (kind) {
     FOR_EACH_WASM_TYPE(CREATE_CASE)
     }
     RELEASE_ASSERT_NOT_REACHED();
-    return nullptr;
+    return { };
 }
 #undef CREATE_CASE
 
-#define CREATE_CASE(name, ...) case PackedType::name: return #name;
-inline const char* makeString(PackedType packedType)
+#define CREATE_CASE(name, ...) case PackedType::name: return #name ## _s;
+inline ASCIILiteral makeString(PackedType packedType)
 {
     switch (packedType) {
     FOR_EACH_WASM_PACKED_TYPE(CREATE_CASE)
     }
     RELEASE_ASSERT_NOT_REACHED();
-    return nullptr;
+    return { };
 }
 #undef CREATE_CASE
 
@@ -501,19 +502,19 @@ inline uint32_t memoryLog2Alignment(ExtAtomicOpType op)
     return 0;
 }
 
-#define CREATE_CASE(name, ...) case name: return #name;
-inline const char* makeString(OpType op)
+#define CREATE_CASE(name, ...) case name: return #name ## _s;
+inline ASCIILiteral makeString(OpType op)
 {
     switch (op) {
     FOR_EACH_WASM_OP(CREATE_CASE)
     }
     RELEASE_ASSERT_NOT_REACHED();
-    return nullptr;
+    return { };
 }
 #undef CREATE_CASE
 
-#define CREATE_CASE(name, ...) case ExtAtomicOpType::name: return #name;
-inline const char* makeString(ExtAtomicOpType op)
+#define CREATE_CASE(name, ...) case ExtAtomicOpType::name: return #name ## _s;
+inline ASCIILiteral makeString(ExtAtomicOpType op)
 {
     switch (op) {
     FOR_EACH_WASM_EXT_ATOMIC_LOAD_OP(CREATE_CASE)
@@ -522,7 +523,7 @@ inline const char* makeString(ExtAtomicOpType op)
     FOR_EACH_WASM_EXT_ATOMIC_OTHER_OP(CREATE_CASE)
     }
     RELEASE_ASSERT_NOT_REACHED();
-    return nullptr;
+    return { };
 }
 #undef CREATE_CASE
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyArrayConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyArrayConstructor.cpp
@@ -51,7 +51,7 @@ JSC_DEFINE_HOST_FUNCTION(callJSWebAssemblyArray, (JSGlobalObject* globalObject, 
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WebAssembly.Array"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WebAssembly.Array"_s));
 }
 
 WebAssemblyArrayConstructor* WebAssemblyArrayConstructor::create(VM& vm, Structure* structure, WebAssemblyArrayPrototype* thisPrototype)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
@@ -85,7 +85,7 @@ JSC_DEFINE_HOST_FUNCTION(callJSWebAssemblyException, (JSGlobalObject* globalObje
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WebAssembly.Exception"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WebAssembly.Exception"_s));
 }
 
 WebAssemblyExceptionConstructor* WebAssemblyExceptionConstructor::create(VM& vm, Structure* structure, WebAssemblyExceptionPrototype* thisPrototype)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.cpp
@@ -162,7 +162,7 @@ JSC_DEFINE_HOST_FUNCTION(callJSWebAssemblyGlobal, (JSGlobalObject* globalObject,
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WebAssembly.Global"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WebAssembly.Global"_s));
 }
 
 WebAssemblyGlobalConstructor* WebAssemblyGlobalConstructor::create(VM& vm, Structure* structure, WebAssemblyGlobalPrototype* thisPrototype)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyInstanceConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyInstanceConstructor.cpp
@@ -77,7 +77,7 @@ JSC_DEFINE_HOST_FUNCTION(callJSWebAssemblyInstance, (JSGlobalObject* globalObjec
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WebAssembly.Instance"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WebAssembly.Instance"_s));
 }
 
 WebAssemblyInstanceConstructor* WebAssemblyInstanceConstructor::create(VM& vm, Structure* structure, WebAssemblyInstancePrototype* thisPrototype)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
@@ -139,7 +139,7 @@ JSC_DEFINE_HOST_FUNCTION(callJSWebAssemblyMemory, (JSGlobalObject* globalObject,
 {
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, throwScope, "WebAssembly.Memory"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, throwScope, "WebAssembly.Memory"_s));
 }
 
 WebAssemblyMemoryConstructor* WebAssemblyMemoryConstructor::create(VM& vm, Structure* structure, WebAssemblyMemoryPrototype* thisPrototype)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
@@ -174,7 +174,7 @@ JSC_DEFINE_HOST_FUNCTION(callJSWebAssemblyModule, (JSGlobalObject* globalObject,
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WebAssembly.Module"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WebAssembly.Module"_s));
 }
 
 JSWebAssemblyModule* WebAssemblyModuleConstructor::createModule(JSGlobalObject* globalObject, CallFrame* callFrame, Vector<uint8_t>&& buffer)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp
@@ -133,7 +133,7 @@ JSC_DEFINE_HOST_FUNCTION(callJSWebAssemblyTable, (JSGlobalObject* globalObject, 
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WebAssembly.Table"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WebAssembly.Table"_s));
 }
 
 WebAssemblyTableConstructor* WebAssemblyTableConstructor::create(VM& vm, Structure* structure, WebAssemblyTablePrototype* thisPrototype)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTagConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTagConstructor.cpp
@@ -94,7 +94,7 @@ JSC_DEFINE_HOST_FUNCTION(callJSWebAssemblyTag, (JSGlobalObject* globalObject, Ca
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WebAssembly.Tag"));
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "WebAssembly.Tag"_s));
 }
 
 WebAssemblyTagConstructor* WebAssemblyTagConstructor::create(VM& vm, Structure* structure, WebAssemblyTagPrototype* thisPrototype)

--- a/Source/WTF/wtf/DateMath.cpp
+++ b/Source/WTF/wtf/DateMath.cpp
@@ -1024,7 +1024,7 @@ double parseDate(std::span<const LChar> dateString)
 String makeRFC2822DateString(unsigned dayOfWeek, unsigned day, unsigned month, unsigned year, unsigned hours, unsigned minutes, unsigned seconds, int utcOffset)
 {
     StringBuilder stringBuilder;
-    stringBuilder.append(weekdayName[dayOfWeek], ", ", day, ' ', monthName[month], ' ', year, ' ');
+    stringBuilder.append(weekdayName[dayOfWeek], ", "_s, day, ' ', monthName[month], ' ', year, ' ');
 
     appendTwoDigitNumber(stringBuilder, hours);
     stringBuilder.append(':');

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -165,7 +165,7 @@ String encodeForFileName(const String& inputString)
             if (character <= 0xFF)
                 result.append('%', hex(character, 2));
             else
-                result.append("%+", hex(static_cast<uint8_t>(character >> 8), 2), hex(static_cast<uint8_t>(character), 2));
+                result.append("%+"_s, hex(static_cast<uint8_t>(character >> 8), 2), hex(static_cast<uint8_t>(character), 2));
         } else
             result.append(character);
         previousCharacter = character;

--- a/Source/WTF/wtf/Logger.cpp
+++ b/Source/WTF/wtf/Logger.cpp
@@ -38,8 +38,8 @@ Lock loggerObserverLock;
 String Logger::LogSiteIdentifier::toString() const
 {
     if (className)
-        return makeString(className, "::"_s, methodName, '(', hex(objectPtr), ") "_s);
-    return makeString(methodName, '(', hex(objectPtr), ") "_s);
+        return makeString(className, "::"_s, span(methodName), '(', hex(objectPtr), ") "_s);
+    return makeString(span(methodName), '(', hex(objectPtr), ") "_s);
 }
 
 String LogArgument<const void*>::toString(const void* argument)

--- a/Source/WTF/wtf/NativePromise.h
+++ b/Source/WTF/wtf/NativePromise.h
@@ -1582,7 +1582,7 @@ template<typename ResolveValueT, typename RejectValueT, unsigned options>
 struct LogArgument<NativePromise<ResolveValueT, RejectValueT, options>> {
     static String toString(const NativePromise<ResolveValueT, RejectValueT, options>& p)
     {
-        return makeString("NativePromise", LogArgument<const void*>::toString(&p), '<', LogArgument<Logger::LogSiteIdentifier>::toString(p.logSiteIdentifier()), '>');
+        return makeString("NativePromise"_s, LogArgument<const void*>::toString(&p), '<', LogArgument<Logger::LogSiteIdentifier>::toString(p.logSiteIdentifier()), '>');
     }
 };
 
@@ -1590,7 +1590,7 @@ template<>
 struct LogArgument<GenericPromise> {
     static String toString(const GenericPromise& p)
     {
-        return makeString("GenericPromise", LogArgument<const void*>::toString(&p), '<', LogArgument<Logger::LogSiteIdentifier>::toString(p.logSiteIdentifier()), '>');
+        return makeString("GenericPromise"_s, LogArgument<const void*>::toString(&p), '<', LogArgument<Logger::LogSiteIdentifier>::toString(p.logSiteIdentifier()), '>');
     }
 };
 

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -1368,7 +1368,7 @@ Vector<String> removeQueryParameters(URL& url, Function<bool(const String&)>&& s
             continue;
         }
 
-        queryWithoutRemovalKeys.append(queryWithoutRemovalKeys.isEmpty() ? "" : "&", bytes);
+        queryWithoutRemovalKeys.append(queryWithoutRemovalKeys.isEmpty() ? ""_s : "&"_s, bytes);
     }
 
     if (!removedParameters.isEmpty())

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -1109,7 +1109,7 @@ URLParser::URLParser(String&& input, const URL& base, const URLTextEncoding* non
 #if ASSERT_ENABLED
     if (!m_didSeeSyntaxViolation) {
         // Force a syntax violation at the beginning to make sure we get the same result.
-        URLParser parser(makeString(" ", m_inputString), base, nonUTF8QueryEncoding);
+        URLParser parser(makeString(' ', m_inputString), base, nonUTF8QueryEncoding);
         URL parsed = parser.result();
         if (parsed.isValid())
             ASSERT(allValuesEqual(parser.result(), m_url));

--- a/Source/WTF/wtf/cocoa/ResourceUsageCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/ResourceUsageCocoa.cpp
@@ -58,7 +58,7 @@ void logFootprintComparison(const std::array<TagInfo, 256>& before, const std::a
             continue;
         String tagName = displayNameForVMTag(i);
         if (!tagName)
-            tagName = makeString("Tag ", i);
+            tagName = makeString("Tag "_s, i);
         WTFLogAlways("  %02X %16s %10ld %10ld %10ld",
             i,
             tagName.ascii().data(),

--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -165,6 +165,7 @@ private:
     unsigned m_length;
 };
 
+// FIXME: Port call sites to use ASCIILiteral or std::span and remove.
 template<> class StringTypeAdapter<const char*, void> : public StringTypeAdapter<const LChar*, void> {
 public:
     StringTypeAdapter(const char* characters)
@@ -173,6 +174,7 @@ public:
     }
 };
 
+// FIXME: Port call sites to use ASCIILiteral or std::span and remove.
 template<> class StringTypeAdapter<char*, void> : public StringTypeAdapter<const char*, void> {
 public:
     StringTypeAdapter(const char* characters)
@@ -181,10 +183,10 @@ public:
     }
 };
 
-template<> class StringTypeAdapter<ASCIILiteral, void> : public StringTypeAdapter<const char*, void> {
+template<> class StringTypeAdapter<ASCIILiteral, void> : public StringTypeAdapter<const LChar*, void> {
 public:
     StringTypeAdapter(ASCIILiteral characters)
-        : StringTypeAdapter<const char*, void> { characters }
+        : StringTypeAdapter<const LChar*, void> { characters.characters8() }
     {
     }
 };

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -35,7 +35,7 @@ namespace WGSL::AST {
 
 struct Indent {
     Indent(StringDumper& dumper)
-        : scope(dumper.m_indent, dumper.m_indent + "    ")
+        : scope(dumper.m_indent, dumper.m_indent + "    "_s)
     { }
     SetForScope<String> scope;
 };

--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -32,6 +32,7 @@
 #include <numbers>
 #include <wtf/Assertions.h>
 #include <wtf/DataLog.h>
+#include <wtf/text/StringConcatenateNumbers.h>
 
 namespace WGSL {
 
@@ -700,7 +701,7 @@ CONSTANT_FUNCTION(BitwiseShiftLeft)
     const auto& shift = [&]<typename T>(T left, uint32_t right) -> ConstantResult {
         constexpr auto bitSize = sizeof(T) * 8;
         if (right >= bitSize)
-            return makeUnexpected(makeString("shift left value must be less than the bit width of the shifted value, which is ", String::number(bitSize)));
+            return makeUnexpected(makeString("shift left value must be less than the bit width of the shifted value, which is "_s, bitSize));
 
         if constexpr (std::is_unsigned_v<T>) {
             uint64_t mask = -1ull << (bitSize - right);
@@ -737,7 +738,7 @@ CONSTANT_FUNCTION(BitwiseShiftRight)
     const auto& shift = [&]<typename T>(T left, uint32_t right) -> ConstantResult {
         constexpr auto bitSize = sizeof(T) * 8;
         if (right >= bitSize)
-            return makeUnexpected(makeString("shift right value must be less than the bit width of the shifted value, which is ", String::number(bitSize)));
+            return makeUnexpected(makeString("shift right value must be less than the bit width of the shifted value, which is "_s, bitSize));
         return { left >> right };
     };
 
@@ -767,7 +768,7 @@ CONSTANT_FUNCTION(I32)
             auto result = convertInteger<int32_t>(*abstractInt);
             if (result)
                 return { *result };
-            return makeUnexpected(makeString("value ", String::number(*abstractInt), " cannot be represented as 'i32'"));
+            return makeUnexpected(makeString("value "_s, *abstractInt, " cannot be represented as 'i32'"_s));
         }
     }
 
@@ -781,7 +782,7 @@ CONSTANT_FUNCTION(U32)
             auto result = convertInteger<uint32_t>(*abstractInt);
             if (result)
                 return { *result };
-            return makeUnexpected(makeString("value ", String::number(*abstractInt), " cannot be represented as 'u32'"));
+            return makeUnexpected(makeString("value "_s, *abstractInt, " cannot be represented as 'u32'"_s));
         }
     }
 
@@ -1246,7 +1247,7 @@ CONSTANT_FUNCTION(Ldexp)
             if (abstractE2 + bias <= 0)
                 return { static_cast<double>(0) };
             if (abstractE2 > bias + 1)
-                return makeUnexpected(makeString("e2 must be less than or equal to ", String::number(bias + 1)));
+                return makeUnexpected(makeString("e2 must be less than or equal to "_s, bias + 1));
             return { std::ldexp(*abstractE1, abstractE2) };
         }
 
@@ -1256,7 +1257,7 @@ CONSTANT_FUNCTION(Ldexp)
             if (i32E2 + bias <= 0)
                 return { static_cast<float>(0) };
             if (i32E2 > bias + 1)
-                return makeUnexpected(makeString("e2 must be less than or equal to ", String::number(bias + 1)));
+                return makeUnexpected(makeString("e2 must be less than or equal to "_s, bias + 1));
             return { std::ldexp(*f32E1, i32E2) };
         }
         if (auto* f16E1 = std::get_if<half>(&e1)) {
@@ -1264,7 +1265,7 @@ CONSTANT_FUNCTION(Ldexp)
             if (i32E2 + bias <= 0)
                 return { static_cast<half>(0) };
             if (i32E2 > bias + 1)
-                return makeUnexpected(makeString("e2 must be less than or equal to ", String::number(bias + 1)));
+                return makeUnexpected(makeString("e2 must be less than or equal to "_s, bias + 1));
             return { static_cast<half>(std::ldexp(*f16E1, i32E2)) };
         }
         RELEASE_ASSERT_NOT_REACHED();
@@ -1336,7 +1337,7 @@ UNARY_OPERATION(QuantizeToF16, F32, [&](float arg) -> ConstantResult {
     UNUSED_PARAM(resultType);
     auto converted = convertFloat<half>(arg);
     if (!converted)
-        return makeUnexpected(makeString("value ", String::number(arg), " cannot be represented as 'f16'"));
+        return makeUnexpected(makeString("value "_s, String::number(arg), " cannot be represented as 'f16'"_s));
     return { { static_cast<float>(*converted) } };
 });
 
@@ -1564,7 +1565,7 @@ CONSTANT_FUNCTION(Pack2x16float)
         auto e = std::get<float>(vector.elements[i]);
         auto converted = convertFloat<half>(e);
         if (!converted)
-            return makeUnexpected(makeString("value ", String::number(e), " cannot be represented as 'f16'"));
+            return makeUnexpected(makeString("value "_s, e, " cannot be represented as 'f16'"_s));
         packed[i] = *converted;
     }
     return { { bitwise_cast<uint32_t>(packed) } };
@@ -1669,12 +1670,12 @@ CONSTANT_FUNCTION(Bitcast)
         else if (auto* abstractInt = std::get_if<int64_t>(&argument)) {
             auto i32 = convertInteger<int32_t>(*abstractInt);
             if (!i32)
-                return { makeString("value ", String::number(*abstractInt), " cannot be represented as 'i32'") };
+                return { makeString("value "_s, String::number(*abstractInt), " cannot be represented as 'i32'"_s) };
             value = bitwise_cast<uint32_t>(*i32);
         } else if (auto* abstractFloat = std::get_if<double>(&argument)) {
             auto f32 = convertFloat<float>(*abstractFloat);
             if (!f32)
-                return { makeString("value ", String::number(*abstractFloat), " cannot be represented as 'f32'") };
+                return { makeString("value "_s, String::number(*abstractFloat), " cannot be represented as 'f32'"_s) };
             value = bitwise_cast<uint32_t>(*f32);
         } else {
             RELEASE_ASSERT_NOT_REACHED();
@@ -1734,20 +1735,20 @@ CONSTANT_FUNCTION(Bitcast)
         if (primitive.kind == Types::Primitive::U32) {
             auto result = convertInteger<uint32_t>(*abstractInt);
             if (!result.has_value())
-                return makeUnexpected(makeString("value ", String::number(*abstractInt), " cannot be represented as 'u32'"));
+                return makeUnexpected(makeString("value "_s, *abstractInt, " cannot be represented as 'u32'"_s));
             return { *result };
         }
 
         auto result = convertInteger<int32_t>(*abstractInt);
         if (!result.has_value())
-            return makeUnexpected(makeString("value ", String::number(*abstractInt), " cannot be represented as 'i32'"));
+            return makeUnexpected(makeString("value "_s, *abstractInt, " cannot be represented as 'i32'"_s));
         return { convertValue<BitwiseCast>(resultType, *result) };
     }
 
     if (auto* abstractFloat = std::get_if<double>(&argument)) {
         auto result = convertFloat<float>(*abstractFloat);
         if (!result.has_value())
-            return makeUnexpected(makeString("value ", String::number(*abstractFloat), " cannot be represented as 'f32'"));
+            return makeUnexpected(makeString("value "_s, *abstractFloat, " cannot be represented as 'f32'"_s));
         return { convertValue<BitwiseCast>(resultType, *result) };
     }
 

--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -86,8 +86,8 @@ EntryPointRewriter::EntryPointRewriter(ShaderModule& shaderModule, const AST::Fu
 
 void EntryPointRewriter::rewrite()
 {
-    m_structTypeName = makeString("__", m_function.name(), "_inT");
-    m_structParameterName = makeString("__", m_function.name(), "_in");
+    m_structTypeName = makeString("__"_s, m_function.name(), "_inT"_s);
+    m_structParameterName = makeString("__"_s, m_function.name(), "_in"_s);
 
     collectParameters();
     checkReturnType();
@@ -131,9 +131,9 @@ void EntryPointRewriter::checkReturnType()
         return;
 
     if (auto* structType = std::get_if<Types::Struct>(namedTypeName->inferredType())) {
-        const auto& duplicateStruct = [&] (AST::StructureRole role, const char* suffix) {
+        const auto& duplicateStruct = [&] (AST::StructureRole role, ASCIILiteral suffix) {
             ASSERT(structType->structure.role() == AST::StructureRole::UserDefined);
-            String returnStructName = makeString("__", structType->structure.name(), "_", suffix);
+            String returnStructName = makeString("__"_s, structType->structure.name(), '_', suffix);
             auto& returnStruct = m_shaderModule.astBuilder().construct<AST::Structure>(
                 SourceSpan::empty(),
                 AST::Identifier::make(returnStructName),
@@ -151,18 +151,18 @@ void EntryPointRewriter::checkReturnType()
         };
 
         if (m_stage == ShaderStage::Fragment) {
-            duplicateStruct(AST::StructureRole::FragmentOutput, "FragmentOutput");
+            duplicateStruct(AST::StructureRole::FragmentOutput, "FragmentOutput"_s);
             return;
         }
 
-        duplicateStruct(AST::StructureRole::VertexOutput, "VertexOutput");
+        duplicateStruct(AST::StructureRole::VertexOutput, "VertexOutput"_s);
         return;
     }
 
     if (m_stage != ShaderStage::Fragment || !m_function.returnTypeBuiltin().has_value())
         return;
 
-    String returnStructName = makeString("__", m_function.name(), "_FragmentOutput");
+    String returnStructName = makeString("__"_s, m_function.name(), "_FragmentOutput"_s);
     auto& fieldType = m_shaderModule.astBuilder().construct<AST::IdentifierExpression>(
         SourceSpan::empty(),
         AST::Identifier::make(namedTypeName->identifier())
@@ -310,7 +310,7 @@ void EntryPointRewriter::visit(Vector<String>& path, MemberOrParameter&& data)
             // ${path}.${data.name} = __builtin${builtinID}
             // Note that we don't use ${data.name} on the right-hand side because it's the name of a
             // struct field, and it might not be unique.
-            auto builtinName = makeString("__builtin", String::number(m_builtinID++));
+            auto builtinName = makeString("__builtin"_s, String::number(m_builtinID++));
             materialize(path, data, IsBuiltin::Yes, &builtinName);
             m_builtins.append({
                 {

--- a/Source/WebGPU/WGSL/GlobalSorting.cpp
+++ b/Source/WebGPU/WGSL/GlobalSorting.cpp
@@ -269,7 +269,7 @@ static std::optional<FailedCheck> reorder(AST::Declaration::List& list)
             // variables with the same name), while the type checker will also identify
             // redeclarations of different types (e.g. a variable and a struct with the
             // same name)
-            return FailedCheck { Vector<Error> { Error(makeString("redeclaration of '", node.name(), "'"), node.span()) }, { } };
+            return FailedCheck { Vector<Error> { Error(makeString("redeclaration of '"_s, node.name(), '\''), node.span()) }, { } };
         }
         graphNodeList.append(graphNode);
     }
@@ -328,11 +328,11 @@ static std::optional<FailedCheck> reorder(AST::Declaration::List& list)
             break;
         }
     }
-    error.append("encountered a dependency cycle: ", cycleNode->astNode().name());
+    error.append("encountered a dependency cycle: "_s, cycleNode->astNode().name());
     do {
         ASSERT(!node->outgoingEdges().isEmpty());
         node = &node->outgoingEdges().first().target();
-        error.append(" -> ", node->astNode().name());
+        error.append(" -> "_s, node->astNode().name());
     } while (node != cycleNode);
     return FailedCheck { Vector<Error> { Error(error.toString(), cycleNode->astNode().span()) }, { } };
 }

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -145,20 +145,20 @@ private:
     HashMap<String, ConstantValue> m_overrides;
 };
 
-static const char* serializeAddressSpace(AddressSpace addressSpace)
+static ASCIILiteral serializeAddressSpace(AddressSpace addressSpace)
 {
     switch (addressSpace) {
     case AddressSpace::Function:
     case AddressSpace::Private:
-        return "thread";
+        return "thread"_s;
     case AddressSpace::Workgroup:
-        return "threadgroup";
+        return "threadgroup"_s;
     case AddressSpace::Uniform:
-        return "constant";
+        return "constant"_s;
     case AddressSpace::Storage:
-        return "device";
+        return "device"_s;
     case AddressSpace::Handle:
-        return nullptr;
+        return { };
     }
 }
 
@@ -840,33 +840,33 @@ void FunctionDefinitionWriter::visit(AST::AlignAttribute&)
     // serializing structs.
 }
 
-static const char* convertToSampleMode(InterpolationType type, InterpolationSampling sampleType)
+static ASCIILiteral convertToSampleMode(InterpolationType type, InterpolationSampling sampleType)
 {
     switch (type) {
     case InterpolationType::Flat:
-        return "flat";
+        return "flat"_s;
     case InterpolationType::Linear:
         switch (sampleType) {
         case InterpolationSampling::Center:
-            return "center_no_perspective";
+            return "center_no_perspective"_s;
         case InterpolationSampling::Centroid:
-            return "centroid_no_perspective";
+            return "centroid_no_perspective"_s;
         case InterpolationSampling::Sample:
-            return "sample_no_perspective";
+            return "sample_no_perspective"_s;
         }
     case InterpolationType::Perspective:
         switch (sampleType) {
         case InterpolationSampling::Center:
-            return "center_perspective";
+            return "center_perspective"_s;
         case InterpolationSampling::Centroid:
-            return "centroid_perspective";
+            return "centroid_perspective"_s;
         case InterpolationSampling::Sample:
-            return "sample_perspective";
+            return "sample_perspective"_s;
         }
     }
 
     ASSERT_NOT_REACHED();
-    return "flat";
+    return "flat"_s;
 }
 
 void FunctionDefinitionWriter::visit(AST::InterpolateAttribute& attribute)
@@ -953,30 +953,30 @@ void FunctionDefinitionWriter::visit(const Type* type)
             m_stringBuilder.append('>');
         },
         [&](const Texture& texture) {
-            const char* type;
-            const char* access = "sample";
+            ASCIILiteral type;
+            ASCIILiteral access = "sample"_s;
             switch (texture.kind) {
             case Types::Texture::Kind::Texture1d:
-                type = "texture1d";
+                type = "texture1d"_s;
                 break;
             case Types::Texture::Kind::Texture2d:
-                type = "texture2d";
+                type = "texture2d"_s;
                 break;
             case Types::Texture::Kind::Texture2dArray:
-                type = "texture2d_array";
+                type = "texture2d_array"_s;
                 break;
             case Types::Texture::Kind::Texture3d:
-                type = "texture3d";
+                type = "texture3d"_s;
                 break;
             case Types::Texture::Kind::TextureCube:
-                type = "texturecube";
+                type = "texturecube"_s;
                 break;
             case Types::Texture::Kind::TextureCubeArray:
-                type = "texturecube_array";
+                type = "texturecube_array"_s;
                 break;
             case Types::Texture::Kind::TextureMultisampled2d:
-                type = "texture2d_ms";
-                access = "read";
+                type = "texture2d_ms"_s;
+                access = "read"_s;
                 break;
             }
             m_stringBuilder.append(type, '<');
@@ -984,31 +984,31 @@ void FunctionDefinitionWriter::visit(const Type* type)
             m_stringBuilder.append(", access::"_s, access, '>');
         },
         [&](const TextureStorage& texture) {
-            const char* base;
-            const char* mode;
+            ASCIILiteral base;
+            ASCIILiteral mode;
             switch (texture.kind) {
             case Types::TextureStorage::Kind::TextureStorage1d:
-                base = "texture1d";
+                base = "texture1d"_s;
                 break;
             case Types::TextureStorage::Kind::TextureStorage2d:
-                base = "texture2d";
+                base = "texture2d"_s;
                 break;
             case Types::TextureStorage::Kind::TextureStorage2dArray:
-                base = "texture2d_array";
+                base = "texture2d_array"_s;
                 break;
             case Types::TextureStorage::Kind::TextureStorage3d:
-                base = "texture3d";
+                base = "texture3d"_s;
                 break;
             }
             switch (texture.access) {
             case AccessMode::Read:
-                mode = "read";
+                mode = "read"_s;
                 break;
             case AccessMode::Write:
-                mode = "write";
+                mode = "write"_s;
                 break;
             case AccessMode::ReadWrite:
-                mode = "read_write";
+                mode = "read_write"_s;
                 break;
             }
             m_stringBuilder.append(base, '<');
@@ -1016,29 +1016,29 @@ void FunctionDefinitionWriter::visit(const Type* type)
             m_stringBuilder.append(", access::"_s, mode, '>');
         },
         [&](const TextureDepth& texture) {
-            const char* base;
+            ASCIILiteral base;
             switch (texture.kind) {
             case TextureDepth::Kind::TextureDepth2d:
-                base = "depth2d";
+                base = "depth2d"_s;
                 break;
             case TextureDepth::Kind::TextureDepth2dArray:
-                base = "depth2d_array";
+                base = "depth2d_array"_s;
                 break;
             case TextureDepth::Kind::TextureDepthCube:
-                base = "depthcube";
+                base = "depthcube"_s;
                 break;
             case TextureDepth::Kind::TextureDepthCubeArray:
-                base = "depthcube_array";
+                base = "depthcube_array"_s;
                 break;
             case TextureDepth::Kind::TextureDepthMultisampled2d:
-                base = "depth2d_ms";
+                base = "depth2d_ms"_s;
                 break;
             }
             m_stringBuilder.append(base, "<float>"_s);
         },
         [&](const Reference& reference) {
-            const char* addressSpace = serializeAddressSpace(reference.addressSpace);
-            if (!addressSpace) {
+            auto addressSpace = serializeAddressSpace(reference.addressSpace);
+            if (addressSpace.isNull()) {
                 visit(reference.element);
                 return;
             }
@@ -1049,7 +1049,7 @@ void FunctionDefinitionWriter::visit(const Type* type)
             m_stringBuilder.append('&');
         },
         [&](const Pointer& pointer) {
-            const char* addressSpace = serializeAddressSpace(pointer.addressSpace);
+            auto addressSpace = serializeAddressSpace(pointer.addressSpace);
             if (pointer.accessMode == AccessMode::Read)
                 m_stringBuilder.append("const "_s);
             if (addressSpace)
@@ -1128,7 +1128,7 @@ static void visitArguments(FunctionDefinitionWriter* writer, AST::CallExpression
 
 static void emitTextureDimensions(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    const auto& get = [&](const char* property) {
+    const auto& get = [&](ASCIILiteral property) {
         writer->visit(call.arguments()[0]);
         writer->stringBuilder().append(".get_"_s, property, '(');
         if (call.arguments().size() > 1)
@@ -1159,23 +1159,23 @@ static void emitTextureGather(FunctionDefinitionWriter* writer, AST::CallExpress
 {
     ASSERT(call.arguments().size() > 1);
     unsigned offset = 0;
-    const char* component = nullptr;
+    ASCIILiteral component;
     bool hasOffset = true;
     auto& firstArgument = call.arguments()[0];
     if (std::holds_alternative<Types::Primitive>(*firstArgument.inferredType())) {
         offset = 1;
         switch (firstArgument.constantValue()->integerValue()) {
         case 0:
-            component = "x";
+            component = "x"_s;
             break;
         case 1:
-            component = "y";
+            component = "y"_s;
             break;
         case 2:
-            component = "z";
+            component = "z"_s;
             break;
         case 3:
-            component = "w";
+            component = "w"_s;
             break;
         default:
             RELEASE_ASSERT_NOT_REACHED();
@@ -1198,7 +1198,7 @@ static void emitTextureGather(FunctionDefinitionWriter* writer, AST::CallExpress
     }
     if (!hasOffset)
         writer->stringBuilder().append(", int2(0)"_s);
-    if (component)
+    if (!component.isNull())
         writer->stringBuilder().append(", component::"_s, component);
     writer->stringBuilder().append(')');
 }
@@ -1224,15 +1224,15 @@ static void emitTextureLoad(FunctionDefinitionWriter* writer, AST::CallExpressio
         writer->stringBuilder().append(".read"_s);
         writer->stringBuilder().append('(');
         bool is1d = true;
-        const char* cast = "uint";
+        auto cast = "uint"_s;
         if (const auto* vector = std::get_if<Types::Vector>(call.arguments()[1].inferredType())) {
             is1d = false;
             switch (vector->size) {
             case 2:
-                cast = "uint2";
+                cast = "uint2"_s;
                 break;
             case 3:
-                cast = "uint3";
+                cast = "uint3"_s;
                 break;
             default:
                 RELEASE_ASSERT_NOT_REACHED();
@@ -1314,33 +1314,33 @@ static void emitTextureSampleGrad(FunctionDefinitionWriter* writer, AST::CallExp
     auto& textureType = std::get<Types::Texture>(*texture.inferredType());
 
     unsigned gradientIndex;
-    const char* gradientFunction;
+    ASCIILiteral gradientFunction;
     switch (textureType.kind) {
     case Types::Texture::Kind::Texture1d:
     case Types::Texture::Kind::Texture2d:
     case Types::Texture::Kind::TextureMultisampled2d:
         gradientIndex = 3;
-        gradientFunction = "gradient2d";
+        gradientFunction = "gradient2d"_s;
         break;
 
     case Types::Texture::Kind::Texture3d:
         gradientIndex = 3;
-        gradientFunction = "gradient3d";
+        gradientFunction = "gradient3d"_s;
         break;
 
     case Types::Texture::Kind::TextureCube:
         gradientIndex = 3;
-        gradientFunction = "gradientcube";
+        gradientFunction = "gradientcube"_s;
         break;
 
     case Types::Texture::Kind::Texture2dArray:
         gradientIndex = 4;
-        gradientFunction = "gradient2d";
+        gradientFunction = "gradient2d"_s;
         break;
 
     case Types::Texture::Kind::TextureCubeArray:
         gradientIndex = 4;
-        gradientFunction = "gradientcube";
+        gradientFunction = "gradientcube"_s;
         break;
     }
     writer->visit(texture);
@@ -1526,14 +1526,14 @@ static void emitTextureNumSamples(FunctionDefinitionWriter* writer, AST::CallExp
 
 static void emitTextureStore(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
-    const char* cast = "uint";
+    auto cast = "uint"_s;
     if (const auto* vector = std::get_if<Types::Vector>(call.arguments()[1].inferredType())) {
         switch (vector->size) {
         case 2:
-            cast = "uint2";
+            cast = "uint2"_s;
             break;
         case 3:
-            cast = "uint3";
+            cast = "uint3"_s;
             break;
         default:
             RELEASE_ASSERT_NOT_REACHED();
@@ -1586,7 +1586,7 @@ static void emitWorkgroupUniformLoad(FunctionDefinitionWriter* writer, AST::Call
     writer->stringBuilder().append(')');
 }
 
-static void atomicFunction(const char* name, FunctionDefinitionWriter* writer, AST::CallExpression& call)
+static void atomicFunction(ASCIILiteral name, FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
     writer->stringBuilder().append(name, '(');
     bool first = true;
@@ -1690,7 +1690,7 @@ static void emitDynamicOffset(FunctionDefinitionWriter* writer, AST::CallExpress
 {
     auto* targetType = call.target().inferredType();
     auto& pointer = std::get<Types::Pointer>(*targetType);
-    auto* addressSpace = serializeAddressSpace(pointer.addressSpace);
+    auto addressSpace = serializeAddressSpace(pointer.addressSpace);
 
     writer->stringBuilder().append("(*("_s);
     writer->visit(targetType);
@@ -1957,16 +1957,16 @@ void FunctionDefinitionWriter::serializeBinaryExpression(AST::Expression& lhs, A
         if (auto* vectorType = std::get_if<Types::Vector>(rightType))
             rightType = vectorType->element;
 
-        const char* helperFunction = nullptr;
+        ASCIILiteral helperFunction;
         if (satisfies(rightType, Constraints::Integer)) {
             if (isDiv)
-                helperFunction = "__wgslDiv";
+                helperFunction = "__wgslDiv"_s;
             else
-                helperFunction = "__wgslMod";
+                helperFunction = "__wgslMod"_s;
         } else if (isMod)
-            helperFunction = "fmod";
+            helperFunction = "fmod"_s;
 
-        if (helperFunction) {
+        if (!helperFunction.isNull()) {
             m_stringBuilder.append(helperFunction, '(');
             visit(lhs);
             m_stringBuilder.append(", "_s);
@@ -2111,7 +2111,7 @@ void FunctionDefinitionWriter::visit(AST::AbstractFloatLiteral& literal)
     NumberToStringBuffer buffer;
     WTF::numberToStringWithTrailingPoint(literal.value(), buffer);
 
-    m_stringBuilder.append(&buffer[0]);
+    m_stringBuilder.append(span(&buffer[0]));
 }
 
 void FunctionDefinitionWriter::visit(AST::Float32Literal& literal)
@@ -2119,7 +2119,7 @@ void FunctionDefinitionWriter::visit(AST::Float32Literal& literal)
     NumberToStringBuffer buffer;
     WTF::numberToStringWithTrailingPoint(literal.value(), buffer);
 
-    m_stringBuilder.append(&buffer[0]);
+    m_stringBuilder.append(span(&buffer[0]));
 }
 
 void FunctionDefinitionWriter::visit(AST::Float16Literal& literal)
@@ -2127,7 +2127,7 @@ void FunctionDefinitionWriter::visit(AST::Float16Literal& literal)
     NumberToStringBuffer buffer;
     WTF::numberToStringWithTrailingPoint(literal.value(), buffer);
 
-    m_stringBuilder.append(&buffer[0]);
+    m_stringBuilder.append(span(&buffer[0]));
 }
 
 void FunctionDefinitionWriter::visit(AST::Statement& statement)
@@ -2406,19 +2406,19 @@ void FunctionDefinitionWriter::serializeConstant(const Type* type, ConstantValue
             case Primitive::AbstractFloat: {
                 NumberToStringBuffer buffer;
                 WTF::numberToStringWithTrailingPoint(std::get<double>(value), buffer);
-                m_stringBuilder.append(&buffer[0]);
+                m_stringBuilder.append(span(&buffer[0]));
                 break;
             }
             case Primitive::F32: {
                 NumberToStringBuffer buffer;
                 WTF::numberToStringWithTrailingPoint(std::get<float>(value), buffer);
-                m_stringBuilder.append(&buffer[0]);
+                m_stringBuilder.append(span(&buffer[0]));
                 break;
             }
             case Primitive::F16: {
                 NumberToStringBuffer buffer;
                 WTF::numberToStringWithTrailingPoint(std::get<half>(value), buffer);
-                m_stringBuilder.append(&buffer[0], 'h');
+                m_stringBuilder.append(span(&buffer[0]), 'h');
                 break;
             }
             case Primitive::Bool:

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -48,7 +48,7 @@ struct TemplateTypes {
 
     static void appendNameTo(StringBuilder& builder)
     {
-        builder.append(toString(TT), ", ");
+        builder.append(toString(TT), ", "_s);
         TemplateTypes<TTs...>::appendNameTo(builder);
     }
 };
@@ -825,7 +825,7 @@ Result<AST::Structure::Ref> Parser<Lexer>::parseStructure(AST::Attribute::List&&
         PARSE(member, StructureMember);
         auto result = seenMembers.add(member.get().name());
         if (!result.isNewEntry)
-            FAIL(makeString("duplicate member '", member.get().name(), "' in struct '", name, "'"));
+            FAIL(makeString("duplicate member '"_s, member.get().name(), "' in struct '"_s, name, '\''));
         members.append(member);
         if (current().type == TokenType::Comma)
             consume();
@@ -834,7 +834,7 @@ Result<AST::Structure::Ref> Parser<Lexer>::parseStructure(AST::Attribute::List&&
     }
 
     if (members.isEmpty())
-        FAIL(makeString("structures must have at least one member"));
+        FAIL("structures must have at least one member"_str);
 
     CONSUME_TYPE(BraceRight);
 


### PR DESCRIPTION
#### d66a7a4500272a9a2e71925dcf30497f14b983f3
<pre>
Stop using `const char*` in string concatenation in JSC
<a href="https://bugs.webkit.org/show_bug.cgi?id=273756">https://bugs.webkit.org/show_bug.cgi?id=273756</a>

Reviewed by Tim Nguyen.

This is a step towards removing the StringTypeAdapter specializations
for `const char*`.

* Source/JavaScriptCore/API/JSAPIGlobalObject.mm:
(JSC::JSAPIGlobalObject::moduleLoaderFetch):
* Source/JavaScriptCore/API/JSContextRef.cpp:
(BacktraceFunctor::operator() const):
* Source/JavaScriptCore/API/JSScript.mm:
(-[JSScript writeCache:]):
* Source/JavaScriptCore/API/tests/ExecutionTimeLimitTest.cpp:
(testExecutionTimeLimit):
* Source/JavaScriptCore/dfg/DFGCFAPhase.cpp:
(JSC::DFG::CFAPhase::performBlockCFA):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::opName):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp:
(JSC::edgeTypeToString):
(JSC::snapshotTypeToString):
(JSC::HeapSnapshotBuilder::json):
* Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp:
(Inspector::BackendDispatcher::getPropertyValue):
(Inspector::BackendDispatcher::getBoolean):
(Inspector::BackendDispatcher::getInteger):
(Inspector::BackendDispatcher::getDouble):
(Inspector::BackendDispatcher::getString):
(Inspector::BackendDispatcher::getValue):
(Inspector::BackendDispatcher::getObject):
(Inspector::BackendDispatcher::getArray):
* Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h:
* Source/JavaScriptCore/interpreter/StackVisitor.cpp:
(JSC::StackVisitor::Frame::toString const):
* Source/JavaScriptCore/jsc.cpp:
* Source/JavaScriptCore/parser/Parser.h:
(JSC::Parser::updateErrorWithNameAndMessage):
* Source/JavaScriptCore/runtime/AtomicsObject.cpp:
* Source/JavaScriptCore/runtime/BigIntConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ConsoleClient.cpp:
(JSC::ConsoleClient::printConsoleMessageWithArguments):
* Source/JavaScriptCore/runtime/Error.cpp:
(JSC::makeDOMAttributeGetterTypeErrorMessage):
(JSC::makeDOMAttributeSetterTypeErrorMessage):
(JSC::throwConstructorCannotBeCalledAsFunctionTypeError):
* Source/JavaScriptCore/runtime/Error.h:
* Source/JavaScriptCore/runtime/ErrorPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ExceptionHelpers.cpp:
(JSC::notAFunctionSourceAppender):
(JSC::createErrorForInvalidGlobalFunctionDeclaration):
(JSC::createErrorForInvalidGlobalVarDeclaration):
* Source/JavaScriptCore/runtime/FinalizationRegistryConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/FunctionConstructor.cpp:
(JSC::stringifyFunction):
* Source/JavaScriptCore/runtime/FunctionExecutable.cpp:
(JSC::FunctionExecutable::toStringSlow):
* Source/JavaScriptCore/runtime/FunctionPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::IntlDateTimeFormat::initializeDateTimeFormat):
(JSC::IntlDateTimeFormat::createDateIntervalFormatIfNecessary):
* Source/JavaScriptCore/runtime/IntlDisplayNamesConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlDurationFormatConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlListFormatConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlLocaleConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlPluralRulesConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlRelativeTimeFormatConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlSegmenterConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSArrayBufferConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSCJSValue.h:
* Source/JavaScriptCore/runtime/JSCJSValueInlines.h:
(JSC::JSValue::toIndex const):
* Source/JavaScriptCore/runtime/JSDataViewPrototype.cpp:
(JSC::getData):
(JSC::setData):
* Source/JavaScriptCore/runtime/JSFunction.cpp:
(JSC::JSFunction::toString):
(JSC::JSFunction::setFunctionName):
(JSC::JSFunction::reifyName):
* Source/JavaScriptCore/runtime/JSFunctionInlines.h:
(JSC::makeNameWithOutOfMemoryCheck):
(JSC::JSFunction::originalName):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::defineOwnProperty):
* Source/JavaScriptCore/runtime/JSModuleRecord.cpp:
(JSC::JSModuleRecord::instantiateDeclarations):
* Source/JavaScriptCore/runtime/MapConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/NativeExecutable.cpp:
(JSC::NativeExecutable::toStringSlow):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::OptionsHelper::Option::name const):
(JSC::OptionsHelper::Option::description const):
(JSC::invertBoolOptionValue):
(JSC::Options::setAliasedOption):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/runtime/ProxyConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ProxyObject.cpp:
(JSC::ProxyObject::getHandlerTrap):
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::toSourceString const):
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::SamplingProfiler::reportTopBytecodes):
* Source/JavaScriptCore/runtime/SetConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ShadowRealmConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalCalendarConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalDurationConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalInstantConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalPlainDateConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalPlainDateTimeConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalPlainTimeConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalTimeZoneConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TypeSet.cpp:
(JSC::StructureShape::stringRepresentation):
* Source/JavaScriptCore/runtime/WeakMapConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/WeakObjectRefConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/WeakSetConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/WasmBBQDisassembler.cpp:
(JSC::Wasm::BBQDisassembler::dumpVectorForInstructions):
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::prepareImpl):
* Source/JavaScriptCore/wasm/WasmBranchHintsSectionParser.cpp:
(JSC::Wasm::BranchHintsSectionParser::parse):
* Source/JavaScriptCore/wasm/WasmCompilationMode.cpp:
(JSC::Wasm::makeString):
* Source/JavaScriptCore/wasm/WasmCompilationMode.h:
* Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp:
(JSC::Wasm::ConstExprGenerator::addArrayNew):
(JSC::Wasm::ConstExprGenerator::addArrayNewDefault):
(JSC::Wasm::ConstExprGenerator::addArrayNewFixed):
(JSC::Wasm::ConstExprGenerator::addStructNewDefault):
(JSC::Wasm::ConstExprGenerator::addStructNew):
(JSC::Wasm::ConstExprGenerator::addAnyConvertExtern):
(JSC::Wasm::ConstExprGenerator::addExternConvertAny):
* Source/JavaScriptCore/wasm/WasmEntryPlan.cpp:
(JSC::Wasm::EntryPlan::prepare):
* Source/JavaScriptCore/wasm/WasmEntryPlan.h:
(JSC::Wasm::EntryPlan::tryReserveCapacity):
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::makeString):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParserTypes::TypedExpression::dump const):
(JSC::Wasm::FunctionParser::typeToStringModuleRelative const):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parse):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseConstantExpression):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseBody):
(JSC::Wasm::FunctionParser&lt;Context&gt;::binaryCase):
(JSC::Wasm::FunctionParser&lt;Context&gt;::unaryCase):
(JSC::Wasm::FunctionParser&lt;Context&gt;::load):
(JSC::Wasm::FunctionParser&lt;Context&gt;::store):
(JSC::Wasm::FunctionParser&lt;Context&gt;::truncSaturated):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicLoad):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicStore):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicBinaryRMW):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicCompareExchange):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicWait):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicNotify):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicFence):
(JSC::Wasm::FunctionParser&lt;Context&gt;::simd):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseTableIndex):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseIndexForLocal):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseIndexForGlobal):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseFunctionIndex):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExceptionIndex):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseBranchTarget):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseDelegateTarget):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseElementIndex):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseDataSegmentIndex):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseTableCopyImmediates):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseAnnotatedSelectImmediates):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseMemoryFillImmediate):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseMemoryCopyImmediates):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseMemoryInitImmediates):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseStructTypeIndex):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseStructFieldIndex):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseStructTypeIndexAndFieldIndex):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseStructFieldManipulation):
(JSC::Wasm::FunctionParser&lt;Context&gt;::checkBranchTarget):
(JSC::Wasm::FunctionParser&lt;Context&gt;::checkLocalInitialized):
(JSC::Wasm::FunctionParser&lt;Context&gt;::unify):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseArrayTypeDefinition):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):
* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
(JSC::Wasm::IPIntPlan::prepareImpl):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::prepareImpl):
* Source/JavaScriptCore/wasm/WasmNameSectionParser.cpp:
(JSC::Wasm::NameSectionParser::parse):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addLocal):
(JSC::Wasm::OMGIRGenerator::addArguments):
* Source/JavaScriptCore/wasm/WasmParser.h:
(JSC::Wasm::ParserBase::parseImmLaneIdx):
(JSC::Wasm::ParserBase::parseBlockSignature):
(JSC::Wasm::ParserBase::parseReftypeSignature):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseType):
(JSC::Wasm::SectionParser::parseImport):
(JSC::Wasm::SectionParser::parseFunction):
(JSC::Wasm::SectionParser::parseResizableLimits):
(JSC::Wasm::SectionParser::parseTableHelper):
(JSC::Wasm::SectionParser::parseTable):
(JSC::Wasm::SectionParser::parseMemoryHelper):
(JSC::Wasm::SectionParser::parseMemory):
(JSC::Wasm::SectionParser::parseGlobal):
(JSC::Wasm::SectionParser::parseExport):
(JSC::Wasm::SectionParser::parseStart):
(JSC::Wasm::SectionParser::parseElement):
(JSC::Wasm::SectionParser::parseInitExpr):
(JSC::Wasm::SectionParser::validateElementTableIdx):
(JSC::Wasm::SectionParser::parseFunctionType):
(JSC::Wasm::SectionParser::parsePackedType):
(JSC::Wasm::SectionParser::parseStorageType):
(JSC::Wasm::SectionParser::parseStructType):
(JSC::Wasm::SectionParser::parseArrayType):
(JSC::Wasm::SectionParser::parseRecursionGroup):
(JSC::Wasm::SectionParser::checkSubtypeValidity):
(JSC::Wasm::SectionParser::parseSubtype):
(JSC::Wasm::SectionParser::parseElementKind):
(JSC::Wasm::SectionParser::parseIndexCountForElementSection):
(JSC::Wasm::SectionParser::parseElementSegmentVectorOfExpressions):
(JSC::Wasm::SectionParser::parseElementSegmentVectorOfIndexes):
(JSC::Wasm::SectionParser::parseGlobalType):
(JSC::Wasm::SectionParser::parseData):
(JSC::Wasm::SectionParser::parseDataCount):
(JSC::Wasm::SectionParser::parseException):
(JSC::Wasm::SectionParser::parseCustom):
* Source/JavaScriptCore/wasm/WasmSections.h:
(JSC::Wasm::makeString):
* Source/JavaScriptCore/wasm/WasmStreamingParser.cpp:
(JSC::Wasm::StreamingParser::fail):
(JSC::Wasm::dumpWasmSource):
(JSC::Wasm::StreamingParser::parseModuleHeader):
(JSC::Wasm::StreamingParser::parseSectionID):
(JSC::Wasm::StreamingParser::parseCodeSectionSize):
(JSC::Wasm::StreamingParser::parseFunctionSize):
(JSC::Wasm::StreamingParser::parseFunctionPayload):
(JSC::Wasm::StreamingParser::parseSectionPayload):
(JSC::Wasm::StreamingParser::addBytes):
(JSC::Wasm::StreamingParser::failOnState):
(JSC::Wasm::StreamingParser::finalize):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::makeString):
* Source/JavaScriptCore/wasm/generateWasmOpsHeader.py:
* Source/JavaScriptCore/wasm/js/WebAssemblyArrayConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyInstanceConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeImports):
* Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyTagConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WTF/wtf/DateMath.cpp:
(WTF::makeRFC2822DateString):
* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::encodeForFileName):
* Source/WTF/wtf/Logger.cpp:
(WTF::Logger::LogSiteIdentifier::toString const):
* Source/WTF/wtf/NativePromise.h:
(WTF::LogArgument&lt;GenericPromise&gt;::toString):
* Source/WTF/wtf/URL.cpp:
(WTF::removeQueryParameters):
* Source/WTF/wtf/URLParser.cpp:
(WTF::URLParser::URLParser):
* Source/WTF/wtf/cocoa/ResourceUsageCocoa.cpp:
(WTF::logFootprintComparison):
* Source/WTF/wtf/text/StringConcatenate.h:
* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
(WGSL::AST::Indent::Indent):
* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::AttributeValidator::visit):
(WGSL::AttributeValidator::parseBuiltin):
(WGSL::AttributeValidator::parseLocation):
(WGSL::AttributeValidator::validateInterpolation):
(WGSL::AttributeValidator::validateInvariant):
(WGSL::AttributeValidator::update):
(WGSL::AttributeValidator::set):
(WGSL::AttributeValidator::validateIO):
(WGSL::AttributeValidator::validateBuiltinIO):
(WGSL::AttributeValidator::validateLocationIO):
(WGSL::AttributeValidator::validateStructIO):
* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::CONSTANT_FUNCTION):
(WGSL::UNARY_OPERATION):
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::rewrite):
(WGSL::EntryPointRewriter::checkReturnType):
(WGSL::EntryPointRewriter::visit):
* Source/WebGPU/WGSL/GlobalSorting.cpp:
(WGSL::reorder):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::visitCallee):
(WGSL::RewriteGlobalVariables::getPacking):
(WGSL::RewriteGlobalVariables::collectGlobals):
(WGSL::RewriteGlobalVariables::packStructType):
(WGSL::RewriteGlobalVariables::determineUsedGlobals):
(WGSL::RewriteGlobalVariables::insertStructs):
(WGSL::RewriteGlobalVariables::insertMaterializations):
(WGSL::RewriteGlobalVariables::storeInitialValue):
(WGSL::RewriteGlobalVariables::argumentBufferParameterName):
(WGSL::RewriteGlobalVariables::argumentBufferStructName):
(WGSL::RewriteGlobalVariables::dynamicOffsetVariableName):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::serializeAddressSpace):
(WGSL::Metal::convertToSampleMode):
(WGSL::Metal::FunctionDefinitionWriter::visit):
(WGSL::Metal::emitTextureDimensions):
(WGSL::Metal::emitTextureGather):
(WGSL::Metal::emitTextureLoad):
(WGSL::Metal::emitTextureSampleGrad):
(WGSL::Metal::emitTextureStore):
(WGSL::Metal::atomicFunction):
(WGSL::Metal::emitDynamicOffset):
(WGSL::Metal::FunctionDefinitionWriter::serializeBinaryExpression):
(WGSL::Metal::FunctionDefinitionWriter::serializeConstant):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::TemplateTypes::appendNameTo):
(WGSL::Parser&lt;Lexer&gt;::parseStructure):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::TypeChecker):
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::bitcast):
(WGSL::TypeChecker::lookupType):
(WGSL::TypeChecker::vectorFieldAccess):
(WGSL::TypeChecker::chooseOverload):
(WGSL::TypeChecker::analyze):
(WGSL::TypeChecker::resolve):
(WGSL::TypeChecker::introduceType):
(WGSL::TypeChecker::convertValue):
(WGSL::TypeChecker::introduceValue):
(WGSL::TypeChecker::introduceFunction):
(WGSL::TypeChecker::allocateSimpleConstructor):
(WGSL::TypeChecker::allocateTextureStorageConstructor):
(WGSL::TypeChecker::texelFormat):
(WGSL::TypeChecker::accessMode):
(WGSL::TypeChecker::addressSpace):

Canonical link: <a href="https://commits.webkit.org/278403@main">https://commits.webkit.org/278403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ded6c9029a8251bbd4d0e5b28995c2ad8627ab79

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53668 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1099 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/749 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41117 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27374 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43399 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22221 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24790 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/656 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8787 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43741 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46768 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/718 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55257 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/49908 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25507 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/641 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48524 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47562 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27630 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57387 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7293 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26500 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11789 "Passed tests") | 
<!--EWS-Status-Bubble-End-->