### PR TITLE
[webkitscmpy] Define current user during testing

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/environment.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/environment.py
@@ -30,6 +30,7 @@ class Environment(ContextStack):
 
     def __init__(self, **kwargs):
         super(Environment, self).__init__(cls=Environment)
+        self.environ = kwargs
 
         from mock import patch
         from webkitcorepy.credentials import _cache

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
@@ -25,7 +25,7 @@ import sys
 
 from collections import defaultdict
 from datetime import datetime
-from webkitcorepy import decorators, string_utils, CallByNeed
+from webkitcorepy import decorators, string_utils, CallByNeed, Environment
 from webkitscmpy import Commit, Contributor, PullRequest
 from webkitscmpy.remote.scm import Scm
 
@@ -599,7 +599,10 @@ class BitBucket(Scm):
         return response.text.rstrip()
 
     def credentials(self, required=True, validate=False, save_in_keyring=None):
-        return None, None
+        name = self.domain.replace('.', '_')
+        username = Environment.instance().get('{}_USERNAME'.format(name.upper()))
+        password = Environment.instance().get('{}_PASSWORD'.format(name.upper()))
+        return username, password
 
     @property
     def is_git(self):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -1739,7 +1739,10 @@ No pre-PR checks to run""")
         )
 
     def test_bitbucket_update(self):
-        with mocks.remote.BitBucket() as remote, mocks.local.Git(self.path, remote='ssh://git@{}/{}/{}.git'.format(
+        with mocks.remote.BitBucket(environment=Environment(**{
+            'BITBUCKET_EXAMPLE_COM_USERNAME': 'timcommitter',
+            'BITBUCKET_EXAMPLE_COM_PASSWORD': 'password',
+        })) as remote, mocks.local.Git(self.path, remote='ssh://git@{}/{}/{}.git'.format(
             remote.hosts[0], remote.project.split('/')[1], remote.project.split('/')[3],
         )) as repo, mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', []):
             with OutputCapture():
@@ -1778,7 +1781,10 @@ No pre-PR checks to run""")
         )
 
     def test_bitbucket_append(self):
