### PR TITLE
Improve test coverage of sink values for trusted types [part1].

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5503,6 +5503,7 @@ webkit.org/b/261849 imported/w3c/web-platform-tests/css/css-scroll-anchoring/zer
 webkit.org/b/261849 imported/w3c/web-platform-tests/css/css-scroll-anchoring/start-edge-in-block-layout-direction.html [ Skip ]
 
 # Trusted Types aren't fully implemented yet
+webkit.org/b/272196 imported/w3c/web-platform-tests/trusted-types/trusted-types-createHTMLDocument.html [ Pass Failure ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-eval.html [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting.html [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-Document-execCommand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-Document-execCommand.html
@@ -35,7 +35,11 @@
   }
 
   // Test that with a default policy, all comamnds will work again.
-  trustedTypes.createPolicy("default", {"createHTML": x => x});
+  trustedTypes.createPolicy("default", {"createHTML": (x, _, sink) => {
+    assert_equals(sink, 'Document execCommand');
+    return x;
+  }});
+
   for (const command of commands) {
     test(t => {
       document.execCommand(command, false, "<em>Hello World</em>");

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-DOMWindowTimers-setTimeout-setInterval.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-DOMWindowTimers-setTimeout-setInterval.html
@@ -54,7 +54,14 @@
     });
   }, "`window.setInterval(null)` throws.");
 
-  let policy = window.trustedTypes.createPolicy("default", { createScript: x => "0" });
+  let policy = window.trustedTypes.createPolicy("default", { createScript: (x, _, sink) => {
+    if (x === "timeoutTestString") {
+      assert_equals(sink, 'Window setTimeout');
+    } else if (x === "intervalTestString") {
+      assert_equals(sink, 'Window setInterval');
+    }
+    return "0";
+  }});
   // After default policy creation string assignment implicitly calls createScript.
   test(t => {
     setTimeout(INPUTS.SCRIPT);

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/modify-attributes-in-callback.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/modify-attributes-in-callback.html
@@ -13,7 +13,8 @@
 
   let target = "data-x";
   trustedTypes.createPolicy("default", {
-    createHTML: (s) => {
+    createHTML: (s, _, sink) => {
+      assert_equals(sink, 'HTMLIFrameElement srcdoc');
       iframe.removeAttribute(target);
       return s;
     }

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/require-trusted-types-for.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/require-trusted-types-for.html
@@ -64,7 +64,10 @@
     return new Promise(resolve => {
       p = trustedTypes.createPolicy("policyA", {createScript: s => s + 1});
       p1 = trustedTypes.createPolicy("policyA", {createHTML: _ => ""});
-      p2 = trustedTypes.createPolicy("default", {createScript: s => s});
+      p2 = trustedTypes.createPolicy("default", {createScript: (s, _, sink) => {
+        assert_equals(sink, 'HTMLScriptElement innerText');
+        return s;
+      }});
       script = p.createScript("1");
       assert_equals(script.toString(), "11");
       s = document.createElement("script");

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-createHTMLDocument.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-createHTMLDocument.html
@@ -55,8 +55,12 @@ for (let doc_type in doc_types) {
 // (which hanve't yet run).
 promise_test(t => {
   return new Promise(resolve => {
-    trustedTypes.createPolicy("default",
-                              { createHTML: s => s + " [default]" });
+    trustedTypes.createPolicy("default", {
+      createHTML: (s, _, sink) => {
+        assert_equals(sink, 'Element innerHTML');
+        return s + " [default]";
+      }
+    });
     resolve();
   });
 }, "Install default policy.")

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-duplicate-names-without-enforcement.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-duplicate-names-without-enforcement.html
@@ -6,6 +6,10 @@
 <body>
 <script>
 const policy = { createHTML: a => a };
+const policy_default = { createHTML: (a, _, sink) => {
+  assert_equals(sink, 'Element innerHTML');
+  return a;
+}};
 
 test(t => {
   // The spec demands that duplicate policies are allowed when TT is not
@@ -20,11 +24,11 @@ test(t => {
 test(t => {
   // The spec demands that duplicate "default" policy creation fails, even
   // when TT is not enforced.
-  let p = trustedTypes.createPolicy("default", policy);
+  let p = trustedTypes.createPolicy("default", policy_default);
   assert_true(p instanceof TrustedTypePolicy);
 
   // The second instance should throw:
-  assert_throws_js(TypeError, _ => trustedTypes.createPolicy("default", policy));
+  assert_throws_js(TypeError, _ => trustedTypes.createPolicy("default", policy_default));
 }, "createPolicy - duplicate \"default\" policy is never allowed.");
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/worker-constructor.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/worker-constructor.https.html
@@ -64,7 +64,16 @@ promise_test(t => {
 // Tests with default policy.
 promise_test(t => {
   trustedTypes.createPolicy("default", {
-      createScriptURL: s => s.replace("potato", "https") });
+    createScriptURL: (s, _, sink) => {
+      if (s === "Worker") {
+        assert_equals(sink, 'Worker constructor');
+      } else if (s === "SharedWorker") {
+        assert_equals(sink, 'SharedWorker constructor');
+      } else if (s == "service_worker") {
+        assert_equals(sink, 'ServiceWorkerContainer register');
+      }
+      return s.replace("potato", "https");
+    }});
   return Promise.resolve();
 }, "Setup default policy.");
 


### PR DESCRIPTION
#### 885b108aec57dca7af8f4b473fdbb274b79d6f54
<pre>
Improve test coverage of sink values for trusted types [part1].
<a href="https://bugs.webkit.org/show_bug.cgi?id=273763">https://bugs.webkit.org/show_bug.cgi?id=273763</a>

Reviewed by Manuel Rego Casasnovas.

Check the sink value for defaul policy in the tests.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-Document-execCommand.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-DOMWindowTimers-setTimeout-setInterval.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/modify-attributes-in-callback.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/require-trusted-types-for.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-createHTMLDocument.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-duplicate-names-without-enforcement.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/worker-constructor.https.html:

Canonical link: <a href="https://commits.webkit.org/279045@main">https://commits.webkit.org/279045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2b359121b5baf96cc53645a350c78d3c1f0e18c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51764 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55030 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2456 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37447 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42116 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1514 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28705 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44652 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23246 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25995 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1912 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/650 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47954 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2004 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56623 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26885 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49521 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28122 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44740 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48760 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11432 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29019 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27859 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->