### PR TITLE
Refactor OMG call patchpoint and tail call patchpoint

### DIFF
--- a/JSTests/wasm/stress/cc-int-to-int-tail-call.js
+++ b/JSTests/wasm/stress/cc-int-to-int-tail-call.js
@@ -1,0 +1,58 @@
+//@ skip
+//@ requireOptions("--useIPIntWrappers=1", "--useWebAssemblyTailCalls=1")
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (type $sig_test (func (param i32) (result i32)))
+    (table $t 1 funcref)
+    (elem (i32.const 0) $test)
+
+    (func $test (export "test") (param $x i32) (result i32)
+        (i32.add (local.get $x) (i32.const 42))
+    )
+
+    (func (export "test_with_call") (param $x i32) (result i32)
+        (return_call $test (i32.add (local.get $x) (i32.const 1337)))
+    )
+
+    (func (export "test_with_call_indirect") (param $x i32) (result i32)
+        (local.get $x)
+        (i32.const 98)
+        i32.add
+        (return_call_indirect $t (type $sig_test) (i32.const 0))
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true, tail_call: true })
+    const { test, test_with_call, test_with_call_indirect } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(test(5), 42 + 5)
+        assert.eq(test(), 42 + 0)
+        assert.eq(test(null), 42 + 0)
+        assert.eq(test({ }), 42 + 0)
+        assert.eq(test({ }, 10), 42 + 0)
+        assert.eq(test(20.1, 10), 42 + 20)
+        assert.eq(test(10, 20.1), 42 + 10)
+        assert.eq(test_with_call(5), 42 + 5 + 1337)
+        assert.eq(test_with_call(), 42 + 0 + 1337)
+        assert.eq(test_with_call(null), 42 + 0 + 1337)
+        assert.eq(test_with_call({ }), 42 + 0 + 1337)
+        assert.eq(test_with_call({ }, 10), 42 + 0 + 1337)
+        assert.eq(test_with_call(20.1, 10), 42 + 20 + 1337)
+        assert.eq(test_with_call(10, 20.1), 42 + 10 + 1337)
+        assert.eq(test_with_call_indirect(5), 42 + 5 + 98)
+        assert.eq(test_with_call_indirect(), 42 + 0 + 98)
+        assert.eq(test_with_call_indirect(null), 42 + 0 + 98)
+        assert.eq(test_with_call_indirect({ }), 42 + 0 + 98)
+        assert.eq(test_with_call_indirect({ }, 10), 42 + 0 + 98)
+        assert.eq(test_with_call_indirect(20.1, 10), 42 + 20 + 98)
+        assert.eq(test_with_call_indirect(10, 20.1), 42 + 10 + 98)
+    }
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1249,7 +1249,7 @@ private:
             // FIXME: Support wasm IC.
             // DirectCall to wasm function has suboptimal implementation. We avoid using DirectCall if we know that function is a wasm function.
             // https://bugs.webkit.org/show_bug.cgi?id=220339
-            if (executable->intrinsic() == WasmFunctionIntrinsic) {
+            if (executable->intrinsic() == WasmFunctionIntrinsic && !Options::forceICFailure()) {
                 if (m_node->op() != Call) // FIXME: We should support tail-call.
                     break;
                 if (!function)

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -825,18 +825,20 @@ void Options::notifyOptionsChanged()
         if (Options::forceAllFunctionsToUseSIMD() && !Options::useWebAssemblySIMD())
             Options::forceAllFunctionsToUseSIMD() = false;
 
-        if (Options::useWebAssemblySIMD() && !(Options::useWasmLLInt() || Options::useWasmIPInt())) {
-            // The LLInt is responsible for discovering if functions use SIMD.
-            // If we can't run using it, then we should be conservative.
-            Options::forceAllFunctionsToUseSIMD() = true;
-        }
-
         if (Options::useWebAssemblyTailCalls()) {
             // The single-pass BBQ JIT doesn't support these features currently, so we should use a different
             // BBQ backend if any of them are enabled. We should remove these limitations as support for each
             // is added.
             // FIXME: Add WASM tail calls support to single-pass BBQ JIT. https://bugs.webkit.org/show_bug.cgi?id=253192
             Options::useBBQJIT() = false;
+            Options::useWasmLLInt() = true;
+            Options::wasmLLIntTiersUpToBBQ() = false;
+        }
+
+        if (Options::useWebAssemblySIMD() && !(Options::useWasmLLInt() || Options::useWasmIPInt())) {
+            // The LLInt is responsible for discovering if functions use SIMD.
+            // If we can't run using it, then we should be conservative.
+            Options::forceAllFunctionsToUseSIMD() = true;
         }
     }
 

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -89,6 +89,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(VM& vm
 
     jit.emitFunctionPrologue();
     GPRReg scratchGPR = GPRInfo::nonPreservedNonArgumentGPR0;
+    JIT_COMMENT(jit, "Store callee from ptr: ", RawPointer(&callee), " value, ", RawPointer(CalleeBits::boxNativeCallee(&callee)));
     jit.move(CCallHelpers::TrustedImmPtr(CalleeBits::boxNativeCallee(&callee)), scratchGPR);
     static_assert(CallFrameSlot::codeBlock + 1 == CallFrameSlot::callee);
     if constexpr (is32Bit()) {


### PR DESCRIPTION
#### c88311640e5fed73c815ddc6e06c4575b4364fcf
<pre>
Refactor OMG call patchpoint and tail call patchpoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=273823">https://bugs.webkit.org/show_bug.cgi?id=273823</a>

Reviewed by Yusuke Suzuki.

The wasm tail calls feature does not currently work when the new frame
overlaps the old frame in interesting ways, so the tail calls tests
were disabled. Then, OMG inlining broke tail calls, causing an assertion failure.

This patch does not fix tail calls, but it does fix that assertion.

It also refactors both versions of create[Tail]CallPatchpoint to look
the same. This makes it a little nicer to read, but more importantly,
it makes it easier for a follow-up patch to fix OMG tail calls.

The main reason for this change is so that the follow-up patch is easier to read.

* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitIndirectCall):
(JSC::Wasm::OMGIRGenerator::createCallPatchpoint):
(JSC::Wasm::OMGIRGenerator::createTailCallPatchpoint):
(JSC::Wasm::OMGIRGenerator::addCall):

Canonical link: <a href="https://commits.webkit.org/279055@main">https://commits.webkit.org/279055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c210d0a136450e1ec7cb9a843d67b6f4a25c9025

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52369 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55643 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3092 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2791 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1970 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29335 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45201 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23668 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26555 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2476 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1251 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/45718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48450 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2626 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57239 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51877 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2653 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28728 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45321 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11437 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29640 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64185 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28473 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12156 "Found 11 new JSC stress test failures: stress/proxy-set-prototype-of.js.dfg-eager, stress/setter-frame-flush.js.default, stress/spread-non-array.js.mini-mode, stress/spread-non-array.js.no-llint, wasm.yaml/wasm/function-tests/dead-call.js.wasm-eager, wasm.yaml/wasm/function-tests/i32-load8-s.js.wasm-eager, wasm.yaml/wasm/function-tests/loop-sum.js.wasm-eager, wasm.yaml/wasm/function-tests/rotr.js.wasm-eager, wasm.yaml/wasm/stress/dont-stack-overflow-in-air.js.wasm-eager, wasm.yaml/wasm/stress/exception-multiple-instances.js.wasm-eager ... (failure)") | 
<!--EWS-Status-Bubble-End-->