### PR TITLE
Add Element::hasClassName

### DIFF
--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -712,7 +712,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
         return tagMatches(element, selector);
 
     if (selector.match() == CSSSelector::Match::Class)
-        return element.hasClass() && element.classNames().contains(selector.value());
+        return element.hasClassName(selector.value());
 
     if (selector.match() == CSSSelector::Match::Id) {
         ASSERT(!selector.value().isNull());

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -664,6 +664,7 @@ public:
     inline bool hasClass() const;
     inline bool hasName() const;
     inline const SpaceSplitString& classNames() const;
+    inline bool hasClassName(const AtomString& className) const;
 
     ScrollPosition savedLayerScrollPosition() const;
     void setSavedLayerScrollPosition(const ScrollPosition&);

--- a/Source/WebCore/dom/ElementInlines.h
+++ b/Source/WebCore/dom/ElementInlines.h
@@ -160,6 +160,13 @@ inline const SpaceSplitString& Element::classNames() const
     return elementData()->classNames();
 }
 
+inline bool Element::hasClassName(const AtomString& className) const
+{
+    if (!elementData())
+        return false;
+    return elementData()->classNames().contains(className);
+}
+
 inline unsigned Element::attributeCount() const
 {
     ASSERT(elementData());

--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -126,7 +126,7 @@ static RefPtr<HTMLElement> imageOverlayHost(const Node& node)
 
 bool isDataDetectorResult(const HTMLElement& element)
 {
-    return imageOverlayHost(element) && element.hasClass() && element.classNames().contains(imageOverlayDataDetectorClass());
+    return imageOverlayHost(element) && element.hasClassName(imageOverlayDataDetectorClass());
 }
 
 std::optional<CharacterRange> characterRange(const VisibleSelection& selection)
@@ -269,7 +269,7 @@ static Elements updateSubtree(HTMLElement& element, const TextRecognitionResult&
 
         auto& containerClass = controlsHost->mediaControlsContainerClassName();
         for (auto& child : childrenOfType<HTMLDivElement>(shadowRoot.get())) {
-            if (child.hasClass() && child.classNames().contains(containerClass))
+            if (child.hasClassName(containerClass))
                 return &child;
         }
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -394,7 +394,7 @@ ALWAYS_INLINE void SelectorDataList::executeSingleClassNameSelectorData(const Co
 
     const AtomString& className = selectorData.selector->value();
     for (auto& element : descendantsOfType<Element>(const_cast<ContainerNode&>(rootNode))) {
-        if (element.hasClass() && element.classNames().contains(className)) {
+        if (element.hasClassName(className)) {
             appendOutputForElement(output, element);
             if constexpr (std::is_same_v<OutputType, Element*>)
                 return;

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -60,7 +60,7 @@ inline bool TextManipulationControllerExclusionRule::match(const Element& elemen
     }, [&element] (AttributeRule rule) {
         return equalIgnoringASCIICase(element.getAttribute(rule.name), rule.value);
     }, [&element] (ClassRule rule) {
-        return element.hasClass() && element.classNames().contains(rule.className);
+        return element.hasClassName(rule.className);
     });
 }
 

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -229,7 +229,9 @@ bool Quirks::shouldTooltipPreventFromProceedingWithClick(const Element& element)
 
     if (!isDomain("covid.cdc.gov"_s))
         return false;
-    return element.hasClass() && element.classNames().contains("tooltip"_s);
+
+    static MainThreadNeverDestroyed<const AtomString> tooltipClass("tooltip"_s);
+    return element.hasClassName(tooltipClass.get());
 }
 
 // google.com https://bugs.webkit.org/show_bug.cgi?id=223700
@@ -941,7 +943,7 @@ bool Quirks::shouldBypassBackForwardCache() const
                 static MainThreadNeverDestroyed<const AtomString> signInId("signIn"_s);
                 static MainThreadNeverDestroyed<const AtomString> loadingClass("loading"_s);
                 RefPtr signinButton = document->getElementById(signInId.get());
-                return signinButton && signinButton->classNames().contains(loadingClass.get());
+                return signinButton && signinButton->hasClassName(loadingClass.get());
             }
         }
     }
