### PR TITLE
[Navigation] Consolidate "document is fully active" check in navigate

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-detached-unserializablestate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-detached-unserializablestate-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL navigate() with unserializable state in a detached iframe throws "DataCloneError", not "InvalidStateError" assert_throws_dom: function "() => { throw committedReason; }" threw object "InvalidStateError: Invalid state" that is not a DOMException DataCloneError: property "code" is equal to 11, expected 25
+PASS navigate() with unserializable state in a detached iframe throws "DataCloneError", not "InvalidStateError"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-detached-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-detached-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL navigate() with an invalid URL in a detached iframe throws "SyntaxError", not "InvalidStateError" assert_throws_dom: function "() => { throw committedReason; }" threw object "InvalidStateError: Invalid state" that is not a DOMException SyntaxError: property "code" is equal to 11, expected 12
+PASS navigate() with an invalid URL in a detached iframe throws "SyntaxError", not "InvalidStateError"
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -233,10 +233,7 @@ Navigation::Result Navigation::reload(ReloadOptions&& options, Ref<DeferredPromi
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-navigate
 Navigation::Result Navigation::navigate(const String& url, NavigateOptions&& options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
-    if (!frame())
-        return createErrorResult(WTFMove(committed), WTFMove(finished), ExceptionCode::InvalidStateError, "Invalid state"_s);
-
-    auto newURL = frame()->document()->completeURL(url);
+    auto newURL = window()->document()->completeURL(url);
     const URL& currentURL = scriptExecutionContext()->url();
 
     if (!newURL.isValid())


### PR DESCRIPTION
#### df4f8114adb94520ac83c8a0b0d8b4aaba7e1028
<pre>
[Navigation] Consolidate &quot;document is fully active&quot; check in navigate
<a href="https://bugs.webkit.org/show_bug.cgi?id=273972">https://bugs.webkit.org/show_bug.cgi?id=273972</a>

Reviewed by Alex Christensen.

The navigate method starts of by (partly) checking whether the document is fully active by
checking that the frame exists, however the &quot;document is fully active&quot; check should be done
in step 7 (see [1]). So remove the frame check and rely on the later call to isFullyActive
to get the correct order of handling possible errors.

[1] <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-navigate">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-navigate</a>

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-detached-unserializablestate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-detached-expected.txt:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::navigate):

Canonical link: <a href="https://commits.webkit.org/278627@main">https://commits.webkit.org/278627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1d40fff83aee5e4a29c7da10aff9857c68fc24b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51143 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30445 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54400 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1833 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53446 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/36771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1507 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41655 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44080 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22771 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25400 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1336 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47380 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1408 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55996 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26253 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1301 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49051 "Found 2 new test failures: imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-not-fired-after-removing-scroller.tentative.html, webgl/2.0.y/conformance2/textures/webgl_canvas/tex-3d-srgb8_alpha8-rgba-unsigned_byte.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27501 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44147 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48190 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11187 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28382 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27232 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->