### PR TITLE
Simplify 2D context memory cost calculations

### DIFF
--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -30,6 +30,7 @@
 #include "IntSize.h"
 #include "PixelBuffer.h"
 #include "TaskSource.h"
+#include <atomic>
 #include <wtf/HashSet.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/WeakHashSet.h>
@@ -97,7 +98,9 @@ public:
     void makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect = ShouldApplyPostProcessingToDirtyRect::Yes);
 
     size_t memoryCost() const;
+#if ENABLE(RESOURCE_USAGE)
     size_t externalMemoryCost() const;
+#endif
 
     void setOriginClean() { m_originClean = true; }
     void setOriginTainted() { m_originClean = false; }
@@ -159,7 +162,6 @@ protected:
 
     RefPtr<ImageBuffer> setImageBuffer(RefPtr<ImageBuffer>&&) const;
     virtual bool hasCreatedImageBuffer() const { return false; }
-    static size_t activePixelMemory();
 
     RefPtr<ImageBuffer> allocateImageBuffer() const;
     String lastFillText() const { return m_lastFillText; }
@@ -171,11 +173,9 @@ private:
     virtual void createImageBuffer() const { }
     bool shouldAccelerate(uint64_t area) const;
 
-
     mutable IntSize m_size;
-    mutable Lock m_imageBufferAssignmentLock;
     mutable RefPtr<ImageBuffer> m_imageBuffer;
-    mutable size_t m_imageBufferCost { 0 };
+    mutable std::atomic<size_t> m_imageBufferMemoryCost { 0 };
     mutable std::unique_ptr<GraphicsContextStateSaver> m_contextStateSaver;
 
     String m_lastFillText;

--- a/Source/WebCore/html/OffscreenCanvas.idl
+++ b/Source/WebCore/html/OffscreenCanvas.idl
@@ -54,6 +54,8 @@ enum OffscreenRenderingContextType
     Conditional=OFFSCREEN_CANVAS,
     ConditionalForWorker=OFFSCREEN_CANVAS_IN_WORKERS,
     EnabledForContext,
+    ReportExtraMemoryCost,
+    ReportExternalMemoryCost,
     Exposed=(Window,Worker)
 ] interface OffscreenCanvas : EventTarget {
     [CallWith=CurrentScriptExecutionContext] constructor([EnforceRange] unsigned long width, [EnforceRange] unsigned long height);

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -119,7 +119,6 @@ public:
             BackendType::renderingMode,
             ImageBufferBackend::calculateBaseTransform(parameters),
             BackendType::calculateMemoryCost(parameters),
-            BackendType::calculateExternalMemoryCost(parameters)
         };
     }
 
@@ -163,7 +162,6 @@ public:
     RenderingMode renderingMode() const { return m_backendInfo.renderingMode; }
     AffineTransform baseTransform() const { return m_backendInfo.baseTransform; }
     size_t memoryCost() const { return m_backendInfo.memoryCost; }
-    size_t externalMemoryCost() const { return m_backendInfo.externalMemoryCost; }
     const ImageBufferBackend::Info& backendInfo() { return m_backendInfo; }
 
     // Returns NativeImage of the current drawing results. Results in an immutable copy of the current back buffer.

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -103,13 +103,11 @@ public:
         RenderingMode renderingMode;
         AffineTransform baseTransform;
         size_t memoryCost;
-        size_t externalMemoryCost;
     };
 
     WEBCORE_EXPORT virtual ~ImageBufferBackend();
 
     WEBCORE_EXPORT static size_t calculateMemoryCost(const IntSize& backendSize, unsigned bytesPerRow);
-    static size_t calculateExternalMemoryCost(const Parameters&) { return 0; }
     WEBCORE_EXPORT static AffineTransform calculateBaseTransform(const Parameters&);
 
     virtual GraphicsContext& context() = 0;

--- a/Source/WebCore/platform/graphics/NullImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/NullImageBufferBackend.h
@@ -39,7 +39,6 @@ public:
     WEBCORE_EXPORT static std::unique_ptr<NullImageBufferBackend> create(const Parameters&, const ImageBufferCreationContext&);
     WEBCORE_EXPORT ~NullImageBufferBackend();
     static size_t calculateMemoryCost(const Parameters&) { return 0; }
-    static size_t calculateExternalMemoryCost(const Parameters&) { return 0; }
 
     NullGraphicsContext& context() final;
     RefPtr<NativeImage> copyNativeImage() final;

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -68,11 +68,6 @@ size_t ImageBufferIOSurfaceBackend::calculateMemoryCost(const Parameters& parame
     return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize));
 }
 
