### PR TITLE
[GStreamer][WebRTC] Improve error checking in DataChannel backend

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
@@ -193,8 +193,17 @@ bool GStreamerDataChannelHandler::sendStringData(const CString& text)
 {
     DC_DEBUG("Sending string of length: %zu", text.length());
     DC_TRACE("Sending string %s", text.data());
+#if GST_CHECK_VERSION(1, 22, 0)
+    GUniqueOutPtr<GError> error;
+    // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/1958
+    gst_webrtc_data_channel_send_string_full(GST_WEBRTC_DATA_CHANNEL(m_channel.get()), text.data(), &error.outPtr());
+    if (error)
+        DC_WARNING("Unable to send string, error: %s", error->message);
+    return !error;
+#else
     g_signal_emit_by_name(m_channel.get(), "send-string", text.data());
     return true;
+#endif
 }
 
 bool GStreamerDataChannelHandler::sendRawData(std::span<const uint8_t> data)
@@ -202,8 +211,17 @@ bool GStreamerDataChannelHandler::sendRawData(std::span<const uint8_t> data)
     DC_DEBUG("Sending raw data of length: %zu", data.size());
     DC_MEMDUMP("Sending raw data", data.data(), data.size());
     auto bytes = adoptGRef(g_bytes_new(data.data(), data.size()));
+#if GST_CHECK_VERSION(1, 22, 0)
+    GUniqueOutPtr<GError> error;
+    // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/1958
+    gst_webrtc_data_channel_send_data_full(GST_WEBRTC_DATA_CHANNEL(m_channel.get()), bytes.get(), &error.outPtr());
+    if (error)
+        DC_WARNING("Unable to send raw data, error: %s", error->message);
+    return !error;
+#else
     g_signal_emit_by_name(m_channel.get(), "send-data", bytes.get());
     return true;
+#endif
 }
 
 void GStreamerDataChannelHandler::close()
@@ -240,7 +258,7 @@ bool GStreamerDataChannelHandler::checkState()
 
     RTCDataChannelState state;
     switch (channelState) {
-#if !GST_CHECK_VERSION(1, 21, 1)
+#if !GST_CHECK_VERSION(1, 22, 0)
     // Removed in https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/2099.
     case GST_WEBRTC_DATA_CHANNEL_STATE_NEW:
 #endif


### PR DESCRIPTION
#### b023c541869491bacd7a9c0980dae6821881e95b
<pre>
[GStreamer][WebRTC] Improve error checking in DataChannel backend
<a href="https://bugs.webkit.org/show_bug.cgi?id=273932">https://bugs.webkit.org/show_bug.cgi?id=273932</a>

Reviewed by Xabier Rodriguez-Calvar.

Use the new gst_webrtc_data_channel_send_{string,data}_full APIs when available. Also fix
GST_CHECK_VERSION ifdefs, those should use stable release numbering unless the needed check is for a
development version not shipped yet.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp:
(WebCore::GStreamerDataChannelHandler::sendStringData):
(WebCore::GStreamerDataChannelHandler::sendRawData):
(WebCore::GStreamerDataChannelHandler::checkState):

Canonical link: <a href="https://commits.webkit.org/278611@main">https://commits.webkit.org/278611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4294bf67d9ec66ef65fb78af4b2bdf663f83e97

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54208 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1640 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53252 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41490 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27892 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43895 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22620 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25226 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1151 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9390 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47207 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1222 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55802 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1118 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48900 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43966 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47987 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11179 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28187 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27040 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->