@@ -954,7 +956,7 @@ bool Quirks::shouldBypassBackForwardCache() const
     static MainThreadNeverDestroyed<const AtomString> googleDocsOverlayDivClass("docs-homescreen-freeze-el-full"_s);
     auto* firstChildInBody = document->body() ? document->body()->firstChild() : nullptr;
     if (RefPtr div = dynamicDowncast<HTMLDivElement>(firstChildInBody)) {
-        if (div->hasClass() && div->classNames().contains(googleDocsOverlayDivClass))
+        if (div->hasClassName(googleDocsOverlayDivClass))
             return true;
     }
 
@@ -1120,14 +1122,14 @@ bool Quirks::isMicrosoftTeamsRedirectURL(const URL& url)
 
 static bool elementHasClassInClosestAncestors(const Element& element, const AtomString& className, unsigned distance)
 {
-    if (element.hasClass() && element.classNames().contains(className))
+    if (element.hasClassName(className))
         return true;
 
     unsigned currentDistance = 0;
     RefPtr ancestor = dynamicDowncast<Element>(element.parentNode());
     while (ancestor && currentDistance < distance) {
         ++currentDistance;
-        if (ancestor->hasClass() && ancestor->classNames().contains(className))
+        if (ancestor->hasClassName(className))
             return true;
 
         ancestor = dynamicDowncast<Element>(ancestor->parentNode());

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -954,7 +954,7 @@ void Adjuster::adjustForSiteSpecificQuirks(RenderStyle& style) const
             static MainThreadNeverDestroyed<const AtomString> instreamNativeVideoDivClass("instream-native-video--mobile"_s);
             static MainThreadNeverDestroyed<const AtomString> videoElementID("vjs_video_3_html5_api"_s);
 
-            if (div->hasClass() && div->classNames().contains(instreamNativeVideoDivClass)) {
+            if (div->hasClassName(instreamNativeVideoDivClass)) {
                 RefPtr video = dynamicDowncast<HTMLVideoElement>(div->treeScope().getElementById(videoElementID));
                 if (video && video->isFullscreen())
                     style.setEffectiveDisplay(DisplayType::Block);
@@ -966,7 +966,7 @@ void Adjuster::adjustForSiteSpecificQuirks(RenderStyle& style) const
         static MainThreadNeverDestroyed<const AtomString> playerClassName("top-player-video-element"_s);
         bool isFullscreen = fullscreenManager->isFullscreen();
         RefPtr video = dynamicDowncast<HTMLVideoElement>(m_element);
-        if (video && isFullscreen && video->hasClass() && video->classNames().contains(playerClassName) && style.objectFit() == ObjectFit::Fill)
+        if (video && isFullscreen && video->hasClassName(playerClassName) && style.objectFit() == ObjectFit::Fill)
             style.setObjectFit(ObjectFit::Contain);
     }
 #endif


### PR DESCRIPTION
#### f2ae3f6424c5f386f2baccac56add011938f4093
<pre>
Add Element::hasClassName
<a href="https://bugs.webkit.org/show_bug.cgi?id=273925">https://bugs.webkit.org/show_bug.cgi?id=273925</a>
<a href="https://rdar.apple.com/127789854">rdar://127789854</a>

Reviewed by Ryosuke Niwa.

This patch cherry-picks [1]. Simply this is good as a refactoring.

[1]: <a href="https://chromium-review.googlesource.com/c/chromium/src/+/5479574">https://chromium-review.googlesource.com/c/chromium/src/+/5479574</a>

* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementInlines.h:
(WebCore::Element::hasClassName const):
* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::isDataDetectorResult):
(WebCore::ImageOverlay::updateSubtree):
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::SelectorDataList::executeSingleClassNameSelectorData const):
* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::TextManipulationControllerExclusionRule::match const):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldTooltipPreventFromProceedingWithClick const):
(WebCore::Quirks::shouldBypassBackForwardCache const):
(WebCore::elementHasClassInClosestAncestors):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustForSiteSpecificQuirks const):

Canonical link: <a href="https://commits.webkit.org/278580@main">https://commits.webkit.org/278580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/942b8c0a977840cf1a156ebdd9521307219723db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54197 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1629 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1292 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41484 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-backgrounds/background-color-body-propagation-006.html, imported/w3c/web-platform-tests/css/css-backgrounds/background-color-root-propagation-002.html, imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-auto-last-word-001.html, imported/w3c/web-platform-tests/css/css-view-transitions/new-content-scaling.html, imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43885 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22614 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25215 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1141 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9379 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47197 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55791 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26045 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1105 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48892 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43956 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47977 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28175 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7402 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27029 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->