### PR TITLE
Update implementation of TT enforcement for document.write(ln)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Document-write-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Document-write-expected.txt
@@ -1,4 +1,11 @@
-Quack, I want to be a duck!
+abcdefghijkl
 
 PASS document.write with html assigned via policy (successful transformation).
+PASS document.writeln with html assigned via policy (successful transformation).
+PASS document.write(TrustedHTML, TrustedHTML)
+PASS document.writeln(TrustedHTML, TrustedHTML)
+PASS document.write(TrustedHTML, String)
+PASS document.writeln(TrustedHTML, String)
+PASS document.write(String, String)
+PASS document.writeln(String, String)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Document-write.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Document-write.html
@@ -11,4 +11,64 @@
     document.write(html);
     assert_true(document.body.innerText.indexOf(RESULTS.HTML) !== -1);
   }, "document.write with html assigned via policy (successful transformation).");
+
+  test(t => {
+    document.body.innerText = '';
+    let p = createHTML_policy(window, 1);
+    let html = p.createHTML(INPUTS.HTML);
+    document.writeln(html);
+    assert_true(document.body.innerText.indexOf(RESULTS.HTML) !== -1);
+  }, "document.writeln with html assigned via policy (successful transformation).");
+
+  test(t => {
+    document.body.innerText = '';
+    let p = createHTML_policy(window, 1);
+    let a = p.createHTML("abcdef");
+    let b = p.createHTML("ghijkl");
+    document.write(a, b);
+    assert_equals(document.body.innerText, "abcdefghijkl");
+  }, "document.write(TrustedHTML, TrustedHTML)");
+
+  test(t => {
+    document.body.innerText = '';
+    let p = createHTML_policy(window, 1);
+    let a = p.createHTML("abcdef");
+    let b = p.createHTML("ghijkl");
+    document.writeln(a, b);
+    assert_equals(document.body.innerText, "abcdefghijkl");
+  }, "document.writeln(TrustedHTML, TrustedHTML)");
+
+  test(t => {
+    document.body.innerText = '';
+    let p = createHTML_policy(window, 1);
+    let a = p.createHTML("abcdef");
+    let b = "ghijkl";
+    document.write(a, b);
+    assert_equals(document.body.innerText, "abcdefghijkl");
+  }, "document.write(TrustedHTML, String)");
+
+  test(t => {
+    document.body.innerText = '';
+    let p = createHTML_policy(window, 1);
+    let a = p.createHTML("abcdef");
+    let b = "ghijkl";
+    document.writeln(a, b);
+    assert_equals(document.body.innerText, "abcdefghijkl");
+  }, "document.writeln(TrustedHTML, String)");
+
+  test(t => {
+    document.body.innerText = '';
+    let a = "abcdef";
+    let b = "ghijkl";
+    document.write(a, b);
+    assert_equals(document.body.innerText, "abcdefghijkl");
+  }, "document.write(String, String)");
+
+  test(t => {
+    document.body.innerText = '';
+    let a = "abcdef";
+    let b = "ghijkl";
+    document.writeln(a, b);
+    assert_equals(document.body.innerText, "abcdefghijkl");
+  }, "document.writeln(String, String)");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Document-write-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Document-write-expected.txt
@@ -2,14 +2,28 @@ CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the followin
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-Quack, I want to be a duck!
+CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+abczxcvbnjkl
 
 PASS document.write with html assigned via policy (successful URL transformation).
+PASS document.write with multiple trusted arguments.
 PASS document.writeln with html assigned via policy (successful URL transformation).
+PASS document.writeln with multiple trusted arguments.
 PASS `document.write(string)` throws
+PASS `document.write(string, string)` throws
+PASS `document.write(string, TrustedHTML)` throws
 PASS `document.writeln(string)` throws
+PASS `document.writeln(string, string)` throws
+PASS `document.writeln(string, TrustedHTML)` throws
 PASS `document.write(null)` throws
 PASS `document.writeln(null)` throws
 PASS `document.write(string)` observes default policy
+PASS `document.write(string, string)` observes default policy
+PASS `document.write(string, TrustedHTML)` observes default policy
 PASS `document.writeln(string)` observes default policy
+PASS `document.writeln(string, string)` observes default policy
+PASS `document.writeln(string, TrustedHTML)` observes default policy
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Document-write.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Document-write.html
@@ -18,6 +18,14 @@
     assert_equals(document.body.innerText, RESULTS.HTML);
   }, "document.write with html assigned via policy (successful URL transformation).");
 
+  test(t => {
+    document.body.innerText = '';
+    let a = p.createHTML("abcdef");
+    let b = p.createHTML("ghijkl");
+    document.write(a,b);
+    assert_equals(document.body.innerText, "abcdefghijkl");
+  }, "document.write with multiple trusted arguments.");
+
   // TrustedURL assignments do not throw. (Now for writeln.)
   test(t => {
     document.body.innerText = '';
@@ -25,6 +33,14 @@
     document.writeln(html);
     assert_equals(document.body.innerText, RESULTS.HTML);
   }, "document.writeln with html assigned via policy (successful URL transformation).");
