### PR TITLE
Move compute table functions from FEComponentTransferSoftwareApplier to FEComponentTransfer

### DIFF
--- a/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
+++ b/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
@@ -64,6 +64,9 @@ public:
     WEBCORE_EXPORT static Ref<FEComponentTransfer> create(const ComponentTransferFunction& redFunc, const ComponentTransferFunction& greenFunc, const ComponentTransferFunction& blueFunc, const ComponentTransferFunction& alphaFunc, DestinationColorSpace = DestinationColorSpace::SRGB());
     static Ref<FEComponentTransfer> create(ComponentTransferFunctions&&);
 
+    using LookupTable = std::array<uint8_t, 256>;
+    static LookupTable computeLookupTable(const ComponentTransferFunction&);
+
     bool operator==(const FEComponentTransfer&) const;
 
     ComponentTransferFunction redFunction() const { return m_functions[ComponentTransferChannel::Red]; }

--- a/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
@@ -34,93 +34,15 @@
 
 namespace WebCore {
 
-void FEComponentTransferSoftwareApplier::computeIdentityTable(LookupTable&, const ComponentTransferFunction&)
-{
-}
-
-void FEComponentTransferSoftwareApplier::computeTabularTable(LookupTable& values, const ComponentTransferFunction& transferFunction)
-{
-    const Vector<float>& tableValues = transferFunction.tableValues;
-    unsigned n = tableValues.size();
-    if (n < 1)
-        return;
-    for (unsigned i = 0; i < values.size(); ++i) {
-        double c = i / 255.0;
-        unsigned k = static_cast<unsigned>(c * (n - 1));
-        double v1 = tableValues[k];
-        double v2 = tableValues[std::min((k + 1), (n - 1))];
-        double val = 255.0 * (v1 + (c * (n - 1) - k) * (v2 - v1));
-        val = std::max(0.0, std::min(255.0, val));
-        values[i] = static_cast<uint8_t>(val);
-    }
-}
-
-void FEComponentTransferSoftwareApplier::computeDiscreteTable(LookupTable& values, const ComponentTransferFunction& transferFunction)
-{
-    const Vector<float>& tableValues = transferFunction.tableValues;
-    unsigned n = tableValues.size();
-    if (n < 1)
-        return;
-    for (unsigned i = 0; i < values.size(); ++i) {
-        unsigned k = static_cast<unsigned>((i * n) / 255.0);
-        k = std::min(k, n - 1);
-        double val = 255 * tableValues[k];
-        val = std::max(0.0, std::min(255.0, val));
-        values[i] = static_cast<uint8_t>(val);
-    }
-}
-
-void FEComponentTransferSoftwareApplier::computeLinearTable(LookupTable& values, const ComponentTransferFunction& transferFunction)
-{
-    for (unsigned i = 0; i < values.size(); ++i) {
-        double val = transferFunction.slope * i + 255 * transferFunction.intercept;
-        val = std::max(0.0, std::min(255.0, val));
-        values[i] = static_cast<uint8_t>(val);
-    }
-}
-
-void FEComponentTransferSoftwareApplier::computeGammaTable(LookupTable& values, const ComponentTransferFunction& transferFunction)
-{
-    for (unsigned i = 0; i < values.size(); ++i) {
-        double exponent = transferFunction.exponent; // RCVT doesn't like passing a double and a float to pow, so promote this to double
-        double val = 255.0 * (transferFunction.amplitude * pow((i / 255.0), exponent) + transferFunction.offset);
-        val = std::max(0.0, std::min(255.0, val));
-        values[i] = static_cast<uint8_t>(val);
-    }
-}
-
-FEComponentTransferSoftwareApplier::LookupTable FEComponentTransferSoftwareApplier::computeLookupTable(const ComponentTransferFunction& function)
-{
-    LookupTable table;
-
-    for (unsigned i = 0; i < table.size(); ++i)
-        table[i] = i;
-
-    using TransferType = void (*)(LookupTable&, const ComponentTransferFunction&);
-    TransferType callEffect[] = {
-        computeIdentityTable,   // FECOMPONENTTRANSFER_TYPE_UNKNOWN
-        computeIdentityTable,   // FECOMPONENTTRANSFER_TYPE_IDENTITY
-        computeTabularTable,    // FECOMPONENTTRANSFER_TYPE_TABLE
-        computeDiscreteTable,   // FECOMPONENTTRANSFER_TYPE_DISCRETE
-        computeLinearTable,     // FECOMPONENTTRANSFER_TYPE_LINEAR
-        computeGammaTable       // FECOMPONENTTRANSFER_TYPE_GAMMA
-    };
-
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(static_cast<size_t>(function.type) < std::size(callEffect));
-    callEffect[static_cast<size_t>(function.type)](table, function);
-
-    return table;
-}
-
 void FEComponentTransferSoftwareApplier::applyPlatform(PixelBuffer& pixelBuffer) const
 {
     auto* data = pixelBuffer.bytes().data();
     auto pixelByteLength = pixelBuffer.bytes().size();
 
-    auto redTable   = computeLookupTable(m_effect.redFunction());
-    auto greenTable = computeLookupTable(m_effect.greenFunction());
-    auto blueTable  = computeLookupTable(m_effect.blueFunction());
-    auto alphaTable = computeLookupTable(m_effect.alphaFunction());
+    auto redTable   = FEComponentTransfer::computeLookupTable(m_effect.redFunction());
+    auto greenTable = FEComponentTransfer::computeLookupTable(m_effect.greenFunction());
+    auto blueTable  = FEComponentTransfer::computeLookupTable(m_effect.blueFunction());
+    auto alphaTable = FEComponentTransfer::computeLookupTable(m_effect.alphaFunction());
 
     for (unsigned pixelOffset = 0; pixelOffset < pixelByteLength; pixelOffset += 4) {
         data[pixelOffset]     = redTable[data[pixelOffset]];

--- a/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.h
@@ -40,16 +40,6 @@ public:
 private:
     bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
 
-    using LookupTable = std::array<uint8_t, 256>;
-
-    static void computeIdentityTable(LookupTable&, const ComponentTransferFunction&);
-    static void computeTabularTable(LookupTable&, const ComponentTransferFunction&);
-    static void computeDiscreteTable(LookupTable&, const ComponentTransferFunction&);
-    static void computeLinearTable(LookupTable&, const ComponentTransferFunction&);
-    static void computeGammaTable(LookupTable&, const ComponentTransferFunction&);
-
-    static LookupTable computeLookupTable(const ComponentTransferFunction&);
-
     void applyPlatform(PixelBuffer&) const;
 };
 


### PR DESCRIPTION
#### 82f851ba6e367121f35f2ca6d2bdc96e944bbf83
<pre>
Move compute table functions from FEComponentTransferSoftwareApplier to FEComponentTransfer
<a href="https://bugs.webkit.org/show_bug.cgi?id=273817">https://bugs.webkit.org/show_bug.cgi?id=273817</a>

Reviewed by Nikolas Zimmermann.

Skia implementation will need those functions too, by moving them we
will be able to use them without duplicating the code.

* Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp:
(WebCore::FEComponentTransfer::computeLookupTable):
* Source/WebCore/platform/graphics/filters/FEComponentTransfer.h:
* Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp:
(WebCore::FEComponentTransferSoftwareApplier::applyPlatform const):
(WebCore::FEComponentTransferSoftwareApplier::computeIdentityTable): Deleted.
(WebCore::FEComponentTransferSoftwareApplier::computeTabularTable): Deleted.
(WebCore::FEComponentTransferSoftwareApplier::computeDiscreteTable): Deleted.
(WebCore::FEComponentTransferSoftwareApplier::computeLinearTable): Deleted.
(WebCore::FEComponentTransferSoftwareApplier::computeGammaTable): Deleted.
(WebCore::FEComponentTransferSoftwareApplier::computeLookupTable): Deleted.
* Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.h:

Canonical link: <a href="https://commits.webkit.org/278458@main">https://commits.webkit.org/278458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fbf3cfc5060e36119419cc5f5914a77249b8743

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50605 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2919 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53864 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1295 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52908 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/946 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41254 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52704 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43591 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22365 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24940 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/840 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9045 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46934 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55453 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25706 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48664 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26964 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43729 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47720 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11088 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27830 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26696 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->