### PR TITLE
[webkitscmpy] Fix GitHub mock reviewing

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
@@ -499,8 +499,12 @@ class GitHub(bmocks.GitHub):
             for candidate in self.pull_requests:
                 if stripped_url.split('/')[5] != str(candidate['number']):
                     continue
+                state = json.get('event', 'COMMENT')
                 candidate['reviews'].append(
-                    dict(user=dict(login=auth.username), state=json.get('event', 'COMMENT')),
+                    dict(user=dict(login=auth.username), state=dict(
+                        REQUEST_CHANGES='CHANGES_REQUESTED',
+                        APPROVE='APPROVED',
+                    ).get(state, state)),
                 )
                 if 'body' in json:
                     self.issues[candidate['number']]['comments'].append(

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -2139,8 +2139,23 @@ Reviewed by NOBODY (OOPS!).
             self.assertEqual(pr.blockers, [Contributor('Suspicious Reviewer', ['sreviewer@webkit.org'])])
 
             pr.review(comment='Looks good!', approve=True)
+
+            pr = repo.pull_requests.get(1)
             self.assertEqual(pr.comments[-1].content, 'Looks good!')
             self.assertEqual(len(pr.approvers), 2)
+
+    def test_review_reject(self):
+        with self.webserver():
+            repo = remote.GitHub(self.remote)
+            pr = repo.pull_requests.get(1)
+            self.assertEqual(pr.approvers, [Contributor('Eager Reviewer', ['ereviewer@webkit.org'])])
+            self.assertEqual(pr.blockers, [Contributor('Suspicious Reviewer', ['sreviewer@webkit.org'])])
+
+            pr.review(comment='Needs work.', approve=False)
+
+            pr = repo.pull_requests.get(1)
+            self.assertEqual(pr.comments[-1].content, 'Needs work.')
+            self.assertEqual(len(pr.blockers), 2)
 
     def test_status(self):
         with self.webserver():


### PR DESCRIPTION
#### a53feed8099c0e7166b36b8bcc39a5b63e07d508
<pre>
[webkitscmpy] Fix GitHub mock reviewing
<a href="https://bugs.webkit.org/show_bug.cgi?id=273784">https://bugs.webkit.org/show_bug.cgi?id=273784</a>
<a href="https://rdar.apple.com/127615550">rdar://127615550</a>

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py:
(GitHub.request): Convert &apos;APPROVE&apos; to &apos;APPROVED&apos; and &apos;REQUEST_CHANGES&apos; to &apos;CHANGES_REQUESTED&apos;.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
(TestNetworkPullRequestGitHub.test_review):
(TestNetworkPullRequestGitHub.test_review_reject):

Canonical link: <a href="https://commits.webkit.org/278592@main">https://commits.webkit.org/278592@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b044666748adf01022cacce03e6492d3327b497

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50484 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53743 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1174 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52787 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/824 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41178 "Found 1 new test failure: webgl/2.0.y/conformance2/textures/webgl_canvas/tex-3d-srgb8_alpha8-rgba-unsigned_byte.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52583 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27436 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43454 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22283 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/50335 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24845 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/712 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8862 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46826 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/773 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55332 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25582 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/707 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48586 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/50505 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26843 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47631 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27707 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7410 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->