### PR TITLE
[Skia] Implement FEDropShadow and FEComponentTransfer filters

### DIFF
--- a/LayoutTests/css3/filters/effect-drop-shadow-clip-abspos.html
+++ b/LayoutTests/css3/filters/effect-drop-shadow-clip-abspos.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-10" />
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-1727" />
 <style>
 .container {
     filter: drop-shadow(5px 5px 5px black);

--- a/LayoutTests/imported/blink/css3/filters/effect-drop-shadow-clip-abspos.html
+++ b/LayoutTests/imported/blink/css3/filters/effect-drop-shadow-clip-abspos.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name="fuzzy" content="maxDifference=1; totalPixels=4-28" />
+<meta name="fuzzy" content="maxDifference=2; totalPixels=0-1021" />
 <style>
 .container {
     -webkit-filter: drop-shadow(5px 5px 5px black);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filters-drop-shadow-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filters-drop-shadow-002.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=350411">
 <link rel="match" href="reference/filters-drop-shadow-002-ref.html">
 <meta name="assert" content="Check that clipping gets correctly applied on children of a container with a drop-shadow filter in effect."/>
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-28" />
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-1021" />
 <style>
 .container {
     filter: drop-shadow(5px 5px 5px black);

--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -24,6 +24,8 @@
 page/skia/MemoryReleaseSkia.cpp
 
 platform/graphics/filters/skia/FEColorMatrixSkiaApplier.cpp
+platform/graphics/filters/skia/FEComponentTransferSkiaApplier.cpp
+platform/graphics/filters/skia/FEDropShadowSkiaApplier.cpp
 platform/graphics/filters/skia/FEGaussianBlurSkiaApplier.cpp
 platform/graphics/filters/skia/SourceGraphicSkiaApplier.cpp
 

--- a/Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp
@@ -33,6 +33,10 @@
 #include "FEComponentTransferCoreImageApplier.h"
 #endif
 
+#if USE(SKIA)
+#include "FEComponentTransferSkiaApplier.h"
+#endif
+
 namespace WebCore {
 
 Ref<FEComponentTransfer> FEComponentTransfer::create(const ComponentTransferFunction& redFunction, const ComponentTransferFunction& greenFunction, const ComponentTransferFunction& blueFunction, const ComponentTransferFunction& alphaFunction, DestinationColorSpace colorSpace)
@@ -65,6 +69,9 @@ bool FEComponentTransfer::operator==(const FEComponentTransfer& other) const
 OptionSet<FilterRenderingMode> FEComponentTransfer::supportedFilterRenderingModes() const
 {
     OptionSet<FilterRenderingMode> modes = FilterRenderingMode::Software;
+#if USE(SKIA)
+    modes.add(FilterRenderingMode::Accelerated);
+#endif
 #if USE(CORE_IMAGE)
     if (FEComponentTransferCoreImageApplier::supportsCoreImageRendering(*this))
         modes.add(FilterRenderingMode::Accelerated);
@@ -76,6 +83,8 @@ std::unique_ptr<FilterEffectApplier> FEComponentTransfer::createAcceleratedAppli
 {
 #if USE(CORE_IMAGE)
     return FilterEffectApplier::create<FEComponentTransferCoreImageApplier>(*this);
+#elif USE(SKIA)
+    return FilterEffectApplier::create<FEComponentTransferSkiaApplier>(*this);
 #else
     return nullptr;
 #endif
@@ -83,7 +92,11 @@ std::unique_ptr<FilterEffectApplier> FEComponentTransfer::createAcceleratedAppli
 
 std::unique_ptr<FilterEffectApplier> FEComponentTransfer::createSoftwareApplier() const
 {
+#if USE(SKIA)
+    return FilterEffectApplier::create<FEComponentTransferSkiaApplier>(*this);
+#else
     return FilterEffectApplier::create<FEComponentTransferSoftwareApplier>(*this);
+#endif
 }
 
 bool FEComponentTransfer::setType(ComponentTransferChannel channel, ComponentTransferType type)

--- a/Source/WebCore/platform/graphics/filters/FEDropShadow.h
+++ b/Source/WebCore/platform/graphics/filters/FEDropShadow.h
@@ -64,6 +64,7 @@ private:
 
     OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const override;
 
+    std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
     std::optional<GraphicsStyle> createGraphicsStyle(const Filter&) const override;
 

--- a/Source/WebCore/platform/graphics/filters/skia/FEComponentTransferSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/FEComponentTransferSkiaApplier.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FEComponentTransferSkiaApplier.h"
+
+#if USE(SKIA)
+
+#include "FEComponentTransfer.h"
+#include "FilterImage.h"
+#include "GraphicsContext.h"
+#include "ImageBuffer.h"
+#include "NativeImage.h"
+#include <skia/core/SkCanvas.h>
+#include <skia/core/SkColorFilter.h>
+
+namespace WebCore {
+
+bool FEComponentTransferSkiaApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
+{
+    ASSERT(inputs.size() == 1);
+    auto& input = inputs[0].get();
+
+    RefPtr resultImage = result.imageBuffer();
+    RefPtr sourceImage = input.imageBuffer();
+    if (!resultImage || !sourceImage)
+        return false;
+
+    auto nativeImage = sourceImage->createNativeImageReference();
+    if (!nativeImage || !nativeImage->platformImage())
+        return false;
+
+    auto alphaTable = m_effect.computeLookupTable(m_effect.alphaFunction());
+    auto redTable = m_effect.computeLookupTable(m_effect.redFunction());
+    auto greenTable = m_effect.computeLookupTable(m_effect.greenFunction());
+    auto blueTable = m_effect.computeLookupTable(m_effect.blueFunction());
+
+    SkPaint paint;
+    paint.setColorFilter(SkColorFilters::TableARGB(alphaTable.data(), redTable.data(), greenTable.data(), blueTable.data()));
+
+    auto inputOffsetWithinResult = input.absoluteImageRectRelativeTo(result).location();
+    resultImage->context().platformContext()->drawImage(nativeImage->platformImage(), inputOffsetWithinResult.x(), inputOffsetWithinResult.y(), { }, &paint);
+    return true;
+}
+
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/filters/skia/FEComponentTransferSkiaApplier.h
+++ b/Source/WebCore/platform/graphics/filters/skia/FEComponentTransferSkiaApplier.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(SKIA)
+
+#include "FilterEffectApplier.h"
+
+namespace WebCore {
+
+class FEComponentTransfer;
+struct ComponentTransferFunction;
+
+class FEComponentTransferSkiaApplier final : public FilterEffectConcreteApplier<FEComponentTransfer> {
+    WTF_MAKE_FAST_ALLOCATED;
+    using Base = FilterEffectConcreteApplier<FEComponentTransfer>;
+
+public:
+    using Base::Base;
+
+private:
+    bool apply(const Filter&, const FilterImageVector&, FilterImage&) const final;
+};
+
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/filters/skia/FEDropShadowSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/FEDropShadowSkiaApplier.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FEDropShadowSkiaApplier.h"
+
+#if USE(SKIA)
+
+#include "FEDropShadow.h"
+#include "Filter.h"
+#include "FilterImage.h"
+#include "GraphicsContext.h"
+#include "ImageBuffer.h"
+#include "NativeImage.h"
+#include <skia/core/SkCanvas.h>
+#include <skia/effects/SkImageFilters.h>
+
+namespace WebCore {
+
+bool FEDropShadowSkiaApplier::apply(const Filter& filter, const FilterImageVector& inputs, FilterImage& result) const
+{
+    ASSERT(inputs.size() == 1);
+    auto& input = inputs[0].get();
+
+    RefPtr resultImage = result.imageBuffer();
+    RefPtr sourceImage = input.imageBuffer();
+    if (!resultImage || !sourceImage)
+        return false;
+
+    auto nativeImage = sourceImage->createNativeImageReference();
+    if (!nativeImage || !nativeImage->platformImage())
+        return false;
+
+    auto offset = filter.scaledByFilterScale(filter.resolvedSize({ m_effect.dx(), m_effect.dy() }));
+    auto sigma = filter.scaledByFilterScale(filter.resolvedSize({ m_effect.stdDeviationX(), m_effect.stdDeviationY() }));
+
+    SkPaint paint;
+
+    auto shadowColorWithAlpha = m_effect.shadowColor().colorWithAlphaMultipliedBy(m_effect.shadowOpacity());
+    paint.setImageFilter(SkImageFilters::DropShadow(offset.width(), offset.height(), sigma.width(), sigma.height(), shadowColorWithAlpha, nullptr));
+
+    auto inputOffsetWithinResult = input.absoluteImageRectRelativeTo(result).location();
+    resultImage->context().platformContext()->drawImage(nativeImage->platformImage(), inputOffsetWithinResult.x(), inputOffsetWithinResult.y(), { }, &paint);
+    return true;
+}
+
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/filters/skia/FEDropShadowSkiaApplier.h
+++ b/Source/WebCore/platform/graphics/filters/skia/FEDropShadowSkiaApplier.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(SKIA)
+
+#include "FilterEffectApplier.h"
+
+namespace WebCore {
+
+class FEDropShadow;
+
+class FEDropShadowSkiaApplier final : public FilterEffectConcreteApplier<FEDropShadow> {
+    WTF_MAKE_FAST_ALLOCATED;
+    using Base = FilterEffectConcreteApplier<FEDropShadow>;
+
+public:
+    using Base::Base;
+
+private:
+    bool apply(const Filter&, const FilterImageVector&, FilterImage&) const final;
+};
+
+} // namespace WebCore
+
+#endif // USE(SKIA)


### PR DESCRIPTION
#### 931d2cd37b1190dfff814283b4a8ef10d985dc08
<pre>
[Skia] Implement FEDropShadow and FEComponentTransfer filters
<a href="https://bugs.webkit.org/show_bug.cgi?id=273774">https://bugs.webkit.org/show_bug.cgi?id=273774</a>

Reviewed by Carlos Garcia Campos.

Skia supports 3 filters already: FEColorMatrix, FEGaussianBlur, and
SourceGraphics. They were added as part of the initial bootstrapping
of Skia filters, mostly as a coding exercise and proof of concept.

CSSFilter.cpp uses two other filters directly: FEComponentTransfer,
and FEDropShadow. Indirectly it uses SVG filters, but that&apos;s a rarer
case.

Implement the FEDropShadow and FEComponentTransfer filters in Skia.

The FEDropShadow filter naturally enabled the drop-shadow() CSS filter.
It&apos;s implemented using the drop shadow image effect provided by Skia.

The FEComponentTransfer filter is a little less correspondent. It&apos;s
used for the CSS invert(), opacity(), contrast(), and brightness()
filters. It&apos;s implemented using the color table filter, in a similar
fashion to the software applier.

Adjust tests to allow slightly more fuzziness, as the shadows look
visually identical.

* LayoutTests/css3/filters/effect-drop-shadow-clip-abspos.html:
* LayoutTests/imported/blink/css3/filters/effect-drop-shadow-clip-abspos.html:
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filters-drop-shadow-002.html:
* Source/WebCore/platform/SourcesSkia.txt:
* Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp:
(WebCore::FEComponentTransfer::supportedFilterRenderingModes const):
(WebCore::FEComponentTransfer::createAcceleratedApplier const):
(WebCore::FEComponentTransfer::createSoftwareApplier const):
* Source/WebCore/platform/graphics/filters/FEDropShadow.cpp:
(WebCore::FEDropShadow::supportedFilterRenderingModes const):
(WebCore::FEDropShadow::createAcceleratedApplier const):
(WebCore::FEDropShadow::createSoftwareApplier const):
* Source/WebCore/platform/graphics/filters/FEDropShadow.h:
* Source/WebCore/platform/graphics/filters/skia/FEComponentTransferSkiaApplier.cpp: Added.
(WebCore::FEComponentTransferSkiaApplier::apply const):
* Source/WebCore/platform/graphics/filters/skia/FEComponentTransferSkiaApplier.h: Added.
* Source/WebCore/platform/graphics/filters/skia/FEDropShadowSkiaApplier.cpp: Added.
(WebCore::FEDropShadowSkiaApplier::apply const):
* Source/WebCore/platform/graphics/filters/skia/FEDropShadowSkiaApplier.h: Added.

Canonical link: <a href="https://commits.webkit.org/280005@main">https://commits.webkit.org/280005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc8a309503b19c3ddc60d708d062fa2336eeacd2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55687 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3136 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54718 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42616 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2006 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54509 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45240 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23702 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26712 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2515 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1295 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57283 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27539 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2693 "Found 1 new test failure: wasm/window-postmessage.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50010 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28772 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45360 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49262 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12287 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29684 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28517 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->