### PR TITLE
Re-import WPT css/css-fonts/parsing/

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7431,3 +7431,7 @@ webkit.org/b/272417 imported/w3c/web-platform-tests/svg/path/property/priority.s
 
 # re-import css/css-align WPT failure
 webkit.org/b/271692 imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-break-overflow-020.html [ ImageOnlyFailure ]
+
+# re-import css/css-fonts/parsing crash. Skip until https://bugs.webkit.org/show_bug.cgi?id=273888 is fixed
+webkit.org/b/273888 imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-invalid.html [ Skip ]
+webkit.org/b/273888 imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-valid.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/WEB_FEATURES.yml
@@ -1,0 +1,28 @@
+features:
+- name: font-optical-sizing
+  files:
+  - font-optical-sizing-*
+- name: font-palette
+  files:
+  - font-palette-*
+  - font-palette-values-*
+- name: font-synthesis
+  files:
+  - font-synthesis-computed.html
+  - font-synthesis-invalid.html
+  - font-synthesis-valid.html
+- name: font-synthesis-position
+  files:
+  - font-synthesis-position*
+- name: font-synthesis-small-caps
+  files:
+  - font-synthesis-small-caps*
+- name: font-synthesis-style
+  files:
+  - font-synthesis-style*
+- name: font-synthesis-weight
+  files:
+  - font-synthesis-weight*
+- name: font-variant-alternates
+  files:
+  - font-variant-alternates-*

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-list-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-list-expected.txt
@@ -7,6 +7,7 @@ PASS Check that src: local("myfont") format(opentype), url(foo.ttf) is valid
 PASS Check that src: url(not a valid url/bar.ttf), url(foo.ttf) is valid
 PASS Check that src: url(foo.ttf) format(bad), url(foo.ttf) is valid
 PASS Check that src: url(foo.ttf) tech(unknown), url(foo.ttf) is valid
+PASS Check that src: url(foo.ttf) tech(color-COLRv0) otherfunc(othervalue), url(foo.ttf) is valid
 PASS Check that src: url(foo.ttf), url(something.ttf) format(broken) is valid
 PASS Check that src: /* an empty component */, url(foo.ttf) is valid
 PASS Check that src: local(""), url(foo.ttf), unparseable-garbage, local("another font name") is valid
@@ -14,4 +15,5 @@ PASS Check that src: local(), local(initial) is invalid
 PASS Check that src: local("textfont") format(opentype), local("emoji") tech(color-COLRv0) is invalid
 PASS Check that src: local(), /*empty*/, url(should be quoted.ttf), junk is invalid
 PASS Check that src: url(foo.ttf) format(unknown), url(bar.ttf) tech(broken) is invalid
+PASS Check that src: url(foo.ttf) tech(color-COLRv0) otherfunc(othervalue), junk is invalid
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-list.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-list.html
@@ -19,6 +19,7 @@
     { src: 'url(not a valid url/bar.ttf), url(foo.ttf)', valid: true },
     { src: 'url(foo.ttf) format(bad), url(foo.ttf)', valid: true },
     { src: 'url(foo.ttf) tech(unknown), url(foo.ttf)', valid: true },
+    { src: 'url(foo.ttf) tech(color-COLRv0) otherfunc(othervalue), url(foo.ttf)', valid: true },
     { src: 'url(foo.ttf), url(something.ttf) format(broken)', valid: true },
     { src: '/* an empty component */, url(foo.ttf)', valid: true },
     { src: 'local(""), url(foo.ttf), unparseable-garbage, local("another font name")', valid: true },
@@ -27,6 +28,7 @@
     { src: 'local("textfont") format(opentype), local("emoji") tech(color-COLRv0)', valid: false },
     { src: 'local(), /*empty*/, url(should be quoted.ttf), junk', valid: false },
     { src: 'url(foo.ttf) format(unknown), url(bar.ttf) tech(broken)', valid: false },
