### PR TITLE
[Site Isolation] Scrolling on iOS

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4608,8 +4608,6 @@ webkit.org/b/257904 http/tests/site-isolation/draw-after-navigation.html [ Skip 
 webkit.org/b/257904 http/tests/site-isolation/draw-with-size-after-same-origin-navigation.html [ Skip ]
 webkit.org/b/257904 http/tests/site-isolation/page-zoom.html [ Skip ]
 
-webkit.org/b/269550 http/tests/site-isolation/scrolling/ [ Skip ]
-
 # This test can't be enabled on iOS until EventSenderProxy::keyDown() is implemented on iOS.
 http/tests/site-isolation/key-events.html [ Skip ]
 

--- a/LayoutTests/platform/ios/http/tests/site-isolation/scrolling/basic-scrolling-tree-expected.txt
+++ b/LayoutTests/platform/ios/http/tests/site-isolation/scrolling/basic-scrolling-tree-expected.txt
@@ -1,0 +1,36 @@
+Verifies scrolling tree for simple page.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+(scrolling tree
+  (frame scrolling node
+    (scrollable area size width=800 height=600)
+    (total content size width=800 height=600)
+    (last committed scroll position (0,0))
+    (scrollable area parameters
+      (horizontal scroll elasticity 1)
+      (vertical scroll elasticity 1)
+      (horizontal scrollbar mode 0)
+      (vertical scrollbar mode 0))
+    (layout viewport (0,0) width=800 height=600)
+    (min layoutViewport origin (0,0))
+    (max layoutViewport origin (0,0))
+    (behavior for fixed 1)
+    (frame hosting node
+      (has hosting context identifier )
+      (frame scrolling node
+        (scrollable area size width=300 height=300)
+        (total content size width=300 height=300)
+        (last committed scroll position (0,0))
+        (scrollable area parameters
+          (horizontal scroll elasticity 1)
+          (vertical scroll elasticity 1)
+          (horizontal scrollbar mode 0)
+          (vertical scrollbar mode 0))
+        (layout viewport (0,0) width=300 height=300)
+        (min layoutViewport origin (0,0))
+        (max layoutViewport origin (0,0))
+        (behavior for fixed 1)))))
+

--- a/LayoutTests/platform/ios/http/tests/site-isolation/scrolling/multiple-root-frames-expected.txt
+++ b/LayoutTests/platform/ios/http/tests/site-isolation/scrolling/multiple-root-frames-expected.txt
@@ -1,0 +1,51 @@
+Verifies scrolling tree for page with multiple iframes in the same process.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+(scrolling tree
+  (frame scrolling node
+    (scrollable area size width=800 height=600)
+    (total content size width=800 height=600)
+    (last committed scroll position (0,0))
+    (scrollable area parameters
+      (horizontal scroll elasticity 1)
+      (vertical scroll elasticity 1)
+      (horizontal scrollbar mode 0)
+      (vertical scrollbar mode 0))
+    (layout viewport (0,0) width=800 height=600)
+    (min layoutViewport origin (0,0))
+    (max layoutViewport origin (0,0))
+    (behavior for fixed 1)
+    (frame hosting node
+      (has hosting context identifier )
+      (frame scrolling node
+        (scrollable area size width=300 height=400)
+        (total content size width=300 height=400)
+        (last committed scroll position (0,0))
+        (scrollable area parameters
+          (horizontal scroll elasticity 1)
+          (vertical scroll elasticity 1)
+          (horizontal scrollbar mode 0)
+          (vertical scrollbar mode 0))
+        (layout viewport (0,0) width=300 height=400)
+        (min layoutViewport origin (0,0))
+        (max layoutViewport origin (0,0))
+        (behavior for fixed 1)))
+    (frame hosting node
+      (has hosting context identifier )
+      (frame scrolling node
+        (scrollable area size width=200 height=100)
+        (total content size width=200 height=100)
+        (last committed scroll position (0,0))
+        (scrollable area parameters
+          (horizontal scroll elasticity 1)
+          (vertical scroll elasticity 1)
+          (horizontal scrollbar mode 0)
+          (vertical scrollbar mode 0))
+        (layout viewport (0,0) width=200 height=100)
+        (min layoutViewport origin (0,0))
+        (max layoutViewport origin (0,0))
+        (behavior for fixed 1)))))
+

--- a/LayoutTests/platform/ios/http/tests/site-isolation/scrolling/remove-root-frame-expected.txt
+++ b/LayoutTests/platform/ios/http/tests/site-isolation/scrolling/remove-root-frame-expected.txt
@@ -1,0 +1,36 @@
+Verifies that root frames are successfully removed from scrolling trees when removed from the DOM.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+(scrolling tree
+  (frame scrolling node
+    (scrollable area size width=800 height=600)
+    (total content size width=800 height=600)
+    (last committed scroll position (0,0))
+    (scrollable area parameters
+      (horizontal scroll elasticity 1)
+      (vertical scroll elasticity 1)
+      (horizontal scrollbar mode 0)
+      (vertical scrollbar mode 0))
+    (layout viewport (0,0) width=800 height=600)
+    (min layoutViewport origin (0,0))
+    (max layoutViewport origin (0,0))
+    (behavior for fixed 1)
+    (frame hosting node
+      (has hosting context identifier )
+      (frame scrolling node
+        (scrollable area size width=300 height=400)
+        (total content size width=300 height=400)
+        (last committed scroll position (0,0))
+        (scrollable area parameters
+          (horizontal scroll elasticity 1)
+          (vertical scroll elasticity 1)
+          (horizontal scrollbar mode 0)
+          (vertical scrollbar mode 0))
+        (layout viewport (0,0) width=300 height=400)
+        (min layoutViewport origin (0,0))
+        (max layoutViewport origin (0,0))
+        (behavior for fixed 1)))))
+

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -342,13 +342,7 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
         }
 
 #if ENABLE(ASYNC_SCROLLING)
-#if PLATFORM(IOS_FAMILY)
-        if (!layerTreeTransaction.isMainFrameProcessTransaction()) {
-            // TODO: rdar://123104203 Making scrolling trees work with site isolation on iOS.
-            return;
-        }
-#endif
-        requestedScroll = webPageProxy->scrollingCoordinatorProxy()->commitScrollingTreeState(connection, scrollingTreeTransaction, layerTreeTransaction.remoteContextHostedIdentifier());
+    requestedScroll = webPageProxy->scrollingCoordinatorProxy()->commitScrollingTreeState(connection, scrollingTreeTransaction, layerTreeTransaction.remoteContextHostedIdentifier());
 #endif
     };
 


### PR DESCRIPTION
#### d45c5323a89128da243986d228e339872f71ef42
<pre>
[Site Isolation] Scrolling on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=273913">https://bugs.webkit.org/show_bug.cgi?id=273913</a>
<a href="https://rdar.apple.com/123104203">rdar://123104203</a>

Reviewed by Simon Fraser.

Make scrolling work on iOS.

* LayoutTests/platform/ios/TestExpectations:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):

Canonical link: <a href="https://commits.webkit.org/288166@main">https://commits.webkit.org/288166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80fe87e826530e3fffb3b7dc1584d7d52422f3a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86508 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32983 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9301 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63901 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21624 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1120 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74579 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44184 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1022 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28756 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31402 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72349 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29367 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87939 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9193 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6553 "Found 1 new test failure: http/wpt/mediarecorder/pause-recording-timeSlice.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72269 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9378 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70398 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71491 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15596 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14522 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/579 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12716 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9144 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14680 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8984 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12509 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10792 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->