### PR TITLE
[Navigation] Improve maintaining the entries list and their interaction with HistoryItems

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6878,7 +6878,6 @@ imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/ [ Sk
 # These failures include UUIDs that change every run.
 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-back-same-document.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-reload.html [ Failure ]
-imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-replace.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-replace-same-document.html [ Failure ]
 
 # Crash caused by detach.

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-back-same-doc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-back-same-doc-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL currententrychange fires for history.back() assert_equals: expected "traverse" but got "push"
+PASS currententrychange fires for history.back()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-pushState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-pushState-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL currententrychange fires for history.pushState() assert_true: expected true got false
+PASS currententrychange fires for history.pushState()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-replaceState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-replaceState-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL currententrychange fires for history.replaceState() assert_true: expected true got false
+PASS currententrychange fires for history.replaceState()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigate-from-initial-about-blank-same-doc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigate-from-initial-about-blank-same-doc-expected.txt
@@ -1,4 +1,4 @@
 
 
-PASS currententrychange does not fire when navigating away from the initial about:blank
+FAIL currententrychange does not fire when navigating away from the initial about:blank assert_unreached: currententrychange should not fire Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigate-from-initial-about-blank-same-doc-popup-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigate-from-initial-about-blank-same-doc-popup-expected.txt
@@ -1,3 +1,3 @@
 
-PASS currententrychange does not fire when navigating away from the initial about:blank (popup window)
+FAIL currententrychange does not fire when navigating away from the initial about:blank (popup window) assert_unreached: currententrychange should not fire Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-back-forward-same-doc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-back-forward-same-doc-expected.txt
@@ -1,3 +1,3 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+FAIL currententrychange fires for same-document navigation.back() and navigation.forward() assert_false: expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-replace-same-doc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-replace-same-doc-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL currententrychange fires for navigation.navigate() with replace assert_equals: expected -1 but got 1
+FAIL currententrychange fires for navigation.navigate() with replace assert_equals: expected -1 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-does-not-fire-navigate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-does-not-fire-navigate-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL A cross-origin traversal does not fire the navigate event assert_equals: expected 1 but got 2
+PASS A cross-origin traversal does not fire the navigate event
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-redirect-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT A traversal that redirects from same-origin to cross-origin fires the navigate event Test timed out
+PASS A traversal that redirects from same-origin to cross-origin fires the navigate event
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-crossorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-crossorigin-expected.txt
@@ -1,4 +1,4 @@
 
 
-PASS clicking on an <a> element that navigates same-document targeting a cross-origin window
+FAIL clicking on an <a> element that navigates same-document targeting a cross-origin window assert_true: cancelable expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-sameorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-sameorigin-expected.txt
@@ -1,4 +1,4 @@
 Click me
 
-PASS clicking on an <a> element that navigates same-document targeting a same-origin window
+FAIL clicking on an <a> element that navigates same-document targeting a same-origin window assert_true: cancelable expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-samedocument-crossorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-samedocument-crossorigin-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL using location.href to navigate same-document targeting a cross-origin window assert_equals: navigationType expected "push" but got "replace"
+FAIL using location.href to navigate same-document targeting a cross-origin window assert_true: cancelable expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-samedocument-sameorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-samedocument-sameorigin-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL using location.href to navigate same-document targeting a same-origin window assert_equals: navigationType expected "push" but got "replace"
+FAIL using location.href to navigate same-document targeting a same-origin window assert_true: cancelable expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-samedocument-crossorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-samedocument-crossorigin-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL using window.open() to navigate same-document targeting a cross-origin window assert_equals: navigationType expected "push" but got "replace"
+FAIL using window.open() to navigate same-document targeting a cross-origin window assert_true: cancelable expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-samedocument-crossorigin-sameorigindomain.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-samedocument-crossorigin-sameorigindomain.sub-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL using window.open() to navigate same-document targeting a same-origin-domain (but cross-origin) window assert_equals: navigationType expected "push" but got "replace"
+FAIL using window.open() to navigate same-document targeting a same-origin-domain (but cross-origin) window assert_true: cancelable expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-samedocument-sameorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-samedocument-sameorigin-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL using window.open() to navigate same-document targeting a same-origin window assert_equals: navigationType expected "push" but got "replace"
+FAIL using window.open() to navigate same-document targeting a same-origin window assert_true: cancelable expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-crossorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-crossorigin-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL submitting a <form> element that navigates same-document targeting a cross-origin window assert_equals: navigationType expected "push" but got "replace"
+FAIL submitting a <form> element that navigates same-document targeting a cross-origin window assert_true: cancelable expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-crossorigin-sameorigindomain.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-crossorigin-sameorigindomain.sub-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL submitting a <form> element that navigates cross-document targeting a same-origin-domain (but cross-origin) window assert_equals: navigationType expected "push" but got "replace"
+FAIL submitting a <form> element that navigates cross-document targeting a same-origin-domain (but cross-origin) window assert_true: cancelable expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-sameorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-sameorigin-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL submitting a <form> element that navigates same-document targeting a same-origin window assert_equals: navigationType expected "push" but got "replace"
+FAIL submitting a <form> element that navigates same-document targeting a same-origin window assert_true: cancelable expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/event-constructor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/event-constructor-expected.txt
@@ -1,10 +1,8 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS can't bypass required members by omitting the dictionary entirely
 PASS destination is required
-TIMEOUT signal is required Test timed out
-TIMEOUT all properties are reflected back Test timed out
-TIMEOUT defaults are as expected Test timed out
-TIMEOUT hasUAVisualTransition is default false Test timed out
+PASS signal is required
+PASS all properties are reflected back
+PASS defaults are as expected
+PASS hasUAVisualTransition is default false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-and-navigate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-and-navigate-expected.txt
@@ -1,3 +1,5 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Using intercept() then navigate() in the ensuing currententrychange should abort the finished promise (but not the committed promise) Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-cross-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-cross-origin-expected.txt
@@ -1,7 +1,6 @@
 FAIL: Timed out waiting for notifyDone to be called
 
 Directory listing for /
-
 %CERTS_DIR%
 .cache
 .gitattributes

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-history-pushState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-history-pushState-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT event.intercept() should proceed if the given promise resolves Test timed out
+FAIL event.intercept() should proceed if the given promise resolves assert_equals: expected "#1" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-history-replaceState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-history-replaceState-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT event.intercept() should proceed if the given promise resolves Test timed out
+FAIL event.intercept() should proceed if the given promise resolves assert_equals: expected "#1" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-navigation-back-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-navigation-back-expected.txt
@@ -1,3 +1,5 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT event.intercept() can intercept navigation.back() Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-on-synthetic-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-on-synthetic-event-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT event.intercept() throws if invoked on a synthetic event Test timed out
+PASS event.intercept() throws if invoked on a synthetic event
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-after-detach-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-after-detach-expected.txt
@@ -1,6 +1,3 @@
 
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigate event destination after iframe detach Test timed out
+PASS navigate event destination after iframe detach
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-dynamic-index-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-dynamic-index-expected.txt
@@ -1,3 +1,3 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+FAIL navigate event destination.index should be dynamic assert_equals: expected -1 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-back-forward-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-back-forward-expected.txt
@@ -1,3 +1,3 @@
 
-PASS navigate event destination.getState() on back/forward navigation
+FAIL navigate event destination.getState() on back/forward navigation assert_not_equals: got disallowed value undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-after-fragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-after-fragment-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL history.back() fires the navigate event and sets hashChange when reversing a fragment navigation assert_equals: expected "traverse" but got "push"
+PASS history.back() fires the navigate event and sets hashChange when reversing a fragment navigation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-after-pushState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-after-pushState-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL history.back() fires the navigate event when reversing a pushState() assert_equals: expected "traverse" but got "push"
+PASS history.back() fires the navigate event when reversing a pushState()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-pushState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-pushState-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT history.pushState() fires the navigate event Test timed out
+FAIL history.pushState() fires the navigate event assert_false: expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-replaceState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-replaceState-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT history.replaceState() fires the navigate event Test timed out
+FAIL history.replaceState() fires the navigate event assert_false: expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-iframe-location-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-iframe-location-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL location API on another window fires navigate event in the target window only assert_equals: expected "push" but got "replace"
+FAIL location API on another window fires navigate event in the target window only assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-same-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-same-document-expected.txt
@@ -1,3 +1,3 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+PASS navigate event for navigation.back() - same-document
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-same-document-in-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-same-document-in-iframe-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigate event for navigation.back() - same-document in an iframe Test timed out
+PASS navigate event for navigation.back() - same-document in an iframe
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-window-open-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-window-open-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL window.open() fires navigate event in target window but not source assert_equals: expected "push" but got "replace"
+FAIL window.open() fires navigate event in target window but not source assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-window-open-self-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-window-open-self-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL window.open() fires navigate event when targeting self assert_equals: expected "push" but got "replace"
+PASS window.open() fires navigate event when targeting self
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-cross-document-preventDefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-cross-document-preventDefault-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL navigation.back() cross-document cannot be cancelled with the navigate event assert_equals: expected 0 but got 2
+PASS navigation.back() cross-document cannot be cancelled with the navigate event
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-same-document-preventDefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-same-document-preventDefault-expected.txt
@@ -1,3 +1,3 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+FAIL navigation.back() same-document preventDefault promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: navigateerror_called"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigation.traverseTo() in an iframe with same-document preventDefault in its parent Test timed out
+FAIL navigation.traverseTo() in an iframe with same-document preventDefault in its parent assert_unreached: navigate event should not fire in the iframe, because the traversal was cancelled in the top window Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-same-document-preventDefault-multiple-windows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-same-document-preventDefault-multiple-windows-expected.txt
@@ -1,3 +1,5 @@
-FAIL: Timed out waiting for notifyDone to be called
+CONSOLE MESSAGE: Unhandled Promise Rejection: AbortError: Navigation aborted
 
+
+PASS navigation.traverseTo() - if a top window cancels the traversal, any iframes should not fire navigate
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/replaceState-inside-back-handler-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/replaceState-inside-back-handler-expected.txt
@@ -1,3 +1,6 @@
-FAIL: Timed out waiting for notifyDone to be called
+CONSOLE MESSAGE: RangeError: Maximum call stack size exceeded.
 
+Harness Error (FAIL), message = RangeError: Maximum call stack size exceeded.
+
+PASS replaceState inside a navigate event for navigation.back()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/after-detach-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/after-detach-expected.txt
@@ -1,6 +1,3 @@
 
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigation.currentEntry/entries()/canGoBack/canGoForward after iframe removal Test timed out
+PASS navigation.currentEntry/entries()/canGoBack/canGoForward after iframe removal
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/current-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/current-basic-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Basic tests for navigation.currentEntry assert_not_equals: got disallowed value object "[object NavigationHistoryEntry]"
+FAIL Basic tests for navigation.currentEntry assert_not_equals: got disallowed value "http://web-platform.test:8800/navigation-api/navigation-history-entry/current-basic.html#6"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/index-not-in-entries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/index-not-in-entries-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entry.index should return -1 when not in navigation.entries() assert_equals: expected -1 but got 1
+FAIL entry.index should return -1 when not in navigation.entries() assert_equals: expected -1 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-back-same-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-back-same-document-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL NavigationHistoryEntry's key and id on same-document back navigation assert_not_equals: got disallowed value "c6782442-aa4a-487e-94a7-68b0ade1bcae"
+Harness Error (TIMEOUT), message = null
+
+PASS NavigationHistoryEntry's key and id on same-document back navigation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-reload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-reload-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL NavigationHistoryEntry's key and id after location.reload() assert_equals: expected "08f565c0-2333-4357-8371-4f4e83c6a28d" but got "df843c57-da51-481d-86ee-8668e6da624d"
+FAIL NavigationHistoryEntry's key and id after location.reload() assert_equals: expected "dc17d31f-282e-4b1c-bd3d-b76a69dcd382" but got "3bf32a01-b088-40e6-ae3c-5967c1dff230"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-replace-cross-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-replace-cross-origin-expected.txt
@@ -1,4 +1,4 @@
 
 
-PASS NavigationHistoryEntry's key and id after location.replace()
+FAIL NavigationHistoryEntry's key and id after location.replace() assert_not_equals: got disallowed value "e669243f-8e2e-4ce9-8e98-37fcebc9196c"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-replace-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-replace-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL NavigationHistoryEntry's key and id after location.replace() assert_equals: expected "8ea1a174-726c-42bd-b039-e8a4c1bf3523" but got "d54c00de-4c4e-401b-b5b8-b1d27e7f1dc6"
+PASS NavigationHistoryEntry's key and id after location.replace()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/sameDocument-after-fragment-navigate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/sameDocument-after-fragment-navigate-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL entry.sameDocument after same-document navigations assert_not_equals: got disallowed value object "[object NavigationHistoryEntry]"
+PASS entry.sameDocument after same-document navigations
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-back-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-back-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigation.back() goes to the nearest back entry Test timed out
+PASS navigation.back() goes to the nearest back entry
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-forward-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-forward-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigation.forward() goes to the nearest forward entry Test timed out
+PASS navigation.forward() goes to the nearest forward entry
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-traverseTo-back-multiple-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-traverseTo-back-multiple-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigation.traverseTo() goes to the nearest entry when going back Test timed out
+PASS navigation.traverseTo() goes to the nearest entry when going back
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-traverseTo-forward-multiple-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-traverseTo-forward-multiple-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigation.traverseTo() goes to the nearest entry when going forward Test timed out
+PASS navigation.traverseTo() goes to the nearest entry when going forward
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/forward-to-pruned-entry-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/forward-to-pruned-entry-expected.txt
@@ -1,3 +1,3 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+FAIL If forward pruning clobbers the target of a traverse, abort assert_equals: expected 1 but got 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-replace-same-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-replace-same-document-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_equals: expected "4ee017b9-616c-4b0e-84b8-06f91fea3afd" but got "a73e2a7c-e045-4897-946e-9cec39c2a75f"
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_equals: expected "34c66e70-c401-4b89-b4df-11f4c044fff7" but got "519e15d0-f2c0-45d0-b0eb-159df815a265"
 
 PASS navigate() with history: 'replace' option
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL back() promises assert_equals: expected "#1" but got ""
+PASS back() promises
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-intercept-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-intercept-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL back() and intercept() with a fulfilled promise assert_equals: expected "#1" but got ""
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT back() and intercept() with a fulfilled promise Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-intercept-rejected-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-intercept-rejected-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL back() promise rejection with rejected intercept() assert_equals: expected "#1" but got ""
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT back() promise rejection with rejected intercept() Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/forward-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/forward-expected.txt
@@ -1,3 +1,3 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+PASS forward() promises
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/forward-intercept-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/forward-intercept-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL forward() and intercept() with a fulfilled promise assert_equals: expected "#1" but got ""
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT forward() and intercept() with a fulfilled promise Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/forward-intercept-rejected-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/forward-intercept-rejected-expected.txt
@@ -1,3 +1,5 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT forward() promise rejection with rejected intercept() Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL navigate() promises assert_equals: expected "#1" but got ""
+PASS navigate() promises
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept-interrupted-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept-interrupted-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL interrupted navigate() promises with intercept() assert_equals: expected 4 but got 2
+FAIL interrupted navigate() promises with intercept() assert_equals: expected 3 but got 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-interrupted-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-interrupted-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL interrupted navigate() promises assert_array_equals: expected property 1 to be "#1" but got "" (expected array ["", "#1", "#2"] got ["", "", "#1"])
+FAIL interrupted navigate() promises assert_unreached: Should have rejected: undefined Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-interrupted-within-onnavigate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-interrupted-within-onnavigate-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: AbortError: Navigation aborted
 
-FAIL if navigate() is called inside onnavigate, the previous navigation and navigate event are cancelled assert_array_equals: expected property 1 to be "#2" but got "" (expected array ["", "#2"] got ["", ""])
+PASS if navigate() is called inside onnavigate, the previous navigation and navigate event are cancelled
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-unload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-unload-expected.txt
@@ -1,4 +1,2 @@
-
-
-FAIL navigate() inside onunload assert_unreached: finished must not fulfill Reached unreachable code
+FAIL: Timed out waiting for notifyDone to be called
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-unload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-unload-expected.txt
@@ -1,4 +1,2 @@
-
-
-FAIL reload() inside onunload assert_unreached: finished must not fulfill Reached unreachable code
+FAIL: Timed out waiting for notifyDone to be called
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-detach-same-document-before-navigate-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-detach-same-document-before-navigate-event-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT traverseTo() promise rejections when detaching an iframe before onnavigate (same-document) Test timed out
+FAIL traverseTo() promise rejections when detaching an iframe before onnavigate (same-document) assert_unreached: navigate should not fire Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-detach-same-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-detach-same-document-expected.txt
@@ -1,5 +1,4 @@
 
-
 Harness Error (TIMEOUT), message = null
 
 TIMEOUT traverseTo() promise rejections when detaching an iframe inside onnavigate (same-document) Test timed out

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL traverseTo() promises assert_equals: expected "#1" but got ""
+PASS traverseTo() promises
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-intercept-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-intercept-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL traverseTo() and intercept() with a fulfilled promise assert_equals: expected "#1" but got ""
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT traverseTo() and intercept() with a fulfilled promise Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-intercept-rejected-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-intercept-rejected-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL traverseTo() promise rejection with rejected intercept() assert_equals: expected "#1" but got ""
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT traverseTo() promise rejection with rejected intercept() Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-repeated-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-repeated-expected.txt
@@ -1,3 +1,3 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+FAIL Repeated navigation.traverseTo() with the same key assert_equals: committed promises must be equal expected object "[object Promise]" but got object "[object Promise]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-after-adding-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-after-adding-iframe-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigation.traverseTo() should work in an iframe that is not present in all history entries Test timed out
+PASS navigation.traverseTo() should work in an iframe that is not present in all history entries
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-after-data-url-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-after-data-url-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.traverseTo() should work in an iframe that started at a data: url assert_equals: expected 3 but got 5
+PASS navigation.traverseTo() should work in an iframe that started at a data: url
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-detach-between-navigate-and-navigatesuccess-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-detach-between-navigate-and-navigatesuccess-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Detach a window between when a traverseTo() fires navigate and navigatesuccess Test timed out
+FAIL Detach a window between when a traverseTo() fires navigate and navigatesuccess assert_unreached: navigatesuccess must not fire Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-multiple-steps-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-multiple-steps-expected.txt
@@ -1,3 +1,3 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+PASS goto() can precisely traverse multiple steps in the joint session history
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-same-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-same-document-expected.txt
@@ -1,3 +1,3 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+PASS same-document navigate.traverseTo(), back(), and forward()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-with-cross-origin-in-history-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-with-cross-origin-in-history-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.traverseTo() should work in an iframe that has navigated across origins assert_equals: expected 3 but got 5
+PASS navigation.traverseTo() should work in an iframe that has navigated across origins
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/currententrychange-before-popstate-intercept-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/currententrychange-before-popstate-intercept-expected.txt
@@ -1,3 +1,5 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT currententrychange fires before popstate for navigation.back() and navigation.forward() Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/currententrychange-dispose-ordering-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/currententrychange-dispose-ordering-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Ordering between Navigation currententrychange and NavigationHistoryEntry dispose events assert_equals: expected -1 but got 1
+FAIL Ordering between Navigation currententrychange and NavigationHistoryEntry dispose events assert_equals: expected -1 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-after-bfcache-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-after-bfcache-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT entries() must contain the forward-history page after navigating back to a bfcached page Test timed out
+NOTRUN entries() must contain the forward-history page after navigating back to a bfcached page Should be BFCached but actually wasn't
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-child-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-child-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Dispose events should fire when entries are removed by a navigation in a different frame Test timed out
+FAIL Dispose events should fire when entries are removed by a navigation in a different frame assert_equals: expected 0 but got 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL dispose events when forward-pruning same-document entries assert_equals: expected "#2" but got "#1"
+PASS dispose events when forward-pruning same-document entries
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-intercept-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-intercept-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL dispose events when forward-pruning same-document entries assert_equals: expected "#2" but got "#1"
+FAIL dispose events when forward-pruning same-document entries assert_equals: expected 3 but got 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-navigate-during-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-navigate-during-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL navigate() during a same-document-navigation-initiated dispose works (since it's after the previous navigation) assert_equals: expected "#2" but got "#1"
+PASS navigate() during a same-document-navigation-initiated dispose works (since it's after the previous navigation)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-replaceState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-replaceState-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL dispose events when doing a same-document replace using history.replaceState() assert_true: expected true got false
+PASS dispose events when doing a same-document replace using history.replaceState()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-skip-current-on-truncate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-skip-current-on-truncate-expected.txt
@@ -1,3 +1,4 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+
+PASS Removing a currentEntry from the joint session history shouldn't dispose it
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/history-pushState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/history-pushState-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL entry.getState() after history.pushState() assert_equals: expected (undefined) undefined but got (object) object "[object Object]"
+PASS entry.getState() after history.pushState()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/same-document-away-and-back-location-api-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/same-document-away-and-back-location-api-expected.txt
@@ -1,3 +1,10 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: undefined is not an object (evaluating 'entry1.getState().statevar')
 
-FAIL entry.getState() behavior after navigating away using the location API, then back assert_equals: expected 3 but got 4
+Harness Error (FAIL), message = Unhandled rejection: undefined is not an object (evaluating 'entry1.getState().statevar')
+
+TIMEOUT entry.getState() behavior after navigating away using the location API, then back Test timed out
+
+Harness Error (FAIL), message = Unhandled rejection: undefined is not an object (evaluating 'entry1.getState().statevar')
+
+TIMEOUT entry.getState() behavior after navigating away using the location API, then back Test timed out
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-crossorigin-sameorigindomain.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-crossorigin-sameorigindomain.sub-expected.txt
@@ -1,4 +1,4 @@
 
 
-PASS clicking on an <a> element that navigates same-document targeting a same-origin-domain (but cross-origin) window
+FAIL clicking on an <a> element that navigates same-document targeting a same-origin-domain (but cross-origin) window assert_true: cancelable expected true got false
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-samedocument-crossorigin-sameorigindomain.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-samedocument-crossorigin-sameorigindomain.sub-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL using location.href to navigate same-document targeting a same-origin-domain (but cross-origin) window assert_equals: navigationType expected "push" but got "replace"
+FAIL using location.href to navigate same-document targeting a same-origin-domain (but cross-origin) window assert_true: cancelable expected true got false
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-navigations-in-multiple-windows-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-navigations-in-multiple-windows-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.entries() behavior when multiple windows navigate. assert_not_equals: got disallowed value "http://web-platform.test:8800/navigation-api/navigation-history-entry/entries-after-navigations-in-multiple-windows.html"
+FAIL navigation.entries() behavior when multiple windows navigate. assert_equals: expected 2 but got 1
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-navigate-parent-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-navigate-parent-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL A sandboxed iframe can use its sibling's navigation object to call navigate(), as long as allow-same-origin is present assert_equals: expected "http://web-platform.test:8800/navigation-api/navigation-methods/sandboxing-navigate-parent.html#2" but got "http://web-platform.test:8800/navigation-api/navigation-methods/sandboxing-navigate-parent.html"
+PASS A sandboxed iframe can use its sibling's navigation object to call navigate(), as long as allow-same-origin is present
 

--- a/LayoutTests/swipe/navigate-event-back-swipe-verify-ua-transition.html
+++ b/LayoutTests/swipe/navigate-event-back-swipe-verify-ua-transition.html
@@ -68,15 +68,15 @@ window.onload = async function () {
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
 
-    navigation.onnavigate = function(e) {
-        log("hasUAVisualTransition " + e.hasUAVisualTransition);
-        updateContent();
-    };
-
     await UIHelper.delayFor(0);
 
     history.pushState(null, null, "#second");
     updateContent();
+
+    navigation.onnavigate = function(e) {
+        log("hasUAVisualTransition " + e.hasUAVisualTransition);
+        updateContent();
+    };
 
     await UIHelper.delayFor(0);
     await startSwipeGesture();

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10064,7 +10064,7 @@ void Document::navigateFromServiceWorker(const URL& url, CompletionHandler<void(
             callback(ScheduleLocationChangeResult::Stopped);
             return;
         }
-        frame->navigationScheduler().scheduleLocationChange(*weakThis, weakThis->securityOrigin(), url, frame->loader().outgoingReferrer(), LockHistory::Yes, LockBackForwardList::No, [callback = WTFMove(callback)](auto result) mutable {
+        frame->navigationScheduler().scheduleLocationChange(*weakThis, weakThis->securityOrigin(), url, frame->loader().outgoingReferrer(), LockHistory::Yes, LockBackForwardList::No, NavigationHistoryBehavior::Auto, [callback = WTFMove(callback)](auto result) mutable {
             callback(result);
         });
     });

--- a/Source/WebCore/history/BackForwardController.cpp
+++ b/Source/WebCore/history/BackForwardController.cpp
@@ -170,6 +170,17 @@ RefPtr<HistoryItem> BackForwardController::itemAtIndex(int i)
     return protectedClient()->itemAtIndex(i);
 }
 
+Vector<Ref<HistoryItem>> BackForwardController::allItems()
+{
+    Vector<Ref<HistoryItem>> historyItems;
+    for (int index = -1 * static_cast<int>(backCount()); index <= static_cast<int>(forwardCount()); index++) {
+        if (RefPtr item = itemAtIndex(index))
+            historyItems.append(item.releaseNonNull());
+    }
+
+    return historyItems;
+}
+
 void BackForwardController::close()
 {
     protectedClient()->close();

--- a/Source/WebCore/history/BackForwardController.h
+++ b/Source/WebCore/history/BackForwardController.h
@@ -70,6 +70,8 @@ public:
     WEBCORE_EXPORT RefPtr<HistoryItem> currentItem();
     WEBCORE_EXPORT RefPtr<HistoryItem> forwardItem();
 
+    Vector<Ref<HistoryItem>> allItems();
+
 private:
     Ref<Page> protectedPage() const;
     Ref<BackForwardClient> protectedClient() const;

--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CachedPage.h"
 
+#include "BackForwardController.h"
 #include "Document.h"
 #include "DocumentLoader.h"
 #include "Element.h"
@@ -36,6 +37,7 @@
 #include "LocalFrame.h"
 #include "LocalFrameLoaderClient.h"
 #include "LocalFrameView.h"
+#include "Navigation.h"
 #include "Node.h"
 #include "Page.h"
 #include "PageTransitionEvent.h"
@@ -178,6 +180,13 @@ void CachedPage::restore(Page& page)
     if (m_needsUpdateContentsSize) {
         if (RefPtr frameView = mainFrame->virtualView())
             frameView->updateContentsSize();
+    }
+
+    if (page.settings().navigationAPIEnabled() && focusedDocument->domWindow()) {
+        auto& backForwardController = page.backForward();
+        Ref currentItem = *backForwardController.currentItem();
+        auto allItems = backForwardController.allItems();
+        focusedDocument->domWindow()->navigation().updateForReactivation(allItems, currentItem);
     }
 
     firePageShowEvent(page);

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -55,6 +55,7 @@ HistoryItem::HistoryItem(Client& client, const String& urlString, std::optional<
     , m_originalURLString(urlString)
     , m_pruningReason(PruningReason::None)
     , m_identifier(identifier ? *identifier : BackForwardItemIdentifier::generate())
+    , m_uuidIdentifier(WTF::UUID::createVersion4Weak())
     , m_client(client)
 {
 }
@@ -88,6 +89,7 @@ HistoryItem::HistoryItem(const HistoryItem& item)
     , m_scaleIsInitial(item.m_scaleIsInitial)
 #endif
     , m_identifier(item.m_identifier)
+    , m_uuidIdentifier(WTF::UUID::createVersion4Weak())
     , m_client(item.m_client)
 {
 }

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -37,6 +37,7 @@
 #include "SerializedScriptValue.h"
 #include <memory>
 #include <wtf/RefCounted.h>
+#include <wtf/UUID.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -83,10 +84,13 @@ public:
     WEBCORE_EXPORT Ref<HistoryItem> copy() const;
 
     const BackForwardItemIdentifier& identifier() const { return m_identifier; }
+    const WTF::UUID& uuidIdentifier() const { return m_uuidIdentifier; }
 
     // Resets the HistoryItem to its initial state, as returned by create().
     void reset();
-    
+
+    bool operator==(const HistoryItem& other) const { return identifier() == other.identifier(); }
+
     WEBCORE_EXPORT const String& originalURLString() const;
     WEBCORE_EXPORT const String& urlString() const;
     
@@ -288,6 +292,7 @@ private:
 #endif
 
     BackForwardItemIdentifier m_identifier;
+    WTF::UUID m_uuidIdentifier;
     std::optional<PolicyContainer> m_policyContainer;
     Ref<Client> m_client;
 };

--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -111,6 +111,8 @@ public:
     void setAdvancedPrivacyProtections(OptionSet<AdvancedPrivacyProtections> policy) { m_advancedPrivacyProtections = policy; }
     OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections() const { return m_advancedPrivacyProtections; }
 
+    NavigationHistoryBehavior navigationHistoryBehavior() const { return m_navigationHistoryBehavior; }
+    void setNavigationHistoryBehavior(NavigationHistoryBehavior historyHandling) { m_navigationHistoryBehavior = historyHandling; }
 private:
     Ref<Document> m_requester;
     Ref<SecurityOrigin> m_requesterSecurityOrigin;
@@ -133,6 +135,7 @@ private:
     bool m_isRequestFromClientOrUserInput { false };
     bool m_isInitialFrameSrcLoad { false };
     OptionSet<AdvancedPrivacyProtections> m_advancedPrivacyProtections;
+    NavigationHistoryBehavior m_navigationHistoryBehavior { NavigationHistoryBehavior::Auto };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -388,7 +388,7 @@ private:
 
     void continueLoadAfterNavigationPolicy(const ResourceRequest&, FormState*, NavigationPolicyDecision, AllowNavigationToInvalidURL);
     void continueLoadAfterNewWindowPolicy(const ResourceRequest&, FormState*, const AtomString& frameName, const NavigationAction&, ShouldContinuePolicyCheck, AllowNavigationToInvalidURL, NewFrameOpenerPolicy);
-    void continueFragmentScrollAfterNavigationPolicy(const ResourceRequest&, const SecurityOrigin* requesterOrigin, bool shouldContinue);
+    void continueFragmentScrollAfterNavigationPolicy(const ResourceRequest&, const SecurityOrigin* requesterOrigin, bool shouldContinue, NavigationHistoryBehavior);
 
     bool shouldPerformFragmentNavigation(bool isFormSubmission, const String& httpMethod, FrameLoadType, const URL&);
     void scrollToFragmentWithParentBoundary(const URL&, bool isNewNavigation = true);
@@ -425,7 +425,7 @@ private:
     WEBCORE_EXPORT void detachChildren();
     void closeAndRemoveChild(LocalFrame&);
 
-    void loadInSameDocument(URL, RefPtr<SerializedScriptValue> stateObject, const SecurityOrigin* requesterOrigin, bool isNewNavigation);
+    void loadInSameDocument(URL, RefPtr<SerializedScriptValue> stateObject, const SecurityOrigin* requesterOrigin, bool isNewNavigation, NavigationHistoryBehavior historyHandling = NavigationHistoryBehavior::Auto);
 
     void prepareForLoadStart();
     void provisionalLoadStarted();

--- a/Source/WebCore/loader/FrameLoaderTypes.h
+++ b/Source/WebCore/loader/FrameLoaderTypes.h
@@ -88,6 +88,12 @@ enum class NavigationType : uint8_t {
     Other
 };
 
+enum class NavigationHistoryBehavior : uint8_t {
+    Auto,
+    Push,
+    Replace
+};
+
 enum class ShouldOpenExternalURLsPolicy : uint8_t {
     ShouldNotAllow,
     ShouldAllowExternalSchemesButNotAppLinks,

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -45,6 +45,7 @@
 #include "LocalFrameLoaderClient.h"
 #include "LocalFrameView.h"
 #include "Logging.h"
+#include "Navigation.h"
 #include "Page.h"
 #include "ScrollingCoordinator.h"
 #include "SerializedScriptValue.h"
@@ -929,6 +930,9 @@ void HistoryController::pushState(RefPtr<SerializedScriptValue>&& stateObject, c
 
     addVisitedLink(*page, URL({ }, urlString));
     frame->checkedLoader()->client().updateGlobalHistory();
+
+    if (document && document->settings().navigationAPIEnabled())
+        document->protectedWindow()->navigation().updateForNavigation(*currentItem, NavigationNavigationType::Push);
 }
 
 void HistoryController::replaceState(RefPtr<SerializedScriptValue>&& stateObject, const String& urlString)
@@ -956,6 +960,9 @@ void HistoryController::replaceState(RefPtr<SerializedScriptValue>&& stateObject
 
     addVisitedLink(*page, URL({ }, urlString));
     frame->checkedLoader()->client().updateGlobalHistory();
+
+    if (RefPtr document = frame->document(); document && document->settings().navigationAPIEnabled())
+        document->protectedWindow()->navigation().updateForNavigation(*currentItem, NavigationNavigationType::Replace);
 }
 
 void HistoryController::replaceCurrentItem(RefPtr<HistoryItem>&& item)

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -516,7 +516,7 @@ LockBackForwardList NavigationScheduler::mustLockBackForwardList(Frame& targetFr
     return LockBackForwardList::No;
 }
 
-void NavigationScheduler::scheduleLocationChange(Document& initiatingDocument, SecurityOrigin& securityOrigin, const URL& url, const String& referrer, LockHistory lockHistory, LockBackForwardList lockBackForwardList, CompletionHandler<void(ScheduleLocationChangeResult)>&& completionHandler)
+void NavigationScheduler::scheduleLocationChange(Document& initiatingDocument, SecurityOrigin& securityOrigin, const URL& url, const String& referrer, LockHistory lockHistory, LockBackForwardList lockBackForwardList, NavigationHistoryBehavior historyHandling, CompletionHandler<void(ScheduleLocationChangeResult)>&& completionHandler)
 {
     if (!shouldScheduleNavigation(url))
         return completionHandler(ScheduleLocationChangeResult::Stopped);
@@ -541,6 +541,7 @@ void NavigationScheduler::scheduleLocationChange(Document& initiatingDocument, S
         frameLoadRequest.setLockBackForwardList(lockBackForwardList);
         frameLoadRequest.disableNavigationToInvalidURL();
         frameLoadRequest.setShouldOpenExternalURLsPolicy(initiatingDocument.shouldOpenExternalURLsPolicyToPropagate());
+        frameLoadRequest.setNavigationHistoryBehavior(historyHandling);
         if (loader)
             loader->changeLocation(WTFMove(frameLoadRequest));
         return completionHandler(ScheduleLocationChangeResult::Completed);

--- a/Source/WebCore/loader/NavigationScheduler.h
+++ b/Source/WebCore/loader/NavigationScheduler.h
@@ -61,7 +61,7 @@ public:
     bool locationChangePending();
 
     void scheduleRedirect(Document& initiatingDocument, double delay, const URL&, IsMetaRefresh);
-    void scheduleLocationChange(Document& initiatingDocument, SecurityOrigin&, const URL&, const String& referrer, LockHistory = LockHistory::Yes, LockBackForwardList = LockBackForwardList::Yes, CompletionHandler<void(ScheduleLocationChangeResult)>&& = [] (ScheduleLocationChangeResult) { });
+    void scheduleLocationChange(Document& initiatingDocument, SecurityOrigin&, const URL&, const String& referrer, LockHistory = LockHistory::Yes, LockBackForwardList = LockBackForwardList::Yes, NavigationHistoryBehavior historyHandling = NavigationHistoryBehavior::Auto, CompletionHandler<void(ScheduleLocationChangeResult)>&& = [] (ScheduleLocationChangeResult) { });
     void scheduleFormSubmission(Ref<FormSubmission>&&);
     void scheduleRefresh(Document& initiatingDocument);
     void scheduleHistoryNavigation(int steps);

--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -266,7 +266,7 @@ LocalFrame* FrameLoader::SubframeLoader::loadOrRedirectSubframe(HTMLFrameOwnerEl
                 page->willChangeLocationInCompletelyLoadedSubframe();
         }
 
-        frame->checkedNavigationScheduler()->scheduleLocationChange(initiatingDocument, initiatingDocument->protectedSecurityOrigin(), upgradedRequestURL, m_frame->loader().outgoingReferrer(), lockHistory, lockBackForwardList, WTFMove(stopDelayingLoadEvent));
+        frame->checkedNavigationScheduler()->scheduleLocationChange(initiatingDocument, initiatingDocument->protectedSecurityOrigin(), upgradedRequestURL, m_frame->loader().outgoingReferrer(), lockHistory, lockBackForwardList, NavigationHistoryBehavior::Auto, WTFMove(stopDelayingLoadEvent));
     } else
         frame = loadSubframe(ownerElement, upgradedRequestURL, frameName, m_frame->loader().outgoingReferrerURL());
 

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -91,6 +91,7 @@ struct WindowFeatures;
 struct WindowPostMessageOptions;
 
 enum class SetLocationLocking : bool { LockHistoryBasedOnGestureState, LockHistoryAndBackForwardList };
+enum class NavigationHistoryBehavior : uint8_t;
 
 using IntDegrees = int32_t;
 
@@ -111,7 +112,7 @@ public:
     using RefCounted::deref;
 
     WEBCORE_EXPORT Location& location();
-    virtual void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, SetLocationLocking = SetLocationLocking::LockHistoryBasedOnGestureState) = 0;
+    virtual void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, NavigationHistoryBehavior, SetLocationLocking = SetLocationLocking::LockHistoryBasedOnGestureState) = 0;
 
     bool closed() const;
     WEBCORE_EXPORT void close();

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -35,6 +35,7 @@
 #include "LocalFrame.h"
 #include "LocalFrameLoaderClient.h"
 #include "Logging.h"
+#include "Navigation.h"
 #include "NavigationScheduler.h"
 #include "OriginAccessPatterns.h"
 #include "Page.h"
@@ -270,6 +271,12 @@ ExceptionOr<void> History::stateObjectAdded(RefPtr<SerializedScriptValue>&& data
         if (stateObjectType == StateObjectType::Replace)
             return Exception { ExceptionCode::SecurityError, makeString("Attempt to use history.replaceState() more than "_s, perStateObjectTimeSpanLimit, " times per "_s, stateObjectTimeSpan.seconds(), " seconds"_s) };
         return Exception { ExceptionCode::SecurityError, makeString("Attempt to use history.pushState() more than "_s, perStateObjectTimeSpanLimit, " times per "_s, stateObjectTimeSpan.seconds(), " seconds"_s) };
+    }
+
+    if (RefPtr document = frame->document(); document && document->settings().navigationAPIEnabled()) {
+        auto& navigation = document->domWindow()->navigation();
+        if (!navigation.dispatchPushReplaceReloadNavigateEvent(fullURL, stateObjectType == StateObjectType::Push ? NavigationNavigationType::Push : NavigationNavigationType::Replace, true))
+            return { };
     }
 
     Checked<unsigned> urlSize = fullURL.string().length();

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2447,7 +2447,7 @@ void LocalDOMWindow::finishedLoading()
     }
 }
 
-void LocalDOMWindow::setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, SetLocationLocking locking)
+void LocalDOMWindow::setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, NavigationHistoryBehavior historyHandling, SetLocationLocking locking)
 {
     if (!isCurrentlyDisplayedInFrame())
         return;
@@ -2479,7 +2479,8 @@ void LocalDOMWindow::setLocation(LocalDOMWindow& activeWindow, const URL& comple
     frame->checkedNavigationScheduler()->scheduleLocationChange(*activeDocument, activeDocument->protectedSecurityOrigin(),
         // FIXME: What if activeDocument()->frame() is 0?
         completedURL, activeDocument->frame()->loader().outgoingReferrer(),
-        lockHistory, lockBackForwardList);
+        lockHistory, lockBackForwardList,
+        historyHandling);
 }
 
 void LocalDOMWindow::printErrorMessage(const String& message) const

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -373,7 +373,7 @@ private:
 
     void closePage() final;
     void eventListenersDidChange() final;
-    void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, SetLocationLocking) final;
+    void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, NavigationHistoryBehavior, SetLocationLocking) final;
 
     bool allowedToChangeWindowGeometry() const;
 

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -92,11 +92,7 @@ public:
     using RefCounted<Navigation>::ref;
     using RefCounted<Navigation>::deref;
 
