### PR TITLE
Drop CString::dataAsUInt8Ptr() in favor of span()

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorConnectionClient.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorConnectionClient.cpp
@@ -52,14 +52,14 @@ std::optional<ConnectionID> RemoteInspectorConnectionClient::createClient(Platfo
     return endpoint.createClient(socket, *this);
 }
 
-void RemoteInspectorConnectionClient::send(ConnectionID id, const uint8_t* data, size_t size)
+void RemoteInspectorConnectionClient::send(ConnectionID id, std::span<const uint8_t> data)
 {
-    auto message = MessageParser::createMessage(data, size);
+    auto message = MessageParser::createMessage(data);
     if (message.isEmpty())
         return;
 
     auto& endpoint = RemoteInspectorSocketEndpoint::singleton();
-    endpoint.send(id, message.data(), message.size());
+    endpoint.send(id, message);
 }
 
 void RemoteInspectorConnectionClient::didReceive(RemoteInspectorSocketEndpoint&, ConnectionID clientID, Vector<uint8_t>&& data)

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorConnectionClient.h
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorConnectionClient.h
@@ -45,7 +45,7 @@ public:
 
     std::optional<ConnectionID> connectInet(const char* serverAddr, uint16_t serverPort);
     std::optional<ConnectionID> createClient(PlatformSocketType);
-    void send(ConnectionID, const uint8_t* data, size_t);
+    void send(ConnectionID, std::span<const uint8_t>);
 
     void didReceive(RemoteInspectorSocketEndpoint&, ConnectionID, Vector<uint8_t>&&) final;
 

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorMessageParser.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorMessageParser.cpp
@@ -46,16 +46,15 @@ MessageParser::MessageParser(Function<void(Vector<uint8_t>&&)>&& listener)
 {
 }
 
