### PR TITLE
[WebGPU] Invalid command buffers need to get dealloc'ed in a timely fashion

### DIFF
--- a/Source/WebGPU/WebGPU/CommandBuffer.h
+++ b/Source/WebGPU/WebGPU/CommandBuffer.h
@@ -42,9 +42,9 @@ class Device;
 class CommandBuffer : public WGPUCommandBufferImpl, public RefCounted<CommandBuffer>, public CanMakeWeakPtr<CommandBuffer> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<CommandBuffer> create(id<MTLCommandBuffer> commandBuffer, Device& device)
+    static Ref<CommandBuffer> create(id<MTLCommandBuffer> commandBuffer, id<MTLSharedEvent> event, Device& device)
     {
-        return adoptRef(*new CommandBuffer(commandBuffer, device));
+        return adoptRef(*new CommandBuffer(commandBuffer, event, device));
     }
     static Ref<CommandBuffer> createInvalid(Device& device)
     {
@@ -68,10 +68,11 @@ public:
     void waitForCompletion();
 
 private:
-    CommandBuffer(id<MTLCommandBuffer>, Device&);
+    CommandBuffer(id<MTLCommandBuffer>, id<MTLSharedEvent>, Device&);
     CommandBuffer(Device&);
 
     id<MTLCommandBuffer> m_commandBuffer { nil };
+    id<MTLSharedEvent> m_abortEvent { nil };
     id<MTLCommandBuffer> m_cachedCommandBuffer { nil };
     int m_bufferMapCount { 0 };
 

--- a/Source/WebGPU/WebGPU/CommandBuffer.mm
+++ b/Source/WebGPU/WebGPU/CommandBuffer.mm
@@ -30,8 +30,9 @@
 
 namespace WebGPU {
 
-CommandBuffer::CommandBuffer(id<MTLCommandBuffer> commandBuffer, Device& device)
+CommandBuffer::CommandBuffer(id<MTLCommandBuffer> commandBuffer, id<MTLSharedEvent> event, Device& device)
     : m_commandBuffer(commandBuffer)
+    , m_abortEvent(event)
     , m_device(device)
 {
 }
@@ -50,6 +51,7 @@ void CommandBuffer::setLabel(String&& label)
 
 void CommandBuffer::makeInvalid(NSString* lastError)
 {
+    [m_abortEvent setSignaledValue:1];
     m_lastErrorString = lastError;
     m_device->getQueue().commitMTLCommandBuffer(m_commandBuffer);
     m_commandBuffer = nil;

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -57,9 +57,9 @@ class Texture;
 class CommandEncoder : public WGPUCommandEncoderImpl, public RefCounted<CommandEncoder>, public CommandsMixin, public CanMakeWeakPtr<CommandEncoder> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<CommandEncoder> create(id<MTLCommandBuffer> commandBuffer, Device& device)
+    static Ref<CommandEncoder> create(id<MTLCommandBuffer> commandBuffer, id<MTLSharedEvent> event, Device& device)
     {
-        return adoptRef(*new CommandEncoder(commandBuffer, device));
+        return adoptRef(*new CommandEncoder(commandBuffer, event, device));
     }
     static Ref<CommandEncoder> createInvalid(Device& device)
     {
@@ -106,7 +106,7 @@ public:
     bool encoderIsCurrent(id<MTLCommandEncoder>) const;
 
 private:
-    CommandEncoder(id<MTLCommandBuffer>, Device&);
+    CommandEncoder(id<MTLCommandBuffer>, id<MTLSharedEvent>, Device&);
     CommandEncoder(Device&);
 
     NSString* errorValidatingCopyBufferToBuffer(const Buffer& source, uint64_t sourceOffset, const Buffer& destination, uint64_t destinationOffset, uint64_t size);
@@ -123,6 +123,7 @@ private:
     NSString* errorValidatingCopyTextureToBuffer(const WGPUImageCopyTexture&, const WGPUImageCopyBuffer&, const WGPUExtent3D&) const;
 
     id<MTLCommandBuffer> m_commandBuffer { nil };
+    id<MTLSharedEvent> m_abortCommandBuffer { nil };
     id<MTLBlitCommandEncoder> m_blitCommandEncoder { nil };
     id<MTLCommandEncoder> m_existingCommandEncoder { nil };
     struct PendingTimestampWrites {

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -98,17 +98,18 @@ Ref<CommandEncoder> Device::createCommandEncoder(const WGPUCommandEncoderDescrip
 
     auto *commandBufferDescriptor = [MTLCommandBufferDescriptor new];
     commandBufferDescriptor.errorOptions = MTLCommandBufferErrorOptionEncoderExecutionStatus;
-    id<MTLCommandBuffer> commandBuffer = getQueue().commandBufferWithDescriptor(commandBufferDescriptor);
-    if (!commandBuffer)
+    auto commandBufferWithEvent = getQueue().commandBufferWithDescriptor(commandBufferDescriptor);
+    if (!commandBufferWithEvent.first)
         return CommandEncoder::createInvalid(*this);
 
-    commandBuffer.label = fromAPI(descriptor.label);
+    commandBufferWithEvent.first.label = fromAPI(descriptor.label);
 
-    return CommandEncoder::create(commandBuffer, *this);
+    return CommandEncoder::create(commandBufferWithEvent.first, commandBufferWithEvent.second, *this);
 }
 
-CommandEncoder::CommandEncoder(id<MTLCommandBuffer> commandBuffer, Device& device)
+CommandEncoder::CommandEncoder(id<MTLCommandBuffer> commandBuffer, id<MTLSharedEvent> event, Device& device)
     : m_commandBuffer(commandBuffer)
+    , m_abortCommandBuffer(event)
     , m_device(device)
 {
 }
@@ -1200,6 +1201,7 @@ void CommandEncoder::makeInvalid(NSString* errorString)
 {
     endEncoding(m_existingCommandEncoder);
     m_blitCommandEncoder = nil;
+    [m_abortCommandBuffer setSignaledValue:1];
     m_device->getQueue().commitMTLCommandBuffer(m_commandBuffer);
 
     m_commandBuffer = nil;
@@ -1743,7 +1745,8 @@ Ref<CommandBuffer> CommandEncoder::finish(const WGPUCommandBufferDescriptor& des
 
     commandBuffer.label = fromAPI(descriptor.label);
 
-    auto result = CommandBuffer::create(commandBuffer, m_device);
+    auto result = CommandBuffer::create(commandBuffer, m_abortCommandBuffer, m_device);
+    m_abortCommandBuffer = nil;
     m_cachedCommandBuffer = result;
     m_cachedCommandBuffer->setBufferMapCount(m_bufferMapCount);
     if (m_makeSubmitInvalid)

--- a/Source/WebGPU/WebGPU/MetalSPI.h
+++ b/Source/WebGPU/WebGPU/MetalSPI.h
@@ -24,10 +24,14 @@
  */
 
 #if USE(INTERNAL_APPLE_SDK)
+#import <Metal/MTLCommandBuffer_Private.h>
 #import <Metal/MTLResource_Private.h>
 #else
 @protocol MTLResourceSPI <MTLResource>
 @optional
 - (kern_return_t)setOwnerWithIdentity:(mach_port_t)task_id_token;
+@end
+@protocol MTLCommandBufferSPI <MTLCommandBuffer>
+- (void)encodeConditionalAbortEvent:(id <MTLSharedEvent>)event;
 @end
 #endif

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -311,7 +311,7 @@ void PresentationContextIOSurface::present()
     if (Texture* texturePtr = textureRefPtr.get(); texturePtr && m_computePipelineState) {
         MTLCommandBufferDescriptor *descriptor = [MTLCommandBufferDescriptor new];
         descriptor.errorOptions = MTLCommandBufferErrorOptionEncoderExecutionStatus;
-        id<MTLCommandBuffer> commandBuffer = m_device->getQueue().commandBufferWithDescriptor(descriptor);
+        id<MTLCommandBuffer> commandBuffer = m_device->getQueue().commandBufferWithDescriptor(descriptor).first;
         MTLComputePassDescriptor* computeDescriptor = [MTLComputePassDescriptor new];
         computeDescriptor.dispatchType = MTLDispatchTypeSerial;
 

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -75,7 +75,7 @@ public:
 
     const Device& device() const;
     void clearTextureIfNeeded(const WGPUImageCopyTexture&, NSUInteger);
-    id<MTLCommandBuffer> commandBufferWithDescriptor(MTLCommandBufferDescriptor*);
+    std::pair<id<MTLCommandBuffer>, id<MTLSharedEvent>> commandBufferWithDescriptor(MTLCommandBufferDescriptor*);
     void commitMTLCommandBuffer(id<MTLCommandBuffer>);
     void setEncoderForBuffer(id<MTLCommandBuffer>, id<MTLCommandEncoder>);
     id<MTLCommandEncoder> encoderForBuffer(id<MTLCommandBuffer>) const;
@@ -101,6 +101,7 @@ private:
 
     id<MTLCommandQueue> m_commandQueue { nil };
     id<MTLCommandBuffer> m_commandBuffer { nil };
+    id<MTLSharedEvent> m_commandBufferEvent { nil };
     id<MTLBlitCommandEncoder> m_blitCommandEncoder { nil };
     ThreadSafeWeakPtr<Device> m_device; // The only kind of queues that exist right now are default queues, which are owned by Devices.
 


### PR DESCRIPTION
#### 36690be3ace7d6538426b49977b8e57c095684c5
<pre>
[WebGPU] Invalid command buffers need to get dealloc&apos;ed in a timely fashion
<a href="https://bugs.webkit.org/show_bug.cgi?id=273328">https://bugs.webkit.org/show_bug.cgi?id=273328</a>
&lt;radar://127121787&gt;

Reviewed by Tadeu Zagallo.

Discard invalid command buffers instead of submitting
them to the driver which results in incorrect behavior
and/or uintended side effects.

* Source/WebGPU/WebGPU/CommandBuffer.h:
(WebGPU::CommandBuffer::create):
* Source/WebGPU/WebGPU/CommandBuffer.mm:
(WebGPU::CommandBuffer::CommandBuffer):
(WebGPU::CommandBuffer::makeInvalid):
* Source/WebGPU/WebGPU/CommandEncoder.h:
(WebGPU::CommandEncoder::create):
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::Device::createCommandEncoder):
(WebGPU::CommandEncoder::CommandEncoder):
(WebGPU::CommandEncoder::makeInvalid):
(WebGPU::CommandEncoder::finish):
* Source/WebGPU/WebGPU/MetalSPI.h:
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
* Source/WebGPU/WebGPU/Queue.h:
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::ensureBlitCommandEncoder):
(WebGPU::Queue::commandBufferWithDescriptor):

Canonical link: <a href="https://commits.webkit.org/278474@main">https://commits.webkit.org/278474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/509e53b4e2b0bcebadb1dbdc902b47112623e128

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2959 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53901 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1333 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/983 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41283 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27595 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43618 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22397 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24983 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9083 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46962 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55491 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25744 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48699 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27001 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43762 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11102 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27869 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26733 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->