### PR TITLE
ImageDecoderCG::createFrameImageAtIndex's use of m_uti is not thread safe

### DIFF
--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -273,7 +273,7 @@ size_t ImageDecoderCG::bytesDecodedToDetermineProperties() const
     // behavior is unchanged.
     return 13088;
 }
-    
+
 String ImageDecoderCG::filenameExtension() const
 {
     return WebCore::preferredExtensionForImageType(uti());
@@ -555,9 +555,8 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     CGImageSetCachingFlags(image.get(), kCGImageCachingTemporary);
 ALLOW_DEPRECATED_DECLARATIONS_END
 #endif // PLATFORM(IOS_FAMILY)
-    
-    String uti = this->uti();
-    if (uti.isEmpty() || uti != "public.xbitmap-image"_s)
+
+    if (!m_isXBitmapImage)
         return image;
     
     // If it is an xbm image, mask out all the white areas to render them transparent.
@@ -660,6 +659,7 @@ void ImageDecoderCG::setData(const FragmentedSharedBuffer& data, bool allDataRec
     CGImageSourceUpdateData(m_nativeDecoder.get(), contiguousData->createCFData().get(), allDataReceived);
     
     m_uti = decodeUTI(contiguousData.get());
+    m_isXBitmapImage = m_uti == "public.xbitmap-image"_s;
 }
 
 bool ImageDecoderCG::canDecodeType(const String& mimeType)

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.h
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ImageDecoder.h"
+#include <atomic>
 
 #if USE(CG)
 
@@ -83,6 +84,7 @@ private:
 #endif
     
     bool m_isAllDataReceived { false };
+    std::atomic<bool> m_isXBitmapImage { false };
     mutable EncodedDataStatus m_encodedDataStatus { EncodedDataStatus::Unknown };
     String m_uti;
     RetainPtr<CGImageSourceRef> m_nativeDecoder;


### PR DESCRIPTION
#### f0697eb70f0c468754be1a19f643033da4b6beb0
<pre>
ImageDecoderCG::createFrameImageAtIndex&apos;s use of m_uti is not thread safe
<a href="https://bugs.webkit.org/show_bug.cgi?id=273801">https://bugs.webkit.org/show_bug.cgi?id=273801</a>

Reviewed by Said Abou-Hallawa.

Replace the use of ImageDecoderCG::uti in ImageDecoderCG::createFrameImageAtIndex
with a boolean to make it thread safe.

* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::ImageDecoderCG::createFrameImageAtIndex):
(WebCore::ImageDecoderCG::setData):
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.h:
* Source/WebCore/platform/network/DataURLDecoder.cpp:
(WebCore::DataURLDecoder::parseMediaType):

Canonical link: <a href="https://commits.webkit.org/278438@main">https://commits.webkit.org/278438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/226aff05883e69ee670298d2a783ce04cc6cf4c5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29847 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53810 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1241 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52854 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/891 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41214 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27493 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43522 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22325 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/24890 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/782 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8929 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55399 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25649 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48621 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/26910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43675 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47672 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/27774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7320 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/26642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->