### PR TITLE
Use constexpr in some geometry classes

### DIFF
--- a/Source/WebCore/platform/LayoutUnit.h
+++ b/Source/WebCore/platform/LayoutUnit.h
@@ -66,7 +66,7 @@ const int intMinForLayoutUnit = INT_MIN / kFixedPointDenominator;
 
 class LayoutUnit {
 public:
-    LayoutUnit() : m_value(0) { }
+    constexpr LayoutUnit() : m_value(0) { }
     LayoutUnit(const LayoutUnit&) = default;
     LayoutUnit(int value) { setValue(value); }
     LayoutUnit(unsigned short value) { setValue(value); }
@@ -117,15 +117,15 @@ public:
         return v;
     }
 
-    int toInt() const { return m_value / kFixedPointDenominator; }
-    float toFloat() const { return static_cast<float>(m_value) / kFixedPointDenominator; }
-    double toDouble() const { return static_cast<double>(m_value) / kFixedPointDenominator; }
-    unsigned toUnsigned() const { REPORT_OVERFLOW(m_value >= 0); return toInt(); }
+    constexpr int toInt() const { return m_value / kFixedPointDenominator; }
+    constexpr float toFloat() const { return static_cast<float>(m_value) / kFixedPointDenominator; }
+    constexpr double toDouble() const { return static_cast<double>(m_value) / kFixedPointDenominator; }
+    constexpr unsigned toUnsigned() const { REPORT_OVERFLOW(m_value >= 0); return toInt(); }
 
-    operator int() const { return toInt(); }
-    operator float() const { return toFloat(); }
-    operator double() const { return toDouble(); }
-    explicit operator bool() const { return m_value; }
+    constexpr operator int() const { return toInt(); }
+    constexpr operator float() const { return toFloat(); }
+    constexpr operator double() const { return toDouble(); }
+    explicit constexpr operator bool() const { return m_value; }
 
     LayoutUnit& operator++()
     {
@@ -133,7 +133,7 @@ public:
         return *this;
     }
 
-    inline int rawValue() const { return m_value; }
+    constexpr int rawValue() const { return m_value; }
     inline void setRawValue(int value) { m_value = value; }
     void setRawValue(long long value)
     {
@@ -147,6 +147,7 @@ public:
         returnValue.setRawValue(::abs(m_value));
         return returnValue;
     }
+
     int ceil() const
     {
         if (UNLIKELY(m_value >= INT_MAX - kFixedPointDenominator + 1))

--- a/Source/WebCore/platform/graphics/IntPoint.h
+++ b/Source/WebCore/platform/graphics/IntPoint.h
@@ -58,16 +58,16 @@ class IntRect;
 
 class IntPoint {
 public:
-    IntPoint() : m_x(0), m_y(0) { }
-    IntPoint(int x, int y) : m_x(x), m_y(y) { }
+    constexpr IntPoint() : m_x(0), m_y(0) { }
+    constexpr IntPoint(int x, int y) : m_x(x), m_y(y) { }
     explicit IntPoint(const IntSize& size) : m_x(size.width()), m_y(size.height()) { }
     WEBCORE_EXPORT explicit IntPoint(const FloatPoint&); // don't do this implicitly since it's lossy
 
-    static IntPoint zero() { return IntPoint(); }
-    bool isZero() const { return !m_x && !m_y; }
+    static constexpr IntPoint zero() { return IntPoint(); }
+    constexpr bool isZero() const { return !m_x && !m_y; }
 
-    int x() const { return m_x; }
-    int y() const { return m_y; }
+    constexpr int x() const { return m_x; }
+    constexpr int y() const { return m_y; }
 
     void setX(int x) { m_x = x; }
     void setY(int y) { m_y = y; }
@@ -86,7 +86,7 @@ public:
         this->scale(scale, scale);
     }
     
-    IntPoint expandedTo(const IntPoint& other) const
+    constexpr IntPoint expandedTo(const IntPoint& other) const
     {
         return {
             m_x > other.m_x ? m_x : other.m_x,
@@ -94,7 +94,7 @@ public:
         };
     }
 
-    IntPoint shrunkTo(const IntPoint& other) const
+    constexpr IntPoint shrunkTo(const IntPoint& other) const
     {
         return {
             m_x < other.m_x ? m_x : other.m_x,

--- a/Source/WebCore/platform/graphics/LayoutPoint.h
+++ b/Source/WebCore/platform/graphics/LayoutPoint.h
@@ -37,14 +37,14 @@ namespace WebCore {
 
 class LayoutPoint {
 public:
-    LayoutPoint() { }
+    constexpr LayoutPoint() { }
     template<typename T, typename U> LayoutPoint(T x, U y) : m_x(x), m_y(y) { }
     LayoutPoint(const IntPoint& point) : m_x(point.x()), m_y(point.y()) { }
     explicit LayoutPoint(const FloatPoint& size) : m_x(size.x()), m_y(size.y()) { }
     explicit LayoutPoint(const LayoutSize& size) : m_x(size.width()), m_y(size.height()) { }
 
-    static LayoutPoint zero() { return LayoutPoint(); }
-    bool isZero() const { return !m_x && !m_y; }
+    static constexpr LayoutPoint zero() { return LayoutPoint(); }
+    constexpr bool isZero() const { return !m_x && !m_y; }
 
     LayoutUnit x() const { return m_x; }
     LayoutUnit y() const { return m_y; }


### PR DESCRIPTION
#### eb42c47c896489c50aea83ab8be3ca19ac393ecd
<pre>
Use constexpr in some geometry classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=273954">https://bugs.webkit.org/show_bug.cgi?id=273954</a>
<a href="https://rdar.apple.com/127819143">rdar://127819143</a>

Reviewed by Wenson Hsieh and Matthieu Dubet.

Add constexpr to more constructors and functions on IntPoint/LayoutPoint/LayoutUnit to
allow for these types to be used in compile-time constants.

* Source/WebCore/platform/LayoutUnit.h:
(WebCore::LayoutUnit::LayoutUnit):
(WebCore::LayoutUnit::toInt const):
(WebCore::LayoutUnit::toFloat const):
(WebCore::LayoutUnit::toDouble const):
(WebCore::LayoutUnit::toUnsigned const):
(WebCore::LayoutUnit::operator int const):
(WebCore::LayoutUnit::operator float const):
(WebCore::LayoutUnit::operator double const):
(WebCore::LayoutUnit::operator bool const):
(WebCore::LayoutUnit::rawValue const):
* Source/WebCore/platform/graphics/IntPoint.h:
(WebCore::IntPoint::IntPoint):
(WebCore::IntPoint::zero):
(WebCore::IntPoint::isZero const):
(WebCore::IntPoint::x const):
(WebCore::IntPoint::y const):
(WebCore::IntPoint::expandedTo const):
(WebCore::IntPoint::shrunkTo const):
* Source/WebCore/platform/graphics/LayoutPoint.h:
(WebCore::LayoutPoint::LayoutPoint):
(WebCore::LayoutPoint::zero):
(WebCore::LayoutPoint::isZero const):

Canonical link: <a href="https://commits.webkit.org/278589@main">https://commits.webkit.org/278589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d5aa031cd94dcb57ec80d7b5cceadd2c11e4e82

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54250 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1682 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53294 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1368 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41536 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53091 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27935 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43934 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22655 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25270 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1189 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9433 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47250 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1263 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55844 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48947 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27351 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44005 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48069 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11167 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28229 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27082 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->