### PR TITLE
TestWebKitAPI.KeyboardInputTests.EditableWebViewRequiresKeyboardWhenFirstResponder fails on iPhone Simulator

### DIFF
--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -519,6 +519,7 @@ typedef enum {
 - (void)setInlineCompletionAsMarkedText:(NSAttributedString *)inlineCompletion selectedRange:(NSRange)selectedRange inputString:(NSString *)inputString searchString:(NSString *)searchString;
 @property (nonatomic, readonly) BOOL hasInlineCompletionAsMarkedText;
 @property (nonatomic, readonly) UIKeyboardInputMode *currentInputModeInPreference;
+@property (nonatomic, readonly) BOOL hardwareKeyboardAttached;
 @end
 
 #if PLATFORM(IOS) || PLATFORM(VISION)

--- a/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
@@ -925,8 +925,19 @@ TEST(KeyboardInputTests, DoNotCrashWhenFocusingSelectWithoutViewSnapshot)
     [webView waitForNextPresentationUpdate];
 }
 
+static BOOL overrideHardwareKeyboardAttached(id, SEL)
+{
+    return NO;
+}
+
 TEST(KeyboardInputTests, EditableWebViewRequiresKeyboardWhenFirstResponder)
 {
+    InstanceMethodSwizzler swizzler {
+        UIKeyboardImpl.class,
+        @selector(hardwareKeyboardAttached),
+        reinterpret_cast<IMP>(overrideHardwareKeyboardAttached)
+    };
+
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto delegate = adoptNS([TestInputDelegate new]);
     [webView _setInputDelegate:delegate.get()];


### PR DESCRIPTION
#### a03f439c11675760e68b40b59fabfd4be3727c37
<pre>
TestWebKitAPI.KeyboardInputTests.EditableWebViewRequiresKeyboardWhenFirstResponder fails on iPhone Simulator
<a href="https://bugs.webkit.org/show_bug.cgi?id=273737">https://bugs.webkit.org/show_bug.cgi?id=273737</a>
<a href="https://rdar.apple.com/127547640">rdar://127547640</a>

Reviewed by Abrar Rahman Protyasha and Megan Gardner.

Prior to BrowserEngineKit adoption, WebKit would use UIKit SPI (`-[UIPressesEvent _hidEvent]`) to
keep track of when a hardware keyboard key is pressed; when observed, we&apos;d then set a boolean flag,
`_seenHardwareKeyDownInNonEditableElement`, which allows us to then return YES from
`-_requiresKeyboardWhenFirstResponder`. This is crucial for key event compatibility, in the case
where the web page listens for key events outside of the context of editing, and the user is using a
hardware keyboard on iOS (and can therefore dispatch keyboard events without the help of a software
keyboard).

With BrowserEngineKit adoption, we no longer rely on the aforementioned SPI; UIKit instead
automatically returns `YES`, as long as `-hardwareKeyboardAttached` is set. However, because this is
set by default when running tests in the iOS simulator, `-_requiresKeyboardWhenFirstResponder` now
returns `YES` right after loading the test markup.

Account for this change in the test by swizzling out `-hardwareKeyboardAttached` to simulate the
keyboard being detached, when running this test.

* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:
* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:
(TestWebKitAPI::overrideHardwareKeyboardAttached):
(TestWebKitAPI::TEST(KeyboardInputTests, EditableWebViewRequiresKeyboardWhenFirstResponder)):

Canonical link: <a href="https://commits.webkit.org/278427@main">https://commits.webkit.org/278427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/514b1afed970efb9c1b4983abd5a2b7c1c17b9f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2808 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53763 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1194 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52807 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/844 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41187 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52603 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27457 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43482 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22293 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/24864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/741 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8882 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46847 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/802 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55352 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25602 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/723 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/26863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43634 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47643 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11069 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27727 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/26595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->