-    enum class HistoryBehavior : uint8_t {
-        Auto,
-        Push,
-        Replace,
-    };
+    using HistoryBehavior = NavigationHistoryBehavior;
 
     struct UpdateCurrentEntryOptions {
         JSC::JSValue state;
@@ -127,7 +123,7 @@ public:
     bool canGoBack() const;
     bool canGoForward() const;
 
-    void initializeEntries(const Ref<HistoryItem>& currentItem, Vector<Ref<HistoryItem>> &items);
+    void initializeEntries(Ref<HistoryItem>&& currentItem, Vector<Ref<HistoryItem>>& items);
 
     Result navigate(const String& url, NavigateOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
 
@@ -139,11 +135,12 @@ public:
 
     ExceptionOr<void> updateCurrentEntry(UpdateCurrentEntryOptions&&);
 
-    bool dispatchTraversalNavigateEvent(Ref<HistoryItem>);
+    bool dispatchTraversalNavigateEvent(HistoryItem&);
     bool dispatchPushReplaceReloadNavigateEvent(const URL&, NavigationNavigationType, bool isSameDocument);
     bool dispatchDownloadNavigateEvent(const URL&, const String& downloadFilename);
 
     void updateForNavigation(Ref<HistoryItem>&&, NavigationNavigationType);
+    void updateForReactivation(Vector<Ref<HistoryItem>>& newHistoryItems, HistoryItem& reactivatedItem);
 
 private:
     explicit Navigation(LocalDOMWindow&);
@@ -155,7 +152,7 @@ private:
     void derefEventTarget() final { deref(); }
 
     bool hasEntriesAndEventsDisabled() const;
-    Result performTraversal(const String& key, Navigation::Options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished);
+    Result performTraversal(const String& key, Navigation::Options, FrameLoadType, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished);
     std::optional<Ref<NavigationHistoryEntry>> findEntryByKey(const String& key);
     ExceptionOr<RefPtr<SerializedScriptValue>> serializeState(JSC::JSValue state);
     bool innerDispatchNavigateEvent(NavigationNavigationType, Ref<NavigationDestination>&&, const String& downloadRequestFilename);

--- a/Source/WebCore/page/NavigationHistoryEntry.cpp
+++ b/Source/WebCore/page/NavigationHistoryEntry.cpp
@@ -40,21 +40,10 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(NavigationHistoryEntry);
 
-NavigationHistoryEntry::NavigationHistoryEntry(ScriptExecutionContext* context, Ref<HistoryItem>& historyItem)
+NavigationHistoryEntry::NavigationHistoryEntry(ScriptExecutionContext* context, Ref<HistoryItem>&& historyItem)
     : ContextDestructionObserver(context)
-    , m_url(historyItem->url())
-    , m_key(WTF::UUID::createVersion4())
     , m_id(WTF::UUID::createVersion4())
-    , m_associatedHistoryItem(historyItem)
-    , m_documentSequenceNumber(historyItem->documentSequenceNumber())
-{
-}
-
-NavigationHistoryEntry::NavigationHistoryEntry(ScriptExecutionContext* context, const URL& url)
-    : ContextDestructionObserver(context)
-    , m_url(url)
-    , m_key(WTF::UUID::createVersion4())
-    , m_id(WTF::UUID::createVersion4())
+    , m_associatedHistoryItem(WTFMove(historyItem))
 {
 }
 
@@ -73,7 +62,7 @@ const String& NavigationHistoryEntry::url() const
     RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
     if (!document || !document->isFullyActive())
         return nullString();
-    return m_url.string();
+    return m_associatedHistoryItem->urlString();
 }
 
 String NavigationHistoryEntry::key() const
@@ -81,7 +70,7 @@ String NavigationHistoryEntry::key() const
     RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
     if (!document || !document->isFullyActive())
         return nullString();
-    return m_key.toString();
+    return m_associatedHistoryItem->uuidIdentifier().toString();
 }
 
 String NavigationHistoryEntry::id() const
