### PR TITLE
Adopt SIMD in attribute and text scanning

### DIFF
--- a/Source/WTF/wtf/text/StringParsingBuffer.h
+++ b/Source/WTF/wtf/text/StringParsingBuffer.h
@@ -53,7 +53,7 @@ public:
 
     constexpr void setPosition(const CharacterType* position)
     {
-        ASSERT(!m_data.empty());
+        ASSERT(position <= m_data.data() + m_data.size());
         m_data = { position, m_data.data() + m_data.size() };
     }
 

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -466,7 +466,7 @@ private:
     template<typename ParentTag> void parseCompleteInput()
     {
         parseChildren<ParentTag>(m_destinationParent.get());
-        if (m_parsingBuffer.hasCharactersRemaining())
+        if (UNLIKELY(m_parsingBuffer.hasCharactersRemaining()))
             didFail(HTMLFastPathResult::FailedDidntReachEndOfInput);
     }
 
@@ -477,21 +477,65 @@ private:
     String scanText()
     {
         auto* start = m_parsingBuffer.position();
-        while (m_parsingBuffer.hasCharactersRemaining() && *m_parsingBuffer != '<') {
-            // '&' indicates escape sequences, '\r' might require
-            // https://infra.spec.whatwg.org/#normalize-newlines
-            if (*m_parsingBuffer == '&' || *m_parsingBuffer == '\r') {
+        auto* cursor = start;
+        const auto* end = start + m_parsingBuffer.lengthRemaining();
+        ([&]() ALWAYS_INLINE_LAMBDA {
+            constexpr size_t stride = 16 / sizeof(CharacterType);
+            using UnsignedType = std::make_unsigned_t<CharacterType>;
+            if (static_cast<size_t>(end - cursor) >= stride) {
+                const auto quoteMask = SIMD::splat(static_cast<UnsignedType>('<'));
+                const auto escapeMask = SIMD::splat(static_cast<UnsignedType>('&'));
+                const auto newlineMask = SIMD::splat(static_cast<UnsignedType>('\r'));
+                const auto zeroMask = SIMD::splat(static_cast<UnsignedType>(0));
+
+                auto match = [&](auto* cursor) ALWAYS_INLINE_LAMBDA {
+                    auto input = SIMD::load(bitwise_cast<const UnsignedType*>(cursor));
+                    auto quotes = SIMD::equal(input, quoteMask);
+                    auto escapes = SIMD::equal(input, escapeMask);
+                    auto newlines = SIMD::equal(input, newlineMask);
+                    auto zeros = SIMD::equal(input, zeroMask);
+                    auto mask = SIMD::merge(zeros, SIMD::merge(quotes, SIMD::merge(escapes, newlines)));
+                    return SIMD::findFirstNonZeroIndex(mask);
+                };
+
+                for (; cursor + (stride - 1) < end; cursor += stride) {
+                    if (auto index = match(cursor)) {
+                        cursor += index.value();
+                        return;
+                    }
+                }
+                if (cursor < end) {
+                    if (auto index = match(end - stride)) {
+                        cursor = end - stride + index.value();
+                        return;
+                    }
+                    cursor = end;
+                }
+                return;
+            }
+
+            for (; cursor != end; ++cursor) {
+                auto character = *cursor;
+                if (character == '<' || character == '&' || character == '\r' || character == '\0')
+                    return;
+            }
+        }());
+        m_parsingBuffer.setPosition(cursor);
+
+        if (cursor != end) {
+            if (UNLIKELY(*cursor == '\0'))
+                return didFail(HTMLFastPathResult::FailedContainsNull, String());
+
+            if (*cursor == '&' || *cursor == '\r') {
                 m_parsingBuffer.setPosition(start);
                 return scanEscapedText();
             }
-            if (UNLIKELY(*m_parsingBuffer == '\0'))
-                return didFail(HTMLFastPathResult::FailedContainsNull, String());
-
-            m_parsingBuffer.advance();
         }
-        unsigned length = m_parsingBuffer.position() - start;
+
+        unsigned length = cursor - start;
         if (UNLIKELY(length >= Text::defaultLengthLimit))
             return didFail(HTMLFastPathResult::FailedBigText, String());
+
         return length ? String({ start, length }) : String();
     }
 
@@ -540,7 +584,7 @@ private:
                 m_parsingBuffer.advance();
                 m_charBuffer.append(c);
             }
-            if (m_parsingBuffer.atEnd() || !isCharAfterTagNameOrAttribute(*m_parsingBuffer))
+            if (UNLIKELY(m_parsingBuffer.atEnd() || !isCharAfterTagNameOrAttribute(*m_parsingBuffer)))
                 return didFail(HTMLFastPathResult::FailedParsingTagName, ElementName::Unknown);
             skipWhile<isASCIIWhitespace>(m_parsingBuffer);
             return findHTMLElementName(m_charBuffer.span());
@@ -596,22 +640,64 @@ private:
         if (m_parsingBuffer.hasCharactersRemaining() && isQuoteCharacter(*m_parsingBuffer)) {
             auto quoteChar = m_parsingBuffer.consume();
             start = m_parsingBuffer.position();
-            for (; m_parsingBuffer.hasCharactersRemaining() && *m_parsingBuffer != quoteChar; m_parsingBuffer.advance()) {
-                if (*m_parsingBuffer == '&' || *m_parsingBuffer == '\r') {
+            auto* cursor = start;
+            const auto* end = start + m_parsingBuffer.lengthRemaining();
+            ([&]() ALWAYS_INLINE_LAMBDA {
+                constexpr size_t stride = 16 / sizeof(CharacterType);
+                using UnsignedType = std::make_unsigned_t<CharacterType>;
+                if (static_cast<size_t>(end - cursor) >= stride) {
+                    const auto quoteMask = SIMD::splat(static_cast<UnsignedType>(quoteChar));
+                    const auto escapeMask = SIMD::splat(static_cast<UnsignedType>('&'));
+                    const auto newlineMask = SIMD::splat(static_cast<UnsignedType>('\r'));
+
+                    auto match = [&](auto* cursor) ALWAYS_INLINE_LAMBDA {
+                        auto input = SIMD::load(bitwise_cast<const UnsignedType*>(cursor));
+                        auto quotes = SIMD::equal(input, quoteMask);
+                        auto escapes = SIMD::equal(input, escapeMask);
+                        auto newlines = SIMD::equal(input, newlineMask);
+                        auto mask = SIMD::merge(quotes, SIMD::merge(escapes, newlines));
+                        return SIMD::findFirstNonZeroIndex(mask);
+                    };
+
+                    for (; cursor + (stride - 1) < end; cursor += stride) {
+                        if (auto index = match(cursor)) {
+                            cursor += index.value();
+                            return;
+                        }
+                    }
+                    if (cursor < end) {
+                        if (auto index = match(end - stride)) {
+                            cursor = end - stride + index.value();
+                            return;
+                        }
+                        cursor = end;
+                    }
+                    return;
+                }
+
+                for (; cursor != end; ++cursor) {
+                    auto character = *cursor;
+                    if (character == quoteChar || character == '&' || character == '\r')
+                        return;
+                }
+            }());
+
+            if (UNLIKELY(cursor == end))
+                return didFail(HTMLFastPathResult::FailedParsingQuotedAttributeValue, emptyAtom());
+
+            length = cursor - start;
+            if (UNLIKELY(*cursor != quoteChar)) {
+                if (LIKELY(*cursor == '&' || *cursor == '\r')) {
                     m_parsingBuffer.setPosition(start - 1);
                     return scanEscapedAttributeValue();
                 }
+                return didFail(HTMLFastPathResult::FailedParsingQuotedAttributeValue, emptyAtom());
             }
-            if (m_parsingBuffer.atEnd())
-                return didFail(HTMLFastPathResult::FailedParsingQuotedAttributeValue, emptyAtom());
-
-            length = m_parsingBuffer.position() - start;
-            if (m_parsingBuffer.consume() != quoteChar)
-                return didFail(HTMLFastPathResult::FailedParsingQuotedAttributeValue, emptyAtom());
+            m_parsingBuffer.setPosition(cursor + 1);
         } else {
             skipWhile<isValidUnquotedAttributeValueChar>(m_parsingBuffer);
             length = m_parsingBuffer.position() - start;
-            if (m_parsingBuffer.atEnd() || !isCharAfterUnquotedAttribute(*m_parsingBuffer))
+            if (UNLIKELY(m_parsingBuffer.atEnd() || !isCharAfterUnquotedAttribute(*m_parsingBuffer)))
                 return didFail(HTMLFastPathResult::FailedParsingUnquotedAttributeValue, emptyAtom());
         }
         return HTMLNameCache::makeAttributeValue({ start, length });
@@ -700,7 +786,7 @@ private:
                 // We assume that we found the closing tag. The tagName will be checked by the caller `parseContainerElement()`.
                 return;
             }
-            if (++m_elementDepth == Settings::defaultMaximumHTMLParserDOMTreeDepth)
+            if (UNLIKELY(++m_elementDepth == Settings::defaultMaximumHTMLParserDOMTreeDepth))
                 return didFail(HTMLFastPathResult::FailedMaxDepth);
             auto child = ParentTag::parseChild(parent, *this);
             --m_elementDepth;
@@ -719,7 +805,7 @@ private:
         while (true) {
             auto attributeName = scanAttributeName();
             if (attributeName == nullQName()) {
-                if (m_parsingBuffer.hasCharactersRemaining()) {
+                if (LIKELY(m_parsingBuffer.hasCharactersRemaining())) {
                     if (*m_parsingBuffer == '>') {
                         m_parsingBuffer.advance();
                         break;
@@ -727,7 +813,7 @@ private:
                     if (*m_parsingBuffer == '/') {
                         m_parsingBuffer.advance();
                         skipWhile<isASCIIWhitespace>(m_parsingBuffer);
-                        if (m_parsingBuffer.atEnd() || m_parsingBuffer.consume() != '>')
+                        if (UNLIKELY(m_parsingBuffer.atEnd() || m_parsingBuffer.consume() != '>'))
                             return didFail(HTMLFastPathResult::FailedParsingAttributes);
                         break;
                     }
@@ -847,7 +933,7 @@ private:
             parent.parserAppendChild(element);
         element->beginParsingChildren();
         parseChildren<Tag>(element);
-        if (parsingFailed() || m_parsingBuffer.atEnd())
+        if (UNLIKELY(parsingFailed() || m_parsingBuffer.atEnd()))
             return didFail(HTMLFastPathResult::FailedEndOfInputReachedForContainer, element);
 
         // parseChildren<Tag>(element) stops after the (hopefully) closing tag's `<`
@@ -856,12 +942,12 @@ private:
         m_parsingBuffer.advance();
 
         if (UNLIKELY(!skipCharactersExactly(m_parsingBuffer, Tag::tagNameCharacters))) {
-            if (!skipLettersExactlyIgnoringASCIICase(m_parsingBuffer, Tag::tagNameCharacters))
+            if (UNLIKELY(!skipLettersExactlyIgnoringASCIICase(m_parsingBuffer, Tag::tagNameCharacters)))
                 return didFail(HTMLFastPathResult::FailedEndTagNameMismatch, element);
         }
         skipWhile<isASCIIWhitespace>(m_parsingBuffer);
 
-        if (m_parsingBuffer.atEnd() || m_parsingBuffer.consume() != '>')
+        if (UNLIKELY(m_parsingBuffer.atEnd() || m_parsingBuffer.consume() != '>'))
             return didFail(HTMLFastPathResult::FailedUnexpectedTagNameCloseState, element);
 
         element->finishParsingChildren();


### PR DESCRIPTION
#### e8401be1912bd7ccd878b2605d7edf2c91cf74f4
<pre>
Adopt SIMD in attribute and text scanning
<a href="https://bugs.webkit.org/show_bug.cgi?id=273977">https://bugs.webkit.org/show_bug.cgi?id=273977</a>
<a href="https://rdar.apple.com/127843610">rdar://127843610</a>

Reviewed by Mark Lam.

This patch integrates SIMD into attribute value and string scanning.
We also attach UNLIKELY / LIKELY to bailout paths.

* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::parseCompleteInput):
(WebCore::HTMLFastPathParser::scanText):
(WebCore::HTMLFastPathParser::scanTagName):
(WebCore::HTMLFastPathParser::scanAttributeValue):
(WebCore::HTMLFastPathParser::parseChildren):
(WebCore::HTMLFastPathParser::parseAttributes):
(WebCore::HTMLFastPathParser::parseContainerElement):

Canonical link: <a href="https://commits.webkit.org/278647@main">https://commits.webkit.org/278647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/412f72f5c3d62e0cae9ab6c160dd1327e0d5ec26

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54334 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1766 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53379 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1441 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41592 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28010 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44017 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22711 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25337 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1271 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9517 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/44416 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47317 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1345 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55929 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/50579 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26187 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48992 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44085 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48122 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28315 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/58053 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7447 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27166 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11942 "Passed tests") | 
<!--EWS-Status-Bubble-End-->