### PR TITLE
[Unified Text Replacement] [macOS] Add SPI to WKWebViewConfiguration to configure unified text replacement behavior

### DIFF
--- a/Source/WebKit/Shared/WebUnifiedTextReplacementContextData.h
+++ b/Source/WebKit/Shared/WebUnifiedTextReplacementContextData.h
@@ -27,14 +27,9 @@
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
 
-namespace WTF {
-class UUID;
-}
-
-namespace WebCore {
-struct AttributedString;
-struct CharacterRange;
-}
+#import <WebCore/AttributedString.h>
+#import <WebCore/CharacterRange.h>
+#import <wtf/UUID.h>
 
 namespace WebKit {
 
@@ -47,6 +42,13 @@ struct WebUnifiedTextReplacementContextData {
     WTF::UUID uuid;
     WebCore::AttributedString attributedText;
     WebCore::CharacterRange range;
+};
+
+enum class WebUnifiedTextReplacementBehavior : uint8_t {
+    None,
+    Default,
+    Limited,
+    Complete,
 };
 
 }

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -28,6 +28,7 @@
 #include "APIObject.h"
 #include "WebPreferencesDefaultValues.h"
 #include "WebURLSchemeHandler.h"
+#include "WebUnifiedTextReplacementContextData.h"
 #include <WebCore/ContentSecurityPolicy.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/ShouldRelaxThirdPartyCookieBlocking.h>
@@ -376,6 +377,11 @@ public:
     bool allowsInlinePredictions() const { return m_data.allowsInlinePredictions; }
     void setAllowsInlinePredictions(bool allows) { m_data.allowsInlinePredictions = allows; }
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+    WebKit::WebUnifiedTextReplacementBehavior unifiedTextReplacementBehavior() const { return m_data.unifiedTextReplacementBehavior; }
+    void setUnifiedTextReplacementBehavior(WebKit::WebUnifiedTextReplacementBehavior behavior) { m_data.unifiedTextReplacementBehavior = behavior; }
+#endif
+
     void setShouldRelaxThirdPartyCookieBlocking(WebCore::ShouldRelaxThirdPartyCookieBlocking value) { m_data.shouldRelaxThirdPartyCookieBlocking = value; }
     WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking() const { return m_data.shouldRelaxThirdPartyCookieBlocking; }
 
@@ -571,6 +577,10 @@ private:
         bool allowsInlinePredictions { false };
         bool scrollToTextFragmentIndicatorEnabled { true };
         bool scrollToTextFragmentMarkingEnabled { true };