-size_t ImageBufferIOSurfaceBackend::calculateExternalMemoryCost(const Parameters& parameters)
-{
-    return calculateMemoryCost(parameters);
-}
-
 std::unique_ptr<ImageBufferIOSurfaceBackend> ImageBufferIOSurfaceBackend::create(const Parameters& parameters, const ImageBufferCreationContext& creationContext)
 {
     IntSize backendSize = calculateSafeBackendSize(parameters);

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
@@ -42,7 +42,6 @@ public:
     static IntSize calculateSafeBackendSize(const Parameters&);
     static unsigned calculateBytesPerRow(const IntSize& backendSize);
     static size_t calculateMemoryCost(const Parameters&);
-    static size_t calculateExternalMemoryCost(const Parameters&);
 
     static std::unique_ptr<ImageBufferIOSurfaceBackend> create(const Parameters&, const ImageBufferCreationContext&);
 

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
@@ -51,11 +51,6 @@ size_t ImageBufferRemoteIOSurfaceBackend::calculateMemoryCost(const Parameters& 
     return ImageBufferIOSurfaceBackend::calculateMemoryCost(parameters);
 }
 
-size_t ImageBufferRemoteIOSurfaceBackend::calculateExternalMemoryCost(const Parameters& parameters)
-{
-    return ImageBufferIOSurfaceBackend::calculateExternalMemoryCost(parameters);
-}
-
 std::unique_ptr<ImageBufferRemoteIOSurfaceBackend> ImageBufferRemoteIOSurfaceBackend::create(const Parameters& parameters, ImageBufferBackendHandle handle)
 {
     if (!std::holds_alternative<MachSendRight>(handle)) {

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
@@ -40,7 +40,6 @@ class ImageBufferRemoteIOSurfaceBackend final : public WebCore::ImageBufferBacke
 public:
     static WebCore::IntSize calculateSafeBackendSize(const Parameters&);
     static size_t calculateMemoryCost(const Parameters&);
-    static size_t calculateExternalMemoryCost(const Parameters&);
 
     static std::unique_ptr<ImageBufferRemoteIOSurfaceBackend> create(const Parameters&, ImageBufferBackendHandle);
 


### PR DESCRIPTION
#### 6939c8db7b65abc775360f3586781a975024dcd0
<pre>
Simplify 2D context memory cost calculations
<a href="https://bugs.webkit.org/show_bug.cgi?id=273769">https://bugs.webkit.org/show_bug.cgi?id=273769</a>
<a href="https://rdar.apple.com/127601234">rdar://127601234</a>

Reviewed by Simon Fraser.

Avoid calling into ImageBuffer from GC threads. Instead, use the already
existing CanvasBase member variable to keep track of the canvas memory
use.

Set all the canvas memory as &quot;external memory cost&quot;. This is the memory
that is expected to be allocated from other sources than
bmalloc/libcmalloc heap. As 2D context backing store is currently in
GPUP, it cannot be attributed to bmalloc. The Extra/External
calculations are duplicated in other categories, and should be fixed
in other work.

Use the memory cost calculations in OffscreenCanvas, too.

Notify inspector of context changes after all the member state has been
updated. Inspector calls might re-enter calling back any member function
so it&apos;s better that the member state is defined.

Remove unused s_activePixelMemory.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::memoryCost const):
(WebCore::CanvasBase::externalMemoryCost const):
(WebCore::CanvasBase::setImageBuffer const):
(WebCore::CanvasBase::activePixelMemory): Deleted.
* Source/WebCore/html/CanvasBase.h:
(WebCore::CanvasBase::hasCreatedImageBuffer const):
* Source/WebCore/html/OffscreenCanvas.idl:
* Source/WebCore/platform/graphics/ImageBuffer.h:
(WebCore::ImageBuffer::populateBackendInfo):
(WebCore::ImageBuffer::memoryCost const):
(WebCore::ImageBuffer::externalMemoryCost const): Deleted.
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::calculateExternalMemoryCost): Deleted.
* Source/WebCore/platform/graphics/NullImageBufferBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::calculateExternalMemoryCost): Deleted.
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp:
(WebKit::ImageBufferRemoteIOSurfaceBackend::calculateExternalMemoryCost): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h:

Canonical link: <a href="https://commits.webkit.org/278797@main">https://commits.webkit.org/278797@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76519e850c4654a34d2b61ad3df49e27fdc437eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54729 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2155 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53765 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1835 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41906 "") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53561 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28409 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23030 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25715 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1639 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47684 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1720 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56321 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26581 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1600 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49300 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27821 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44442 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48477 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11290 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28714 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27556 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->