### PR TITLE
TestWebKitAPI.WKScrollViewTests.AsynchronousWheelEventHandling fails on iOS Simulator

### DIFF
--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -311,6 +311,8 @@ typedef NS_ENUM(NSUInteger, UIScrollPhase) {
 };
 
 @interface UIScrollEvent : UIEvent
+- (CGPoint)locationInView:(UIView *)view;
+- (CGVector)_adjustedAcceleratedDeltaInView:(UIView *)view;
 @end
 
 @interface UITextInteractionAssistant : NSObject <UIResponderStandardEditActions>


### PR DESCRIPTION
#### 5d8844437faecf993b1c4e0e9ebd4413a20f71ea
<pre>
TestWebKitAPI.WKScrollViewTests.AsynchronousWheelEventHandling fails on iOS Simulator
<a href="https://bugs.webkit.org/show_bug.cgi?id=273739">https://bugs.webkit.org/show_bug.cgi?id=273739</a>
<a href="https://rdar.apple.com/127547694">rdar://127547694</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

The initializer `-[BEScrollViewScrollUpdate initWithScrollEvent:phase:]` is marked `NS_DIRECT` in
BrowserEngineKit, so attempts to initialize a scroll update for testing fail due to invoking an
unrecognized selector (in 273582@main, I&apos;d previously been testing against a local debug build of
BrowserEngineKit that did not inline this initializer, so the test was passing as expected).

Fix this by adjusting the testing strategy, so that we instead initialize a mock Objective-C object
(`WKTestScrollViewScrollUpdate`) which implements identical functionality.

* Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm:
(-[WKTestScrollViewScrollUpdate initWithScrollEvent:phase:]):
(-[WKTestScrollViewScrollUpdate phase]):
(-[WKTestScrollViewScrollUpdate timestamp]):
(-[WKTestScrollViewScrollUpdate locationInView:]):
(-[WKTestScrollViewScrollUpdate translationInView:]):
(createScrollUpdate):
(TEST(WKScrollViewTests, AsynchronousWheelEventHandling)):

Canonical link: <a href="https://commits.webkit.org/278426@main">https://commits.webkit.org/278426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b93a2cc2c0d17fddeb7ac48aa09ddacbad0d8436

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53748 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1179 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52792 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/829 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41180 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52588 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27439 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43462 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22285 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24848 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/720 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8867 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46829 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/781 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55337 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25587 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/710 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43617 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11068 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27712 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26580 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->