+
+  test(t => {
+    document.body.innerText = '';
+    let a = p.createHTML("abcdef");
+    let b = p.createHTML("ghijkl");
+    document.writeln(a,b);
+    assert_equals(document.body.innerText, "abcdefghijkl");
+  }, "document.writeln with multiple trusted arguments.");
 
   // String assignments throw.
   test(t => {
@@ -35,6 +51,26 @@
     assert_equals(document.body.innerText, old);
   }, "`document.write(string)` throws");
 
+  test(t => {
+    const old = document.body.innerText;
+    assert_throws_js(TypeError, _ => {
+      let a = "abcdef";
+      let b = "ghijkl";
+      document.write(a, b);
+    });
+    assert_equals(document.body.innerText, old);
+  }, "`document.write(string, string)` throws");
+
+  test(t => {
+    const old = document.body.innerText;
+    assert_throws_js(TypeError, _ => {
+      let a = "abcdef";
+      let b = p.createHTML("ghijkl");
+      document.write(a, b);
+    });
+    assert_equals(document.body.innerText, old);
+  }, "`document.write(string, TrustedHTML)` throws");
+
   // String assignments throw. (Now for writeln.)
   test(t => {
     const old = document.body.innerText;
@@ -43,6 +79,26 @@
     });
     assert_equals(document.body.innerText, old);
   }, "`document.writeln(string)` throws");
+
+  test(t => {
+    const old = document.body.innerText;
+    assert_throws_js(TypeError, _ => {
+      let a = "abcdef";
+      let b = "ghijkl";
+      document.writeln(a, b);
+    });
+    assert_equals(document.body.innerText, old);
+  }, "`document.writeln(string, string)` throws");
+
+  test(t => {
+    const old = document.body.innerText;
+    assert_throws_js(TypeError, _ => {
+      let a = "abcdef";
+      let b = p.createHTML("ghijkl");
+      document.writeln(a, b);
+    });
+    assert_equals(document.body.innerText, old);
+  }, "`document.writeln(string, TrustedHTML)` throws");
 
   // Null assignment throws.
   test(t => {
@@ -63,7 +119,11 @@
   }, "`document.writeln(null)` throws");
 
   let default_policy = trustedTypes.createPolicy('default',
-      { createHTML: createHTMLJS }, true );
+          { createHTML: (html) => {
+              return html.replace("Hi", "Quack")
+                      .replace("transformed", "a duck")
+                      .replace("defghi", "zxcvbn")
+            } }, true );
 
   // Default policy works.
   test(t => {
@@ -72,10 +132,42 @@
     assert_equals(document.body.innerText, RESULTS.HTML);
   }, "`document.write(string)` observes default policy");
 
+  test(t => {
+    document.body.innerText = '';
+    let a = "abcdef";
+    let b = "ghijkl";
+    document.write(a, b);
+    assert_equals(document.body.innerText, "abczxcvbnjkl");
+  }, "`document.write(string, string)` observes default policy");
+
+  test(t => {
+    document.body.innerText = '';
+    let a = "abcdef";
+    let b = p.createHTML("ghijkl");
+    document.write(a, b);
+    assert_equals(document.body.innerText, "abczxcvbnjkl");
+  }, "`document.write(string, TrustedHTML)` observes default policy");
+
   // Default policy works. (Now for writeln.)
   test(t => {
     document.body.innerText = '';
     document.writeln(INPUTS.HTML);
     assert_equals(document.body.innerText, RESULTS.HTML);
   }, "`document.writeln(string)` observes default policy");
+
+  test(t => {
+    document.body.innerText = '';
+    let a = "abcdef";
+    let b = "ghijkl";
+    document.writeln(a, b);
+    assert_equals(document.body.innerText, "abczxcvbnjkl");
+  }, "`document.writeln(string, string)` observes default policy");
+
+  test(t => {
+    document.body.innerText = '';
+    let a = "abcdef";
+    let b = p.createHTML("ghijkl");
+    document.writeln(a, b);
+    assert_equals(document.body.innerText, "abczxcvbnjkl");
+  }, "`document.writeln(string, TrustedHTML)` observes default policy");
 </script>