-Vector<uint8_t> MessageParser::createMessage(const uint8_t* data, size_t size)
+Vector<uint8_t> MessageParser::createMessage(std::span<const uint8_t> data)
 {
-    if (!data || !size || size > UINT_MAX)
+    if (data.empty() || data.size() > std::numeric_limits<uint32_t>::max())
         return Vector<uint8_t>();
 
-    auto messageBuffer = Vector<uint8_t>(size + sizeof(uint32_t));
-    uint32_t uintSize = static_cast<uint32_t>(size);
-    uint32_t nboSize = htonl(uintSize);
+    auto messageBuffer = Vector<uint8_t>(data.size() + sizeof(uint32_t));
+    uint32_t nboSize = htonl(static_cast<uint32_t>(data.size()));
     memcpy(&messageBuffer[0], &nboSize, sizeof(uint32_t));
-    memcpy(&messageBuffer[sizeof(uint32_t)], data, uintSize);
+    memcpy(&messageBuffer[sizeof(uint32_t)], data.data(), data.size());
     return messageBuffer;
 }
 

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorMessageParser.h
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorMessageParser.h
@@ -35,7 +35,7 @@ namespace Inspector {
 class MessageParser {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Vector<uint8_t> createMessage(const uint8_t*, size_t);
+    static Vector<uint8_t> createMessage(std::span<const uint8_t>);
 
     MessageParser() { }
     MessageParser(Function<void(Vector<uint8_t>&&)>&&);

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
@@ -80,8 +80,7 @@ void RemoteInspector::sendWebInspectorEvent(const String& event)
     if (!m_clientConnection)
         return;
 
-    const CString message = event.utf8();
-    send(m_clientConnection.value(), reinterpret_cast<const uint8_t*>(message.data()), message.length());
+    send(m_clientConnection.value(), event.utf8().span());
 }
 
 void RemoteInspector::start()

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocketEndpoint.h
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocketEndpoint.h
@@ -74,9 +74,7 @@ public:
     void invalidateClient(Client&);
     void invalidateListener(Listener&);
 
-    void send(ConnectionID, const uint8_t* data, size_t);
-    inline void send(ConnectionID id, const Vector<uint8_t>& data) { send(id, data.data(), data.size()); }
-    inline void send(ConnectionID id, const char* data, size_t length) { send(id, reinterpret_cast<const uint8_t*>(data), length); }
+    void send(ConnectionID, std::span<const uint8_t>);
 
     std::optional<ConnectionID> createClient(PlatformSocketType, Client&);
 

--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -884,7 +884,7 @@ static String escapeUnsafeCharacters(const String& sourceBuffer)
 
 String userVisibleURL(const CString& url)
 {
-    auto* before = url.dataAsUInt8Ptr();
+    auto before = url.span();
     int length = url.length();
 
     if (!length)
@@ -900,7 +900,7 @@ String userVisibleURL(const CString& url)
 
     char* q = after.data();
     {
-        const unsigned char* p = before;
+        auto p = before;
         for (int i = 0; i < length; i++) {
             unsigned char c = p[i];
             // unescape escape sequences that indicate bytes greater than 0x7f

--- a/Source/WTF/wtf/cf/CFURLExtras.cpp
+++ b/Source/WTF/wtf/cf/CFURLExtras.cpp
@@ -30,6 +30,11 @@
 
 namespace WTF {
 
+RetainPtr<CFDataRef> bytesAsCFData(std::span<const uint8_t> bytes)
+{
+    return adoptCF(CFDataCreate(nullptr, bytes.data(), bytes.size()));
+}
+
 RetainPtr<CFDataRef> bytesAsCFData(CFURLRef url)
 {
     if (!url)

--- a/Source/WTF/wtf/cf/CFURLExtras.h
+++ b/Source/WTF/wtf/cf/CFURLExtras.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <span>
 #include <wtf/Forward.h>
 
 typedef const struct __CFData* CFDataRef;
@@ -34,6 +35,7 @@ namespace WTF {
 
 constexpr size_t URLBytesVectorInlineCapacity = 2048;
 
+RetainPtr<CFDataRef> bytesAsCFData(std::span<const uint8_t>);
 RetainPtr<CFDataRef> bytesAsCFData(CFURLRef);
 WTF_EXPORT_PRIVATE String bytesAsString(CFURLRef);
 WTF_EXPORT_PRIVATE Vector<uint8_t, URLBytesVectorInlineCapacity> bytesAsVector(CFURLRef);

--- a/Source/WTF/wtf/cf/URLCF.cpp
+++ b/Source/WTF/wtf/cf/URLCF.cpp
@@ -65,7 +65,8 @@ RetainPtr<CFURLRef> URL::createCFURL() const
         result = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, characters.data(), characters.size(), kCFStringEncodingUTF8, nullptr, true));
     } else {
         CString utf8 = m_string.utf8();
-        result = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, utf8.dataAsUInt8Ptr(), utf8.length(), kCFStringEncodingUTF8, nullptr, true));
+        auto utf8Span = utf8.span();
+        result = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, utf8Span.data(), utf8Span.size(), kCFStringEncodingUTF8, nullptr, true));
     }
 
     if (protocolIsInHTTPFamily() && !isSameOrigin(result.get(), *this))

--- a/Source/WTF/wtf/persistence/PersistentCoders.cpp
+++ b/Source/WTF/wtf/persistence/PersistentCoders.cpp
@@ -60,7 +60,7 @@ void Coder<CString>::encodeForPersistence(Encoder& encoder, const CString& strin
 
     uint32_t length = string.length();
     encoder << length;
-    encoder.encodeFixedLengthData({ string.dataAsUInt8Ptr(), length });
+    encoder.encodeFixedLengthData(string.span());
 }
 
 std::optional<CString> Coder<CString>::decodeForPersistence(Decoder& decoder)

--- a/Source/WTF/wtf/text/CString.cpp
+++ b/Source/WTF/wtf/text/CString.cpp
@@ -121,7 +121,7 @@ bool operator==(const CString& a, const CString& b)
         return false;
     if (a.length() != b.length())
         return false;
-    return equal(a.dataAsUInt8Ptr(), b.span());
+    return equal(a.span().data(), b.span());
 }
 
 bool operator==(const CString& a, const char* b)

--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -75,8 +75,6 @@ public:
 
     std::string toStdString() const { return m_buffer ? std::string(m_buffer->data()) : std::string(); }
 
