### PR TITLE
REGRESSION (278522@main): [ MacOS iOS ] http/wpt/webauthn/idl.https.html is a consistent failure

### DIFF
--- a/LayoutTests/http/wpt/webauthn/idl.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/idl.https-expected.txt
@@ -1,5 +1,4 @@
 Description
-
 This test verifies that the implementations of the WebAuthN API match with its WebIDL definition.
 
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7297,4 +7297,3 @@ webkit.org/b/273848 [ Release ] imported/w3c/web-platform-tests/html/semantics/e
 
 webkit.org/b/273905 svg/filters/filter-on-root-tile-boundary.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/273963 http/wpt/webauthn/idl.https.html [ Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1878,4 +1878,3 @@ webkit.org/b/273588 fast/forms/select/mac-wk2/inactive-appearance.html [ Pass Im
 
 webkit.org/b/273905 [ X86_64 ] svg/filters/filter-on-root-tile-boundary.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/273963 http/wpt/webauthn/idl.https.html [ Failure ]


### PR DESCRIPTION
#### c5996866a40db4944832be58564404c7c572a8cb
<pre>
REGRESSION (278522@main): [ MacOS iOS ] http/wpt/webauthn/idl.https.html is a consistent failure
<a href="https://rdar.apple.com/127827007">rdar://127827007</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=273963">https://bugs.webkit.org/show_bug.cgi?id=273963</a>

Unreviewed, rebaseline.

The whitespace for this test changed, rebaselining.

* LayoutTests/http/wpt/webauthn/idl.https-expected.txt:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/278585@main">https://commits.webkit.org/278585@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10bc21a5e9d19765dfe3746b4f154da193d3fa1e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/51031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3359 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/54288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1720 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1389 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/54288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/53130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/27963 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/43965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/54288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/50880 "Build is in progress. Recent messages:") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/1220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9471 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/1293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/55882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/26139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/55882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/27389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/44034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/55882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/28268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7405 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/27120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->