### PR TITLE
Update equalIgnoringASCIICase() to take in 2 spans, instead of a raw pointer and a span

### DIFF
--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -78,7 +78,6 @@ template<> ALWAYS_INLINE constexpr bool isLatin1(LChar)
 
 using CodeUnitMatchFunction = bool (*)(UChar);
 
-template<typename CharacterTypeA, typename CharacterTypeB> bool equalIgnoringASCIICase(const CharacterTypeA*, std::span<const CharacterTypeB>);
 template<typename CharacterTypeA, typename CharacterTypeB> bool equalIgnoringASCIICase(std::span<const CharacterTypeA>, std::span<const CharacterTypeB>);
 
 template<typename StringClassA, typename StringClassB> bool equalIgnoringASCIICaseCommon(const StringClassA&, const StringClassB&);
@@ -484,20 +483,20 @@ template<typename StringClass, unsigned length> bool equal(const StringClass& a,
     return equal(a.span16().data(), { codeUnits, length });
 }
 
-template<typename CharacterTypeA, typename CharacterTypeB>
-inline bool equalIgnoringASCIICase(const CharacterTypeA* a, std::span<const CharacterTypeB> b)
+template<typename CharacterTypeA, typename CharacterTypeB> inline bool equalIgnoringASCIICaseWithLength(std::span<const CharacterTypeA> a, std::span<const CharacterTypeB> b, size_t lengthToCheck)
 {
-    for (auto bCharacter : b) {
-        if (toASCIILower(*a) != toASCIILower(bCharacter))
+    ASSERT(a.size() >= lengthToCheck);
+    ASSERT(b.size() >= lengthToCheck);
+    for (size_t i = 0; i < lengthToCheck; ++i) {
+        if (toASCIILower(a[i]) != toASCIILower(b[i]))
             return false;
-        ++a;
     }
     return true;
 }
 
 template<typename CharacterTypeA, typename CharacterTypeB> inline bool equalIgnoringASCIICase(std::span<const CharacterTypeA> a, std::span<const CharacterTypeB> b)
 {
-    return a.size() == b.size() && equalIgnoringASCIICase(a.data(), b);
+    return a.size() == b.size() && equalIgnoringASCIICaseWithLength(a, b, a.size());
 }
 
 template<typename StringClassA, typename StringClassB>
@@ -508,27 +507,22 @@ bool equalIgnoringASCIICaseCommon(const StringClassA& a, const StringClassB& b)
 
     if (a.is8Bit()) {
         if (b.is8Bit())
-            return equalIgnoringASCIICase(a.span8().data(), b.span8());
-
-        return equalIgnoringASCIICase(a.span8().data(), b.span16());
+            return equalIgnoringASCIICaseWithLength(a.span8(), b.span8(), b.length());
+        return equalIgnoringASCIICaseWithLength(a.span8(), b.span16(), b.length());
     }
-
     if (b.is8Bit())
-        return equalIgnoringASCIICase(a.span16().data(), b.span8());
-
-    return equalIgnoringASCIICase(a.span16().data(), b.span16());
+        return equalIgnoringASCIICaseWithLength(a.span16(), b.span8(), b.length());
+    return equalIgnoringASCIICaseWithLength(a.span16(), b.span16(), b.length());
 }
 
 template<typename StringClassA> bool equalIgnoringASCIICaseCommon(const StringClassA& a, const char* b)
 {
-    auto bSpan = span(b);
+    auto bSpan = span8(b);
     if (a.length() != bSpan.size())
         return false;
-
     if (a.is8Bit())
-        return equalIgnoringASCIICase(a.span8().data(), bSpan);
-
-    return equalIgnoringASCIICase(a.span16().data(), bSpan);
+        return equalIgnoringASCIICaseWithLength(a.span8(), bSpan, bSpan.size());
+    return equalIgnoringASCIICaseWithLength(a.span16(), bSpan, bSpan.size());
 }
 
 template <typename SearchCharacterType, typename MatchCharacterType>
