### PR TITLE
Function enableTextIndicatorStyleAfterElementWithID does not respect passed in elementID.

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -378,8 +378,6 @@ void WebPage::updateTextIndicatorStyleVisibilityForID(const WTF::UUID uuid, bool
 
 void WebPage::enableTextIndicatorStyleAfterElementWithID(const String& elementID, const WTF::UUID& uuid)
 {
-    // FIXME: move the start of the range to be after the element with the ID listed.
-
     RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
     if (!frame) {
         ASSERT_NOT_REACHED();
@@ -403,6 +401,12 @@ void WebPage::enableTextIndicatorStyleAfterElementWithID(const String& elementID
     if (!simpleRange) {
         ASSERT_NOT_REACHED();
         return;
+    }
+
+    if (RefPtr element = document->getElementById(elementID)) {
+        auto elementRange = makeRangeSelectingNodeContents(*element);
+        if (!elementRange.collapsed())
+            simpleRange->start = elementRange.end;
     }
 
     m_textIndicatorStyleEnablementRanges.add(uuid, createLiveRange(*simpleRange));


### PR DESCRIPTION
#### 3379399f99957ad7de3c3a5d348c638b77ce42ae
<pre>
Function enableTextIndicatorStyleAfterElementWithID does not respect passed in elementID.
<a href="https://bugs.webkit.org/show_bug.cgi?id=273980">https://bugs.webkit.org/show_bug.cgi?id=273980</a>
<a href="https://rdar.apple.com/127847591">rdar://127847591</a>

Reviewed by Aditya Keerthi.

Finish implementation of enableTextIndicatorStyleAfterElementWithID
by actually using the element to determine the range for the
textIndicator.

* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::enableTextIndicatorStyleAfterElementWithID):

Canonical link: <a href="https://commits.webkit.org/278603@main">https://commits.webkit.org/278603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4dde79f19ae6c0d75cba9b585b0d65d3d957abc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51068 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54325 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1757 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1430 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41582 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44005 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22703 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25330 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9508 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47310 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1333 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55920 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1230 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48987 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27426 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44073 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48117 "Found 1 new API test failure: /WebKitGTK/TestSSL:/webkit/WebKitWebView/tls-http-auth (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11173 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28306 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27157 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->