@@ -108,12 +97,10 @@ bool NavigationHistoryEntry::sameDocument() const
     RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
     if (!document || !document->isFullyActive())
         return false;
-    if (!m_documentSequenceNumber)
-        return false;
     RefPtr currentItem = document->frame()->checkedHistory()->currentItem();
     if (!currentItem)
         return false;
-    return currentItem->documentSequenceNumber() == *m_documentSequenceNumber;
+    return currentItem->documentSequenceNumber() == m_associatedHistoryItem->documentSequenceNumber();
 }
 
 JSC::JSValue NavigationHistoryEntry::getState(JSDOMGlobalObject& globalObject) const
@@ -122,10 +109,7 @@ JSC::JSValue NavigationHistoryEntry::getState(JSDOMGlobalObject& globalObject) c
     if (!document || !document->isFullyActive())
         return JSC::jsUndefined();
 
-    if (!m_associatedHistoryItem)
-        return JSC::jsUndefined();
-
-    auto stateObject = m_associatedHistoryItem->get().navigationAPIStateObject();
+    auto stateObject = m_associatedHistoryItem->navigationAPIStateObject();
     if (!stateObject)
         return JSC::jsUndefined();
 
@@ -134,10 +118,7 @@ JSC::JSValue NavigationHistoryEntry::getState(JSDOMGlobalObject& globalObject) c
 
 void NavigationHistoryEntry::setState(RefPtr<SerializedScriptValue>&& state)
 {
-    if (!m_associatedHistoryItem)
-        return;
-
-    m_associatedHistoryItem->get().setNavigationAPIStateObject(WTFMove(state));
+    m_associatedHistoryItem->setNavigationAPIStateObject(WTFMove(state));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -30,7 +30,6 @@
 #include "EventTarget.h"
 #include "HistoryItem.h"
 #include <wtf/RefCounted.h>
-#include <wtf/UUID.h>
 
 namespace JSC {
 class JSValue;
@@ -46,8 +45,7 @@ public:
     using RefCounted<NavigationHistoryEntry>::ref;
     using RefCounted<NavigationHistoryEntry>::deref;
 
-    static Ref<NavigationHistoryEntry> create(ScriptExecutionContext* context, Ref<HistoryItem>& historyItem) { return adoptRef(*new NavigationHistoryEntry(context, historyItem)); }
-    static Ref<NavigationHistoryEntry> create(ScriptExecutionContext* context, const URL& url) { return adoptRef(*new NavigationHistoryEntry(context, url)); }
+    static Ref<NavigationHistoryEntry> create(ScriptExecutionContext* context, Ref<HistoryItem>&& historyItem) { return adoptRef(*new NavigationHistoryEntry(context, WTFMove(historyItem))); }
 
     const String& url() const;
     String key() const;
@@ -58,21 +56,18 @@ public:
 
     void setState(RefPtr<SerializedScriptValue>&&);
 
+    HistoryItem& associatedHistoryItem() const { return m_associatedHistoryItem; }
+
 private:
-    NavigationHistoryEntry(ScriptExecutionContext*, Ref<HistoryItem>&);
-    NavigationHistoryEntry(ScriptExecutionContext*, const URL&);
+    NavigationHistoryEntry(ScriptExecutionContext*, Ref<HistoryItem>&&);
 
     enum EventTargetInterfaceType eventTargetInterface() const final;
     ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 
-    const URL m_url;
-    const WTF::UUID m_key;
     const WTF::UUID m_id;
-    // TODO: Every entry is supposed to have an associated history item.
-    std::optional<Ref<HistoryItem>> m_associatedHistoryItem;
-    std::optional<long long> m_documentSequenceNumber;
+    Ref<HistoryItem> m_associatedHistoryItem;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -136,7 +136,7 @@ ExceptionOr<void> RemoteDOMWindow::postMessage(JSC::JSGlobalObject& lexicalGloba
     return { };
 }
 
-void RemoteDOMWindow::setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, SetLocationLocking locking)
+void RemoteDOMWindow::setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, NavigationHistoryBehavior historyHandling, SetLocationLocking locking)
 {
     // FIXME: Add some or all of the security checks in LocalDOMWindow::setLocation. <rdar://116500603>
     // FIXME: Refactor this duplicate code to share with LocalDOMWindow::setLocation. <rdar://116500603>
@@ -155,7 +155,8 @@ void RemoteDOMWindow::setLocation(LocalDOMWindow& activeWindow, const URL& compl
     frame->navigationScheduler().scheduleLocationChange(*activeDocument, activeDocument->securityOrigin(),
         // FIXME: What if activeDocument()->frame() is 0?
         completedURL, activeDocument->frame()->loader().outgoingReferrer(),
-        lockHistory, lockBackForwardList);
+        lockHistory, lockBackForwardList,
+        historyHandling);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/RemoteDOMWindow.h
+++ b/Source/WebCore/page/RemoteDOMWindow.h
@@ -71,7 +71,7 @@ private:
     WEBCORE_EXPORT RemoteDOMWindow(RemoteFrame&, GlobalWindowIdentifier&&);
 
     void closePage() final;
-    void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, SetLocationLocking) final;
+    void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, NavigationHistoryBehavior, SetLocationLocking) final;
 
     WeakPtr<RemoteFrame> m_frame;
 };


