### PR TITLE
Un-disable WebAuthenticationPanel local authenticator API tests

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -1271,8 +1271,7 @@ TEST(WebAuthenticationPanel, MultipleAccounts)
 // which are required to run local authenticator tests.
 #if USE(APPLE_INTERNAL_SDK) || PLATFORM(IOS) || PLATFORM(VISION)
 
-// Re-enable as part of test development in https://bugs.webkit.org/show_bug.cgi?id=270583
-TEST(WebAuthenticationPanel, DISABLED_LAError)
+TEST(WebAuthenticationPanel, LAError)
 {
     reset();
     RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-la-error" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
@@ -1288,8 +1287,7 @@ TEST(WebAuthenticationPanel, DISABLED_LAError)
     Util::run(&webAuthenticationPanelUpdateLAError);
 }
 
-// Re-enable as part of test development in https://bugs.webkit.org/show_bug.cgi?id=270583
-TEST(WebAuthenticationPanel, DISABLED_LADuplicateCredential)
+TEST(WebAuthenticationPanel, LADuplicateCredential)
 {
     reset();
     RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-la-duplicate-credential" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
@@ -1307,8 +1305,7 @@ TEST(WebAuthenticationPanel, DISABLED_LADuplicateCredential)
     cleanUpKeychain(emptyString());
 }
 
-// Re-enable as part of test development in https://bugs.webkit.org/show_bug.cgi?id=270583
-TEST(WebAuthenticationPanel, DISABLED_LADuplicateCredentialWithConsent)
+TEST(WebAuthenticationPanel, LADuplicateCredentialWithConsent)
 {
     reset();
     RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-la-duplicate-credential" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
@@ -1329,8 +1326,7 @@ TEST(WebAuthenticationPanel, DISABLED_LADuplicateCredentialWithConsent)
     cleanUpKeychain(emptyString());
 }
 
-// Re-enable as part of test development in https://bugs.webkit.org/show_bug.cgi?id=270583
-TEST(WebAuthenticationPanel, DISABLED_LANoCredential)
+TEST(WebAuthenticationPanel, LANoCredential)
 {
     reset();
     // In case this wasn't cleaned up by another test.
@@ -1349,8 +1345,7 @@ TEST(WebAuthenticationPanel, DISABLED_LANoCredential)
     Util::run(&webAuthenticationPanelUpdateLANoCredential);
 }
 
