### PR TITLE
Add support for importmap integrity

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6126,6 +6126,11 @@ imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/js
 imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload.html [ Skip ]
 imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header.html [ Skip ]
 
+imported/w3c/web-platform-tests/import-maps/dynamic-integrity.html [ DumpJSConsoleLogInStdErr ]
+imported/w3c/web-platform-tests/import-maps/static-integrity.html [ DumpJSConsoleLogInStdErr ]
+imported/w3c/web-platform-tests/import-maps/no-referencing-script-integrity.html [ DumpJSConsoleLogInStdErr ]
+imported/w3c/web-platform-tests/import-maps/nonimport-integrity.html [ DumpJSConsoleLogInStdErr ]
+
 # These tests have been timing out since their import.
 imported/w3c/web-platform-tests/import-maps/data-driven [ Skip ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: import-maps
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/test-helper.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/test-helper.js
@@ -19,10 +19,10 @@ function createTestIframe(importMap, importMapBaseURL) {
       iframe.src = 'data:text/html;base64,' + btoa(testHTML);
     } else {
       iframe.src = '/common/blank.html';
-      iframe.onload = () => {
+      iframe.addEventListener('load', () => {
         iframe.contentDocument.write(testHTML);
         iframe.contentDocument.close();
-      };
+      }, {once: true});
     }
     document.body.appendChild(iframe);
   });

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/dynamic-integrity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/dynamic-integrity-expected.txt
@@ -1,0 +1,14 @@
+
+PASS script was not loaded, as its resolved URL failed its integrity check
+PASS script was loaded, as its resolved URL had no integrity check, despite its specifier having one
+PASS script was loaded, as its integrity check passed
+PASS Script with no import definition was not loaded, as it failed its integrity check
+PASS Bare specifier script was not loaded, as it failed its integrity check
+PASS Bare specifier used for integrity loaded, as its definition should have used the URL
+PASS script was loaded, as its integrity check passed, despite having an extra invalid hash
+PASS script was loaded, as its integrity check passed, despite having an invalid suffix
+PASS script was loaded, as its integrity check passed given multiple hashes. This also makes sure that the larger hash is picked
+PASS script was loaded, as its integrity check was ignored, as it was defined using a URL that looks like a bare specifier
+PASS Script imported inside an event handler was loaded as its valid integrity check passed
+PASS Script imported inside an event handler was not loaded as its integrity check failed
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/dynamic-integrity.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/dynamic-integrity.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "./resources/log.js?pipe=sub&name=ResolvesToBadHash": "./resources/log.js?pipe=sub&name=BadHash",
+    "./resources/log.js?pipe=sub&name=ResolvesToNoHash": "./resources/log.js?pipe=sub&name=NoHash",
+    "./resources/log.js?pipe=sub&name=GoodHash": "./resources/log.js?pipe=sub&name=GoodHash",
+    "bare": "./resources/log.js?pipe=sub&name=BareURL",
+    "bare2": "./resources/log.js?pipe=sub&name=F"
+  },
+  "integrity": {
+    "./resources/log.js?pipe=sub&name=BadHash": "sha384-foobar",
+    "./resources/log.js?pipe=sub&name=ResolvesToNoHash": "sha384-foobar",
+    "./resources/log.js?pipe=sub&name=GoodHash": "sha384-SwfgBqInhSlLziU454cYhGgwPpae+d3VHZcY+vjZIO/gxRGt2u3Jsfyvure/Ww0u",
+    "./resources/log.js?pipe=sub&name=InvalidExtra": "sha384-WsKk8nzJFPhk/4pWR4LYoPhEu3xaAc6PdIm4vmqoZVWqEgMYmZgOg9XJKxgD1+8v foobar-rOJN8igD0+jW6lwNN3+InhXTgQztVHlq/HJ0riswXp8kMoiIDx5JpmCwuVem6Ll9q2LFNSu1xq23bsBMMQk1rg==",
+    "./resources/log.js?pipe=sub&name=Suffix": "sha384-lbOWldbmji7sCHI/L8iVJ+elmFIMp41p+aYOLxqQfZMqtoFeHFVe/ASRA0IyZ1/9?foobar",
+    "./resources/log.js?pipe=sub&name=Multiple": "sha384-foobar sha512-rOJN8igD0+jW6lwNN3+InhXTgQztVHlq/HJ0riswXp8kMoiIDx5JpmCwuVem6Ll9q2LFNSu1xq23bsBMMQk1rg==",
+    "./resources/log.js?pipe=sub&name=BadHashWithNoImport": "sha384-foobar",
+    "./resources/log.js?pipe=sub&name=BareURL": "sha384-foobar",
+    "./resources/log.js?pipe=sub&name=EventHandlerPass": "sha384-d4yrBK8a55vlyYz2QEnlaU64PPpdKBkblD2KmfozI61mC1ij6RrZJaGCTsVxPuJ2",
+    "./resources/log.js?pipe=sub&name=EventHandlerFail": "sha384-foobar",
+    "bare2": "sha384-foobar",
+    "resources/log.js?pipe=sub&name=Bare": "sha384-foobar"
+  }
+}
+</script>
+<script>
+let log;
+const test_not_loaded = (url, description) => {
+  promise_test(async t => {
+    log = [];
+    await promise_rejects_js(t, TypeError, import(url));
+    assert_array_equals(log, []);
+  }, description);
+};
+
+const test_loaded = (url, log_expectation, description) => {
+  promise_test(async t => {
+    log = [];
+    await import(url);
+    assert_array_equals(log, log_expectation);
+  }, description);
+};
+
+test_not_loaded(
+  "./resources/log.js?pipe=sub&name=ResolvesToBadHash",
+  "script was not loaded, as its resolved URL failed its integrity check"
+);
+test_loaded(
+  "./resources/log.js?pipe=sub&name=ResolvesToNoHash",
+  ["log:NoHash"],
+  "script was loaded, as its resolved URL had no integrity check, despite its specifier having one"
+);
+test_loaded(
+  "./resources/log.js?pipe=sub&name=GoodHash",
+  ["log:GoodHash"],
+  "script was loaded, as its integrity check passed"
+);
+test_not_loaded(
+  "./resources/log.js?pipe=sub&name=BadHashWithNoImport",
+  "Script with no import definition was not loaded, as it failed its integrity check"
+);
+test_not_loaded(
+  "bare",
+  "Bare specifier script was not loaded, as it failed its integrity check"
+);
+test_loaded(
+  "bare2",
+  ["log:F"],
+  "Bare specifier used for integrity loaded, as its definition should have used the URL"
+);
+test_loaded(
+  "./resources/log.js?pipe=sub&name=InvalidExtra",
+  ["log:InvalidExtra"],
+  "script was loaded, as its integrity check passed, despite having an extra invalid hash"
+);
+test_loaded(
+  "./resources/log.js?pipe=sub&name=Suffix",
+  ["log:Suffix"],
+  "script was loaded, as its integrity check passed, despite having an invalid suffix"
+);
+test_loaded(
+  "./resources/log.js?pipe=sub&name=Multiple",
+  ["log:Multiple"],
+  "script was loaded, as its integrity check passed given multiple hashes. This also makes sure that the larger hash is picked"
+);
+test_loaded(
+  "./resources/log.js?pipe=sub&name=Bare",
+  ["log:Bare"],
+  "script was loaded, as its integrity check was ignored, as it was defined using a URL that looks like a bare specifier"
+);
+
+promise_test(async () => {
+  log = [];
+  const img = new Image();
+  const promise = new Promise((resolve, reject) => {
+    img.onload = () => {
+      import('./resources/log.js?pipe=sub&name=EventHandlerPass').then(resolve).catch(reject);
+    };
+    img.src = "/images/green.png?1";
+  });
+
+  await promise;
+  assert_equals(log.length, 1);
+  assert_equals(log[0], "log:EventHandlerPass");
+}, "Script imported inside an event handler was loaded as its valid integrity check passed");
+
+promise_test(async t => {
+  log = [];
+  const img = new Image();
+  const promise = new Promise((resolve, reject) => {
+    img.onload = () => {
+      import('./resources/log.js?pipe=sub&name=EventHandlerFail').then(resolve).catch(reject);
+    };
+    img.src = "/images/green.png?2";
+  });
+
+  await promise_rejects_js(t, TypeError, promise);
+}, "Script imported inside an event handler was not loaded as its integrity check failed");
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/no-referencing-script-integrity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/no-referencing-script-integrity-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Script was not loaded as its integrity check failed
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/no-referencing-script-integrity-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/no-referencing-script-integrity-valid-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Script was loaded as its valid integrity check passed
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/no-referencing-script-integrity-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/no-referencing-script-integrity-valid.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+let log = [];
+</script>
+<script type="importmap">
+{
+  "integrity": {
+    "./resources/log.js?pipe=sub&name=NoReferencingScriptValidCheck": "sha384-5eRmXQSBE6H5ENdymdZxcyiIfJL1dxtH8p+hOelZY7Jzk+gt0gYyemrGY0cEaThF"
+  }
+}
+</script>
+<script>
+let promiseResolve;
+let promiseReject;
+let promise = new Promise((resolve, reject) => {
+  promiseResolve = resolve;
+  promiseReject = reject;
+});
+</script>
+</head>
+<body>
+<!-- This is testing the part of
+https://html.spec.whatwg.org/multipage/webappapis.html#hostloadimportedmodule
+where step 6's condition is false and referencingScript remains null.
+Therefore, the onload event must be defined as an HTML attribute, outside of any script tag.
+-->
+<img src="/images/green.png?2"
+  onload="import('./resources/log.js?pipe=sub&name=NoReferencingScriptValidCheck').then(promiseResolve).catch(promiseReject)">
+<script>
+promise_test(async () => {
+  await promise;
+  assert_equals(log.length, 1);
+  assert_equals(log[0], "log:NoReferencingScriptValidCheck");
+}, "Script was loaded as its valid integrity check passed");
+</script>
+</body>
+</html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/no-referencing-script-integrity.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/no-referencing-script-integrity.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+let log = [];
+</script>
+<script type="importmap">
+{
+  "integrity": {
+    "./resources/log.js?pipe=sub&name=NoReferencingScriptInvalidCheck": "sha384-Li9vy3DqF8tnTXuiaAJuML3ky+er10rcgNR/VqsVpcw+ThHmYcwiB1pbOxEbzJr7"
+  }
+}
+</script>
+<script>
+let promiseResolve;
+let promiseReject;
+let promise = new Promise((resolve, reject) => {
+  promiseResolve = resolve;
+  promiseReject = reject;
+});
+</script>
+</head>
+<body>
+<!-- This is testing the part of
+https://html.spec.whatwg.org/multipage/webappapis.html#hostloadimportedmodule
+where step 6's condition is false and referencingScript remains null.
+Therefore, the onload event must be defined as an HTML attribute, outside of any script tag.
+-->
+<img src="/images/green.png"
+  onload="import('./resources/log.js?pipe=sub&name=NoReferencingScriptInvalidCheck').then(promiseResolve).catch(promiseReject)">
+<script type="module">
+promise_test(async t => {
+  await promise_rejects_js(t, TypeError, promise);
+}, "Script was not loaded as its integrity check failed");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/nonimport-integrity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/nonimport-integrity-expected.txt
@@ -1,0 +1,12 @@
+
+PASS Script was not loaded as its integrity check was not ignored
+PASS Script was loaded as its correct integrity attribute was not ignored
+PASS Script was loaded as its empty integrity attribute was not ignored
+PASS Script was not loaded as its bad integrity attribute was not overridden
+FAIL Modulepreload was not loaded as its integrity check was not ignored assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Modulepreload was loaded as its correct integrity attribute was not ignored
+PASS Modulepreload was loaded as its empty integrity attribute was not ignored
+FAIL Modulepreload was not loaded as its bad integrity attribute was not ignored promise_test: Unhandled rejection with value: object "Error: It shouldn't have loaded"
+PASS Classic script was loaded as its integrity check was ignored
+PASS Image was loaded as its integrity check was ignored
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/nonimport-integrity.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/nonimport-integrity.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+let log = [];
+</script>
+<script type="importmap">
+{
+  "integrity": {
+    "./resources/log.js?pipe=sub&name=ModuleNoIntegrity": "sha384-foobar",
+    "./resources/log.js?pipe=sub&name=ModuleIntegrity": "sha384-foobar",
+    "./resources/log.js?pipe=sub&name=ModuleEmptyIntegrity": "sha384-foobar",
+    "./resources/log.js?pipe=sub&name=ModuleBadIntegrityAttribute": "sha384-COhDkp+ybIZ9wz9hUaSJ5NzKcn8wOMZMpsACZfTeEdBRtNcX5yWJnFn+lIK77Tay",
+    "./resources/log.js?pipe=sub&name=ModulePreloadNoIntegrity": "sha384-foobar",
+    "./resources/log.js?pipe=sub&name=ModulePreloadIntegrity": "sha384-foobar",
+    "./resources/log.js?pipe=sub&name=ModulePreloadEmptyIntegrity": "sha384-foobar",
+    "./resources/log.js?pipe=sub&name=ModulePreloadBadIntegrityAttribute": "sha384-026dlUs9+KSmPb0Uc7oUPOlWBO67o7vSFdfLJZWEVTvKCly5NXO8+CsOXl54ZBqJ",
+    "./resources/log.js?pipe=sub&name=NonModule": "sha384-foobar",
+    "/images/green.png": "sha384-foobar"
+  }
+}
+</script>
+<script type="module">
+const test_not_loaded = async (elem) => {
+  const promise = new Promise((resolve, reject) => {
+    elem.onload = () =>  {
+       reject(new Error("It shouldn't have loaded"));
+     };
+    elem.onerror = resolve;
+  });
+  document.head.appendChild(elem);
+  const event = await promise;
+  assert_equals(event.type, "error");
+};
+
+promise_test(async t => {
+  log = [];
+  const script = document.createElement("script");
+  script.type = "module";
+  script.src = "./resources/log.js?pipe=sub&name=ModuleNoIntegrity";
+  await test_not_loaded(script);
+}, "Script was not loaded as its integrity check was not ignored");
+
+promise_test(async () => {
+  log = [];
+  const script = document.createElement("script");
+  script.type = "module";
+  script.integrity = "sha384-QtZrhNFOSmHASHnBdmGg+zrVz5hjukCBakaqwT2pcG7w+QTa/niK16csP6kXAeXI";
+  script.src = "./resources/log.js?pipe=sub&name=ModuleIntegrity";
+  const promise = new Promise((resolve, reject) => {
+    script.onload = resolve;
+    script.onerror = reject;
+  });
+  document.head.appendChild(script);
+  await promise;
+  assert_equals(log.length, 1);
+  assert_equals(log[0], "log:ModuleIntegrity");
+}, "Script was loaded as its correct integrity attribute was not ignored");
+
+promise_test(async () => {
+  log = [];
+  const script = document.createElement("script");
+  script.type = "module";
+  script.integrity = "";
+  script.src = "./resources/log.js?pipe=sub&name=ModuleEmptyIntegrity";
+  const promise = new Promise((resolve, reject) => {
+    script.onload = resolve;
+    script.onerror = reject;
+  });
+  document.head.appendChild(script);
+  await promise;
+  assert_equals(log.length, 1);
+  assert_equals(log[0], "log:ModuleEmptyIntegrity");
+}, "Script was loaded as its empty integrity attribute was not ignored");
+
+promise_test(async t => {
+  log = [];
+  const script = document.createElement("script");
+  script.type = "module";
+  script.integrity = "sha384-foobar";
+  script.src = "./resources/log.js?pipe=sub&name=ModuleBadIntegrityAttribute";
+  await test_not_loaded(script);
+}, "Script was not loaded as its bad integrity attribute was not overridden");
+
+promise_test(async t => {
+  const link = document.createElement("link");
+  link.rel = "modulepreload";
+  link.href = "./resources/log.js?pipe=sub&name=ModulePreloadNoIntegrity";
+  const promise = new Promise((resolve, reject) => {
+    link.onload = resolve;
+    link.onerror = () => { reject(Error()); };
+  });
+  document.head.appendChild(link);
+  await promise_rejects_js(t, Error, promise);
+}, "Modulepreload was not loaded as its integrity check was not ignored");
+
+promise_test(async () => {
+  const link = document.createElement("link");
+  link.rel = "modulepreload";
+  link.integrity = "sha384-iDG3WysExtjWvD9QwQrC7nGXRvO0jM+r7Z2cOLMDO2geMlEtmN9j9xfqHfzT45+9";
+  link.href = "./resources/log.js?pipe=sub&name=ModulePreloadIntegrity";
+  const promise = new Promise((resolve, reject) => {
+    link.onload = resolve;
+    link.onerror = reject;
+  });
+  document.head.appendChild(link);
+  await promise;
+}, "Modulepreload was loaded as its correct integrity attribute was not ignored");
+
+promise_test(async () => {
+  const link = document.createElement("link");
+  link.rel = "modulepreload";
+  link.integrity = "";
+  link.href = "./resources/log.js?pipe=sub&name=ModulePreloadEmptyIntegrity";
+  const promise = new Promise((resolve, reject) => {
+    link.onload = resolve;
+    link.onerror = reject;
+  });
+  document.head.appendChild(link);
+  await promise;
+}, "Modulepreload was loaded as its empty integrity attribute was not ignored");
+
+promise_test(async t => {
+  const link = document.createElement("link");
+  link.rel = "modulepreload";
+  link.integrity = "sha384-foobar";
+  link.href = "./resources/log.js?pipe=sub&name=ModulePreloadBadIntegrityAttribute";
+  await test_not_loaded(link);
+}, "Modulepreload was not loaded as its bad integrity attribute was not ignored");
+
+promise_test(async () => {
+  log = [];
+  const script = document.createElement("script");
+  script.src = "./resources/log.js?pipe=sub&name=NonModule";
+  const promise = new Promise((resolve, reject) => {
+    script.onload = resolve;
+    script.onerror = reject;
+  });
+  document.head.appendChild(script);
+  await promise;
+  assert_equals(log.length, 1);
+  assert_equals(log[0], "log:NonModule");
+}, "Classic script was loaded as its integrity check was ignored");
+
+promise_test(async () => {
+  const img = document.createElement("img");
+  const promise = new Promise((resolve, reject) => {
+    img.onload = resolve;
+    img.onerror = reject;
+  });
+  img.src = "/images/green.png";
+  document.head.appendChild(img);
+  await promise;
+}, "Image was loaded as its integrity check was ignored");
+</script>
+</head>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/static-integrity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/static-integrity-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Static script did not load as it failed its integrity check
+PASS Static script loaded as its integrity check passed
+PASS Static script did not load as it failed its integrity check, even without an import defined
+PASS Static script loaded as its integrity check passed without an import defined
+PASS HTML-based module script did not load as its integrity check failed.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/static-integrity.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/static-integrity.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+let log = [];
+</script>
+<script type="importmap">
+{
+  "imports": {
+    "./resources/log.js?pipe=sub&name=A": "./resources/log.js?pipe=sub&name=B",
+    "./resources/log.js?pipe=sub&name=C": "./resources/log.js?pipe=sub&name=D"
+  },
+  "integrity": {
+    "./resources/log.js?pipe=sub&name=B": "sha384-Li9vy3DqF8tnTXuiaAJuML3ky+er10rcgNR/VqsVpcw+ThHmYcwiB1pbOxEbzJr7",
+    "./resources/log.js?pipe=sub&name=D": "sha384-rxZqznFuOnvObm6JJKVmwzBXrsRG25IepqKDFHGhtitRu9YPjxPpRPMIu2hzvtxF",
+    "./resources/log.js?pipe=sub&name=X": "sha384-mCon9M46vUfNK2Wb3yjvBmpBw/3hwB+wMYS8IzDBng+7//R5Qao35E1azo4gFVzx",
+    "./resources/log.js?pipe=sub&name=Y": "sha384-u0yaFlBF39Au++qcn+MGL/Ml7UmuVfLymNJAz6Yyi4RqyUfWelcuAzVyE8Shs9xn",
+    "./resources/log.js?pipe=sub&name=Z": "sha384-u0yaFlBF39Au++qcn+MGL/Ml7UmuVfLymNJAz6Yyi4RqyUfWelcuAzVyE8Shs9xn"
+  }
+}
+</script>
+<script type="module">
+import './resources/log.js?pipe=sub&name=A';
+</script>
+<script type="module">
+test(t => {
+  assert_array_equals(log, []);
+}, 'Static script did not load as it failed its integrity check');
+log = [];
+</script>
+<script type="module">
+import './resources/log.js?pipe=sub&name=C';
+</script>
+<script type="module">
+test(t => {
+  assert_array_equals(log, ["log:D"]);
+}, 'Static script loaded as its integrity check passed');
+log = [];
+</script>
+<script type="module">
+import './resources/log.js?pipe=sub&name=X';
+</script>
+<script type="module">
+test(t => {
+  assert_array_equals(log, []);
+}, 'Static script did not load as it failed its integrity check, even' +
+   ' without an import defined');
+log = [];
+</script>
+<script type="module">
+import './resources/log.js?pipe=sub&name=Y';
+</script>
+<script type="module">
+test(t => {
+  assert_array_equals(log, ["log:Y"]);
+}, 'Static script loaded as its integrity check passed without an import' +
+   ' defined');
+log = [];
+</script>
+<script type="module" src="./resources/log.js?pipe=sub&name=Z">;
+</script>
+<script type="module">
+test(t => {
+  assert_array_equals(log, []);
+}, 'HTML-based module script did not load as its integrity check failed.');
+log = [];
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/import-maps/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/import-maps/w3c-import.log
@@ -15,11 +15,17 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/import-maps/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/import-maps/data-url-specifiers.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/dynamic-integrity.html
 /LayoutTests/imported/w3c/web-platform-tests/import-maps/http-url-like-specifiers.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/import-maps/import-maps-base-url.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/import-maps/module-map-key.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/no-referencing-script-integrity-valid.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/no-referencing-script-integrity.html
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/nonimport-integrity.html
 /LayoutTests/imported/w3c/web-platform-tests/import-maps/not-as-classic-script.html
 /LayoutTests/imported/w3c/web-platform-tests/import-maps/script-supports-importmap.html
 /LayoutTests/imported/w3c/web-platform-tests/import-maps/static-import.py
