### PR TITLE
MIMETypeRegistry::isPostScriptMIMEType() is no longer a relevant question

### DIFF
--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -383,11 +383,6 @@ bool CachedImage::isPDFResource() const
     return Image::isPDFResource(response().mimeType(), url());
 }
 
-bool CachedImage::isPostScriptResource() const
-{
-    return Image::isPostScriptResource(response().mimeType(), url());
-}
-
 void CachedImage::clear()
 {
     destroyDecodedData();
@@ -521,21 +516,10 @@ void CachedImage::updateBufferInternal(const FragmentedSharedBuffer& data)
 
     EncodedDataStatus encodedDataStatus = EncodedDataStatus::Unknown;
 
-    if (isPostScriptResource()) {
-#if PLATFORM(MAC) && !USE(WEBKIT_IMAGE_DECODERS)
-        // Delay updating the image with the PostScript data till all the data
-        // is received so it can be converted to PDF data.
-        return;
-#else
-        // Set the encodedDataStatus to Error so loading this image will be canceled.
-        encodedDataStatus = EncodedDataStatus::Error;
-#endif
-    } else {
-        // Have the image update its data from its internal buffer. Decoding the image data
-        // will be delayed until info (like size or specific image frames) are queried which
-        // usually happens when the observers are repainted.
-        encodedDataStatus = updateImageData(false);
-    }
+    // Have the image update its data from its internal buffer. Decoding the image data
+    // will be delayed until info (like size or specific image frames) are queried which
+    // usually happens when the observers are repainted.
+    encodedDataStatus = updateImageData(false);
 
     if (encodedDataStatus > EncodedDataStatus::Error && encodedDataStatus < EncodedDataStatus::SizeAvailable)
         return;

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -125,7 +125,6 @@ private:
     void setBodyDataFrom(const CachedResource&) final;
 
     bool isPDFResource() const;
-    bool isPostScriptResource() const;
 
     void createImage();
     void clearImage();

--- a/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -645,11 +645,6 @@ bool MIMETypeRegistry::isPDFMIMEType(const String& mimeType)
     return set.contains(mimeType);
 }
 
-bool MIMETypeRegistry::isPostScriptMIMEType(const String& mimeType)
-{
-    return equalLettersIgnoringASCIICase(mimeType, "application/postscript"_s);
-}
-
 bool MIMETypeRegistry::canShowMIMEType(const String& mimeType)
 {
     if (isSupportedImageMIMEType(mimeType) || isSupportedNonImageMIMEType(mimeType) || isSupportedMediaMIMEType(mimeType))

--- a/Source/WebCore/platform/MIMETypeRegistry.h
+++ b/Source/WebCore/platform/MIMETypeRegistry.h
@@ -103,7 +103,6 @@ public:
 
     // Check to see if a MIME type is one of the common PDF/PS types.
     WEBCORE_EXPORT static bool isPDFMIMEType(const String& mimeType);
-    static bool isPostScriptMIMEType(const String& mimeType);
 
     WEBCORE_EXPORT static bool isUSDMIMEType(const String& mimeType);
 

--- a/Source/WebCore/platform/graphics/Image.cpp
+++ b/Source/WebCore/platform/graphics/Image.cpp
@@ -99,7 +99,7 @@ RefPtr<Image> Image::create(ImageObserver& observer)
         return SVGImage::create(observer);
 
     auto url = observer.sourceUrl();
-    if (isPDFResource(mimeType, url) || isPostScriptResource(mimeType, url)) {
+    if (isPDFResource(mimeType, url)) {
 #if USE(CG) && !USE(WEBKIT_IMAGE_DECODERS)
         if (!DeprecatedGlobalSettings::arePDFImagesEnabled())
             return nullptr;
@@ -133,14 +133,6 @@ bool Image::isPDFResource(const String& mimeType, const URL& url)
         return url.path().endsWithIgnoringASCIICase(".pdf"_s);
     return MIMETypeRegistry::isPDFMIMEType(mimeType);
 }
-
-bool Image::isPostScriptResource(const String& mimeType, const URL& url)
-{
-    if (mimeType.isEmpty())
-        return url.path().endsWithIgnoringASCIICase(".ps"_s);
-    return MIMETypeRegistry::isPostScriptMIMEType(mimeType);
-}
-
 
 EncodedDataStatus Image::setData(RefPtr<FragmentedSharedBuffer>&& data, bool allDataReceived)
 {

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -66,7 +66,6 @@ public:
     WEBCORE_EXPORT static std::optional<Ref<Image>> create(RefPtr<ShareableBitmap>&&);
     WEBCORE_EXPORT static bool supportsType(const String&);
     static bool isPDFResource(const String& mimeType, const URL&);
-    static bool isPostScriptResource(const String& mimeType, const URL&);
 
     virtual bool isBitmapImage() const { return false; }
     virtual bool isGeneratedImage() const { return false; }


### PR DESCRIPTION
#### 8694a007981ee2d1fc99680947127b6596d9a891
<pre>
MIMETypeRegistry::isPostScriptMIMEType() is no longer a relevant question
<a href="https://bugs.webkit.org/show_bug.cgi?id=273858">https://bugs.webkit.org/show_bug.cgi?id=273858</a>
<a href="https://rdar.apple.com/127706013">rdar://127706013</a>

Reviewed by Tim Horton.

After 278471@main, the only callers of isPostScriptMIMEType() are
Image::create() and CachedImage::updateBufferInternal(), both of which
use the check to convert PostScript data to PDF data. Since we no longer
ship this translation capability, we no longer need to check for the
presence of a PostScript resource.

* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::updateBufferInternal):
(WebCore::CachedImage::isPostScriptResource const): Deleted.
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/platform/MIMETypeRegistry.cpp:
(WebCore::MIMETypeRegistry::isPostScriptMIMEType): Deleted.
* Source/WebCore/platform/MIMETypeRegistry.h:
* Source/WebCore/platform/graphics/Image.cpp:
(WebCore::Image::create):
(WebCore::Image::isPostScriptResource): Deleted.
* Source/WebCore/platform/graphics/Image.h:

Canonical link: <a href="https://commits.webkit.org/278520@main">https://commits.webkit.org/278520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c4d525047293d70d4db6b1b82db2b910c11ef8f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53994 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1426 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53038 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1076 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41343 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43703 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22467 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25045 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/959 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9176 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/44071 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47026 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1021 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55584 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25837 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48758 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27094 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43816 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47825 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11135 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27962 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26826 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->