### PR TITLE
Add IPC for SkData

### DIFF
--- a/Source/WebKit/Platform/Skia.cmake
+++ b/Source/WebKit/Platform/Skia.cmake
@@ -12,6 +12,7 @@ list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
 
 list(APPEND WebKit_SERIALIZATION_IN_FILES
     Shared/skia/CoreIPCSkColorSpace.serialization.in
+    Shared/skia/CoreIPCSkData.serialization.in
 )
 
 list(APPEND WebKit_LIBRARIES

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -34,6 +34,7 @@
 
 #if USE(SKIA)
 #include <skia/core/SkColorSpace.h>
+#include <skia/core/SkData.h>
 #endif
 
 #if PLATFORM(GTK)
@@ -75,6 +76,12 @@ template<> struct ArgumentCoder<sk_sp<SkColorSpace>> {
     static void encode(Encoder&, const sk_sp<SkColorSpace>&);
     static void encode(StreamConnectionEncoder&, const sk_sp<SkColorSpace>&);
     static std::optional<sk_sp<SkColorSpace>> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<sk_sp<SkData>> {
+    static void encode(Encoder&, const sk_sp<SkData>&);
+    static void encode(StreamConnectionEncoder&, const sk_sp<SkData>&);
+    static std::optional<sk_sp<SkData>> decode(Decoder&);
 };
 #endif
 

--- a/Source/WebKit/Shared/skia/CoreIPCSkData.h
+++ b/Source/WebKit/Shared/skia/CoreIPCSkData.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2024 Sony Interactive Entertainment Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(SKIA)
+
+#include <skia/core/SkData.h>
+
+namespace WebKit {
+
+class CoreIPCSkData {
+public:
+    CoreIPCSkData(sk_sp<SkData> skData)
+        : m_skData(WTFMove(skData))
+    {
+    }
+
+    CoreIPCSkData(std::span<const uint8_t> data)
+        : m_skData(SkData::MakeWithCopy(data.data(), data.size()))
+    {
+    }
+
+    sk_sp<SkData> skData() const { return m_skData; }
+
+    std::span<const uint8_t> dataReference() const
+    {
+        return { m_skData->bytes(), m_skData->size() };
+    }
+
+private:
+    sk_sp<SkData> m_skData;
+};
+
+} // namespace WebKit
+
+#endif // USE(SKIA)

--- a/Source/WebKit/Shared/skia/CoreIPCSkData.serialization.in
+++ b/Source/WebKit/Shared/skia/CoreIPCSkData.serialization.in
@@ -1,0 +1,27 @@
+# Copyright (C) 2024 Sony Interactive Entertainment Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+webkit_platform_headers: "CoreIPCSkData.h"
+
+[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCSkData {
+    std::span<const uint8_t> dataReference();
+}

--- a/Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.cpp
+++ b/Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.cpp
@@ -29,6 +29,7 @@
 #if USE(SKIA)
 
 #include "CoreIPCSkColorSpace.h"
+#include "CoreIPCSkData.h"
 #include "StreamConnectionEncoder.h"
 #include <WebCore/Font.h>
 
@@ -72,6 +73,24 @@ std::optional<sk_sp<SkColorSpace>> ArgumentCoder<sk_sp<SkColorSpace>>::decode(De
     if (UNLIKELY(!decoder.isValid()))
         return std::nullopt;
     return colorSpace->skColorSpace();
+}
+
+void ArgumentCoder<sk_sp<SkData>>::encode(Encoder& encoder, const sk_sp<SkData>& data)
+{
+    encoder << WebKit::CoreIPCSkData(data);
+}
+
+void ArgumentCoder<sk_sp<SkData>>::encode(StreamConnectionEncoder& encoder, const sk_sp<SkData>& data)
+{
+    encoder << WebKit::CoreIPCSkData(data);
+}
+
+std::optional<sk_sp<SkData>> ArgumentCoder<sk_sp<SkData>>::decode(Decoder& decoder)
+{
+    auto data = decoder.decode<WebKit::CoreIPCSkData>();
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
+    return data->skData();
 }
 
 } // namespace IPC


### PR DESCRIPTION
#### 7f78e4799e9778e292febfbab858754745c580ac
<pre>
Add IPC for SkData
<a href="https://bugs.webkit.org/show_bug.cgi?id=273890">https://bugs.webkit.org/show_bug.cgi?id=273890</a>

Reviewed by Alex Christensen.

Add a wrapper of `SkData` for serialization over IPC.

* Source/WebKit/Platform/Skia.cmake:
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/skia/CoreIPCSkData.h: Added.
(WebKit::CoreIPCSkData::CoreIPCSkData):
(WebKit::CoreIPCSkData::skData const):
(WebKit::CoreIPCSkData::dataReference const):
* Source/WebKit/Shared/skia/CoreIPCSkData.serialization.in: Added.
* Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.cpp:
(IPC::ArgumentCoder&lt;sk_sp&lt;SkData&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;sk_sp&lt;SkData&gt;&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/278536@main">https://commits.webkit.org/278536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/170e49fbd0b874d6b74d74fe4745629bd33b1f62

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54134 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1566 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1220 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27812 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43825 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/22576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25150 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9316 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47135 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1151 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55728 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25978 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1030 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48848 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27235 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43898 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11145 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28104 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26966 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->