### PR TITLE
Text invisible after a UnifiedTextReplacement session ends.

### DIFF
--- a/Source/WebCore/dom/DocumentMarker.h
+++ b/Source/WebCore/dom/DocumentMarker.h
@@ -126,6 +126,10 @@ public:
     };
 #endif
 
+    struct TransparentContentData {
+        WTF::UUID uuid;
+    };
+
     using Data = std::variant<
         String
         , DictationData // DictationAlternatives
@@ -140,6 +144,7 @@ public:
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
         , UnifiedTextReplacementData // UnifiedTextReplacement
 #endif
+        , TransparentContentData // TransparentContent
     >;
 
     DocumentMarker(Type, OffsetRange, Data&& = { });

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm
@@ -287,6 +287,21 @@ void UnifiedTextReplacementController::didEndTextReplacementSession(const WTF::U
     m_originalDocumentNodes.remove(uuid);
     m_replacedDocumentNodes.remove(uuid);
     m_replacementLocationOffsets.remove(uuid);
+
+    removeTransparentMarkersForSession(uuid, *sessionRange);
+}
+
+void UnifiedTextReplacementController::removeTransparentMarkersForSession(const WTF::UUID& uuid, WebCore::SimpleRange& range)
+{
+    RefPtr document = this->document();
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    document->markers().filterMarkers(range, [&] (const WebCore::DocumentMarker& marker) {
+        return std::get<WebCore::DocumentMarker::TransparentContentData>(marker.data()).uuid == uuid ? WebCore::FilterMarkerResult::Remove : WebCore::FilterMarkerResult::Keep;
+    }, { WebCore::DocumentMarker::Type::TransparentContent });
 }
 
 void UnifiedTextReplacementController::textReplacementSessionDidReceiveTextWithReplacementRange(const WTF::UUID& uuid, const WebCore::AttributedString& attributedText, const WebCore::CharacterRange& range, const WebUnifiedTextReplacementContextData& context)

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -311,7 +311,7 @@ DictionaryPopupInfo WebPage::dictionaryPopupInfoForRange(LocalFrame& frame, cons
 }
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
-std::optional<WebCore::SimpleRange> WebPage::getRangeforUUID(const WTF::UUID& uuid)
+std::optional<WebCore::SimpleRange> WebPage::getRangeForUUID(const WTF::UUID& uuid)
 {
     auto range = m_unifiedTextReplacementController->contextRangeForSessionWithUUID(uuid);
     if (range)
@@ -323,7 +323,7 @@ std::optional<WebCore::SimpleRange> WebPage::getRangeforUUID(const WTF::UUID& uu
 
 void WebPage::getTextIndicatorForID(const WTF::UUID& uuid, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&& completionHandler)
 {
-    auto sessionRange = getRangeforUUID(uuid);
+    auto sessionRange = getRangeForUUID(uuid);
 
     if (!sessionRange) {
         completionHandler(std::nullopt);
@@ -361,7 +361,7 @@ void WebPage::updateTextIndicatorStyleVisibilityForID(const WTF::UUID uuid, bool
         return;
     }
 
-    auto sessionRange = getRangeforUUID(uuid);
+    auto sessionRange = getRangeForUUID(uuid);
 
     if (!sessionRange) {
         completionHandler();
@@ -369,9 +369,9 @@ void WebPage::updateTextIndicatorStyleVisibilityForID(const WTF::UUID uuid, bool
     }
 
     if (visible)
-        document->markers().removeMarkers(*sessionRange, { DocumentMarker::Type::TransparentContent });
+        m_unifiedTextReplacementController->removeTransparentMarkersForSession(uuid, *sessionRange);
     else
-        document->markers().addMarker(*sessionRange, DocumentMarker::Type::TransparentContent);
+        document->markers().addMarker(*sessionRange, DocumentMarker::Type::TransparentContent, { DocumentMarker::TransparentContentData { uuid } });
 
     completionHandler();
 }

--- a/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
+++ b/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
@@ -77,6 +77,8 @@ public:
 
     std::optional<WebCore::SimpleRange> contextRangeForSessionWithUUID(const WTF::UUID&) const;
 
+    void removeTransparentMarkersForSession(const WTF::UUID&, WebCore::SimpleRange&);
+
 private:
     std::optional<std::tuple<WebCore::Node&, WebCore::DocumentMarker&>> findReplacementMarkerContainingRange(const WebCore::SimpleRange&) const;
     std::optional<std::tuple<WebCore::Node&, WebCore::DocumentMarker&>> findReplacementMarkerByUUID(const WebCore::SimpleRange& outerRange, const WTF::UUID& replacementUUID) const;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2249,7 +2249,7 @@ private:
 
     void textReplacementSessionDidReceiveEditAction(const WTF::UUID&, WebKit::WebTextReplacementDataEditAction);
 
-    std::optional<WebCore::SimpleRange> getRangeforUUID(const WTF::UUID&);
+    std::optional<WebCore::SimpleRange> getRangeForUUID(const WTF::UUID&);
 
     void getTextIndicatorForID(const WTF::UUID&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
 


### PR DESCRIPTION
#### 2605e06756ff1850794011b2f6ec62e4ef865710
<pre>
Text invisible after a UnifiedTextReplacement session ends.
<a href="https://bugs.webkit.org/show_bug.cgi?id=273850">https://bugs.webkit.org/show_bug.cgi?id=273850</a>
<a href="https://rdar.apple.com/127563319">rdar://127563319</a>

Reviewed by Aditya Keerthi.

We should be getting a call to set the text visible again, but
since that isn&apos;t happening we should remove the document markers
associated with a session when it ends. This is a good thing
to do regardless, and unblocks us while waiting for a more
correct solution.

* Source/WebCore/dom/DocumentMarker.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm:
(WebKit::UnifiedTextReplacementController::didEndTextReplacementSession&lt;WebUnifiedTextReplacementType::PlainText&gt;):
(WebKit::UnifiedTextReplacementController::didEndTextReplacementSession):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::updateTextIndicatorStyleVisibilityForID):

Canonical link: <a href="https://commits.webkit.org/278509@main">https://commits.webkit.org/278509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd7882c23f4b28b56c194d44df085e1e109eb874

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53991 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1423 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53035 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36291 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41340 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52831 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27676 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43701 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22463 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25043 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/957 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9173 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47024 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55581 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25834 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/910 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48753 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27091 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/43815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47817 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11130 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27959 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26823 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->