### PR TITLE
BlobStreamSource does not seem to enqueue aggressively received buffers

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -203,6 +203,8 @@ fast/shapes/shape-outside-floats/shape-outside-imagedata-overflow.html [ Skip ]
 
 webkit.org/b/247625 [ Debug ] fast/block/float/intrusive-floats-with-reverted-inline-content.html [ Skip ]
 
+[ Debug ] fast/files/blob-stream-chunks.html [ Skip ]
+
 # Only iOS supports QuickLook
 quicklook [ Skip ]
 http/tests/quicklook [ Skip ]

--- a/LayoutTests/fast/files/blob-stream-chunks-expected.txt
+++ b/LayoutTests/fast/files/blob-stream-chunks-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Process blob data as chunks
+PASS Cancel load while chunks are flowing
+

--- a/LayoutTests/fast/files/blob-stream-chunks.html
+++ b/LayoutTests/fast/files/blob-stream-chunks.html
@@ -1,0 +1,31 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+<script>
+promise_test(async t => {
+    const blob = new Blob(new Uint8Array(512 * 1024 * 10));
+    const reader = blob.stream().getReader();
+
+    let result = await reader.read();
+    assert_false(result.done);
+    while (!result.done)
+        result = await reader.read();
+    await reader.closed.then(() => { }, () => { });
+}, "Process blob data as chunks");
+
+promise_test(async t => {
+    const blob = new Blob(new Uint8Array(512 * 1024 * 10));
+    const reader = blob.stream().getReader();
+
+    const result = await reader.read();
+    assert_false(result.done);
+    reader.cancel();
+    await reader.closed.then(() => { }, () => { });
+}, "Cancel load while chunks are flowing");
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 7bfec45dfb8bebb0915202c524fc5ee48efd4d93
<pre>
BlobStreamSource does not seem to enqueue aggressively received buffers
<a href="https://rdar.apple.com/127653288">rdar://127653288</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=273813">https://bugs.webkit.org/show_bug.cgi?id=273813</a>

Reviewed by Alex Christensen.

Instead of pushing data coming from blobs as array buffers on the internal ReadableStream queue,
we are now keeping the blob data within a queue owned by the source.
This reduces the need to convert blob data to JS objects to the time when web page actually needs it.

Skipping the test in debug as the test is timing out due to the created buffer size.

* LayoutTests/TestExpectations:
* LayoutTests/fast/files/blob-stream-chunks-expected.txt: Added.
* LayoutTests/fast/files/blob-stream-chunks.html: Added.
* Source/WebCore/fileapi/Blob.cpp:
(WebCore::Blob::stream):

Canonical link: <a href="https://commits.webkit.org/278693@main">https://commits.webkit.org/278693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d956fbcf26d128dc99b79074e7da1e4c5305a80

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54570 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2000 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1679 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41788 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44244 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22906 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25584 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1502 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-autofocus.html (failure)") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47553 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1575 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56163 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26425 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1466 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49187 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27668 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44307 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48355 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11225 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28558 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27403 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->