### PR TITLE
[JSC] Leverage simde in JSON

### DIFF
--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -1203,7 +1203,7 @@ inline void copyElements(LChar* __restrict destination, const UChar* __restrict 
     copyElements(bitwise_cast<uint8_t*>(destination), bitwise_cast<const uint16_t*>(source), length);
 }
 
-#if CPU(ARM64)
+#if CPU(ARM64) || CPU(X86_64)
 
 ALWAYS_INLINE simde_uint8x16_t loadBulk(const uint8_t* ptr)
 {
@@ -1213,6 +1213,16 @@ ALWAYS_INLINE simde_uint8x16_t loadBulk(const uint8_t* ptr)
 ALWAYS_INLINE simde_uint16x8_t loadBulk(const uint16_t* ptr)
 {
     return simde_vld1q_u16(ptr);
+}
+
+ALWAYS_INLINE void storeBulk(simde_uint8x16_t value, uint8_t* ptr)
+{
+    return simde_vst1q_u8(ptr, value);
+}
+
+ALWAYS_INLINE void storeBulk(simde_uint16x8_t value, uint16_t* ptr)
+{
+    return simde_vst1q_u16(ptr, value);
 }
 
 ALWAYS_INLINE simde_uint8x16_t mergeBulk(simde_uint8x16_t accumulated, simde_uint8x16_t input)
@@ -1236,23 +1246,63 @@ ALWAYS_INLINE bool isNonZeroBulk(simde_uint16x8_t accumulated)
 }
 
 template<LChar character, LChar... characters>
-ALWAYS_INLINE simde_uint8x16_t compareBulk(simde_uint8x16_t input)
+ALWAYS_INLINE simde_uint8x16_t equalBulk(simde_uint8x16_t input)
 {
     auto result = simde_vceqq_u8(input, simde_vmovq_n_u8(character));
     if constexpr (!sizeof...(characters))
         return result;
     else
-        return mergeBulk(result, compareBulk<characters...>(input));
+        return mergeBulk(result, equalBulk<characters...>(input));
 }
 
 template<UChar character, UChar... characters>
-ALWAYS_INLINE simde_uint16x8_t compareBulk(simde_uint16x8_t input)
+ALWAYS_INLINE simde_uint16x8_t equalBulk(simde_uint16x8_t input)
 {
     auto result = simde_vceqq_u16(input, simde_vmovq_n_u16(character));
     if constexpr (!sizeof...(characters))
         return result;
     else
-        return mergeBulk(result, compareBulk<characters...>(input));
+        return mergeBulk(result, equalBulk<characters...>(input));
+}
+
+ALWAYS_INLINE simde_uint8x16_t equalBulk(simde_uint8x16_t lhs, simde_uint8x16_t rhs)
+{
+    return simde_vceqq_u8(lhs, rhs);
+}
+
+ALWAYS_INLINE simde_uint16x8_t equalBulk(simde_uint16x8_t lhs, simde_uint16x8_t rhs)
+{
+    return simde_vceqq_u16(lhs, rhs);
+}
+
+template<LChar character, LChar... characters>
+ALWAYS_INLINE simde_uint8x16_t lessThanBulk(simde_uint8x16_t input)
+{
+    auto result = simde_vcltq_u8(input, simde_vmovq_n_u8(character));
+    if constexpr (!sizeof...(characters))
+        return result;
+    else
+        return mergeBulk(result, lessThanBulk<characters...>(input));
+}
+
+template<UChar character, UChar... characters>
+ALWAYS_INLINE simde_uint16x8_t lessThanBulk(simde_uint16x8_t input)
+{
+    auto result = simde_vcltq_u16(input, simde_vmovq_n_u16(character));
+    if constexpr (!sizeof...(characters))
+        return result;
+    else
+        return mergeBulk(result, lessThanBulk<characters...>(input));
+}
+
+ALWAYS_INLINE simde_uint8x16_t lessThanBulk(simde_uint8x16_t lhs, simde_uint8x16_t rhs)
+{
+    return simde_vcltq_u8(lhs, rhs);
+}
+
+ALWAYS_INLINE simde_uint16x8_t lessThanBulk(simde_uint16x8_t lhs, simde_uint16x8_t rhs)
+{
+    return simde_vcltq_u16(lhs, rhs);
 }
 
 #endif
@@ -1270,7 +1320,7 @@ ALWAYS_INLINE bool charactersContain(std::span<const CharacterType> span)
     auto* data = span.data();
     size_t length = span.size();
 
-#if CPU(ARM64)
+#if CPU(ARM64) || CPU(X86_64)
     constexpr size_t stride = 16 / sizeof(CharacterType);
     using UnsignedType = std::make_unsigned_t<CharacterType>;
     using BulkType = decltype(loadBulk(static_cast<const UnsignedType*>(nullptr)));
@@ -1278,10 +1328,10 @@ ALWAYS_INLINE bool charactersContain(std::span<const CharacterType> span)
         size_t index = 0;
         BulkType accumulated { };
         for (; index + (stride - 1) < length; index += stride)
-            accumulated = mergeBulk(accumulated, compareBulk<characters...>(loadBulk(bitwise_cast<const UnsignedType*>(data + index))));
+            accumulated = mergeBulk(accumulated, equalBulk<characters...>(loadBulk(bitwise_cast<const UnsignedType*>(data + index))));
 
         if (index < length)
-            accumulated = mergeBulk(accumulated, compareBulk<characters...>(loadBulk(bitwise_cast<const UnsignedType*>(data + length - stride))));
+            accumulated = mergeBulk(accumulated, equalBulk<characters...>(loadBulk(bitwise_cast<const UnsignedType*>(data + length - stride))));
 
         return isNonZeroBulk(accumulated);
     }


### PR DESCRIPTION
#### 0eefc8d96ec2ab9b8b0454a3aa99888efaa5926d
<pre>
[JSC] Leverage simde in JSON
<a href="https://bugs.webkit.org/show_bug.cgi?id=273791">https://bugs.webkit.org/show_bug.cgi?id=273791</a>
<a href="https://rdar.apple.com/127622193">rdar://127622193</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::FastStringifier&lt;CharType&gt;::append):
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::LiteralParser&lt;CharType&gt;::Lexer::lexString):
* Source/WTF/wtf/text/StringCommon.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0eefc8d96ec2ab9b8b0454a3aa99888efaa5926d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50516 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2820 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53775 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1206 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41196 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43492 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22303 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24872 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/751 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8894 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43849 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46856 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55364 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/50016 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25614 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/735 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48606 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43644 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47653 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27739 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57494 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26607 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11815 "Passed tests") | 
<!--EWS-Status-Bubble-End-->