### PR TITLE
Web Inspector: iOS remote inspector overlay region for margin or padding sometimes have triangular shape instead of rectangular

### DIFF
--- a/Source/WebCore/platform/graphics/FloatQuad.cpp
+++ b/Source/WebCore/platform/graphics/FloatQuad.cpp
@@ -50,14 +50,14 @@ static inline float max4(float a, float b, float c, float d)
     return std::max(std::max(a, b), std::max(c, d));
 }
 
-inline float dot(const FloatSize& a, const FloatSize& b)
+inline double dot(const FloatSize& a, const FloatSize& b)
 {
-    return a.width() * b.width() + a.height() * b.height();
+    return static_cast<double>(a.width()) * b.width() + static_cast<double>(a.height()) * b.height();
 }
 
-inline float determinant(const FloatSize& a, const FloatSize& b)
+inline double determinant(const FloatSize& a, const FloatSize& b)
 {
-    return a.width() * b.height() - a.height() * b.width();
+    return static_cast<double>(a.width()) * b.height() - static_cast<double>(a.height()) * b.width();
 }
 
 inline bool isPointInTriangle(const FloatPoint& p, const FloatPoint& t1, const FloatPoint& t2, const FloatPoint& t3)
@@ -68,16 +68,16 @@ inline bool isPointInTriangle(const FloatPoint& p, const FloatPoint& t1, const F
     FloatSize v2 = p - t1;
     
     // Compute dot products
-    float dot00 = dot(v0, v0);
-    float dot01 = dot(v0, v1);
-    float dot02 = dot(v0, v2);
-    float dot11 = dot(v1, v1);
-    float dot12 = dot(v1, v2);
+    double dot00 = dot(v0, v0);
+    double dot01 = dot(v0, v1);
+    double dot02 = dot(v0, v2);
+    double dot11 = dot(v1, v1);
+    double dot12 = dot(v1, v2);
 
     // Compute barycentric coordinates
-    float invDenom = 1.0f / (dot00 * dot11 - dot01 * dot01);
-    float u = (dot11 * dot02 - dot01 * dot12) * invDenom;
-    float v = (dot00 * dot12 - dot01 * dot02) * invDenom;
+    double invDenom = 1 / (dot00 * dot11 - dot01 * dot01);
+    double u = (dot11 * dot02 - dot01 * dot12) * invDenom;
+    double v = (dot00 * dot12 - dot01 * dot02) * invDenom;
 
     // Check if point is in triangle
     return (u >= 0) && (v >= 0) && (u + v <= 1);


### PR DESCRIPTION
#### 2042f4866c2acb04fbe38626c7b46511ae8e8cf7
<pre>
Web Inspector: iOS remote inspector overlay region for margin or padding sometimes have triangular shape instead of rectangular
<a href="https://rdar.apple.com/127390961">rdar://127390961</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=273976">https://bugs.webkit.org/show_bug.cgi?id=273976</a>

Reviewed by NOBODY (OOPS!).

When painting the margin or padding regions for displaying the inspector
overlay, FloatQuad provides functions to compute which sub-region should
be left unpainted because it&apos;s occupied by the element itself. When
performing those geometry computations, there are intermediate results
that are products of two `float`s, but those in the original code were
still stored with `float`s. This fix make FloatQuad use `double` for
such intermediate results to prevent significant precision loss where
point containment may be incorrectly identified.

* Source/WebCore/platform/graphics/FloatQuad.cpp:
(WebCore::dot):
(WebCore::determinant):
(WebCore::isPointInTriangle):
   - Use double to hold numbers that include products of two floats.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2042f4866c2acb04fbe38626c7b46511ae8e8cf7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4640 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55494 "Hash 2042f486 for PR 28367 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2943 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54524 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2641 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/55494 "Hash 2042f486 for PR 28367 does not build (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1893 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45073 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/55494 "Hash 2042f486 for PR 28367 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26450 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2347 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1102 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48353 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57090 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27345 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2550 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49893 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28579 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45189 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49134 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29491 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28323 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->