### PR TITLE
[GLIB] Factor out GRefPtr<> serialization to a new argument coder

### DIFF
--- a/Source/WebKit/Shared/glib/ArgumentCodersGLib.h
+++ b/Source/WebKit/Shared/glib/ArgumentCodersGLib.h
@@ -35,19 +35,19 @@ typedef struct _GVariant GVariant;
 
 namespace IPC {
 
-template<> struct ArgumentCoder<GRefPtr<GByteArray>> {
-    static void encode(Encoder&, const GRefPtr<GByteArray>&);
-    static std::optional<GRefPtr<GByteArray>> decode(Decoder&);
+template<> struct ArgumentCoder<GByteArray*> {
+    static void encode(Encoder&, GByteArray*);
+    static std::optional<GByteArray*> decode(Decoder&);
 };
 
-template<> struct ArgumentCoder<GRefPtr<GVariant>> {
-    static void encode(Encoder&, const GRefPtr<GVariant>&);
-    static std::optional<GRefPtr<GVariant>> decode(Decoder&);
+template<> struct ArgumentCoder<GVariant*> {
+    static void encode(Encoder&, GVariant*);
+    static std::optional<GVariant*> decode(Decoder&);
 };
 
-template<> struct ArgumentCoder<GRefPtr<GTlsCertificate>> {
-    static void encode(Encoder&, const GRefPtr<GTlsCertificate>&);
-    static std::optional<GRefPtr<GTlsCertificate>> decode(Decoder&);
+template<> struct ArgumentCoder<GTlsCertificate*> {
+    static void encode(Encoder&, GTlsCertificate*);
+    static std::optional<GTlsCertificate*> decode(Decoder&);
 };
 
 template<> struct ArgumentCoder<GTlsCertificateFlags> {
@@ -55,9 +55,9 @@ template<> struct ArgumentCoder<GTlsCertificateFlags> {
     static std::optional<GTlsCertificateFlags> decode(Decoder&);
 };
 
-template<> struct ArgumentCoder<GRefPtr<GUnixFDList>> {
-    static void encode(Encoder&, const GRefPtr<GUnixFDList>&);
-    static std::optional<GRefPtr<GUnixFDList>> decode(Decoder&);
+template<> struct ArgumentCoder<GUnixFDList*> {
+    static void encode(Encoder&, GUnixFDList*);
+    static std::optional<GUnixFDList*> decode(Decoder&);
 };
 
 } // namespace IPC

--- a/Source/WebKit/Shared/gtk/ArgumentCodersGtk.cpp
+++ b/Source/WebKit/Shared/gtk/ArgumentCodersGtk.cpp
@@ -39,14 +39,14 @@ namespace IPC {
 using namespace WebCore;
 using namespace WebKit;
 
-void ArgumentCoder<GRefPtr<GtkPrintSettings>>::encode(Encoder& encoder, const GRefPtr<GtkPrintSettings>& argument)
+void ArgumentCoder<GtkPrintSettings*>::encode(Encoder& encoder, GtkPrintSettings* argument)
 {
     GRefPtr<GtkPrintSettings> printSettings = argument ? argument : adoptGRef(gtk_print_settings_new());
     GRefPtr<GVariant> variant = adoptGRef(gtk_print_settings_to_gvariant(printSettings.get()));
     encoder << variant;
 }
 
-std::optional<GRefPtr<GtkPrintSettings>> ArgumentCoder<GRefPtr<GtkPrintSettings>>::decode(Decoder& decoder)
+std::optional<GtkPrintSettings*> ArgumentCoder<GtkPrintSettings*>::decode(Decoder& decoder)
 {
     auto variant = decoder.decode<GRefPtr<GVariant>>();
     if (UNLIKELY(!variant))
@@ -55,14 +55,14 @@ std::optional<GRefPtr<GtkPrintSettings>> ArgumentCoder<GRefPtr<GtkPrintSettings>
     return gtk_print_settings_new_from_gvariant(variant->get());
 }
 
-void ArgumentCoder<GRefPtr<GtkPageSetup>>::encode(Encoder& encoder, const GRefPtr<GtkPageSetup>& argument)
+void ArgumentCoder<GtkPageSetup*>::encode(Encoder& encoder, GtkPageSetup* argument)
 {
     GRefPtr<GtkPageSetup> pageSetup = argument ? argument : adoptGRef(gtk_page_setup_new());
     GRefPtr<GVariant> variant = adoptGRef(gtk_page_setup_to_gvariant(pageSetup.get()));
     encoder << variant;
 }
 
-std::optional<GRefPtr<GtkPageSetup>> ArgumentCoder<GRefPtr<GtkPageSetup>>::decode(Decoder& decoder)
+std::optional<GtkPageSetup*> ArgumentCoder<GtkPageSetup*>::decode(Decoder& decoder)
 {
     auto variant = decoder.decode<GRefPtr<GVariant>>();
     if (UNLIKELY(!variant))

--- a/Source/WebKit/Shared/gtk/ArgumentCodersGtk.h
+++ b/Source/WebKit/Shared/gtk/ArgumentCodersGtk.h
@@ -37,14 +37,14 @@ class SelectionData;
 
 namespace IPC {
 
-template<> struct ArgumentCoder<GRefPtr<GtkPrintSettings>> {
-    static void encode(Encoder&, const GRefPtr<GtkPrintSettings>&);
-    static std::optional<GRefPtr<GtkPrintSettings>> decode(Decoder&);
+template<> struct ArgumentCoder<GtkPrintSettings*> {
+    static void encode(Encoder&, GtkPrintSettings*);
+    static std::optional<GtkPrintSettings*> decode(Decoder&);
 };
 
-template<> struct ArgumentCoder<GRefPtr<GtkPageSetup>> {
-    static void encode(Encoder&, const GRefPtr<GtkPageSetup>&);
-    static std::optional<GRefPtr<GtkPageSetup>> decode(Decoder&);
+template<> struct ArgumentCoder<GtkPageSetup*> {
+    static void encode(Encoder&, GtkPageSetup*);
+    static std::optional<GtkPageSetup*> decode(Decoder&);
 };
 
 } // namespace IPC


### PR DESCRIPTION
#### c11badf6f7585170683101774a8feb6de49f20ac
<pre>
[GLIB] Factor out GRefPtr&lt;&gt; serialization to a new argument coder
<a href="https://bugs.webkit.org/show_bug.cgi?id=273762">https://bugs.webkit.org/show_bug.cgi?id=273762</a>

Reviewed by NOBODY (OOPS!).

Instead of having several argument coders dealing with the possibility
of a GRefPtr&lt;&gt; being empty, factor that logic out to a single argument
coder for GRefPtr&lt;T&gt;, and let other coders handle non-NULL GLib structures
instead.

* Source/WebKit/Platform/IPC/glib/ArgumentCodersGlib.h:
(IPC::ArgumentCoder&lt;GRefPtr&lt;T&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;T&gt;&gt;::decode):
* Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp:
(IPC::&gt;::encode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GByteArray&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;GRefPtr&lt;GByteArray&gt;&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;GRefPtr&lt;GVariant&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;GRefPtr&lt;GVariant&gt;&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;GRefPtr&lt;GTlsCertificate&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;GRefPtr&lt;GTlsCertificate&gt;&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;GRefPtr&lt;GUnixFDList&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;GRefPtr&lt;GUnixFDList&gt;&gt;::decode): Deleted.
* Source/WebKit/Shared/glib/ArgumentCodersGLib.h:
* Source/WebKit/Shared/gtk/ArgumentCodersGtk.cpp:
(IPC::&gt;::encode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GtkPrintSettings&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;GRefPtr&lt;GtkPrintSettings&gt;&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;GRefPtr&lt;GtkPageSetup&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;GRefPtr&lt;GtkPageSetup&gt;&gt;::decode): Deleted.
* Source/WebKit/Shared/gtk/ArgumentCodersGtk.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c11badf6f7585170683101774a8feb6de49f20ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29714 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53679 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1110 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41124 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43408 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22228 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24794 "Found unexpected failure with change (failure)") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8798 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46772 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/727 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55268 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25518 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/651 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48554 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26779 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43574 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47570 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27641 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26511 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->