### PR TITLE
https://bugs.webkit.org/show_bug.cgi?id=273929

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-cross-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-cross-document-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL cross-document navigate() promises never settle assert_unreached: finished must not fulfill Reached unreachable code
+PASS cross-document navigate() promises never settle
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-initial-about-blank-cross-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-initial-about-blank-cross-document-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigate() in initial about:blank document (cross-document) assert_unreached: finished must not fulfill Reached unreachable code
+PASS navigate() in initial about:blank document (cross-document)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-initial-about-blank-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-initial-about-blank-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigate() in initial about:blank document assert_unreached: finished must not fulfill Reached unreachable code
+PASS navigate() in initial about:blank document
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-opaque-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-opaque-origin-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.navigate() in an opaque origin iframe assert_unreached: finished must not fulfill Reached unreachable code
+PASS navigation.navigate() in an opaque origin iframe
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL reload() promises never settle (without intercept()) assert_unreached: finished must not fulfill Reached unreachable code
+PASS reload() promises never settle (without intercept())
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-initial-about-blank-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-initial-about-blank-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL reload() in initial about:blank document assert_unreached: finished must not fulfill Reached unreachable code
+PASS reload() in initial about:blank document
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -176,8 +176,7 @@ NavigationAPIMethodTracker Navigation::maybeSetUpcomingNonTraversalTracker(Ref<D
 {
     auto apiMethodTracker = NavigationAPIMethodTracker(lastTrackerID++, WTFMove(committed), WTFMove(finished), WTFMove(info), WTFMove(serializedState));
 
-    // FIXME: Only mark handled, but not rejected as handled either.
-    apiMethodTracker.finishedPromise->resolve();
+    apiMethodTracker.finishedPromise->markAsHandled();
 
     ASSERT(!m_upcomingNonTraverseMethodTracker);
     if (!hasEntriesAndEventsDisabled())
@@ -192,8 +191,7 @@ NavigationAPIMethodTracker Navigation::addUpcomingTrarveseAPIMethodTracker(Ref<D
     auto apiMethodTracker = NavigationAPIMethodTracker(lastTrackerID++, WTFMove(committed), WTFMove(finished), WTFMove(info), nullptr);
     apiMethodTracker.key = key;
 
-    // FIXME: Only mark handled, but not rejected as handled either.
-    apiMethodTracker.finishedPromise->resolve();
+    apiMethodTracker.finishedPromise->markAsHandled();
 
     m_upcomingTraverseMethodTrackers.add(key, apiMethodTracker);
 


### PR DESCRIPTION
#### 328cefc3aef0a4667d9be0117591fe7785e30b8e
<pre>
<a href="https://bugs.webkit.org/show_bug.cgi?id=273929">https://bugs.webkit.org/show_bug.cgi?id=273929</a>
[Navigation] Mark promise as handled

Reviewed by NOBODY (OOPS!).

WIP.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-cross-document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-initial-about-blank-cross-document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-initial-about-blank-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-opaque-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-initial-about-blank-expected.txt:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::maybeSetUpcomingNonTraversalTracker):
(WebCore::Navigation::addUpcomingTrarveseAPIMethodTracker):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/328cefc3aef0a4667d9be0117591fe7785e30b8e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3442 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54366 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1798 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1473 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41620 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53208 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44047 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22739 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25372 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1301 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-autofocus.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9549 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47351 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1375 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55961 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26219 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1268 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49020 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27467 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44115 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48158 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28347 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27198 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->