+/LayoutTests/imported/w3c/web-platform-tests/import-maps/static-integrity.html

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-resources.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-resources.https-expected.txt
@@ -29,6 +29,10 @@ PASS Script load (url:https://localhost:9443/service-workers/service-worker/reso
 PASS Script load (url:https://localhost:9443/service-workers/service-worker/resources/sample?test27)
 PASS Script load (url:https://localhost:9443/service-workers/service-worker/resources/sample?test28)
 PASS Script load (url:https://localhost:9443/service-workers/service-worker/resources/sample?test29)
+PASS Module Script load (url:https://localhost:9443/service-workers/service-worker/resources/sample?test_module)
+FAIL Module Script load (url:https://localhost:9443/service-workers/service-worker/resources/sample?test_modulepreload) assert_equals: integrity of Module Script load (url:https://localhost:9443/service-workers/service-worker/resources/sample?test_modulepreload) must be sha384-foobar. expected "sha384-foobar" but got ""
+FAIL Module Script load (url:https://localhost:9443/service-workers/service-worker/resources/sample?test_moduleimport) assert_equals: integrity of Module Script load (url:https://localhost:9443/service-workers/service-worker/resources/sample?test_moduleimport) must be sha384-foobar. expected "sha384-foobar" but got ""
+PASS Module Script load (url:https://localhost:9443/service-workers/service-worker/resources/sample?test_moduleimportdynamic)
 PASS CSS load (url:https://localhost:9443/service-workers/service-worker/resources/sample?test30)
 PASS CSS load (url:https://localhost:9443/service-workers/service-worker/resources/sample?test31)
 PASS CSS load (url:https://localhost:9443/service-workers/service-worker/resources/sample?test32)

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-resources.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-resources.https.html
@@ -90,7 +90,67 @@ function script_integrity_test(frame, url, integrity, expected_integrity) {
       destination: 'script',
       message: `Script load (url:${actual_url})`
     };
-  frame.contentWindow.load_script_with_integrity(actual_url, integrity);
+  frame.contentWindow.load_script_with_integrity(actual_url, { integrity });
+  return add_promise_to_test(actual_url);
+}
+
+function module_script_integrity_test(frame, url, integrity, expected_integrity) {
+  const actual_url = url + "_module";
+  expected_results[actual_url] = {
+      url: actual_url,
+      mode: 'cors',
+      credentials: 'same-origin',
+      redirect: 'follow',
+      integrity: expected_integrity,
+      destination: 'script',
+      message: `Module Script load (url:${actual_url})`
+    };
+  frame.contentWindow.load_script_with_integrity(actual_url, { integrity, type: "module" });
+  return add_promise_to_test(actual_url);
+}
+
+function modulepreload_integrity_test(frame, url, integrity, expected_integrity) {
+  const actual_url = url + "_modulepreload";
+  expected_results[actual_url] = {
+      url: actual_url,
+      mode: 'cors',
+      credentials: 'same-origin',
+      redirect: 'follow',
+      integrity: expected_integrity,
+      destination: 'script',
+      message: `Module Script load (url:${actual_url})`
+    };
+  frame.contentWindow.load_modulepreload_with_integrity(actual_url, integrity);
+  return add_promise_to_test(actual_url);
+}
+
+function import_module_integrity_test(frame, url, expected_integrity) {
+  const actual_url = url + "_moduleimport";
+  expected_results[actual_url] = {
+      url: actual_url,
+      mode: 'cors',
+      credentials: 'same-origin',
+      redirect: 'follow',
+      integrity: expected_integrity,
+      destination: 'script',
+      message: `Module Script load (url:${actual_url})`
+    };
+  frame.contentWindow.import_modulescript(actual_url);
+  return add_promise_to_test(actual_url);
+}
+
+function import_dynamic_module_integrity_test(frame, url, expected_integrity) {
+  const actual_url = url + "_moduleimportdynamic";
+  expected_results[actual_url] = {
+      url: actual_url,
+      mode: 'cors',
+      credentials: 'same-origin',
+      redirect: 'follow',
+      integrity: expected_integrity,
+      destination: 'script',
+      message: `Module Script load (url:${actual_url})`
+    };
+  frame.contentWindow.import_dynamic_modulescript(actual_url);
   return add_promise_to_test(actual_url);
 }
 
@@ -253,6 +313,19 @@ promise_test(async t => {
                               'sha256-foo sha384-abc ');
   await script_integrity_test(f, LOCAL_URL, 'sha256-foo sha256-abc',
                               'sha256-foo sha256-abc');
+  await module_script_integrity_test(f, LOCAL_URL,
+                                     null,
+                                     'sha384-foobar');
+
+  await modulepreload_integrity_test(f, LOCAL_URL,
+                                     null,
+                                     'sha384-foobar');
+
+  await import_module_integrity_test(f, LOCAL_URL,
+                                     'sha384-foobar');
+
+  await import_dynamic_module_integrity_test(f, LOCAL_URL,
+                                     'sha384-foobar');
 
   await css_integrity_test(f, LOCAL_URL, '     ', '     ');
   await css_integrity_test(

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/fetch-request-resources-iframe.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/fetch-request-resources-iframe.https.html
@@ -1,5 +1,15 @@
 <script src="test-helpers.sub.js?pipe=sub"></script>
 <body>
+<script type="importmap">
+{
+  "integrity": {
+    "./sample?test_module": "sha384-foobar",
+    "./sample?test_modulepreload": "sha384-foobar",
+    "./sample?test_moduleimport": "sha384-foobar",
+    "./sample?test_moduleimportdynamic": "sha384-foobar"
+  }
+}
+</script>
 <script>
 
 function load_image(url, cross_origin) {
@@ -50,11 +60,40 @@ function load_css_image_set(url, type) {
   }
 }
 
-function load_script_with_integrity(url, integrity) {
+function load_script_with_integrity(url, { integrity, type } = { }) {
   const script = document.createElement('script');
+  if (type) {
+    script.type = type;
+  }
   script.src = url;
-  script.integrity = integrity;
+  if (integrity) {
+    script.integrity = integrity;
+  }
   document.body.appendChild(script);
+}
+
+function import_modulescript(url) {
+  const script = document.createElement('script');
+  script.type = "module";
+  script.innerHTML = `import "${url}";`;
+  document.body.appendChild(script);
+}
+
+function import_dynamic_modulescript(url) {
+  const script = document.createElement('script');
+  script.type = "module";
+  script.innerHTML = `import("${url}");`;
+  document.body.appendChild(script);
+}
+
+function load_modulepreload_with_integrity(url, integrity) {
+  const link = document.createElement('link');
+  link.href = url;
+  if (integrity) {
+    link.integrity = integrity;
+  }
+  link.rel = "modulepreload";
+  document.body.appendChild(link);
 }
 
 function load_css_with_integrity(url, integrity) {

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-resources.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-resources.https-expected.txt
@@ -29,6 +29,10 @@ PASS Script load (url:https://web-platform.test:9443/service-workers/service-wor
 PASS Script load (url:https://web-platform.test:9443/service-workers/service-worker/resources/sample?test27)
 PASS Script load (url:https://web-platform.test:9443/service-workers/service-worker/resources/sample?test28)
 PASS Script load (url:https://web-platform.test:9443/service-workers/service-worker/resources/sample?test29)
+PASS Module Script load (url:https://web-platform.test:9443/service-workers/service-worker/resources/sample?test_module)
+FAIL Module Script load (url:https://web-platform.test:9443/service-workers/service-worker/resources/sample?test_modulepreload) assert_equals: integrity of Module Script load (url:https://web-platform.test:9443/service-workers/service-worker/resources/sample?test_modulepreload) must be sha384-foobar. expected "sha384-foobar" but got ""
+FAIL Module Script load (url:https://web-platform.test:9443/service-workers/service-worker/resources/sample?test_moduleimport) assert_equals: integrity of Module Script load (url:https://web-platform.test:9443/service-workers/service-worker/resources/sample?test_moduleimport) must be sha384-foobar. expected "sha384-foobar" but got ""
+PASS Module Script load (url:https://web-platform.test:9443/service-workers/service-worker/resources/sample?test_moduleimportdynamic)
 PASS CSS load (url:https://web-platform.test:9443/service-workers/service-worker/resources/sample?test30)
 PASS CSS load (url:https://web-platform.test:9443/service-workers/service-worker/resources/sample?test31)
 PASS CSS load (url:https://web-platform.test:9443/service-workers/service-worker/resources/sample?test32)

--- a/Source/JavaScriptCore/runtime/ImportMap.h
+++ b/Source/JavaScriptCore/runtime/ImportMap.h
@@ -43,6 +43,7 @@ public:
         SpecifierMap m_map;
     };
     using Scopes = Vector<ScopeEntry>;
+    using IntegrityMap = HashMap<URL, String>;
 
     class Reporter {
     public:
@@ -58,6 +59,8 @@ public:
     bool isAcquiringImportMaps() const { return m_isAcquiringImportMaps; }
     void setAcquiringImportMaps() { m_isAcquiringImportMaps = false; }
 
+    JS_EXPORT_PRIVATE String integrityForURL(const URL&) const;
+
 private:
     ImportMap() = default;
 
@@ -65,6 +68,8 @@ private:
 
     SpecifierMap m_imports;
     Scopes m_scopes;
+    IntegrityMap m_integrity;
+
     bool m_isAcquiringImportMaps : 1 { true };
 };
 

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -346,7 +346,10 @@ bool ScriptElement::requestModuleScript(const TextPosition& scriptStartPosition)
         }
 
         m_isExternalScript = true;
-        Ref script = LoadableModuleScript::create(nonce, element->attributeWithoutSynchronization(HTMLNames::integrityAttr), referrerPolicy(), fetchPriorityHint(), crossOriginMode,
+        AtomString integrity = element->attributeWithoutSynchronization(HTMLNames::integrityAttr);
+        if (integrity.isNull())
+            integrity = AtomString { document->globalObject()->importMap().integrityForURL(moduleScriptRootURL) };
+        Ref script = LoadableModuleScript::create(nonce, integrity, referrerPolicy(), fetchPriorityHint(), crossOriginMode,
             scriptCharset(), element->localName(), element->isInUserAgentShadowTree());
         m_loadableScript = script.copyRef();
         if (RefPtr frame = element->document().frame())


### PR DESCRIPTION
#### 339bcec0f9ff29fbd56e7209f4a01f2b12b14ac3
<pre>
Add support for importmap integrity
<a href="https://bugs.webkit.org/show_bug.cgi?id=272884">https://bugs.webkit.org/show_bug.cgi?id=272884</a>

Reviewed by Ryosuke Niwa.

Imported ES modules can&apos;t currently have integrity checks, which means
they can&apos;t be used in sites where integrity checks are a necessity, for
security and privacy reasons.
This implements such support, by adding an &quot;integrity&quot; section to import
maps.

See <a href="https://github.com/whatwg/html/pull/10269">https://github.com/whatwg/html/pull/10269</a>

* LayoutTests/TestExpectations: Ignored console logs to avoid flakiness
* LayoutTests/imported/w3c/web-platform-tests/import-maps/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/data-driven/resources/test-helper.js:
(createTestIframe): Updated through import.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/dynamic-integrity-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/dynamic-integrity.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/no-referencing-script-integrity-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/no-referencing-script-integrity-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/no-referencing-script-integrity-valid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/no-referencing-script-integrity.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/nonimport-integrity-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/nonimport-integrity.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/static-integrity-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/static-integrity.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/import-maps/w3c-import.log: Imports.
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-resources.https-expected.txt: Updated.
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-resources.https.html: Updated to cover Request.integrity.
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/fetch-request-resources-iframe.https.html: Updated to cover Request.integrity.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-resources.https-expected.txt: Updated.
* Source/JavaScriptCore/runtime/ImportMap.cpp:
(JSC::ImportMap::resolveImportMatch): Typos and spec link.
(JSC::parseURLLikeModuleSpecifier): Typos and spec link.
(JSC::ImportMap::resolve const): Typos and spec link.
(JSC::normalizeSpecifierKey): Typos and spec link.
(JSC::sortAndNormalizeSpecifierMap): Typos and spec link.
(JSC::ImportMap::registerImportMap): Add parsing for the integrity
section.
(JSC::ImportMap::getIntegrity const): Getter for integrity based on URL.
* Source/JavaScriptCore/runtime/ImportMap.h:
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::ScriptModuleLoader::importModule): Add integrity to outgoing
requests.
(WebCore::ScriptModuleLoader::notifyFinished): Enforce integrity from
the importmap on responses, even if integrity wasn&apos;t present in the
request. Needed for static imports triggered by JSCore.
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::requestModuleScript): Add integrity to outgoing
requests for top-level modules, if they don&apos;t already have an integrity
attribute.

Canonical link: <a href="https://commits.webkit.org/279096@main">https://commits.webkit.org/279096@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac14677b6ae8b0f78d38e1263020962d1bd09fa4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4774 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55627 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3076 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54658 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2775 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42571 "Found 1 new test failure: webgl/2.0.y/conformance2/textures/webgl_canvas/tex-3d-rgba4-rgba-unsigned_short_4_4_4_4.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1960 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45180 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23651 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26595 "4 new passes 3 flakes") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2455 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1235 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/45702 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48485 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57223 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/51861 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2642 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49963 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28712 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45300 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49209 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11462 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29624 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/64169 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28457 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12149 "Found 7 new JSC stress test failures: stress/proxy-set-prototype-of.js.bytecode-cache, stress/proxy-set-prototype-of.js.mini-mode, stress/sampling-profiler-display-name.js.dfg-eager-no-cjit-validate, stress/spread-non-array.js.no-llint, wasm.yaml/wasm/references/is_null.js.wasm-eager, wasm.yaml/wasm/stress/immutable-globals.js.wasm-eager, wasm.yaml/wasm/stress/wasm-to-wasm.js.wasm-eager (failure)") | 
<!--EWS-Status-Bubble-End-->