### PR TITLE
[webkitscmpy] Fix setting title in mock Bitbucket server

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/bitbucket.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/bitbucket.py
@@ -353,9 +353,11 @@ class BitBucket(mocks.Requests):
                 return mocks.Response.fromJson({})
             if method == 'PUT':
                 self.pull_requests[existing].update(json)
-                self.pull_requests[existing]['fromRef']['displayId'] = '/'.join(json['fromRef']['id'].split('/')[-2:])
                 self.pull_requests[existing]['fromRef']['latestCommit'] = json['fromRef']['latestCommit']
-                self.pull_requests[existing]['toRef']['displayId'] = '/'.join(json['toRef']['id'].split('/')[-2:])
+                if 'id' in json['fromRef']:
+                    self.pull_requests[existing]['fromRef']['displayId'] = '/'.join(json['fromRef']['id'].split('/')[-2:])
+                if 'id' in json['toRef']:
+                    self.pull_requests[existing]['toRef']['displayId'] = '/'.join(json['toRef']['id'].split('/')[-2:])
             if len(split_url) < 11:
                 return mocks.Response.fromJson({key: value for key, value in self.pull_requests[existing].items() if key not in ('commit', 'activities')})
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -2064,6 +2064,15 @@ Reviewed by NOBODY (OOPS!).
             self.assertEqual(pr.base, 'main')
             self.assertEqual(pr.draft, False)
 
+    def test_title(self):
+        with self.webserver():
+            pr = remote.GitHub(self.remote).pull_requests.get(1)
+            self.assertEqual(pr.title, 'Example Change')
+            pr.generator.update(pr, title='New Title')
+
+            pr = remote.GitHub(self.remote).pull_requests.get(1)
+            self.assertEqual(pr.title, 'New Title')
+
     def test_reviewers(self):
         with self.webserver():
             pr = remote.GitHub(self.remote).pull_requests.get(1)
@@ -2359,6 +2368,15 @@ Reviewed by NOBODY (OOPS!).
             self.assertEqual(pr.hash, '95507e3a1a4a919d1a156abbc279fdf6d24b13f5')
             self.assertEqual(pr.base, 'main')
             self.assertEqual(pr.draft, False)
+
+    def test_title(self):
+        with self.webserver():
+            pr = remote.BitBucket(self.remote).pull_requests.get(1)
+            self.assertEqual(pr.title, 'Example Change')
+            pr.generator.update(pr, title='New Title')
+
+            pr = remote.BitBucket(self.remote).pull_requests.get(1)
+            self.assertEqual(pr.title, 'New Title')
 
     def test_reviewers(self):
         with self.webserver():


### PR DESCRIPTION
#### 98c351128f7e2568a553e42cbe198fb58d89d271
<pre>
[webkitscmpy] Fix setting title in mock Bitbucket server
<a href="https://bugs.webkit.org/show_bug.cgi?id=273884">https://bugs.webkit.org/show_bug.cgi?id=273884</a>
<a href="https://rdar.apple.com/127751416">rdar://127751416</a>

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/bitbucket.py:
(BitBucket.request): Allow underdefined &apos;fromRef&apos; and &apos;toRef&apos;.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
(TestNetworkPullRequestGitHub.test_title):
(TestNetworkPullRequestBitBucket.test_title):

Canonical link: <a href="https://commits.webkit.org/278593@main">https://commits.webkit.org/278593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/235683f1fc6123e673ecb75006d04e5004a9cb97

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54090 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1522 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53134 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36403 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41412 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22540 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/50682 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25120 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1047 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9272 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47102 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55684 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25933 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/992 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48823 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/50852 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27190 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43867 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47905 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28058 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7411 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26922 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->