### PR TITLE
[JSC] Use std::span::data in super hot function

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/IntlObjectInlines.h
@@ -222,10 +222,12 @@ ALWAYS_INLINE bool followedByNonLatinCharacter(std::span<const LChar>, size_t)
 template<typename CharacterType1, typename CharacterType2>
 UCollationResult compareASCIIWithUCADUCETLevel3(std::span<const CharacterType1> characters1, std::span<const CharacterType2> characters2)
 {
+    auto* data1 = characters1.data();
+    auto* data2 = characters2.data();
     ASSERT(characters1.size() == characters2.size());
     for (size_t position = 0; position < characters1.size(); ++position) {
-        auto lhs = characters1[position];
-        auto rhs = characters2[position];
+        auto lhs = data1[position];
+        auto rhs = data2[position];
         uint8_t leftWeight = ducetLevel3Weights[lhs];
         uint8_t rightWeight = ducetLevel3Weights[rhs];
         if (leftWeight == rightWeight)
@@ -235,7 +237,6 @@ UCollationResult compareASCIIWithUCADUCETLevel3(std::span<const CharacterType1> 
     return UCOL_EQUAL;
 }
 
-// FIXME: This should take is std::spans.
 template<typename CharacterType1, typename CharacterType2>
 inline std::optional<UCollationResult> compareASCIIWithUCADUCET(std::span<const CharacterType1> characters1, std::span<const CharacterType2> characters2)
 {
@@ -244,10 +245,12 @@ inline std::optional<UCollationResult> compareASCIIWithUCADUCET(std::span<const 
             return UCOL_EQUAL;
     }
 
+    auto* data1 = characters1.data();
+    auto* data2 = characters2.data();
     size_t commonLength = std::min(characters1.size(), characters2.size());
     for (unsigned position = 0; position < commonLength; ++position) {
-        auto lhs = characters1[position];
-        auto rhs = characters2[position];
+        auto lhs = data1[position];
+        auto rhs = data2[position];
 
         if (!canUseASCIIUCADUCETComparison(lhs) || !canUseASCIIUCADUCETComparison(rhs))
             return std::nullopt;
@@ -269,13 +272,13 @@ inline std::optional<UCollationResult> compareASCIIWithUCADUCET(std::span<const 
 
     // If the next character is valid, then we do not need to look into the rest of characters.
     if (characters1.size() > characters2.size()) {
-        auto lhs = characters1[characters2.size()];
+        auto lhs = data1[characters2.size()];
         if (!canUseASCIIUCADUCETComparison(lhs))
             return std::nullopt;
         return UCOL_GREATER;
     }
 
-    auto rhs = characters2[characters1.size()];
+    auto rhs = data2[characters1.size()];
     if (!canUseASCIIUCADUCETComparison(rhs))
         return std::nullopt;
     return UCOL_LESS;


### PR DESCRIPTION
#### ed761c32df612de54e54f1ae711fe6ff3155c7d1
<pre>
[JSC] Use std::span::data in super hot function
<a href="https://bugs.webkit.org/show_bug.cgi?id=273852">https://bugs.webkit.org/show_bug.cgi?id=273852</a>
<a href="https://rdar.apple.com/127703218">rdar://127703218</a>

Reviewed by Keith Miller.

With 277836@main and 278441@main, we observed large regression in JetStream2/cdjs.
This patch attempts to recover that regression.

* Source/JavaScriptCore/runtime/IntlObjectInlines.h:
(JSC::compareASCIIWithUCADUCETLevel3):
(JSC::compareASCIIWithUCADUCET):

Canonical link: <a href="https://commits.webkit.org/278486@main">https://commits.webkit.org/278486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7767ef8dea8887c61732a7dd6c5ad4275ba63a7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50718 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53977 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1409 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1059 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27664 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43687 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22448 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/943 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9159 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/44054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55567 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/50221 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25820 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/899 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48741 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/27077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/43805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47804 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27945 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57696 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7342 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/26809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11876 "Passed tests") | 
<!--EWS-Status-Bubble-End-->