### PR TITLE
[webkitpy] Limit size of shards

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner_unittest.py
@@ -327,6 +327,16 @@ class SharderTests(unittest.TestCase):
              ('.', ['ietestcenter/Javascript/11.1.5_4-4-c-1.html']),
              ('.', ['dom/html/level2/html/HTMLAnchorElement06.html'])])
 
+    def test_large_shard(self):
+        shards = self.get_shards(
+            num_workers=2,
+            fully_parallel=False,
+            test_list=['fast/css/test-{}'.format(i) for i in range(256)],
+        )
+        self.assertEqual(len(shards), 2)
+        self.assertEqual(len(shards[0].test_inputs), 128)
+        self.assertEqual(len(shards[1].test_inputs), 128)
+
 
 class ShardTests(unittest.TestCase):
     def test_pickle(self):


### PR DESCRIPTION
#### 4b70ddd67b1d85c4771146b0f5edd5e3287e35d7
<pre>
[webkitpy] Limit size of shards
<a href="https://bugs.webkit.org/show_bug.cgi?id=273899">https://bugs.webkit.org/show_bug.cgi?id=273899</a>
<a href="https://rdar.apple.com/127764963">rdar://127764963</a>

Reviewed by NOBODY (OOPS!).

Establish a rough ceiling on shard size by taking directories greater than 256 tests and then
separating each file into a bucket based on path. While this doesn&apos;t provide a hard limit on
shard size, it does ensure that adding or removing a test will not change the shard all other
tests are run in.

* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py:
(Sharder.bucket_for): Basic hash function which returns a consistent (but random) shard bucket.
(Sharder._shard_by_directory): Establish a maximum shard size of around 256. Note that this isn&apos;t precise
because our sharding algorithm prioritizes keeping shards consistent as tests are added and removed.
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner_unittest.py:
(SharderTests.test_large_shard):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b70ddd67b1d85c4771146b0f5edd5e3287e35d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3192 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54133 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1565 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36447 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1221 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41439 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27811 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43824 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22567 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/50725 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25151 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1079 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9315 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47134 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1141 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55727 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25977 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1031 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48853 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27234 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47936 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28103 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26965 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->