### PR TITLE
[Site Isolation] Owner element should be preserved when switching between LocalFrame and RemoteFrame

### DIFF
--- a/LayoutTests/http/tests/site-isolation/load-event-after-transition-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/load-event-after-transition-expected.txt
@@ -1,0 +1,5 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+PASS Load event fired after switching to a local frame.
+

--- a/LayoutTests/http/tests/site-isolation/load-event-after-transition.html
+++ b/LayoutTests/http/tests/site-isolation/load-event-after-transition.html
@@ -1,0 +1,18 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+onload = () => {
+    let i = document.getElementById('testiframe');
+    i.src = 'http://127.0.0.1:8000/site-isolation/resources/green-background.html';
+    i.addEventListener('load', function() {
+        testPassed("Load event fired after switching to a local frame.");
+        testRunner.notifyDone();
+    })
+}
+</script>
+<iframe id='testiframe' src="http://localhost:8000/site-isolation/resources/green-background.html"></iframe>

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -80,7 +80,8 @@ Frame::~Frame()
 
 #if ASSERT_ENABLED
     auto it = allFrames().find(m_frameID);
-    ASSERT(it != allFrames().end());
+    if (it == allFrames().end())
+        return;
     if (it->value.ptr() == this)
         allFrames().remove(it);
     else
@@ -195,6 +196,15 @@ bool Frame::hasOpenedFrames() const
 CheckedRef<HistoryController> Frame::checkedHistory() const
 {
     return m_history.get();
+}
+
+void Frame::setOwnerElement(HTMLFrameOwnerElement* element)
+{
+    m_ownerElement = element;
+    if (element) {
+        element->clearContentFrame();
+        element->setContentFrame(*this);
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -83,6 +83,7 @@ public:
 
     WEBCORE_EXPORT void detachFromPage();
 
+    WEBCORE_EXPORT void setOwnerElement(HTMLFrameOwnerElement*);
     inline HTMLFrameOwnerElement* ownerElement() const; // Defined in HTMLFrameOwnerElement.h.
     inline RefPtr<HTMLFrameOwnerElement> protectedOwnerElement() const; // Defined in HTMLFrameOwnerElement.h.
 

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -201,7 +201,7 @@ Ref<LocalFrame> LocalFrame::createSubframe(Page& page, ClientCreator&& clientCre
     return adoptRef(*new LocalFrame(page, WTFMove(clientCreator), identifier, &ownerElement, ownerElement.document().frame(), nullptr));
 }
 
-Ref<LocalFrame> LocalFrame::createSubframeHostedInAnotherProcess(Page& page, ClientCreator&& clientCreator, FrameIdentifier identifier, Frame& parent)
+Ref<LocalFrame> LocalFrame::createProvisionalSubframe(Page& page, ClientCreator&& clientCreator, FrameIdentifier identifier, Frame& parent)
 {
     return adoptRef(*new LocalFrame(page, WTFMove(clientCreator), identifier, nullptr, &parent, nullptr));
 }

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -120,7 +120,7 @@ public:
     using ClientCreator = CompletionHandler<UniqueRef<LocalFrameLoaderClient>(LocalFrame&)>;
     WEBCORE_EXPORT static Ref<LocalFrame> createMainFrame(Page&, ClientCreator&&, FrameIdentifier, Frame* opener);
     WEBCORE_EXPORT static Ref<LocalFrame> createSubframe(Page&, ClientCreator&&, FrameIdentifier, HTMLFrameOwnerElement&);
-    WEBCORE_EXPORT static Ref<LocalFrame> createSubframeHostedInAnotherProcess(Page&, ClientCreator&&, FrameIdentifier, Frame& parent);
+    WEBCORE_EXPORT static Ref<LocalFrame> createProvisionalSubframe(Page&, ClientCreator&&, FrameIdentifier, Frame& parent);
 
     WEBCORE_EXPORT void init();
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -417,7 +417,7 @@ void WebFrame::createProvisionalFrame(ProvisionalFrameCreationParameters&& param
     auto clientCreator = [this, protectedThis = Ref { *this }] (auto& localFrame) mutable {
         return makeUniqueRef<WebLocalFrameLoaderClient>(localFrame, WTFMove(protectedThis), makeInvalidator());
     };
-    auto localFrame = parent ? LocalFrame::createSubframeHostedInAnotherProcess(*corePage, WTFMove(clientCreator), m_frameID, *parent) : LocalFrame::createMainFrame(*corePage, WTFMove(clientCreator), m_frameID, remoteFrame->opener());
+    auto localFrame = parent ? LocalFrame::createProvisionalSubframe(*corePage, WTFMove(clientCreator), m_frameID, *parent) : LocalFrame::createMainFrame(*corePage, WTFMove(clientCreator), m_frameID, remoteFrame->opener());
     m_provisionalFrame = localFrame.ptr();
     localFrame->init();
 
@@ -465,6 +465,7 @@ void WebFrame::commitProvisionalFrame()
     m_coreFrame = localFrame.get();
     remoteFrame->setView(nullptr);
     localFrame->tree().setSpecifiedName(remoteFrame->tree().specifiedName());
+    localFrame->setOwnerElement(ownerElement.get());
     if (remoteFrame->isMainFrame())
         corePage->setMainFrame(*localFrame);
     localFrame->takeWindowProxyFrom(*remoteFrame);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -2531,8 +2531,6 @@ TEST(SiteIsolation, NavigateIframeToProvisionalNavigationFailure)
 // FIXME: Make a test that tries to access its parent that used to be remote during a provisional navigation of
 // the parent to that domain to verify that even the main frame uses provisional frames.
 
-// FIXME: <rdar://127638179> Call load event on iframe after switching from RemoteFrame to LocalFrame.
-
 TEST(SiteIsolation, OpenThenClose)
 {
     HTTPServer server({


### PR DESCRIPTION
#### 6f62e90b5cac93d820552a99e2241e9a90875514
<pre>
[Site Isolation] Owner element should be preserved when switching between LocalFrame and RemoteFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=273809">https://bugs.webkit.org/show_bug.cgi?id=273809</a>
<a href="https://rdar.apple.com/127638179">rdar://127638179</a>

Reviewed by Charlie Wolfe.

Otherwise it suddenly becomes null from the point of view of the Frame and DOMWindow,
which prevents things like the load event from flowing to the event listeners.

I also rename createSubframeHostedInAnotherProcess to createProvisionalSubframe because
the contents aren&apos;t necessarily hosted in another process.

This test hit a case where sometimes a frame was created and destroyed before the frame
we transitioned from was destroyed, so I updated the assertion to not assert in that case.

* LayoutTests/http/tests/site-isolation/load-event-after-transition-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/load-event-after-transition.html: Added.
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::setOwnerElement):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::createProvisionalSubframe):
(WebCore::LocalFrame::createSubframeHostedInAnotherProcess): Deleted.
* Source/WebCore/page/LocalFrame.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::createProvisionalFrame):
(WebKit::WebFrame::commitProvisionalFrame):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:

Canonical link: <a href="https://commits.webkit.org/278472@main">https://commits.webkit.org/278472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdaf106227c21b796f0bd5a7abcada4bdb57f4fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53899 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1331 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/981 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41285 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27594 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43620 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22401 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24982 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/876 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9081 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46961 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/938 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55489 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25742 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/841 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48698 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26999 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43764 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47753 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27867 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7336 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26731 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->