### PR TITLE
Invalidation handler for assertion is not being called

### DIFF
--- a/Source/WebKit/Platform/cocoa/AssertionCapability.mm
+++ b/Source/WebKit/Platform/cocoa/AssertionCapability.mm
@@ -31,9 +31,7 @@
 #import "Logging.h"
 #import <BrowserEngineKit/BrowserEngineKit.h>
 
-#if USE(LEGACY_EXTENSIONKIT_SPI)
 #import "ExtensionKitSoftLink.h"
-#endif
 
 namespace WebKit {
 
@@ -49,12 +47,23 @@ AssertionCapability::AssertionCapability(String environmentIdentifier, String do
     _SECapability* capability = [get_SECapabilityClass() assertionWithDomain:m_domain name:m_name environmentIdentifier:m_environmentIdentifier willInvalidate:m_willInvalidateBlock.get() didInvalidate:m_didInvalidateBlock.get()];
     setPlatformCapability(capability);
 #else
-    if (m_name == "Suspended"_s)
-        setPlatformCapability([BEProcessCapability suspended]);
-    else if (m_name == "Background"_s)
-        setPlatformCapability([BEProcessCapability background]);
-    else if (m_name == "Foreground"_s)
-        setPlatformCapability([BEProcessCapability foreground]);
+    if (m_name == "Suspended"_s) {
+        if ([BEProcessCapability respondsToSelector:@selector(suspended:)])
+            setPlatformCapability([BEProcessCapability suspended:m_didInvalidateBlock.get()]);
+        else
+            setPlatformCapability([BEProcessCapability suspended]);
+    } else if (m_name == "Background"_s) {
+        if ([BEProcessCapability respondsToSelector:@selector(background:)])
+            setPlatformCapability([BEProcessCapability background:m_didInvalidateBlock.get()]);
+        else
+            setPlatformCapability([BEProcessCapability background]);
+    }
+    else if (m_name == "Foreground"_s) {
+        if ([BEProcessCapability respondsToSelector:@selector(foreground:)])
+            setPlatformCapability([BEProcessCapability foreground:m_didInvalidateBlock.get()]);
+        else
+            setPlatformCapability([BEProcessCapability foreground]);
+    }
 #endif
 }
 

--- a/Source/WebKit/Platform/spi/Cocoa/ExtensionKitSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/ExtensionKitSPI.h
@@ -27,6 +27,7 @@
 
 #if USE(EXTENSIONKIT)
 
+#import <BrowserEngineKit/BECapability.h>
 #import <BrowserEngineKit/BrowserEngineKit.h>
 
 #import <Foundation/Foundation.h>
@@ -148,6 +149,12 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)assertionWithDomain:(NSString *)domain name:(NSString *)name environmentIdentifier:(NSString *)environmentIdentifier;
 + (instancetype)assertionWithDomain:(NSString *)domain name:(NSString *)name environmentIdentifier:(NSString *)environmentIdentifier willInvalidate:(void (^)())willInvalidateBlock didInvalidate:(void (^)())didInvalidateBlock;
 @property (nonatomic, readonly) NSString *mediaEnvironment;
+@end
+
+@interface BEProcessCapability (InvalidationHandler)
++(instancetype)background:(void (^)(void))didInvalidate;
++(instancetype)foreground:(void (^)(void))didInvalidate;
++(instancetype)suspended:(void (^)(void))didInvalidate;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
#### e2601915acec089b828b50cbd0dbabcf58b30d5e
<pre>
Invalidation handler for assertion is not being called
<a href="https://bugs.webkit.org/show_bug.cgi?id=273877">https://bugs.webkit.org/show_bug.cgi?id=273877</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

WebKit depends on having the invalidation handler called when the system invalidates an assertion.

* Source/WebKit/Platform/cocoa/AssertionCapability.mm:
* Source/WebKit/Platform/spi/Cocoa/ExtensionKitSPI.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2601915acec089b828b50cbd0dbabcf58b30d5e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50815 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54074 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1506 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1156 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41396 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27762 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43777 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22524 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25107 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9256 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47088 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1095 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55668 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25917 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/976 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48808 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27174 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47885 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28042 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26906 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->