### PR TITLE
Improve test coverage of sink values - part2.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/default-policy-callback-arguments.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/default-policy-callback-arguments.html
@@ -17,6 +17,17 @@
       assert_equals(args[0], current_case[0], "Expecting the value.");
       assert_equals(args[1], current_case[1], "Expecting the type name.");
       assert_equals(args[2], current_case[2], "Expecting the sink name.");
+      switch (args[1]) {
+        case TrustedScriptURL:
+          assert_equals(args[2], 'HTMLScriptElement src');
+          break;
+        case TrustedHTML:
+          assert_equals(args[2], 'Element innerHTML');
+          break;
+        case TrustedScript:
+          assert_equals(args[2], 'HTMLScriptElement text');
+          break;
+      }
       return args[0];
     }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/default-policy-report-only.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/default-policy-report-only.html
@@ -54,7 +54,7 @@ testCases.forEach(c => {
 });
 
 // A trusted type policy that forces a number of edge cases.
-function policy(str) {
+function policy(str, type, sink) {
   if (str == "throw")
     throw RangeError();
   else if (str == "null")
@@ -65,8 +65,20 @@ function policy(str) {
     return document.bla();
   else if (str == "done")
     return null;
-  else
+  else {
+    switch (type) {
+      case TrustedScriptURL:
+        assert_equals(sink, 'HTMLScriptElement src');
+        break;
+      case TrustedHTML:
+        assert_equals(sink, 'Element innerHTML');
+        break;
+      case TrustedScript:
+        assert_equals(sink, 'HTMLScriptElement text');
+        break;
+    }
     return "sanitized: " + str;
+  }
 }
 
 trustedTypes.createPolicy("default", {

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/default-policy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/default-policy.html
@@ -54,7 +54,7 @@ testCases.forEach(c => {
 });
 
 // A trusted type policy that forces a number of edge cases.
-function policy(str) {
+function policy(str, type, sink) {
   if (str == "throw")
     throw RangeError();
   else if (str == "null")
@@ -65,8 +65,20 @@ function policy(str) {
     return document.bla();
   else if (str == "done")
     return null;
-  else
+  else {
+    switch (type) {
+      case TrustedScriptURL:
+        assert_equals(sink, 'HTMLScriptElement src');
+        break;
+      case TrustedHTML:
+        assert_equals(sink, 'Element innerHTML');
+        break;
+      case TrustedScript:
+        assert_equals(sink, 'HTMLScriptElement text');
+        break;
+    }
     return "sanitized: " + str;
+  }
 }
 
 trustedTypes.createPolicy("default", {


### PR DESCRIPTION
#### bcace83dfe07692e49565696b881a1cd682a8776
<pre>
Improve test coverage of sink values - part2.
<a href="https://bugs.webkit.org/show_bug.cgi?id=273763">https://bugs.webkit.org/show_bug.cgi?id=273763</a>

Reviewed by Tim Nguyen.

Add checks on sink values.

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/default-policy-callback-arguments.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/default-policy-report-only.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/default-policy.html:

Specifically for default policy test files.

Canonical link: <a href="https://commits.webkit.org/278804@main">https://commits.webkit.org/278804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/846ee2e225d07f587e7fb5d6121959f24f49b816

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54543 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1976 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1655 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41767 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53385 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44217 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22885 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25561 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1475 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47530 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56139 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26401 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1443 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49166 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27644 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44280 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48326 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11296 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28534 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27379 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->