### PR TITLE
Web Inspector: Improve selectors to change title area height

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/Variables.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Variables.css
@@ -423,15 +423,13 @@ body {
             --border-color-secondary: hsl(0, 0%, 24%);
         }
     }
-    
-    &:is(.mac-platform):not(.mac-platform.monterey, .mac-platform.big-sur):not(.docked) {
-        /* keep in sync with `WI.undockedTitleAreaHeight` */
-        --undocked-title-area-height: calc(22px / var(--zoom-factor));
-    }
 
     &:is(.mac-platform.monterey, .mac-platform.big-sur):not(.docked) {
-        /* keep in sync with `WI.undockedTitleAreaHeight` */
         --undocked-title-area-height: calc(27px / var(--zoom-factor));
+    }
+
+    &:is(.mac-platform.catalina):not(.docked) {
+        --undocked-title-area-height: calc(22px / var(--zoom-factor));
     }
 
     &.mac-platform {


### PR DESCRIPTION
#### 2cc44d12c344312c06dcf55fbdd8db7ada26cbd2
<pre>
Web Inspector: Improve selectors to change title area height
<a href="https://bugs.webkit.org/show_bug.cgi?id=255585">https://bugs.webkit.org/show_bug.cgi?id=255585</a>

Reviewed by Devin Rousso.

Use only :is selectors to match MacOS and apply the non-zero title area
height. The conditions expressed this way in CSS are easier to reason
about when comparing them to the WI.undockedTitleAreaHeight() function.

Improvement suggested by Devin Rousso.

* Source/WebInspectorUI/UserInterface/Views/Variables.css:
(&amp;:is(.mac-platform.monterey, .mac-platform.big-sur):not(.docked)):
(&amp;:is(.mac-platform.catalina):not(.docked)):
(&amp;:is(.mac-platform):not(.mac-platform.monterey, .mac-platform.big-sur):not(.docked)): Deleted.

Canonical link: <a href="https://commits.webkit.org/278552@main">https://commits.webkit.org/278552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5a5d170ccc1d70ee7e8e876b4717db93418b76b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50945 "Failed to checkout and rebase branch from PR 28287") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54203 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/1635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1298 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53044 "Failed to checkout and rebase branch from PR 28287") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/27886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/43892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/22613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/1148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9385 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/1219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55797 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/26052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1113 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27304 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/43963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28182 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7383 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27035 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->