### PR TITLE
REGRESSION(275291@main): Some AVIF images in ford.com are not displayed on macOS Monterey

### DIFF
--- a/Source/WebCore/PAL/ThirdParty/libavif/src/read.c
+++ b/Source/WebCore/PAL/ThirdParty/libavif/src/read.c
@@ -787,7 +787,7 @@ static avifResult avifCheckItemID(const char * boxFourcc, uint32_t itemID, avifD
     return AVIF_RESULT_OK;
 }
 
-static avifResult avifMetaFindOrCreateItem(avifMeta * meta, uint32_t itemID, avifDecoderItem ** item, avifDiagnostics * diag)
+static avifResult avifMetaFindOrCreateItem(avifMeta * meta, uint32_t itemID, avifDecoderItem ** item)
 {
     *item = NULL;
     AVIF_ASSERT_OR_RETURN(itemID != 0);
@@ -796,18 +796,6 @@ static avifResult avifMetaFindOrCreateItem(avifMeta * meta, uint32_t itemID, avi
         if (meta->items.item[i]->id == itemID) {
             *item = meta->items.item[i];
             return AVIF_RESULT_OK;
-        }
-    }
-
-    if (meta->items.count != 0) {
-        // ISO/IEC 23008-12, First edition, 2017-12, Section 9.3.1:
-        //   Each ItemPropertyAssociation box shall be ordered by increasing item_ID, and there shall
-        //   be at most one association box for each item_ID, in any ItemPropertyAssociation box.
-        const uint32_t lastID = meta->items.item[meta->items.count - 1]->id;
-        if (itemID <= lastID) {
-            avifBreakOnError();
-            avifDiagnosticsPrintf(diag, "The added itemID [%u] does not preserve the itemID order", itemID);
-            return AVIF_RESULT_BMFF_PARSE_FAILED;
         }
     }
 
@@ -1777,7 +1765,7 @@ static avifResult avifParseItemLocationBox(avifMeta * meta, const uint8_t * raw,
 #endif // AVIF_ENABLE_EXPERIMENTAL_AVIR
 
         avifDecoderItem * item;
-        AVIF_CHECKRES(avifMetaFindOrCreateItem(meta, itemID, &item, diag));
+        AVIF_CHECKRES(avifMetaFindOrCreateItem(meta, itemID, &item));
         if (item->extents.count > 0) {
             // This item has already been given extents via this iloc box. This is invalid.
             avifDiagnosticsPrintf(diag, "Item ID [%u] contains duplicate sets of extents", itemID);
@@ -2391,7 +2379,7 @@ static avifResult avifParseItemPropertyAssociation(avifMeta * meta, const uint8_
         prevItemID = itemID;
 
         avifDecoderItem * item;
-        AVIF_CHECKRES(avifMetaFindOrCreateItem(meta, itemID, &item, diag));
+        AVIF_CHECKRES(avifMetaFindOrCreateItem(meta, itemID, &item));
         if (item->ipmaSeen) {
             avifDiagnosticsPrintf(diag, "Duplicate Box[ipma] for item ID [%u]", itemID);
             return AVIF_RESULT_BMFF_PARSE_FAILED;
@@ -2667,7 +2655,7 @@ static avifResult avifParseItemInfoEntry(avifMeta * meta, const uint8_t * raw, s
     }
 #endif // AVIF_ENABLE_EXPERIMENTAL_AVIR
     avifDecoderItem * item;
-    AVIF_CHECKRES(avifMetaFindOrCreateItem(meta, itemID, &item, diag));
+    AVIF_CHECKRES(avifMetaFindOrCreateItem(meta, itemID, &item));
 
     memcpy(item->type, itemType, sizeof(itemType));
     item->contentType = contentType;
@@ -2736,7 +2724,7 @@ static avifResult avifParseItemReferenceBox(avifMeta * meta, const uint8_t * raw
         AVIF_CHECKRES(avifCheckItemID("iref", fromID, diag));
 
         avifDecoderItem * item;
-        AVIF_CHECKRES(avifMetaFindOrCreateItem(meta, fromID, &item, diag));
+        AVIF_CHECKRES(avifMetaFindOrCreateItem(meta, fromID, &item));
         if (!memcmp(irefHeader.type, "dimg", 4)) {
             if (item->hasDimgFrom) {
                 // ISO/IEC 23008-12 (HEIF) 6.6.1: The number of SingleItemTypeReferenceBoxes with the box type 'dimg'
@@ -2774,7 +2762,7 @@ static avifResult avifParseItemReferenceBox(avifMeta * meta, const uint8_t * raw
             } else if (!memcmp(irefHeader.type, "dimg", 4)) {
                 // derived images refer in the opposite direction
                 avifDecoderItem * dimg;
-                AVIF_CHECKRES(avifMetaFindOrCreateItem(meta, toID, &dimg, diag));
+                AVIF_CHECKRES(avifMetaFindOrCreateItem(meta, toID, &dimg));
 
                 dimg->dimgForID = fromID;
                 dimg->dimgIdx = refIndex;
@@ -3574,7 +3562,7 @@ static avifResult avifParseCondensedImageBox(avifMeta * meta, uint64_t rawOffset
 
     meta->primaryItemID = 1;
     avifDecoderItem * colorItem;
-    AVIF_CHECKRES(avifMetaFindOrCreateItem(meta, meta->primaryItemID, &colorItem, diag));
+    AVIF_CHECKRES(avifMetaFindOrCreateItem(meta, meta->primaryItemID, &colorItem));
     memcpy(colorItem->type, "av01", 4);
     colorItem->width = width;
     colorItem->height = height;
@@ -3583,7 +3571,7 @@ static avifResult avifParseCondensedImageBox(avifMeta * meta, uint64_t rawOffset
 
     avifDecoderItem * alphaItem = NULL;
     if (hasAlpha) {
-        AVIF_CHECKRES(avifMetaFindOrCreateItem(meta, /*itemID=*/2, &alphaItem, diag));
+        AVIF_CHECKRES(avifMetaFindOrCreateItem(meta, /*itemID=*/2, &alphaItem));
         memcpy(alphaItem->type, "av01", 4);
         alphaItem->width = width;
         alphaItem->height = height;
@@ -3688,7 +3676,7 @@ static avifResult avifParseCondensedImageBox(avifMeta * meta, uint64_t rawOffset
 
     if (hasExif) {
         avifDecoderItem * exifItem;
-        AVIF_CHECKRES(avifMetaFindOrCreateItem(meta, /*itemID=*/3, &exifItem, diag));
+        AVIF_CHECKRES(avifMetaFindOrCreateItem(meta, /*itemID=*/3, &exifItem));
         memcpy(exifItem->type, "Exif", 4);
         exifItem->descForID = colorItem->id;
         colorItem->premByID = alphaIsPremultiplied;
@@ -3703,7 +3691,7 @@ static avifResult avifParseCondensedImageBox(avifMeta * meta, uint64_t rawOffset
 
     if (hasXMP) {
         avifDecoderItem * xmpItem;
-        AVIF_CHECKRES(avifMetaFindOrCreateItem(meta, /*itemID=*/4, &xmpItem, diag));
+        AVIF_CHECKRES(avifMetaFindOrCreateItem(meta, /*itemID=*/4, &xmpItem));
         memcpy(xmpItem->type, "mime", 4);
         memcpy(xmpItem->contentType.contentType, xmpContentType, xmpContentTypeSize);
         xmpItem->descForID = colorItem->id;
@@ -4046,7 +4034,7 @@ avifResult avifDecoderNthImageMaxExtent(const avifDecoder * decoder, uint32_t fr
                 // The data comes from an item. Let avifDecoderItemMaxExtent() do the heavy lifting.
 
                 avifDecoderItem * item;
-                AVIF_CHECKRES(avifMetaFindOrCreateItem(decoder->data->meta, sample->itemID, &item, decoder->data->diag));
+                AVIF_CHECKRES(avifMetaFindOrCreateItem(decoder->data->meta, sample->itemID, &item));
                 avifResult maxExtentResult = avifDecoderItemMaxExtent(item, sample, &sampleExtent);
                 if (maxExtentResult != AVIF_RESULT_OK) {
                     return maxExtentResult;
@@ -4085,7 +4073,7 @@ static avifResult avifDecoderPrepareSample(avifDecoder * decoder, avifDecodeSamp
             // The data comes from an item. Let avifDecoderItemRead() do the heavy lifting.
 
             avifDecoderItem * item;
-            AVIF_CHECKRES(avifMetaFindOrCreateItem(decoder->data->meta, sample->itemID, &item, decoder->data->diag));
+            AVIF_CHECKRES(avifMetaFindOrCreateItem(decoder->data->meta, sample->itemID, &item));
             avifROData itemContents;
             if (sample->offset > SIZE_MAX) {
                 return AVIF_RESULT_BMFF_PARSE_FAILED;
@@ -4352,8 +4340,7 @@ static avifResult avifMetaFindAlphaItem(avifMeta * meta,
                                         const avifTileInfo * colorInfo,
                                         avifDecoderItem ** alphaItem,
                                         avifTileInfo * alphaInfo,
-                                        avifBool * isAlphaItemInInput,
-                                        avifDiagnostics * diag)
+                                        avifBool * isAlphaItemInInput)
 {
     for (uint32_t itemIndex = 0; itemIndex < meta->items.count; ++itemIndex) {
         avifDecoderItem * item = meta->items.item[itemIndex];
@@ -4411,17 +4398,25 @@ static avifResult avifMetaFindAlphaItem(avifMeta * meta,
         }
     }
     AVIF_ASSERT_OR_RETURN(alphaItemCount == colorItemCount);
-    // Figure out the last used itemID.
+    // Find an unused ID.
     avifResult result;
-    const uint32_t lastID = meta->items.item[meta->items.count - 1]->id;
-    if (lastID == UINT32_MAX) {
-        // In the improbable case where the last ID is the maximum one, ids cannot be kept ordered.
-        avifDiagnosticsPrintf(diag,
-                              "Cannot set an itemID for alpha that fits the increasing "
-                              "order as the maximum possible ID is in use.");
+    if (meta->items.count >= UINT32_MAX - 1) {
+        // In the improbable case where all IDs are used.
         result = AVIF_RESULT_DECODE_ALPHA_FAILED;
     } else {
-        result = avifMetaFindOrCreateItem(meta, lastID + 1, alphaItem, diag); // Create new empty item.
+        uint32_t newItemID = 0;
+        avifBool isUsed;
+        do {
+            ++newItemID;
+            isUsed = AVIF_FALSE;
+            for (uint32_t i = 0; i < meta->items.count; ++i) {
+                if (meta->items.item[i]->id == newItemID) {
+                    isUsed = AVIF_TRUE;
+                    break;
+                }
+            }
+        } while (isUsed && newItemID != 0);
+        result = avifMetaFindOrCreateItem(meta, newItemID, alphaItem); // Create new empty item.
     }
     if (result != AVIF_RESULT_OK) {
         avifFree(alphaItemIndices);
@@ -4565,7 +4560,7 @@ static avifResult avifDecoderFindGainMapItem(const avifDecoder * decoder,
 
     AVIF_ASSERT_OR_RETURN(gainMapItemID != 0);
     avifDecoderItem * gainMapItemTmp;
-    AVIF_CHECKRES(avifMetaFindOrCreateItem(data->meta, gainMapItemID, &gainMapItemTmp, data->diag));
+    AVIF_CHECKRES(avifMetaFindOrCreateItem(data->meta, gainMapItemID, &gainMapItemTmp));
     if (avifDecoderItemShouldBeSkipped(gainMapItemTmp)) {
         avifDiagnosticsPrintf(data->diag, "Box[tmap] gain map item %d is not a supported image type", gainMapItemID);
         return AVIF_RESULT_INVALID_TONE_MAPPED_IMAGE;
@@ -4891,8 +4886,7 @@ avifResult avifDecoderReset(avifDecoder * decoder)
                                             &data->tileInfos[AVIF_ITEM_COLOR],
                                             &mainItems[AVIF_ITEM_ALPHA],
                                             &data->tileInfos[AVIF_ITEM_ALPHA],
-                                            &isAlphaItemInInput,
-                                            data->diag));
+                                            &isAlphaItemInInput));
         if (mainItems[AVIF_ITEM_ALPHA]) {
             AVIF_CHECKRES(avifDecoderItemReadAndParse(decoder,
                                                       mainItems[AVIF_ITEM_ALPHA],


### PR DESCRIPTION
#### 3d68c0149da5cbe662ccbc996d62b52a76eab11a
<pre>
REGRESSION(275291@main): Some AVIF images in ford.com are not displayed on macOS Monterey
<a href="https://bugs.webkit.org/show_bug.cgi?id=273902">https://bugs.webkit.org/show_bug.cgi?id=273902</a>
<a href="https://rdar.apple.com/126883177">rdar://126883177</a>

Reviewed by Per Arne Vollan.

This caused by the commit 5ff8f49de0537fd9c6ec23fa7489b435a5e07b32 which was
included in 275291@main. This commit 2790a811a2c5a688f633f4e1431d02507425e355
revertedd this change. WebKit needs to port the revert to get this bug fixed.

* Source/WebCore/PAL/ThirdParty/libavif/src/read.c:
(avifMetaFindOrCreateItem):
(avifParseItemLocationBox):
(avifParseItemPropertyAssociation):
(avifParseItemInfoEntry):
(avifParseItemReferenceBox):
(avifParseCondensedImageBox):

Canonical link: <a href="https://commits.webkit.org/278535@main">https://commits.webkit.org/278535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01dcaeb80b62eac06da5cd7759a753ad175f86f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50886 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54144 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1576 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53188 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1231 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52984 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27821 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/43835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/22578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/1091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9326 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47143 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/1156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55738 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25988 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27245 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/43909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28116 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7373 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26976 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->