### PR TITLE
[run-webkit-tests] Route media tests to a mutually exclusive group

### DIFF
--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -261,6 +261,15 @@ class Port(object):
 
         return paths
 
+    def sharding_groups(self):
+        return {}
+
+    def group_for_shard(self, shard):
+        for group, filter_fn in self.sharding_groups().items():
+            if filter_fn(shard):
+                return group
+        return None
+
     def check_build(self):
         """This routine is used to ensure that the build is up to date
         and all the needed binaries are present."""

--- a/Tools/Scripts/webkitpy/port/darwin.py
+++ b/Tools/Scripts/webkitpy/port/darwin.py
@@ -53,6 +53,11 @@ class DarwinPort(ApplePort):
             # with MallocStackLogging enabled.
             self.set_option_default("batch_size", 1000)
 
+    def sharding_groups(self):
+        return {
+            'media': lambda shard: 'media' in shard.name or 'webaudio' in shard.name,
+        }
+
     def default_timeout_ms(self):
         if self.get_option('guard_malloc'):
             return 350 * 1000

--- a/Tools/Scripts/webkitpy/port/darwin_testcase.py
+++ b/Tools/Scripts/webkitpy/port/darwin_testcase.py
@@ -30,6 +30,7 @@ from webkitpy.common.system.filesystem_mock import MockFileSystem
 from webkitpy.common.system.executive_mock import MockExecutive, MockExecutive2, MockProcess, ScriptError
 from webkitpy.common.system.systemhost_mock import MockSystemHost
 from webkitpy.common.version_name_map import VersionNameMap
+from webkitpy.layout_tests.controllers.layout_test_runner import TestShard
 
 from webkitcorepy import OutputCapture
 
@@ -39,6 +40,17 @@ class DarwinTest(port_testcase.PortTestCase):
     def assert_skipped_file_search_paths(self, port_name, expected_paths, use_webkit2=False):
         port = self.make_port(port_name=port_name, options=MockOptions(webkit_test_runner=use_webkit2))
         self.assertEqual(port._skipped_file_search_paths(), expected_paths)
+
+    def test_sharding_groups(self):
+        port = self.make_port()
+        self.assertEqual(sorted(port.sharding_groups().keys()), ['media'])
+        self.assertEqual('media', port.group_for_shard(TestShard('media/something', [])))
+        self.assertEqual('media', port.group_for_shard(TestShard('webaudio/something', [])))
+        self.assertEqual('media', port.group_for_shard(TestShard('fast/media/something', [])))
+        self.assertEqual('media', port.group_for_shard(TestShard('media-session/something', [])))
+        self.assertEqual('media', port.group_for_shard(TestShard('imported/mediacapture-fromelement/something', [])))
+        self.assertEqual('media', port.group_for_shard(TestShard('something/media', [])))
+        self.assertEqual(None, port.group_for_shard(TestShard('fast/something', [])))
 
     def test_default_timeout_ms(self):
         super(DarwinTest, self).test_default_timeout_ms()

--- a/Tools/Scripts/webkitpy/port/port_testcase.py
+++ b/Tools/Scripts/webkitpy/port/port_testcase.py
@@ -48,6 +48,7 @@ from webkitpy.port.config import apple_additions
 from webkitpy.port.driver import DriverOutput
 from webkitpy.port.image_diff import ImageDiffer, ImageDiffResult
 from webkitpy.port.server_process_mock import MockServerProcess
+from webkitpy.layout_tests.controllers.layout_test_runner import TestShard
 from webkitpy.layout_tests.servers import http_server_base
 from webkitpy.tool.mocktool import MockOptions
 
@@ -126,6 +127,17 @@ class PortTestCase(unittest.TestCase):
         port = self.port_maker(host, port_name, options=options, **kwargs)
         port._config.build_directory = lambda configuration, for_host=False: '/mock-build'
         return port
+
+    def test_sharding_groups(self):
+        port = self.make_port()
+        self.assertEqual(sorted(port.sharding_groups().keys()), [])
+        self.assertEqual(None, port.group_for_shard(TestShard('media/something', [])))
+        self.assertEqual(None, port.group_for_shard(TestShard('webaudio/something', [])))
+        self.assertEqual(None, port.group_for_shard(TestShard('fast/media/something', [])))
+        self.assertEqual(None, port.group_for_shard(TestShard('media-session/something', [])))
+        self.assertEqual(None, port.group_for_shard(TestShard('imported/mediacapture-fromelement/something', [])))
+        self.assertEqual(None, port.group_for_shard(TestShard('something/media', [])))
+        self.assertEqual(None, port.group_for_shard(TestShard('fast/something', [])))
 
     def test_default_timeout_ms(self):
         self.assertEqual(self.make_port(options=MockOptions(configuration='Release')).default_timeout_ms(), 30000)


### PR DESCRIPTION
#### 7b0ca1365193adda601a2af7d1c2a53a913b21c6
<pre>
[run-webkit-tests] Route media tests to a mutually exclusive group
<a href="https://bugs.webkit.org/show_bug.cgi?id=273797">https://bugs.webkit.org/show_bug.cgi?id=273797</a>
<a href="https://rdar.apple.com/127629496">rdar://127629496</a>

Reviewed by Sam Sneddon.

We have evidence that media tests can interfere with one another. We should run media
tests in a dedicated worker so that these tests never interfere with other media tests.

* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py:
(LayoutTestRunner.run_tests): Use groups as defined by the current port. Dispatch grouped shards
first, so that we aren&apos;t waiting on groups at the end of the test run.
(TestShard.__init__): Support empty test list.
* Tools/Scripts/webkitpy/port/base.py:
(Port.sharding_groups): Return all groups and their callback definitions.
(Port.group_for_shard): Given a shard, return the group that shard is part of.
* Tools/Scripts/webkitpy/port/darwin.py:
(DarwinPort.sharding_groups): Add dedicated &apos;media&apos; and &apos;mediacapture&apos; groups for all shards
containing a media or mediacapture tests.
* Tools/Scripts/webkitpy/port/darwin_testcase.py:
(DarwinTest.test_lanes):
* Tools/Scripts/webkitpy/port/port_testcase.py:
(PortTestCase.test_lanes):

Canonical link: <a href="https://commits.webkit.org/279079@main">https://commits.webkit.org/279079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db2d0514a54f257385573bad8be10372f4ae5a64

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55555 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3004 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54586 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42532 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1921 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54377 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45122 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23607 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/52125 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26483 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2396 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1163 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48388 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57151 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27407 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2588 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49924 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28640 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49164 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11450 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29552 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28385 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->