+
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+        WebKit::WebUnifiedTextReplacementBehavior unifiedTextReplacementBehavior { WebKit::WebUnifiedTextReplacementBehavior::Default };
+#endif
 
         WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking { WebCore::ShouldRelaxThirdPartyCookieBlocking::No };
         WTF::String attributedBundleIdentifier;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -127,6 +127,60 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     return _pageConfiguration->allowsInlinePredictions();
 }
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+
+static _WKUnifiedTextReplacementBehavior convertToPlatformBehavior(WebKit::WebUnifiedTextReplacementBehavior behavior)
+{
+    switch (behavior) {
+    case WebKit::WebUnifiedTextReplacementBehavior::None:
+        return _WKUnifiedTextReplacementBehaviorNone;
+
+    case WebKit::WebUnifiedTextReplacementBehavior::Default:
+        return _WKUnifiedTextReplacementBehaviorDefault;
+
+    case WebKit::WebUnifiedTextReplacementBehavior::Limited:
+        return _WKUnifiedTextReplacementBehaviorLimited;
+
+    case WebKit::WebUnifiedTextReplacementBehavior::Complete:
+        return _WKUnifiedTextReplacementBehaviorComplete;
+    }
+}
+
+static WebKit::WebUnifiedTextReplacementBehavior convertToWebBehavior(_WKUnifiedTextReplacementBehavior behavior)
+{
+    switch (behavior) {
+    case _WKUnifiedTextReplacementBehaviorNone:
+        return WebKit::WebUnifiedTextReplacementBehavior::None;
+
+    case _WKUnifiedTextReplacementBehaviorDefault:
+        return WebKit::WebUnifiedTextReplacementBehavior::Default;
+
+    case _WKUnifiedTextReplacementBehaviorLimited:
+        return WebKit::WebUnifiedTextReplacementBehavior::Limited;
+
+    case _WKUnifiedTextReplacementBehaviorComplete:
+        return WebKit::WebUnifiedTextReplacementBehavior::Complete;
+    }
+}
+
+#endif
+
+- (void)_setUnifiedTextReplacementBehavior:(_WKUnifiedTextReplacementBehavior)behavior
+{
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+    _pageConfiguration->setUnifiedTextReplacementBehavior(convertToWebBehavior(behavior));
+#endif
+}
+
+- (_WKUnifiedTextReplacementBehavior)_unifiedTextReplacementBehavior
+{
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+    return convertToPlatformBehavior(_pageConfiguration->unifiedTextReplacementBehavior());
+#else
+    return _WKUnifiedTextReplacementBehaviorNone;
+#endif
+}
+
 #if PLATFORM(IOS_FAMILY)
 - (void)setAllowsInlineMediaPlayback:(BOOL)allows
 {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
@@ -48,6 +48,13 @@ typedef NS_ENUM(NSUInteger, _WKContentSecurityPolicyModeForExtension) {
     _WKContentSecurityPolicyModeForExtensionManifestV3
 } WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
+typedef NS_ENUM(NSUInteger, _WKUnifiedTextReplacementBehavior) {
+    _WKUnifiedTextReplacementBehaviorNone = 0,
+    _WKUnifiedTextReplacementBehaviorDefault,
+    _WKUnifiedTextReplacementBehaviorLimited,
+    _WKUnifiedTextReplacementBehaviorComplete
+} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 @class WKWebView;
 @class _WKApplicationManifest;
 @class _WKVisitedLinkStore;
@@ -172,6 +179,9 @@ typedef NS_ENUM(NSUInteger, _WKContentSecurityPolicyModeForExtension) {
 @property (nonatomic, setter=_setScrollToTextFragmentIndicatorEnabled:) BOOL _scrollToTextFragmentIndicatorEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @property (nonatomic, setter=_setScrollToTextFragmentMarkingEnabled:) BOOL _scrollToTextFragmentMarkingEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
+@property (nonatomic, setter=_setUnifiedTextReplacementBehavior:) _WKUnifiedTextReplacementBehavior _unifiedTextReplacementBehavior WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 @end
 
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -181,6 +181,10 @@ struct WebHitTestResultData;
 enum class ContinueUnsafeLoad : bool;
 enum class UndoOrRedo : bool;
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+enum class WebUnifiedTextReplacementBehavior : uint8_t;
+#endif
+
 typedef id <NSValidatedUserInterfaceItem> ValidationItem;
 typedef Vector<RetainPtr<ValidationItem>> ValidationVector;
 typedef HashMap<String, ValidationVector> ValidationMap;
@@ -695,6 +699,10 @@ public:
     void handleContextMenuTranslation(const WebCore::TranslationContextMenuInfo&);
 #endif
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+    WebUnifiedTextReplacementBehavior unifiedTextReplacementBehavior() const;
+#endif
+
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT) && ENABLE(CONTEXT_MENUS)
     bool canHandleSwapCharacters() const;
     void handleContextMenuSwapCharacters(WebCore::IntRect selectionBoundsInRootView);
@@ -722,22 +730,8 @@ public:
 #endif
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
-    void willBeginTextReplacementSession(const WTF::UUID&, WebUnifiedTextReplacementType, CompletionHandler<void(const Vector<WebUnifiedTextReplacementContextData>&)>&&);
+    bool wantsCompleteUnifiedTextReplacementBehavior() const;
 
-    void didBeginTextReplacementSession(const WTF::UUID&, const Vector<WebUnifiedTextReplacementContextData>&);
-
-    void textReplacementSessionDidReceiveReplacements(const WTF::UUID&, const Vector<WebTextReplacementData>&, const WebUnifiedTextReplacementContextData&, bool finished);
-
-    void textReplacementSessionDidUpdateStateForReplacement(const WTF::UUID&, WebTextReplacementDataState, const WebTextReplacementData&, const WebUnifiedTextReplacementContextData&);
-
-    void didEndTextReplacementSession(const WTF::UUID&, bool accepted);
-
-    void textReplacementSessionDidReceiveTextWithReplacementRange(const WTF::UUID&, const WebCore::AttributedString&, const WebCore::CharacterRange&, const WebUnifiedTextReplacementContextData&);
-
-    void textReplacementSessionDidReceiveEditAction(const WTF::UUID&, WebTextReplacementDataEditAction);
-#endif
-
-#if ENABLE(UNIFIED_TEXT_REPLACEMENT_UI)
     void addTextIndicatorStyleForID(WTF::UUID, WKTextIndicatorStyleType);
     void removeTextIndicatorStyleForID(WTF::UUID);
 #endif


### PR DESCRIPTION
#### df94cb9a762a346ea7ef1cb57abd9f04774c2824
<pre>
[Unified Text Replacement] [macOS] Add SPI to WKWebViewConfiguration to configure unified text replacement behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=273886">https://bugs.webkit.org/show_bug.cgi?id=273886</a>
<a href="https://rdar.apple.com/127749267">rdar://127749267</a>

Reviewed by Wenson Hsieh.

* Source/WebKit/Shared/WebUnifiedTextReplacementContextData.h:
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::unifiedTextReplacementBehavior const):
(API::PageConfiguration::setUnifiedTextReplacementBehavior):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(convertToPlatformBehavior):
(convertToWebBehavior):
(-[WKWebViewConfiguration _setUnifiedTextReplacementBehavior:]):
(-[WKWebViewConfiguration _unifiedTextReplacementBehavior]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::selectionDidChange):
(WebKit::WebViewImpl::wantsCompleteUnifiedTextReplacementBehavior const):
(WebKit::WebViewImpl::unifiedTextReplacementBehavior const):
(WebKit::WebViewImpl::canHandleSwapCharacters const):
(WebKit::WebViewImpl::willBeginTextReplacementSession): Deleted.
(WebKit::WebViewImpl::didBeginTextReplacementSession): Deleted.
(WebKit::WebViewImpl::textReplacementSessionDidReceiveReplacements): Deleted.
(WebKit::WebViewImpl::textReplacementSessionDidUpdateStateForReplacement): Deleted.
(WebKit::WebViewImpl::didEndTextReplacementSession): Deleted.
(WebKit::WebViewImpl::textReplacementSessionDidReceiveTextWithReplacementRange): Deleted.
(WebKit::WebViewImpl::textReplacementSessionDidReceiveEditAction): Deleted.

Canonical link: <a href="https://commits.webkit.org/278617@main">https://commits.webkit.org/278617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de623f27383b26811cfe6e52a0bb56e26c71f3ab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54399 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/1832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1506 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41649 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53241 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/28075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/44079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22765 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/1407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55995 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/26252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49048 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/27500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/44146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/28381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7425 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/27231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->