-// Re-enable as part of test development in https://bugs.webkit.org/show_bug.cgi?id=270583
-TEST(WebAuthenticationPanel, DISABLED_LAMakeCredentialAllowLocalAuthenticator)
+TEST(WebAuthenticationPanel, LAMakeCredentialAllowLocalAuthenticator)
 {
     reset();
     RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-la" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
@@ -1371,8 +1366,7 @@ TEST(WebAuthenticationPanel, DISABLED_LAMakeCredentialAllowLocalAuthenticator)
 
 #if PLATFORM(MAC)
 
-// Re-enable as part of test development in https://bugs.webkit.org/show_bug.cgi?id=270583
-TEST(WebAuthenticationPanel, DISABLED_LAGetAssertion)
+TEST(WebAuthenticationPanel, LAGetAssertion)
 {
     reset();
     RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-la" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
@@ -1391,8 +1385,7 @@ TEST(WebAuthenticationPanel, DISABLED_LAGetAssertion)
     cleanUpKeychain(emptyString());
 }
 
-// Re-enable as part of test development in https://bugs.webkit.org/show_bug.cgi?id=270583
-TEST(WebAuthenticationPanel, DISABLED_LAGetAssertionMultipleCredentialStore)
+TEST(WebAuthenticationPanel, LAGetAssertionMultipleCredentialStore)
 {
     reset();
     RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-la" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
@@ -1419,8 +1412,7 @@ TEST(WebAuthenticationPanel, DISABLED_LAGetAssertionMultipleCredentialStore)
     cleanUpKeychain(emptyString());
 }
 
-// Re-enable as part of test development in https://bugs.webkit.org/show_bug.cgi?id=270583
-TEST(WebAuthenticationPanel, DISABLED_LAGetAssertionNoMockNoUserGesture)
+TEST(WebAuthenticationPanel, LAGetAssertionNoMockNoUserGesture)
 {
     reset();
     webAuthenticationPanelRequestNoGesture = false;
@@ -1441,8 +1433,7 @@ TEST(WebAuthenticationPanel, DISABLED_LAGetAssertionNoMockNoUserGesture)
 #endif
 }
 
-// Re-enable as part of test development in https://bugs.webkit.org/show_bug.cgi?id=270583
-TEST(WebAuthenticationPanel, DISABLED_LAGetAssertionMultipleOrder)
+TEST(WebAuthenticationPanel, LAGetAssertionMultipleOrder)
 {
     reset();
     RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-get-assertion-la" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
@@ -1731,8 +1722,7 @@ TEST(WebAuthenticationPanel, MakeCredentialSPITimeout)
 // For macOS, only internal builds can sign keychain entitlemnets
 // which are required to run local authenticator tests.
 #if USE(APPLE_INTERNAL_SDK) || PLATFORM(IOS) || PLATFORM(VISION)
-// Re-enable as part of test development in https://bugs.webkit.org/show_bug.cgi?id=270583
-TEST(WebAuthenticationPanel, DISABLED_MakeCredentialLA)
+TEST(WebAuthenticationPanel, MakeCredentialLA)
 {
     reset();
 
@@ -1769,8 +1759,7 @@ TEST(WebAuthenticationPanel, DISABLED_MakeCredentialLA)
     Util::run(&webAuthenticationPanelRan);
 }
 
-// Re-enable as part of test development in https://bugs.webkit.org/show_bug.cgi?id=270583
-TEST(WebAuthenticationPanel, DISABLED_MakeCredentialLAClientDataHashMediation)
+TEST(WebAuthenticationPanel, MakeCredentialLAClientDataHashMediation)
 {
     reset();
 
@@ -1808,8 +1797,7 @@ TEST(WebAuthenticationPanel, DISABLED_MakeCredentialLAClientDataHashMediation)
     Util::run(&webAuthenticationPanelRan);
 }
 
-// Re-enable as part of test development in https://bugs.webkit.org/show_bug.cgi?id=270583
-TEST(WebAuthenticationPanel, DISABLED_MakeCredentialLAAttestationFalback)
+TEST(WebAuthenticationPanel, MakeCredentialLAAttestationFalback)
 {
     reset();
 
@@ -1942,8 +1930,7 @@ TEST(WebAuthenticationPanel, GetAssertionSPITimeout)
 // For macOS, only internal builds can sign keychain entitlemnets
 // which are required to run local authenticator tests.
 #if USE(APPLE_INTERNAL_SDK) || PLATFORM(IOS) || PLATFORM(VISION)
-// Re-enable as part of test development in https://bugs.webkit.org/show_bug.cgi?id=270583
-TEST(WebAuthenticationPanel, DISABLED_GetAssertionLA)
+TEST(WebAuthenticationPanel, GetAssertionLA)
 {
     reset();
     auto beforeTime = adoptNS([[NSDate alloc] init]);
@@ -2006,8 +1993,7 @@ TEST(WebAuthenticationPanel, DISABLED_GetAssertionLA)
     Util::run(&webAuthenticationPanelRan);
 }
 
-// Re-enable as part of test development in https://bugs.webkit.org/show_bug.cgi?id=270583
-TEST(WebAuthenticationPanel, DISABLED_GetAssertionLAClientDataHashMediation)
+TEST(WebAuthenticationPanel, GetAssertionLAClientDataHashMediation)
 {
     reset();
 
@@ -2057,8 +2043,7 @@ TEST(WebAuthenticationPanel, DISABLED_GetAssertionLAClientDataHashMediation)
     Util::run(&webAuthenticationPanelRan);
 }
 
-// Re-enable as part of test development in https://bugs.webkit.org/show_bug.cgi?id=270583
-TEST(WebAuthenticationPanel, DISABLED_GetAssertionNullUserHandle)
+TEST(WebAuthenticationPanel, GetAssertionNullUserHandle)
 {
     reset();
 


### PR DESCRIPTION
#### 852eb0ce9fc1015a834caadcb8d0a0ea6c845e89
<pre>
Un-disable WebAuthenticationPanel local authenticator API tests
<a href="https://rdar.apple.com/124156975">rdar://124156975</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=270590">https://bugs.webkit.org/show_bug.cgi?id=270590</a>

Unreviewed, test gardening.

These pass now and can be un-disabled.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::TEST(WebAuthenticationPanel, LAError)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, LADuplicateCredential)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, LADuplicateCredentialWithConsent)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, LANoCredential)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, LAMakeCredentialAllowLocalAuthenticator)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, LAGetAssertion)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, LAGetAssertionMultipleCredentialStore)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, LAGetAssertionNoMockNoUserGesture)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, LAGetAssertionMultipleOrder)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, MakeCredentialLA)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, MakeCredentialLAClientDataHashMediation)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, MakeCredentialLAAttestationFalback)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionLA)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionLAClientDataHashMediation)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionNullUserHandle)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, DISABLED_LAError)): Deleted.
(TestWebKitAPI::TEST(WebAuthenticationPanel, DISABLED_LADuplicateCredential)): Deleted.
(TestWebKitAPI::TEST(WebAuthenticationPanel, DISABLED_LADuplicateCredentialWithConsent)): Deleted.
(TestWebKitAPI::TEST(WebAuthenticationPanel, DISABLED_LANoCredential)): Deleted.
(TestWebKitAPI::TEST(WebAuthenticationPanel, DISABLED_LAMakeCredentialAllowLocalAuthenticator)): Deleted.
(TestWebKitAPI::TEST(WebAuthenticationPanel, DISABLED_LAGetAssertion)): Deleted.
(TestWebKitAPI::TEST(WebAuthenticationPanel, DISABLED_LAGetAssertionMultipleCredentialStore)): Deleted.
(TestWebKitAPI::TEST(WebAuthenticationPanel, DISABLED_LAGetAssertionNoMockNoUserGesture)): Deleted.
(TestWebKitAPI::TEST(WebAuthenticationPanel, DISABLED_LAGetAssertionMultipleOrder)): Deleted.
(TestWebKitAPI::TEST(WebAuthenticationPanel, DISABLED_MakeCredentialLA)): Deleted.
(TestWebKitAPI::TEST(WebAuthenticationPanel, DISABLED_MakeCredentialLAClientDataHashMediation)): Deleted.
(TestWebKitAPI::TEST(WebAuthenticationPanel, DISABLED_MakeCredentialLAAttestationFalback)): Deleted.
(TestWebKitAPI::TEST(WebAuthenticationPanel, DISABLED_GetAssertionLA)): Deleted.
(TestWebKitAPI::TEST(WebAuthenticationPanel, DISABLED_GetAssertionLAClientDataHashMediation)): Deleted.
(TestWebKitAPI::TEST(WebAuthenticationPanel, DISABLED_GetAssertionNullUserHandle)): Deleted.

Canonical link: <a href="https://commits.webkit.org/278615@main">https://commits.webkit.org/278615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e19df6976948b08303321b4907beaff3d7fa140f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30351 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54306 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1738 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53351 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1408 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41566 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53148 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43984 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22687 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25320 "Found unexpected failure with change (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1239 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9489 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47300 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1312 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55901 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26157 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1210 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48973 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27407 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44053 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48106 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11181 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28286 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27138 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->