### PR TITLE
Need a method to take a UIKeyCommand and return whether any Web Extension command matches

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -39,6 +39,7 @@
 
 #if TARGET_OS_IPHONE
 @class UIMenuElement;
+@class UIKeyCommand;
 #else
 @class NSEvent;
 @class NSMenuItem;
@@ -570,6 +571,17 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  @discussion This method performs the given command as if it was triggered by a user gesture within the context of the focused window and active tab.
  */
 - (void)performCommand:(_WKWebExtensionCommand *)command;
+
+#if TARGET_OS_IPHONE
+/*!
+ @abstract Performs the command associated with the given UIKeyCommand.
+ @discussion This method checks for a command corresponding to the provided UIKeyCommand and performs it, if available. The app should use this method to perform
+ any extension commands at an appropriate time in the app's responder object that handles the performWebExtensionCommandForKeyCommand: action.
+ @param event The UIKeyCommand received by the first responder.
+ @result Returns `YES` if a command corresponding to the UIKeyCommand was found and performed, `NO` otherwise.
+ */
+- (BOOL)performCommandForKeyCommand:(UIKeyCommand *)keyCommand;
+#endif
 
 #if TARGET_OS_OSX
 /*!

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -573,6 +573,15 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
     _webExtensionContext->performCommand(command._webExtensionCommand, WebKit::WebExtensionContext::UserTriggered::Yes);
 }
 
+#if TARGET_OS_IPHONE
+- (BOOL)performCommandForKeyCommand:(UIKeyCommand *)keyCommand
+{
+    NSParameterAssert([keyCommand isKindOfClass:UIKeyCommand.class]);
+
+    return _webExtensionContext->performCommand(keyCommand);
+}
+#endif
+
 #if USE(APPKIT)
 - (BOOL)performCommandForEvent:(NSEvent *)event
 {
@@ -1113,6 +1122,13 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(_WKWe
 - (void)performCommand:(_WKWebExtensionCommand *)command
 {
 }
+
+#if TARGET_OS_IPHONE
+- (BOOL)performCommandForKeyCommand:(UIKeyCommand *)keyCommand
+{
+    return NO;
+}
+#endif
 
 #if USE(APPKIT)
 - (BOOL)performCommandForEvent:(NSEvent *)event

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -2624,6 +2624,33 @@ void WebExtensionContext::performCommand(WebExtensionCommand& command, UserTrigg
     fireCommandEventIfNeeded(command, activeTab.get());
 }
 
+#if TARGET_OS_IPHONE
+WebExtensionCommand* WebExtensionContext::commandMatchingKeyCommand(UIKeyCommand *keyCommand)
+{
+    ASSERT(keyCommand);
+    for (auto& command : commands()) {
+        if (command->matchesKeyCommand(keyCommand))
+            return command.ptr();
+    }
+
+    return nullptr;
+}
+
+bool WebExtensionContext::performCommand(UIKeyCommand *keyCommand)
+{
+    ASSERT(isLoaded());
+    if (!isLoaded())
+        return false;
+
+    if (RefPtr result = commandMatchingKeyCommand(keyCommand)) {
+        performCommand(*result, UserTriggered::Yes);
+        return true;
+    }
+
+    return false;
+}
+#endif
+
 #if USE(APPKIT)
 WebExtensionCommand* WebExtensionContext::command(NSEvent *event)
 {

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h
@@ -50,13 +50,9 @@ using CocoaMenuItem = UIMenuElement;
 #endif
 
 #if defined(__OBJC__) && PLATFORM(IOS_FAMILY)
-using WebExtensionKeyCommandHandlerBlock = void (^)(void);
-
 @interface _WKWebExtensionKeyCommand : UIKeyCommand
 
-+ (instancetype)commandWithTitle:(NSString *)title image:(UIImage *)image input:(NSString *)input modifierFlags:(UIKeyModifierFlags)modifierFlags handler:(WebExtensionKeyCommandHandlerBlock)handler;
-
-@property (nonatomic, copy) WebExtensionKeyCommandHandlerBlock handler;
++ (UIKeyCommand *)commandWithTitle:(NSString *)title image:(UIImage *)image input:(NSString *)input modifierFlags:(UIKeyModifierFlags)modifierFlags identifier:(NSString *)identifier;
 
 @end
 #endif // PLATFORM(IOS_FAMILY)
@@ -103,6 +99,7 @@ public:
 
 #if PLATFORM(IOS_FAMILY)
     UIKeyCommand *keyCommand() const;
+    bool matchesKeyCommand(UIKeyCommand *) const;
 #endif
 
 #if USE(APPKIT)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -435,6 +435,10 @@ public:
     WebExtensionCommand* command(const String& identifier);
     void performCommand(WebExtensionCommand&, UserTriggered = UserTriggered::No);
 
+#if TARGET_OS_IPHONE
+    WebExtensionCommand* commandMatchingKeyCommand(UIKeyCommand *);
+    bool performCommand(UIKeyCommand *);
+#endif
 #if USE(APPKIT)
     WebExtensionCommand* command(NSEvent *);
     bool performCommand(NSEvent *);


### PR DESCRIPTION
#### fdb3855c7cd3ac3bba2c68998b92948e4fb3be9d
<pre>
Need a method to take a UIKeyCommand and return whether any Web Extension command matches
<a href="https://bugs.webkit.org/show_bug.cgi?id=273920">https://bugs.webkit.org/show_bug.cgi?id=273920</a>
<a href="https://rdar.apple.com/127787491">rdar://127787491</a> (Need a method to take a UIKeyCommand and return whether any Web Extension command matches (273920))

Reviewed by Brian Weinstein.

Introduces a couple of convenience methods that triggers the applicable
WebExtensionCommand based on a given UIKeyCommand.

This pattern is done for AppKit already, but lacks the UIKit counterpart.

This is needed because the existing _WKWebExtensionKeyCommand.handler is
never called because _WKWebExtensionKeyCommand itself will never be in the
responder chain. Therefore the app needs to pass the received UIKeyCommand
object back to the extensions stack for handling. The new methods in this patch
enables such handling.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext performCommandForKeyCommand:]):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm:
(+[_WKWebExtensionKeyCommand commandWithTitle:image:input:modifierFlags:identifier:]):
(-[_WKWebExtensionKeyCommand performWebExtensionCommandForKeyCommand:]):
(WebKit::WebExtensionCommand::keyCommand const):

(WebKit::WebExtensionCommand::matchesKeyCommand const):
Ideally WebExtensionCommand should have a globally unique identity that can
be propagated into UIKeyCommand.propertyList. But there isn&apos;t such identity
right now. Let&apos;s just check for the input, modifierKeys, and the dev-provided command identifier for now.

(+[_WKWebExtensionKeyCommand commandWithTitle:image:input:modifierFlags:handler:]): Deleted.
UIKeyCommand isn&apos;t really meant to be subclassed. This subclass exists today
just to attach a _handler to the UIKeyCommand object. But when the key is
pressed, the UIKeyCommand object we will receive is actually another object
created by the system. So this _handler is actually never called.
So, let&apos;s vend the base class UIKeyCommand instead.
_WKWebExtensionKeyCommand still exists after this patch just to provide a
namespace for the designated selector -performWebExtensionCommandForKeyCommand:
to live somewhere reasonable.

(-[_WKWebExtensionKeyCommand copyWithZone:]): Deleted.
(-[_WKWebExtensionKeyCommand performWithSender:target:]): Deleted.
(-[_WKWebExtensionKeyCommand _resolvedTargetFromFirstTarget:sender:]): Deleted.
(-[_WKWebExtensionKeyCommand _performWithTarget:]): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::command):
(WebKit::WebExtensionContext::performCommand):
* Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:

Canonical link: <a href="https://commits.webkit.org/278619@main">https://commits.webkit.org/278619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/285a2927a5d99dcad8bf5d14858b04012495157b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54382 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1815 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1489 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41638 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28059 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44064 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22754 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25386 "4 new passes 7 flakes") | | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47365 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55978 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26235 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1290 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49034 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27483 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44131 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48168 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28364 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7427 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27214 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->