### PR TITLE
Annotate some main-thread-only classes and protocols in WebKit API

### DIFF
--- a/Source/WebKit/Shared/API/Cocoa/WKFoundation.h
+++ b/Source/WebKit/Shared/API/Cocoa/WKFoundation.h
@@ -56,6 +56,12 @@
 #define WK_NULLABLE_RESULT _Nullable
 #endif
 
+#ifdef NS_SWIFT_UI_ACTOR
+#define WK_SWIFT_UI_ACTOR NS_SWIFT_UI_ACTOR
+#else
+#define WK_SWIFT_UI_ACTOR
+#endif
+
 #ifndef WK_FRAMEWORK_HEADER_POSTPROCESSING_ENABLED
 
 #define WK_API_AVAILABLE(...)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.h
@@ -32,6 +32,7 @@
  */
 NS_ASSUME_NONNULL_BEGIN
 
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 @interface WKBackForwardList : NSObject
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.h
@@ -31,6 +31,7 @@
  */
 NS_ASSUME_NONNULL_BEGIN
 
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 @interface WKBackForwardListItem : NSObject
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleList.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleList.h
@@ -27,6 +27,7 @@
 
 #import <Foundation/Foundation.h>
 
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
 @interface WKContentRuleList : NSObject
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.h
@@ -29,6 +29,7 @@
 
 @class WKContentRuleList;
 
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
 @interface WKContentRuleListStore : NSObject
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.h
@@ -40,6 +40,7 @@ For example:
 - If you store a variable in JavaScript in the scope of a particular WKContentWorld while viewing a particular web page document, after navigating to a new document that variable will be gone.
 - If you store a variable in JavaScript in the scope of a particular WKContentWorld in one WKWebView, that variable will not exist in the same world in another WKWebView.
 */
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(11.0), ios(14.0))
 @interface WKContentWorld : NSObject
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfo.h
@@ -31,6 +31,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(ios(13.0))
 @interface WKContextMenuElementInfo : NSObject
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKDownload.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKDownload.h
@@ -34,6 +34,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 WK_CLASS_AVAILABLE(macos(11.3), ios(14.5))
+WK_SWIFT_UI_ACTOR
 @interface WKDownload : NSObject<NSProgressReporting>
 
 /* @abstract The request used to initiate this download.
@@ -53,7 +54,7 @@ WK_CLASS_AVAILABLE(macos(11.3), ios(14.5))
  @discussion To attempt to resume the download, call WKWebView resumeDownloadFromResumeData: with the data given to the completionHandler.
  If no resume attempt is possible with this server, completionHandler will be called with nil.
  */
-- (void)cancel:(void(^ _Nullable)(NSData * _Nullable resumeData))completionHandler;
+- (void)cancel:(WK_SWIFT_UI_ACTOR void(^ _Nullable)(NSData * _Nullable resumeData))completionHandler;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKDownloadDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKDownloadDelegate.h
@@ -40,6 +40,7 @@ typedef NS_ENUM(NSInteger, WKDownloadRedirectPolicy) {
 
 NS_ASSUME_NONNULL_BEGIN
 
+WK_SWIFT_UI_ACTOR
 @protocol WKDownloadDelegate <NSObject>
 
 @required
@@ -56,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
  URL is non-null, it must be a file that does not exist in a directory that does exist
  and can be written to.
  */
-- (void)download:(WKDownload *)download decideDestinationUsingResponse:(NSURLResponse *)response suggestedFilename:(NSString *)suggestedFilename completionHandler:(void (^)(NSURL * _Nullable destination))completionHandler;
+- (void)download:(WKDownload *)download decideDestinationUsingResponse:(NSURLResponse *)response suggestedFilename:(NSString *)suggestedFilename completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSURL * _Nullable destination))completionHandler;
 
 @optional
 
@@ -68,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
  to proceed with the redirection.
  @discussion If you do not implement this method, all server suggested redirects will be taken.
  */
-- (void)download:(WKDownload *)download willPerformHTTPRedirection:(NSHTTPURLResponse *)response newRequest:(NSURLRequest *)request decisionHandler:(void (^)(WKDownloadRedirectPolicy))decisionHandler WK_SWIFT_ASYNC_NAME(download(_:decidedPolicyForHTTPRedirection:newRequest:)) WK_SWIFT_ASYNC(4);
+- (void)download:(WKDownload *)download willPerformHTTPRedirection:(NSHTTPURLResponse *)response newRequest:(NSURLRequest *)request decisionHandler:(WK_SWIFT_UI_ACTOR void (^)(WKDownloadRedirectPolicy))decisionHandler WK_SWIFT_ASYNC_NAME(download(_:decidedPolicyForHTTPRedirection:newRequest:)) WK_SWIFT_ASYNC(4);
 
 /* @abstract Invoked when the download needs to respond to an authentication challenge.
  @param download The download that received the authentication challenge.
@@ -80,7 +81,7 @@ NS_ASSUME_NONNULL_BEGIN
  credential.
  @discussion If you do not implement this method, the web view will respond to the authentication challenge with the NSURLSessionAuthChallengeRejectProtectionSpace disposition.
  */
-- (void)download:(WKDownload *)download didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))completionHandler WK_SWIFT_ASYNC_NAME(download(_:respondTo:));
+- (void)download:(WKDownload *)download didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))completionHandler WK_SWIFT_ASYNC_NAME(download(_:respondTo:));
 
 /* @abstract Invoked when the download has finished successfully.
  @param download The download that finished.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFindConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFindConfiguration.h
@@ -27,6 +27,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.15.4), ios(13.4))
 @interface WKFindConfiguration : NSObject <NSCopying>
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFindResult.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFindResult.h
@@ -27,6 +27,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.15.4), ios(13.4))
 @interface WKFindResult : NSObject <NSCopying>
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.h
@@ -36,6 +36,7 @@
  */
 NS_ASSUME_NONNULL_BEGIN
 
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 @interface WKFrameInfo : NSObject <NSCopying>
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.h
@@ -37,6 +37,7 @@ typedef NS_ENUM(NSInteger, WKCookiePolicy) {
 } NS_SWIFT_NAME(WKHTTPCookieStore.CookiePolicy) WK_API_AVAILABLE(macos(14.0), ios(17.0));
 
 WK_API_AVAILABLE(macos(10.13), ios(11.0))
+WK_SWIFT_UI_ACTOR
 @protocol WKHTTPCookieStoreObserver <NSObject>
 @optional
 - (void)cookiesDidChangeInCookieStore:(WKHTTPCookieStore *)cookieStore;
