### PR TITLE
Sync navigation-api from WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: navigation
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script>
+promise_test(async t => {
+  let i = document.createElement("iframe");
+  i.src = "resources/cross-origin-redirect-on-second-visit.py?key=" + token();
+  document.body.appendChild(i);
+
+  // Wait for after the load event so that the navigation doesn't get converted
+  // into a replace navigation.
+  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+
+  let original_iframe_url = i.contentWindow.location.href;
+
+  // Do a cross-document push navigation in the iframe.
+  i.contentWindow.navigation.navigate("/common/blank.html");
+  await new Promise(resolve => i.onload = resolve);
+
+  // Go back. This will trigger a cross-origin redirect, but the navigate event
+  // should still fire, and the event url should be the pre-redirect url (which
+  // is same-origin).
+  history.back();
+  let navigate_event_url = await new Promise(resolve => i.contentWindow.navigation.onnavigate = e => {
+    resolve(e.destination.url);
+  });
+  await new Promise(resolve => i.onload = resolve);
+  assert_equals(navigate_event_url, original_iframe_url);
+}, "A traversal that redirects from same-origin to cross-origin fires the navigate event");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/event-constructor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/event-constructor.html
@@ -78,7 +78,8 @@ async_test(t => {
     assert_equals(event.downloadRequest, downloadRequest);
     assert_equals(event.info, info);
     assert_equals(event.hasUAVisualTransition, hasUAVisualTransition);
-    assert_equals(event.sourceElement, sourceElement);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(event.sourceElement, sourceElement);
   });
   history.pushState(2, null, "#2");
 }, "all properties are reflected back");
@@ -98,7 +99,8 @@ async_test(t => {
     assert_equals(event.formData, null);
     assert_equals(event.downloadRequest, null);
     assert_equals(event.info, undefined);
-    assert_equals(event.sourceElement, null);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(event.sourceElement, null);
   });
   history.pushState(3, null, "#3");
 }, "defaults are as expected");

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-cross-origin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-cross-origin.html
@@ -17,7 +17,8 @@ async_test(t => {
     assert_equals(e.destination.key, "");
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
-    assert_equals(e.sourceElement, document.getElementById("a"));
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, document.getElementById("a"));
     e.preventDefault();
   });
   a.click();

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-download-userInitiated.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-download-userInitiated.html
@@ -21,7 +21,8 @@ async_test(t => {
     assert_equals(e.destination.key, "");
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
-    assert_equals(e.sourceElement, document.getElementById("a"));
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, document.getElementById("a"));
     e.preventDefault();
     t.step_timeout(t.step_func_done(() => assert_equals(location.hash, "")), 0);
   });

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-download.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-download.html
@@ -25,7 +25,8 @@ for (const [tag, download_attr] of tests) {
       assert_equals(e.destination.key, "");
       assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
-      assert_equals(e.sourceElement, a);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, a);
       e.preventDefault();
     });
     a.click();

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-fragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-fragment-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Fragment <a> click fires navigate event assert_equals: expected (object) Element node <a id="a" href="#1"></a> but got (undefined) undefined
+PASS Fragment <a> click fires navigate event
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-fragment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-fragment.html
@@ -17,7 +17,8 @@ async_test(t => {
     assert_equals(e.destination.key, "");
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
-    assert_equals(e.sourceElement, document.getElementById("a"));
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, document.getElementById("a"));
     e.preventDefault();
     t.step_timeout(t.step_func_done(() => assert_equals(location.hash, "")), 0);
   });

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-same-origin-cross-document.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-same-origin-cross-document.html
@@ -18,7 +18,8 @@ async_test(t => {
     assert_equals(e.destination.key, "");
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
-    assert_equals(e.sourceElement, document.getElementById("a"));
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, document.getElementById("a"));
     e.preventDefault();
   });
   a.click();

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-userInitiated-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-userInitiated-expected.txt
@@ -1,4 +1,4 @@
 Click me
 
