### PR TITLE
[Site Isolation] Make performDragOperation aware of site-isolated i-frames

### DIFF
--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -54,6 +54,7 @@
 #include "EmptyBadgeClient.h"
 #include "EmptyFrameLoaderClient.h"
 #include "FormState.h"
+#include "FrameIdentifier.h"
 #include "FrameNetworkingContext.h"
 #include "HTMLFormElement.h"
 #include "HistoryItem.h"
@@ -240,6 +241,7 @@ class EmptyDiagnosticLoggingClient final : public DiagnosticLoggingClient {
 
 class EmptyDragClient final : public DragClient {
     void willPerformDragDestinationAction(DragDestinationAction, const DragData&) final { }
+    void willPerformDragDestinationAction(DragDestinationAction, const DragData&, FrameIdentifier, CompletionHandler<void()>&& completionHandler) final { completionHandler(); }
     void willPerformDragSourceAction(DragSourceAction, const IntPoint&, DataTransfer&) final { }
     OptionSet<DragSourceAction> dragSourceActionMaskForPoint(const IntPoint&) final { return { }; }
     void startDrag(DragItem, DataTransfer&, Frame&) final { }

--- a/Source/WebCore/page/DragClient.h
+++ b/Source/WebCore/page/DragClient.h
@@ -29,6 +29,7 @@
 #include "DragData.h"
 #include "DragItem.h"
 #include "FloatPoint.h"
+#include "FrameIdentifier.h"
 #include "IntPoint.h"
 
 namespace WebCore {
@@ -49,6 +50,7 @@ public:
     virtual bool useLegacyDragClient() { return true; }
 
     virtual void willPerformDragDestinationAction(DragDestinationAction, const DragData&) = 0;
+    virtual void willPerformDragDestinationAction(DragDestinationAction, const DragData&, FrameIdentifier, CompletionHandler<void()>&&) = 0;
     virtual void willPerformDragSourceAction(DragSourceAction, const IntPoint&, DataTransfer&) = 0;
     virtual void didConcludeEditDrag() { }
     virtual OptionSet<DragSourceAction> dragSourceActionMaskForPoint(const IntPoint& rootViewPoint) = 0;

--- a/Source/WebCore/page/DragController.h
+++ b/Source/WebCore/page/DragController.h
@@ -55,7 +55,7 @@ struct DragState;
 struct PromisedAttachmentInfo;
 struct RemoteUserInputEventData;
 
-class DragController {
+class DragController : public CanMakeSingleThreadWeakPtr<DragController> {
     WTF_MAKE_NONCOPYABLE(DragController); WTF_MAKE_FAST_ALLOCATED;
 public:
     DragController(Page&, std::unique_ptr<DragClient>&&);
@@ -65,7 +65,7 @@ public:
 
     WEBCORE_EXPORT std::variant<std::optional<DragOperation>, RemoteUserInputEventData> dragEnteredOrUpdated(LocalFrame&, DragData&&);
     WEBCORE_EXPORT void dragExited(LocalFrame&, DragData&&);
-    WEBCORE_EXPORT bool performDragOperation(DragData&&);
+    WEBCORE_EXPORT void performDragOperation(DragData&&, LocalFrame&, CompletionHandler<void(bool)>&&);
     WEBCORE_EXPORT void dragCancelled();
 
     bool mouseIsOverFileInput() const { return m_fileInputElementUnderMouse; }
@@ -106,6 +106,8 @@ public:
     static const int DragIconRightInset;
     static const int DragIconBottomInset;
     static const float DragImageAlpha;
+    DragClient& client() const { return *m_client; }
+
 
 private:
     void updateSupportedTypeIdentifiersForDragHandlingMethod(DragHandlingMethod, const DragData&) const;
@@ -139,8 +141,6 @@ private:
         return true;
 #endif
     }
-
-    DragClient& client() const { return *m_client; }
 
     bool tryToUpdateDroppedImagePlaceholders(const DragData&);
     void removeAllDroppedImagePlaceholders();

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -133,7 +133,7 @@ enum class ImmediateActionStage : uint8_t {
     ActionCompleted
 };
 
-class EventHandler final : public CanMakeCheckedPtr<EventHandler> {
+class EventHandler final : public CanMakeCheckedPtr<EventHandler>, public CanMakeWeakPtr<EventHandler> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EventHandler);
 public:
@@ -180,7 +180,7 @@ public:
     };
     DragTargetResponse updateDragAndDrop(const PlatformMouseEvent&, const std::function<std::unique_ptr<Pasteboard>()>&, OptionSet<DragOperation>, bool draggingFiles);
     void cancelDragAndDrop(const PlatformMouseEvent&, std::unique_ptr<Pasteboard>&&, OptionSet<DragOperation>, bool draggingFiles);
-    bool performDragAndDrop(const PlatformMouseEvent&, std::unique_ptr<Pasteboard>&&, OptionSet<DragOperation>, bool draggingFiles);
+    void performDragAndDrop(const PlatformMouseEvent&, std::unique_ptr<Pasteboard>&&, OptionSet<DragOperation>, bool draggingFiles, const HitTestResult&, CompletionHandler<void(bool)>&&);
     void updateDragStateAfterEditDragIfNeeded(Element& rootEditableElement);
     static Element* draggedElement();
     static RefPtr<Element> protectedDraggedElement();

--- a/Source/WebCore/page/RemoteFrameClient.h
+++ b/Source/WebCore/page/RemoteFrameClient.h
@@ -38,6 +38,7 @@ class SecurityOriginData;
 enum class RenderAsTextFlag : uint16_t;
 
 struct MessageWithMessagePorts;
+struct RemoteUserInputEventData;
 
 class RemoteFrameClient : public FrameLoaderClient {
     WTF_MAKE_FAST_ALLOCATED;
@@ -53,6 +54,9 @@ public:
     virtual void unbindRemoteAccessibilityFrames(int) = 0;
     virtual void focus() = 0;
     virtual void unfocus() = 0;
+#if PLATFORM(COCOA) && ENABLE(DRAG_SUPPORT)
+    virtual void propagateDragAndDrop(FrameIdentifier, WebCore::RemoteUserInputEventData, CompletionHandler<void(bool)>&&) = 0;
+#endif
     virtual void documentURLForConsoleLog(CompletionHandler<void(const URL&)>&&) = 0;
     virtual ~RemoteFrameClient() { }
 };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3390,19 +3390,56 @@ void WebPageProxy::dragExited(DragData& dragData)
     performDragControllerAction(DragControllerAction::Exited, dragData);
 }
 
-void WebPageProxy::performDragOperation(DragData& dragData, const String& dragStorageName, SandboxExtension::Handle&& sandboxExtensionHandle, Vector<SandboxExtension::Handle>&& sandboxExtensionsForUpload)
-{
 #if PLATFORM(COCOA)
-    grantAccessToCurrentPasteboardData(dragStorageName);
+void WebPageProxy::propagateDragAndDrop(IPC::Connection& connection, FrameIdentifier frameID, RemoteUserInputEventData remoteUserInputEventData, CompletionHandler<void(bool)>&& completionHandler)
+{
+    auto& currentOperation = internals().currentDragOperationData;
+    if (!currentOperation) {
+        ASSERT_NOT_REACHED();
+        completionHandler(false);
+        return;
+    }
+    MESSAGE_CHECK_BASE(!currentOperation->lastFrameID ||  currentOperation->lastFrameID == frameID, &connection);
+    currentOperation->lastFrameID = remoteUserInputEventData.targetFrameID;
+
+    RefPtr targetFrame = WebFrameProxy::webFrame(remoteUserInputEventData.targetFrameID);
+    sendWithAsyncReplyToProcessContainingFrame(remoteUserInputEventData.targetFrameID, Messages::WebPage::PerformDragOperation(remoteUserInputEventData.targetFrameID, currentOperation->dragData), [completionHandler = WTFMove(completionHandler)](bool handled) mutable {
+        completionHandler(handled);
+    });
+}
+
+void WebPageProxy::fetchSandboxExtensionsForDragAction(IPC::Connection& connection, FrameIdentifier frameID, CompletionHandler<void(SandboxExtension::Handle&&, Vector<SandboxExtension::Handle>&&)>&& completionHandler)
+{
+    auto& currentOperation = internals().currentDragOperationData;
+    if (!currentOperation) {
+        ASSERT_NOT_REACHED();
+        completionHandler({ }, { });
+        return;
+    }
+    RefPtr frame = WebFrameProxy::webFrame(frameID);
+    if (!frame) {
+        ASSERT_NOT_REACHED();
+        completionHandler({ }, { });
+        return;
+    }
+    MESSAGE_CHECK_BASE(!currentOperation->lastFrameID ||  currentOperation->lastFrameID == frameID, &connection);
+    grantAccessToCurrentPasteboardData(currentOperation->dragStorageName, frameID);
+    completionHandler(WTFMove(currentOperation->sandboxExtensionHandle), WTFMove(currentOperation->sandboxExtensionsForUpload));
+}
 #endif
 
+void WebPageProxy::performDragOperation(DragData& dragData, const String& dragStorageName, SandboxExtension::Handle&& sandboxExtensionHandle, Vector<SandboxExtension::Handle>&& sandboxExtensionsForUpload, const std::optional<WebCore::FrameIdentifier>& frameID)
+{
 #if PLATFORM(GTK)
     performDragControllerAction(DragControllerAction::PerformDragOperation, dragData);
 #else
     if (!hasRunningProcess())
         return;
-
-    sendWithAsyncReply(Messages::WebPage::PerformDragOperation(dragData, WTFMove(sandboxExtensionHandle), WTFMove(sandboxExtensionsForUpload)), [this, protectedThis = Ref { *this }] (bool handled) {
+    if (!frameID)
+        internals().currentDragOperationData = { dragData, dragStorageName, WTFMove(sandboxExtensionHandle), WTFMove(sandboxExtensionsForUpload), std::nullopt };
+    sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::PerformDragOperation(frameID, internals().currentDragOperationData->dragData), [this, protectedThis = Ref { *this }, frameID] (bool handled) mutable {
+        if (!frameID)
+            internals().currentDragOperationData = std::nullopt;
         protectedPageClient()->didPerformDragOperation(handled);
     });
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1485,7 +1485,7 @@ public:
     void dragEntered(WebCore::DragData&, const String& dragStorageName = String());
     void dragUpdated(WebCore::DragData&, const String& dragStorageName = String());
     void dragExited(WebCore::DragData&);
-    void performDragOperation(WebCore::DragData&, const String& dragStorageName, SandboxExtensionHandle&&, Vector<SandboxExtensionHandle>&&);
+    void performDragOperation(WebCore::DragData&, const String& dragStorageName, SandboxExtensionHandle&&, Vector<SandboxExtensionHandle>&&, const std::optional<WebCore::FrameIdentifier>& = std::nullopt);
 
     void didPerformDragControllerAction(std::optional<WebCore::DragOperation>, WebCore::DragHandlingMethod, bool mouseIsOverFileInput, unsigned numberOfItemsToBeAccepted, const WebCore::IntRect& insertionRect, const WebCore::IntRect& editableElementRect);
     void dragEnded(const WebCore::IntPoint& clientPosition, const WebCore::IntPoint& globalPosition, OptionSet<WebCore::DragOperation>, const std::optional<WebCore::FrameIdentifier>& = std::nullopt);
@@ -1493,6 +1493,8 @@ public:
     void dragCancelled();
     void setDragCaretRect(const WebCore::IntRect&);
 #if PLATFORM(COCOA)
+    void propagateDragAndDrop(IPC::Connection&, WebCore::FrameIdentifier, WebCore::RemoteUserInputEventData, CompletionHandler<void(bool)>&&);
+    void fetchSandboxExtensionsForDragAction(IPC::Connection&, WebCore::FrameIdentifier, CompletionHandler<void(SandboxExtensionHandle&&, Vector<SandboxExtensionHandle>&&)>&&);
     void startDrag(const WebCore::DragItem&, WebCore::ShareableBitmapHandle&& dragImageHandle);
     void setPromisedDataForImage(IPC::Connection&, const String& pasteboardName, WebCore::SharedMemoryHandle&& imageHandle, const String& filename, const String& extension,
         const String& title, const String& url, const String& visibleURL, WebCore::SharedMemoryHandle&& archiveHandle, const String& originIdentifier);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -302,6 +302,8 @@ messages -> WebPageProxy {
 
     # Drag and drop messages
 #if PLATFORM(COCOA) && ENABLE(DRAG_SUPPORT)
+    PropagateDragAndDrop(WebCore::FrameIdentifier frameID, struct WebCore::RemoteUserInputEventData remoteUserInputData) -> (bool handled)
+    FetchSandboxExtensionsForDragAction(WebCore::FrameIdentifier frameID) -> (WebKit::SandboxExtensionHandle sandboxExtensionHandle, Vector<WebKit::SandboxExtensionHandle> sandboxExtensionsForUpload)
     StartDrag(struct WebCore::DragItem dragItem, WebCore::ShareableBitmapHandle dragImage)
     SetPromisedDataForImage(String pasteboardName, WebCore::SharedMemory::Handle imageHandle, String filename, String extension, String title, String url, String visibleURL, WebCore::SharedMemory::Handle archiveHandle, String originIdentifier)
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -59,6 +59,7 @@
 
 #if ENABLE(DRAG_SUPPORT)
 #include <WebCore/DragActions.h>
+#include <WebCore/DragData.h>
 #endif
 
 #if PLATFORM(MACCATALYST)
@@ -252,9 +253,18 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
 #endif
 
 #if ENABLE(DRAG_SUPPORT)
+    struct DragOperationData {
+        WebCore::DragData dragData;
+        String dragStorageName;
+        SandboxExtension::Handle sandboxExtensionHandle;
+        Vector<SandboxExtension::Handle> sandboxExtensionsForUpload;
+        std::optional<WebCore::FrameIdentifier> lastFrameID;
+    };
+
     WebCore::IntRect currentDragCaretEditableElementRect;
     WebCore::IntRect currentDragCaretRect;
     WebCore::DragHandlingMethod currentDragHandlingMethod { WebCore::DragHandlingMethod::None };
+    std::optional<DragOperationData> currentDragOperationData;
 #endif
 
 #if ENABLE(INPUT_TYPE_COLOR)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp
@@ -41,6 +41,25 @@ void WebDragClient::willPerformDragDestinationAction(DragDestinationAction actio
         m_page->mayPerformUploadDragDestinationAction(); // Upload can happen from a drop event handler, so we should prepare early.
 }
 
+void WebDragClient::willPerformDragDestinationAction(DragDestinationAction action, const DragData& dragData, FrameIdentifier frameID, CompletionHandler<void()>&& completionHandler)
+{
+#if PLATFORM(COCOA)
+    m_page->fetchSandboxExtensionsForDragAction(frameID, [page = RefPtr { m_page.get() }, action, completionHandler = WTFMove(completionHandler)] () mutable {
+        if (!page) {
+            completionHandler();
+            return;
+        }
+        if (action == DragDestinationAction::Load)
+            page->willPerformLoadDragDestinationAction();
+        else
+            page->mayPerformUploadDragDestinationAction();
+        completionHandler();
+    });
+#else
+    completionHandler();
+#endif
+}
+
 void WebDragClient::willPerformDragSourceAction(DragSourceAction, const IntPoint&, DataTransfer&)
 {
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.h
@@ -44,6 +44,7 @@ public:
 
 private:
     void willPerformDragDestinationAction(WebCore::DragDestinationAction, const WebCore::DragData&) override;
+    void willPerformDragDestinationAction(WebCore::DragDestinationAction, const WebCore::DragData&, WebCore::FrameIdentifier, CompletionHandler<void()>&&) override;
     void willPerformDragSourceAction(WebCore::DragSourceAction, const WebCore::IntPoint&, WebCore::DataTransfer&) override;
     OptionSet<WebCore::DragSourceAction> dragSourceActionMaskForPoint(const WebCore::IntPoint& windowPoint) override;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -181,4 +181,14 @@ void WebRemoteFrameClient::applyWebsitePolicies(WebsitePoliciesData&& websitePol
     coreFrame->setCustomNavigatorPlatform(websitePolicies.customNavigatorPlatform);
 }
 
+#if PLATFORM(COCOA) && ENABLE(DRAG_SUPPORT)
+void WebRemoteFrameClient::propagateDragAndDrop(FrameIdentifier frameID, WebCore::RemoteUserInputEventData remoteUserInputEventData, CompletionHandler<void(bool)>&& completionHandler)
+{
+    if (RefPtr page = m_frame->page())
+        page->sendWithAsyncReply(Messages::WebPageProxy::PropagateDragAndDrop(frameID, WTFMove(remoteUserInputEventData)), WTFMove(completionHandler));
+    else
+        completionHandler(false);
+}
+#endif
+
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
@@ -50,6 +50,9 @@ private:
     void bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier, Vector<uint8_t>&&, CompletionHandler<void(Vector<uint8_t>, int)>&&) final;
     void unbindRemoteAccessibilityFrames(int) final;
     void updateRemoteFrameAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint) final;
+#if PLATFORM(COCOA) && ENABLE(DRAG_SUPPORT)
+    void propagateDragAndDrop(WebCore::FrameIdentifier, WebCore::RemoteUserInputEventData, CompletionHandler<void(bool)>&&) final;
+#endif
 
     void closePage() final;
     void focus() final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5394,8 +5394,10 @@ void WebPage::performDragControllerAction(DragControllerAction action, const Int
         return completionHandler(std::nullopt, DragHandlingMethod::None, false, 0, { }, { }, std::nullopt);
 
     case DragControllerAction::PerformDragOperation: {
-        m_page->dragController().performDragOperation(WTFMove(dragData));
-        return completionHandler(std::nullopt, DragHandlingMethod::None, false, 0, { }, { }, std::nullopt);
+        m_page->dragController().performDragOperation(WTFMove(dragData), *localMainFrame, [completionHandler = WTFMove(completionHandler)] (bool) mutable {
+            completionHandler(std::nullopt, DragHandlingMethod::None, false, 0, { }, { }, std::nullopt);
+        });
+        return;
     }
     }
     ASSERT_NOT_REACHED();
@@ -5409,12 +5411,14 @@ void WebPage::performDragControllerAction(std::optional<FrameIdentifier> frameID
     auto* frame = frameID ? WebProcess::singleton().webFrame(*frameID) : &mainWebFrame();
     if (!frame) {
         ASSERT_NOT_REACHED();
+        completionHandler(std::nullopt, DragHandlingMethod::None, false, 0, { }, { }, std::nullopt);
         return;
     }
 
     RefPtr localFrame = frame->coreLocalFrame();
     if (!localFrame) {
         ASSERT_NOT_REACHED();
+        completionHandler(std::nullopt, DragHandlingMethod::None, false, 0, { }, { }, std::nullopt);
         return;
     }
 
@@ -5436,24 +5440,30 @@ void WebPage::performDragControllerAction(std::optional<FrameIdentifier> frameID
     ASSERT_NOT_REACHED();
 }
 
-void WebPage::performDragOperation(WebCore::DragData&& dragData, SandboxExtension::Handle&& sandboxExtensionHandle, Vector<SandboxExtension::Handle>&& sandboxExtensionsHandleArray, CompletionHandler<void(bool)>&& completionHandler)
+void WebPage::performDragOperation(std::optional<WebCore::FrameIdentifier> frameID, WebCore::DragData&& dragData, CompletionHandler<void(bool)>&& completionHandler)
 {
     ASSERT(!m_pendingDropSandboxExtension);
 
-    m_pendingDropSandboxExtension = SandboxExtension::create(WTFMove(sandboxExtensionHandle));
-    for (size_t i = 0; i < sandboxExtensionsHandleArray.size(); i++) {
-        if (auto extension = SandboxExtension::create(WTFMove(sandboxExtensionsHandleArray[i])))
-            m_pendingDropExtensionsForFileUpload.append(extension);
+    auto* frame = frameID ? WebProcess::singleton().webFrame(*frameID) : &mainWebFrame();
+
+    if (!frame) {
+        ASSERT_NOT_REACHED();
+        completionHandler(false);
+        return;
     }
 
-    bool handled = m_page->dragController().performDragOperation(WTFMove(dragData));
+    RefPtr localFrame = frame->coreLocalFrame();
+    if (!localFrame) {
+        ASSERT_NOT_REACHED();
+        completionHandler(false);
+        return;
+    }
 
-    // If we started loading a local file, the sandbox extension tracker would have adopted this
-    // pending drop sandbox extension. If not, we'll play it safe and clear it.
-    m_pendingDropSandboxExtension = nullptr;
-
-    m_pendingDropExtensionsForFileUpload.clear();
-    completionHandler(handled);
+    m_page->dragController().performDragOperation(WTFMove(dragData), *localFrame, [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)](bool handled) mutable {
+        if (!weakThis)
+            return;
+        completionHandler(handled);
+    });
 }
 #endif
 
@@ -5495,6 +5505,20 @@ void WebPage::mayPerformUploadDragDestinationAction()
         m_pendingDropExtensionsForFileUpload[i]->consumePermanently();
     m_pendingDropExtensionsForFileUpload.clear();
 }
+
+#if PLATFORM(COCOA)
+void WebPage::fetchSandboxExtensionsForDragAction(FrameIdentifier frameID, CompletionHandler<void()>&& completionHandler)
+{
+    sendWithAsyncReply(Messages::WebPageProxy::FetchSandboxExtensionsForDragAction(frameID), [this, completionHandler = WTFMove(completionHandler)] (SandboxExtension::Handle&& sandboxExtensionHandle, Vector<SandboxExtension::Handle>&& sandboxExtensionsHandleArray) mutable {
+        m_pendingDropSandboxExtension = SandboxExtension::create(WTFMove(sandboxExtensionHandle));
+        for (size_t i = 0; i < sandboxExtensionsHandleArray.size(); i++) {
+            if (auto extension = SandboxExtension::create(WTFMove(sandboxExtensionsHandleArray[i])))
+                m_pendingDropExtensionsForFileUpload.append(extension);
+        }
+        completionHandler();
+    });
+}
+#endif
 
 void WebPage::didStartDrag()
 {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1177,7 +1177,7 @@ public:
 
 #if ENABLE(DRAG_SUPPORT) && !PLATFORM(GTK)
     void performDragControllerAction(std::optional<WebCore::FrameIdentifier>, DragControllerAction, WebCore::DragData&&, CompletionHandler<void(std::optional<WebCore::DragOperation>, WebCore::DragHandlingMethod, bool, unsigned, WebCore::IntRect, WebCore::IntRect, std::optional<WebCore::RemoteUserInputEventData>)>&&);
-    void performDragOperation(WebCore::DragData&&, SandboxExtension::Handle&&, Vector<SandboxExtension::Handle>&&, CompletionHandler<void(bool)>&&);
+    void performDragOperation(std::optional<WebCore::FrameIdentifier>, WebCore::DragData&&, CompletionHandler<void(bool)>&&);
 #endif
 
 #if ENABLE(DRAG_SUPPORT)
@@ -1185,7 +1185,9 @@ public:
 
     void willPerformLoadDragDestinationAction();
     void mayPerformUploadDragDestinationAction();
-
+#if PLATFORM(COCOA)
+    void fetchSandboxExtensionsForDragAction(WebCore::FrameIdentifier, CompletionHandler<void()>&&);
+#endif
     void willStartDrag() { ASSERT(!m_isStartingDrag); m_isStartingDrag = true; }
     void didStartDrag();
     void dragCancelled();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -356,7 +356,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 #endif
 #if !PLATFORM(GTK) && ENABLE(DRAG_SUPPORT)
     PerformDragControllerAction(std::optional<WebCore::FrameIdentifier> frameID, enum:uint8_t WebKit::DragControllerAction action, WebCore::DragData dragData) -> (std::optional<WebCore::DragOperation> dragOperation, enum:uint8_t WebCore::DragHandlingMethod dragHandlingMethod, bool mouseIsOverFileInput, unsigned numberOfItemsToBeAccepted, WebCore::IntRect insertionRect, WebCore::IntRect editableElementRect, struct std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData)
-    PerformDragOperation(WebCore::DragData dragData, WebKit::SandboxExtensionHandle sandboxExtensionHandle, Vector<WebKit::SandboxExtensionHandle> sandboxExtensionsForUpload) -> (bool handled)
+    PerformDragOperation(std::optional<WebCore::FrameIdentifier> frameID, WebCore::DragData dragData) -> (bool handled)
 #endif
 #if ENABLE(DRAG_SUPPORT)
     DidStartDrag()

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.h
@@ -37,6 +37,7 @@ public:
     bool useLegacyDragClient() override;
 
     void willPerformDragDestinationAction(WebCore::DragDestinationAction, const WebCore::DragData&) override;
+    void willPerformDragDestinationAction(WebCore::DragDestinationAction, const WebCore::DragData&, WebCore::FrameIdentifier, CompletionHandler<void()>&&) override;
     void willPerformDragSourceAction(WebCore::DragSourceAction, const WebCore::IntPoint&, WebCore::DataTransfer&) override;
     OptionSet<WebCore::DragSourceAction> dragSourceActionMaskForPoint(const WebCore::IntPoint& windowPoint) override;
     void startDrag(WebCore::DragItem, WebCore::DataTransfer&, WebCore::Frame&) override;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
@@ -59,6 +59,7 @@
 #import <WebCore/PagePasteboardContext.h>
 #import <WebCore/Pasteboard.h>
 #import <WebCore/PasteboardWriter.h>
+#import <wtf/CompletionHandler.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 using namespace WebCore;
@@ -132,6 +133,11 @@ OptionSet<WebCore::DragSourceAction> WebDragClient::dragSourceActionMaskForPoint
 void WebDragClient::willPerformDragSourceAction(WebCore::DragSourceAction action, const WebCore::IntPoint& mouseDownPoint, WebCore::DataTransfer& dataTransfer)
 {
     [[m_webView _UIDelegateForwarder] webView:m_webView willPerformDragSourceAction:kit(action) fromPoint:mouseDownPoint withPasteboard:[NSPasteboard pasteboardWithName:dataTransfer.pasteboard().name()]];
+}
+
+void WebDragClient::willPerformDragDestinationAction(WebCore::DragDestinationAction, const DragData&, WebCore::FrameIdentifier, CompletionHandler<void()>&& completionHandler)
+{
+    completionHandler();
 }
 
 void WebDragClient::startDrag(DragItem dragItem, DataTransfer& dataTransfer, Frame& frame)
@@ -220,6 +226,11 @@ void WebDragClient::willPerformDragDestinationAction(WebCore::DragDestinationAct
 {
 }
 
+void WebDragClient::willPerformDragDestinationAction(WebCore::DragDestinationAction, const DragData&, WebCore::FrameIdentifier, CompletionHandler<void()>&& completionHandler)
+{
+    completionHandler();
+}
+
 OptionSet<WebCore::DragSourceAction> WebDragClient::dragSourceActionMaskForPoint(const IntPoint&)
 {
     return { };
@@ -253,6 +264,11 @@ bool WebDragClient::useLegacyDragClient()
 
 void WebDragClient::willPerformDragDestinationAction(WebCore::DragDestinationAction, const DragData&)
 {
+}
+
+void WebDragClient::willPerformDragDestinationAction(WebCore::DragDestinationAction, const DragData&, WebCore::FrameIdentifier, CompletionHandler<void()>&& completionHandler)
+{
+    completionHandler();
 }
 
 OptionSet<WebCore::DragSourceAction> WebDragClient::dragSourceActionMaskForPoint(const IntPoint&)

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -2022,9 +2022,17 @@ static WebCore::ApplicationCacheStorage& webApplicationCacheStorage()
 
 - (BOOL)_tryToPerformDataInteraction:(id <UIDropSession>)session client:(CGPoint)clientPosition global:(CGPoint)globalPosition operation:(uint64_t)operation
 {
+    RefPtr localMainFrame = [self _mainCoreFrame];
+    if (!localMainFrame)
+        return NO;
+
     WebThreadLock();
     auto dragData = [self dragDataForSession:session client:clientPosition global:globalPosition operation:operation];
-    return _private->page->dragController().performDragOperation(WTFMove(dragData));
+    bool preventedDefault = false;
+    _private->page->dragController().performDragOperation(WTFMove(dragData), *localMainFrame, [&preventedDefault] (bool dragPreventedDefault) mutable {
+        preventedDefault = dragPreventedDefault;
+    });
+    return preventedDefault;
 }
 
 - (void)_endedDataInteraction:(CGPoint)clientPosition global:(CGPoint)globalPosition
@@ -6399,7 +6407,8 @@ static bool needsWebViewInitThreadWorkaround()
                     fileNames->append(path.get());
                     if (fileNames->size() == fileCount) {
                         dragData->setFileNames(*fileNames);
-                        core(self)->dragController().performDragOperation(WebCore::DragData { *dragData });
+                        RefPtr localMainFrame = dynamicDowncast<WebCore::LocalFrame>(_private->page->mainFrame());
+                        core(self)->dragController().performDragOperation(WebCore::DragData { *dragData }, *localMainFrame, [] (bool) mutable { });
                         delete dragData;
                         delete fileNames;
                     }
@@ -6409,10 +6418,11 @@ static bool needsWebViewInitThreadWorkaround()
 
         return true;
     }
-    bool returnValue = core(self)->dragController().performDragOperation(WebCore::DragData { *dragData });
+    RefPtr localMainFrame = dynamicDowncast<WebCore::LocalFrame>(_private->page->mainFrame());
+    core(self)->dragController().performDragOperation(WebCore::DragData { *dragData }, *localMainFrame, [](bool) mutable { });
     delete dragData;
 
-    return returnValue;
+    return true;
 }
 
 - (NSView *)_hitTest:(NSPoint *)point dragTypes:(NSSet *)types


### PR DESCRIPTION
#### b61df3ca2ad3d0c6fbddb8b7fdacbaa8978555e9
<pre>
[Site Isolation] Make performDragOperation aware of site-isolated i-frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=273847">https://bugs.webkit.org/show_bug.cgi?id=273847</a>
<a href="https://rdar.apple.com/127699330">rdar://127699330</a>

Reviewed by NOBODY (OOPS!).

This PR starts to handle performDragOperation for site-isolated i-frames. This is
how files that are drag and dropped make it into a webpage. It also prevents dragging
a file onto a page that handles these events from instead navigating the page, which
is the behavior dragging a file into a site-isolated i-frame before this change.

Added an API test to exercise this behavior.

* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::performDragOperation):
* Source/WebCore/page/DragController.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::performDragOperation):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::remoteEventDataForPosition):
(WebKit::WebPage::performDragOperation):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView performDragOperation:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, DragDrop)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6738870df0f4062abcf0ffbdb7b6b8b81cb267ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64846 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11462 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63045 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11737 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49255 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7958 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37492 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30081 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34177 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9998 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10375 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56003 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10294 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66575 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4859 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10122 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56619 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4880 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56809 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4028 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36079 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37161 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38254 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36906 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->