### PR TITLE
Replace `String::fromUTF8(const LChar*)` with `String::fromUTF8(std::span<const char8_t>)`

### DIFF
--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -63,7 +63,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 static String fromStdFileSystemPath(const std::filesystem::path& path)
 {
-    return String::fromUTF8(reinterpret_cast<const LChar*>(path.u8string().c_str()));
+    return String::fromUTF8(span(path.u8string()));
 }
 
 #endif // HAVE(STD_FILESYSTEM) || HAVE(STD_EXPERIMENTAL_FILESYSTEM)

--- a/Source/WTF/wtf/text/ASCIIFastPath.h
+++ b/Source/WTF/wtf/text/ASCIIFastPath.h
@@ -60,10 +60,16 @@ template<> struct NonASCIIMask<4, UChar> {
 template<> struct NonASCIIMask<4, LChar> {
     static inline uint32_t value() { return 0x80808080U; }
 };
+template<> struct NonASCIIMask<4, char8_t> {
+    static inline uint32_t value() { return 0x80808080U; }
+};
 template<> struct NonASCIIMask<8, UChar> {
     static inline uint64_t value() { return 0xFF80FF80FF80FF80ULL; }
 };
 template<> struct NonASCIIMask<8, LChar> {
+    static inline uint64_t value() { return 0x8080808080808080ULL; }
+};
+template<> struct NonASCIIMask<8, char8_t> {
     static inline uint64_t value() { return 0x8080808080808080ULL; }
 };
 

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -58,6 +58,11 @@ inline std::span<const char> span(const char* string)
     return { string, string ? strlen(string) : 0 };
 }
 
+inline std::span<const char8_t> span(const std::u8string& string)
+{
+    return { string.data(), string.length() };
+}
+
 template<typename CharacterType> inline constexpr bool isLatin1(CharacterType character)
 {
     using UnsignedCharacterType = typename std::make_unsigned<CharacterType>::type;

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -463,7 +463,7 @@ void String::convertTo16Bit()
 }
 
 template<bool replaceInvalidSequences>
-String fromUTF8Impl(std::span<const LChar> string)
+String fromUTF8Impl(std::span<const char8_t> string)
 {
     RELEASE_ASSERT(string.size() <= String::MaxLength);
 
@@ -471,13 +471,13 @@ String fromUTF8Impl(std::span<const LChar> string)
         return emptyString();
 
     if (charactersAreAllASCII(string))
-        return StringImpl::create(string);
+        return StringImpl::create(spanReinterpretCast<const LChar>(string));
 
     Vector<UChar, 1024> buffer(string.size());
  
     auto result = replaceInvalidSequences
-        ? Unicode::convertReplacingInvalidSequences(spanReinterpretCast<const char8_t>(string), buffer.mutableSpan())
-        : Unicode::convert(spanReinterpretCast<const char8_t>(string), buffer.mutableSpan());
+        ? Unicode::convertReplacingInvalidSequences(string, buffer.mutableSpan())
+        : Unicode::convert(string, buffer.mutableSpan());
     if (result.code != Unicode::ConversionResultCode::Success)
         return { };
 
@@ -485,34 +485,27 @@ String fromUTF8Impl(std::span<const LChar> string)
     return StringImpl::create(result.buffer);
 }
 
-String String::fromUTF8(std::span<const LChar> string)
+String String::fromUTF8(std::span<const char8_t> string)
 {
     if (!string.data())
         return { };
     return fromUTF8Impl<false>(string);
 }
 
-String String::fromUTF8ReplacingInvalidSequences(std::span<const LChar> characters)
+String String::fromUTF8ReplacingInvalidSequences(std::span<const char8_t> characters)
 {
     if (!characters.data())
         return { };
     return fromUTF8Impl<true>(characters);
 }
 
-String String::fromUTF8(const LChar* string)
-{
-    if (!string)
-        return { };
-    return fromUTF8Impl<false>({ string, strlen(reinterpret_cast<const char*>(string)) });
-}
-
-String String::fromUTF8WithLatin1Fallback(std::span<const LChar> string)
+String String::fromUTF8WithLatin1Fallback(std::span<const char8_t> string)
 {
     String utf8 = fromUTF8(string);
     if (!utf8) {
         // Do this assertion before chopping the size_t down to unsigned.
         RELEASE_ASSERT(string.size() <= String::MaxLength);
-        return string;
+        return spanReinterpretCast<const LChar>(string);
     }
     return utf8;
 }

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -262,15 +262,17 @@ public:
     WTF_EXPORT_PRIVATE void convertTo16Bit();
 
     // String::fromUTF8 will return a null string if the input data contains invalid UTF-8 sequences.
