### PR TITLE
[GCC] Unreviewed, build fix for Debian Stable after 278486@main

### DIFF
--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -1067,9 +1067,9 @@ void FastStringifier<CharType>::append(JSValue value)
             if (span.size() >= stride) {
                 using UnsignedType = std::make_unsigned_t<CharType>;
                 using BulkType = decltype(WTF::loadBulk(static_cast<const UnsignedType*>(nullptr)));
-                constexpr auto quoteMask = WTF::splatBulk(static_cast<UnsignedType>('"'));
-                constexpr auto escapeMask = WTF::splatBulk(static_cast<UnsignedType>('\\'));
-                constexpr auto controlMask = WTF::splatBulk(static_cast<UnsignedType>(' '));
+                const auto quoteMask = WTF::splatBulk(static_cast<UnsignedType>('"'));
+                const auto escapeMask = WTF::splatBulk(static_cast<UnsignedType>('\\'));
+                const auto controlMask = WTF::splatBulk(static_cast<UnsignedType>(' '));
                 const auto* ptr = span.data();
                 const auto* end = ptr + span.size();
                 auto* cursorEnd = cursor + span.size();
@@ -1082,8 +1082,8 @@ void FastStringifier<CharType>::append(JSValue value)
                     auto controls = WTF::lessThanBulk(input, controlMask);
                     accumulated = WTF::mergeBulk(accumulated, WTF::mergeBulk(quotes, WTF::mergeBulk(escapes, controls)));
                     if constexpr (sizeof(CharType) != 1) {
-                        constexpr auto surrogateMask = WTF::splatBulk(static_cast<UnsignedType>(0xf800));
-                        constexpr auto surrogateCheckMask = WTF::splatBulk(static_cast<UnsignedType>(0xd800));
+                        const auto surrogateMask = WTF::splatBulk(static_cast<UnsignedType>(0xf800));
+                        const auto surrogateCheckMask = WTF::splatBulk(static_cast<UnsignedType>(0xd800));
                         accumulated = WTF::mergeBulk(accumulated, WTF::equalBulk(simde_vandq_u16(input, surrogateMask), surrogateCheckMask));
                     }
                 }
@@ -1095,8 +1095,8 @@ void FastStringifier<CharType>::append(JSValue value)
                     auto controls = WTF::lessThanBulk(input, controlMask);
                     accumulated = WTF::mergeBulk(accumulated, WTF::mergeBulk(quotes, WTF::mergeBulk(escapes, controls)));
                     if constexpr (sizeof(CharType) != 1) {
-                        constexpr auto surrogateMask = WTF::splatBulk(static_cast<UnsignedType>(0xf800));
-                        constexpr auto surrogateCheckMask = WTF::splatBulk(static_cast<UnsignedType>(0xd800));
+                        const auto surrogateMask = WTF::splatBulk(static_cast<UnsignedType>(0xf800));
+                        const auto surrogateCheckMask = WTF::splatBulk(static_cast<UnsignedType>(0xd800));
                         accumulated = WTF::mergeBulk(accumulated, WTF::equalBulk(simde_vandq_u16(input, surrogateMask), surrogateCheckMask));
                     }
                 }
@@ -1121,10 +1121,10 @@ void FastStringifier<CharType>::append(JSValue value)
             if (span.size() >= stride) {
                 using UnsignedType = std::make_unsigned_t<LChar>;
                 using BulkType = decltype(WTF::loadBulk(static_cast<const UnsignedType*>(nullptr)));
-                constexpr auto quoteMask = WTF::splatBulk(static_cast<UnsignedType>('"'));
-                constexpr auto escapeMask = WTF::splatBulk(static_cast<UnsignedType>('\\'));
-                constexpr auto controlMask = WTF::splatBulk(static_cast<UnsignedType>(' '));
-                constexpr auto zeros = WTF::splatBulk(static_cast<UnsignedType>(0));
+                const auto quoteMask = WTF::splatBulk(static_cast<UnsignedType>('"'));
+                const auto escapeMask = WTF::splatBulk(static_cast<UnsignedType>('\\'));
+                const auto controlMask = WTF::splatBulk(static_cast<UnsignedType>(' '));
+                const auto zeros = WTF::splatBulk(static_cast<UnsignedType>(0));
                 const auto* ptr = span.data();
                 const auto* end = ptr + span.size();
                 auto* cursorEnd = cursor + span.size();


### PR DESCRIPTION
#### 1ee00a2309c03ed119e8591022ba14f936440d71
<pre>
[GCC] Unreviewed, build fix for Debian Stable after 278486@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=273852">https://bugs.webkit.org/show_bug.cgi?id=273852</a>

Internal compiler error: unexpected expression _static_cast&lt;UnsignedType&gt;(&apos;\&quot;&apos;)_ of kind static_cast_expr.

Replace &apos;constexpr&apos; for &apos;const&apos;.

* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::FastStringifier&lt;CharType&gt;::append):

Canonical link: <a href="https://commits.webkit.org/278511@main">https://commits.webkit.org/278511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f79a0230ecaf33ab7296cb4f6a7e874d58d6646

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50781 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54040 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1472 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36373 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1122 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41375 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52880 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43748 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22503 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25099 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1004 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9222 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/44117 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47080 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1066 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55630 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/50284 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48783 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27140 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/43838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47861 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28008 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57759 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7352 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26872 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11897 "Passed tests") | 
<!--EWS-Status-Bubble-End-->