### PR TITLE
[WebXR] WebXR tests crash with full GPU Process

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
@@ -56,6 +56,11 @@ struct WebXRAttachmentSet {
     T colorBuffer;
     T depthStencilBuffer;
 
+    operator bool() const
+    {
+        return colorBuffer; // Need colorBuffer at the minimum!
+    }
+
     void release(GraphicsContextGL& gl)
     {
         colorBuffer.release(gl);

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -269,14 +269,19 @@ struct FrameData {
         std::array<uint16_t, 2> framebufferSize;
         MachSendRight completionSyncEvent;
     };
+
+    struct ExternalTexture {
+        MachSendRight handle;
+        bool isSharedTexture;
+    };
 #endif
 
     struct LayerData {
 #if PLATFORM(COCOA)
         std::optional<LayerSetupData> layerSetup = { std::nullopt };
         uint64_t renderingFrameIndex { 0 };
-        std::tuple<MachSendRight, bool> colorTexture = { MachSendRight(), false };
-        std::tuple<MachSendRight, bool> depthStencilBuffer = { MachSendRight(), false };
+        ExternalTexture colorTexture = { MachSendRight(), false };
+        ExternalTexture depthStencilBuffer = { MachSendRight(), false };
 #else
         WebCore::IntSize framebufferSize;
         PlatformGLObject opaqueTexture { 0 };

--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -108,11 +108,13 @@ WebCore::IntSize SimulatedXRDevice::recommendedResolution(PlatformXR::SessionMod
 
 void SimulatedXRDevice::initializeTrackingAndRendering(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&)
 {
+#if !PLATFORM(COCOA)
     GraphicsContextGLAttributes attributes;
     attributes.depth = false;
     attributes.stencil = false;
     attributes.antialias = false;
     m_gl = createWebProcessGraphicsContextGL(attributes);
+#endif
 
     if (m_trackingAndRenderingClient) {
         // WebXR FakeDevice waits for simulateInputConnection calls to add input sources-
@@ -134,11 +136,13 @@ void SimulatedXRDevice::shutDownTrackingAndRendering()
     if (m_supportsShutdownNotification)
         simulateShutdownCompleted();
     stopTimer();
+#if !PLATFORM(COCOA)
     if (m_gl) {
         for (auto layer : m_layers)
             m_gl->deleteTexture(layer.value);
         m_gl = nullptr;
     }
+#endif
     m_layers.clear();
 }
 
@@ -155,9 +159,11 @@ void SimulatedXRDevice::frameTimerFired()
 
     for (auto& layer : m_layers) {
 #if PLATFORM(COCOA)
-        auto surface = IOSurface::create(nullptr, recommendedResolution(PlatformXR::SessionMode::ImmersiveVr), DestinationColorSpace::SRGB());
         data.layers.add(layer.key, PlatformXR::FrameData::LayerData {
-            .colorTexture = std::make_tuple(surface->createSendRight(), false)
+            .layerSetup = PlatformXR::FrameData::LayerSetupData {
+                .framebufferSize { static_cast<uint16_t>(layer.value.width()), static_cast<uint16_t>(layer.value.height()) }
+            },
+            .colorTexture = { MachSendRight(), false }
         });
 #else
         data.layers.add(layer.key, PlatformXR::FrameData::LayerData {
@@ -185,6 +191,12 @@ void SimulatedXRDevice::requestFrame(RequestFrameCallback&& callback)
 
 std::optional<PlatformXR::LayerHandle> SimulatedXRDevice::createLayerProjection(uint32_t width, uint32_t height, bool alpha)
 {
+#if PLATFORM(COCOA)
+    // TODO: Might need to pass the format type to WebXROpaqueFramebuffer to ensure alpha is handled correctly in tests.
+    UNUSED_PARAM(alpha);
+    PlatformXR::LayerHandle handle = ++m_layerIndex;
+    m_layers.add(handle, IntSize { static_cast<int>(width), static_cast<int>(height) });
+#else
     using GL = GraphicsContextGL;
     if (!m_gl)
         return std::nullopt;
@@ -200,15 +212,18 @@ std::optional<PlatformXR::LayerHandle> SimulatedXRDevice::createLayerProjection(
     m_gl->texImage2D(GL::TEXTURE_2D, 0, colorFormat, width, height, 0, colorFormat, GL::UNSIGNED_BYTE, 0);
 
     m_layers.add(handle, texture);
-    return handle;    
+#endif
+    return handle;
 }
 
 void SimulatedXRDevice::deleteLayer(PlatformXR::LayerHandle handle)
 {
     auto it = m_layers.find(handle);
     if (it != m_layers.end()) {
+#if !PLATFORM(COCOA)
         if (m_gl)
             m_gl->deleteTexture(it->value);
+#endif
         m_layers.remove(it);
     }
 }

--- a/Source/WebCore/testing/WebFakeXRDevice.h
+++ b/Source/WebCore/testing/WebFakeXRDevice.h
@@ -32,6 +32,7 @@
 #include "FakeXRBoundsPoint.h"
 #include "FakeXRInputSourceInit.h"
 #include "FakeXRViewInit.h"
+#include "IntSizeHash.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "PlatformXR.h"
 #include "Timer.h"
@@ -103,8 +104,12 @@ private:
     bool m_supportsShutdownNotification { false };
     Timer m_frameTimer;
     RequestFrameCallback m_FrameCallback;
-    RefPtr<WebCore::GraphicsContextGL> m_gl;
+#if PLATFORM(COCOA)
+    HashMap<PlatformXR::LayerHandle, WebCore::IntSize> m_layers;
+#else
     HashMap<PlatformXR::LayerHandle, PlatformGLObject> m_layers;
+    RefPtr<WebCore::GraphicsContextGL> m_gl;
+#endif
     uint32_t m_layerIndex { 0 };
     Vector<Ref<WebFakeXRInputController>> m_inputConnections;
 };

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -110,14 +110,19 @@ enum class PlatformXR::XRTargetRayMode : uint8_t {
     std::array<uint16_t, 2> framebufferSize;
     MachSendRight completionSyncEvent;
 };
+
+[Nested, RValue] struct PlatformXR::FrameData::ExternalTexture {
+    MachSendRight handle;
+    bool isSharedTexture;
+};
 #endif
 
 [Nested, RValue] struct PlatformXR::FrameData::LayerData {
 #if PLATFORM(COCOA)
     std::optional<PlatformXR::FrameData::LayerSetupData> layerSetup;
     uint64_t renderingFrameIndex;
-    std::tuple<MachSendRight, bool> colorTexture;
-    std::tuple<MachSendRight, bool> depthStencilBuffer;
+    PlatformXR::FrameData::ExternalTexture colorTexture;
+    PlatformXR::FrameData::ExternalTexture depthStencilBuffer;
 #else
     WebCore::IntSize framebufferSize;
     PlatformGLObject opaqueTexture;


### PR DESCRIPTION
#### e7ae0d2e886fadd38c4fc0cde13fc9da1b30f9f9
<pre>
[WebXR] WebXR tests crash with full GPU Process
<a href="https://bugs.webkit.org/show_bug.cgi?id=233913">https://bugs.webkit.org/show_bug.cgi?id=233913</a>
<a href="https://rdar.apple.com/86139280">rdar://86139280</a>

Reviewed by Mike Wyrzykowski.

Fix SimulatedXRDevice to work on Cocoa again.

SimulatedXRDevice had been patched to create a dummy IOSurface so the code would
compile but it was never tested. SimulatedXRDevice was written before GPU
process and was expecting to be able to create an OpenGL texture that could be
passed as WebXROpaqueFramebuffer&apos;s compositor texture.

Instead of using OpenGL, or IOSurface, for Cocoa we now create a temporary
renderbuffer to be used as the display color buffer, internal to
WebXROpaqueFramebuffer, if a null MachSendRight is received via
PlatformXR::FrameData::LayerData.

Fixed a logic error in WebXROpaqueFramebuffer::setupFramebuffer which was
causing the drawing attachments to never be allocated. This was causing the
checkFramebufferStatus in blitShared to fail.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::makeExternalImageSource):
(WebCore::createAndBindTempBuffer):
(WebCore::toIntSize):
(WebCore::WebXROpaqueFramebuffer::startFrame):
(WebCore::WebXROpaqueFramebuffer::setupFramebuffer):
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h:
(WebCore::WebXRAttachmentSet::operator bool const):
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::SimulatedXRDevice::initializeTrackingAndRendering):
(WebCore::SimulatedXRDevice::shutDownTrackingAndRendering):
(WebCore::SimulatedXRDevice::frameTimerFired):
(WebCore::SimulatedXRDevice::createLayerProjection):
(WebCore::SimulatedXRDevice::deleteLayer):
* Source/WebCore/testing/WebFakeXRDevice.h:
* Source/WebKit/Shared/XR/PlatformXR.serialization.in:

Canonical link: <a href="https://commits.webkit.org/278668@main">https://commits.webkit.org/278668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ccf4c91fa052937b1269efaddd10586773dca12

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51095 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3428 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54352 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1784 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53397 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1459 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41606 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53194 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28030 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44036 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22725 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25355 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1290 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9535 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47334 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55947 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26205 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1256 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49012 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27453 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44104 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48142 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28333 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7455 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27184 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->