### PR TITLE
WASM tail calls should work in OMG tier

### DIFF
--- a/JSTests/wasm.yaml
+++ b/JSTests/wasm.yaml
@@ -64,7 +64,7 @@
 - path: wasm/threads-spec-tests
   cmd: runWebAssemblyThreadsSpecTest :normal
 - path: wasm/tail-call-spec-tests
-  cmd: skip
+  cmd: runWebAssemblyTailCallSpecTest :normal
 - path: wasm/extended-const-spec-tests
   cmd: runWebAssemblyExtendedConstSpecTest :normal
 

--- a/JSTests/wasm/stress/cc-int-to-int-tail-call.js
+++ b/JSTests/wasm/stress/cc-int-to-int-tail-call.js
@@ -1,5 +1,6 @@
 //@ skip
-//@ requireOptions("--useInterpretedJSEntryWrappers=1", "--useWebAssemblyTailCalls=1")
+//@ requireOptions("--useIPIntWrappers=1", "--useWebAssemblyTailCalls=true", "--maximumWebAssemblyCalleeSIzeForInlining=0")
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-tail-call-simple.js
+++ b/JSTests/wasm/stress/simd-tail-call-simple.js
@@ -1,0 +1,71 @@
+//@ requireOptions("--useWebAssemblyTailCalls=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func $call_same_size (export "call_same_size") (param f64) (param f64) (result i64)
+      (f32.const 1337) (f32x4.splat)
+      (return_call $callee_same_size))
+    (func $callee_same_size (param $i v128) (result i64)
+      (i64.add (i64.trunc_f32_s (f32x4.extract_lane 3 (local.get $i))) (i64.const 42)))
+    (func $call_same_size_with_stack (export "call_same_size_with_stack") (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (result i64)
+      (f32.const 1337) (f32x4.splat)
+      (f32.const 1) (f32x4.splat)
+      (f32.const 2) (f32x4.splat)
+      (f32.const 3) (f32x4.splat)
+      (f32.const 4) (f32x4.splat)
+      (f32.const 5) (f32x4.splat)
+      (f32.const 6) (f32x4.splat)
+      (f32.const 7) (f32x4.splat)
+      (f32.const 8)
+      (f32.const 9) (f32x4.splat)
+      (return_call $callee_same_size_with_stack))
+    (func $callee_same_size_with_stack (param $i0 v128) (param $i1 v128) (param $i2 v128) (param $i3 v128) (param $i4 v128) (param $i5 v128) (param $i6 v128) (param $i7 v128) (param $i8 f32) (param $i9 v128) (result i64)
+      (i64.add (i64.trunc_f32_s (f32x4.extract_lane 3 (local.get $i9))) (i64.trunc_f32_s (local.get $i8))))
+    
+    (func $call_bigger_with_stack (export "call_bigger_with_stack") (result i64)
+      (f32.const 1337) (f32x4.splat)
+      (f32.const 1) (f32x4.splat)
+      (f32.const 2) (f32x4.splat)
+      (f32.const 3) (f32x4.splat)
+      (f32.const 4) (f32x4.splat)
+      (f32.const 5) (f32x4.splat)
+      (f32.const 6) (f32x4.splat)
+      (f32.const 7) (f32x4.splat)
+      (f32.const 8)
+      (f32.const 90) (f32x4.splat)
+      (return_call $callee_bigger_with_stack))
+    (func $callee_bigger_with_stack (param $i0 v128) (param $i1 v128) (param $i2 v128) (param $i3 v128) (param $i4 v128) (param $i5 v128) (param $i6 v128) (param $i7 v128) (param $i8 f32) (param $i9 v128) (result i64)
+      (i64.add (i64.trunc_f32_s (f32x4.extract_lane 3 (local.get $i9))) (i64.trunc_f32_s (local.get $i8))))
+    (func $call_smaller_with_stack (export "call_smaller_with_stack") (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64) (param f64)  (param f64) (param f64) (param f64) (param f64)  (param $i11 f32) (result i64)
+      (f32.const 1337) (f32x4.splat)
+      (f32.const 1) (f32x4.splat)
+      (f32.const 2) (f32x4.splat)
+      (f32.const 3) (f32x4.splat)
+      (f32.const 4) (f32x4.splat)
+      (f32.const 5) (f32x4.splat)
+      (f32.const 6) (f32x4.splat)
+      (f32.const 7) (f32x4.splat)
+      (f32.const 8)
+      (f32.const 90) (f32x4.splat)
+      (return_call $callee_smaller_with_stack))
+    (func $callee_smaller_with_stack (param $i0 v128) (param $i1 v128) (param $i2 v128) (param $i3 v128) (param $i4 v128) (param $i5 v128) (param $i6 v128) (param $i7 v128) (param $i8 f32) (param $i9 v128) (result i64)
+      (i64.add (i64.trunc_f32_s (f32x4.extract_lane 3 (local.get $i9))) (i64.trunc_f32_s (local.get $i8))))
+  )
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true, tail_call: true, exceptions: true })
+    const { call_same_size, call_same_size_with_stack, call_bigger_with_stack, call_smaller_with_stack } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(call_same_size(), 1337n + 42n)
+        assert.eq(call_same_size_with_stack(), 9n + 8n)
+        assert.eq(call_bigger_with_stack(), 90n + 8n)
+        assert.eq(call_smaller_with_stack(), 90n + 8n)
+    }
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-tail-calls-throw.js
+++ b/JSTests/wasm/stress/simd-tail-calls-throw.js
@@ -1,5 +1,5 @@
-//@ requireOptions("--useWebAssemblySIMD=1","--useWebAssemblyTailCalls=1")
-//@ skip
+//@ requireOptions("--useWebAssemblyTailCalls=true", "--maximumWebAssemblyCalleeSIzeForInlining=0")
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/tail-call-double.js
+++ b/JSTests/wasm/stress/tail-call-double.js
@@ -1,0 +1,71 @@
+//@ requireOptions("--useWebAssemblyTailCalls=true", "--maximumWebAssemblyCalleeSIzeForInlining=0")
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (import "m" "callee_same_size" (func $callee_same_size (param $i f64) (result i64)))
+    (import "m" "callee_same_size_with_stack" (func $callee_same_size_with_stack (param $i0 f64) (param $i1 f64) (param $i2 f64) (param $i3 f64) (param $i4 f64) (param $i5 f64) (param $i6 f64) (param $i7 f64) (param $i8 f64) (param $i9 f64) (result i64)))
+    (import "m" "callee_bigger_with_stack" (func $callee_bigger_with_stack (param $i0 f64) (param $i1 f64) (param $i2 f64) (param $i3 f64) (param $i4 f64) (param $i5 f64) (param $i6 f64) (param $i7 f64) (param $i8 f64) (param $i9 f64) (result i64)))
+    (import "m" "callee_smaller_with_stack" (func $callee_smaller_with_stack (param $i0 f64) (param $i1 f64) (param $i2 f64) (param $i3 f64) (param $i4 f64) (param $i5 f64) (param $i6 f64) (param $i7 f64) (param $i8 f64) (param $i9 f64) (result i64)))
+    (func $call_same_size (export "call_same_size") (result i64)
+      (f64.const 1337)
+      (return_call $callee_same_size))
+    (func $call_same_size_with_stack (export "call_same_size_with_stack") (param $i0 f64) (param $i1 f64) (param $i2 f64) (param $i3 f64) (param $i4 f64) (param $i5 f64) (param $i6 f64) (param $i7 f64) (param $i8 f64) (param $i9 f64) (result i64)
+      (f64.const 1337)
+      (f64.const 1)
+      (f64.const 2)
+      (f64.const 3)
+      (f64.const 4)
+      (f64.const 5)
+      (f64.const 6)
+      (f64.const 7)
+      (f64.const 8)
+      (f64.const 9)
+      (return_call $callee_same_size_with_stack))
+    (func $call_bigger_with_stack (export "call_bigger_with_stack") (result i64)
+      (f64.const 1337)
+      (f64.const 1)
+      (f64.const 2)
+      (f64.const 3)
+      (f64.const 4)
+      (f64.const 5)
+      (f64.const 6)
+      (f64.const 7)
+      (f64.const 8)
+      (f64.const 90)
+      (return_call $callee_bigger_with_stack))
+    (func $call_smaller_with_stack (export "call_smaller_with_stack") (param $i0 f64) (param $i1 f64) (param $i2 f64) (param $i3 f64) (param $i4 f64) (param $i5 f64) (param $i6 f64) (param $i7 f64) (param $i8 f64) (param $i9 f64) (param $i10 f64) (param $i11 f64) (result i64)
+      (f64.const 1337)
+      (f64.const 1)
+      (f64.const 2)
+      (f64.const 3)
+      (f64.const 4)
+      (f64.const 5)
+      (f64.const 6)
+      (f64.const 7)
+      (f64.const 8)
+      (f64.const 90)
+      (return_call $callee_smaller_with_stack))
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, { m: {
+      callee_same_size: (i) => { return BigInt(i) + 42n },
+      callee_same_size_with_stack: (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9) => { return BigInt(i9) + BigInt(i2) },
+      callee_bigger_with_stack: (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11) => { return BigInt(i9) + BigInt(i2) },
+      callee_smaller_with_stack: (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9) => { return BigInt(i9) + BigInt(i2) },
+    } }, { simd: true, tail_call: true, exceptions: true })
+    const { call_same_size, call_same_size_with_stack, call_bigger_with_stack, call_smaller_with_stack } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(call_same_size(), 1337n + 42n)
+        assert.eq(call_same_size_with_stack(), 9n + 2n)
+        assert.eq(call_same_size_with_stack(1.5, 2.5, 3.0, 4.0, 5.0, 6.0, 7.5, -8.5, -9.5, -10.5), 9n + 2n)
+        assert.eq(call_bigger_with_stack(), 90n + 2n)
+        assert.eq(call_smaller_with_stack(), 90n + 2n)
+    }
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/tail-call-js-inline.js
+++ b/JSTests/wasm/stress/tail-call-js-inline.js
@@ -1,0 +1,70 @@
+//@ requireOptions("--useWebAssemblyTailCalls=true")
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (import "m" "callee_same_size" (func $callee_same_size (param $i f32) (result i64)))
+    (import "m" "callee_same_size_with_stack" (func $callee_same_size_with_stack (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (result i64)))
+    (import "m" "callee_bigger_with_stack" (func $callee_bigger_with_stack (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (result i64)))
+    (import "m" "callee_smaller_with_stack" (func $callee_smaller_with_stack (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (result i64)))
+    (func $call_same_size (export "call_same_size") (result i64)
+      (f32.const 1337)
+      (return_call $callee_same_size))
+    (func $call_same_size_with_stack (export "call_same_size_with_stack") (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (result i64)
+      (f32.const 1337)
+      (f32.const 1)
+      (f32.const 2)
+      (f32.const 3)
+      (f32.const 4)
+      (f32.const 5)
+      (f32.const 6)
+      (f32.const 7)
+      (f32.const 8)
+      (f32.const 9)
+      (return_call $callee_same_size_with_stack))
+    (func $call_bigger_with_stack (export "call_bigger_with_stack") (result i64)
+      (f32.const 1337)
+      (f32.const 1)
+      (f32.const 2)
+      (f32.const 3)
+      (f32.const 4)
+      (f32.const 5)
+      (f32.const 6)
+      (f32.const 7)
+      (f32.const 8)
+      (f32.const 90)
+      (return_call $callee_bigger_with_stack))
+    (func $call_smaller_with_stack (export "call_smaller_with_stack") (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (param $i10 f32) (param $i11 f32) (result i64)
+      (f32.const 1337)
+      (f32.const 1)
+      (f32.const 2)
+      (f32.const 3)
+      (f32.const 4)
+      (f32.const 5)
+      (f32.const 6)
+      (f32.const 7)
+      (f32.const 8)
+      (f32.const 90)
+      (return_call $callee_smaller_with_stack))
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, { m: {
+      callee_same_size: (i) => { return BigInt(i) + 42n },
+      callee_same_size_with_stack: (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9) => { return BigInt(i9) + BigInt(i2) },
+      callee_bigger_with_stack: (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11) => { return BigInt(i9) + BigInt(i2) },
+      callee_smaller_with_stack: (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9) => { return BigInt(i9) + BigInt(i2) },
+    } }, { simd: true, tail_call: true, exceptions: true })
+    const { call_same_size, call_same_size_with_stack, call_bigger_with_stack, call_smaller_with_stack } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(call_same_size(), 1337n + 42n)
+        assert.eq(call_same_size_with_stack(), 9n + 2n)
+        assert.eq(call_bigger_with_stack(), 90n + 2n)
+        assert.eq(call_smaller_with_stack(), 90n + 2n)
+    }
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/tail-call-js.js
+++ b/JSTests/wasm/stress/tail-call-js.js
@@ -1,0 +1,71 @@
+//@ requireOptions("--useWebAssemblyTailCalls=true", "--maximumWebAssemblyCalleeSIzeForInlining=0")
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (import "m" "callee_same_size" (func $callee_same_size (param $i f32) (result i64)))
+    (import "m" "callee_same_size_with_stack" (func $callee_same_size_with_stack (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (result i64)))
+    (import "m" "callee_bigger_with_stack" (func $callee_bigger_with_stack (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (result i64)))
+    (import "m" "callee_smaller_with_stack" (func $callee_smaller_with_stack (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (result i64)))
+    (func $call_same_size (export "call_same_size") (result i64)
+      (f32.const 1337)
+      (return_call $callee_same_size))
+    (func $call_same_size_with_stack (export "call_same_size_with_stack") (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (result i64)
+      (f32.const 1337)
+      (f32.const 1)
+      (f32.const 2)
+      (f32.const 3)
+      (f32.const 4)
+      (f32.const 5)
+      (f32.const 6)
+      (f32.const 7)
+      (f32.const 8)
+      (f32.const 9)
+      (return_call $callee_same_size_with_stack))
+    (func $call_bigger_with_stack (export "call_bigger_with_stack") (result i64)
+      (f32.const 1337)
+      (f32.const 1)
+      (f32.const 2)
+      (f32.const 3)
+      (f32.const 4)
+      (f32.const 5)
+      (f32.const 6)
+      (f32.const 7)
+      (f32.const 8)
+      (f32.const 90)
+      (return_call $callee_bigger_with_stack))
+    (func $call_smaller_with_stack (export "call_smaller_with_stack") (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (param $i10 f32) (param $i11 f32) (result i64)
+      (f32.const 1337)
+      (f32.const 1)
+      (f32.const 2)
+      (f32.const 3)
+      (f32.const 4)
+      (f32.const 5)
+      (f32.const 6)
+      (f32.const 7)
+      (f32.const 8)
+      (f32.const 90)
+      (return_call $callee_smaller_with_stack))
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, { m: {
+      callee_same_size: (i) => { return BigInt(i) + 42n },
+      callee_same_size_with_stack: (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9) => { return BigInt(i9) + BigInt(i2) },
+      callee_bigger_with_stack: (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11) => { return BigInt(i9) + BigInt(i2) },
+      callee_smaller_with_stack: (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9) => { return BigInt(i9) + BigInt(i2) },
+    } }, { simd: true, tail_call: true, exceptions: true })
+    const { call_same_size, call_same_size_with_stack, call_bigger_with_stack, call_smaller_with_stack } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(call_same_size(), 1337n + 42n)
+        assert.eq(call_same_size_with_stack(), 9n + 2n)
+        assert.eq(call_same_size_with_stack(1.5, 2.5, 3.0, 4.0, 5.0, 6.0, 7.5, 8.5, 9.5, 10.5), 9n + 2n)
+        assert.eq(call_bigger_with_stack(), 90n + 2n)
+        assert.eq(call_smaller_with_stack(), 90n + 2n)
+    }
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/tail-call-simple-int.js
+++ b/JSTests/wasm/stress/tail-call-simple-int.js
@@ -1,0 +1,70 @@
+//@ requireOptions("--useWebAssemblyTailCalls=true", "--maximumWebAssemblyCalleeSIzeForInlining=0")
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func $call_same_size (export "call_same_size") (result i32)
+      (i32.const 1337)
+      (return_call $callee_same_size))
+    (func $callee_same_size (param $i i32) (result i32)
+      (i32.add (local.get $i) (i32.const 42)))
+    (func $call_same_size_with_stack (export "call_same_size_with_stack") (param $i0 i32) (param $i1 i32) (param $i2 i32) (param $i3 i32) (param $i4 i32) (param $i5 i32) (param $i6 i32) (param $i7 i32) (param $i8 i32) (param $i9 i32) (result i32)
+      (i32.const 1337)
+      (i32.const 1)
+      (i32.const 2)
+      (i32.const 3)
+      (i32.const 4)
+      (i32.const 5)
+      (i32.const 6)
+      (i32.const 7)
+      (i32.const 8)
+      (i32.const 9)
+      (return_call $callee_same_size_with_stack))
+    (func $callee_same_size_with_stack (param $i0 i32) (param $i1 i32) (param $i2 i32) (param $i3 i32) (param $i4 i32) (param $i5 i32) (param $i6 i32) (param $i7 i32) (param $i8 i32) (param $i9 i32) (result i32)
+      (i32.add (local.get $i9) (local.get $i2)))
+    
+    (func $call_bigger_with_stack (export "call_bigger_with_stack") (result i32)
+      (i32.const 1337)
+      (i32.const 1)
+      (i32.const 2)
+      (i32.const 3)
+      (i32.const 4)
+      (i32.const 5)
+      (i32.const 6)
+      (i32.const 7)
+      (i32.const 8)
+      (i32.const 90)
+      (return_call $callee_bigger_with_stack))
+    (func $callee_bigger_with_stack (param $i0 i32) (param $i1 i32) (param $i2 i32) (param $i3 i32) (param $i4 i32) (param $i5 i32) (param $i6 i32) (param $i7 i32) (param $i8 i32) (param $i9 i32) (result i32)
+      (i32.add (local.get $i9) (local.get $i2)))
+    (func $call_smaller_with_stack (export "call_smaller_with_stack") (param $i0 i32) (param $i1 i32) (param $i2 i32) (param $i3 i32) (param $i4 i32) (param $i5 i32) (param $i6 i32) (param $i7 i32) (param $i8 i32) (param $i9 i32) (param $i10 i32) (param $i11 i32) (result i32)
+      (i32.const 1337)
+      (i32.const 1)
+      (i32.const 2)
+      (i32.const 3)
+      (i32.const 4)
+      (i32.const 5)
+      (i32.const 6)
+      (i32.const 7)
+      (i32.const 8)
+      (i32.const 90)
+      (return_call $callee_smaller_with_stack))
+    (func $callee_smaller_with_stack (param $i0 i32) (param $i1 i32) (param $i2 i32) (param $i3 i32) (param $i4 i32) (param $i5 i32) (param $i6 i32) (param $i7 i32) (param $i8 i32) (param $i9 i32) (result i32)
+      (i32.add (local.get $i9) (local.get $i2)))
+  )
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true, tail_call: true, exceptions: true })
+    const { call_same_size, call_same_size_with_stack, call_bigger_with_stack, call_smaller_with_stack } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(call_same_size(), 1337 + 42)
+        assert.eq(call_same_size_with_stack(), 9 + 2)
+        assert.eq(call_bigger_with_stack(), 90 + 2)
+        assert.eq(call_smaller_with_stack(), 90 + 2)
+    }
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/tail-call-simple.js
+++ b/JSTests/wasm/stress/tail-call-simple.js
@@ -1,0 +1,70 @@
+//@ requireOptions("--useWebAssemblyTailCalls=true", "--maximumWebAssemblyCalleeSIzeForInlining=0")
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func $call_same_size (export "call_same_size") (result i64)
+      (f32.const 1337)
+      (return_call $callee_same_size))
+    (func $callee_same_size (param $i f32) (result i64)
+      (i64.add (i64.trunc_f32_s (local.get $i)) (i64.const 42)))
+    (func $call_same_size_with_stack (export "call_same_size_with_stack") (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (result i64)
+      (f32.const 1337)
+      (f32.const 1)
+      (f32.const 2)
+      (f32.const 3)
+      (f32.const 4)
+      (f32.const 5)
+      (f32.const 6)
+      (f32.const 7)
+      (f32.const 8)
+      (f32.const 9)
+      (return_call $callee_same_size_with_stack))
+    (func $callee_same_size_with_stack (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (result i64)
+      (i64.add (i64.trunc_f32_s (local.get $i9)) (i64.trunc_f32_s (local.get $i2))))
+    
+    (func $call_bigger_with_stack (export "call_bigger_with_stack") (result i64)
+      (f32.const 1337)
+      (f32.const 1)
+      (f32.const 2)
+      (f32.const 3)
+      (f32.const 4)
+      (f32.const 5)
+      (f32.const 6)
+      (f32.const 7)
+      (f32.const 8)
+      (f32.const 90)
+      (return_call $callee_bigger_with_stack))
+    (func $callee_bigger_with_stack (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (result i64)
+      (i64.add (i64.trunc_f32_s (local.get $i9)) (i64.trunc_f32_s (local.get $i2))))
+    (func $call_smaller_with_stack (export "call_smaller_with_stack") (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (param $i10 f32) (param $i11 f32) (result i64)
+      (f32.const 1337)
+      (f32.const 1)
+      (f32.const 2)
+      (f32.const 3)
+      (f32.const 4)
+      (f32.const 5)
+      (f32.const 6)
+      (f32.const 7)
+      (f32.const 8)
+      (f32.const 90)
+      (return_call $callee_smaller_with_stack))
+    (func $callee_smaller_with_stack (param $i0 f32) (param $i1 f32) (param $i2 f32) (param $i3 f32) (param $i4 f32) (param $i5 f32) (param $i6 f32) (param $i7 f32) (param $i8 f32) (param $i9 f32) (result i64)
+      (i64.add (i64.trunc_f32_s (local.get $i9)) (i64.trunc_f32_s (local.get $i2))))
+  )
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true, tail_call: true, exceptions: true })
+    const { call_same_size, call_same_size_with_stack, call_bigger_with_stack, call_smaller_with_stack } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(call_same_size(), 1337n + 42n)
+        assert.eq(call_same_size_with_stack(), 9n + 2n)
+        assert.eq(call_bigger_with_stack(), 90n + 2n)
+        assert.eq(call_smaller_with_stack(), 90n + 2n)
+    }
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/tail-call.js
+++ b/JSTests/wasm/stress/tail-call.js
@@ -1,5 +1,4 @@
 //@ requireOptions("--useWebAssemblyTailCalls=true", "--maximumWebAssemblyCalleeSizeForInlining=0")
