### PR TITLE
[Skia][Nicosia] Use a content layer for the canvas when accelerated

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1498,6 +1498,7 @@ http/tests/security/contentSecurityPolicy/report-only-from-header.py [ DumpJSCon
 webkit.org/b/272582 fast/canvas/canvas-strokePath-gradient-shadow.html [ Failure ]
 webkit.org/b/272582 fast/canvas/canvas-strokeRect-alpha-shadow.html [ Failure ]
 webkit.org/b/272582 fast/canvas/canvas-strokeRect-gradient-shadow.html [ Failure ]
+webkit.org/b/274513 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-canvas.html [ ImageOnlyFailure ]
 
 webkit.org/b/273239 fast/canvas/canvas-scale-shadowBlur.html [ Failure ]
 webkit.org/b/273239 imported/w3c/web-platform-tests/html/canvas/element/shadows/2d.shadow.composite.1.html [ Failure ]

--- a/LayoutTests/platform/glib/compositing/canvas/accelerated-canvas-compositing-expected.txt
+++ b/LayoutTests/platform/glib/compositing/canvas/accelerated-canvas-compositing-expected.txt
@@ -11,7 +11,6 @@ Tests whether an accelerated canvas creates a compositing layer.
         (GraphicsLayer
           (position 8.00 50.00)
           (bounds 174.00 131.00)
-          (drawsContent 1)
         )
       )
     )

--- a/LayoutTests/platform/glib/compositing/canvas/accelerated-canvas-compositing-size-limit-expected.txt
+++ b/LayoutTests/platform/glib/compositing/canvas/accelerated-canvas-compositing-size-limit-expected.txt
@@ -14,28 +14,23 @@ Verifies Canvas 2D Context accelerated backing store behavior.
           (position 112.00 94.00)
           (anchor 0.50 0.49)
           (bounds 100.00 57.00)
-          (drawsContent 1)
         )
         (GraphicsLayer
           (position 216.00 94.00)
           (anchor 0.50 0.49)
           (bounds 100.00 57.00)
-          (drawsContent 1)
         )
         (GraphicsLayer
           (position 320.00 94.00)
           (bounds 100.00 56.00)
-          (drawsContent 1)
         )
         (GraphicsLayer
           (position 424.00 94.00)
           (bounds 100.00 56.00)
-          (drawsContent 1)
         )
         (GraphicsLayer
           (position 528.00 96.00)
           (bounds 100.00 54.00)
-          (drawsContent 1)
         )
         (GraphicsLayer
           (position 632.00 112.00)

--- a/LayoutTests/platform/glib/compositing/layer-creation/compositing-policy-expected.txt
+++ b/LayoutTests/platform/glib/compositing/layer-creation/compositing-policy-expected.txt
@@ -1,0 +1,34 @@
+transform: translate3d(10px, 1px, 1px)
+Has backing under low memory.
+transform: translateZ(0)
+translateZ(0): No backing under low memory.
+transform: translate3d(10px, 1px, 0)
+No backing under low memory.
+will-change: transform
+No backing under low memory.
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 1018.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 1018.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (offsetFromRenderer width=-14 height=-14)
+          (position 4.00 478.00)
+          (bounds 336.00 136.00)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (position 18.00 10.00)
+          (bounds 308.00 108.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+          (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [10.00 1.00 1.00 1.00])
+        )
+      )
+    )
+  )
+)
+

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -176,6 +176,8 @@ private:
 
     bool isGPUBased() const;
 
+    bool shouldNotifyRendererOnDidDraw() const;
+
     void refCanvasBase() const final { HTMLElement::ref(); }
     void derefCanvasBase() const final { HTMLElement::deref(); }
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -27,6 +27,7 @@
 
 #include "CanvasBase.h"
 #include "GraphicsLayerContentsDisplayDelegate.h"
+#include "ImageBuffer.h"
 #include "ScriptWrappable.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -262,6 +262,13 @@ bool CanvasRenderingContext2DBase::isAccelerated() const
 #endif
 }
 
