### PR TITLE
Update static analyzer bot scripts

### DIFF
--- a/Tools/Scripts/compare-static-analysis-results
+++ b/Tools/Scripts/compare-static-analysis-results
@@ -26,8 +26,8 @@ import subprocess
 import argparse
 import sys
 
-CHECKERS = ['UncountedCallArgsChecker', 'UncountedLocalVarsChecker']
-PROJECTS = ['WebKit', 'WebCore']
+CHECKERS = ['NoUncountedMemberChecker', 'RefCntblBaseVirtualDtor', 'UncountedCallArgsChecker', 'UncountedLocalVarsChecker']
+PROJECTS = ['WebCore', 'WebKit']
 
 
 def parser():
@@ -44,18 +44,24 @@ def parser():
         '--build-output',
         dest='build_output',
         help='output from new build',
-        required=True
     )
     parser.add_argument(
         '--scan-build-path',
         dest='scan_build',
         help='path to scan-build'
     )
-
     return parser.parse_args()
 
 
 def find_diff(file1, file2, mode):
+    # Create empty file if the corresponding one doesn't exist - this happens if a checker is added or removed
+    if not os.path.exists(f'{file1}-{mode}'):
+        f = open(f'{file1}-{mode}', 'a')
+        f.close()
+    if not os.path.exists(f'{file2}-{mode}'):
+        f = open(f'{file2}-{mode}', 'a')
+        f.close()
+
     # Find new regressions
     new_lines_list = []
     find_issues_cmd = f"/usr/bin/grep -F -v -f {file1}-{mode} {file2}-{mode}"
@@ -94,19 +100,18 @@ def compare_project_results(args, archive_path, new_path, project):
         new_issues_total.update(new_issues)
         new_files_total.update(new_files)
 
-        print(f'    Fixed {len(fixed_issues)} issue(s).')
-        print(f'    Fixed {len(fixed_files)} file(s).')
-        print(f'    {len(new_issues)} new issue(s).')
-        print(f'    {len(new_files)} new file(s) with issues.\n')
+        print(f'    Issues fixed: {len(fixed_issues)}')
+        print(f'    Files fixed: {len(fixed_files)}')
+        print(f'    New issues: {len(new_issues)}')
+        print(f'    New files with issues: {len(new_files)}\n')
 
-    if new_issues_total:
+    if new_issues_total and args.scan_build:
         create_filtered_results_dir(args, project, new_issues_total, 'StaticAnalyzerRegressions')
 
-    return new_issues_total
+    return new_issues_total, new_files_total
 
 
 def create_filtered_results_dir(args, project, issues, category='StaticAnalyzerRegressions'):
-    print(f'Creating {category} and linking results...')
     # Create symlinks to new issues only so that we can run scan-build to generate new index.html files
     path_to_reports = os.path.abspath(f'{args.build_output}/{category}/{project}/StaticAnalyzerReports')
     subprocess.run(['mkdir', '-p', path_to_reports])
@@ -123,16 +128,20 @@ def create_filtered_results_dir(args, project, issues, category='StaticAnalyzerR
 def main():
     args = parser()
     new_issues_total = set()
+    new_files_total = set()
 
     for project in PROJECTS:
         archive_path = os.path.abspath(f'{args.archived_dir}/{project}')
         new_path = os.path.abspath(f'{args.new_dir}/{project}')
         print(f'\n------ {project} ------\n')
-        new_issues = compare_project_results(args, archive_path, new_path, project)
+        new_issues, new_files = compare_project_results(args, archive_path, new_path, project)
         new_issues_total.update(new_issues)
+        new_files_total.update(new_files)
 
     if new_issues_total:
         print(f'\nTotal new issues: {len(new_issues_total)}')
+    if new_files_total:
+        print(f'Total new files: {len(new_files_total)}')
 
     return 0
 

--- a/Tools/Scripts/generate-dirty-files
+++ b/Tools/Scripts/generate-dirty-files
@@ -28,11 +28,13 @@ import json
 import sys
 
 CHECKER_MAP = {
+    'Member variable is a raw-pointer/reference to reference-countable type': 'NoUncountedMemberChecker',
+    "Reference-countable base class doesn't have virtual destructor": 'RefCntblBaseVirtualDtor',
     'Uncounted call argument for a raw pointer/reference parameter': 'UncountedCallArgsChecker',
     'Uncounted raw pointer or reference not provably backed by ref-counted variable': 'UncountedLocalVarsChecker'
 }
 
-PROJECTS = ['WebKit', 'WebCore']
+PROJECTS = ['WebCore', 'WebKit']
 
 
 def parser():
@@ -84,10 +86,7 @@ def parse_results_file(args, file_path):
 
 
 def find_project_results(args, project, file_list, results_data):
-    bug_counts = {
-        'Uncounted call argument for a raw pointer/reference parameter': 0,
-        'Uncounted raw pointer or reference not provably backed by ref-counted variable': 0
-    }
+    bug_counts = {}
 
     for result_file in file_list:
         if result_file:
@@ -96,6 +95,8 @@ def find_project_results(args, project, file_list, results_data):
                 continue
 
             # Create files listing issue hashes and file names.
+            if bug_type not in bug_counts:
+                bug_counts[bug_type] = 0
             bug_counts[bug_type] += 1
             issue_obj = {"hash": issue_hash, "bugtype": bug_type, "line": bug_line}
             list_of_issues = results_data.get(file_name, [])


### PR DESCRIPTION
#### abd7e7b3bbfd3fafab8efb1adb4501438cc1f182
<pre>
Update static analyzer bot scripts
<a href="https://bugs.webkit.org/show_bug.cgi?id=273857">https://bugs.webkit.org/show_bug.cgi?id=273857</a>
<a href="https://rdar.apple.com/127705479">rdar://127705479</a>

Reviewed by Ryosuke Niwa and David Kilzer.

Changes logging to be concise and readable.
Adds NoUncountedMemberChecker and RefCntblBaseVirtualDtor to the checker lists.

* Tools/Scripts/compare-static-analysis-results: Renamed from Tools/Scripts/compare-static-analysis-results.py.
(parser):
(find_diff):
(compare_project_results):
(create_filtered_results_dir):
(main):
* Tools/Scripts/generate-dirty-files: Renamed from Tools/Scripts/generate-dirty-files.py.
(parser):
(parse_results_file):
(find_project_results):
(find_all_results):
(main):

Canonical link: <a href="https://commits.webkit.org/278523@main">https://commits.webkit.org/278523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7f50069be301bbc895613e4bba7feca08e92705

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/50860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3178 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/54119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/1551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/53163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1203 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/54119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/52959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/27799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/43814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/54119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/1070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-skia~~](https://ews-build.webkit.org/#/builders/52/builds/9301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/1132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/55713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/25962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/55713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/27219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/43889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/55713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/28087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7363 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/26951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->