### PR TITLE
Changing font size while the selection is inside a <picture> element breaks source selection

### DIFF
--- a/LayoutTests/editing/style/apply-font-size-to-picture-expected.txt
+++ b/LayoutTests/editing/style/apply-font-size-to-picture-expected.txt
@@ -1,0 +1,19 @@
+Test changing font size inside <picture>.
+
+Initial state:
+| <picture>
+|   <source>
+|     srcset="../resources/abe.png"
+|   <img>
+|     src=""
+
+After font size change:
+| <font>
+|   size="7"
+|   <picture>
+|     <source>
+|       srcset="../resources/abe.png"
+|     <#selection-anchor>
+|     <img>
+|       src=""
+|     <#selection-focus>

--- a/LayoutTests/editing/style/apply-font-size-to-picture.html
+++ b/LayoutTests/editing/style/apply-font-size-to-picture.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/dump-as-markup.js"></script>
+<div id="editor" contenteditable><picture><source srcset="../resources/abe.png"/><img src=""></picture></div>
+<script>
+
+Markup.description('Test changing font size inside <picture>.');
+
+var picture = document.querySelector('picture');
+Markup.dump(editor, 'Initial state');
+
+window.getSelection().setBaseAndExtent(picture, 1, picture, 2);
+document.execCommand('styleWithCSS', false, 'false');
+document.execCommand("FontSize", false, 7);
+Markup.dump(editor, 'After font size change');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -1442,6 +1442,8 @@ void ApplyStyleCommand::applyInlineStyleChange(Node& passedStart, Node& passedEn
                 fontContainer = fontElement;
             if (is<HTMLSpanElement>(*container) || (!is<HTMLSpanElement>(styleContainer) && container->hasChildNodes()))
                 styleContainer = container;
+            if (!canHaveChildrenForEditing(*startNode))
+                break;
         }
         auto* startNodeFirstChild = startNode->firstChild();
         if (!startNodeFirstChild)


### PR DESCRIPTION
#### 585d66186f6e55555c359ac442f5caaf1703da59
<pre>
Changing font size while the selection is inside a &lt;picture&gt; element breaks source selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=273782">https://bugs.webkit.org/show_bug.cgi?id=273782</a>
<a href="https://rdar.apple.com/123786373">rdar://123786373</a>

Reviewed by Wenson Hsieh and Ryosuke Niwa.

When changing font properties using editor commands, a &lt;font&gt; element may wrap
the selected nodes. However, when selecting a &lt;picture&gt; element, the selection
is actually around the contained &lt;img&gt;. Consequently, changing the font currently
inserts the &lt;font&gt; element as a child of the &lt;picture&gt;. This behavior breaks
source selection, as &lt;picture&gt; elements should only contain &lt;source&gt; and &lt;img&gt;
elements.

Fix by ensuring the &lt;font&gt; element wraps the &lt;picture&gt;.

* LayoutTests/editing/style/apply-font-size-to-picture-expected.txt: Added.
* LayoutTests/editing/style/apply-font-size-to-picture.html: Added.
* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::ApplyStyleCommand::applyInlineStyleChange):

Canonical link: <a href="https://commits.webkit.org/278429@main">https://commits.webkit.org/278429@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/958c9b129a25faaf5df1da668dc0da27d5ffdb7d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2779 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53734 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1165 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52778 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41172 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27430 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43456 "Found 1 new API test failure: TestWebKitAPI.ResourceLoadStatistics.GrandfatherCallback (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22277 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24839 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/714 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8853 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55323 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/699 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48582 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26834 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43612 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47627 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27698 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7310 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26566 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->