### PR TITLE
MiniBrowser: Add option to run-minibrowser to open Web Inspector

### DIFF
--- a/Tools/MiniBrowser/mac/AppDelegate.m
+++ b/Tools/MiniBrowser/mac/AppDelegate.m
@@ -43,6 +43,7 @@
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 
 static const NSString * const kURLArgumentString = @"--url";
+static const NSString * const kShowWebInspectorArgumentString = @"--inspector";
 
 enum {
     WebKit1NewWindowTag = 1,
@@ -326,6 +327,10 @@ static NSNumber *_currentBadge;
 
     [[controller window] makeKeyAndOrderFront:sender];
     [controller loadURLString:[self targetURLOrDefaultURL]];
+
+    NSArray *args = [[NSProcessInfo processInfo] arguments];
+    if ([args containsObject:kShowWebInspectorArgumentString])
+        [controller showWebInspector];
 }
 
 - (IBAction)newPrivateWindow:(id)sender
@@ -339,6 +344,10 @@ static NSNumber *_currentBadge;
     [_browserWindowControllers addObject:controller];
 
     [controller loadURLString:_settingsController.defaultURL];
+
+    NSArray *args = [[NSProcessInfo processInfo] arguments];
+    if ([args containsObject:kShowWebInspectorArgumentString])
+        [controller showWebInspector];
 }
 
 - (IBAction)newEditorWindow:(id)sender
@@ -349,6 +358,10 @@ static NSNumber *_currentBadge;
 
     [[controller window] makeKeyAndOrderFront:sender];
     [controller loadHTMLString:@"<html><body></body></html>"];
+
+    NSArray *args = [[NSProcessInfo processInfo] arguments];
+    if ([args containsObject:kShowWebInspectorArgumentString])
+        [controller showWebInspector];
 }
 
 - (void)didCreateBrowserWindowController:(BrowserWindowController *)controller

--- a/Tools/MiniBrowser/mac/BrowserWindowController.h
+++ b/Tools/MiniBrowser/mac/BrowserWindowController.h
@@ -80,6 +80,7 @@
 - (IBAction)dumpSourceToConsole:(id)sender;
 
 - (IBAction)showHideWebInspector:(id)sender;
+- (void)showWebInspector;
 
 - (IBAction)toggleMainThreadStalls:(id)sender;
 - (BOOL)mainThreadStallsEnabled;

--- a/Tools/MiniBrowser/mac/BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/BrowserWindowController.m
@@ -256,6 +256,11 @@
     [self doesNotRecognizeSelector:_cmd];
 }
 
+- (void)showWebInspector
+{
+    [self doesNotRecognizeSelector:_cmd];
+}
+
 - (IBAction)togglePictureInPicture:(id)sender
 {
     [self doesNotRecognizeSelector:_cmd];

--- a/Tools/MiniBrowser/mac/WK1BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK1BrowserWindowController.m
@@ -295,6 +295,15 @@ static BOOL areEssentiallyEqual(double a, double b)
         [inspector show:sender];
 }
 
+- (void)showWebInspector
+{
+    WebInspector *inspector = _webView.inspector;
+    if (inspector.isOpen)
+        return;
+
+    [inspector show:nil];
+}
+
 - (IBAction)toggleAlwaysShowsHorizontalScroller:(id)sender
 {
     _webView.alwaysShowHorizontalScroller = !_webView.alwaysShowHorizontalScroller;

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -430,6 +430,15 @@ static BOOL areEssentiallyEqual(double a, double b)
         [inspector show];
 }
 
+- (void)showWebInspector
+{
+    _WKInspector *inspector = _webView._inspector;
+    if (inspector.isVisible)
+        return;
+
+    [inspector show];
+}
+
 - (IBAction)toggleAlwaysShowsHorizontalScroller:(id)sender
 {
     _webView._alwaysShowsHorizontalScroller = !_webView._alwaysShowsHorizontalScroller;

--- a/Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py
+++ b/Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py
@@ -48,6 +48,8 @@ def main(argv):
 
     option_parser.add_argument('url', metavar='url', type=lambda s: decode(s, 'utf8'), nargs='?',
                                help='Website URL to load')
+    option_parser.add_argument('--inspector', action='store_const', const='--inspector',
+                               help='Show Web Inspector after loading page')
     options, args = option_parser.parse_known_args(argv)
 
     if not options.platform:
@@ -59,6 +61,9 @@ def main(argv):
     browser_args = [decode(s, "utf-8") for s in option_parser.convert_arg_line_to_args(' '.join(args))[0].split()]
     if options.url:
         browser_args.append(options.url)
+
+    if options.inspector:
+        browser_args.append(options.inspector)
 
     try:
         port = factory.PortFactory(Host()).get(options.platform, options=options)


### PR DESCRIPTION
#### 6108e0c5fe0e182cf616681c17657a6c853762eb
<pre>
MiniBrowser: Add option to run-minibrowser to open Web Inspector
<a href="https://bugs.webkit.org/show_bug.cgi?id=273783">https://bugs.webkit.org/show_bug.cgi?id=273783</a>
<a href="https://rdar.apple.com/127615032">rdar://127615032</a>

Reviewed by NOBODY (OOPS!).

Adds a new `--inspector` option to the `run-minibrowser` script
to automatically open Web Inspector when loading page.

Implements support for the new option in the Mac build of MiniBrowser.

* Tools/MiniBrowser/mac/AppDelegate.m:
(-[BrowserAppDelegate newWindow:]):
(-[BrowserAppDelegate newPrivateWindow:]):
(-[BrowserAppDelegate newEditorWindow:]):
* Tools/MiniBrowser/mac/BrowserWindowController.h:
* Tools/MiniBrowser/mac/BrowserWindowController.m:
(-[BrowserWindowController showWebInspector]):
* Tools/MiniBrowser/mac/WK1BrowserWindowController.m:
(-[WK1BrowserWindowController showWebInspector]):
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController showWebInspector]):
* Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py:
(main):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6108e0c5fe0e182cf616681c17657a6c853762eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53740 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1171 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52784 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/821 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41176 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52580 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27431 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43467 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22281 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/50332 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24840 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/725 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8859 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46821 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55329 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25579 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/705 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48581 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26840 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43622 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47626 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27704 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->