### PR TITLE
[view-transitions] https://simple-set-demos.glitch.me/dust-no-raf/ flickers more as animation is re-ran

### DIFF
--- a/LayoutTests/webanimations/accelerated-animation-removed-permanently-when-forward-filling-expected.txt
+++ b/LayoutTests/webanimations/accelerated-animation-removed-permanently-when-forward-filling-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Accelerated animations are no longer accelerated when forward-filling, even if other animations in the stack are running accelerated.
+

--- a/LayoutTests/webanimations/accelerated-animation-removed-permanently-when-forward-filling.html
+++ b/LayoutTests/webanimations/accelerated-animation-removed-permanently-when-forward-filling.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+#target {
+    width: 100px;
+    height: 100px;
+    background-color: black;
+}
+
+</style>
+</head>
+<body>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/rendering-frames.js"></script>
+<div id="target"></div>
+
+<script>
+
+promise_test(async () => {
+    const target = document.getElementById("target");
+    const fill = "both";
+    const duration = 2000;
+
+    const transform = target.animate(
+        { transform: "none" },
+        { duration, fill }
+    );
+
+    const opacity = target.animate(
+        { opacity: [0, 1] },
+        { duration: 1, fill }
+    );
+
+    target.animate(
+        { opacity: [1, 0] },
+        { duration, fill }
+    );
+
+    // Wait until the replaced opacity animation has finished and then terminate
+    // the transform animation on the next frame.
+    await opacity.finished;
+    await renderingFrames(1);
+    transform.finish();
+
+    // Wait another frame for the accelerated changes to be committed.
+    await renderingFrames(1);
+
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 1, "There should be one single accelerated animation.");
+}, "Accelerated animations are no longer accelerated when forward-filling, even if other animations in the stack are running accelerated.");
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1918,6 +1918,8 @@ void KeyframeEffect::applyPendingAcceleratedActionsOrUpdateTimingProperties()
 #endif
 
     if (m_pendingAcceleratedActions.isEmpty()) {
+        if (getComputedTiming().phase != AnimationEffectPhase::Active)
+            return;
         m_pendingAcceleratedActions.append(AcceleratedAction::UpdateProperties);
         m_lastRecordedAcceleratedAction = AcceleratedAction::Play;
         applyPendingAcceleratedActions();


### PR DESCRIPTION
#### d1bb2bd1b7a474e08ef8fb7c17d209e96c781a6f
<pre>
[view-transitions] <a href="https://simple-set-demos.glitch.me/dust-no-raf/">https://simple-set-demos.glitch.me/dust-no-raf/</a> flickers more as animation is re-ran
<a href="https://bugs.webkit.org/show_bug.cgi?id=273649">https://bugs.webkit.org/show_bug.cgi?id=273649</a>
<a href="https://rdar.apple.com/127458540">rdar://127458540</a>

Reviewed by Dean Jackson.

If an effect targeting an accelerated CSS property enters a phase [0] other than &quot;active&quot;, for instance
when it&apos;s forward-filling, `KeyframeEffect::updateAcceleratedActions()` will enqueue a `Stop` accelerated
action for that animation and thus remove its matching accelerated animation on the next frame.

However, if an element is targeted by multiple animations for the same accelerated CSS property,
`KeyframeEffect::applyPendingAcceleratedActionsOrUpdateTimingProperties()` will process an
`UpdateProperties` accelerated action for all effects in the stack to ensure that they are indeed
running.

In the case of this demo, there are three forward-filling animations applied to the same element. A
bottom-most one targeting `transform`, then two animations targeting `opacity`. The first two animations
end early but the third animation runs longer and it is when that animation is the sole &quot;active&quot; animation
that we enter a state where the two mechanisms described above will intermittently remove the forward-filling
`opacity` animation and then re-start it in the next frame. This yields the visible flickering effect.

We now check that an animation is in the &quot;active&quot; phase before restarting it to ensure it is in the right
state when processing a keyframe effect stack.

[0] <a href="https://drafts.csswg.org/web-animations-1/#animation-effect-phases-and-states">https://drafts.csswg.org/web-animations-1/#animation-effect-phases-and-states</a>

* LayoutTests/webanimations/accelerated-animation-removed-permanently-when-forward-filling-expected.txt: Added.
* LayoutTests/webanimations/accelerated-animation-removed-permanently-when-forward-filling.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::applyPendingAcceleratedActionsOrUpdateTimingProperties):

Canonical link: <a href="https://commits.webkit.org/278434@main">https://commits.webkit.org/278434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1195f91ee462ce62372276b847dddb8d15aed42

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53745 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1176 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52789 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/826 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41179 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22284 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24847 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/717 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8864 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46828 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55334 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25584 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/709 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48587 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26845 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47632 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27709 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7316 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26577 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->