@@ -46,6 +47,7 @@ WK_API_AVAILABLE(macos(10.13), ios(11.0))
  A WKHTTPCookieStore object allows managing the HTTP cookies associated with a particular WKWebsiteDataStore.
  */
 WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
+WK_SWIFT_UI_ACTOR
 @interface WKHTTPCookieStore : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -53,18 +55,18 @@ WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
 /*! @abstract Fetches all stored cookies.
  @param completionHandler A block to invoke with the fetched cookies.
  */
-- (void)getAllCookies:(void (^)(NSArray<NSHTTPCookie *> *))completionHandler;
+- (void)getAllCookies:(WK_SWIFT_UI_ACTOR void (^)(NSArray<NSHTTPCookie *> *))completionHandler;
 
 /*! @abstract Set a cookie.
  @param cookie The cookie to set.
  @param completionHandler A block to invoke once the cookie has been stored.
  */
-- (void)setCookie:(NSHTTPCookie *)cookie completionHandler:(nullable void (^)(void))completionHandler;
+- (void)setCookie:(NSHTTPCookie *)cookie completionHandler:(nullable WK_SWIFT_UI_ACTOR void (^)(void))completionHandler;
 
 /*! @abstract Delete the specified cookie.
  @param completionHandler A block to invoke once the cookie has been deleted.
  */
-- (void)deleteCookie:(NSHTTPCookie *)cookie completionHandler:(nullable void (^)(void))completionHandler WK_SWIFT_ASYNC_NAME(deleteCookie(_:));
+- (void)deleteCookie:(NSHTTPCookie *)cookie completionHandler:(nullable WK_SWIFT_UI_ACTOR void (^)(void))completionHandler WK_SWIFT_ASYNC_NAME(deleteCookie(_:));
 
 /*! @abstract Adds a WKHTTPCookieStoreObserver object with the cookie store.
  @param observer The observer object to add.
@@ -82,12 +84,12 @@ WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
   @param policy A value indicating whether cookies are allowed. The default value is WKCookiePolicyAllow.
   @param completionHandler A block to invoke once the cookie policy has been set.
   */
-- (void)setCookiePolicy:(WKCookiePolicy)policy completionHandler:(nullable void (^)(void))completionHandler WK_API_AVAILABLE(macos(14.0), ios(17.0));
+- (void)setCookiePolicy:(WKCookiePolicy)policy completionHandler:(nullable WK_SWIFT_UI_ACTOR void (^)(void))completionHandler WK_API_AVAILABLE(macos(14.0), ios(17.0));
 
 /*! @abstract Get whether cookies are allowed.
  @param completionHandler A block to invoke with the value of whether cookies are allowed.
  */
-- (void)getCookiePolicy:(void (^)(WKCookiePolicy))completionHandler WK_SWIFT_ASYNC_NAME(getter:cookiePolicy()) WK_API_AVAILABLE(macos(14.0), ios(17.0));
+- (void)getCookiePolicy:(WK_SWIFT_UI_ACTOR void (^)(WKCookiePolicy))completionHandler WK_SWIFT_ASYNC_NAME(getter:cookiePolicy()) WK_API_AVAILABLE(macos(14.0), ios(17.0));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigation.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigation.h
@@ -33,6 +33,7 @@
  also passed to the navigation delegate methods, to uniquely identify a webpage
  load from start to finish.
  */
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 @interface WKNavigation : NSObject
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.h
@@ -56,6 +56,7 @@ typedef NS_ENUM(NSInteger, WKNavigationType) {
 /*! 
 A WKNavigationAction object contains information about an action that may cause a navigation, used for making policy decisions.
  */
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 @interface WKNavigationAction : NSObject
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationDelegate.h
@@ -65,6 +65,7 @@ typedef NS_ENUM(NSInteger, WKNavigationResponsePolicy) {
  methods for tracking progress for main frame navigations and for deciding
  policy for main frame and subframe navigations.
  */
+WK_SWIFT_UI_ACTOR
 @protocol WKNavigationDelegate <NSObject>
 
 @optional
@@ -77,7 +78,7 @@ typedef NS_ENUM(NSInteger, WKNavigationResponsePolicy) {
  navigation. The argument is one of the constants of the enumerated type WKNavigationActionPolicy.
  @discussion If you do not implement this method, the web view will load the request or, if appropriate, forward it to another application.
  */
-- (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler WK_SWIFT_ASYNC(3);
+- (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(WK_SWIFT_UI_ACTOR void (^)(WKNavigationActionPolicy))decisionHandler WK_SWIFT_ASYNC(3);
 
 /*! @abstract Decides whether to allow or cancel a navigation.
  @param webView The web view invoking the delegate method.
@@ -91,7 +92,7 @@ typedef NS_ENUM(NSInteger, WKNavigationResponsePolicy) {
  @discussion If you implement this method,
  -webView:decidePolicyForNavigationAction:decisionHandler: will not be called.
  */
-- (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction preferences:(WKWebpagePreferences *)preferences decisionHandler:(void (^)(WKNavigationActionPolicy, WKWebpagePreferences *))decisionHandler WK_SWIFT_ASYNC(4) WK_API_AVAILABLE(macos(10.15), ios(13.0));
+- (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction preferences:(WKWebpagePreferences *)preferences decisionHandler:(WK_SWIFT_UI_ACTOR void (^)(WKNavigationActionPolicy, WKWebpagePreferences *))decisionHandler WK_SWIFT_ASYNC(4) WK_API_AVAILABLE(macos(10.15), ios(13.0));
 
 /*! @abstract Decides whether to allow or cancel a navigation after its
  response is known.
@@ -102,7 +103,7 @@ typedef NS_ENUM(NSInteger, WKNavigationResponsePolicy) {
  navigation. The argument is one of the constants of the enumerated type WKNavigationResponsePolicy.
  @discussion If you do not implement this method, the web view will allow the response, if the web view can show it.
  */
-- (void)webView:(WKWebView *)webView decidePolicyForNavigationResponse:(WKNavigationResponse *)navigationResponse decisionHandler:(void (^)(WKNavigationResponsePolicy))decisionHandler WK_SWIFT_ASYNC(3);
+- (void)webView:(WKWebView *)webView decidePolicyForNavigationResponse:(WKNavigationResponse *)navigationResponse decisionHandler:(WK_SWIFT_UI_ACTOR void (^)(WKNavigationResponsePolicy))decisionHandler WK_SWIFT_ASYNC(3);
 
 /*! @abstract Invoked when a main frame navigation starts.
  @param webView The web view invoking the delegate method.
@@ -155,7 +156,7 @@ typedef NS_ENUM(NSInteger, WKNavigationResponsePolicy) {
  credential.
  @discussion If you do not implement this method, the web view will respond to the authentication challenge with the NSURLSessionAuthChallengeRejectProtectionSpace disposition.
  */
-- (void)webView:(WKWebView *)webView didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential * _Nullable credential))completionHandler WK_SWIFT_ASYNC_NAME(webView(_:respondTo:));
+- (void)webView:(WKWebView *)webView didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential * _Nullable credential))completionHandler WK_SWIFT_ASYNC_NAME(webView(_:respondTo:));
 
 /*! @abstract Invoked when the web view's web content process is terminated.
  @param webView The web view whose underlying web content process was terminated.
@@ -167,7 +168,7 @@ typedef NS_ENUM(NSInteger, WKNavigationResponsePolicy) {
  @param challenge The authentication challenge.
  @param decisionHandler The decision handler you must invoke to respond to indicate whether or not to continue with the connection establishment.
  */
-- (void)webView:(WKWebView *)webView authenticationChallenge:(NSURLAuthenticationChallenge *)challenge shouldAllowDeprecatedTLS:(void (^)(BOOL))decisionHandler WK_SWIFT_ASYNC_NAME(webView(_:shouldAllowDeprecatedTLSFor:)) WK_SWIFT_ASYNC(3) WK_API_AVAILABLE(macos(11.0), ios(14.0));
+- (void)webView:(WKWebView *)webView authenticationChallenge:(NSURLAuthenticationChallenge *)challenge shouldAllowDeprecatedTLS:(WK_SWIFT_UI_ACTOR void (^)(BOOL))decisionHandler WK_SWIFT_ASYNC_NAME(webView(_:shouldAllowDeprecatedTLSFor:)) WK_SWIFT_ASYNC(3) WK_API_AVAILABLE(macos(11.0), ios(14.0));
 
 /*
  @abstract Called after using WKNavigationActionPolicyDownload.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.h
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*! Contains information about a navigation response, used for making policy decisions.
  */
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 @interface WKNavigationResponse : NSObject
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParameters.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParameters.h
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*! WKOpenPanelParameters contains parameters that a file upload control has specified.
  */
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.12))
 @interface WKOpenPanelParameters : NSObject
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPDFConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPDFConfiguration.h
@@ -29,6 +29,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.15.4), ios(13.4))
 @interface WKPDFConfiguration : NSObject <NSCopying>
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.h
@@ -31,6 +31,7 @@
  view. The preferences object associated with a web view is specified by
  its web view configuration.
  */
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 @interface WKPreferences : NSObject <NSSecureCoding>
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.h
@@ -33,6 +33,7 @@
  implementation-defined process limit is reached; after that, web views
  with the same process pool end up sharing web content processes.
  */
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 @interface WKProcessPool : NSObject <NSSecureCoding>
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKScriptMessage.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKScriptMessage.h
@@ -36,6 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*! A WKScriptMessage object contains information about a message sent from
  a webpage.
  */
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 @interface WKScriptMessage : NSObject
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKScriptMessageHandler.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKScriptMessageHandler.h
@@ -35,6 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*! A class conforming to the WKScriptMessageHandler protocol provides a
  method for receiving messages from JavaScript running in a webpage.
  */
