### PR TITLE
[view-transitions] Refactor timing of "update callback done" and related

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/duplicate-tag-rejects-start.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/duplicate-tag-rejects-start.html
@@ -33,18 +33,18 @@ promise_test(async t => {
     let updateCallbackDoneResolved = false;
     transition.updateCallbackDone.then(() => { updateCallbackDoneResolved = true; }, reject);
 
-    // Then finished resolves since updateCallbackDone was already resolved.
-    let finishResolved = false;
-    transition.updateCallbackDone.then(() => {
-      assert_true(updateCallbackDoneResolved, "updateCallbackDone not resolved before finish");
-      finishResolved = true;
-    }, reject);
-
-    // Finally ready rejects.
+    // Ready rejects.
+    let readyRejected = false;
     transition.ready.then(reject, () => {
-      assert_true(finishResolved, "finish not resolved before ready");
-      resolve();
+      readyRejected = true;
+      assert_true(updateCallbackDoneResolved, "updateCallbackDone should resolve before ready was rejected");
     });
+
+    // Then finished resolves since updateCallbackDone was already resolved.
+    transition.finished.then(() => {
+      assert_true(readyRejected, "finished should resolve after ready was rejected");
+      resolve();
+    }, reject);
   });
 }, "Two different elements with the same name in the new DOM should skip the transition");
 </script>

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -219,13 +219,19 @@ void JSPromise::reject(JSGlobalObject* lexicalGlobalObject, JSValue value)
     }
 }
 
-void JSPromise::rejectAsHandled(JSGlobalObject* lexicalGlobalObject, JSValue value)
+// https://webidl.spec.whatwg.org/#mark-a-promise-as-handled
+void JSPromise::markAsHandled(JSGlobalObject* lexicalGlobalObject)
 {
-    // Setting isHandledFlag before calling reject since this removes round-trip between JSC and PromiseRejectionTracker, and it does not show an user-observable behavior.
     VM& vm = lexicalGlobalObject->vm();
     uint32_t flags = this->flags();
     if (!(flags & isFirstResolvingFunctionCalledFlag))
         internalField(Field::Flags).set(vm, this, jsNumber(flags | isHandledFlag));
+}
+
+void JSPromise::rejectAsHandled(JSGlobalObject* lexicalGlobalObject, JSValue value)
+{
+    // Setting isHandledFlag before calling reject since this removes round-trip between JSC and PromiseRejectionTracker, and it does not show an user-observable behavior.
+    markAsHandled(lexicalGlobalObject);
     reject(lexicalGlobalObject, value);
 }
 

--- a/Source/JavaScriptCore/runtime/JSPromise.h
+++ b/Source/JavaScriptCore/runtime/JSPromise.h
@@ -84,6 +84,7 @@ public:
     JS_EXPORT_PRIVATE void rejectAsHandled(JSGlobalObject*, JSValue);
     JS_EXPORT_PRIVATE void reject(JSGlobalObject*, Exception*);
     JS_EXPORT_PRIVATE void rejectAsHandled(JSGlobalObject*, Exception*);
+    JS_EXPORT_PRIVATE void markAsHandled(JSGlobalObject*);
     JS_EXPORT_PRIVATE void performPromiseThen(JSGlobalObject*, JSFunction*, JSFunction*, JSValue);
 
     JS_EXPORT_PRIVATE JSPromise* rejectWithCaughtException(JSGlobalObject*, ThrowScope&);

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
@@ -202,6 +202,11 @@ public:
     void whenSettled(Function<void()>&&);
     bool needsAbort() const { return m_needsAbort; }
 
+    void markAsHandled() const
+    {
+        deferred()->markAsHandled(globalObject());
+    }
+
 private:
     DeferredPromise(JSDOMGlobalObject& globalObject, JSC::JSPromise& deferred, Mode mode)
         : DOMGuarded<JSC::JSPromise>(globalObject, deferred)


### PR DESCRIPTION
#### 5169139ac1127c419017b37d9f2106a2c199070f
<pre>
[view-transitions] Refactor timing of &quot;update callback done&quot; and related
<a href="https://bugs.webkit.org/show_bug.cgi?id=273969">https://bugs.webkit.org/show_bug.cgi?id=273969</a>
<a href="https://rdar.apple.com/127834364">rdar://127834364</a>

Reviewed by Darin Adler.

Implements:
<a href="https://github.com/w3c/csswg-drafts/commit/9d5ed6f403cc02b62674e7dd645eaec7598b8135">https://github.com/w3c/csswg-drafts/commit/9d5ed6f403cc02b62674e7dd645eaec7598b8135</a>

<a href="https://github.com/w3c/csswg-drafts/commit/f62c43823f27926efeadfea7945487a6126a7bb8">https://github.com/w3c/csswg-drafts/commit/f62c43823f27926efeadfea7945487a6126a7bb8</a>

This makes the algorithm only react to the update callback from a single place.

Also fix duplicate-tag-rejects-start.html to not check for updateCallbackDone promise timing twice.
The correct timing is: “update callback done -&gt; ready rejects -&gt; finished resolves” (as the &quot;Skip the view transition&quot; algorithm expects)

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/duplicate-tag-rejects-start.html:
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::markAsHandled):
(JSC::JSPromise::rejectAsHandled):
* Source/JavaScriptCore/runtime/JSPromise.h:
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.h:
(WebCore::DeferredPromise::markAsHandled const):
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::callUpdateCallback):
(WebCore::ViewTransition::setupViewTransition):

Canonical link: <a href="https://commits.webkit.org/278606@main">https://commits.webkit.org/278606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8922899f54f318fc1a526472ca012e97cb7d0ea6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54347 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1779 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53392 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1454 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28023 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44030 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/22730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25348 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1284 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9530 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/44429 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47327 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1358 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55942 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/50592 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26200 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1251 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27448 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44098 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/11174 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28328 "Built successfully") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/58112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7421 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27179 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/58112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->