-//@ skip
 import * as assert from "../assert.js";
 import Builder from "../Builder.js";
 

--- a/Source/JavaScriptCore/assembler/MacroAssembler.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.cpp
@@ -58,6 +58,11 @@ void MacroAssembler::probeDebug(Function<void(Probe::Context&)> func)
     probe(tagCFunction<JITProbePtrTag>(stdFunctionCallback), new Function<void(Probe::Context&)>(WTFMove(func)));
 }
 
+void MacroAssembler::probeDebugSIMD(Function<void(Probe::Context&)> func)
+{
+    probe(tagCFunction<JITProbePtrTag>(stdFunctionCallback), new Function<void(Probe::Context&)>(WTFMove(func)), Probe::SavedFPWidth::SaveVectors);
+}
+
 } // namespace JSC
 
 namespace WTF {

--- a/Source/JavaScriptCore/assembler/MacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.h
@@ -2418,6 +2418,7 @@ public:
 
     // This leaks memory. Must not be used for production.
     JS_EXPORT_PRIVATE void probeDebug(Function<void(Probe::Context&)>);
+    JS_EXPORT_PRIVATE void probeDebugSIMD(Function<void(Probe::Context&)>);
 
     // Let's you print from your JIT generated code.
     // See comments in MacroAssemblerPrinter.h for examples of how to use this.

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -12672,6 +12672,10 @@ IGNORE_CLANG_WARNINGS_END
                 // https://bugs.webkit.org/show_bug.cgi?id=196570
                 jit.loadPtr(wasmFunction->entrypointLoadLocation(), scratchGPR);
                 jit.call(scratchGPR, WasmEntryPtrTag);
+
+                // Restore stack pointer after call (we may tail call)
+                jit.addPtr(MacroAssembler::TrustedImm32(-static_cast<int32_t>(params.proc().frameSize())), MacroAssembler::framePointerRegister, MacroAssembler::stackPointerRegister);
+
             });
 
         if (signature.returnsVoid())

