### PR TITLE
[iOS] ElementTargeting.ReplacedRendererSizeIgnoresPageScaleAndZoom is a flaky failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
@@ -456,7 +456,10 @@ TEST(ElementTargeting, ReplacedRendererSizeIgnoresPageScaleAndZoom)
     [webView _setPageZoomFactor:2];
     [webView _setPageScale:1.5 withOrigin:CGPointZero];
 #else
-    [[webView scrollView] setZoomScale:3 animated:NO];
+    RetainPtr scrollView = [webView scrollView];
+    [scrollView setZoomScale:3 animated:NO];
+    [scrollView setContentOffset:CGPointZero];
+    [webView waitForNextVisibleContentRectUpdate];
 #endif
     [webView waitForNextPresentationUpdate];
     RetainPtr targetAfterScaling = [[webView targetedElementInfoAt:CGPointMake(100, 100)] firstObject];

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -144,6 +144,7 @@ struct AutocorrectionContext {
 - (void)performAfterLoading:(dispatch_block_t)actions;
 
 - (void)waitForNextPresentationUpdate;
+- (void)waitForNextVisibleContentRectUpdate;
 - (void)waitUntilActivityStateUpdateDone;
 - (void)forceDarkMode;
 - (NSString *)stylePropertyAtSelectionStart:(NSString *)propertyName;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -949,10 +949,19 @@ static InputSessionChangeCount nextInputSessionChangeCount()
 - (void)waitForNextPresentationUpdate
 {
     __block bool done = false;
-    [self _doAfterNextPresentationUpdate:^() {
+    [self _doAfterNextPresentationUpdate:^{
         done = true;
     }];
 
+    TestWebKitAPI::Util::run(&done);
+}
+
+- (void)waitForNextVisibleContentRectUpdate
+{
+    __block bool done = false;
+    [self _doAfterNextVisibleContentRectUpdate:^{
+        done = true;
+    }];
     TestWebKitAPI::Util::run(&done);
 }
 


### PR DESCRIPTION
#### d110152c9e76310103dc843da0fdd5b892f19080
<pre>
[iOS] ElementTargeting.ReplacedRendererSizeIgnoresPageScaleAndZoom is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=273856">https://bugs.webkit.org/show_bug.cgi?id=273856</a>

Reviewed by Aditya Keerthi.

This test was previously relying on the fact that `-setZoomScale:animated:` after navigation would
(usually) not actually result in a scale change, after the next rendering update. As such, this test
only passes because the point `(100, 100)` ends up hit-testing to the same inspected element.

This bug was fixed in 278484@main, but as a result, it exposes a bug in the test, since
`-setZoomScale:animated:` uses the center of the scroll view as the anchor point (rather than the
origin), which means that hit-testing `(100, 100)` now misses and hits text instead.

Address this by using `-setZoomScale:animated:` and `-setContentOffset:` to zoom to scale 3 and
scroll to the origin, and then carry out the hit-test.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm:
(TestWebKitAPI::TEST(ElementTargeting, ReplacedRendererSizeIgnoresPageScaleAndZoom)):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestWKWebView waitForNextPresentationUpdate]):
(-[TestWKWebView waitForNextVisibleContentRectUpdate]):

Canonical link: <a href="https://commits.webkit.org/278492@main">https://commits.webkit.org/278492@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3189e1ed25886e02b065a6bbeb9610353b1b520b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3056 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53998 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1430 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53042 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41342 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52838 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27680 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43706 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22465 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25046 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/962 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9180 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47027 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1024 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55588 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25841 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/915 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48756 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27098 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/43818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47821 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11114 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27966 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26830 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->