### PR TITLE
Exclude NSURLNetworkServiceTypeBackground from traffic being hinted

### DIFF
--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -188,8 +188,7 @@ static void adjustNetworkServiceTypeIfNecessary(WebCore::ResourceRequestRequeste
     if (requester == WebCore::ResourceRequestRequester::Media) {
         if (mutableRequest.networkServiceType == NSURLNetworkServiceTypeDefault || mutableRequest.networkServiceType == NSURLNetworkServiceTypeBackground)
             mutableRequest.networkServiceType = NSURLNetworkServiceTypeVideo;
-    } else if (requester == WebCore::ResourceRequestRequester::Beacon)
-        mutableRequest.networkServiceType = NSURLNetworkServiceTypeBackground;
+    }
 }
 
 NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataTaskClient& client, const NetworkLoadParameters& parameters)


### PR DESCRIPTION
#### 675eaf23f6ed1babc0fc60a725d77f6b7c2ba9ce
<pre>
Exclude NSURLNetworkServiceTypeBackground from traffic being hinted
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::adjustNetworkServiceTypeIfNecessary):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87c8631bb0533fb98f439c61f5985ed82d3ef0d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51008 "Failed to checkout and rebase branch from PR 28352") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54265 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1697 "Failed to checkout and rebase branch from PR 28352") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1364 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53106 "Failed to checkout and rebase branch from PR 28352") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27948 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22663 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9448 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1278 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55859 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26115 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1177 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27366 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44020 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28244 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27097 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->