--- a/Source/JavaScriptCore/jit/CCallHelpers.h
+++ b/Source/JavaScriptCore/jit/CCallHelpers.h
@@ -902,11 +902,11 @@ public:
         storeWasmCalleeCallee(scratchRegister());
     }
 
-    DataLabelPtr storeWasmCalleeCalleePatchable()
+    DataLabelPtr storeWasmCalleeCalleePatchable(int offset = 0)
     {
         JIT_COMMENT(*this, "Store Callee's wasm callee (patchable)");
         auto patch = moveWithPatch(TrustedImmPtr(nullptr), scratchRegister());
-        auto addr = CCallHelpers::addressOfCalleeCalleeFromCallerPerspective(0);
+        auto addr = CCallHelpers::addressOfCalleeCalleeFromCallerPerspective(offset);
 #if USE(JSVALUE64)
         storePtr(scratchRegister(), addr);
 #elif USE(JSVALUE32_64)


### PR DESCRIPTION
#### a2db78b8fdbef3caa09cb0165315ef552a073590
<pre>
WASM tail calls should work in OMG tier
<a href="https://bugs.webkit.org/show_bug.cgi?id=273875">https://bugs.webkit.org/show_bug.cgi?id=273875</a>

Reviewed by Keith Miller.

Tom&apos;s original patch was correct, but we told him to elide moves to temporary storage when they
weren&apos;t needed. Unfortunately, the current version on ToT clobbers a bunch of important stuff. Let&apos;s
fix that.

We also fix up LLInt, since it had a bit of bit rot.

Finally, we add a new kind of tail call, a fake tail call, for the case when an inlined call makes
a tail call.

There is still more work to be done to ensure that this code is correct; Tests for stack traces,
inlined calls that clobber instance, and more advanced stack / regalloc situations are all
still needed.

* JSTests/wasm/stress/simd-tail-call-simple.js: Added.
* JSTests/wasm/stress/tail-call-js.js: Added.
* JSTests/wasm/stress/tail-call-simple.js: Added.
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:

Canonical link: <a href="https://commits.webkit.org/281110@main">https://commits.webkit.org/281110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27b7bd41c72bc44d15f29421affe58f001ca3c9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62267 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9084 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9282 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47457 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6470 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60671 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35539 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50704 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28309 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32283 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8005 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8088 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/51731 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54235 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8277 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63970 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57882 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2553 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8281 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54779 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2562 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50730 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54863 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12993 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2146 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79643 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33796 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13275 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34882 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35966 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34627 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->