### PR TITLE
[UnifiedPDF] When an incremental PDF completes its load, blank pages are still visible

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -344,6 +344,10 @@ protected:
     virtual Ref<WebCore::Scrollbar> createScrollbar(WebCore::ScrollbarOrientation);
     virtual void destroyScrollbar(WebCore::ScrollbarOrientation);
 
+    virtual void incrementalLoadingDidProgress() { }
+    virtual void incrementalLoadingDidCancel() { }
+    virtual void incrementalLoadingDidFinish() { }
+
 #if ENABLE(PDF_HUD)
     void updateHUDLocation();
     WebCore::IntRect frameForHUDInRootViewCoordinates() const;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -386,6 +386,8 @@ void PDFPluginBase::streamDidReceiveData(const SharedBuffer& buffer)
     if (m_incrementalLoader)
         m_incrementalLoader->incrementalPDFStreamDidReceiveData(buffer);
 #endif
+
+    incrementalLoadingDidProgress();
 }
 
 void PDFPluginBase::streamDidFinishLoading()
@@ -415,6 +417,7 @@ void PDFPluginBase::streamDidFinishLoading()
         installPDFDocument();
     }
 
+    incrementalLoadingDidFinish();
     tryRunScriptsInPDFDocument();
 
 #if ENABLE(PDF_HUD)
@@ -436,6 +439,8 @@ void PDFPluginBase::streamDidFail()
     if (m_incrementalLoader)
         m_incrementalLoader->incrementalPDFStreamDidFail();
 #endif
+
+    incrementalLoadingDidCancel();
 }
 
 #if HAVE(INCREMENTAL_PDF_APIS)
@@ -517,6 +522,8 @@ void PDFPluginBase::receivedNonLinearizedPDFSentinel()
 
     if (m_incrementalLoader)
         m_incrementalLoader->receivedNonLinearizedPDFSentinel();
+
+    incrementalLoadingDidCancel();
 
     if (!m_documentFinishedLoading || m_pdfDocument)
         return;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
@@ -224,8 +224,6 @@ void AsyncPDFRenderer::coverageRectDidChange(const FloatRect& coverageRect)
     auto pageCoverage = plugin->pageCoverageForRect(coverageRect);
     auto pagePreviewScale = plugin->scaleForPagePreviews();
 
-    LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::coverageRectDidChange " << coverageRect << " " << pageCoverage << " - preview scale " << pagePreviewScale);
-
     PDFPageIndexSet unwantedPageIndices;
     for (auto pageIndex : m_pagePreviews.keys())
         unwantedPageIndices.add(pageIndex);
@@ -242,6 +240,8 @@ void AsyncPDFRenderer::coverageRectDidChange(const FloatRect& coverageRect)
 
     for (auto pageIndex : unwantedPageIndices)
         removePreviewForPage(pageIndex);
+
+    LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::coverageRectDidChange " << coverageRect << " " << pageCoverage << " - preview scale " << pagePreviewScale << " - have " << m_pagePreviews.size() << " page previews and " << m_enqueuedPagePreviews.size() << " enqueued");
 }
 
 void AsyncPDFRenderer::tilingScaleFactorDidChange(float)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -93,6 +93,7 @@ public:
     float scale() const { return m_scale; }
 
     void updateLayout(WebCore::IntSize pluginSize, ShouldUpdateAutoSizeScale);
+    WebCore::FloatSize contentsSize() const;
     WebCore::FloatSize scaledContentsSize() const;
 
     void setDisplayMode(DisplayMode displayMode) { m_displayMode = displayMode; }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
@@ -413,6 +413,11 @@ IntDegrees PDFDocumentLayout::rotationForPageAtIndex(PageIndex index) const
     return m_pageGeometry[index].rotation;
 }
 
+FloatSize PDFDocumentLayout::contentsSize() const
+{
+    return m_documentBounds.size();
+}
+
 FloatSize PDFDocumentLayout::scaledContentsSize() const
 {
     return m_documentBounds.size().scaled(m_scale);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -199,6 +199,10 @@ private:
 
     void teardown() override;
 
+    void incrementalLoadingDidProgress() override;
+    void incrementalLoadingDidCancel() override;
+    void incrementalLoadingDidFinish() override;
+
     void installPDFDocument() override;
 
 #if ENABLE(UNIFIED_PDF_DATA_DETECTION)
@@ -425,6 +429,9 @@ private:
     void updateLayerHierarchy();
     void updateLayerPositions();
 
+    void incrementalLoadingRepaintTimerFired();
+    void repaintForIncrementalLoad();
+
     void didChangeScrollOffset() override;
     void didChangeIsInWindow();
 
@@ -591,6 +598,8 @@ private:
 
     bool m_inActiveAutoscroll { false };
     WebCore::Timer m_autoscrollTimer { *this, &UnifiedPDFPlugin::autoscrollTimerFired };
+
+    WebCore::Timer m_incrementalLoadingRepaintTimer { *this, &UnifiedPDFPlugin::incrementalLoadingRepaintTimerFired };
 
     RetainPtr<WKPDFFormMutationObserver> m_pdfMutationObserver;
 


### PR DESCRIPTION
#### 7208a15cb4af909a38d444b9e4aaf1c56fb013bd
<pre>
[UnifiedPDF] When an incremental PDF completes its load, blank pages are still visible
<a href="https://bugs.webkit.org/show_bug.cgi?id=273917">https://bugs.webkit.org/show_bug.cgi?id=273917</a>
<a href="https://rdar.apple.com/127713604">rdar://127713604</a>

Reviewed by Tim Horton.

While loading an incremental PDF (potentially over a slow network connection), nothing
currently triggers repaints, so we never show pages as they load, nor do we repaint all
the pages when the load completes. This can leave you with blank pages until you scroll
or zoom.

Fix by hooking up some virtual functions on the plugin to give UnifiedPDFPlugin a way
to know when incremental loads progress, finish or cancel. While progressing, fire
a repeating timer every 1s to trigger repaints (we currently can&apos;t know which pages
become valid based on data ranges). Also trigger a repaint when the load completes.
This repaints use the coverage rect to only invalidate visible pages.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::incrementalLoadingDidProgress):
(WebKit::PDFPluginBase::incrementalLoadingDidCancel):
(WebKit::PDFPluginBase::incrementalLoadingDidFinish):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::streamDidReceiveData):
(WebKit::PDFPluginBase::streamDidFinishLoading):
(WebKit::PDFPluginBase::streamDidFail):
(WebKit::PDFPluginBase::receivedNonLinearizedPDFSentinel):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::coverageRectDidChange):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::contentsSize const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::installPDFDocument):
(WebKit::UnifiedPDFPlugin::incrementalLoadingDidProgress):
(WebKit::UnifiedPDFPlugin::incrementalLoadingDidCancel):
(WebKit::UnifiedPDFPlugin::incrementalLoadingDidFinish):
(WebKit::UnifiedPDFPlugin::updatePageBackgroundLayers):
(WebKit::UnifiedPDFPlugin::incrementalLoadingRepaintTimerFired):
(WebKit::UnifiedPDFPlugin::repaintForIncrementalLoad):
(WebKit::UnifiedPDFPlugin::paintContents):

Canonical link: <a href="https://commits.webkit.org/278597@main">https://commits.webkit.org/278597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d648943eeae3172ddf707959e377ba4839dd199a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3374 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54303 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1735 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1425 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41570 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43985 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22690 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25314 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9486 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47290 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55898 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26154 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27404 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44054 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11169 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28283 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27135 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->