### PR TITLE
Make setupTransitionPseudoElements end in an up-to-date render tree

### DIFF
--- a/LayoutTests/fast/css/view-transition-pseudo-element-styles-crash-expected.txt
+++ b/LayoutTests/fast/css/view-transition-pseudo-element-styles-crash-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash.

--- a/LayoutTests/fast/css/view-transition-pseudo-element-styles-crash.html
+++ b/LayoutTests/fast/css/view-transition-pseudo-element-styles-crash.html
@@ -1,0 +1,15 @@
+<style>
+html { content: url("#foo"); }
+</style>
+<script>
+if (testRunner) {
+  testRunner.waitUntilDone();
+  testRunner.dumpAsText();
+}
+
+function runTest() {
+  document.startViewTransition();
+  setTimeout(function() { document.write("Test passes if it does not crash."); testRunner.notifyDone(); }, 10);
+}
+</script>
+<body onload=runTest()>

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -495,6 +495,9 @@ void ViewTransition::setupTransitionPseudoElements()
 
     if (RefPtr documentElement = document()->documentElement())
         documentElement->invalidateStyleInternal();
+
+    // Ensure style & render tree are up-to-date.
+    protectedDocument()->updateStyleIfNeeded();
 }
 
 // https://drafts.csswg.org/css-view-transitions/#activate-view-transition


### PR DESCRIPTION
#### 268766c7de0d0900b5c389d62be961065c6ea3dc
<pre>
Make setupTransitionPseudoElements end in an up-to-date render tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=273962">https://bugs.webkit.org/show_bug.cgi?id=273962</a>

Reviewed by Tim Nguyen.

It is important for setupTransitionPseudoElements to end in an up-to-date render tree,
after potentially invaliding the document element, since updatePseudoElementStyles expects
that for copying element properties.

* LayoutTests/fast/css/view-transition-pseudo-element-styles-crash-expected.txt: Added.
* LayoutTests/fast/css/view-transition-pseudo-element-styles-crash.html: Added.
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::setupTransitionPseudoElements):

Canonical link: <a href="https://commits.webkit.org/278608@main">https://commits.webkit.org/278608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57e112ae1ae2b17f393aad53a869143dc0121e8d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54357 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1789 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53402 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41614 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44039 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22733 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25361 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1293 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9540 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47340 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1367 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55952 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1261 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49014 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27458 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44107 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48144 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11175 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28338 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27189 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->