@@ -536,13 +530,13 @@ size_t findIgnoringASCIICase(std::span<const SearchCharacterType> source, std::s
 {
     ASSERT(source.size() >= matchCharacters.size());
 
-    const SearchCharacterType* startSearchedCharacters = source.data() + startOffset;
+    auto startSearchedCharacters = source.subspan(startOffset);
 
     // delta is the number of additional times to test; delta == 0 means test only once.
-    size_t delta = source.size() - matchCharacters.size();
+    size_t delta = startSearchedCharacters.size() - matchCharacters.size();
 
     for (size_t i = 0; i <= delta; ++i) {
-        if (equalIgnoringASCIICase(startSearchedCharacters + i, matchCharacters))
+        if (equalIgnoringASCIICaseWithLength(startSearchedCharacters.subspan(i), matchCharacters, matchCharacters.size()))
             return startOffset + i;
     }
     return notFound;
@@ -964,8 +958,7 @@ template<typename StringClass> inline bool startsWithLettersIgnoringASCIICaseCom
 
 inline bool equalIgnoringASCIICase(const char* a, const char* b)
 {
-    auto spanB = span(b);
-    return strlen(a) == spanB.size() && equalIgnoringASCIICase(a, spanB);
+    return equalIgnoringASCIICase(span8(a), span8(b));
 }
 
 inline bool equalLettersIgnoringASCIICase(ASCIILiteral a, ASCIILiteral b)
@@ -980,7 +973,7 @@ inline bool equalLettersIgnoringASCIICase(const char* string, ASCIILiteral liter
 
 inline bool equalIgnoringASCIICase(const char* string, ASCIILiteral literal)
 {
-    return strlen(string) == literal.length() && equalIgnoringASCIICase(string, literal.span8());
+    return equalIgnoringASCIICase(span8(string), literal.span8());
 }
 
 inline bool equalIgnoringASCIICase(ASCIILiteral a, ASCIILiteral b)
@@ -1356,6 +1349,7 @@ ALWAYS_INLINE bool charactersContain(std::span<const CharacterType> span)
 }
 
 using WTF::equalIgnoringASCIICase;
+using WTF::equalIgnoringASCIICaseWithLength;
 using WTF::equalLettersIgnoringASCIICase;
 using WTF::isLatin1;
 using WTF::span;

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -1250,13 +1250,13 @@ inline size_t findIgnoringASCIICase(StringView source, StringView stringToFind, 
 
     if (source.is8Bit()) {
         if (stringToFind.is8Bit())
-            return findIgnoringASCIICase(source.span8().first(searchLength), stringToFind.span8(), static_cast<size_t>(start));
-        return findIgnoringASCIICase(source.span8().first(searchLength), stringToFind.span16(), static_cast<size_t>(start));
+            return WTF::findIgnoringASCIICase(source.span8(), stringToFind.span8(), static_cast<size_t>(start));
+        return WTF::findIgnoringASCIICase(source.span8(), stringToFind.span16(), static_cast<size_t>(start));
     }
 
     if (stringToFind.is8Bit())
-        return findIgnoringASCIICase(source.span16().first(searchLength), stringToFind.span8(), static_cast<size_t>(start));
-    return findIgnoringASCIICase(source.span16().first(searchLength), stringToFind.span16(), static_cast<size_t>(start));
+        return WTF::findIgnoringASCIICase(source.span16(), stringToFind.span8(), static_cast<size_t>(start));
+    return WTF::findIgnoringASCIICase(source.span16(), stringToFind.span16(), static_cast<size_t>(start));
 }
 
 inline bool startsWith(StringView reference, StringView prefix)
@@ -1281,12 +1281,12 @@ inline bool startsWithIgnoringASCIICase(StringView reference, StringView prefix)
 
     if (reference.is8Bit()) {
         if (prefix.is8Bit())
-            return equalIgnoringASCIICase(reference.span8().data(), prefix.span8());
-        return equalIgnoringASCIICase(reference.span8().data(), prefix.span16());
+            return equalIgnoringASCIICaseWithLength(reference.span8(), prefix.span8(), prefix.length());
+        return equalIgnoringASCIICaseWithLength(reference.span8(), prefix.span16(), prefix.length());
     }
     if (prefix.is8Bit())
-        return equalIgnoringASCIICase(reference.span16().data(), prefix.span8());
-    return equalIgnoringASCIICase(reference.span16().data(), prefix.span16());
+        return equalIgnoringASCIICaseWithLength(reference.span16(), prefix.span8(), prefix.length());
+    return equalIgnoringASCIICaseWithLength(reference.span16(), prefix.span16(), prefix.length());
 }
 
 inline bool endsWith(StringView reference, StringView suffix)
@@ -1319,12 +1319,12 @@ inline bool endsWithIgnoringASCIICase(StringView reference, StringView suffix)
 
     if (reference.is8Bit()) {
         if (suffix.is8Bit())
-            return equalIgnoringASCIICase(reference.span8().data() + startOffset, suffix.span8());
-        return equalIgnoringASCIICase(reference.span8().data() + startOffset, suffix.span16());
+            return equalIgnoringASCIICaseWithLength(reference.span8().subspan(startOffset), suffix.span8(), suffix.length());
+        return equalIgnoringASCIICaseWithLength(reference.span8().subspan(startOffset), suffix.span16(), suffix.length());
     }
     if (suffix.is8Bit())
-        return equalIgnoringASCIICase(reference.span16().data() + startOffset, suffix.span8());
-    return equalIgnoringASCIICase(reference.span16().data() + startOffset, suffix.span16());
+        return equalIgnoringASCIICaseWithLength(reference.span16().subspan(startOffset), suffix.span8(), suffix.length());
+    return equalIgnoringASCIICaseWithLength(reference.span16().subspan(startOffset), suffix.span16(), suffix.length());
 }
 
 inline size_t String::find(StringView string) const


### PR DESCRIPTION
#### 56ee9c85d0f254dc1515c1f6356a7dff89995c52
<pre>
Update equalIgnoringASCIICase() to take in 2 spans, instead of a raw pointer and a span
<a href="https://bugs.webkit.org/show_bug.cgi?id=273835">https://bugs.webkit.org/show_bug.cgi?id=273835</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/text/StringCommon.h:
* Source/WTF/wtf/text/StringView.h:
(WTF::startsWithIgnoringASCIICase):
(WTF::endsWithIgnoringASCIICase):

Canonical link: <a href="https://commits.webkit.org/278550@main">https://commits.webkit.org/278550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b93f4e95b4e021e8a8409209547be534f00a2cb5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54175 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1607 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36492 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1274 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41465 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43863 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22595 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25183 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1120 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9357 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/44252 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47168 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55769 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/50419 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26021 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1090 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48876 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27276 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47959 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28149 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57894 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7381 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27007 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11918 "Passed tests") | 
<!--EWS-Status-Bubble-End-->