+WK_SWIFT_UI_ACTOR
 @protocol WKScriptMessageHandler <NSObject>
 
 @required

--- a/Source/WebKit/UIProcess/API/Cocoa/WKScriptMessageHandlerWithReply.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKScriptMessageHandlerWithReply.h
@@ -35,6 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*! A class conforming to  the WKScriptMessageHandlerWithReply protocol provides a
 method for receiving messages from JavaScript running in a webpage and replying to them asynchronously.
 */
+WK_SWIFT_UI_ACTOR
 @protocol WKScriptMessageHandlerWithReply <NSObject>
 
 /*! @abstract Invoked when a script message is received from a webpage.
@@ -87,7 +88,7 @@ method for receiving messages from JavaScript running in a webpage and replying 
    - The JavaScript promise is fulfilled with the value 42.
    - JavaScript execution continues and the value 42 is returned.
  */
-- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message replyHandler:(void (^)(id _Nullable reply, NSString *_Nullable errorMessage))replyHandler WK_SWIFT_ASYNC(3) WK_API_AVAILABLE(macos(11.0), ios(14.0));
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message replyHandler:(WK_SWIFT_UI_ACTOR void (^)(id _Nullable reply, NSString *_Nullable errorMessage))replyHandler WK_SWIFT_ASYNC(3) WK_API_AVAILABLE(macos(11.0), ios(14.0));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKSecurityOrigin.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKSecurityOrigin.h
@@ -34,6 +34,7 @@
  */
 NS_ASSUME_NONNULL_BEGIN
 
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.11), ios(9.0))
 @interface WKSecurityOrigin : NSObject
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKSnapshotConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKSnapshotConfiguration.h
@@ -30,6 +30,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
 @interface WKSnapshotConfiguration : NSObject <NSCopying>
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegate.h
@@ -73,6 +73,7 @@ typedef NS_ENUM(NSInteger, WKDialogResult) {
 /*! A class conforming to the WKUIDelegate protocol provides methods for
  presenting native UI on behalf of a webpage.
  */
+WK_SWIFT_UI_ACTOR
 @protocol WKUIDelegate <NSObject>
 
 @optional
@@ -112,7 +113,7 @@ typedef NS_ENUM(NSInteger, WKDialogResult) {
 
  If you do not implement this method, the web view will behave as if the user selected the OK button.
  */
-- (void)webView:(WKWebView *)webView runJavaScriptAlertPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(void))completionHandler;
+- (void)webView:(WKWebView *)webView runJavaScriptAlertPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(WK_SWIFT_UI_ACTOR void (^)(void))completionHandler;
 
 /*! @abstract Displays a JavaScript confirm panel.
  @param webView The web view invoking the delegate method.
@@ -128,7 +129,7 @@ typedef NS_ENUM(NSInteger, WKDialogResult) {
 
  If you do not implement this method, the web view will behave as if the user selected the Cancel button.
  */
-- (void)webView:(WKWebView *)webView runJavaScriptConfirmPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(BOOL result))completionHandler;
+- (void)webView:(WKWebView *)webView runJavaScriptConfirmPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(WK_SWIFT_UI_ACTOR void (^)(BOOL result))completionHandler;
 
 /*! @abstract Displays a JavaScript text input panel.
  @param webView The web view invoking the delegate method.
@@ -146,7 +147,7 @@ typedef NS_ENUM(NSInteger, WKDialogResult) {
 
  If you do not implement this method, the web view will behave as if the user selected the Cancel button.
  */
