### PR TITLE
[WGSL] Add ability to toggle printing generated metal code

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
@@ -28,14 +28,13 @@
 
 #include "AST.h"
 #include "MetalFunctionWriter.h"
+#include <notify.h>
 #include <wtf/DataLog.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WGSL {
 
 namespace Metal {
-
-static constexpr bool dumpMetalCode = true;
 
 static StringView metalCodePrologue()
 {
@@ -51,6 +50,15 @@ static StringView metalCodePrologue()
 
 static void dumpMetalCodeIfNeeded(StringBuilder& stringBuilder)
 {
+    static bool dumpMetalCode = false;
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        int dumpMetalCodeToken;
+        notify_register_dispatch("com.apple.WebKit.WebGPU.TogglePrintMetalCode", &dumpMetalCodeToken, dispatch_get_main_queue(), ^(int) {
+            dumpMetalCode = !dumpMetalCode;
+        });
+    });
+
     if (dumpMetalCode) {
         dataLogLn("Generated Metal code:");
         dataLogLn(stringBuilder.toString());


### PR DESCRIPTION
#### da243b55b76d925ed39a8dc0431b14eeb438f5a6
<pre>
[WGSL] Add ability to toggle printing generated metal code
<a href="https://bugs.webkit.org/show_bug.cgi?id=273966">https://bugs.webkit.org/show_bug.cgi?id=273966</a>
&lt;<a href="https://rdar.apple.com/problem/127830520">rdar://problem/127830520</a>&gt;

Reviewed by Tadeu Zagallo.

Don&apos;t log the metal source by default, but still allow it to be toggled
on to print it.

* Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp:
(WGSL::Metal::dumpMetalCodeIfNeeded):

Canonical link: <a href="https://commits.webkit.org/278701@main">https://commits.webkit.org/278701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f137cad81684a251e5377aaa979786afce99537

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54267 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1699 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1366 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41546 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53108 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43957 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22665 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25286 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9450 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47263 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1280 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55861 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26117 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1178 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48955 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27368 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44022 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48177 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11233 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28246 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27099 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->