-        with mocks.remote.BitBucket() as remote, mocks.local.Git(self.path, remote='ssh://git@{}/{}/{}.git'.format(
+        with mocks.remote.BitBucket(environment=Environment(**{
+            'BITBUCKET_EXAMPLE_COM_USERNAME': 'timcommitter',
+            'BITBUCKET_EXAMPLE_COM_PASSWORD': 'password',
+        })) as remote, mocks.local.Git(self.path, remote='ssh://git@{}/{}/{}.git'.format(
             remote.hosts[0], remote.project.split('/')[1], remote.project.split('/')[3],
         )) as repo, mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', []):
             with OutputCapture():
@@ -1817,7 +1823,10 @@ No pre-PR checks to run""")
         )
 
     def test_bitbucket_reopen(self):
-        with mocks.remote.BitBucket() as remote, mocks.local.Git(self.path, remote='ssh://git@{}/{}/{}.git'.format(
+        with mocks.remote.BitBucket(environment=Environment(**{
+            'BITBUCKET_EXAMPLE_COM_USERNAME': 'timcommitter',
+            'BITBUCKET_EXAMPLE_COM_PASSWORD': 'password',
+        })) as remote, mocks.local.Git(self.path, remote='ssh://git@{}/{}/{}.git'.format(
             remote.hosts[0], remote.project.split('/')[1], remote.project.split('/')[3],
         )) as repo, mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', []):
             with OutputCapture():
@@ -1970,8 +1979,11 @@ class TestNetworkPullRequestGitHub(unittest.TestCase):
     remote = 'https://github.example.com/WebKit/WebKit'
 
     @classmethod
-    def webserver(cls):
-        result = mocks.remote.GitHub()
+    def webserver(cls, user='tcontributor'):
+        result = mocks.remote.GitHub(environment=Environment(
+            GITHUB_EXAMPLE_COM_USERNAME=user,
+            GITHUB_EXAMPLE_COM_TOKEN='password',
+        ))
         result.users.create('Eager Reviewer', 'ereviewer', ['ereviewer@webkit.org'])
         result.users.create('Reluctant Reviewer', 'rreviewer', ['rreviewer@webkit.org'])
         result.users.create('Suspicious Reviewer', 'sreviewer', ['sreviewer@webkit.org'])
@@ -2187,7 +2199,7 @@ Reviewed by NOBODY (OOPS!).
                 '+',
                 '+Reviewed by NOBODY (OOPS!).',
                 '>>>>',
-                'username <?>: We need a review before landing',
+                'tcontributor <?>: We need a review before landing',
                 '<<<<',
                 '+* Source/file.cpp:',
             ], list(pr.diff(comments=True)))
@@ -2202,7 +2214,7 @@ Reviewed by NOBODY (OOPS!).
                 '--- a/ChangeLog',
                 '+++ b/ChangeLog',
                 '>>>>',
-                'username <?>: ChangeLogs are deprecated, please remove',
+                'tcontributor <?>: ChangeLogs are deprecated, please remove',
                 '<<<<',
                 '@@ -1,0 +1,0 @@',
                 '+Example Change',
@@ -2229,8 +2241,8 @@ Reviewed by NOBODY (OOPS!).
                 '--- a/ChangeLog',
                 '+++ b/ChangeLog',
                 '>>>>',
-                'username <?>: Top-level comment 1',
-                'username <?>: Top-level comment 2',
+                'tcontributor <?>: Top-level comment 1',
+                'tcontributor <?>: Top-level comment 2',
                 '<<<<',
                 '@@ -1,0 +1,0 @@',
                 '+Example Change',
@@ -2238,8 +2250,8 @@ Reviewed by NOBODY (OOPS!).
                 '+',
                 '+Reviewed by NOBODY (OOPS!).',
                 '>>>>',
-                'username <?>: Line comment 1',
-                'username <?>: Line comment 2',
+                'tcontributor <?>: Line comment 1',
+                'tcontributor <?>: Line comment 2',
                 '<<<<',
                 '+* Source/file.cpp:',
             ], list(pr.diff(comments=True)))
@@ -2249,8 +2261,11 @@ class TestNetworkPullRequestBitBucket(unittest.TestCase):
     remote = 'https://bitbucket.example.com/projects/WEBKIT/repos/webkit'
 
     @classmethod
-    def webserver(cls):
-        result = mocks.remote.BitBucket()
+    def webserver(cls, user='tcontributor'):
+        result = mocks.remote.BitBucket(environment=Environment(
+            BITBUCKET_EXAMPLE_COM_USERNAME=user,
+            BITBUCKET_EXAMPLE_COM_PASSWORD='password',
+        ))
         result.pull_requests = [dict(
             id=1,
             state='OPEN',
@@ -2406,7 +2421,7 @@ Reviewed by NOBODY (OOPS!).
     def test_whoami(self):
         with self.webserver():
             repo = remote.BitBucket(self.remote)
-            self.assertEqual(repo.whoami(), 'timcommitter')
+            self.assertEqual(repo.whoami(), 'tcontributor')
 
     def test_review(self):
         with self.webserver():


### PR DESCRIPTION
#### b72f1b6d58ee4ecf73ff42f53dbae52ea7996ee2
<pre>
[webkitscmpy] Define current user during testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=273781">https://bugs.webkit.org/show_bug.cgi?id=273781</a>
<a href="https://rdar.apple.com/127612128">rdar://127612128</a>

Reviewed by Dewei Zhu.

BitBucket users a generic username for testing. We should allow callers of the BitBucket mock to
define a username used for mock interactions.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/environment.py:
(Environment.__init__): Add dictionary to fetch mock environment from before environment is instantiated.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/bitbucket.py:
(BitBucket.__init__): Accept mock environment for the duration of the mock server.
(BitBucket.__enter__): Enter mock environment.
(BitBucket.__exit__): Exit mock environment.
(BitBucket.request): Return dynamic username.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
(BitBucket.credentials): Pull credentials from environment.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:

Canonical link: <a href="https://commits.webkit.org/278464@main">https://commits.webkit.org/278464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98386860f7deb52d5a7494c2e186455a1749acd1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53733 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1164 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52777 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/814 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41173 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27428 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43455 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22278 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/50325 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24837 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/713 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8852 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46818 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55322 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25572 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/702 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48577 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/50495 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26833 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47622 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27697 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7332 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26565 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->