-- (void)webView:(WKWebView *)webView runJavaScriptTextInputPanelWithPrompt:(NSString *)prompt defaultText:(nullable NSString *)defaultText initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(NSString * _Nullable result))completionHandler;
+- (void)webView:(WKWebView *)webView runJavaScriptTextInputPanelWithPrompt:(NSString *)prompt defaultText:(nullable NSString *)defaultText initiatedByFrame:(WKFrameInfo *)frame completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSString * _Nullable result))completionHandler;
 
 
 /*! @abstract A delegate to request permission for microphone audio and camera video access.
@@ -157,14 +158,14 @@ typedef NS_ENUM(NSInteger, WKDialogResult) {
  @param decisionHandler The completion handler to call once the decision is made
  @discussion If not implemented, the result is the same as calling the decisionHandler with WKPermissionDecisionPrompt.
  */
-- (void)webView:(WKWebView *)webView requestMediaCapturePermissionForOrigin:(WKSecurityOrigin *)origin initiatedByFrame:(WKFrameInfo *)frame type:(WKMediaCaptureType)type decisionHandler:(void (^)(WKPermissionDecision decision))decisionHandler WK_SWIFT_ASYNC_NAME(webView(_:decideMediaCapturePermissionsFor:initiatedBy:type:)) WK_SWIFT_ASYNC(5) WK_API_AVAILABLE(macos(12.0), ios(15.0));
+- (void)webView:(WKWebView *)webView requestMediaCapturePermissionForOrigin:(WKSecurityOrigin *)origin initiatedByFrame:(WKFrameInfo *)frame type:(WKMediaCaptureType)type decisionHandler:(WK_SWIFT_UI_ACTOR void (^)(WKPermissionDecision decision))decisionHandler WK_SWIFT_ASYNC_NAME(webView(_:decideMediaCapturePermissionsFor:initiatedBy:type:)) WK_SWIFT_ASYNC(5) WK_API_AVAILABLE(macos(12.0), ios(15.0));
 
 /*! @abstract Allows your app to determine whether or not the given security origin should have access to the device's orientation and motion.
  @param securityOrigin The security origin which requested access to the device's orientation and motion.
  @param frame The frame that initiated the request.
  @param decisionHandler The decision handler to call once the app has made its decision.
  */
-- (void)webView:(WKWebView *)webView requestDeviceOrientationAndMotionPermissionForOrigin:(WKSecurityOrigin *)origin initiatedByFrame:(WKFrameInfo *)frame decisionHandler:(void (^)(WKPermissionDecision decision))decisionHandler WK_API_AVAILABLE(ios(15.0)) WK_API_UNAVAILABLE(macos);
+- (void)webView:(WKWebView *)webView requestDeviceOrientationAndMotionPermissionForOrigin:(WKSecurityOrigin *)origin initiatedByFrame:(WKFrameInfo *)frame decisionHandler:(WK_SWIFT_UI_ACTOR void (^)(WKPermissionDecision decision))decisionHandler WK_API_AVAILABLE(ios(15.0)) WK_API_UNAVAILABLE(macos);
 
 #if TARGET_OS_IPHONE
 
@@ -213,7 +214,7 @@ typedef NS_ENUM(NSInteger, WKDialogResult) {
  * Pass a valid UIContextMenuConfiguration to show a context menu, or pass nil to not show a context menu.
  */
 
-- (void)webView:(WKWebView *)webView contextMenuConfigurationForElement:(WKContextMenuElementInfo *)elementInfo completionHandler:(void (^)(UIContextMenuConfiguration * _Nullable configuration))completionHandler WK_SWIFT_ASYNC_NAME(webView(_:contextMenuConfigurationFor:)) WK_API_AVAILABLE(ios(13.0));
+- (void)webView:(WKWebView *)webView contextMenuConfigurationForElement:(WKContextMenuElementInfo *)elementInfo completionHandler:(WK_SWIFT_UI_ACTOR void (^)(UIContextMenuConfiguration * _Nullable configuration))completionHandler WK_SWIFT_ASYNC_NAME(webView(_:contextMenuConfigurationFor:)) WK_API_AVAILABLE(ios(13.0));
 
 /**
  * @abstract Called when the context menu will be presented.
@@ -253,7 +254,7 @@ typedef NS_ENUM(NSInteger, WKDialogResult) {
 
  If you do not implement this method, the web view will display the default Lockdown Mode message.
  */
-- (void)webView:(WKWebView *)webView showLockdownModeFirstUseMessage:(NSString *)message completionHandler:(void (^)(WKDialogResult))completionHandler WK_API_AVAILABLE(ios(13.0));
+- (void)webView:(WKWebView *)webView showLockdownModeFirstUseMessage:(NSString *)message completionHandler:(WK_SWIFT_UI_ACTOR void (^)(WKDialogResult))completionHandler WK_API_AVAILABLE(ios(13.0));
 
 /**
  * @abstract Called when the web view is about to present its edit menu.
@@ -283,7 +284,7 @@ typedef NS_ENUM(NSInteger, WKDialogResult) {
 
  If you do not implement this method, the web view will behave as if the user selected the Cancel button.
  */
-- (void)webView:(WKWebView *)webView runOpenPanelWithParameters:(WKOpenPanelParameters *)parameters initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(NSArray<NSURL *> * _Nullable URLs))completionHandler WK_API_AVAILABLE(macos(10.12));
+- (void)webView:(WKWebView *)webView runOpenPanelWithParameters:(WKOpenPanelParameters *)parameters initiatedByFrame:(WKFrameInfo *)frame completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSArray<NSURL *> * _Nullable URLs))completionHandler WK_API_AVAILABLE(macos(10.12));
 
 #endif
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKURLSchemeHandler.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKURLSchemeHandler.h
@@ -35,6 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*! A class conforming to the WKURLSchemeHandler protocol provides methods for
  loading resources with URL schemes that WebKit doesn't know how to handle itself.
  */