+    { src: 'url(foo.ttf) tech(color-COLRv0) otherfunc(othervalue), junk', valid: false },
   ];
 
   for (let t of tests) {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-invalid-expected.txt
@@ -20,4 +20,8 @@ PASS CSS Fonts Module Level 4: parsing @font-palette-values 17
 PASS CSS Fonts Module Level 4: parsing @font-palette-values 18
 PASS CSS Fonts Module Level 4: parsing @font-palette-values 19
 PASS CSS Fonts Module Level 4: parsing @font-palette-values 20
+PASS CSS Fonts Module Level 4: parsing @font-palette-values 21
+FAIL CSS Fonts Module Level 4: parsing @font-palette-values 22 assert_equals: expected -1 but got 27
+PASS CSS Fonts Module Level 4: parsing @font-palette-values 23
+PASS CSS Fonts Module Level 4: parsing @font-palette-values 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-invalid.html
@@ -115,13 +115,33 @@
 @font-palette-values --A {
     override-colors: 0 canvas;
 }
+
+/* 19 */
+@font-palette-values --A {
+    override-colors: 0 currentcolor;
+}
+
+/* 20 */
+@font-palette-values --A {
+    override-colors: 0 light-dark(white, black);
+}
+
+/* 21 */
+@font-palette-values --A {
+    override-colors: 0 color-mix(in lch, red, canvas);
+}
+
+/* 22 */
+@font-palette-values --A {
+    override-colors: 0 light-dark(white, currentcolor);
+}
 </style>
 </head>
 <body>
 <script>
 let rules = document.getElementById("style").sheet.cssRules;
 test(function() {
-    assert_equals(rules.length, 19);
+    assert_equals(rules.length, 23);
 });
 
 test(function() {
@@ -281,6 +301,34 @@ test(function() {
     let rule = rules[18];
     assert_equals(text.indexOf("override-colors"), -1);
     assert_equals(rule.basePalette, "");
+    assert_equals(rule.overrideColors, "");
+});
+
+test(function() {
+    let text = rules[19].cssText;
+    let rule = rules[19];
+    assert_equals(text.indexOf("override-colors"), -1);
+    assert_equals(rule.overrideColors, "");
+});
+
+test(function() {
+    let text = rules[20].cssText;
+    let rule = rules[20];
+    assert_equals(text.indexOf("override-colors"), -1);
+    assert_equals(rule.overrideColors, "");
+});
+
+test(function() {
+    let text = rules[21].cssText;
+    let rule = rules[21];
+    assert_equals(text.indexOf("override-colors"), -1);
+    assert_equals(rule.overrideColors, "");
+});
+
+test(function() {
+    let text = rules[22].cssText;
+    let rule = rules[22];
+    assert_equals(text.indexOf("override-colors"), -1);
     assert_equals(rule.overrideColors, "");
 });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-valid-expected.txt
@@ -32,4 +32,5 @@ PASS CSS Fonts Module Level 4: parsing @font-palette-values 29
 PASS CSS Fonts Module Level 4: parsing @font-palette-values 30
 PASS CSS Fonts Module Level 4: parsing @font-palette-values 31
 PASS CSS Fonts Module Level 4: parsing @font-palette-values 32
+FAIL CSS Fonts Module Level 4: parsing @font-palette-values 33 assert_equals: expected "0 color-mix(in lch, red, blue)" but got "0 rgba(0, 0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-valid.html
@@ -103,6 +103,11 @@
 @font-palette-values --P {
     font-family: foo, bar, baz;
 }
+
+/* 17 */
+@font-palette-values --Q {
+    override-colors: 0 color-mix(in lch, red, blue);
+}
 </style>
 </head>
 <body>
@@ -384,6 +389,14 @@ test(function() {
     assert_equals(rule.fontFamily, "foo, bar, baz");
     assert_equals(rule.basePalette, "");
     assert_equals(rule.overrideColors, "");
+});
+
+test(function() {
+    let rule = rules[17];
+    assert_equals(rule.name, "--Q");
+    assert_equals(rule.fontFamily, "");
+    assert_equals(rule.basePalette, "");
+    assert_equals(rule.overrideColors, "0 color-mix(in lch, red, blue)");
 });
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-computed-expected.txt
@@ -3,8 +3,14 @@ PASS Property font-synthesis value 'none'
 PASS Property font-synthesis value 'weight'
 PASS Property font-synthesis value 'style'
 PASS Property font-synthesis value 'small-caps'
+FAIL Property font-synthesis value 'position' assert_true: 'position' is a supported value for font-synthesis. expected true got false
+FAIL Property font-synthesis value 'small-caps position' assert_true: 'small-caps position' is a supported value for font-synthesis. expected true got false
 PASS Property font-synthesis value 'style small-caps'
+FAIL Property font-synthesis value 'style position' assert_true: 'style position' is a supported value for font-synthesis. expected true got false
+FAIL Property font-synthesis value 'style small-caps position' assert_true: 'style small-caps position' is a supported value for font-synthesis. expected true got false
 PASS Property font-synthesis value 'weight small-caps'
 PASS Property font-synthesis value 'weight style'
+FAIL Property font-synthesis value 'weight position' assert_true: 'weight position' is a supported value for font-synthesis. expected true got false
 PASS Property font-synthesis value 'weight style small-caps'
+FAIL Property font-synthesis value 'weight style small-caps position' assert_true: 'weight style small-caps position' is a supported value for font-synthesis. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-computed.html
@@ -16,10 +16,16 @@ test_computed_value('font-synthesis', 'none');
 test_computed_value('font-synthesis', 'weight');
 test_computed_value('font-synthesis', 'style');
 test_computed_value('font-synthesis', 'small-caps');
+test_computed_value('font-synthesis', 'position');
+test_computed_value('font-synthesis', 'small-caps position');
 test_computed_value('font-synthesis', 'style small-caps');
+test_computed_value('font-synthesis', 'style position');
+test_computed_value('font-synthesis', 'style small-caps position');
 test_computed_value('font-synthesis', 'weight small-caps');
 test_computed_value('font-synthesis', 'weight style');
+test_computed_value('font-synthesis', 'weight position');
 test_computed_value('font-synthesis', 'weight style small-caps');
+test_computed_value('font-synthesis', 'weight style small-caps position');
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-invalid-expected.txt
@@ -2,7 +2,9 @@
 PASS e.style['font-synthesis'] = "auto" should not set the property value
 PASS e.style['font-synthesis'] = "none weight" should not set the property value
 PASS e.style['font-synthesis'] = "none style" should not set the property value
+PASS e.style['font-synthesis'] = "none position" should not set the property value
 PASS e.style['font-synthesis'] = "style none" should not set the property value
 PASS e.style['font-synthesis'] = "none small-caps" should not set the property value
 PASS e.style['font-synthesis'] = "small-caps none" should not set the property value
+PASS e.style['font-synthesis'] = "position none" should not set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-invalid.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>CSS Fonts Module: parsing font-synthesis with invalid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-fonts/#font-synthesis">
-<meta name="assert" content="font-synthesis supports only the grammar 'none | [ weight || style || small-caps ]'.">
+<meta name="assert" content="font-synthesis supports only the grammar 'none | [ weight || style || small-caps || position ]'.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/parsing-testcommon.js"></script>
@@ -14,9 +14,11 @@
 test_invalid_value('font-synthesis', 'auto');
 test_invalid_value('font-synthesis', 'none weight');
 test_invalid_value('font-synthesis', 'none style');
+test_invalid_value('font-synthesis', 'none position');
 test_invalid_value('font-synthesis', 'style none');
 test_invalid_value('font-synthesis', 'none small-caps');
 test_invalid_value('font-synthesis', 'small-caps none');
+test_invalid_value('font-synthesis', 'position none');
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-position-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-position-invalid-expected.txt
@@ -1,0 +1,4 @@
+
+PASS e.style['font-synthesis-position'] = "normal" should not set the property value
+PASS e.style['font-synthesis-position'] = "auto none" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-position-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-position-invalid.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Fonts Module Level 4: parsing font-synthesis-position with invalid values</title>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/7441">
+<meta name="assert" content="font-synthesis-position supports only the grammar 'auto | none'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value('font-synthesis-position', 'normal');
+test_invalid_value('font-synthesis-position', 'auto none');
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-position-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-position-valid-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL e.style['font-synthesis-position'] = "auto" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['font-synthesis-position'] = "none" should set the property value assert_not_equals: property should be set got disallowed value ""
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-position-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-position-valid.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Fonts Module Level 4: parsing font-synthesis-position with valid values</title>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/7441">
+<meta name="assert" content="font-synthesis-position supports the full grammar 'auto | none'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value('font-synthesis-position', 'auto');
+test_valid_value('font-synthesis-position', 'none');
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-valid-expected.txt
@@ -3,10 +3,14 @@ PASS e.style['font-synthesis'] = "none" should set the property value
 PASS e.style['font-synthesis'] = "weight" should set the property value
 PASS e.style['font-synthesis'] = "style" should set the property value
 PASS e.style['font-synthesis'] = "small-caps" should set the property value
+FAIL e.style['font-synthesis'] = "position" should set the property value assert_not_equals: property should be set got disallowed value ""
 PASS e.style['font-synthesis'] = "style weight" should set the property value
 PASS e.style['font-synthesis'] = "small-caps weight" should set the property value
 PASS e.style['font-synthesis'] = "small-caps style" should set the property value
 PASS e.style['font-synthesis'] = "style weight small-caps" should set the property value
 PASS e.style['font-synthesis'] = "style small-caps weight " should set the property value
 PASS e.style['font-synthesis'] = "small-caps style weight " should set the property value
+FAIL e.style['font-synthesis'] = "position style" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['font-synthesis'] = "position weight style" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['font-synthesis'] = "position weight small-caps style" should set the property value assert_not_equals: property should be set got disallowed value ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-valid.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>CSS Fonts Module: parsing font-synthesis with valid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-fonts/#font-synthesis">
-<meta name="assert" content="font-synthesis supports the full grammar 'none | [ weight || style || small-caps ]'.">
+<meta name="assert" content="font-synthesis supports the full grammar 'none | [ weight || style || small-caps || position]'.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/parsing-testcommon.js"></script>
@@ -15,12 +15,16 @@ test_valid_value('font-synthesis', 'none');
 test_valid_value('font-synthesis', 'weight');
 test_valid_value('font-synthesis', 'style');
 test_valid_value('font-synthesis', 'small-caps');
+test_valid_value('font-synthesis', 'position');
 test_valid_value('font-synthesis', 'style weight', 'weight style');
 test_valid_value('font-synthesis', 'small-caps weight', 'weight small-caps');
 test_valid_value('font-synthesis', 'small-caps style', 'style small-caps');
 test_valid_value('font-synthesis', 'style weight small-caps', 'weight style small-caps');
 test_valid_value('font-synthesis', 'style small-caps weight ', 'weight style small-caps');
 test_valid_value('font-synthesis', 'small-caps style weight ', 'weight style small-caps');
+test_valid_value('font-synthesis', 'position style', 'style position');
+test_valid_value('font-synthesis', 'position weight style', 'weight style position');
+test_valid_value('font-synthesis', 'position weight small-caps style', 'weight style small-caps position');
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-variant-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-variant-invalid-expected.txt
@@ -1,5 +1,10 @@
 
 PASS e.style['font-variant'] = "normal none" should not set the property value
+PASS e.style['font-variant'] = "none normal" should not set the property value
+FAIL e.style['font-variant'] = "small-caps normal" should not set the property value assert_equals: expected "" but got "small-caps"
+PASS e.style['font-variant'] = "normal small-caps" should not set the property value
+PASS e.style['font-variant'] = "small-caps none" should not set the property value
+PASS e.style['font-variant'] = "none small-caps" should not set the property value
 PASS e.style['font-variant'] = "common-ligatures no-common-ligatures" should not set the property value
 PASS e.style['font-variant'] = "discretionary-ligatures no-discretionary-ligatures" should not set the property value
 PASS e.style['font-variant'] = "historical-ligatures no-historical-ligatures" should not set the property value

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-variant-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-variant-invalid.html
@@ -12,6 +12,11 @@
 <body>
 <script>
 test_invalid_value('font-variant', 'normal none');
+test_invalid_value('font-variant', 'none normal');
+test_invalid_value('font-variant', 'small-caps normal');
+test_invalid_value('font-variant', 'normal small-caps');
+test_invalid_value('font-variant', 'small-caps none');
+test_invalid_value('font-variant', 'none small-caps');
 
 // <common-lig-values>
 test_invalid_value('font-variant', 'common-ligatures no-common-ligatures');

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/w3c-import.log
@@ -14,6 +14,8 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/WEB_FEATURES.yml
+/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/ahem-ex-500.otf
 /LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-computed.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-format.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-list.html
@@ -55,6 +57,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-style-valid.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-computed.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-invalid.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-position-invalid.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-position-valid.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-small-caps-invalid.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-small-caps-valid.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-style-invalid.html


### PR DESCRIPTION
#### 343bbb4535438673fb7505be3eb9deee8ed001f6
<pre>
Re-import WPT css/css-fonts/parsing/
<a href="https://bugs.webkit.org/show_bug.cgi?id=273851">https://bugs.webkit.org/show_bug.cgi?id=273851</a>
<a href="https://rdar.apple.com/127702961">rdar://127702961</a>

Upstream commit: web-platform-tests/wpt@6fb4ec7

Reviewed by Tim Nguyen.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-list-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-list.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-invalid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-invalid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-valid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-computed.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-invalid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-invalid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-position-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-position-invalid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-position-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-position-valid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-synthesis-valid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-variant-invalid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-variant-invalid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/278526@main">https://commits.webkit.org/278526@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10ea93841f3052990dc5ed12adf12304909e26c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50839 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30136 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54098 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1530 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1181 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41419 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52938 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43797 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22547 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25126 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1053 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9280 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47108 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55692 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25941 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/999 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48834 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27198 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43872 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11138 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28066 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26930 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->