### PR TITLE
Fix event handling conflicts between webkit fullscreen controls and fullscreen controls of youtube.com and vimeo.com

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/macos-fullscreen-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/macos-fullscreen-media-controls.js
@@ -76,6 +76,7 @@ class MacOSFullscreenMediaControls extends MediaControls
         this.bottomControlsBar.children = [this._leftContainer, this._centerContainer, this._rightContainer];
 
         this.bottomControlsBar.element.addEventListener("mousedown", this);
+        this.bottomControlsBar.element.addEventListener("click", this);
 
         this._backgroundClickDelegateNotifier = new BackgroundClickDelegateNotifier(this);
     }

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -57,6 +57,8 @@ class MediaController
 
         media.addEventListener("play", this);
         media.addEventListener(this.fullscreenChangeEventType, this);
+        media.addEventListener("keydown", this);
+        media.addEventListener("keyup", this);
 
         window.addEventListener("keydown", this);
 
@@ -206,14 +208,21 @@ class MediaController
             this._updateControlsIfNeeded();
             // We must immediately perform layouts so that we don't lag behind the media layout size.
             scheduler.flushScheduledLayoutCallbacks();
-        } else if (event.currentTarget === this.media) {
+        } else if (event.type === "keydown" && this.isFullscreen && event.key === " ") {
+            this.togglePlayback();
+            event.preventDefault();
+            event.stopPropagation();
+        }
+        else if (event.type === "keyup" && this.isFullscreen && event.key === " ") {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+
+        if (event.currentTarget === this.media) {
             if (event.type === "play")
                 this.hasPlayed = true;
             this._updateControlsIfNeeded();
             this._updateControlsAvailability();
-        } else if (event.type === "keydown" && this.isFullscreen && event.key === " ") {
-            this.togglePlayback();
-            event.preventDefault();
         }
     }
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8499,6 +8499,10 @@ Element* eventTargetElementForDocument(Document* document)
 {
     if (!document)
         return nullptr;
+#if ENABLE(FULLSCREEN_API)
+    if (CheckedPtr fullscreenManager = document->fullscreenManagerIfExists(); fullscreenManager && fullscreenManager->isFullscreen() && is<HTMLVideoElement>(fullscreenManager->currentFullscreenElement()))
+        return fullscreenManager->currentFullscreenElement();
+#endif
     Element* element = document->focusedElement();
     if (!element) {
         if (auto* pluginDocument = dynamicDowncast<PluginDocument>(*document))


### PR DESCRIPTION
#### 9e2aadd3a06e6cf5ef09873cf5c1d5ef2a848d79
<pre>
Fix event handling conflicts between webkit fullscreen controls and fullscreen controls of youtube.com and vimeo.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=273889">https://bugs.webkit.org/show_bug.cgi?id=273889</a>
<a href="https://rdar.apple.com/126728057">rdar://126728057</a>

Reviewed by Jer Noble.

Currently, when on youtube.com and an element is in in-window or standard fullscreen and we are displaying the default
WebKit media controls, pressing the spacebar to toggle playback does not work because both our event handler and youtube&apos;s
Are being executed. When in fullscreen, the keyboard events are sent to the HTML body, on which YouTube has a Keyup event
Listener that toggles playback if the key is a space. Because our media controls script is loaded after youtube&apos;s, our event
Listeners have no chance of handling the event and stopping propagation.

To fix this, this change makes it so that when a keyboard event is fired while a page is in fullscreen, the event is
first sent to the fullscreen element to be handled, which now has an event listener attached to it for keydown and
Keyup events and stops propagation after handling the spacebar event.

There is also a problem on YouTube.com and Vimeo.com where the website toggles playback when the user clicks or drags the
fullscreen bottom controls bar. To fix this, I attached a click event listener to the controls bar. The event handler
Stops propagation. There is no need for the webpage&apos;s event handlers to be executed at all if the user
Is clicking on our controls bar.

* Source/WebCore/Modules/modern-media-controls/controls/macos-fullscreen-media-controls.js:
* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController):
(MediaController.prototype.handleEvent):
* Source/WebCore/dom/Document.cpp:
(WebCore::eventTargetElementForDocument):

Canonical link: <a href="https://commits.webkit.org/278573@main">https://commits.webkit.org/278573@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfe2cf0ffd247c7f13617ff00e438f58d14d1871

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54232 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1664 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53276 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36558 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1328 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41519 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27917 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43918 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22647 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25251 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1174 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9415 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47232 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55826 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26081 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1141 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48930 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48044 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11160 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28211 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27064 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->