### PR TITLE
[Remote Inspection] Redundant nearby targets should not be surfaced to Web Inspector

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-2.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-2.html
@@ -9,7 +9,6 @@ body, html {
     width: 100%;
     height: 100%;
     font-size: 16px;
-    line-height: 200%;
     -webkit-text-size-adjust: none;
     color: white;
 }
@@ -59,14 +58,50 @@ body, html {
     height: 250px;
     box-sizing: border-box;
 }
+
+.absolute-child {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+}
+
+.blue-dot {
+    width: 24px;
+    height: 24px;
+    border-radius: 12px;
+    background: blue;
+    opacity: 0.5;
+}
+
+section:has(.blue-dot) {
+    width: 50px;
+    height: 50px;
+}
 </style>
 </head>
 <body>
     <div class="box"></div>
     <div class="fixed container"></div>
-    <div class="absolute bottom-right"></div>
-    <div class="absolute bottom-left"></div>
-    <div class="absolute top-right"></div>
+    <div class="absolute bottom-right">
+        <p class="absolute-child">Bottom Right</p>
+        <div class="absolute-child blue-dot"></div>
+    </div>
+    <div class="absolute bottom-left">
+        <div class="absolute-child">
+            <p>Bottom Left</p>
+            <div class="absolute-child blue-dot"></div>
+        </div>
+    </div>
+    <div class="absolute top-right">
+        <div class="outer">
+            <div class="inner">
+                <section>
+                    <div class="absolute-child blue-dot"></div>
+                    <p class="absolute-child">Top Right</p>
+                </section>
+            </div>
+        </div>
+    </div>
     <main>Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo. You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them. Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.</main>
     <script>
         const overlays = [...document.querySelectorAll(".fixed, .absolute")];


### PR DESCRIPTION
#### 5e8cbc9e70f01a95d48990d9328ca7f167714e41
<pre>
[Remote Inspection] Redundant nearby targets should not be surfaced to Web Inspector
<a href="https://bugs.webkit.org/show_bug.cgi?id=273953">https://bugs.webkit.org/show_bug.cgi?id=273953</a>

Reviewed by Abrar Rahman Protyasha.

Currently, it&apos;s possible for the &quot;nearby targets&quot; heuristic to discover redundant elements, in the
case where a nearby target is a parent of another. In this case, it makes sense to only surface the
parent target. Fix this by implementing an algorithm to filter out such elements from the final list
of nearby targets, such that the final list does not contain any target that is a child of another
target.

Changes covered by augmenting the API test ElementTargeting.NearbyOutOfFlowElements.

* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::filterRedundantNearbyTargets):
(WebCore::ElementTargetingController::extractTargets):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-2.html:

Canonical link: <a href="https://commits.webkit.org/278583@main">https://commits.webkit.org/278583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/624af83d1da41eff8758c0ca33275dc60297788f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3313 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54244 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1676 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53288 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/36606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41532 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27928 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43926 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22652 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25265 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1181 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9427 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47243 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55838 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1155 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48941 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43997 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11164 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28223 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27076 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->