+WK_SWIFT_UI_ACTOR
 WK_API_AVAILABLE(macos(10.13), ios(11.0))
 @protocol WKURLSchemeHandler <NSObject>
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.h
@@ -40,6 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
  The user content controller associated with a web view is specified by its
  web view configuration.
  */
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 @interface WKUserContentController : NSObject <NSSecureCoding>
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserScript.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserScript.h
@@ -42,6 +42,7 @@ typedef NS_ENUM(NSInteger, WKUserScriptInjectionTime) {
 
 /*! A @link WKUserScript @/link object represents a script that can be injected into webpages.
  */
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 @interface WKUserScript : NSObject <NSCopying>
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
@@ -57,6 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
  @helperclass @link WKWebViewConfiguration @/link
  Used to configure @link WKWebView @/link instances.
  */
+WK_SWIFT_UI_ACTOR
 #if TARGET_OS_IPHONE
 WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 @interface WKWebView : UIView
@@ -250,7 +251,7 @@ typedef NS_ENUM(NSInteger, WKFullscreenState) {
    - A `frame` value of `nil` to represent the main frame
    - A `contentWorld` value of `WKContentWorld.pageWorld`
 */
-- (void)evaluateJavaScript:(NSString *)javaScriptString completionHandler:(void (^ _Nullable)(_Nullable id, NSError * _Nullable error))completionHandler;
+- (void)evaluateJavaScript:(NSString *)javaScriptString completionHandler:(WK_SWIFT_UI_ACTOR void (^ _Nullable)(_Nullable id, NSError * _Nullable error))completionHandler;
 
 /* @abstract Evaluates the given JavaScript string.
  @param javaScriptString The JavaScript string to evaluate.
@@ -272,7 +273,7 @@ typedef NS_ENUM(NSInteger, WKFullscreenState) {
  evaluateJavaScript: is a great way to set up global state for future JavaScript execution in a given world. (e.g. Importing libraries/utilities that future JavaScript execution will rely on)
  Once your global state is set up, consider using callAsyncJavaScript: for more flexible interaction with the JavaScript programming model.
 */
-- (void)evaluateJavaScript:(NSString *)javaScriptString inFrame:(nullable WKFrameInfo *)frame inContentWorld:(WKContentWorld *)contentWorld completionHandler:(void (^ _Nullable)(_Nullable id, NSError * _Nullable error))completionHandler NS_REFINED_FOR_SWIFT WK_API_AVAILABLE(macos(11.0), ios(14.0));
+- (void)evaluateJavaScript:(NSString *)javaScriptString inFrame:(nullable WKFrameInfo *)frame inContentWorld:(WKContentWorld *)contentWorld completionHandler:(WK_SWIFT_UI_ACTOR void (^ _Nullable)(_Nullable id, NSError * _Nullable error))completionHandler NS_REFINED_FOR_SWIFT WK_API_AVAILABLE(macos(11.0), ios(14.0));
 
 /* @abstract Calls the given JavaScript string as an async JavaScript function, passing the given named arguments to that function.
  @param functionBody The JavaScript string to use as the function body.
@@ -344,30 +345,30 @@ typedef NS_ENUM(NSInteger, WKFullscreenState) {
 
  The above function text will create a promise that will fulfull with the value 42 after a one second delay, wait for it to resolve, then return the fulfillment value of 42.
 */
-- (void)callAsyncJavaScript:(NSString *)functionBody arguments:(nullable NSDictionary<NSString *, id> *)arguments inFrame:(nullable WKFrameInfo *)frame inContentWorld:(WKContentWorld *)contentWorld completionHandler:(void (^ _Nullable)(id WK_NULLABLE_RESULT result, NSError * _Nullable error))completionHandler NS_REFINED_FOR_SWIFT WK_API_AVAILABLE(macos(11.0), ios(14.0));
+- (void)callAsyncJavaScript:(NSString *)functionBody arguments:(nullable NSDictionary<NSString *, id> *)arguments inFrame:(nullable WKFrameInfo *)frame inContentWorld:(WKContentWorld *)contentWorld completionHandler:(WK_SWIFT_UI_ACTOR void (^ _Nullable)(id WK_NULLABLE_RESULT result, NSError * _Nullable error))completionHandler NS_REFINED_FOR_SWIFT WK_API_AVAILABLE(macos(11.0), ios(14.0));
 
 /*! @abstract Closes all out-of-window media presentations in a WKWebView.
  @discussion Includes picture-in-picture and fullscreen.
  */
-- (void)closeAllMediaPresentationsWithCompletionHandler:(void (^_Nullable)(void))completionHandler WK_API_AVAILABLE(macos(12.0), ios(15.0));
+- (void)closeAllMediaPresentationsWithCompletionHandler:(WK_SWIFT_UI_ACTOR void (^_Nullable)(void))completionHandler WK_API_AVAILABLE(macos(12.0), ios(15.0));
 - (void)closeAllMediaPresentations WK_API_DEPRECATED_WITH_REPLACEMENT("closeAllMediaPresentationsWithCompletionHandler:", macos(11.3, 12.0), ios(14.5, 15.0));
 
 /*! @abstract Pauses media playback in WKWebView.
  @discussion Pauses media playback. Media in the page can be restarted by calling play() on a media element or resume() on an AudioContext in JavaScript. A user can also use media controls to play media content after it has been paused.
  */
-- (void)pauseAllMediaPlaybackWithCompletionHandler:(void (^_Nullable)(void))completionHandler WK_API_AVAILABLE(macos(12.0), ios(15.0));
+- (void)pauseAllMediaPlaybackWithCompletionHandler:(WK_SWIFT_UI_ACTOR void (^_Nullable)(void))completionHandler WK_API_AVAILABLE(macos(12.0), ios(15.0));
 #ifndef __swift__
-- (void)pauseAllMediaPlayback:(void (^_Nullable)(void))completionHandler WK_API_DEPRECATED_WITH_REPLACEMENT("pauseAllMediaPlaybackWithCompletionHandler:", macos(11.3, 12.0), ios(14.5, 15.0));
+- (void)pauseAllMediaPlayback:(WK_SWIFT_UI_ACTOR void (^_Nullable)(void))completionHandler WK_API_DEPRECATED_WITH_REPLACEMENT("pauseAllMediaPlaybackWithCompletionHandler:", macos(11.3, 12.0), ios(14.5, 15.0));
 #endif
 
 /*! @abstract Suspends or resumes all media playback in WKWebView.
   @param suspended Whether media playback should be suspended or resumed.
   @discussion If suspended is true, this pauses media playback and blocks all attempts by the page or the user to resume until setAllMediaPlaybackSuspended is called again with suspended set to false. Media playback should always be suspended and resumed in pairs.
 */
-- (void)setAllMediaPlaybackSuspended:(BOOL)suspended completionHandler:(void (^_Nullable)(void))completionHandler WK_API_AVAILABLE(macos(12.0), ios(15.0));
+- (void)setAllMediaPlaybackSuspended:(BOOL)suspended completionHandler:(WK_SWIFT_UI_ACTOR void (^_Nullable)(void))completionHandler WK_API_AVAILABLE(macos(12.0), ios(15.0));
 #ifndef __swift__
-- (void)resumeAllMediaPlayback:(void (^ _Nullable)(void))completionHandler WK_API_DEPRECATED_WITH_REPLACEMENT("setAllMediaPlaybackSuspended:completionHandler:", macos(11.3, 12.0), ios(14.5, 15.0));
-- (void)suspendAllMediaPlayback:(void (^_Nullable)(void))completionHandler WK_API_DEPRECATED_WITH_REPLACEMENT("setAllMediaPlaybackSuspended:completionHandler:", macos(11.3, 12.0), ios(14.5, 15.0));
+- (void)resumeAllMediaPlayback:(WK_SWIFT_UI_ACTOR void (^ _Nullable)(void))completionHandler WK_API_DEPRECATED_WITH_REPLACEMENT("setAllMediaPlaybackSuspended:completionHandler:", macos(11.3, 12.0), ios(14.5, 15.0));
+- (void)suspendAllMediaPlayback:(WK_SWIFT_UI_ACTOR void (^_Nullable)(void))completionHandler WK_API_DEPRECATED_WITH_REPLACEMENT("setAllMediaPlaybackSuspended:completionHandler:", macos(11.3, 12.0), ios(14.5, 15.0));
 #endif
 
 /*! @abstract Get the current media playback state of a WKWebView.
@@ -377,9 +378,9 @@ typedef NS_ENUM(NSInteger, WKFullscreenState) {
  If no media playback exists in the current WKWebView, WKMediaPlaybackState will equal
  WKMediaPlaybackStateNone.
  */
-- (void)requestMediaPlaybackStateWithCompletionHandler:(void (^)(WKMediaPlaybackState))completionHandler WK_API_AVAILABLE(macos(12.0), ios(15.0));
+- (void)requestMediaPlaybackStateWithCompletionHandler:(WK_SWIFT_UI_ACTOR void (^)(WKMediaPlaybackState))completionHandler WK_API_AVAILABLE(macos(12.0), ios(15.0));
 #ifndef __swift__
-- (void)requestMediaPlaybackState:(void (^)(WKMediaPlaybackState))completionHandler WK_API_DEPRECATED_WITH_REPLACEMENT("requestMediaPlaybackStateWithCompletionHandler:", macos(11.3, 12.0), ios(14.5, 15.0));
+- (void)requestMediaPlaybackState:(WK_SWIFT_UI_ACTOR void (^)(WKMediaPlaybackState))completionHandler WK_API_DEPRECATED_WITH_REPLACEMENT("requestMediaPlaybackStateWithCompletionHandler:", macos(11.3, 12.0), ios(14.5, 15.0));
 #endif
 
 /*! @abstract The state of camera capture on a web page.
@@ -402,7 +403,7 @@ typedef NS_ENUM(NSInteger, WKFullscreenState) {
  If value is WKMediaCaptureStateMuted, any active camera capture will become muted.
  If value is WKMediaCaptureStateActive, any muted camera capture will become active.
  */
-- (void)setCameraCaptureState:(WKMediaCaptureState)state completionHandler:(void (^_Nullable)(void))completionHandler WK_API_AVAILABLE(macos(12.0), ios(15.0));
+- (void)setCameraCaptureState:(WKMediaCaptureState)state completionHandler:(WK_SWIFT_UI_ACTOR void (^_Nullable)(void))completionHandler WK_API_AVAILABLE(macos(12.0), ios(15.0));
 
 /*! @abstract Set microphone capture state of a WKWebView.
  @param state state to apply for capture.
@@ -412,7 +413,7 @@ typedef NS_ENUM(NSInteger, WKFullscreenState) {
  If value is WKMediaCaptureStateMuted, any active microphone capture will become muted.
  If value is WKMediaCaptureStateActive, any muted microphone capture will become active.
  */
-- (void)setMicrophoneCaptureState:(WKMediaCaptureState)state completionHandler:(void (^_Nullable)(void))completionHandler WK_API_AVAILABLE(macos(12.0), ios(15.0));
+- (void)setMicrophoneCaptureState:(WKMediaCaptureState)state completionHandler:(WK_SWIFT_UI_ACTOR void (^_Nullable)(void))completionHandler WK_API_AVAILABLE(macos(12.0), ios(15.0));
 
 /*! @abstract Get a snapshot for the visible viewport of WKWebView.
  @param snapshotConfiguration An object that specifies how the snapshot is configured.
@@ -422,9 +423,9 @@ typedef NS_ENUM(NSInteger, WKFullscreenState) {
  device scale. The completionHandler is passed the image of the viewport contents or an error.
  */
 #if TARGET_OS_IPHONE
-- (void)takeSnapshotWithConfiguration:(nullable WKSnapshotConfiguration *)snapshotConfiguration completionHandler:(void (^)(UIImage * _Nullable snapshotImage, NSError * _Nullable error))completionHandler WK_SWIFT_ASYNC_NAME(takeSnapshot(configuration:)) WK_API_AVAILABLE(ios(11.0));
+- (void)takeSnapshotWithConfiguration:(nullable WKSnapshotConfiguration *)snapshotConfiguration completionHandler:(WK_SWIFT_UI_ACTOR void (^)(UIImage * _Nullable snapshotImage, NSError * _Nullable error))completionHandler WK_SWIFT_ASYNC_NAME(takeSnapshot(configuration:)) WK_API_AVAILABLE(ios(11.0));
 #else
-- (void)takeSnapshotWithConfiguration:(nullable WKSnapshotConfiguration *)snapshotConfiguration completionHandler:(void (^)(NSImage * _Nullable snapshotImage, NSError * _Nullable error))completionHandler WK_SWIFT_ASYNC_NAME(takeSnapshot(configuration:)) WK_API_AVAILABLE(macos(10.13));
+- (void)takeSnapshotWithConfiguration:(nullable WKSnapshotConfiguration *)snapshotConfiguration completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSImage * _Nullable snapshotImage, NSError * _Nullable error))completionHandler WK_SWIFT_ASYNC_NAME(takeSnapshot(configuration:)) WK_API_AVAILABLE(macos(10.13));
 #endif
 
 /*! @abstract Create a PDF document representation from the web page currently displayed in the WKWebView
@@ -435,7 +436,7 @@ The completionHandler is passed the resulting PDF document data or an error.
 The data can be used to create a PDFDocument object.
 If the data is written to a file the resulting file is a valid PDF document.
 */
