### PR TITLE
[WebGPU] Index buffer can read outside the range of a vertex buffer

### DIFF
--- a/Source/WebGPU/WebGPU/BindableResource.h
+++ b/Source/WebGPU/WebGPU/BindableResource.h
@@ -29,6 +29,7 @@
 #import <wtf/OptionSet.h>
 #import <wtf/RefPtr.h>
 #import <wtf/Vector.h>
+#import <wtf/WeakPtr.h>
 
 namespace WebGPU {
 
@@ -58,7 +59,7 @@ static constexpr auto isTextureBindGroupEntryUsage(OptionSet<BindGroupEntryUsage
 struct BindGroupEntryUsageData {
     OptionSet<BindGroupEntryUsage> usage { BindGroupEntryUsage::Undefined };
     uint32_t binding { 0 };
-    using Resource = std::variant<RefPtr<const Buffer>, RefPtr<const TextureView>, RefPtr<const ExternalTexture>>;
+    using Resource = std::variant<RefPtr<Buffer>, RefPtr<const TextureView>, RefPtr<const ExternalTexture>>;
     Resource resource;
     static constexpr uint32_t invalidBindingIndex = INT_MAX;
     static constexpr BindGroupEntryUsage invalidBindGroupUsage = static_cast<BindGroupEntryUsage>(std::numeric_limits<std::underlying_type<BindGroupEntryUsage>::type>::max());
@@ -69,6 +70,25 @@ struct BindableResources {
     Vector<BindGroupEntryUsageData> resourceUsages;
     MTLResourceUsage usage;
     MTLRenderStages renderStages;
+};
+
+struct IndexData {
+    uint64_t renderCommand { 0 };
+    uint32_t minVertexCount { UINT32_MAX };
+    uint64_t bufferGpuAddress { 0 };
+    uint32_t indexCount { 0 };
+    uint32_t instanceCount { 0 };
+    uint32_t firstIndex { 0 };
+    int32_t baseVertex { 0 };
+    uint32_t firstInstance { 0 };
+    MTLPrimitiveType primitiveType { MTLPrimitiveTypeTriangle };
+};
+
+struct IndexBufferAndIndexData {
+    WeakPtr<Buffer> indexBuffer;
+    MTLIndexType indexType { MTLIndexTypeUInt16 };
+    NSUInteger indexBufferOffsetInBytes { 0 };
+    IndexData indexData;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -82,6 +82,8 @@ public:
     };
 
     id<MTLBuffer> buffer() const { return m_buffer; }
+    id<MTLBuffer> indirectBuffer() const;
+    id<MTLBuffer> indirectIndexedBuffer() const;
     uint64_t initialSize() const;
     uint64_t currentSize() const;
     WGPUBufferUsageFlags usage() const { return m_usage; }
@@ -92,11 +94,13 @@ public:
     void setCommandEncoder(CommandEncoder&, bool mayModifyBuffer = false) const;
     uint32_t maxIndex(MTLIndexType) const;
     uint8_t* getBufferContents();
+    bool indirectBufferRequiresRecomputation(uint32_t baseIndex, uint32_t indexCount, uint32_t minVertexCount, MTLIndexType) const;
+    void indirectBufferRecomputed(uint32_t baseIndex, uint32_t indexCount, uint32_t minVertexCount, MTLIndexType);
+    void indirectBufferInvalidated();
 
 private:
     Buffer(id<MTLBuffer>, uint64_t initialSize, WGPUBufferUsageFlags, State initialState, MappingRange initialMappingRange, Device&);
     Buffer(Device&);
-    void recomputeMaxIndexValues() const;
 
     bool validateGetMappedRange(size_t offset, size_t rangeSize) const;
     NSString* errorValidatingMapAsync(WGPUMapModeFlags, size_t offset, size_t rangeSize) const;
@@ -104,6 +108,8 @@ private:
     void setState(State);
 
     id<MTLBuffer> m_buffer { nil };
+    id<MTLBuffer> m_indirectBuffer { nil };
+    id<MTLBuffer> m_indirectIndexedBuffer { nil };
 
     // https://gpuweb.github.io/gpuweb/#buffer-interface
 
@@ -115,6 +121,12 @@ private:
     using MappedRanges = RangeSet<Range<size_t>>;
     MappedRanges m_mappedRanges;
     WGPUMapModeFlags m_mapMode { WGPUMapMode_None };
+    struct IndirectArgsCache {
+        uint32_t lastBaseIndex { 0 };
+        uint32_t indexCount { 0 };
+        uint32_t minVertexCount { 0 };
+        MTLIndexType indexType { MTLIndexTypeUInt16 };
+    } m_indirectCache;
 
     const Ref<Device> m_device;
     mutable WeakPtr<CommandEncoder> m_commandEncoder;

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -70,11 +70,11 @@ public:
 
     Ref<ComputePassEncoder> beginComputePass(const WGPUComputePassDescriptor&);
     Ref<RenderPassEncoder> beginRenderPass(const WGPURenderPassDescriptor&);
-    void copyBufferToBuffer(const Buffer& source, uint64_t sourceOffset, const Buffer& destination, uint64_t destinationOffset, uint64_t size);
+    void copyBufferToBuffer(const Buffer& source, uint64_t sourceOffset, Buffer& destination, uint64_t destinationOffset, uint64_t size);
     void copyBufferToTexture(const WGPUImageCopyBuffer& source, const WGPUImageCopyTexture& destination, const WGPUExtent3D& copySize);
     void copyTextureToBuffer(const WGPUImageCopyTexture& source, const WGPUImageCopyBuffer& destination, const WGPUExtent3D& copySize);
     void copyTextureToTexture(const WGPUImageCopyTexture& source, const WGPUImageCopyTexture& destination, const WGPUExtent3D& copySize);
-    void clearBuffer(const Buffer&, uint64_t offset, uint64_t size);
+    void clearBuffer(Buffer&, uint64_t offset, uint64_t size);
     Ref<CommandBuffer> finish(const WGPUCommandBufferDescriptor&);
     void insertDebugMarker(String&& markerLabel);
     void popDebugGroup();

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -711,7 +711,7 @@ void CommandEncoder::decrementBufferMapCount()
         m_cachedCommandBuffer->setBufferMapCount(m_bufferMapCount);
 }
 
-void CommandEncoder::copyBufferToBuffer(const Buffer& source, uint64_t sourceOffset, const Buffer& destination, uint64_t destinationOffset, uint64_t size)
+void CommandEncoder::copyBufferToBuffer(const Buffer& source, uint64_t sourceOffset, Buffer& destination, uint64_t destinationOffset, uint64_t size)
 {
     // https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-copybuffertobuffer
     if (!prepareTheEncoderState()) {
@@ -726,6 +726,7 @@ void CommandEncoder::copyBufferToBuffer(const Buffer& source, uint64_t sourceOff
 
     source.setCommandEncoder(*this);
     destination.setCommandEncoder(*this);
+    destination.indirectBufferInvalidated();
     if (!size || source.isDestroyed() || destination.isDestroyed())
         return;
 
@@ -1261,6 +1262,7 @@ void CommandEncoder::copyTextureToBuffer(const WGPUImageCopyTexture& source, con
     auto& apiDestinationBuffer = fromAPI(destination.buffer);
     sourceTexture.setCommandEncoder(*this);
     apiDestinationBuffer.setCommandEncoder(*this);
+    apiDestinationBuffer.indirectBufferInvalidated();
     if (sourceTexture.isDestroyed() || apiDestinationBuffer.isDestroyed())
         return;
 
@@ -1673,7 +1675,7 @@ bool CommandEncoder::validateClearBuffer(const Buffer& buffer, uint64_t offset, 
     return true;
 }
 
-void CommandEncoder::clearBuffer(const Buffer& buffer, uint64_t offset, uint64_t size)
+void CommandEncoder::clearBuffer(Buffer& buffer, uint64_t offset, uint64_t size)
 {
     // https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-clearbuffer
 
@@ -1697,6 +1699,7 @@ void CommandEncoder::clearBuffer(const Buffer& buffer, uint64_t offset, uint64_t
     }
 
     buffer.setCommandEncoder(*this);
+    buffer.indirectBufferInvalidated();
     auto range = NSMakeRange(static_cast<NSUInteger>(offset), static_cast<NSUInteger>(size));
     if (buffer.isDestroyed() || !size || NSMaxRange(range) > buffer.buffer().length)
         return;

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -135,6 +135,14 @@ public:
     id<MTLTexture> placeholderTexture(WGPUTextureFormat) const;
     bool isDestroyed() const;
     NSString *errorValidatingTextureCreation(const WGPUTextureDescriptor&, const Vector<WGPUTextureFormat>& viewFormats);
+    id<MTLBuffer> dispatchCallBuffer();
+    id<MTLComputePipelineState> dispatchCallPipelineState(id<MTLFunction>);
+    id<MTLRenderPipelineState> indexBufferClampPipeline(MTLIndexType, NSUInteger rasterSampleCount);
+    id<MTLRenderPipelineState> indexedIndirectBufferClampPipeline(NSUInteger rasterSampleCount);
+    id<MTLRenderPipelineState> indirectBufferClampPipeline(NSUInteger rasterSampleCount);
+    id<MTLRenderPipelineState> icbCommandClampPipeline(MTLIndexType, NSUInteger rasterSampleCount);
+    id<MTLRenderPipelineState> copyIndexIndirectArgsPipeline(NSUInteger rasterSampleCount);
+    id<MTLBuffer> safeCreateBuffer(NSUInteger length, MTLStorageMode, MTLCPUCacheMode = MTLCPUCacheModeDefaultCache, MTLHazardTrackingMode = MTLHazardTrackingModeDefault) const;
 
 private:
     Device(id<MTLDevice>, id<MTLCommandQueue> defaultQueue, HardwareCapabilities&&, Adapter&);
@@ -143,7 +151,6 @@ private:
     struct ErrorScope;
     ErrorScope* currentErrorScope(WGPUErrorFilter);
     std::optional<WGPUErrorType> validatePopErrorScope() const;
-    id<MTLBuffer> safeCreateBuffer(NSUInteger length, MTLStorageMode, MTLCPUCacheMode = MTLCPUCacheModeDefaultCache, MTLHazardTrackingMode = MTLHazardTrackingModeDefault) const;
     bool validateCreateIOSurfaceBackedTexture(const WGPUTextureDescriptor&, const Vector<WGPUTextureFormat>& viewFormats, IOSurfaceRef backing);
 
     bool validateRenderPipeline(const WGPURenderPipelineDescriptor&);
@@ -188,6 +195,27 @@ private:
     id<MTLBuffer> m_placeholderBuffer { nil };
     id<MTLTexture> m_placeholderTexture { nil };
     id<MTLTexture> m_placeholderDepthStencilTexture { nil };
+    id<MTLBuffer> m_dispatchCallBuffer { nil };
+    id<MTLComputePipelineState> m_dispatchCallPipelineState { nil };
+
+    id<MTLRenderPipelineState> m_indexBufferClampUintPSO { nil };
+    id<MTLRenderPipelineState> m_indexBufferClampUshortPSO { nil };
+    id<MTLRenderPipelineState> m_indexBufferClampUintPSOMS { nil };
+    id<MTLRenderPipelineState> m_indexBufferClampUshortPSOMS { nil };
+
+    id<MTLRenderPipelineState> m_indexedIndirectBufferClampPSO { nil };
+    id<MTLRenderPipelineState> m_indexedIndirectBufferClampPSOMS { nil };
+
+    id<MTLRenderPipelineState> m_indirectBufferClampPSO { nil };
+    id<MTLRenderPipelineState> m_indirectBufferClampPSOMS { nil };
+
+    id<MTLRenderPipelineState> m_icbCommandClampUintPSO { nil };
+    id<MTLRenderPipelineState> m_icbCommandClampUshortPSO { nil };
+    id<MTLRenderPipelineState> m_icbCommandClampUintPSOMS { nil };
+    id<MTLRenderPipelineState> m_icbCommandClampUshortPSOMS { nil };
+
+    id<MTLRenderPipelineState> m_copyIndexedIndirectArgsPSO { nil };
+    id<MTLRenderPipelineState> m_copyIndexedIndirectArgsPSOMS { nil };
 
     const Ref<Adapter> m_adapter;
 #if HAVE(COREVIDEO_METAL_SUPPORT)

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -178,7 +178,7 @@ NSString* errorValidatingBindGroup(const BindGroup& bindGroup, const BufferBindi
     for (const auto& resourceVector : bindGroup.resources()) {
         for (const auto& resource : resourceVector.resourceUsages) {
             auto bindingIndex = resource.binding;
-            auto* buffer = get_if<RefPtr<const Buffer>>(&resource.resource);
+            auto* buffer = get_if<RefPtr<Buffer>>(&resource.resource);
             if (!buffer)
                 continue;
 

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -102,6 +102,9 @@ public:
     static double quantizedDepthValue(double, WGPUTextureFormat);
     NSString* errorValidatingPipeline(const RenderPipeline&) const;
 
+    static std::pair<id<MTLBuffer>, uint64_t> clampIndirectIndexBufferToValidValues(Buffer*, const Buffer&, MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, Device&, uint32_t rasterSampleCount, id<MTLRenderCommandEncoder>);
+    static id<MTLBuffer> clampIndirectBufferToValidValues(const Buffer&, uint64_t indirectOffset, uint32_t minVertexCount, Device&, uint32_t rasterSampleCount, id<MTLRenderCommandEncoder>);
+
 private:
     RenderPassEncoder(id<MTLRenderCommandEncoder>, const WGPURenderPassDescriptor&, NSUInteger, bool depthReadOnly, bool stencilReadOnly, CommandEncoder&, id<MTLBuffer>, uint64_t maxDrawCount, Device&);
     RenderPassEncoder(CommandEncoder&, Device&, NSString*);
@@ -121,6 +124,10 @@ private:
     bool issuedDrawCall() const;
     void incrementDrawCount(uint32_t = 1);
     bool occlusionQueryIsDestroyed() const;
+    bool clampIndexBufferToValidValues(uint32_t indexCount, uint32_t instanceCount, int32_t baseVertex, uint32_t firstInstance, MTLIndexType, NSUInteger indexBufferOffsetInBytes);
+    uint32_t computeMininumVertexCount() const;
+    std::pair<id<MTLBuffer>, uint64_t> clampIndirectIndexBufferToValidValues(const Buffer&, MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount);
+    id<MTLBuffer> clampIndirectBufferToValidValues(const Buffer&, uint64_t indirectOffset, uint32_t minVertexCount);
 
     id<MTLRenderCommandEncoder> m_renderCommandEncoder { nil };
 
@@ -157,6 +164,7 @@ private:
     id<MTLBuffer> m_visibilityResultBuffer { nil };
     uint32_t m_renderTargetWidth { 0 };
     uint32_t m_renderTargetHeight { 0 };
+    uint32_t m_rasterSampleCount { 1 };
     NSMutableDictionary<NSNumber*, TextureAndClearColor*> *m_attachmentsToClear { nil };
     NSMutableDictionary<NSNumber*, TextureAndClearColor*> *m_allColorAttachments { nil };
     id<MTLTexture> m_depthStencilAttachmentToClear { nil };


### PR DESCRIPTION
#### e6d5e1a6604e5aa2b7786e3f40859274b6353c90
<pre>
[WebGPU] Index buffer can read outside the range of a vertex buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=273828">https://bugs.webkit.org/show_bug.cgi?id=273828</a>
&lt;radar://127672770&gt;

Reviewed by Tadeu Zagallo.

Prevent out of bounds accesses into vertex buffers via drawIndexed,
drawIndirect, and drawIndexedIndirect by running a non-rasterizing
vertex shader immedietly before the draw call.

ICB path rewrites the ICB render commands to avoid out of bounds
accesses.

* Source/WebGPU/WebGPU/BindableResource.h:
* Source/WebGPU/WebGPU/Buffer.h:
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::Buffer):
(WebGPU::Buffer::maxIndex const):
(WebGPU::Buffer::indirectBuffer const):
(WebGPU::Buffer::indirectIndexedBuffer const):
(WebGPU::Buffer::indirectBufferRequiresRecomputation const):
(WebGPU::Buffer::indirectBufferRecomputed):
(WebGPU::Buffer::indirectBufferInvalidated):
(WebGPU::Buffer::recomputeMaxIndexValues const): Deleted.
* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::copyBufferToBuffer):
(WebGPU::CommandEncoder::copyTextureToBuffer):
(WebGPU::CommandEncoder::clearBuffer):
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::addResourceToActiveResources):
(WebGPU::ComputePassEncoder::runPredispatchIndirectCallValidation):
(WebGPU::setCommandEncoder):
* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::GPUFrameCapture::captureFrame):
(WebGPU::Device::dispatchCallBuffer):
(WebGPU::Device::dispatchCallPipelineState):
(WebGPU::Device::copyIndexIndirectArgsPipeline):
(wgpuDeviceReference): Deleted.
(wgpuDeviceRelease): Deleted.
(wgpuDeviceCreateBindGroup): Deleted.
(wgpuDeviceCreateBindGroupLayout): Deleted.
(wgpuDeviceCreateBuffer): Deleted.
(wgpuDeviceCreateCommandEncoder): Deleted.
(wgpuDeviceCreateComputePipeline): Deleted.
(wgpuDeviceCreateComputePipelineAsync): Deleted.
(wgpuDeviceCreateComputePipelineAsyncWithBlock): Deleted.
(wgpuDeviceCreatePipelineLayout): Deleted.
(wgpuDeviceCreateQuerySet): Deleted.
(wgpuDeviceCreateRenderBundleEncoder): Deleted.
(wgpuDeviceCreateRenderPipeline): Deleted.
(wgpuDeviceCreateRenderPipelineAsync): Deleted.
(wgpuDeviceCreateRenderPipelineAsyncWithBlock): Deleted.
(wgpuDeviceCreateSampler): Deleted.
(wgpuDeviceImportExternalTexture): Deleted.
(wgpuDeviceCreateShaderModule): Deleted.
(wgpuDeviceCreateSwapChain): Deleted.
(wgpuDeviceCreateTexture): Deleted.
(wgpuDeviceDestroy): Deleted.
(wgpuDeviceEnumerateFeatures): Deleted.
(wgpuDeviceGetLimits): Deleted.
(wgpuDeviceGetQueue): Deleted.
(wgpuDeviceHasFeature): Deleted.
(wgpuDevicePopErrorScope): Deleted.
(wgpuDevicePopErrorScopeWithBlock): Deleted.
(wgpuDevicePushErrorScope): Deleted.
(wgpuDeviceSetDeviceLostCallback): Deleted.
(wgpuDeviceSetDeviceLostCallbackWithBlock): Deleted.
(wgpuDeviceSetUncapturedErrorCallback): Deleted.
(wgpuDeviceSetUncapturedErrorCallbackWithBlock): Deleted.
(wgpuDeviceSetLabel): Deleted.
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::validateBindGroup):
* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(-[RenderBundleICBWithResources initWithICB:containerBuffer:pipelineState:depthStencilState:cullMode:frontFace:depthClipMode:depthBias:depthBiasSlopeScale:depthBiasClamp:fragmentDynamicOffsetsBuffer:pipeline:]):
(-[RenderBundleICBWithResources minVertexCountForDrawCommand]):
(WebGPU::makeRenderBundleICBWithResources):
(WebGPU::RenderBundleEncoder::addResource):
(WebGPU::RenderBundleEncoder::computeMininumVertexCount const):
(WebGPU::RenderBundleEncoder::storeVertexBufferCountsForValidation):
(WebGPU::RenderBundleEncoder::drawIndexed):
(WebGPU::RenderBundleEncoder::drawIndexedIndirect):
(WebGPU::RenderBundleEncoder::drawIndirect):
(WebGPU::RenderBundleEncoder::endCurrentICB):
(WebGPU::RenderBundleEncoder::setIndexBuffer):
(WebGPU::RenderBundleEncoder::setVertexBuffer):
(-[RenderBundleICBWithResources initWithICB:pipelineState:depthStencilState:cullMode:frontFace:depthClipMode:depthBias:depthBiasSlopeScale:depthBiasClamp:fragmentDynamicOffsetsBuffer:pipeline:]): Deleted.
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::m_maxDrawCount):
(WebGPU::RenderPassEncoder::addResourceToActiveResources):
(WebGPU::RenderPassEncoder::computeMininumVertexCount const):
(WebGPU::RenderPassEncoder::clampIndexBufferToValidValues):
(WebGPU::RenderPassEncoder::clampIndirectIndexBufferToValidValues):
(WebGPU::RenderPassEncoder::clampIndirectBufferToValidValues):
(WebGPU::RenderPassEncoder::drawIndexed):
(WebGPU::RenderPassEncoder::drawIndexedIndirect):
(WebGPU::RenderPassEncoder::drawIndirect):
(WebGPU::RenderPassEncoder::setCommandEncoder):
(WebGPU::RenderPassEncoder::executeBundles):

Canonical link: <a href="https://commits.webkit.org/279182@main">https://commits.webkit.org/279182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d31c8d422953dc598f2a4ab57543081b717304e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5146 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55957 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3402 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42782 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2187 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29702 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45468 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23882 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26822 "4 new passes 11 flakes") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1561 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48714 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2918 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57549 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27816 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2917 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50177 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29040 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45605 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49448 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/table/basic (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11516 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29954 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28792 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->