### PR DESCRIPTION
#### 7e54fb8ea939d9f0dc5d697d9daf410b7cb3b47f
<pre>
[Navigation] Improve maintaining the entries list and their interaction with HistoryItems
<a href="https://bugs.webkit.org/show_bug.cgi?id=273956">https://bugs.webkit.org/show_bug.cgi?id=273956</a>

Reviewed by Alex Christensen.

This changes a few areas but it all adds up to solving the same problems.
I&apos;ll go over the changes by entry point:

- navigation.navigate() takes a historyHandling argument that controls the
  history behavior all the way down.
- navigation.back/forward/traverseTo load the known HistoryItem instead of
  loading a URL as well as specify the correct FrameLoadType.
- the location APIs use the proper historyHandling.
- navigation.entries() is more accurately maintained:
  - On reactivation (loading a cached page from history) we regenerate the entires.
  - On a cross-document navigation we filter out any cross-origin entries.
- history.pushState/history.replaceState changes are reflected in entries.
  - This also no longer changes the key of replaced entries.
- Traversal events use the proper HistoryItem.

This all leads to a more consistent and correct list of entries. In order for adding
these entries to work there were also a few dispatches of NavigateEvent in the
expected places like during a history traversal or history state change.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-back-same-doc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-pushState-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-replaceState-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigate-from-initial-about-blank-same-doc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigate-from-initial-about-blank-same-doc-popup-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-replace-same-doc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-origin-traversal-does-not-fire-navigate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-crossorigin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-sameorigin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/event-constructor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-and-navigate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-history-pushState-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-history-replaceState-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-on-synthetic-event-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-popstate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-same-document-history-back-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-after-detach-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-dynamic-index-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-back-forward-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-after-fragment-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-after-pushState-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-noop-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-pushState-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-replaceState-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-same-document-in-iframe-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-window-open-self-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-cross-document-preventDefault-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/replaceState-inside-back-handler-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-same-document-then-cross-document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/after-detach-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/current-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-in-iframe-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/index-not-in-entries-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-back-same-document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-reload-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-replace-cross-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-replace-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-from-meta-url-censored-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-url-censored-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/sameDocument-after-fragment-navigate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/sameDocument-after-navigate-restore-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/state-after-navigate-restore-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-intercept-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-intercept-rejected-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/forward-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/forward-intercept-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/forward-intercept-rejected-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept-interrupted-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-interrupted-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-unload-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-unload-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-intercept-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-intercept-rejected-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-after-adding-iframe-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-after-data-url-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-detach-between-navigate-and-navigatesuccess-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-with-cross-origin-in-history-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/currententrychange-dispose-ordering-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-after-bfcache-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-child-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-intercept-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-navigate-during-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-replaceState-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-skip-current-on-truncate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-away-and-back-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-location-api-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/location-reload-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/history-pushState-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/same-document-away-and-back-location-api-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-crossorigin-sameorigindomain.sub-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-navigations-in-multiple-windows-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/navigation-api/navigation-methods/sandboxing-navigate-parent-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::navigateFromServiceWorker):
* Source/WebCore/history/BackForwardController.cpp:
(WebCore::BackForwardController::allItems):
* Source/WebCore/history/BackForwardController.h:
* Source/WebCore/history/CachedPage.cpp:
(WebCore::CachedPage::restore):
* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::HistoryItem):
* Source/WebCore/history/HistoryItem.h:
(WebCore::HistoryItem::uuidIdentifier const):
(WebCore::HistoryItem::operator== const):
* Source/WebCore/loader/FrameLoadRequest.h:
(WebCore::FrameLoadRequest::navigationHistoryBehavior const):
(WebCore::FrameLoadRequest::setNavigationHistoryHandling):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::determineNavigationType):
(WebCore::FrameLoader::loadInSameDocument):
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::loadWithDocumentLoader):
(WebCore::FrameLoader::continueFragmentScrollAfterNavigationPolicy):
(WebCore::FrameLoader::loadItem):
(WebCore::FrameLoader::updateNavigationAPIEntries):
(WebCore::determineNavigationType): Deleted.
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::pushState):
(WebCore::HistoryController::replaceState):
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::NavigationScheduler::scheduleLocationChange):
* Source/WebCore/loader/NavigationScheduler.h:
* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::FrameLoader::SubframeLoader::loadOrRedirectSubframe):
* Source/WebCore/page/DOMWindow.h:
* Source/WebCore/page/History.cpp:
(WebCore::History::stateObjectAdded):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::setLocation):
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/Location.cpp:
(WebCore::Location::replace):
(WebCore::Location::setLocation):
* Source/WebCore/page/Navigation.cpp:
(WebCore::getEntryIndexOfHistoryItem):
(WebCore::Navigation::initializeEntries):
(WebCore::Navigation::maybeSetUpcomingNonTraversalTracker):
(WebCore::Navigation::navigate):
(WebCore::Navigation::performTraversal):
(WebCore::Navigation::traverseTo):
(WebCore::Navigation::back):
(WebCore::Navigation::forward):
(WebCore::Navigation::updateForNavigation):
(WebCore::Navigation::updateForReactivation):
(WebCore::Navigation::promoteUpcomingAPIMethodTracker):
(WebCore::Navigation::cleanupAPIMethodTracker):
(WebCore::Navigation::innerDispatchNavigateEvent):
(WebCore::Navigation::dispatchTraversalNavigateEvent):
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/NavigationHistoryEntry.cpp:
(WebCore::NavigationHistoryEntry::NavigationHistoryEntry):
(WebCore::NavigationHistoryEntry::sameDocument const):
(WebCore::NavigationHistoryEntry::getState const):
(WebCore::NavigationHistoryEntry::setState):
* Source/WebCore/page/NavigationHistoryEntry.h:
* Source/WebCore/page/RemoteDOMWindow.cpp:
(WebCore::RemoteDOMWindow::setLocation):
* Source/WebCore/page/RemoteDOMWindow.h:

Canonical link: <a href="https://commits.webkit.org/278960@main">https://commits.webkit.org/278960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a835172948293de10108b2c842d5f46309214db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4506 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55363 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2802 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54394 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2510 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42388 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1786 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54184 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44939 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23459 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2216 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/972 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48218 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56960 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27209 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2378 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49785 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28445 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49009 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11399 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29350 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28186 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->