### PR TITLE
[visionOS] Inform the client when Image Fullscreen is delegated to Quick Look

### DIFF
--- a/Source/WebKit/Shared/FullScreenMediaDetails.h
+++ b/Source/WebKit/Shared/FullScreenMediaDetails.h
@@ -34,7 +34,7 @@ struct FullScreenMediaDetails {
     enum class Type : uint8_t { None, Video, ElementWithVideo, Image };
 
     Type type { Type::None };
-    WebCore::FloatSize videoDimensions { };
+    WebCore::FloatSize mediaDimensions { };
 
     String mimeType { };
     std::optional<WebCore::SharedMemory::Handle> imageHandle { std::nullopt };

--- a/Source/WebKit/Shared/FullScreenMediaDetails.serialization.in
+++ b/Source/WebKit/Shared/FullScreenMediaDetails.serialization.in
@@ -30,7 +30,7 @@
 
 [RValue] struct WebKit::FullScreenMediaDetails {
     WebKit::FullScreenMediaDetails::Type type;
-    WebCore::FloatSize videoDimensions;
+    WebCore::FloatSize mediaDimensions;
     String mimeType;
     std::optional<WebCore::SharedMemory::Handle> imageHandle;
 };

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFullscreenDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFullscreenDelegate.h
@@ -35,6 +35,8 @@ WK_API_AVAILABLE(macos(10.13), ios(11.3))
 - (void)_webViewDidEnterElementFullscreen:(WKWebView *)webView;
 - (void)_webViewWillExitElementFullscreen:(WKWebView *)webView;
 - (void)_webViewDidExitElementFullscreen:(WKWebView *)webView;
+
+- (void)_webView:(WKWebView *)webView didFullscreenImageWithQuickLook:(CGSize)imageDimensions;
 #else
 - (void)_webViewWillEnterFullscreen:(NSView *)webView;
 - (void)_webViewDidEnterFullscreen:(NSView *)webView;

--- a/Source/WebKit/UIProcess/Cocoa/FullscreenClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/FullscreenClient.h
@@ -67,6 +67,9 @@ private:
         bool webViewWillExitElementFullscreen : 1;
         bool webViewDidExitElementFullscreen : 1;
 #endif
+#if ENABLE(QUICKLOOK_FULLSCREEN)
+        bool webViewDidFullscreenImageWithQuickLook : 1;
+#endif
     } m_delegateMethods;
 };
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -204,8 +204,8 @@ void WebFullScreenManagerProxy::enterFullScreen(bool blocksReturnToFullscreenFro
 #endif // QUICKLOOK_FULLSCREEN
 #endif
 
-    auto videoDimensions = mediaDetails.videoDimensions;
-    m_client.enterFullScreen(videoDimensions);
+    auto mediaDimensions = mediaDetails.mediaDimensions;
+    m_client.enterFullScreen(mediaDimensions);
 #else
     UNUSED_PARAM(mediaDetails);
     m_client.enterFullScreen();

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -67,7 +67,7 @@ public:
     virtual void closeFullScreenManager() = 0;
     virtual bool isFullScreen() = 0;
 #if PLATFORM(IOS_FAMILY)
-    virtual void enterFullScreen(WebCore::FloatSize videoDimensions) = 0;
+    virtual void enterFullScreen(WebCore::FloatSize mediaDimensions) = 0;
 #else
     virtual void enterFullScreen() = 0;
 #endif

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -243,7 +243,7 @@ private:
     // WebFullScreenManagerProxyClient
     void closeFullScreenManager() override;
     bool isFullScreen() override;
-    void enterFullScreen(WebCore::FloatSize videoDimensions) override;
+    void enterFullScreen(WebCore::FloatSize mediaDimensions) override;
     void exitFullScreen() override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -793,9 +793,9 @@ bool PageClientImpl::isFullScreen()
     return [webView fullScreenWindowController].isFullScreen;
 }
 
-void PageClientImpl::enterFullScreen(FloatSize videoDimensions)
+void PageClientImpl::enterFullScreen(FloatSize mediaDimensions)
 {
-    [[webView() fullScreenWindowController] enterFullScreen:videoDimensions];
+    [[webView() fullScreenWindowController] enterFullScreen:mediaDimensions];
 }
 
 void PageClientImpl::exitFullScreen()

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
@@ -37,9 +37,13 @@
 #if PLATFORM(VISION)
 @property (readonly, assign, nonatomic) BOOL prefersSceneDimming;
 #endif
+#if ENABLE(QUICKLOOK_FULLSCREEN)
+@property (readonly, assign, nonatomic) BOOL isUsingQuickLook;
+@property (readonly, assign, nonatomic) CGSize imageDimensions;
+#endif
 
 - (id)initWithWebView:(WKWebView *)webView;
-- (void)enterFullScreen:(CGSize)videoDimensions;
+- (void)enterFullScreen:(CGSize)mediaDimensions;
 - (void)beganEnterFullScreenWithInitialFrame:(CGRect)initialFrame finalFrame:(CGRect)finalFrame;
 - (void)requestRestoreFullScreen:(CompletionHandler<void(bool)>&&)completionHandler;
 - (void)requestExitFullScreen;


### PR DESCRIPTION
#### c63f556ac82e248edc81bd57bd430e4eb2012d98
<pre>
[visionOS] Inform the client when Image Fullscreen is delegated to Quick Look
<a href="https://bugs.webkit.org/show_bug.cgi?id=273970">https://bugs.webkit.org/show_bug.cgi?id=273970</a>
&lt;<a href="https://rdar.apple.com/126655604">rdar://126655604</a>&gt;

Reviewed by Aditya Keerthi.

Add a new UI delegate method to notify client when image fullscreen has
been delegated to Quick Look, and plumb the image dimensions to this
method.

* Source/WebKit/UIProcess/API/Cocoa/_WKFullscreenDelegate.h:
Add new UI delegate method.

* Source/WebKit/UIProcess/Cocoa/FullscreenClient.h:
* Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm:
(WebKit::FullscreenClient::setDelegate):
(WebKit::FullscreenClient::didEnterFullscreen):
Call new UI delegate method.

* Source/WebKit/Shared/FullScreenMediaDetails.h:
* Source/WebKit/Shared/FullScreenMediaDetails.serialization.in:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::enterFullScreen):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::enterFullScreen):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h:
Generalize name of variable `videoDimensions` to `mediaDimensions`.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h:
Expose some new public properties.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController isUsingQuickLook]):
(-[WKFullScreenWindowController imageDimensions]):
(-[WKFullScreenWindowController enterFullScreen:]):
Expose some new public properties, and generalize name of variable
`videoDimensions` to `mediaDimensions`.

* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::enterFullScreenForElement):
Add image dimensions to `mediaDetails` struct iff image fullscreen will
be delegated to Quick Look (to avoid interfering with downstream checks
of existence of dimensions).

Canonical link: <a href="https://commits.webkit.org/279728@main">https://commits.webkit.org/279728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5445eca278c94c2a0e551e2f17a107681b98a29

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54162 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6699 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57438 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4886 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41071 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43862 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3263 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56258 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31818 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46898 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25009 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28603 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3035 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50309 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4423 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59031 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29363 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4528 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51303 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30537 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50643 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11832 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31504 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30317 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->