### PR TITLE
[Site Isolation] FrameLoader::loadURL should handle request for existing remote frame properly

### DIFF
--- a/LayoutTests/http/tests/site-isolation/iframe-top-level-navigation-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/iframe-top-level-navigation-expected.txt
@@ -1,0 +1,10 @@
+Verifies top-level navigation initiated by iframe can complete
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Main frame is navigated to new url: http://localhost:8000/site-isolation/iframe-top-level-navigation.html#complete
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/iframe-top-level-navigation.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-top-level-navigation.html
@@ -1,0 +1,22 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+
+description("Verifies top-level navigation initiated by iframe can complete");
+jsTestIsAsync = true;
+
+function runTest() 
+{
+    if (window.location.hash == "#complete") {
+        testPassed("Main frame is navigated to new url: " + window.location.href);
+        finishJSTest();
+        return;
+    }
+
+    var iframe = document.createElement('iframe');
+    iframe.src = "http://localhost:8000/site-isolation/resources/iframe-top-level-navigation-iframe.html";
+    document.body.appendChild(iframe);
+}
+
+</script>
+<body onload="runTest()"></body>

--- a/LayoutTests/http/tests/site-isolation/resources/iframe-top-level-navigation-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/resources/iframe-top-level-navigation-iframe.html
@@ -1,0 +1,8 @@
+<a id="link" href="http://localhost:8000/site-isolation/iframe-top-level-navigation.html#complete" target="_top">Click Me</a>
+<script>
+onload = function() { 
+    internals.withUserGesture(() => {
+        document.getElementById("link").click();
+    });
+}
+</script>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -109,6 +109,7 @@
 #include "PolicyChecker.h"
 #include "ProgressTracker.h"
 #include "Quirks.h"
+#include "RemoteFrame.h"
 #include "ReportingScope.h"
 #include "ResourceLoadInfo.h"
 #include "ResourceLoadObserver.h"
@@ -1504,7 +1505,13 @@ void FrameLoader::loadURL(FrameLoadRequest&& frameLoadRequest, const String& ref
     bool isFormSubmission = formState;
 
     // The search for a target frame is done earlier in the case of form submission.
-    RefPtr targetFrame = isFormSubmission ? nullptr : dynamicDowncast<LocalFrame>(findFrameForNavigation(effectiveFrameName));
+    RefPtr effectiveTargetFrame = findFrameForNavigation(effectiveFrameName);
+    if (is<RemoteFrame>(effectiveTargetFrame)) {
+        effectiveTargetFrame->changeLocation(WTFMove(frameLoadRequest));
+        return;
+    }
+
+    RefPtr targetFrame = isFormSubmission ? nullptr : dynamicDowncast<LocalFrame>(effectiveTargetFrame);
     if (targetFrame && targetFrame != frame.ptr()) {
         frameLoadRequest.setFrameName(selfTargetFrameName());
         targetFrame->checkedLoader()->loadURL(WTFMove(frameLoadRequest), referrer, newLoadType, event, WTFMove(formState), WTFMove(privateClickMeasurement), completionHandlerCaller.release());


### PR DESCRIPTION
#### 3f3246e4670f57dff0fa6f4dfb97da6f0198573c
<pre>
[Site Isolation] FrameLoader::loadURL should handle request for existing remote frame properly
<a href="https://bugs.webkit.org/show_bug.cgi?id=273800">https://bugs.webkit.org/show_bug.cgi?id=273800</a>
<a href="https://rdar.apple.com/127631799">rdar://127631799</a>

Reviewed by Charlie Wolfe.

FrameLoader::loadURL currently falls back to &quot;creating a new window&quot; flow when target frame is a remote frame -- it goes
the PolicyChecker::checkNewWindowPolicy() path. This is problematic because UI process would treat this as loading in a
new frame. To fix this, make `FrameLoader::loadURL` forward request to the remote target frame.

Test: http/tests/site-isolation/iframe-top-level-navigation.html

* LayoutTests/http/tests/site-isolation/iframe-top-level-navigation-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/iframe-top-level-navigation.html: Added.
* LayoutTests/http/tests/site-isolation/resources/iframe-top-level-navigation-iframe.html: Added.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadURL):

Canonical link: <a href="https://commits.webkit.org/278473@main">https://commits.webkit.org/278473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59a1df942e0480489d7cf14cc816836e65aa1713

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53919 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/1351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52963 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1001 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43634 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22411 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24993 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/890 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9101 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46973 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/952 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55509 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25762 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/855 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48708 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/27019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43777 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47764 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11100 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/27887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/26751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->