### PR TITLE
[WTF][CMake] Move platform specific headers to their platform cmake file

### DIFF
--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -356,22 +356,6 @@ set(WTF_PUBLIC_HEADERS
     WorkerPool.h
     dtoa.h
 
-    cf/CFURLExtras.h
-    cf/TypeCastsCF.h
-    cf/VectorCF.h
-
-    cocoa/CrashReporter.h
-    cocoa/Entitlements.h
-    cocoa/NSURLExtras.h
-    cocoa/RuntimeApplicationChecksCocoa.h
-    cocoa/SoftLinking.h
-    cocoa/TollFreeBridging.h
-    cocoa/TypeCastsCocoa.h
-    cocoa/VectorCocoa.h
-
-    darwin/OSLogPrintStream.h
-    darwin/WeakLinking.h
-
     dragonbox/dragonbox.h
     dragonbox/dragonbox_to_chars.h
     dragonbox/ieee754_format.h
@@ -407,23 +391,6 @@ set(WTF_PUBLIC_HEADERS
     fast_float/parse_number.h
     fast_float/simple_decimal_conversion.h
 
-    glib/ChassisType.h
-    glib/GMutexLocker.h
-    glib/GRefPtr.h
-    glib/GSocketMonitor.h
-    glib/GThreadSafeWeakPtr.h
-    glib/GTypedefs.h
-    glib/GUniquePtr.h
-    glib/GWeakPtr.h
-    glib/RunLoopSourcePriority.h
-    glib/Sandbox.h
-    glib/SocketConnection.h
-    glib/WTFGType.h
-
-    linux/CurrentProcessMemoryStatus.h
-    linux/ProcessMemoryFootprint.h
-    linux/RealTimeThreads.h
-
     persistence/PersistentCoders.h
     persistence/PersistentDecoder.h
     persistence/PersistentEncoder.h
@@ -431,29 +398,6 @@ set(WTF_PUBLIC_HEADERS
     simde/simde.h
     simde/arm/neon.h
     simde/arm/sve.h
-
-    spi/cf/CFBundleSPI.h
-    spi/cf/CFStringSPI.h
-
-    spi/cocoa/CFXPCBridgeSPI.h
-    spi/cocoa/CrashReporterClientSPI.h
-    spi/cocoa/IOSurfaceSPI.h
-    spi/cocoa/MachVMSPI.h
-    spi/cocoa/NSLocaleSPI.h
-    spi/cocoa/NSObjCRuntimeSPI.h
-    spi/cocoa/SecuritySPI.h
-    spi/cocoa/objcSPI.h
-
-    spi/darwin/AbortWithReasonSPI.h
-    spi/darwin/CodeSignSPI.h
-    spi/darwin/DataVaultSPI.h
-    spi/darwin/OSVariantSPI.h
-    spi/darwin/ProcessMemoryFootprint.h
-    spi/darwin/SandboxSPI.h
-    spi/darwin/XPCSPI.h
-    spi/darwin/dyldSPI.h
-
-    spi/mac/MetadataSPI.h
 
     text/ASCIIFastPath.h
     text/ASCIILiteral.h
@@ -502,15 +446,10 @@ set(WTF_PUBLIC_HEADERS
     text/UniquedStringImpl.h
     text/WTFString.h
 
-    text/cf/StringConcatenateCF.h
-    text/cf/TextBreakIteratorCF.h
-
     text/icu/TextBreakIteratorICU.h
     text/icu/UTextProvider.h
     text/icu/UTextProviderLatin1.h
     text/icu/UTextProviderUTF16.h
-
-    text/win/WCharStringExtras.h
 
     threads/BinarySemaphore.h
     threads/Signals.h
@@ -520,14 +459,6 @@ set(WTF_PUBLIC_HEADERS
     unicode/UTF8Conversion.h
 
     unicode/icu/ICUHelpers.h
-
-    unix/UnixFileDescriptor.h
-
-    win/DbgHelperWin.h
-    win/GDIObject.h
-    win/PathWalker.h
-    win/SoftLinking.h
-    win/Win32Handle.h
 )
 
 set(WTF_SOURCES

--- a/Source/WTF/wtf/PlatformGTK.cmake
+++ b/Source/WTF/wtf/PlatformGTK.cmake
@@ -25,6 +25,26 @@ list(APPEND WTF_SOURCES
     unix/UniStdExtrasUnix.cpp
 )
 
+list(APPEND WTF_PUBLIC_HEADERS
+    glib/ChassisType.h
+    glib/GMutexLocker.h
+    glib/GRefPtr.h
+    glib/GSocketMonitor.h
+    glib/GThreadSafeWeakPtr.h
+    glib/GTypedefs.h
+    glib/GUniquePtr.h
+    glib/GWeakPtr.h
+    glib/RunLoopSourcePriority.h
+    glib/Sandbox.h
+    glib/SocketConnection.h
+    glib/WTFGType.h
+
+    linux/CurrentProcessMemoryStatus.h
+    linux/ProcessMemoryFootprint.h
+
+    unix/UnixFileDescriptor.h
+)
+
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     list(APPEND WTF_SOURCES
         linux/CurrentProcessMemoryStatus.cpp

--- a/Source/WTF/wtf/PlatformMac.cmake
+++ b/Source/WTF/wtf/PlatformMac.cmake
@@ -62,6 +62,50 @@ list(APPEND WTF_SOURCES
     text/cocoa/TextBreakIteratorInternalICUCocoa.cpp
 )
 
+list(APPEND WTF_PUBLIC_HEADERS
+    cf/CFURLExtras.h
+    cf/TypeCastsCF.h
+    cf/VectorCF.h
+
+    cocoa/CrashReporter.h
+    cocoa/Entitlements.h
+    cocoa/NSURLExtras.h
+    cocoa/RuntimeApplicationChecksCocoa.h
+    cocoa/SoftLinking.h
+    cocoa/TollFreeBridging.h
+    cocoa/TypeCastsCocoa.h
+    cocoa/VectorCocoa.h
+
+    darwin/OSLogPrintStream.h
+    darwin/WeakLinking.h
+
+    spi/cf/CFBundleSPI.h
+    spi/cf/CFStringSPI.h
+
+    spi/cocoa/CFXPCBridgeSPI.h
+    spi/cocoa/CrashReporterClientSPI.h
+    spi/cocoa/IOSurfaceSPI.h
+    spi/cocoa/MachVMSPI.h
+    spi/cocoa/NSLocaleSPI.h
+    spi/cocoa/NSObjCRuntimeSPI.h
+    spi/cocoa/SecuritySPI.h
+    spi/cocoa/objcSPI.h
+
+    spi/darwin/AbortWithReasonSPI.h
+    spi/darwin/CodeSignSPI.h
+    spi/darwin/DataVaultSPI.h
+    spi/darwin/OSVariantSPI.h
+    spi/darwin/ProcessMemoryFootprint.h
+    spi/darwin/SandboxSPI.h
+    spi/darwin/XPCSPI.h
+    spi/darwin/dyldSPI.h
+
+    spi/mac/MetadataSPI.h
+
+    text/cf/StringConcatenateCF.h
+    text/cf/TextBreakIteratorCF.h
+)
+
 file(COPY mac/MachExceptions.defs DESTINATION ${WTF_DERIVED_SOURCES_DIR})
 
 add_custom_command(

--- a/Source/WTF/wtf/PlatformPlayStation.cmake
+++ b/Source/WTF/wtf/PlatformPlayStation.cmake
@@ -19,6 +19,10 @@ list(APPEND WTF_SOURCES
     unix/MemoryPressureHandlerUnix.cpp
 )
 
+list(APPEND WTF_PUBLIC_HEADERS
+    unix/UnixFileDescriptor.h
+)
+
 list(APPEND WTF_LIBRARIES
     ${KERNEL_LIBRARY}
     Threads::Threads

--- a/Source/WTF/wtf/PlatformWPE.cmake
+++ b/Source/WTF/wtf/PlatformWPE.cmake
@@ -28,6 +28,26 @@ list(APPEND WTF_SOURCES
     unix/UniStdExtrasUnix.cpp
 )
 
+list(APPEND WTF_PUBLIC_HEADERS
+    glib/ChassisType.h
+    glib/GMutexLocker.h
+    glib/GRefPtr.h
+    glib/GSocketMonitor.h
+    glib/GThreadSafeWeakPtr.h
+    glib/GTypedefs.h
+    glib/GUniquePtr.h
+    glib/GWeakPtr.h
+    glib/RunLoopSourcePriority.h
+    glib/Sandbox.h
+    glib/SocketConnection.h
+    glib/WTFGType.h
+
+    linux/CurrentProcessMemoryStatus.h
+    linux/ProcessMemoryFootprint.h
+
+    unix/UnixFileDescriptor.h
+)
+
 list(APPEND WTF_LIBRARIES
     ${GLIB_GIO_LIBRARIES}
     ${GLIB_GOBJECT_LIBRARIES}

--- a/Source/WTF/wtf/PlatformWin.cmake
+++ b/Source/WTF/wtf/PlatformWin.cmake
@@ -20,6 +20,16 @@ list(APPEND WTF_SOURCES
     win/Win32Handle.cpp
 )
 
+list(APPEND WTF_PUBLIC_HEADERS
+    text/win/WCharStringExtras.h
+
+    win/DbgHelperWin.h
+    win/GDIObject.h
+    win/PathWalker.h
+    win/SoftLinking.h
+    win/Win32Handle.h
+)
+
 list(APPEND WTF_LIBRARIES
     DbgHelp
     shlwapi


### PR DESCRIPTION
#### 77891133d6725fd6d6f467042b0df9df30440ccb
<pre>
[WTF][CMake] Move platform specific headers to their platform cmake file
<a href="https://bugs.webkit.org/show_bug.cgi?id=273930">https://bugs.webkit.org/show_bug.cgi?id=273930</a>

Reviewed by Adrian Perez de Castro.

* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/PlatformGTK.cmake:
* Source/WTF/wtf/PlatformMac.cmake:
* Source/WTF/wtf/PlatformPlayStation.cmake:
* Source/WTF/wtf/PlatformWPE.cmake:
* Source/WTF/wtf/PlatformWin.cmake:

Canonical link: <a href="https://commits.webkit.org/278554@main">https://commits.webkit.org/278554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e10a8c61e78fb7fff539463a7c1e4d4f6f54aed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3273 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54205 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1637 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1300 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41487 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53046 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27888 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43890 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22617 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25222 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1146 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9387 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/44286 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47203 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1217 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55799 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/50449 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1115 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48896 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27306 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47982 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28184 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/57924 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7384 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27037 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11926 "Passed tests") | 
<!--EWS-Status-Bubble-End-->