### PR TITLE
[Gardening] Update 2 watchOS viewport tests to use Series 9 display size.

### DIFF
--- a/LayoutTests/fast/viewport/watchos/viewport-adaptations-after-navigation-expected.txt
+++ b/LayoutTests/fast/viewport/watchos/viewport-adaptations-after-navigation-expected.txt
@@ -1,1 +1,1 @@
-previous size: (184, 204); current size: (320, 355)
+previous size: (198, 207); current size: (320, 335)

--- a/LayoutTests/fast/viewport/watchos/viewport-with-system-minimum-layout-margins-expected.txt
+++ b/LayoutTests/fast/viewport/watchos/viewport-with-system-minimum-layout-margins-expected.txt
@@ -3,7 +3,7 @@ This test verifies that non-zero horizontal system minimum layout margins affect
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS innerWidth is 132
+PASS innerWidth is 174
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/viewport/watchos/viewport-with-system-minimum-layout-margins.html
+++ b/LayoutTests/fast/viewport/watchos/viewport-with-system-minimum-layout-margins.html
@@ -22,7 +22,7 @@ async function runTest() {
         return;
 
     await UIHelper.ensureVisibleContentRectUpdate();
-    shouldBe("innerWidth", "160");
+    shouldBe("innerWidth", "174");
     finishJSTest();
 }
 </script>


### PR DESCRIPTION
#### b154a7f9dd459ace213b61cf9b1cfcc0926d9b9c
<pre>
[Gardening] Update 2 watchOS viewport tests to use Series 9 display size.
<a href="https://bugs.webkit.org/show_bug.cgi?id=273810">https://bugs.webkit.org/show_bug.cgi?id=273810</a>
<a href="https://rdar.apple.com/127651367">rdar://127651367</a>

Reviewed by Ryan Haddad.

Update screen sizes for 2 watchOS viewport tests.

* LayoutTests/fast/viewport/watchos/viewport-adaptations-after-navigation-expected.txt:
* LayoutTests/fast/viewport/watchos/viewport-with-system-minimum-layout-margins-expected.txt:
* LayoutTests/fast/viewport/watchos/viewport-with-system-minimum-layout-margins.html:

Canonical link: <a href="https://commits.webkit.org/278476@main">https://commits.webkit.org/278476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3db1ed6be6c10d7d6eae44593c87cb006941e3f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50665 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2982 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53924 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1356 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1006 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41296 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27614 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43640 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22414 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24998 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/896 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9106 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46979 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/958 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55514 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25767 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/861 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/27024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/43782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27892 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7337 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/26756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->