### PR TITLE
[WebGPU] enum values are on separate lines in idl files

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUAddressMode.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUAddressMode.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUAddressMode {
+] enum GPUAddressMode {
     "clamp-to-edge",
     "repeat",
     "mirror-repeat"

--- a/Source/WebCore/Modules/WebGPU/GPUAutoLayoutMode.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUAutoLayoutMode.idl
@@ -27,7 +27,6 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUAutoLayoutMode {
+] enum GPUAutoLayoutMode {
     "auto"
 };

--- a/Source/WebCore/Modules/WebGPU/GPUBlendFactor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBlendFactor.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUBlendFactor {
+] enum GPUBlendFactor {
     "zero",
     "one",
     "src",

--- a/Source/WebCore/Modules/WebGPU/GPUBlendOperation.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBlendOperation.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUBlendOperation {
+] enum GPUBlendOperation {
     "add",
     "subtract",
     "reverse-subtract",

--- a/Source/WebCore/Modules/WebGPU/GPUBufferBindingType.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBufferBindingType.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUBufferBindingType {
+] enum GPUBufferBindingType {
     "uniform",
     "storage",
     "read-only-storage"

--- a/Source/WebCore/Modules/WebGPU/GPUBufferMapState.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBufferMapState.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUBufferMapState {
+] enum GPUBufferMapState {
     "unmapped",
     "pending",
     "mapped"

--- a/Source/WebCore/Modules/WebGPU/GPUCanvasAlphaMode.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasAlphaMode.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUCanvasAlphaMode {
+] enum GPUCanvasAlphaMode {
     "opaque",
     "premultiplied"
 };

--- a/Source/WebCore/Modules/WebGPU/GPUCompareFunction.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCompareFunction.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUCompareFunction {
+] enum GPUCompareFunction {
     "never",
     "less",
     "equal",

--- a/Source/WebCore/Modules/WebGPU/GPUCompilationMessageType.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCompilationMessageType.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUCompilationMessageType {
+] enum GPUCompilationMessageType {
     "error",
     "warning",
     "info"

--- a/Source/WebCore/Modules/WebGPU/GPUCullMode.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCullMode.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUCullMode {
+] enum GPUCullMode {
     "none",
     "front",
     "back"

--- a/Source/WebCore/Modules/WebGPU/GPUDeviceLostReason.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUDeviceLostReason.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUDeviceLostReason {
+] enum GPUDeviceLostReason {
     "unknown",
     "destroyed"
 };

--- a/Source/WebCore/Modules/WebGPU/GPUErrorFilter.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUErrorFilter.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUErrorFilter {
+] enum GPUErrorFilter {
     "out-of-memory",
     "validation",
     "internal"

--- a/Source/WebCore/Modules/WebGPU/GPUFeatureName.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUFeatureName.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUFeatureName {
+] enum GPUFeatureName {
     "depth-clip-control",
     "depth32float-stencil8",
     "texture-compression-bc",

--- a/Source/WebCore/Modules/WebGPU/GPUFilterMode.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUFilterMode.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUFilterMode {
+] enum GPUFilterMode {
     "nearest",
     "linear"
 };

--- a/Source/WebCore/Modules/WebGPU/GPUFrontFace.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUFrontFace.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUFrontFace {
+] enum GPUFrontFace {
     "ccw",
     "cw"
 };

--- a/Source/WebCore/Modules/WebGPU/GPUIndexFormat.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUIndexFormat.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUIndexFormat {
+] enum GPUIndexFormat {
     "uint16",
     "uint32"
 };

--- a/Source/WebCore/Modules/WebGPU/GPULoadOp.idl
+++ b/Source/WebCore/Modules/WebGPU/GPULoadOp.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPULoadOp {
+] enum GPULoadOp {
     "load",
     "clear"
 };

--- a/Source/WebCore/Modules/WebGPU/GPUMipmapFilterMode.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUMipmapFilterMode.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUMipmapFilterMode {
+] enum GPUMipmapFilterMode {
     "nearest",
     "linear"
 };

--- a/Source/WebCore/Modules/WebGPU/GPUPipelineErrorReason.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUPipelineErrorReason.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUPipelineErrorReason {
+] enum GPUPipelineErrorReason {
     "validation",
     "internal"
 };

--- a/Source/WebCore/Modules/WebGPU/GPUPowerPreference.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUPowerPreference.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUPowerPreference {
+] enum GPUPowerPreference {
     "low-power",
     "high-performance"
 };

--- a/Source/WebCore/Modules/WebGPU/GPUPredefinedColorSpace.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUPredefinedColorSpace.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUPredefinedColorSpace {
+] enum GPUPredefinedColorSpace {
     "srgb",
     "display-p3"
 };

--- a/Source/WebCore/Modules/WebGPU/GPUPrimitiveTopology.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUPrimitiveTopology.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUPrimitiveTopology {
+] enum GPUPrimitiveTopology {
     "point-list",
     "line-list",
     "line-strip",

--- a/Source/WebCore/Modules/WebGPU/GPUQueryType.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUQueryType.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUQueryType {
+] enum GPUQueryType {
     "occlusion",
     "timestamp"
 };

--- a/Source/WebCore/Modules/WebGPU/GPUSamplerBindingType.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUSamplerBindingType.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUSamplerBindingType {
+] enum GPUSamplerBindingType {
     "filtering",
     "non-filtering",
     "comparison"

--- a/Source/WebCore/Modules/WebGPU/GPUStencilOperation.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUStencilOperation.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUStencilOperation {
+] enum GPUStencilOperation {
     "keep",
     "zero",
     "replace",

--- a/Source/WebCore/Modules/WebGPU/GPUStorageTextureAccess.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUStorageTextureAccess.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUStorageTextureAccess {
+] enum GPUStorageTextureAccess {
     "write-only",
     "read-only",
     "read-write",

--- a/Source/WebCore/Modules/WebGPU/GPUStoreOp.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUStoreOp.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUStoreOp {
+] enum GPUStoreOp {
     "store",
     "discard"
 };

--- a/Source/WebCore/Modules/WebGPU/GPUTextureAspect.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureAspect.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUTextureAspect {
+] enum GPUTextureAspect {
     "all",
     "stencil-only",
     "depth-only"

--- a/Source/WebCore/Modules/WebGPU/GPUTextureDimension.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureDimension.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUTextureDimension {
+] enum GPUTextureDimension {
     "1d",
     "2d",
     "3d"

--- a/Source/WebCore/Modules/WebGPU/GPUTextureFormat.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureFormat.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUTextureFormat {
+] enum GPUTextureFormat {
     // 8-bit formats
     "r8unorm",
     "r8snorm",

--- a/Source/WebCore/Modules/WebGPU/GPUTextureSampleType.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureSampleType.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUTextureSampleType {
+] enum GPUTextureSampleType {
     "float",
     "unfilterable-float",
     "depth",

--- a/Source/WebCore/Modules/WebGPU/GPUTextureViewDimension.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureViewDimension.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUTextureViewDimension {
+] enum GPUTextureViewDimension {
     "1d",
     "2d",
     "2d-array",

--- a/Source/WebCore/Modules/WebGPU/GPUVertexFormat.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUVertexFormat.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUVertexFormat {
+] enum GPUVertexFormat {
     "uint8x2",
     "uint8x4",
     "sint8x2",

--- a/Source/WebCore/Modules/WebGPU/GPUVertexStepMode.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUVertexStepMode.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled
-]
-enum GPUVertexStepMode {
+] enum GPUVertexStepMode {
     "vertex",
     "instance"
 };


### PR DESCRIPTION
#### c1ec6be301dea19f8d9ceee5dad824ff535c18f0
<pre>
[WebGPU] enum values are on separate lines in idl files
<a href="https://bugs.webkit.org/show_bug.cgi?id=253740">https://bugs.webkit.org/show_bug.cgi?id=253740</a>&gt;
&lt;radar://106579273&gt;

Reviewed by Tadeu Zagallo.

Address some stylistic feedback from an earlier PR, no
functional change.

* Source/WebCore/Modules/WebGPU/GPUAddressMode.idl:
* Source/WebCore/Modules/WebGPU/GPUAutoLayoutMode.idl:
* Source/WebCore/Modules/WebGPU/GPUBlendFactor.idl:
* Source/WebCore/Modules/WebGPU/GPUBlendOperation.idl:
* Source/WebCore/Modules/WebGPU/GPUBufferBindingType.idl:
* Source/WebCore/Modules/WebGPU/GPUBufferMapState.idl:
* Source/WebCore/Modules/WebGPU/GPUCanvasAlphaMode.idl:
* Source/WebCore/Modules/WebGPU/GPUCompareFunction.idl:
* Source/WebCore/Modules/WebGPU/GPUCompilationMessageType.idl:
* Source/WebCore/Modules/WebGPU/GPUCullMode.idl:
* Source/WebCore/Modules/WebGPU/GPUDeviceLostReason.idl:
* Source/WebCore/Modules/WebGPU/GPUErrorFilter.idl:
* Source/WebCore/Modules/WebGPU/GPUFeatureName.idl:
* Source/WebCore/Modules/WebGPU/GPUFilterMode.idl:
* Source/WebCore/Modules/WebGPU/GPUFrontFace.idl:
* Source/WebCore/Modules/WebGPU/GPUIndexFormat.idl:
* Source/WebCore/Modules/WebGPU/GPULoadOp.idl:
* Source/WebCore/Modules/WebGPU/GPUMipmapFilterMode.idl:
* Source/WebCore/Modules/WebGPU/GPUPipelineErrorReason.idl:
* Source/WebCore/Modules/WebGPU/GPUPowerPreference.idl:
* Source/WebCore/Modules/WebGPU/GPUPredefinedColorSpace.idl:
* Source/WebCore/Modules/WebGPU/GPUPrimitiveTopology.idl:
* Source/WebCore/Modules/WebGPU/GPUQueryType.idl:
* Source/WebCore/Modules/WebGPU/GPUSamplerBindingType.idl:
* Source/WebCore/Modules/WebGPU/GPUStencilOperation.idl:
* Source/WebCore/Modules/WebGPU/GPUStorageTextureAccess.idl:
* Source/WebCore/Modules/WebGPU/GPUStoreOp.idl:
* Source/WebCore/Modules/WebGPU/GPUTextureAspect.idl:
* Source/WebCore/Modules/WebGPU/GPUTextureDimension.idl:
* Source/WebCore/Modules/WebGPU/GPUTextureFormat.idl:
* Source/WebCore/Modules/WebGPU/GPUTextureSampleType.idl:
* Source/WebCore/Modules/WebGPU/GPUTextureViewDimension.idl:
* Source/WebCore/Modules/WebGPU/GPUVertexFormat.idl:
* Source/WebCore/Modules/WebGPU/GPUVertexStepMode.idl:

Canonical link: <a href="https://commits.webkit.org/278459@main">https://commits.webkit.org/278459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cabd05f825cbe95b689d44e1b76416a388431c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53758 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1189 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52802 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36043 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41185 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52598 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27452 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43474 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22291 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24859 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/732 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8877 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46842 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55347 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25597 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/722 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48592 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26858 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47638 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11090 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27722 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26590 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->