-FAIL Fragment <a> click fires navigate event assert_equals: expected (object) Element node <a id="a" href="#1">Click me</a> but got (undefined) undefined
+PASS Fragment <a> click fires navigate event
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-userInitiated.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-userInitiated.html
@@ -20,7 +20,8 @@ async_test(t => {
     assert_equals(e.destination.key, "");
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
-    assert_equals(e.sourceElement, document.getElementById("a"));
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, document.getElementById("a"));
     e.preventDefault();
     t.step_timeout(t.step_func_done(() => assert_equals(location.hash, "")), 0);
   });

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-with-target.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-with-target.html
@@ -20,10 +20,11 @@ async_test(t => {
       assert_equals(new URL(e.destination.url).pathname,
                     "/navigation-api/navigate-event/foo.html");
       assert_false(e.destination.sameDocument);
-    assert_equals(e.destination.key, "");
-    assert_equals(e.destination.id, "");
+      assert_equals(e.destination.key, "");
+      assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
       e.preventDefault();
     });
     a.click();

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-back-forward.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-back-forward.html
@@ -19,7 +19,8 @@ async_test(t => {
       assert_equals(e.destination.key, "");
       assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
     });
     navigation.back();
   }), 0);

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-navigate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-navigate.html
@@ -16,7 +16,8 @@ async_test(t => {
       assert_equals(e.destination.key, "");
       assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
     });
     navigation.navigate("#foo", { state: navState });
   }, 0);

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-reload.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-reload.html
@@ -16,7 +16,8 @@ async_test(t => {
       assert_equals(e.destination.key, "");
       assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
       e.intercept();
     });
     navigation.updateCurrentEntry({ state: navState });

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-get.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-get.html
@@ -21,7 +21,8 @@ async_test(t => {
 
     // Because it's a GET, not a POST
     assert_equals(e.formData, null);
-    assert_equals(e.sourceElement, form);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, form);
   });
   window.onload = t.step_func(() => form.submit());
 }, "<form> submission with GET method fires navigate event but with formData null");

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-reload.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-reload.html
@@ -12,7 +12,8 @@ async_test(t => {
     iframe.contentWindow.navigation.onnavigate = t.step_func(e => {
       assert_equals(e.navigationType, "push");
       assert_not_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
 
       iframe.onload = t.step_func(() => {
         iframe.contentWindow.navigation.onnavigate = t.step_func_done(e => {

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-traverse.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-traverse.html
@@ -12,7 +12,8 @@ async_test(t => {
     iframe.contentWindow.navigation.onnavigate = t.step_func(e => {
       assert_equals(e.navigationType, "push");
       assert_not_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
 
       iframe.onload = t.step_func(() => {
         // Avoid the replace behavior that occurs if you navigate during the load handler

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-userInitiated.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-userInitiated.html
@@ -24,7 +24,8 @@ async_test(t => {
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
     assert_not_equals(e.formData, null);
-    assert_equals(e.sourceElement, submit);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, submit);
   });
   window.onload = t.step_func(() => test_driver.click(submit));
 }, "<form> submission fires navigate event");

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-with-target.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-with-target.html
@@ -22,7 +22,8 @@ async_test(t => {
       assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
       assert_not_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
     });
     form.submit();
   });

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form.html
@@ -19,7 +19,8 @@ async_test(t => {
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
     assert_not_equals(e.formData, null);
-    assert_equals(e.sourceElement, form);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, form);
   });
   window.onload = t.step_func(() => form.submit());
 }, "<form> submission fires navigate event");

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-after-fragment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-after-fragment.html
@@ -24,7 +24,8 @@ async_test(t => {
       assert_equals(e.destination.id, target_id);
         assert_equals(e.destination.index, start_index);
       assert_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
     });
 
     history.back();

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-after-pushState.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-after-pushState.html
@@ -24,7 +24,8 @@ async_test(t => {
       assert_equals(e.destination.id, target_id);
       assert_equals(e.destination.index, start_index);
       assert_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
     });
 
     history.back();

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-bfcache.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-bfcache.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/html/browsers/browsing-the-web/back-forward-cache/resources/helper.sub.js"></script>
+
+<script>
+runBfcacheTest({
+  targetOrigin: originSameOrigin,
+  funcBeforeBackNavigation: () => {
+    window.did_navigate = false;
+    navigation.onnavigate = () => window.did_navigate = true;
+  },
+  async funcAfterAssertion(pageA, pageB) {
+    // When `funcAfterAssertion` is called, we've already navigated to pageB,
+    // then gone back to pageA with bfcache. Now go forward to pageB so we can
+    // observe whether the navigate event fired.
+    await pageA.execute_script(() => history.forward());
+    await pageB.execute_script(waitForPageShow);
+    assert_true(await pageB.execute_script(() => window.did_navigate));
+  }
+}, "navigate event should fire when traversing to a bfcache hit");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-cross-document.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-cross-document.html
@@ -23,7 +23,8 @@ async_test(t => {
         assert_equals(e.destination.index, 0);
         assert_equals(e.formData, null);
         assert_equals(e.info, undefined);
-        assert_equals(e.sourceElement, null);
+        // NavigateEvent sourceElement is still in development, so test whether it is available.
+        if ("sourceElement" in e) assert_equals(e.sourceElement, null);
       });
       assert_true(i.contentWindow.navigation.canGoBack);
       i.contentWindow.history.back();

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-go-0.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-go-0.html
@@ -18,7 +18,8 @@ async_test(t => {
       assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
       assert_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
       e.preventDefault();
     });
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-pushState.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-pushState.html
@@ -17,7 +17,8 @@ async_test(t => {
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
     assert_equals(e.formData, null);
-    assert_equals(e.sourceElement, null);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, null);
     e.preventDefault();
     t.step_timeout(t.step_func_done(() => {
       assert_equals(location.hash, "");

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-replaceState.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-replaceState.html
@@ -17,7 +17,8 @@ async_test(t => {
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
     assert_equals(e.formData, null);
-    assert_equals(e.sourceElement, null);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, null);
     e.preventDefault();
     t.step_timeout(t.step_func_done(() => {
       assert_equals(location.hash, "");

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-iframe-location.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-iframe-location.html
@@ -21,7 +21,8 @@ async_test(t => {
       assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
       assert_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
       e.preventDefault();
       t.step_timeout(t.step_func_done(() => assert_equals(location.hash, "")), 0);
     });

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-location.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-location.html
@@ -17,7 +17,8 @@ async_test(t => {
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
     assert_equals(e.formData, null);
-    assert_equals(e.sourceElement, null);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, null);
   });
   location.href = "#1";
 }, "location API fires navigate event");

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-meta-refresh.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-meta-refresh.html
@@ -20,7 +20,8 @@ async_test(t => {
       assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
       assert_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
       e.preventDefault();
     });
   });

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-cross-document.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-cross-document.html
@@ -25,7 +25,8 @@ async_test(t => {
         assert_equals(e.destination.index, 0);
         assert_equals(e.formData, null);
         assert_equals(e.info, "hi");
-        assert_equals(e.sourceElement, null);
+        // NavigateEvent sourceElement is still in development, so test whether it is available.
+        if ("sourceElement" in e) assert_equals(e.sourceElement, null);
       });
       i.contentWindow.onbeforeunload = () => beforeunload_called = true;
       assert_true(i.contentWindow.navigation.canGoBack);

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-same-document-in-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-same-document-in-iframe.html
@@ -27,7 +27,8 @@ promise_test(async t => {
     assert_equals(e.destination.index, 0);
     assert_equals(e.formData, null);
     assert_equals(e.info, "hi");
-    assert_equals(e.sourceElement, null);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, null);
   }
   await i.contentWindow.navigation.back({ info: "hi" }).finished;
 }, "navigate event for navigation.back() - same-document in an iframe");

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-same-document.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-same-document.html
@@ -25,7 +25,8 @@ async_test(t => {
         assert_equals(e.formData, null);
         assert_equals(e.info, "hi");
         assert_not_equals(e.hasUAVisualTransition, undefined);
-        assert_equals(e.sourceElement, null);
+        // NavigateEvent sourceElement is still in development, so test whether it is available.
+        if ("sourceElement" in e) assert_equals(e.sourceElement, null);
       });
       assert_true(navigation.canGoBack);
       navigation.back({ info: "hi" });

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-navigate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-navigate.html
@@ -16,7 +16,8 @@ async_test(t => {
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
     assert_equals(e.formData, null);
-    assert_equals(e.sourceElement, null);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, null);
   });
   navigation.navigate("#foo");
 }, "navigate event for navigation.navigate()");

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-svg-anchor-fragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-svg-anchor-fragment-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL <svg:a> click fires navigate event assert_equals: expected (object) Element node <a id="a" href="#1"></a> but got (undefined) undefined
+PASS <svg:a> click fires navigate event
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-svg-anchor-fragment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-svg-anchor-fragment.html
@@ -17,7 +17,8 @@ async_test(t => {
     assert_equals(e.destination.key, "");
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
-    assert_equals(e.sourceElement, document.getElementById("a"));
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, document.getElementById("a"));
     e.preventDefault();
     t.step_timeout(t.step_func_done(() => assert_equals(location.hash, "")), 0);
   });

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-to-srcdoc.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-to-srcdoc.html
@@ -21,7 +21,8 @@ async_test(t => {
       assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
       assert_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
       e.preventDefault();
 
       // Make sure it doesn't navigate anyway.

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-window-open-self.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-window-open-self.html
@@ -16,7 +16,8 @@ async_test(t => {
     assert_equals(e.destination.id, "");
     assert_equals(e.destination.index, -1);
     assert_equals(e.formData, null);
-    assert_equals(e.sourceElement, null);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(e.sourceElement, null);
     e.preventDefault();
   });
   window.onload = t.step_func(() => window.open("#1", "_self"));

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-window-open.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-window-open.html
@@ -21,7 +21,8 @@ async_test(t => {
       assert_equals(e.destination.id, "");
       assert_equals(e.destination.index, -1);
       assert_equals(e.formData, null);
-      assert_equals(e.sourceElement, null);
+      // NavigateEvent sourceElement is still in development, so test whether it is available.
+      if ("sourceElement" in e) assert_equals(e.sourceElement, null);
       e.preventDefault();
     });
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/cross-origin-redirect-on-second-visit.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/cross-origin-redirect-on-second-visit.py
@@ -1,0 +1,31 @@
+import uuid
+
+def redirect_response():
+  location = b'http://localhost:8000/common/blank.html'
+  return (301,
+  [
+    (b'Cache-Control', b'no-cache, no-store, must-revalidate'),
+    (b'Pragma', b'no-cache'),
+    (b'Content-Type', b'text/html'),
+    (b'Location', location),
+  ],
+  b'redirect_body')
+
+def ok_response():
+  return (
+    [
+      (b'Cache-Control', b'no-cache, no-store, must-revalidate'),
+      (b'Pragma', b'no-cache'),
+      (b'Content-Type', b'text/html')
+    ],
+    b'body')
+
+def main(request, response):
+  key = request.GET[b'key'];
+  visited = request.server.stash.take(key)
+  request.server.stash.put(key, True)
+
+  if visited is None:
+    return ok_response()
+
+  return redirect_response()

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/cross-origin-redirect-on-second-visit.py
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/meta-refresh.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/navigatesuccess-cross-document-helper.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/opener-postMessage-onload.html

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/w3c-import.log
@@ -15,6 +15,7 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-does-not-fire-navigate.html
+/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/defaultPrevented-navigation-preempted.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/defaultPrevented-window-stop-after-dispatch.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/event-constructor.html
@@ -59,6 +60,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-after-fragment.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-after-pushState.html
+/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-bfcache.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-cross-document.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-noop.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-go-0.html

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-204-205-download.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-204-205-download.html
@@ -32,11 +32,9 @@ for (const [description, action] of tests) {
 
     const indexBefore = i.contentWindow.navigation.currentEntry.index;
 
-    // One might be surprised that navigate does not fire. (It does fire for the
-    // corresponding tests of navigation.navigate(), i.e., this is
-    // traversal-specific behavior.) See https://github.com/WICG/navigation-api/issues/207
-    // for some discussion.
-    i.contentWindow.navigation.onnavigate = t.unreached_func("onnavigate should not be called");
+    let onnavigate_called = false;
+    i.contentWindow.navigation.onnavigate = () => onnavigate_called = true;
+    i.contentWindow.onunload = t.unreached_func("onunload should not be called");
     i.contentWindow.navigation.onnavigatesuccess = t.unreached_func("onnavigatesuccess should not be called");
     i.contentWindow.navigation.onnavigateerror = t.unreached_func("onnavigateerror should not be called");
 
@@ -47,6 +45,7 @@ for (const [description, action] of tests) {
     await new Promise(resolve => t.step_timeout(resolve, 50));
     assert_equals(i.contentWindow.navigation.currentEntry.index, indexBefore);
     assert_equals(i.contentWindow.navigation.transition, null);
+    assert_true(onnavigate_called);
   }, `back() promises to ${description} never settle`);
 }
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-pagehide.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-pagehide.html
@@ -17,11 +17,11 @@ promise_test(async t => {
   i.contentWindow.navigation.navigate("?1");
 
   await new Promise(resolve => {
-    i.contentWindow.onunload = t.step_func(async () => {
-      await assertBothRejectDOM(t, i.contentWindow.navigation.navigate("https://example.com\u0000mozilla.org"), "SyntaxError", i.contentWindow);
+    i.contentWindow.onpagehide = t.step_func(async () => {
+      await assertBothRejectDOM(t, i.contentWindow.navigation.navigate("?2"), "InvalidStateError", i.contentWindow);
       assert_equals(navigateEventCount, 1);
       resolve();
     });
   });
-}, `navigate() with an invalid URL inside onunload throws "SyntaxError", not "InvalidStateError"`);
+}, `navigate() inside onpagehide`);
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-pagehide.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-pagehide.html
@@ -16,17 +16,12 @@ promise_test(async t => {
 
   i.contentWindow.navigation.navigate("?1");
 
-  let assertionPromise;
   await new Promise(resolve => {
-    i.contentWindow.onunload = t.step_func(() => {
-      assertionPromise = assertBothRejectDOM(t, i.contentWindow.navigation.reload({ state: document.body }), "DataCloneError", i.contentWindow);
+    i.contentWindow.onpagehide = t.step_func(async () => {
+      await assertBothRejectDOM(t, i.contentWindow.navigation.navigate("https://example.com\u0000mozilla.org"), "SyntaxError", i.contentWindow);
       assert_equals(navigateEventCount, 1);
       resolve();
     });
   });
-
-  assert_not_equals(assertionPromise, undefined);
-  await assertionPromise;
-
-}, `reload() with an unserializable state inside onunload throws "DataCloneError", not "InvalidStateError"`);
+}, `navigate() with an invalid URL inside onpagehide throws "SyntaxError", not "InvalidStateError"`);
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-unload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-unload-expected.txt
@@ -1,6 +1,0 @@
-
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigate() with an invalid URL inside onunload throws "SyntaxError", not "InvalidStateError" Test timed out
-

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-pagehide-unserializablestate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-pagehide-unserializablestate.html
@@ -17,11 +17,11 @@ promise_test(async t => {
   i.contentWindow.navigation.navigate("?1");
 
   await new Promise(resolve => {
-    i.contentWindow.onunload = t.step_func(async () => {
+    i.contentWindow.onpagehide = t.step_func(async () => {
       await assertBothRejectDOM(t, i.contentWindow.navigation.navigate("?2", { state: document.body }), "DataCloneError", i.contentWindow);
       assert_equals(navigateEventCount, 1);
       resolve();
     });
   });
-}, `navigate() with an unserializable state inside onunload throws "DataCloneError", not "InvalidStateError"`);
+}, `navigate() with an unserializable state inside onpagehide throws "DataCloneError", not "InvalidStateError"`);
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-unload-unserializablestate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-unload-unserializablestate-expected.txt
@@ -1,6 +1,0 @@
-
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigate() with an unserializable state inside onunload throws "DataCloneError", not "InvalidStateError" Test timed out
-

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-unload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-unload-expected.txt
@@ -1,6 +1,0 @@
-
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigate() inside onunload Test timed out
-

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-pagehide.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-pagehide.html
@@ -17,11 +17,11 @@ promise_test(async t => {
   i.contentWindow.navigation.navigate("?1");
 
   await new Promise(resolve => {
-    i.contentWindow.onunload = t.step_func(async () => {
+    i.contentWindow.onpagehide = t.step_func(async () => {
       await assertBothRejectDOM(t, i.contentWindow.navigation.reload(), "InvalidStateError", i.contentWindow);
       assert_equals(navigateEventCount, 1);
       resolve();
     });
   });
-}, `reload() inside onunload`);
+}, `reload() inside onpagehide`);
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-pagehide-unserializablestate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-pagehide-unserializablestate.html
@@ -16,12 +16,17 @@ promise_test(async t => {
 
   i.contentWindow.navigation.navigate("?1");
 
+  let assertionPromise;
   await new Promise(resolve => {
-    i.contentWindow.onunload = t.step_func(async () => {
-      await assertBothRejectDOM(t, i.contentWindow.navigation.navigate("?2"), "InvalidStateError", i.contentWindow);
+    i.contentWindow.onpagehide = t.step_func(() => {
+      assertionPromise = assertBothRejectDOM(t, i.contentWindow.navigation.reload({ state: document.body }), "DataCloneError", i.contentWindow);
       assert_equals(navigateEventCount, 1);
       resolve();
     });
   });
-}, `navigate() inside onunload`);
+
+  assert_not_equals(assertionPromise, undefined);
+  await assertionPromise;
+
+}, `reload() with an unserializable state inside onpagehide throws "DataCloneError", not "InvalidStateError"`);
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-unload-unserializablestate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-unload-unserializablestate-expected.txt
@@ -1,6 +1,0 @@
-
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT reload() with an unserializable state inside onunload throws "DataCloneError", not "InvalidStateError" Test timed out
-

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-unload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-unload-expected.txt
@@ -1,6 +1,0 @@
-
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT reload() inside onunload Test timed out
-

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/w3c-import.log
@@ -44,6 +44,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-interrupted.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-invalid-url.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-opaque-origin.html
+/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-pagehide.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-preventDefault.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-push-initial-about-blank.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-push-javascript-url.html
@@ -51,10 +52,9 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-detached-unserializablestate.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-beforeunload.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-detached.html
-/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-unload.html
+/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-pagehide.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-unserializablestate.html
-/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-unload-unserializablestate.html
-/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-unload.html
+/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-pagehide-unserializablestate.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-unserializable-state.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-already-detached.html
@@ -64,11 +64,11 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-initial-about-blank.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-intercept-rejected.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-intercept.html
+/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-pagehide.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-preventDefault.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-beforeunload-unserializablestate.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-detached-unserializablestate.html
-/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-unload-unserializablestate.html
-/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-unload.html
+/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-pagehide-unserializablestate.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-unserializable-state.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-already-detached.html

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-cross-document-event-order.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-cross-document-event-order.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe id="i" src="resources/notify-top-early.html"></iframe>
+<script>
+async_test(t => {
+  let events = [];
+  function finish() {
+    assert_array_equals(events, ["onnavigate", "onunload", "readystateinteractive", "domcontentloaded", "readystatecomplete", "onload", "onpageshow"]);
+    t.done();
+  };
+
+  window.onload = t.step_func(() => {
+    i.contentWindow.navigation.navigate("?1");
+    i.onload = t.step_func(() => {
+      window.childStarted = () => {
+        i.contentWindow.navigation.onnavigatesuccess = () => events.push("onnavigatesuccess");
+        i.contentWindow.navigation.onnavigateerror = () => events.push("onnavigateerror");
+        i.contentWindow.onpageshow = () => events.push("onpageshow");
+        i.contentWindow.onhashchange = () => events.push("onhashchange");
+        i.contentWindow.onpopstate = () => events.push("onpopstate");
+        i.onload = t.step_func(() => {
+          events.push("onload");
+          t.step_timeout(finish, 0);
+        });
+        i.contentDocument.addEventListener("DOMContentLoaded", () => events.push("domcontentloaded"));
+        i.contentDocument.onreadystatechange = () => events.push("readystate" + i.contentDocument.readyState);
+      };
+      i.contentWindow.onunload = () => events.push("onunload");
+      i.contentWindow.navigation.onnavigate = () => events.push("onnavigate");
+      i.contentWindow.navigation.back().committed.then(
+        () => events.push("promisefulfilled"), () => events.push("promiserejected"));
+    })
+  });
+}, "back() event ordering for cross-document traversal");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-cross-document-event-order.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-cross-document-event-order.html
@@ -6,7 +6,7 @@
 async_test(t => {
   let events = [];
   function finish() {
-    assert_array_equals(events, ["onnavigate", "readystateinteractive", "domcontentloaded", "readystatecomplete", "onload", "onpageshow"]);
+    assert_array_equals(events, ["onnavigate", "onunload", "readystateinteractive", "domcontentloaded", "readystatecomplete", "onload", "onpageshow"]);
     t.done();
   };
 
@@ -24,6 +24,7 @@ async_test(t => {
       i.contentDocument.addEventListener("DOMContentLoaded", () => events.push("domcontentloaded"));
       i.contentDocument.onreadystatechange = () => events.push("readystate" + i.contentDocument.readyState);
     };
+    i.contentWindow.onunload = () => events.push("onunload");
     i.contentWindow.navigation.onnavigate = () => events.push("onnavigate");
     i.contentWindow.navigation.navigate("?1").committed.then(
         () => events.push("promisefulfilled"), () => events.push("promiserejected"));

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/w3c-import.log
@@ -18,6 +18,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-intercept-reject.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-intercept.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download.html
+/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-cross-document-event-order.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept-reject.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept.html
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document.html

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-intercept-handler-modifies.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-intercept-handler-modifies.html
@@ -26,6 +26,10 @@ promise_test(async t => {
     }
   );
   await navigation.navigate("?go").finished;
+  // Ensure the layout changes and scroll position update from the first
+  // navigation are processed before navigating back, otherwise the restored
+  // scroll postion can be overwritten.
+  await new Promise(resolve => requestAnimationFrame(resolve));
   await navigation.back().finished;
   assert_equals(window.scrollY, 100);
 }, "scroll: state should be saved before intercept handlers run");

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/w3c-import.log
@@ -15,3 +15,4 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/navigation-api/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/navigation-api/WEB_FEATURES.yml


### PR DESCRIPTION
#### b6ec312f2f6c7d6a2df240b5de1974063867562b
<pre>
Sync navigation-api from WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=273815">https://bugs.webkit.org/show_bug.cgi?id=273815</a>

Reviewed by Tim Nguyen.

Based on WPT SHA f409c99393.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/event-constructor.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-cross-origin.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-download-userInitiated.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-download.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-fragment-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-fragment.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-same-origin-cross-document.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-userInitiated-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-userInitiated.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-with-target.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-back-forward.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-navigate.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-reload.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-get.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-reload.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-traverse.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-userInitiated.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form-with-target.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-after-fragment.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-after-pushState.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-bfcache.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-cross-document.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-go-0.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-pushState.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-replaceState.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-iframe-location.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-location.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-meta-refresh.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-cross-document.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-same-document-in-iframe.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-same-document.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-navigate.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-svg-anchor-fragment-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-svg-anchor-fragment.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-to-srcdoc.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-window-open-self.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-window-open.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/cross-origin-redirect-on-second-visit.py: Added.
(redirect_response):
(ok_response):
(main):
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-204-205-download.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-pagehide.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-unload.html.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-pagehide.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-unload.html.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-unload-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-pagehide-unserializablestate.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-unload-unserializablestate.html.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-unload-unserializablestate-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-unload-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-pagehide.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-unload.html.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-pagehide-unserializablestate.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-unload-unserializablestate.html.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-unload-unserializablestate-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-unload-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-cross-document-event-order.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-cross-document-event-order.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-intercept-handler-modifies.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/278449@main">https://commits.webkit.org/278449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a02ab181c05f3b4ce6aa0d1f9ec1fea9ede11ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50596 "17 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53855 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1286 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/937 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41247 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27542 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22357 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/24933 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/834 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9036 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46920 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55444 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25697 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/800 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48656 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26955 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43723 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11082 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27821 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26687 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->