### PR TITLE
The various Base.xcconfigs should have the same header search paths

### DIFF
--- a/Source/WebCore/Configurations/Base.xcconfig
+++ b/Source/WebCore/Configurations/Base.xcconfig
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2023 Apple Inc. All rights reserved.
+// Copyright (C) 2009-2024 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -109,7 +109,9 @@ STRIP_INSTALLED_PRODUCT[config=Debug] = NO;
 SDKROOT = macosx.internal;
 ADDITIONAL_SDKS = $(WK_ADDITIONAL_SDKS);
 
-OTHER_CPLUSPLUSFLAGS = $(inherited) -isystem $(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders;
+HEADER_SEARCH_PATHS = . "$(BUILT_PRODUCTS_DIR)$(WK_LIBRARY_HEADERS_FOLDER_PATH)" $(HEADER_SEARCH_PATHS);
+LIBRARY_SEARCH_PATHS = $(SDK_DIR)$(WK_LIBRARY_INSTALL_PATH) $(inherited);
+SYSTEM_HEADER_SEARCH_PATHS = $(WK_PRIVATE_SDK_DIR)$(WK_ALTERNATE_WEBKIT_SDK_PATH)$(WK_LIBRARY_HEADERS_FOLDER_PATH) $(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders $(inherited);
 
 // This is required to make LLVM_TARGET_TRIPLE_SUFFIX propagate into scripts.
 LLVM_TARGET_TRIPLE_SUFFIX = $(inherited);

--- a/Source/WebKit/Configurations/Base.xcconfig
+++ b/Source/WebKit/Configurations/Base.xcconfig
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2023 Apple Inc. All rights reserved.
+// Copyright (C) 2010-2024 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -116,7 +116,9 @@ AD_HOC_CODE_SIGNING_ALLOWED = YES;
 SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator;
 SUPPORTS_MACCATALYST = YES;
 
-OTHER_CPLUSPLUSFLAGS = $(inherited) -isystem $(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders;
+HEADER_SEARCH_PATHS = . "$(BUILT_PRODUCTS_DIR)$(WK_LIBRARY_HEADERS_FOLDER_PATH)" $(HEADER_SEARCH_PATHS);
+LIBRARY_SEARCH_PATHS = $(SDK_DIR)$(WK_LIBRARY_INSTALL_PATH) $(inherited);
+SYSTEM_HEADER_SEARCH_PATHS = $(WK_PRIVATE_SDK_DIR)$(WK_ALTERNATE_WEBKIT_SDK_PATH)$(WK_LIBRARY_HEADERS_FOLDER_PATH) $(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders $(inherited);
 
 SUPPORTS_TEXT_BASED_API = $(TAPI_USE_SRCROOT);
 SUPPORTS_TEXT_BASED_API[sdk=iphone*] = YES;

--- a/Source/WebKitLegacy/mac/Configurations/Base.xcconfig
+++ b/Source/WebKitLegacy/mac/Configurations/Base.xcconfig
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2023 Apple Inc. All rights reserved.
+// Copyright (C) 2009-2024 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -111,7 +111,9 @@ ADDITIONAL_SDKS = $(WK_ADDITIONAL_SDKS);
 SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator;
 SUPPORTS_MACCATALYST = YES;
 
-OTHER_CPLUSPLUSFLAGS = $(inherited) -isystem $(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders;
+HEADER_SEARCH_PATHS = . "$(BUILT_PRODUCTS_DIR)$(WK_LIBRARY_HEADERS_FOLDER_PATH)" $(HEADER_SEARCH_PATHS);
+LIBRARY_SEARCH_PATHS = $(SDK_DIR)$(WK_LIBRARY_INSTALL_PATH) $(inherited);
+SYSTEM_HEADER_SEARCH_PATHS = $(WK_PRIVATE_SDK_DIR)$(WK_ALTERNATE_WEBKIT_SDK_PATH)$(WK_LIBRARY_HEADERS_FOLDER_PATH) $(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders $(inherited);
 
 LLVM_LTO = $(WK_USER_LTO_MODE_$(WK_LTO_MODE));
 


### PR DESCRIPTION
#### 8927797099a552d32e72e02cec39f6d87a8e03bd
<pre>
The various Base.xcconfigs should have the same header search paths
<a href="https://bugs.webkit.org/show_bug.cgi?id=273802">https://bugs.webkit.org/show_bug.cgi?id=273802</a>
<a href="https://rdar.apple.com/127632562">rdar://127632562</a>

Reviewed by NOBODY (OOPS!).

This seems to have been the source of some tapi issues during the build. JSC would
pass `$(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders` to the
header search paths to tapi but later tapi runs, like WebKit&apos;s, wouldn&apos;t pass this
path and would have errors.

* Source/WebCore/Configurations/Base.xcconfig:
* Source/WebKit/Configurations/Base.xcconfig:
* Source/WebKitLegacy/mac/Configurations/Base.xcconfig:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8927797099a552d32e72e02cec39f6d87a8e03bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53805 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1236 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52849 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/886 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41211 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27489 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43518 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22322 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24886 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/778 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8924 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46871 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55394 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25644 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/751 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48620 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26905 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43671 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47671 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27769 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->