--- a/Source/WebCore/dom/Document+HTML.idl
+++ b/Source/WebCore/dom/Document+HTML.idl
@@ -61,8 +61,8 @@ partial interface Document {
     [CEReactions=Needed, CallWith=EntryDocument, ImplementedAs=openForBindings] Document open(optional DOMString unused1, optional DOMString unused2); // both arguments are ignored.
     [CallWith=ActiveWindow&FirstWindow, ImplementedAs=openForBindings] WindowProxy open(USVString url, [AtomString] DOMString name, DOMString features);
     [CEReactions=Needed, ImplementedAs=closeForBindings] undefined close();
-    [CEReactions=Needed, CallWith=EntryDocument] undefined write(HTMLString... text);
-    [CEReactions=Needed, CallWith=EntryDocument] undefined writeln(HTMLString... text);
+    [CEReactions=Needed, CallWith=EntryDocument] undefined write((TrustedHTML or DOMString)... text);
+    [CEReactions=Needed, CallWith=EntryDocument] undefined writeln((TrustedHTML or DOMString)... text);
 
     // user interaction
     [ImplementedAs=windowProxy] readonly attribute WindowProxy? defaultView;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3937,28 +3937,71 @@ ExceptionOr<void> Document::write(Document* entryDocument, SegmentedString&& tex
     return { };
 }
 
-ExceptionOr<void> Document::write(Document* entryDocument, FixedVector<String>&& strings)
+ExceptionOr<void> Document::write(Document* entryDocument, FixedVector<std::variant<RefPtr<TrustedHTML>, String>>&& strings)
 {
     if (!isHTMLDocument() || m_throwOnDynamicMarkupInsertionCount)
         return Exception { ExceptionCode::InvalidStateError };
 
+    auto isTrusted = true;
     SegmentedString text;
-    for (auto& string : strings)
-        text.append(WTFMove(string));
+    for (auto& entry : strings) {
+        text.append(
+            WTF::switchOn(
+                WTFMove(entry),
+                [&isTrusted](const String& string) -> String {
+                    isTrusted = false;
+                    return string;
+                },
+                [](const RefPtr<TrustedHTML>& html) -> String {
+                    return html->toString();
+                }
+            )
+        );
+    }
+
+    if (!isTrusted) {
+        auto stringValueHolder = trustedTypeCompliantString(TrustedType::TrustedHTML, *scriptExecutionContext(), text.toString(), "Document write"_s);
+        if (stringValueHolder.hasException())
+            return stringValueHolder.releaseException();
+        text.clear();
+        text.append(stringValueHolder.releaseReturnValue());
+    }
 
     return write(entryDocument, WTFMove(text));
 }
 
-ExceptionOr<void> Document::writeln(Document* entryDocument, FixedVector<String>&& strings)
+ExceptionOr<void> Document::writeln(Document* entryDocument, FixedVector<std::variant<RefPtr<TrustedHTML>, String>>&& strings)
 {
     if (!isHTMLDocument() || m_throwOnDynamicMarkupInsertionCount)
         return Exception { ExceptionCode::InvalidStateError };
 
+    auto isTrusted = true;
     SegmentedString text;
-    for (auto& string : strings)
-        text.append(WTFMove(string));
+    for (auto& entry : strings) {
+        text.append(
+            WTF::switchOn(
+                WTFMove(entry),
+                [&isTrusted](const String& string) -> String {
+                    isTrusted = false;
+                    return string;
+                },
+                [](const RefPtr<TrustedHTML>& html) -> String {
+                    return html->toString();
+                }
+            )
+        );
+    }
+
+    if (!isTrusted) {
+        auto stringValueHolder = trustedTypeCompliantString(TrustedType::TrustedHTML, *scriptExecutionContext(), text.toString(), "Document writeln"_s);
+        if (stringValueHolder.hasException())
+            return stringValueHolder.releaseException();
+        text.clear();
+        text.append(stringValueHolder.releaseReturnValue());
+    }
 
     text.append("\n"_s);
+
     return write(entryDocument, WTFMove(text));
 }
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -807,8 +807,8 @@ public:
     void cancelParsing();
 
     ExceptionOr<void> write(Document* entryDocument, SegmentedString&&);
-    WEBCORE_EXPORT ExceptionOr<void> write(Document* entryDocument, FixedVector<String>&&);
-    WEBCORE_EXPORT ExceptionOr<void> writeln(Document* entryDocument, FixedVector<String>&&);
+    WEBCORE_EXPORT ExceptionOr<void> write(Document* entryDocument, FixedVector<std::variant<RefPtr<TrustedHTML>, String>>&&);
+    WEBCORE_EXPORT ExceptionOr<void> writeln(Document* entryDocument, FixedVector<std::variant<RefPtr<TrustedHTML>, String>>&&);
 
     bool wellFormed() const { return m_wellFormed; }
 


### PR DESCRIPTION
#### e84b70e7fa81a96f61afc01534992746135fdc8f
<pre>
Update implementation of TT enforcement for document.write(ln)
<a href="https://bugs.webkit.org/show_bug.cgi?id=273819">https://bugs.webkit.org/show_bug.cgi?id=273819</a>

Reviewed by Ryosuke Niwa.

This patch switches document.write and writeln to use a union IDL type and single call to default policy.

This brings it close to chromium behaviour.

See <a href="https://github.com/whatwg/html/pull/10328">https://github.com/whatwg/html/pull/10328</a>

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/Document-write-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/Document-write.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Document-write-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Document-write.html:
* Source/WebCore/dom/Document+HTML.idl:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::write):
(WebCore::Document::writeln):
* Source/WebCore/dom/Document.h:

Canonical link: <a href="https://commits.webkit.org/278501@main">https://commits.webkit.org/278501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/394c7e83d94fc5f399385b2d27972e773cd2320d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50634 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53893 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1325 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36191 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41280 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52733 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22394 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24977 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/871 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9075 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46955 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/933 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55482 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25736 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/837 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48691 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26993 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47746 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11123 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27861 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26725 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->