-- (void)createPDFWithConfiguration:(nullable WKPDFConfiguration *)pdfConfiguration completionHandler:(void (^)(NSData * _Nullable pdfDocumentData, NSError * _Nullable error))completionHandler NS_REFINED_FOR_SWIFT WK_API_AVAILABLE(macos(11.0), ios(14.0));
+- (void)createPDFWithConfiguration:(nullable WKPDFConfiguration *)pdfConfiguration completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSData * _Nullable pdfDocumentData, NSError * _Nullable error))completionHandler NS_REFINED_FOR_SWIFT WK_API_AVAILABLE(macos(11.0), ios(14.0));
 
 /* @abstract Create WebKit web archive data representing the current web content of the WKWebView
 @param completionHandler A block to invoke when the web archive data is ready.
@@ -443,7 +444,7 @@ If the data is written to a file the resulting file is a valid PDF document.
 It can be used to represent web content on a pasteboard, loaded into a WKWebView directly, and saved to a file for later use.
 The uniform type identifier kUTTypeWebArchive can be used get the related pasteboard type and MIME type.
 */
-- (void)createWebArchiveDataWithCompletionHandler:(void (^)(NSData *, NSError *))completionHandler NS_REFINED_FOR_SWIFT WK_API_AVAILABLE(macos(11.0), ios(14.0));
+- (void)createWebArchiveDataWithCompletionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSData *, NSError *))completionHandler NS_REFINED_FOR_SWIFT WK_API_AVAILABLE(macos(11.0), ios(14.0));
 
 /*! @abstract A Boolean value indicating whether horizontal swipe gestures
  will trigger back-forward list navigations.
@@ -505,7 +506,7 @@ The uniform type identifier kUTTypeWebArchive can be used get the related pasteb
   A match found by the search is selected and the page is scrolled to reveal the selection.
   The completion handler is called after the search completes.
 */
