### PR TITLE
Optimize control flow in nextBreakablePosition()

### DIFF
--- a/Source/WebCore/rendering/BreakLines.h
+++ b/Source/WebCore/rendering/BreakLines.h
@@ -59,6 +59,12 @@ static const UChar lineBreakTableFirstCharacter = '!';
 static const UChar lineBreakTableLastCharacter = 127;
 static const unsigned lineBreakTableColumnCount = (lineBreakTableLastCharacter - lineBreakTableFirstCharacter) / 8 + 1;
 WEBCORE_EXPORT extern const unsigned char lineBreakTable[][lineBreakTableColumnCount];
+inline bool lineBreakTableUnsafeLookup(UChar before, UChar after) // Must range check before calling.
+{
+    const unsigned beforeIndex = before - lineBreakTableFirstCharacter;
+    const unsigned nextIndex = after - lineBreakTableFirstCharacter;
+    return lineBreakTable[beforeIndex][nextIndex / 8] & (1 << (nextIndex % 8));
+}
 
 template<NoBreakSpaceBehavior nonBreakingSpaceBehavior>
 static inline bool isBreakableSpace(UChar character)
@@ -75,61 +81,60 @@ static inline bool isBreakableSpace(UChar character)
     }
 }
 
-inline bool shouldBreakAfter(UChar lastCharacter, UChar character, UChar nextCharacter)
-{
-    // Don't allow line breaking between '-' and a digit if the '-' may mean a minus sign in the context,
-    // while allow breaking in 'ABCD-1234' and '1234-5678' which may be in long URLs.
-    if (character == '-' && isASCIIDigit(nextCharacter))
-        return isASCIIAlphanumeric(lastCharacter);
-
-    // If both ch and nextCh are ASCII characters, use a lookup table for enhanced speed and for compatibility
-    // with other browsers (see comments for asciiLineBreakTable for details).
-    if (character >= lineBreakTableFirstCharacter && character <= lineBreakTableLastCharacter && nextCharacter >= lineBreakTableFirstCharacter && nextCharacter <= lineBreakTableLastCharacter) {
-        const unsigned char* tableRow = lineBreakTable[character - lineBreakTableFirstCharacter];
-        unsigned nextCharacterIndex = nextCharacter - lineBreakTableFirstCharacter;
-        return tableRow[nextCharacterIndex / 8] & (1 << (nextCharacterIndex % 8));
-    }
-    // Otherwise defer to the Unicode algorithm by returning false.
-    return false;
-}
-
-template<NoBreakSpaceBehavior nonBreakingSpaceBehavior>
-inline bool needsLineBreakIterator(UChar character)
-{
-    if (nonBreakingSpaceBehavior == NoBreakSpaceBehavior::Break)
-        return character > lineBreakTableLastCharacter;
-    return character > lineBreakTableLastCharacter && character != noBreakSpace;
-}
-
-// When in non-loose mode, we can use the ASCII shortcut table.
 template<typename CharacterType, LineBreakRules shortcutRules, NoBreakSpaceBehavior nonBreakingSpaceBehavior>
 inline size_t nextBreakablePosition(CachedLineBreakIteratorFactory& lineBreakIteratorFactory, std::span<const CharacterType> string, size_t startPosition)
 {
-    std::optional<unsigned> nextBreak;
-
-    CharacterType lastLastCharacter = startPosition > 1 ? string[startPosition - 2] : static_cast<CharacterType>(lineBreakIteratorFactory.priorContext().secondToLastCharacter());
-    CharacterType lastCharacter = startPosition > 0 ? string[startPosition - 1] : static_cast<CharacterType>(lineBreakIteratorFactory.priorContext().lastCharacter());
+    CharacterType beforeBefore = startPosition > 1 ? string[startPosition - 2]
+        : static_cast<CharacterType>(lineBreakIteratorFactory.priorContext().secondToLastCharacter());
+    CharacterType before = startPosition > 0 ? string[startPosition - 1]
+        : static_cast<CharacterType>(lineBreakIteratorFactory.priorContext().lastCharacter());
     auto priorContextLength = lineBreakIteratorFactory.priorContext().length();
-    for (size_t i = startPosition; i < string.size(); ++i) {
-        CharacterType character = string[i];
 
-        if (isBreakableSpace<nonBreakingSpaceBehavior>(character) || (shortcutRules == LineBreakRules::Normal && shouldBreakAfter(lastLastCharacter, lastCharacter, character)))
+    CharacterType after;
+    std::optional<unsigned> nextBreak;
+    for (size_t i = startPosition; i < string.size(); beforeBefore = before, before = after, ++i) {
+        after = string[i];
+
+        // Breakable spaces.
+        if (isBreakableSpace<nonBreakingSpaceBehavior>(after))
             return i;
 
-        if (shortcutRules == LineBreakRules::Special || needsLineBreakIterator<nonBreakingSpaceBehavior>(character) || needsLineBreakIterator<nonBreakingSpaceBehavior>(lastCharacter)) {
-            if (!nextBreak || nextBreak.value() < i) {
-                // Don't break if positioned at start of primary context and there is no prior context.
-                if (i || priorContextLength) {
-                    auto& breakIterator = lineBreakIteratorFactory.get();
-                    nextBreak = breakIterator.following(i - 1);
-                }
+        // ASCII rapid lookup.
+        if (shortcutRules == LineBreakRules::Normal) { // Not valid for 'loose' line-breaking.
+
+            // Don't allow line breaking between '-' and a digit if the '-' may mean a minus sign in the context,
+            // while allow breaking in 'ABCD-1234' and '1234-5678' which may be in long URLs.
+            if (before == '-' && isASCIIDigit(after)) {
+                if (isASCIIAlphanumeric(beforeBefore))
+                    return i;
+                continue;
             }
-            if (i == nextBreak && !isBreakableSpace<nonBreakingSpaceBehavior>(lastCharacter))
-                return i;
+
+            // If both characters are ASCII, use a lookup table for enhanced speed
+            // and for compatibility with other browsers (see comments on lineBreakTable for details).
+            if (before <= lineBreakTableLastCharacter && after <= lineBreakTableLastCharacter) {
+                if (before >= lineBreakTableFirstCharacter && after >= lineBreakTableFirstCharacter) {
+                    if (lineBreakTableUnsafeLookup(before, after))
+                        return i;
+                } // Else at least one is an ASCII control character; don't break.
+                continue;
+            }
         }
 
-        lastLastCharacter = lastCharacter;
-        lastCharacter = character;
+        // Non-ASCII rapid lookup.
+        if (nonBreakingSpaceBehavior == NoBreakSpaceBehavior::Normal && before == noBreakSpace && after == noBreakSpace)
+            continue;
+
+        // ICU lookup (slow).
+        if (!nextBreak || nextBreak.value() < i) {
+            // Don't break if positioned at start of primary context and there is no prior context.
+            if (i || priorContextLength) {
+                auto& breakIterator = lineBreakIteratorFactory.get();
+                nextBreak = breakIterator.following(i - 1);
+            }
+        }
+        if (i == nextBreak && !isBreakableSpace<nonBreakingSpaceBehavior>(before))
+            return i;
     }
 
     return string.size();


### PR DESCRIPTION
#### 2b27eb4841d2487fd4d3cd00a78f888b246da42c
<pre>
Optimize control flow in nextBreakablePosition()
<a href="https://bugs.webkit.org/show_bug.cgi?id=273793">https://bugs.webkit.org/show_bug.cgi?id=273793</a>
<a href="https://rdar.apple.com/127763823">rdar://127763823</a>

Reviewed by Alan Baradlay.

Reduces conditional checks in nextBreakablePosition by rearranging control flow.
(Also renames some key variables for better understandability.)

* Source/WebCore/rendering/BreakLines.h:
(WebCore::lineBreakTableUnsafeLookup): Create a table lookup inline function.
(WebCore::nextBreakablePosition): Reorganize control flow.
(WebCore::shouldBreakAfter): Deleted by incorporating into nextBreakablePosition.
(WebCore::needsLineBreakIterator): Deleted by dissolving into nextBreakablePosition.

Canonical link: <a href="https://commits.webkit.org/278548@main">https://commits.webkit.org/278548@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79b5f0f58a1d9ac4d88d1ceacdeed3fc284414af

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50869 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54128 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1560 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41436 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27803 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43818 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22564 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25146 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1074 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9310 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47130 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55722 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1027 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48843 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27228 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43893 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47930 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11154 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28096 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26960 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->