### PR TITLE
[WebGPU] Fix build error in WebGPUOutOfMemoryError and WebGPUExternalTextureBindingLayout

### DIFF
--- a/Source/WebKit/Shared/WebGPU/WebGPUExternalTextureBindingLayout.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUExternalTextureBindingLayout.cpp
@@ -36,12 +36,12 @@ namespace WebKit::WebGPU {
 
 std::optional<ExternalTextureBindingLayout> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::ExternalTextureBindingLayout& externalTextureBindingLayout)
 {
-    return { { } };
+    return { ExternalTextureBindingLayout { } };
 }
 
 std::optional<WebCore::WebGPU::ExternalTextureBindingLayout> ConvertFromBackingContext::convertFromBacking(const ExternalTextureBindingLayout& externalTextureBindingLayout)
 {
-    return { { } };
+    return { WebCore::WebGPU::ExternalTextureBindingLayout { } };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebGPU/WebGPUOutOfMemoryError.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUOutOfMemoryError.cpp
@@ -36,7 +36,7 @@ namespace WebKit::WebGPU {
 
 std::optional<OutOfMemoryError> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::OutOfMemoryError& outOfMemoryError)
 {
-    return { { } };
+    return { OutOfMemoryError { } };
 }
 
 RefPtr<WebCore::WebGPU::OutOfMemoryError> ConvertFromBackingContext::convertFromBacking(const OutOfMemoryError& outOfMemoryError)


### PR DESCRIPTION
#### 9d0e5ac99f880403794204c413f0a3d950dd3200
<pre>
[WebGPU] Fix build error in WebGPUOutOfMemoryError and WebGPUExternalTextureBindingLayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=273821">https://bugs.webkit.org/show_bug.cgi?id=273821</a>

Reviewed by Mike Wyrzykowski.

This fixes the error: converting to &apos;std::optional&lt;WebKit::WebGPU::OutOfMemoryError&gt;&apos;
from initializer list would use explicit constructor.

* Source/WebKit/Shared/WebGPU/WebGPUExternalTextureBindingLayout.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
(WebKit::WebGPU::ConvertFromBackingContext::convertFromBacking):
* Source/WebKit/Shared/WebGPU/WebGPUOutOfMemoryError.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):

Canonical link: <a href="https://commits.webkit.org/278537@main">https://commits.webkit.org/278537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e26256c64d49977b1e8a70f3c4a313263239b60d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54131 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1563 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36445 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1239 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41441 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27809 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43826 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22569 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25148 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9313 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47132 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55725 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25976 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1045 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48851 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27232 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43899 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11140 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28101 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26963 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->