-- (void)findString:(NSString *)string withConfiguration:(nullable WKFindConfiguration *)configuration completionHandler:(void (^)(WKFindResult *result))completionHandler NS_REFINED_FOR_SWIFT WK_API_AVAILABLE(macos(11.0), ios(14.0));
+- (void)findString:(NSString *)string withConfiguration:(nullable WKFindConfiguration *)configuration completionHandler:(WK_SWIFT_UI_ACTOR void (^)(WKFindResult *result))completionHandler NS_REFINED_FOR_SWIFT WK_API_AVAILABLE(macos(11.0), ios(14.0));
 
 /* @abstract Checks whether or not WKWebViews handle the given URL scheme by default.
  @param scheme The URL scheme to check.
@@ -517,14 +518,14 @@ The uniform type identifier kUTTypeWebArchive can be used get the related pasteb
  @param completionHandler A block called when the download has started.
  @discussion The download needs its delegate to be set in the completionHandler to receive updates about its progress.
  */
-- (void)startDownloadUsingRequest:(NSURLRequest *)request completionHandler:(void(^)(WKDownload *))completionHandler WK_API_AVAILABLE(macos(11.3), ios(14.5));
+- (void)startDownloadUsingRequest:(NSURLRequest *)request completionHandler:(WK_SWIFT_UI_ACTOR void(^)(WKDownload *))completionHandler WK_API_AVAILABLE(macos(11.3), ios(14.5));
 
 /* @abstract Resumes a download that failed or was canceled.
  @param resumeData Data from a WKDownloadDelegate's didFailWithError or a WKDownload's cancel completionHandler.
  @param completionHandler A block called when the download has resumed.
  @discussion The download needs its delegate to be set in the completionHandler to receive updates about its progress.
  */
-- (void)resumeDownloadFromResumeData:(NSData *)resumeData completionHandler:(void(^)(WKDownload *))completionHandler WK_API_AVAILABLE(macos(11.3), ios(14.5));
+- (void)resumeDownloadFromResumeData:(NSData *)resumeData completionHandler:(WK_SWIFT_UI_ACTOR void(^)(WKDownload *))completionHandler WK_API_AVAILABLE(macos(11.3), ios(14.5));
 
 /* @abstract The media type for the WKWebView
  @discussion The value of mediaType will override the normal value of the CSS media property.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.h
@@ -90,6 +90,7 @@ typedef NS_OPTIONS(NSUInteger, WKAudiovisualMediaTypes) {
  which to initialize a web view.
  @helps Contains properties used to configure a @link WKWebView @/link.
  */
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 @interface WKWebViewConfiguration : NSObject <NSSecureCoding, NSCopying>
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h
@@ -46,6 +46,7 @@ typedef NS_ENUM(NSInteger, WKContentMode) {
  determine the preferences to use when loading and rendering a page.
  @discussion Contains properties used to determine webpage preferences.
  */
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.15), ios(13.0))
 @interface WKWebpagePreferences : NSObject
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.h
@@ -72,6 +72,7 @@ WK_EXTERN NSString * const WKWebsiteDataTypeMediaKeys WK_API_AVAILABLE(macos(14.
 WK_EXTERN NSString * const WKWebsiteDataTypeHashSalt WK_API_AVAILABLE(macos(14.0), ios(17.0));
 
 /*! A WKWebsiteDataRecord represents website data, grouped by domain name using the public suffix list. */
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.11), ios(9.0))
 @interface WKWebsiteDataRecord : NSObject
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
@@ -39,6 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  make use of. This includes cookies, disk and memory caches, and persistent data such as WebSQL,
  IndexedDB databases, and local storage.
  */
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.11), ios(9.0))
 @interface WKWebsiteDataStore : NSObject <NSSecureCoding>
 
@@ -64,21 +65,21 @@ WK_CLASS_AVAILABLE(macos(10.11), ios(9.0))
   @param dataTypes The website data types to fetch records for.
   @param completionHandler A block to invoke when the data records have been fetched.
 */
-- (void)fetchDataRecordsOfTypes:(NSSet<NSString *> *)dataTypes completionHandler:(void (^)(NSArray<WKWebsiteDataRecord *> *))completionHandler WK_SWIFT_ASYNC_NAME(dataRecords(ofTypes:));
+- (void)fetchDataRecordsOfTypes:(NSSet<NSString *> *)dataTypes completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSArray<WKWebsiteDataRecord *> *))completionHandler WK_SWIFT_ASYNC_NAME(dataRecords(ofTypes:));
 
 /*! @abstract Removes website data of the given types for the given data records.
  @param dataTypes The website data types that should be removed.
  @param dataRecords The website data records to delete website data for.
  @param completionHandler A block to invoke when the website data for the records has been removed.
 */
-- (void)removeDataOfTypes:(NSSet<NSString *> *)dataTypes forDataRecords:(NSArray<WKWebsiteDataRecord *> *)dataRecords completionHandler:(void (^)(void))completionHandler;
+- (void)removeDataOfTypes:(NSSet<NSString *> *)dataTypes forDataRecords:(NSArray<WKWebsiteDataRecord *> *)dataRecords completionHandler:(WK_SWIFT_UI_ACTOR void (^)(void))completionHandler;
 
 /*! @abstract Removes all website data of the given types that has been modified since the given date.
  @param dataTypes The website data types that should be removed.
  @param date A date. All website data modified after this date will be removed.
  @param completionHandler A block to invoke when the website data has been removed.
 */
