### PR TITLE
Fix Mail after 278564@main

### DIFF
--- a/Source/WebKit/Shared/API/c/mac/WKObjCTypeWrapperRef.mm
+++ b/Source/WebKit/Shared/API/c/mac/WKObjCTypeWrapperRef.mm
@@ -27,7 +27,10 @@
 #import "WKObjCTypeWrapperRef.h"
 
 #import "ObjCObjectGraph.h"
+#import "WKData.h"
+#import "WKNSData.h"
 #import "WKSharedAPICast.h"
+#import "WKType.h"
 
 WKTypeID WKObjCTypeWrapperGetTypeID()
 {
@@ -36,5 +39,7 @@ WKTypeID WKObjCTypeWrapperGetTypeID()
 
 id WKObjCTypeWrapperGetObject(WKObjCTypeWrapperRef wrapperRef)
 {
+    if (wrapperRef && WKGetTypeID(wrapperRef) == WKDataGetTypeID())
+        return WebKit::wrapper(WebKit::toImpl((WKDataRef)wrapperRef));
     return WebKit::toImpl(wrapperRef)->rootObject();
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/BundleParameters.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/BundleParameters.mm
@@ -28,8 +28,10 @@
 #import "DeprecatedGlobalValues.h"
 #import "PlatformUtilities.h"
 #import "Test.h"
+#import "TestNavigationDelegate.h"
 #import "WKWebViewConfigurationExtras.h"
 #import <WebKit/WKProcessPoolPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
 #import <wtf/RetainPtr.h>
 
 TEST(WebKit, BundleParameters)
@@ -109,4 +111,13 @@ TEST(WebKit, BundleParameters)
 
         TestWebKitAPI::Util::run(&isDone);
     }
+}
+
+TEST(WebKit, LoadDataWithUserData)
+{
+    NSString * const testPlugInClassName = @"BundleParametersPlugIn";
+    auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:testPlugInClassName]);
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    [webView _loadData:NSData.data MIMEType:@"text/html" characterEncodingName:@"utf-8" baseURL:[NSURL URLWithString:@"https://webkit.org/"] userData:NSData.data];
+    [webView _test_waitForDidFinishNavigation];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/BundleParametersPlugIn.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/BundleParametersPlugIn.mm
@@ -32,6 +32,13 @@
 #import <WebKit/WKWebProcessPlugInScriptWorld.h>
 #import <wtf/RetainPtr.h>
 
+#if WK_HAVE_C_SPI
+#import <WebKit/WKBundlePage.h>
+#import <WebKit/WKBundlePageLoaderClient.h>
+#import <WebKit/WKObjCTypeWrapperRef.h>
+#import <WebKit/WKType.h>
+#endif
+
 static NSString * const testParameter1 = @"TestParameter1";
 static NSString * const testParameter2 = @"TestParameter2";
 
@@ -52,6 +59,16 @@ static NSString * const testParameter2 = @"TestParameter2";
     [plugInController.parameters addObserver:self forKeyPath:testParameter1 options:NSKeyValueObservingOptionInitial context:NULL];
     [plugInController.parameters addObserver:self forKeyPath:testParameter2 options:NSKeyValueObservingOptionInitial context:NULL];
     [plugInController.parameters addObserver:self forKeyPath:TestWebKitAPI::Util::TestPlugInClassNameParameter options:NSKeyValueObservingOptionInitial context:NULL];
+
+#if WK_HAVE_C_SPI
+    WKBundlePageLoaderClientV6 loaderClient = { };
+    loaderClient.base.version = 6;
+    loaderClient.willLoadDataRequest = [] (WKBundlePageRef page, WKURLRequestRef, WKDataRef, WKStringRef, WKStringRef, WKURLRef, WKTypeRef userData, const void*) {
+        id data = WKObjCTypeWrapperGetObject((WKObjCTypeWrapperRef)userData);
+        RELEASE_ASSERT([data isKindOfClass:NSData.class]);
+    };
+    WKBundlePageSetPageLoaderClient(static_cast<WKBundlePageRef>(browserContextController), &loaderClient.base);
+#endif
 }
 
 - (void)dealloc


### PR DESCRIPTION
#### f1fd721201cfd12e293dadcba38de89a10cfddc2
<pre>
Fix Mail after 278564@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=273955">https://bugs.webkit.org/show_bug.cgi?id=273955</a>
<a href="https://rdar.apple.com/127819455">rdar://127819455</a>

Reviewed by Brady Eidson.

Mail uses WKObjCTypeWrapperGetObject which of course has 0 tests.
It expected an ObjCObjectGraph, but I&apos;m now giving it an API::Data.
Make it handle an API::Data.

* Source/WebKit/Shared/API/c/mac/WKObjCTypeWrapperRef.mm:
(WKObjCTypeWrapperGetObject):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/BundleParameters.mm:
(TEST(WebKit, LoadDataWithUserData)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/BundleParametersPlugIn.mm:
(-[BundleParametersPlugIn webProcessPlugIn:didCreateBrowserContextController:]):

Canonical link: <a href="https://commits.webkit.org/278579@main">https://commits.webkit.org/278579@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7605f9693a3374518cd2d9c314442131a1c649b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54243 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1675 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53287 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1340 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41531 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43929 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22651 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25264 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1184 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9426 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47242 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1258 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55837 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26093 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1154 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48940 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27344 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44000 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48067 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28222 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7401 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27075 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->