### PR TITLE
[WTF] Introduce SIMDHelpers

### DIFF
--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -872,28 +872,28 @@ ALWAYS_INLINE TokenType LiteralParser<CharType>::Lexer::lexString(LiteralParserT
                 constexpr size_t stride = 16 / sizeof(CharType);
                 using UnsignedType = std::make_unsigned_t<CharType>;
                 if (static_cast<size_t>(m_end - m_ptr) >= stride) {
-                    constexpr auto quoteMask = WTF::splatBulk(static_cast<UnsignedType>('"'));
-                    constexpr auto escapeMask = WTF::splatBulk(static_cast<UnsignedType>('\\'));
-                    constexpr auto controlMask = WTF::splatBulk(static_cast<UnsignedType>(' '));
+                    constexpr auto quoteMask = SIMD::splat(static_cast<UnsignedType>('"'));
+                    constexpr auto escapeMask = SIMD::splat(static_cast<UnsignedType>('\\'));
+                    constexpr auto controlMask = SIMD::splat(static_cast<UnsignedType>(' '));
                     for (; m_ptr + (stride - 1) < m_end; m_ptr += stride) {
-                        auto input = WTF::loadBulk(bitwise_cast<const UnsignedType*>(m_ptr));
-                        auto quotes = WTF::equalBulk(input, quoteMask);
-                        auto escapes = WTF::equalBulk(input, escapeMask);
-                        auto controls = WTF::lessThanBulk(input, controlMask);
-                        auto mask = WTF::mergeBulk(quotes, WTF::mergeBulk(escapes, controls));
-                        if (WTF::isNonZeroBulk(mask)) {
-                            m_ptr += WTF::findFirstNonZeroIndexBulk(mask);
+                        auto input = SIMD::load(bitwise_cast<const UnsignedType*>(m_ptr));
+                        auto quotes = SIMD::equal(input, quoteMask);
+                        auto escapes = SIMD::equal(input, escapeMask);
+                        auto controls = SIMD::lessThan(input, controlMask);
+                        auto mask = SIMD::merge(quotes, SIMD::merge(escapes, controls));
+                        if (auto index = SIMD::findFirstNonZeroIndex(mask)) {
+                            m_ptr += index.value();
                             return;
                         }
                     }
                     if (m_ptr < m_end) {
-                        auto input = WTF::loadBulk(bitwise_cast<const UnsignedType*>(m_end - stride));
-                        auto quotes = WTF::equalBulk(input, quoteMask);
-                        auto escapes = WTF::equalBulk(input, escapeMask);
-                        auto controls = WTF::lessThanBulk(input, controlMask);
-                        auto mask = WTF::mergeBulk(quotes, WTF::mergeBulk(escapes, controls));
-                        if (WTF::isNonZeroBulk(mask)) {
-                            m_ptr = m_end - stride + WTF::findFirstNonZeroIndexBulk(mask);
+                        auto input = SIMD::load(bitwise_cast<const UnsignedType*>(m_end - stride));
+                        auto quotes = SIMD::equal(input, quoteMask);
+                        auto escapes = SIMD::equal(input, escapeMask);
+                        auto controls = SIMD::lessThan(input, controlMask);
+                        auto mask = SIMD::merge(quotes, SIMD::merge(escapes, controls));
+                        if (auto index = SIMD::findFirstNonZeroIndex(mask)) {
+                            m_ptr = m_end - stride + index.value();
                             return;
                         }
                         m_ptr = m_end;

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -840,6 +840,7 @@
 		E383AAC92B6C730B00058E60 /* AdaptiveStringSearcher.h in Headers */ = {isa = PBXBuildFile; fileRef = E383AAC82B6C730B00058E60 /* AdaptiveStringSearcher.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E388886F20C9095100E632BC /* WorkerPool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E388886D20C9095100E632BC /* WorkerPool.cpp */; };
 		E38C41281EB4E0680042957D /* CPUTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38C41261EB4E0680042957D /* CPUTime.cpp */; };
+		E38C82692BECAE9D0071EF52 /* SIMDHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = E38C82682BECAE9D0071EF52 /* SIMDHelpers.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E38D6E271F5522E300A75CC4 /* StringBuilderJSON.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38D6E261F5522E300A75CC4 /* StringBuilderJSON.cpp */; };
 		E392FA2722E92BFF00ECDC73 /* ResourceUsageCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E392FA2622E92BFF00ECDC73 /* ResourceUsageCocoa.cpp */; };
 		E396C11D2BE885D9000CBAE1 /* neon.h in Headers */ = {isa = PBXBuildFile; fileRef = E396C1192BE885D9000CBAE1 /* neon.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1789,6 +1790,7 @@
 		E388886E20C9095100E632BC /* WorkerPool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WorkerPool.h; sourceTree = "<group>"; };
 		E38C41261EB4E0680042957D /* CPUTime.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CPUTime.cpp; sourceTree = "<group>"; };
 		E38C41271EB4E0680042957D /* CPUTime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CPUTime.h; sourceTree = "<group>"; };
+		E38C82682BECAE9D0071EF52 /* SIMDHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SIMDHelpers.h; sourceTree = "<group>"; };
 		E38D6E261F5522E300A75CC4 /* StringBuilderJSON.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StringBuilderJSON.cpp; sourceTree = "<group>"; };
 		E392FA2622E92BFF00ECDC73 /* ResourceUsageCocoa.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ResourceUsageCocoa.cpp; sourceTree = "<group>"; };
 		E396C1192BE885D9000CBAE1 /* neon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = neon.h; sourceTree = "<group>"; };
@@ -2371,6 +2373,7 @@
 				A8A47309151A825B004123FF /* SHA1.h */,
 				0FEB3DCE1BB5D684009D7AAD /* SharedTask.h */,
 				862A8D32278DE74A0014120C /* SignedPtr.h */,
+				E38C82682BECAE9D0071EF52 /* SIMDHelpers.h */,
 				A8A4730A151A825B004123FF /* SimpleStats.h */,
 				795212021F42588800BD6421 /* SingleRootGraph.h */,
 				463CCFBB2B251D77009AB04E /* SingleThreadIntegralWrapper.h */,
@@ -3416,6 +3419,7 @@
 				DDF307F227C086EA006A526F /* Signals.h in Headers */,
 				DD03059327B5DA0D00344002 /* SignedPtr.h in Headers */,
 				E3ABBABE2BE88FBE00D84916 /* simde.h in Headers */,
+				E38C82692BECAE9D0071EF52 /* SIMDHelpers.h in Headers */,
 				E361DB63289115D000B2A2B8 /* simple_decimal_conversion.h in Headers */,
 				DD3DC8F727A4BF8E007E5B61 /* SimpleStats.h in Headers */,
 				DD3DC97627A4BF8E007E5B61 /* SingleRootGraph.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -247,6 +247,7 @@ set(WTF_PUBLIC_HEADERS
     RobinHoodHashTable.h
     RunLoop.h
     SHA1.h
+    SIMDHelpers.h
     SafeStrerror.h
     SaturatedArithmetic.h
     SchedulePair.h

--- a/Source/WTF/wtf/SIMDHelpers.h
+++ b/Source/WTF/wtf/SIMDHelpers.h
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <bit>
+#include <optional>
+#include <wtf/StdLibExtras.h>
+#include <wtf/simde/simde.h>
+
+namespace WTF::SIMD {
+
+constexpr simde_uint8x16_t splat(uint8_t code)
+{
+    return simde_uint8x16_t { code, code, code, code, code, code, code, code, code, code, code, code, code, code, code, code };
+}
+
+constexpr simde_uint16x8_t splat(uint16_t code)
+{
+    return simde_uint16x8_t { code, code, code, code, code, code, code, code };
+}
+
+ALWAYS_INLINE simde_uint8x16_t load(const uint8_t* ptr)
+{
+    return simde_vld1q_u8(ptr);
+}
+
+ALWAYS_INLINE simde_uint16x8_t load(const uint16_t* ptr)
+{
+    return simde_vld1q_u16(ptr);
+}
+
+ALWAYS_INLINE void store(simde_uint8x16_t value, uint8_t* ptr)
+{
+    return simde_vst1q_u8(ptr, value);
+}
+
+ALWAYS_INLINE void store(simde_uint16x8_t value, uint16_t* ptr)
+{
+    return simde_vst1q_u16(ptr, value);
+}
+
+ALWAYS_INLINE simde_uint8x16_t merge(simde_uint8x16_t accumulated, simde_uint8x16_t input)
+{
+    return simde_vorrq_u8(accumulated, input);
+}
+
+ALWAYS_INLINE simde_uint16x8_t merge(simde_uint16x8_t accumulated, simde_uint16x8_t input)
+{
+    return simde_vorrq_u16(accumulated, input);
+}
+
+ALWAYS_INLINE bool isNonZero(simde_uint8x16_t accumulated)
+{
+#if CPU(X86_64)
+    auto raw = simde_uint8x16_to_m128i(accumulated);
+    return !simde_mm_test_all_zeros(raw, raw);
+#else
+    return simde_vmaxvq_u8(accumulated);
+#endif
+}
+
+ALWAYS_INLINE bool isNonZero(simde_uint16x8_t accumulated)
+{
+#if CPU(X86_64)
+    auto raw = simde_uint16x8_to_m128i(accumulated);
+    return !simde_mm_test_all_zeros(raw, raw);
+#else
+    return simde_vmaxvq_u16(accumulated);
+#endif
+}
+
+ALWAYS_INLINE std::optional<uint8_t> findFirstNonZeroIndex(simde_uint8x16_t value)
+{
+#if CPU(X86_64)
+    auto raw = simde_uint8x16_to_m128i(value);
+    uint16_t mask = simde_mm_movemask_epi8(raw);
+    if (!mask)
+        return std::nullopt;
+    return std::countr_zero(mask);
+#else
+    if (!isNonZero(value))
+        return std::nullopt;
+    constexpr simde_uint8x16_t indexMask { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+    return simde_vminvq_u8(simde_vornq_u8(indexMask, value));
+#endif
+}
+
+ALWAYS_INLINE std::optional<uint8_t> findFirstNonZeroIndex(simde_uint16x8_t value)
+{
+#if CPU(X86_64)
+    auto raw = simde_uint16x8_to_m128i(value);
+    uint16_t mask = simde_mm_movemask_epi8(raw);
+    if (!mask)
+        return std::nullopt;
+    return std::countr_zero(mask) >> 1;
+#else
+    if (!isNonZero(value))
+        return std::nullopt;
+    constexpr simde_uint16x8_t indexMask { 0, 1, 2, 3, 4, 5, 6, 7 };
+    return simde_vminvq_u16(simde_vornq_u16(indexMask, value));
+#endif
+}
+
+template<LChar character, LChar... characters>
+ALWAYS_INLINE simde_uint8x16_t equal(simde_uint8x16_t input)
+{
+    auto result = simde_vceqq_u8(input, simde_vmovq_n_u8(character));
+    if constexpr (!sizeof...(characters))
+        return result;
+    else
+        return merge(result, equal<characters...>(input));
+}
+
+template<UChar character, UChar... characters>
+ALWAYS_INLINE simde_uint16x8_t equal(simde_uint16x8_t input)
+{
+    auto result = simde_vceqq_u16(input, simde_vmovq_n_u16(character));
+    if constexpr (!sizeof...(characters))
+        return result;
+    else
+        return merge(result, equal<characters...>(input));
+}
+
+ALWAYS_INLINE simde_uint8x16_t equal(simde_uint8x16_t lhs, simde_uint8x16_t rhs)
+{
+    return simde_vceqq_u8(lhs, rhs);
+}
+
+ALWAYS_INLINE simde_uint16x8_t equal(simde_uint16x8_t lhs, simde_uint16x8_t rhs)
+{
+    return simde_vceqq_u16(lhs, rhs);
+}
+
+ALWAYS_INLINE simde_uint8x16_t lessThan(simde_uint8x16_t lhs, simde_uint8x16_t rhs)
+{
+    return simde_vcltq_u8(lhs, rhs);
+}
+
+ALWAYS_INLINE simde_uint16x8_t lessThan(simde_uint16x8_t lhs, simde_uint16x8_t rhs)
+{
+    return simde_vcltq_u16(lhs, rhs);
+}
+
+}
+
+namespace SIMD = WTF::SIMD;


### PR DESCRIPTION
#### d99e74de2a175bf67cdc2e5aaf0617540fa2a448
<pre>
[WTF] Introduce SIMDHelpers
<a href="https://bugs.webkit.org/show_bug.cgi?id=273927">https://bugs.webkit.org/show_bug.cgi?id=273927</a>
<a href="https://rdar.apple.com/127795191">rdar://127795191</a>

Reviewed by Keith Miller.

This patch adds wtf/SIMDHelpers.h, which offers various SIMD abstraction on the top of simde.
The main motivation is writing SIMD code for LChar / UChar in the same code.
Also, we add some x64 specific optimizations for some of particular primitive operations.

* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::FastStringifier&lt;CharType&gt;::append):
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::LiteralParser&lt;CharType&gt;::Lexer::lexString):
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/SIMDHelpers.h: Added.
(WTF::SIMD::splat):
(WTF::SIMD::load):
(WTF::SIMD::store):
(WTF::SIMD::merge):
(WTF::SIMD::isNonZero):
(WTF::SIMD::findFirstNonZeroIndex):
(WTF::SIMD::equal):
(WTF::SIMD::lessThan):
* Source/WTF/wtf/text/StringCommon.h:

Canonical link: <a href="https://commits.webkit.org/278572@main">https://commits.webkit.org/278572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbdea0ee73ba39fd1998256ce1a7a23faebb34e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54201 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1633 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1296 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41486 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53042 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27885 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43889 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22616 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25218 "Found unexpected failure with change (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1145 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9383 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/44282 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47200 "") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55795 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/50445 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48899 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27302 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47985 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28181 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57920 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7396 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27033 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11925 "Passed tests") | 
<!--EWS-Status-Bubble-End-->