-- (void)removeDataOfTypes:(NSSet<NSString *> *)dataTypes modifiedSince:(NSDate *)date completionHandler:(void (^)(void))completionHandler;
+- (void)removeDataOfTypes:(NSSet<NSString *> *)dataTypes modifiedSince:(NSDate *)date completionHandler:(WK_SWIFT_UI_ACTOR void (^)(void))completionHandler;
 
 /*! @abstract Returns the cookie store representing HTTP cookies in this website data store. */
 @property (nonatomic, readonly) WKHTTPCookieStore *httpCookieStore WK_API_AVAILABLE(macos(10.13), ios(11.0));
@@ -101,13 +102,13 @@ WK_CLASS_AVAILABLE(macos(10.11), ios(9.0))
  @discussion This should be called when the data store is not used any more. Returns error if removal fails
  to complete. WKWebView using the data store must be released before removal.
 */
-+ (void)removeDataStoreForIdentifier:(NSUUID *)identifier completionHandler:(void(^)(NSError * _Nullable))completionHandler WK_API_AVAILABLE(macos(14.0), ios(17.0));
++ (void)removeDataStoreForIdentifier:(NSUUID *)identifier completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSError * _Nullable))completionHandler WK_API_AVAILABLE(macos(14.0), ios(17.0));
 
 /*! @abstract Fetch all data stores identifiers.
  @param completionHandler A block to invoke with an array of identifiers when the operation completes.
  @discussion Default or non-persistent data store do not have an identifier.
 */
-+ (void)fetchAllDataStoreIdentifiers:(void(^)(NSArray<NSUUID *> *))completionHandler WK_SWIFT_ASYNC_NAME(getter:allDataStoreIdentifiers()) WK_API_AVAILABLE(macos(14.0), ios(17.0));
++ (void)fetchAllDataStoreIdentifiers:(WK_SWIFT_UI_ACTOR void(^)(NSArray<NSUUID *> *))completionHandler WK_SWIFT_ASYNC_NAME(getter:allDataStoreIdentifiers()) WK_API_AVAILABLE(macos(14.0), ios(17.0));
 
 #if ((TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 140000) \
     || ((TARGET_OS_IOS || TARGET_OS_MACCATALYST) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 170000) \

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWindowFeatures.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWindowFeatures.h
@@ -31,6 +31,7 @@
  */
 NS_ASSUME_NONNULL_BEGIN
 
+WK_SWIFT_UI_ACTOR
 WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 @interface WKWindowFeatures : NSObject
 


### PR DESCRIPTION
#### 13873b2f58fb7748c641b8f29ebc19e5ea73f267
<pre>
Annotate some main-thread-only classes and protocols in WebKit API
<a href="https://bugs.webkit.org/show_bug.cgi?id=273798">https://bugs.webkit.org/show_bug.cgi?id=273798</a>
<a href="https://rdar.apple.com/127629908">rdar://127629908</a>

Reviewed by Brady Eidson.

Most WebKit APIs are main-thread-only so let&apos;s say so for better
ergonomics and error checking for clients.

I manually tested these classes:

WKBackForwardList
WKBackForwardListItem
WKWebViewConfiguration
WKUserContentController
WKContentRuleList
WKContentRuleListStore
WKContentWorld
WKContextMenuElementInfo
WKDownload
WKFindConfiguration
WKFindResult
WKFrameInfo
WKHTTPCookieStore
WKNavigation
WKNavigationAction
WKNavigationResponse
WKPreferences
WKProcessPool
WKScriptMessage
WKWebsiteDataStore
WKOpenPanelParameters
WKPDFConfiguration
WKSecurityOrigin
WKSnapshotConfiguration
WKUserScript
WKWebpagePreferences
WKWebsiteDataRecord
WKWebView
WKWindowFeatures

...and these callback-to-WebKit APIs:

WKDownloadDelegate
   - decideDestinationUsingResponse
   - willPerformHTTPRedirection
   - didReceiveAuthenticationChallenge

WKUIDelegate
   - runJavaScriptAlertPanelWithMessage
   - runJavaScriptConfirmPanelWithMessage
   - runJavaScriptTextInputPanelWithPrompt
   - requestMediaCapturePermissionForOrigin
   - requestDeviceOrientationAndMotionPermissionForOrigin
   - contextMenuConfigurationForElement
   - showLockdownModeFirstUseMessage
   - runOpenPanelWithParameters

WKScriptMessageHandlerWithReply
   - didReceiveScriptMessage

...and verified that they compile when used in &quot;isolated&quot; (i.e. main thread)
code and fail to compile when used in &quot;nonisolated&quot; (i.e. secondary thread)
code.

I manually tested these protocols:

WKHTTPCookieStoreObserver
WKUIDelegate
WKURLSchemeHandler
WKScriptMessageHandler
WKScriptMessageHandlerWithReply
WKDownloadDelegate
WKNavigationDelegate

...and these callback-to-client APIs:

WKContentRuleListStore
   - compileContentRuleListForIdentifier
   - lookUpContentRuleListForIdentifier
   - removeContentRuleListForIdentifier
   - getAvailableContentRuleListIdentifiers

WKDownload
   - cancel

WKHTTPCookieStore
   - getAllCookies
   - setCookie
   - deleteCookie
   - setCookiePolicy
   - getCookiePolicy

WKWebsiteDataStore
   - fetchDataRecordsOfTypes
   - removeDataOfTypes
   - removeDataOfTypes
   - removeDataStoreForIdentifier
   - fetchAllDataStoreIdentifiers

* WKWebView.h
   - evaluateJavaScript
   - evaluateJavaScript
   - callAsyncJavaScript
   - closeAllMediaPresentationsWithCompletionHandler
   - pauseAllMediaPlaybackWithCompletionHandler
   - setAllMediaPlaybackSuspended
   - requestMediaPlaybackStateWithCompletionHandler
   - setCameraCaptureState
   - setMicrophoneCaptureState
   - takeSnapshotWithConfiguration
   - createPDFWithConfiguration
   - createWebArchiveDataWithCompletionHandler
   - findString
   - startDownloadUsingRequest
   - resumeDownloadFromResumeData

...and verified that they compile when implemented in &quot;isolated&quot; (i.e. main
thread) code.

These classes are thread safe and need no annotation:

WKURLSchemeTask

Canonical link: <a href="https://commits.webkit.org/278930@main">https://commits.webkit.org/278930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3258b4491521277a47d858fdd314a5e549efd46d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54626 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2053 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1732 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41841 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1226 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53462 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28314 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22952 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25633 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/246 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47608 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1626 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56216 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26480 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49238 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27721 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48416 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11376 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28612 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27456 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->