-    WTF_EXPORT_PRIVATE static String fromUTF8(std::span<const LChar>);
-    WTF_EXPORT_PRIVATE static String fromUTF8(const LChar*);
-    static String fromUTF8(std::span<const char> characters) { return fromUTF8(std::span { reinterpret_cast<const LChar*>(characters.data()), characters.size() }); }
-    static String fromUTF8(const char* string) { return fromUTF8(reinterpret_cast<const LChar*>(string)); }
-    static String fromUTF8ReplacingInvalidSequences(std::span<const LChar>);
+    WTF_EXPORT_PRIVATE static String fromUTF8(std::span<const char8_t>);
+    static String fromUTF8(std::span<const LChar> characters) { return fromUTF8({ reinterpret_cast<const char8_t*>(characters.data()), characters.size() }); }
+    static String fromUTF8(std::span<const char> characters) { return fromUTF8({ reinterpret_cast<const char8_t*>(characters.data()), characters.size() }); }
+    static String fromUTF8(const char* string) { return fromUTF8(WTF::span8(string)); }
+    static String fromUTF8ReplacingInvalidSequences(std::span<const char8_t>);
+    static String fromUTF8ReplacingInvalidSequences(std::span<const LChar> characters) { return fromUTF8ReplacingInvalidSequences({ reinterpret_cast<const char8_t*>(characters.data()), characters.size() }); }
 
     // Tries to convert the passed in string to UTF-8, but will fall back to Latin-1 if the string is not valid UTF-8.
-    WTF_EXPORT_PRIVATE static String fromUTF8WithLatin1Fallback(std::span<const LChar>);
-    static String fromUTF8WithLatin1Fallback(std::span<const char> characters) { return fromUTF8WithLatin1Fallback({ reinterpret_cast<const LChar*>(characters.data()), characters.size() }); }
+    WTF_EXPORT_PRIVATE static String fromUTF8WithLatin1Fallback(std::span<const char8_t>);
+    static String fromUTF8WithLatin1Fallback(std::span<const LChar> characters) { return fromUTF8WithLatin1Fallback({ reinterpret_cast<const char8_t*>(characters.data()), characters.size() }); }
+    static String fromUTF8WithLatin1Fallback(std::span<const char> characters) { return fromUTF8WithLatin1Fallback({ reinterpret_cast<const char8_t*>(characters.data()), characters.size() }); }
 
     WTF_EXPORT_PRIVATE static String fromCodePoint(char32_t codePoint);
 

--- a/Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp
@@ -205,7 +205,7 @@ String FontPlatformData::familyName() const
 {
     FcChar8* family = nullptr;
     FcPatternGetString(m_pattern.get(), FC_FAMILY, 0, &family);
-    return String::fromUTF8(family);
+    return String::fromUTF8(span8(reinterpret_cast<const char*>(family)));
 }
 
 Vector<FontPlatformData::FontVariationAxis> FontPlatformData::variationAxes(ShouldLocalizeAxisNames shouldLocalizeAxisNames) const


### PR DESCRIPTION
#### 44f686979a890c8d5e6e4ae4fbbddfaf8ed539df
<pre>
Replace `String::fromUTF8(const LChar*)` with `String::fromUTF8(std::span&lt;const char8_t&gt;)`
<a href="https://bugs.webkit.org/show_bug.cgi?id=273799">https://bugs.webkit.org/show_bug.cgi?id=273799</a>

Reviewed by Sihui Liu.

Replace `String::fromUTF8(const LChar*)` with `String::fromUTF8(std::span&lt;const char8_t&gt;)`
as we&apos;re transitioning towards using std::span, and using char8_t to represent UTF-8.

* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::fromStdFileSystemPath):
* Source/WTF/wtf/text/ASCIIFastPath.h:
* Source/WTF/wtf/text/StringCommon.h:
(WTF::span):
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::fromUTF8Impl):
(WTF::String::fromUTF8):
(WTF::String::fromUTF8ReplacingInvalidSequences):
(WTF::String::fromUTF8WithLatin1Fallback):
* Source/WTF/wtf/text/WTFString.h:

Canonical link: <a href="https://commits.webkit.org/278442@main">https://commits.webkit.org/278442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/039831d751e859e5c40919e726c9705eae744ec9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53813 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1244 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52857 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/894 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41220 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27497 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43529 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22330 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/789 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8932 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43887 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46889 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55402 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/50054 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25652 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/768 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48630 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/26913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43682 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47681 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27777 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57532 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7322 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/26645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11827 "Passed tests") | 
<!--EWS-Status-Bubble-End-->