+RefPtr<GraphicsLayerContentsDisplayDelegate> CanvasRenderingContext2DBase::layerContentsDisplayDelegate()
+{
+    if (auto buffer = canvasBase().buffer())
+        return buffer->layerContentsDisplayDelegate();
+    return nullptr;
+}
+
 bool CanvasRenderingContext2DBase::hasDeferredOperations() const
 {
     // At the time of writing, any draw might linger in IPC buffer or queue of the underlying graphics system, like with Accelerated

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -457,6 +457,8 @@ private:
 
     bool isAccelerated() const override;
 
+    RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() override;
+
     bool hasDeferredOperations() const final;
     void flushDeferredOperations() final;
 

--- a/Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.h
@@ -26,13 +26,13 @@
 #pragma once
 
 #include "GraphicsLayer.h"
-#include "ImageBuffer.h"
 #include <wtf/RefCounted.h>
 
 #if !USE(CA)
 #include "PlatformLayer.h"
 #endif
 namespace WebCore {
+class ImageBuffer;
 #if USE(CA)
 class PlatformCALayer;
 #endif

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -395,6 +395,13 @@ RefPtr<cairo_surface_t> ImageBuffer::createCairoSurface()
 }
 #endif
 
+RefPtr<GraphicsLayerContentsDisplayDelegate> ImageBuffer::layerContentsDisplayDelegate()
+{
+    if (auto* backend = ensureBackend())
+        return backend->layerContentsDisplayDelegate();
+    return nullptr;
+}
+
 RefPtr<NativeImage> ImageBuffer::sinkIntoNativeImage(RefPtr<ImageBuffer> source)
 {
     if (!source)

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -186,6 +186,8 @@ public:
     WEBCORE_EXPORT virtual std::optional<DynamicContentScalingDisplayList> dynamicContentScalingDisplayList();
 #endif
 
+    RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate();
+
     // Returns NativeImage of the current drawing results. Results in an immutable copy of the current back buffer.
     // Caller is responsible for ensuring that the passed reference is the only reference to the ImageBuffer.
     // Has better performance than:

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -28,6 +28,7 @@
 #include "CopyImageOptions.h"
 #include "DestinationColorSpace.h"
 #include "FloatRect.h"
+#include "GraphicsLayerContentsDisplayDelegate.h"
 #include "GraphicsTypesGL.h"
 #include "ImageBufferAllocator.h"
 #include "ImageBufferBackendParameters.h"
@@ -150,6 +151,8 @@ public:
     virtual void ensureNativeImagesHaveCopiedBackingStore() { }
 
     virtual ImageBufferBackendSharing* toBackendSharing() { return nullptr; }
+
+    virtual RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() const { return nullptr; }
 
     const Parameters& parameters() { return m_parameters; }
 

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.h
@@ -30,6 +30,10 @@
 #include "ImageBufferPipe.h"
 #include "NicosiaContentLayer.h"
 
+namespace WebCore {
+class NativeImage;
+}
+
 namespace Nicosia {
 
 class NicosiaImageBufferPipeSourceDisplayDelegate final : public WebCore::GraphicsLayerContentsDisplayDelegate {

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -39,6 +39,18 @@
 #include <skia/gpu/gl/GrGLTypes.h>
 #include <wtf/IsoMallocInlines.h>
 
+#if USE(NICOSIA)
+#include "BitmapTexture.h"
+#include "GLFence.h"
+#include "PlatformLayerDisplayDelegate.h"
+#include "TextureMapperFlags.h"
+#include "TextureMapperPlatformLayerBuffer.h"
+#include "TextureMapperPlatformLayerProxyGL.h"
+#include <skia/gpu/GrBackendSurface.h>
+#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
+#include <skia/gpu/ganesh/gl/GrGLDirectContext.h>
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(ImageBufferSkiaAcceleratedBackend);
@@ -71,9 +83,28 @@ std::unique_ptr<ImageBufferSkiaAcceleratedBackend> ImageBufferSkiaAcceleratedBac
 ImageBufferSkiaAcceleratedBackend::ImageBufferSkiaAcceleratedBackend(const Parameters& parameters, sk_sp<SkSurface>&& surface)
     : ImageBufferSkiaSurfaceBackend(parameters, WTFMove(surface), RenderingMode::Accelerated)
 {
+#if USE(NICOSIA)
+    // Use a content layer for canvas.
+    if (parameters.purpose == RenderingPurpose::Canvas) {
+        m_contentLayer = Nicosia::ContentLayer::create(*this, adoptRef(*new TextureMapperPlatformLayerProxyGL(TextureMapperPlatformLayerProxy::ContentType::Canvas)));
+        m_layerContentsDisplayDelegate = PlatformLayerDisplayDelegate::create(m_contentLayer.get());
+    }
+#endif
 }
 
-ImageBufferSkiaAcceleratedBackend::~ImageBufferSkiaAcceleratedBackend() = default;
+ImageBufferSkiaAcceleratedBackend::~ImageBufferSkiaAcceleratedBackend()
+{
+#if USE(NICOSIA)
+    if (m_texture.back || m_texture.front) {
+        GLContext::ScopedGLContextCurrent scopedContext(*PlatformDisplay::sharedDisplayForCompositing().sharingGLContext());
+        m_texture.back = nullptr;
+        m_texture.front = nullptr;
+    }
+
+    if (m_contentLayer)
+        m_contentLayer->invalidateClient();
+#endif
+}
 
 RefPtr<NativeImage> ImageBufferSkiaAcceleratedBackend::copyNativeImage()
 {
@@ -111,6 +142,57 @@ void ImageBufferSkiaAcceleratedBackend::putPixelBuffer(const PixelBuffer& pixelB
     SkPixmap pixmap(info, pixels, info.minRowBytes64());
     m_surface->writePixels(pixmap, 0, 0);
 }
+
+#if USE(NICOSIA)
+RefPtr<GraphicsLayerContentsDisplayDelegate> ImageBufferSkiaAcceleratedBackend::layerContentsDisplayDelegate() const
+{
+    return m_layerContentsDisplayDelegate;
+}
+
+void ImageBufferSkiaAcceleratedBackend::swapBuffersIfNeeded()
+{
+    auto& display = PlatformDisplay::sharedDisplayForCompositing();
+    if (!display.skiaGLContext()->makeContextCurrent())
+        return;
+
+    RELEASE_ASSERT(m_contentLayer);
+
+    auto* grContext = display.skiaGrContext();
+    RELEASE_ASSERT(grContext);
+    grContext->flushAndSubmit(m_surface.get(), GLFence::isSupported() ? GrSyncCpu::kNo : GrSyncCpu::kYes);
+
+    auto texture = SkSurfaces::GetBackendTexture(m_surface.get(), SkSurface::BackendHandleAccess::kFlushRead);
+    ASSERT(texture.isValid());
+    GrGLTextureInfo textureInfo;
+    bool retrievedTextureInfo = GrBackendTextures::GetGLTextureInfo(texture, &textureInfo);
+    ASSERT_UNUSED(retrievedTextureInfo, retrievedTextureInfo);
+    std::unique_ptr<GLFence> fence = GLFence::create();
+
+    // Switch to the sharing context for the texture copy.
+    if (!display.sharingGLContext()->makeContextCurrent())
+        return;
+
+    auto info = m_surface->imageInfo();
+    IntSize textureSize(info.width(), info.height());
+    if (!m_texture.back)
+        m_texture.back = BitmapTexture::create(textureSize, BitmapTexture::Flags::SupportsAlpha);
+    fence->wait(GLFence::FlushCommands::No);
+    m_texture.back->copyFromExternalTexture(textureInfo.fID);
+    fence = GLFence::create();
+    std::swap(m_texture.back, m_texture.front);
+
+    if (!display.skiaGLContext()->makeContextCurrent())
+        return;
+
+    auto& proxy = m_contentLayer->proxy();
+    Locker locker { proxy.lock() };
+    auto layerBuffer = makeUnique<TextureMapperPlatformLayerBuffer>(m_texture.front->id(), textureSize, TextureMapperFlags::ShouldBlend, GL_DONT_CARE);
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    layerBuffer->setFence(WTFMove(fence));
+#endif
+    downcast<TextureMapperPlatformLayerProxyGL>(proxy).pushNextBuffer(WTFMove(layerBuffer));
+}
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
@@ -31,9 +31,19 @@
 #include "ImageBufferSkiaSurfaceBackend.h"
 #include <wtf/IsoMalloc.h>
 
+#if USE(NICOSIA)
+#include "NicosiaContentLayer.h"
+#endif
+
 namespace WebCore {
 
-class ImageBufferSkiaAcceleratedBackend final : public ImageBufferSkiaSurfaceBackend {
+class BitmapTexture;
+
+class ImageBufferSkiaAcceleratedBackend final : public ImageBufferSkiaSurfaceBackend
+#if USE(NICOSIA)
+    , public Nicosia::ContentLayer::Client
+#endif
+{
     WTF_MAKE_ISO_ALLOCATED(ImageBufferSkiaAcceleratedBackend);
     WTF_MAKE_NONCOPYABLE(ImageBufferSkiaAcceleratedBackend);
 public:
@@ -50,6 +60,18 @@ private:
 
     void getPixelBuffer(const IntRect&, PixelBuffer&) final;
     void putPixelBuffer(const PixelBuffer&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat) final;
+
+#if USE(NICOSIA)
+    RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() const final;
+    void swapBuffersIfNeeded() final;
+
+    RefPtr<Nicosia::ContentLayer> m_contentLayer;
+    RefPtr<GraphicsLayerContentsDisplayDelegate> m_layerContentsDisplayDelegate;
+    struct {
+        RefPtr<BitmapTexture> back;
+        RefPtr<BitmapTexture> front;
+    } m_texture;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxy.h
@@ -43,7 +43,8 @@ public:
         WebGL,
         Video,
         OffscreenCanvas,
-        HolePunch
+        HolePunch,
+        Canvas
     };
 
     class Compositor {

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.cpp
@@ -134,10 +134,15 @@ void TextureMapperPlatformLayerProxyGL::pushNextBuffer(std::unique_ptr<TextureMa
     m_wasBufferDropped = false;
 
 #if HAVE(DISPLAY_LINK)
-    // WebGL changes will cause a composition request during layerFlush. We cannot request
+    // WebGL and Canvas changes will cause a composition request during layerFlush. We cannot request
     // a new compostion here as well or we may trigger two compositions instead of one.
-    if (contentType() == ContentType::WebGL)
+    switch (contentType()) {
+    case ContentType::WebGL:
+    case ContentType::Canvas:
         return;
+    default:
+        break;
+    }
 #endif
 
     if (m_compositor)

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -122,6 +122,10 @@ CanvasCompositingStrategy canvasCompositingStrategy(const RenderObject& renderer
     if (context->isGPUBased())
         return CanvasAsLayerContents;
 
+#if USE(SKIA) && USE(NICOSIA)
+    return CanvasAsLayerContents;
+#endif
+
     return CanvasPaintedToLayer; // On Mac and iOS we paint accelerated canvases into their layers.
 }
 


### PR DESCRIPTION
#### 351014754186c3c53d6374f48b24bf07cb007168
<pre>
[Skia][Nicosia] Use a content layer for the canvas when accelerated
<a href="https://bugs.webkit.org/show_bug.cgi?id=273873">https://bugs.webkit.org/show_bug.cgi?id=273873</a>

Reviewed by Miguel Gomez.

When canvas is accelerated we can pass the canvas texture to the
compositor without having to render it into the layer.

* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::shouldNotifyRendererOnDidDraw const):
(WebCore::HTMLCanvasElement::didDraw):
(WebCore::HTMLCanvasElement::paintsIntoCanvasBuffer const):
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::layerContentsDisplayDelegate):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.h:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::layerContentsDisplayDelegate):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::layerContentsDisplayDelegate const):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::ImageBufferSkiaAcceleratedBackend):
(WebCore::ImageBufferSkiaAcceleratedBackend::~ImageBufferSkiaAcceleratedBackend):
(WebCore::ImageBufferSkiaAcceleratedBackend::layerContentsDisplayDelegate const):
(WebCore::ImageBufferSkiaAcceleratedBackend::swapBuffersIfNeeded):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxy.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.cpp:
(WebCore::TextureMapperPlatformLayerProxyGL::pushNextBuffer):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::canvasCompositingStrategy):

Canonical link: <a href="https://commits.webkit.org/279254@main">https://commits.webkit.org/279254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11e1db1f5fcb0ca89aa27a5ad04e9f87044de2cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52781 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32118 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5267 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56059 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3504 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55086 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3227 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42847 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2261 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29835 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23961 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26927 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2875 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1663 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48802 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3028 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57651 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27921 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3017 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50241 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29142 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45754 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49519 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30058 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7774 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28895 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->