### PR TITLE
WebCodecsVideoFrame::create from another WebCodecsVideoFrame is not correct with regards to timestamp

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/videoFrame-clone-timestamp-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/videoFrame-clone-timestamp-expected.txt
@@ -1,0 +1,3 @@
+
+PASS VideoFrame timestamp should remain consistent when serialized
+

--- a/LayoutTests/http/wpt/webcodecs/videoFrame-clone-timestamp.html
+++ b/LayoutTests/http/wpt/webcodecs/videoFrame-clone-timestamp.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<header>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+</header>
+<body>
+<script>
+
+function makeOffscreenCanvas(width, height, timestamp) {
+  let canvas = new OffscreenCanvas(width, height);
+  let ctx = canvas.getContext('2d');
+  ctx.fillStyle = 'rgba(50, 100, 150, 255)';
+  ctx.fillRect(0, 0, width, height);
+  return new VideoFrame(canvas, { timestamp, duration : 10 });
+}
+
+promise_test(async t => {
+    const frame1 = makeOffscreenCanvas(10, 10, 10);
+    t.add_cleanup(() => frame1.close());
+
+    const frame2 = new VideoFrame(frame1, { timestamp: 100 });
+    t.add_cleanup(() => frame2.close());
+
+    const frame3 = new VideoFrame(frame1);
+    t.add_cleanup(() => frame3.close());
+
+    assert_equals(frame1.timestamp, 10);
+    assert_equals(frame2.timestamp, 100);
+    assert_equals(frame3.timestamp, 10);
+}, "VideoFrame timestamp should remain consistent when serialized");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -269,7 +269,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutio
 {
     if (initFrame->isDetached())
         return Exception { ExceptionCode::InvalidStateError,  "VideoFrame is detached"_s };
-    return initializeFrameFromOtherFrame(context, WTFMove(initFrame), WTFMove(init), VideoFrame::ShouldCloneWithDifferentTimestamp::No);
+    return initializeFrameFromOtherFrame(context, WTFMove(initFrame), WTFMove(init), VideoFrame::ShouldCloneWithDifferentTimestamp::Yes);
 }
 
 static std::optional<Exception> validateI420Sizes(const WebCodecsVideoFrame::BufferInit& init)


### PR DESCRIPTION
#### bbf537ea1dbb7e545f33b2cea59f304fff963016
<pre>
WebCodecsVideoFrame::create from another WebCodecsVideoFrame is not correct with regards to timestamp
<a href="https://rdar.apple.com/127474678">rdar://127474678</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=273775">https://bugs.webkit.org/show_bug.cgi?id=273775</a>

Reviewed by Jean-Yves Avenard.

Make sure to clone in case of a different timestamp to keep WebCodecsVideoFrame and VideoFrame timestamps the same.

* LayoutTests/http/wpt/webcodecs/videoFrame-clone-timestamp-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/videoFrame-clone-timestamp.html: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::create):

Canonical link: <a href="https://commits.webkit.org/278454@main">https://commits.webkit.org/278454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13e45e27aceb62b5d36d3508b8e8cd4d22953227

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53724 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1155 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52768 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36007 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41163 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27422 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43447 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22268 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/24953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/705 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8843 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46812 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/766 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55313 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/689 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48576 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26824 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47640 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11084 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27688 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26556 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->