### PR TITLE
[WGSL] Pointers should not be unpacked

### DIFF
--- a/Source/WebGPU/WGSL/tests/valid/fuzz-127229681.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/fuzz-127229681.wgsl
@@ -1,0 +1,129 @@
+// RUN: %wgslc
+
+struct S {
+  x: array<f32>,
+}
+
+struct Packed {
+  x: vec3<f32>
+}
+
+struct T {a73: u32,
+ x: array<Packed>,
+}
+
+@group(1) @binding(0) var<storage, read_write> x: array<f16>;
+@group(4) @binding(1) var<storage, read_write> y: S;
+@group(0) @binding(3) var<storage, read_write> z: T;
+fn f() -> u32 {
+    let x1 = arrayLength(&x);
+    let  a = pow(2, 2);
+    let xptr = &x;
+    let yptr = &y.x;
+ {
+    let a = pow(2, 2);
+      return x1 +2;
+    return x1 +2;
+}   let zptr = &z.x;
+
+     _ = arrayLength(xptr);  let y2x=arrayLength(xptr);
+        _ = x[0];
+        _ =& x[-1];
+     ;
+        _ = x[0];
+        _ = x[0];
+    { let x = unpack4x8snorm(pack4xI8(vec4i(128, 127, -128, -128))); _ = x[0];
+ }
+        _ = x[0];
+        _ = x[1];
+        _ = x[0];
+        _ = x[1];
+        _ = x[0];
+  _=x[1];_=x[1u];_=x[1u];
+        _ = x[1];
+        _ = x[0];
+    { let x = unpack4x8snorm(pack4xI8(vec4i(128, 127, -128, -128))); _ = x[0];
+ }
+        _ = x[0];
+    { let x = unpack4x8snorm(pack4xI8(vec4i(128, 127, -128, -128))); _ = x[0];
+ }
+y/=*(zptr);
+        _ = x[0];
+        _ = x[0];
+        _ =& x[-1];
+     ;
+y/=*(zptr);
+        _ = x[0];
+    { let x = unpack4x8snorm(pack4xI8(vec4i(128, 127, -128, -128))); _ = x[0];
+ }
+y/=*(zptr);
+        _ = x[0];
+        _ =& x[-1];
+     ;
+y/=*(zptr);
+        _ = x[0];
+        _ =& x[-1];
+     ;
+        _ = x[0];
+    { let x = unpack4x8snorm(pack4xI8(vec4i(128, 127, -128, -128))); _ = x[0];
+ }
+y/=*(zptr);
+        _ = x[0];
+    { let x = (zptr);
+ _ = x[0];
+ }
+y/=*(zptr);
+        _ = x[0];
+        _ = x[0];
+        _ =& x[-1];
+     ;
+y/=*(zptr);
+        _ = x[0];
+        _ =& x[-1];
+     ;
+        _ = x[0];
+    { let x = unpack4x8snorm(pack4xI8(vec4i(128, 127, -128, -128))); _ = x[0];
+ }
+y/=*(zptr);
+        _ = x[0];
+    { let x = unpack4x8snorm(pack4xI8(vec4i(128, 127, -128, -128))); _ = x[0];
+ }
+y/=*(zptr);
+        _ = x[0];
+        _ =& x[-1];
+     ;
+y/=*(zptr);
+        _ = x[0];
+        _ = x[0];
+    { let x = unpack4x8snorm(pack4xI8(vec4i(128, 127, -128, -128))); _ = x[0];
+ }
+y/=*(zptr);
+        _ = x[0];
+        _ = x[0];
+        _ =& x[-1];
+     ;
+y/=*(zptr);
+        _ = x[0];
+    { let x = unpack4x8snorm(pack4xI8(vec4i(128, 127, -128, -128))); _ = x[0];
+ }
+y/=*(zptr);
+        _ = x[0];
+        _ = x[0];
+        _ =& x[-1];
+     ;
+y/=*(zptr);
+        _ = x[0];
+        _ = x[0];
+    { let x = unpack4x8snorm(pack4xI8(vec4i(128, 127, -128, -128))); _ = x[0];
+ }
+y/=*(zptr);
+        _ = x[0];
+    return x1 +2;
+    return x1 +2;
+}
+
+@compute
+fn main() {
+    let x = f();
+}
+


### PR DESCRIPTION
#### a2a16a65166393cc268b7fbafb8f48082ac1984f
<pre>
[WGSL] Pointers should not be unpacked
<a href="https://bugs.webkit.org/show_bug.cgi?id=273894">https://bugs.webkit.org/show_bug.cgi?id=273894</a>
<a href="https://rdar.apple.com/127229681">rdar://127229681</a>

Reviewed by Mike Wyrzykowski.

The fuzzer found a crash due to the base of an index access being incorrectly
unpacked when it was an address-of expression. We would always unpack unary
expressions, since math operations should be performed on unpacked values, but
for pointer operators (address-of and dereference) we do not need to force the
operand to be unpacked.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::visit):
(WGSL::RewriteGlobalVariables::getPacking):
* Source/WebGPU/WGSL/tests/valid/fuzz-127229681.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/278613@main">https://commits.webkit.org/278613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a10c5aecd64fcf27432eb4be393026cab81f7ba1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54114 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1546 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1197 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41437 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52954 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27795 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43811 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22565 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25138 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9296 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47120 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55708 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1034 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48845 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27214 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47927 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11180 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28097 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26946 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->