-    const uint8_t* dataAsUInt8Ptr() const { return reinterpret_cast<const uint8_t*>(data()); }
-
     std::span<const uint8_t> span() const
     {
         if (m_buffer)

--- a/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
+++ b/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
@@ -274,7 +274,8 @@ static void showText(CGContextRef context, float x, float y, CGColorRef color, c
     CFTypeRef values[] = { font.get(), kCFBooleanTrue };
     auto attributes = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     CString cstr = text.ascii();
-    auto string = adoptCF(CFStringCreateWithBytesNoCopy(kCFAllocatorDefault, cstr.dataAsUInt8Ptr(), cstr.length(), kCFStringEncodingASCII, false, kCFAllocatorNull));
+    auto cstrSpan = cstr.span();
+    auto string = adoptCF(CFStringCreateWithBytesNoCopy(kCFAllocatorDefault, cstrSpan.data(), cstrSpan.size(), kCFStringEncodingASCII, false, kCFAllocatorNull));
     auto attributedString = adoptCF(CFAttributedStringCreate(kCFAllocatorDefault, string.get(), attributes.get()));
     auto line = adoptCF(CTLineCreateWithAttributedString(attributedString.get()));
     CGContextSetTextPosition(context, x, y);

--- a/Source/WebCore/platform/graphics/avfoundation/cf/CDMSessionAVFoundationCF.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/cf/CDMSessionAVFoundationCF.cpp
@@ -37,6 +37,7 @@
 #include <JavaScriptCore/Uint8Array.h>
 #include <wtf/SoftLinking.h>
 #include <wtf/UUID.h>
+#include <wtf/cf/CFURLExtras.h>
 #include <wtf/text/CString.h>
 
 namespace WebCore {
@@ -66,9 +67,7 @@ RefPtr<Uint8Array> CDMSessionAVFoundationCF::generateKeyRequest(const String&, U
     auto certificateData = adoptCF(CFDataCreateMutable(kCFAllocatorDefault, certificate->byteLength()));
     CFDataAppendBytes(certificateData.get(), certificate->data(), certificate->byteLength());
 
-    auto assetStr = keyID.utf8();
-    auto assetID = adoptCF(CFDataCreateMutable(kCFAllocatorDefault, assetStr.length()));
-    CFDataAppendBytes(assetID.get(), assetStr.dataAsUInt8Ptr(), assetStr.length());
+    RetainPtr assetID = bytesAsCFData(keyID.utf8().span());
 
     CFErrorRef cfError = nullptr;
     auto keyRequest = adoptCF(AVCFAssetResourceLoadingRequestCreateStreamingContentKeyRequestDataForApp(m_request.get(), certificateData.get(), assetID.get(), nullptr, &cfError));

--- a/Source/WebCore/platform/network/cf/ResourceRequestCFNet.h
+++ b/Source/WebCore/platform/network/cf/ResourceRequestCFNet.h
@@ -120,8 +120,9 @@ inline RetainPtr<CFStringRef> httpHeaderValueUsingSuitableEncoding(HTTPHeaderMap
 {
     if (header.keyAsHTTPHeaderName && *header.keyAsHTTPHeaderName == HTTPHeaderName::LastEventID && !header.value.containsOnlyASCII()) {
         auto utf8Value = header.value.utf8();
+        auto utf8ValueSpan = utf8Value.span();
         // Constructing a string with the UTF-8 bytes but claiming that it’s Latin-1 is the way to get CFNetwork to put those UTF-8 bytes on the wire.
-        return adoptCF(CFStringCreateWithBytes(nullptr, utf8Value.dataAsUInt8Ptr(), utf8Value.length(), kCFStringEncodingISOLatin1, false));
+        return adoptCF(CFStringCreateWithBytes(nullptr, utf8ValueSpan.data(), utf8ValueSpan.size(), kCFStringEncodingISOLatin1, false));
     }
     return header.value.createCFString();
 }

--- a/Source/WebDriver/socket/HTTPServerSocket.cpp
+++ b/Source/WebDriver/socket/HTTPServerSocket.cpp
@@ -107,8 +107,7 @@ void HTTPRequestHandler::didReceive(RemoteInspectorSocketEndpoint&, ConnectionID
 void HTTPRequestHandler::sendResponse(HTTPRequestHandler::Response&& response)
 {
     auto& endpoint = RemoteInspectorSocketEndpoint::singleton();
-    auto packet = packHTTPMessage(WTFMove(response));
-    endpoint.send(m_client.value(), packet.utf8().data(), packet.length());
+    endpoint.send(m_client.value(), packHTTPMessage(WTFMove(response)).utf8().span());
     reset();
 }
 

--- a/Source/WebDriver/socket/SessionHostSocket.cpp
+++ b/Source/WebDriver/socket/SessionHostSocket.cpp
@@ -51,8 +51,7 @@ void SessionHost::sendWebInspectorEvent(const String& event)
     if (!m_clientID)
         return;
 
-    const CString message = event.utf8();
-    send(m_clientID.value(), message.dataAsUInt8Ptr(), message.length());
+    send(m_clientID.value(), event.utf8().span());
 }
 
 void SessionHost::connectToBrowser(Function<void (std::optional<String> error)>&& completionHandler)

--- a/Source/WebKit/Shared/API/c/cf/WKURLCF.mm
+++ b/Source/WebKit/Shared/API/c/cf/WKURLCF.mm
@@ -63,6 +63,7 @@ CFURLRef WKURLCopyCFURL(CFAllocatorRef allocatorRef, WKURLRef URLRef)
     // We first create a CString and then create the CFURL from it. This will ensure that the CFURL is stored in 
     // UTF-8 which uses less memory and is what WebKit clients might expect.
 
-    CString buffer = string.utf8();
-    return CFURLCreateAbsoluteURLWithBytes(nullptr, buffer.dataAsUInt8Ptr(), buffer.length(), kCFStringEncodingUTF8, nullptr, true);
+    auto buffer = string.utf8();
+    auto bufferSpan = buffer.span();
+    return CFURLCreateAbsoluteURLWithBytes(nullptr, bufferSpan.data(), bufferSpan.size(), kCFStringEncodingUTF8, nullptr, true);
 }

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp
@@ -125,8 +125,7 @@ void RemoteInspectorClient::sendWebInspectorEvent(const String& event)
 {
     ASSERT(isMainRunLoop());
     ASSERT(m_connectionID);
-    auto message = event.utf8();
-    send(m_connectionID.value(), message.dataAsUInt8Ptr(), message.length());
+    send(m_connectionID.value(), event.utf8().span());
 }
 
 HashMap<String, Inspector::RemoteInspectorConnectionClient::CallHandler>& RemoteInspectorClient::dispatchMap()


### PR DESCRIPTION
#### 27853e7d160e2e47c96e2e7da0f0f5a152c0a418
<pre>
Drop CString::dataAsUInt8Ptr() in favor of span()
<a href="https://bugs.webkit.org/show_bug.cgi?id=273804">https://bugs.webkit.org/show_bug.cgi?id=273804</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorConnectionClient.cpp:
(Inspector::RemoteInspectorConnectionClient::send):
* Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorConnectionClient.h:
* Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorMessageParser.cpp:
(Inspector::MessageParser::createMessage):
* Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorMessageParser.h:
* Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocketEndpoint.cpp:
(Inspector::RemoteInspectorSocketEndpoint::send):
* Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocketEndpoint.h:
* Source/WTF/wtf/URLHelpers.cpp:
(WTF::URLHelpers::userVisibleURL):
* Source/WTF/wtf/cf/URLCF.cpp:
(WTF::URL::createCFURL const):
* Source/WTF/wtf/persistence/PersistentCoders.cpp:
(WTF::Persistence::Coder&lt;CString&gt;::encodeForPersistence):
* Source/WTF/wtf/text/CString.cpp:
(WTF::operator==):
* Source/WTF/wtf/text/CString.h:
* Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm:
(WebCore::showText):
* Source/WebCore/platform/graphics/avfoundation/cf/CDMSessionAVFoundationCF.cpp:
(WebCore::CDMSessionAVFoundationCF::generateKeyRequest):
* Source/WebCore/platform/network/cf/ResourceRequestCFNet.h:
(WebCore::httpHeaderValueUsingSuitableEncoding):
* Source/WebDriver/socket/SessionHostSocket.cpp:
(WebDriver::SessionHost::sendWebInspectorEvent):
* Source/WebKit/Shared/API/c/cf/WKURLCF.mm:
(WKURLCopyCFURL):
* Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp:
(WebKit::RemoteInspectorClient::sendWebInspectorEvent):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::getAccessibilityTreeData):

Canonical link: <a href="https://commits.webkit.org/278470@main">https://commits.webkit.org/278470@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/015908b936d194e0ec8fd624737a1237d10e04b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53912 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1344 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52956 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/994 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43629 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22406 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/24991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/885 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9094 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/43989 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46971 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/947 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55502 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/50156 "Found 1 new JSC binary failure: testapi (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25755 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/850 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/27012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43772 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47761 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27880 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57631 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7335 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26744 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11855 "Passed tests") | 
<!--EWS-Status-Bubble-End-->