### PR TITLE
Update PermissionsPolicy to match latest spec

### DIFF
--- a/Source/WebCore/Modules/applepay/PaymentSession.cpp
+++ b/Source/WebCore/Modules/applepay/PaymentSession.cpp
@@ -49,7 +49,7 @@ static bool isSecure(DocumentLoader& documentLoader)
 
 ExceptionOr<void> PaymentSession::canCreateSession(Document& document)
 {
-    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Payment, document, LogPermissionsPolicyFailure::Yes))
+    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Payment, document, LogPermissionsPolicyFailure::Yes))
         return Exception { ExceptionCode::SecurityError, "Third-party iframes are not allowed to request payments unless explicitly allowed via Feature-Policy (payment)"_s };
 
     if (!document.frame())

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
@@ -84,7 +84,7 @@ ExceptionOr<void> DOMAudioSession::setType(Type type)
     if (!document)
         return Exception { ExceptionCode::InvalidStateError };
 
-    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Microphone, *document, LogPermissionsPolicyFailure::No))
+    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Microphone, *document, LogPermissionsPolicyFailure::No))
         return { };
 
     document->topDocument().setAudioSessionType(type);
@@ -101,7 +101,7 @@ ExceptionOr<void> DOMAudioSession::setType(Type type)
 DOMAudioSession::Type DOMAudioSession::type() const
 {
     RefPtr document = downcast<Document>(scriptExecutionContext());
-    if (document && !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Microphone, *document, LogPermissionsPolicyFailure::No))
+    if (document && !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Microphone, *document, LogPermissionsPolicyFailure::No))
         return DOMAudioSession::Type::Auto;
 
     return document ? document->topDocument().audioSessionType() : DOMAudioSession::Type::Auto;
@@ -121,7 +121,7 @@ static DOMAudioSession::State computeAudioSessionState()
 DOMAudioSession::State DOMAudioSession::state() const
 {
     RefPtr document = downcast<Document>(scriptExecutionContext());
-    if (!document || !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Microphone, *document, LogPermissionsPolicyFailure::No))
+    if (!document || !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Microphone, *document, LogPermissionsPolicyFailure::No))
         return DOMAudioSession::State::Inactive;
 
     if (!m_state)
@@ -156,7 +156,7 @@ void DOMAudioSession::audioSessionActiveStateChanged()
 void DOMAudioSession::scheduleStateChangeEvent()
 {
     RefPtr document = downcast<Document>(scriptExecutionContext());
-    if (document && !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Microphone, *document, LogPermissionsPolicyFailure::No))
+    if (document && !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Microphone, *document, LogPermissionsPolicyFailure::No))
         return;
 
     if (m_hasScheduleStateChangeEvent)

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -86,7 +86,7 @@ ExceptionOr<const Vector<RefPtr<Gamepad>>&> NavigatorGamepad::getGamepads(Naviga
         return { emptyGamepads.get() };
     }
 
-    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Gamepad, *document, LogPermissionsPolicyFailure::Yes))
+    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Gamepad, *document, LogPermissionsPolicyFailure::Yes))
         return Exception { ExceptionCode::SecurityError, "Third-party iframes are not allowed to call getGamepads() unless explicitly allowed via Feature-Policy (gamepad)"_s };
 
     return NavigatorGamepad::from(navigator)->gamepads();

--- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
+++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
@@ -345,7 +345,7 @@ static void logError(const String& target, const bool isSecure, const bool isMix
     
 bool Geolocation::shouldBlockGeolocationRequests()
 {
-    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Geolocation, *document(), LogPermissionsPolicyFailure::Yes))
+    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Geolocation, *document(), LogPermissionsPolicyFailure::Yes))
         return true;
 
     bool isSecure = SecurityOrigin::isSecure(document()->url()) || document()->isSecureContext();

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -277,19 +277,19 @@ void MediaDevices::getDisplayMedia(DisplayMediaStreamConstraints&& constraints, 
 
 static inline bool checkCameraAccess(const Document& document)
 {
-    return isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Camera, document, LogPermissionsPolicyFailure::No);
+    return isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Camera, document, LogPermissionsPolicyFailure::No);
 }
 
 static inline bool checkMicrophoneAccess(const Document& document)
 {
-    return isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Microphone, document, LogPermissionsPolicyFailure::No);
+    return isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Microphone, document, LogPermissionsPolicyFailure::No);
 }
 
 static inline bool checkSpeakerAccess(const Document& document)
 {
     return document.frame()
         && document.frame()->settings().exposeSpeakersEnabled()
-        && isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::SpeakerSelection, document, LogPermissionsPolicyFailure::No);
+        && isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::SpeakerSelection, document, LogPermissionsPolicyFailure::No);
 }
 
 void MediaDevices::exposeDevices(Vector<CaptureDeviceWithCapabilities>&& newDevices, MediaDeviceHashSalts&& deviceIDHashSalts, EnumerateDevicesPromise&& promise)
@@ -390,8 +390,8 @@ void MediaDevices::listenForDeviceChanges()
     if (!controller)
         return;
 
-    bool canAccessCamera = isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Camera, *document, LogPermissionsPolicyFailure::No);
-    bool canAccessMicrophone = isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Microphone, *document, LogPermissionsPolicyFailure::No);
+    bool canAccessCamera = isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Camera, *document, LogPermissionsPolicyFailure::No);
+    bool canAccessMicrophone = isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Microphone, *document, LogPermissionsPolicyFailure::No);
 
     if (m_listeningForDeviceChanges || (!canAccessCamera && !canAccessMicrophone))
         return;

--- a/Source/WebCore/Modules/mediastream/UserMediaController.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaController.cpp
@@ -71,8 +71,8 @@ void UserMediaController::logGetDisplayMediaDenial(Document& document)
 void UserMediaController::logEnumerateDevicesDenial(Document& document)
 {
     // We redo the check to print to the console log.
-    isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Camera, document, LogPermissionsPolicyFailure::Yes);
-    isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Microphone, document, LogPermissionsPolicyFailure::Yes);
+    isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Camera, document, LogPermissionsPolicyFailure::Yes);
+    isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Microphone, document, LogPermissionsPolicyFailure::Yes);
     if (RefPtr window = document.domWindow())
         window->printErrorMessage("Not allowed to call enumerateDevices."_s);
 }

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
@@ -116,19 +116,19 @@ void UserMediaRequest::start()
     switch (m_request.type) {
     case MediaStreamRequest::Type::DisplayMedia:
     case MediaStreamRequest::Type::DisplayMediaWithAudio:
-        if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::DisplayCapture, document)) {
+        if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::DisplayCapture, document)) {
             deny(MediaAccessDenialReason::PermissionDenied);
             controller->logGetDisplayMediaDenial(document);
             return;
         }
         break;
     case MediaStreamRequest::Type::UserMedia:
-        if (m_request.audioConstraints.isValid && !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Microphone, document)) {
+        if (m_request.audioConstraints.isValid && !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Microphone, document)) {
             deny(MediaAccessDenialReason::PermissionDenied);
             controller->logGetUserMediaDenial(document);
             return;
         }
-        if (m_request.videoConstraints.isValid && !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Camera, document)) {
+        if (m_request.videoConstraints.isValid && !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Camera, document)) {
             deny(MediaAccessDenialReason::PermissionDenied);
             controller->logGetUserMediaDenial(document);
             return;

--- a/Source/WebCore/Modules/permissions/Permissions.cpp
+++ b/Source/WebCore/Modules/permissions/Permissions.cpp
@@ -77,11 +77,11 @@ static bool isAllowedByPermissionsPolicy(const Document& document, PermissionNam
 {
     switch (name) {
     case PermissionName::Camera:
-        return isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Camera, document, LogPermissionsPolicyFailure::No);
+        return isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Camera, document, LogPermissionsPolicyFailure::No);
     case PermissionName::Geolocation:
-        return isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Geolocation, document, LogPermissionsPolicyFailure::No);
+        return isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Geolocation, document, LogPermissionsPolicyFailure::No);
     case PermissionName::Microphone:
-        return isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Microphone, document, LogPermissionsPolicyFailure::No);
+        return isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Microphone, document, LogPermissionsPolicyFailure::No);
     default:
         return true;
     }

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
@@ -56,7 +56,7 @@ void WakeLock::request(WakeLockType lockType, Ref<DeferredPromise>&& promise)
         promise->reject(Exception { ExceptionCode::NotAllowedError, "Document is not fully active"_s });
         return;
     }
-    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::ScreenWakeLock, *document, LogPermissionsPolicyFailure::Yes)) {
+    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::ScreenWakeLock, *document, LogPermissionsPolicyFailure::Yes)) {
         promise->reject(Exception { ExceptionCode::NotAllowedError, "'screen-wake-lock' is not allowed by Feature-Policy"_s });
         return;
     }

--- a/Source/WebCore/Modules/speech/SpeechRecognition.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.cpp
@@ -78,7 +78,7 @@ ExceptionOr<void> SpeechRecognition::startRecognition()
         return Exception { ExceptionCode::UnknownError, "Recognition is not in a valid frame"_s };
 
     auto optionalFrameIdentifier = document->frameID();
-    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Microphone, document.get(), LogPermissionsPolicyFailure::No)) {
+    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Microphone, document.get(), LogPermissionsPolicyFailure::No)) {
         didError({ SpeechRecognitionErrorType::NotAllowed, "Permission is denied"_s });
         return { };
     }

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -234,7 +234,7 @@ void AuthenticatorCoordinator::discoverFromExternalSource(const Document& docume
     // Step 1, 3, 13 are handled by the caller.
     // Step 2.
     // This implements https://www.w3.org/TR/webauthn-2/#sctn-permissions-policy
-    if (scopeAndCrossOriginParent.first != WebAuthn::Scope::SameOrigin && !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::PublickeyCredentialsGetRule, document, LogPermissionsPolicyFailure::No)) {
+    if (scopeAndCrossOriginParent.first != WebAuthn::Scope::SameOrigin && !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::PublickeyCredentialsGetRule, document, LogPermissionsPolicyFailure::No)) {
         promise.reject(Exception { ExceptionCode::NotAllowedError, "The origin of the document is not the same as its ancestors."_s });
         return;
     }

--- a/Source/WebCore/Modules/webxr/WebXRSystem.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.cpp
@@ -165,7 +165,7 @@ void WebXRSystem::isSessionSupported(XRSessionMode mode, IsSessionSupportedPromi
     // 3. If the requesting document's origin is not allowed to use the "xr-spatial-tracking" feature policy,
     //    reject promise with a "SecurityError" DOMException and return it.
     auto document = downcast<Document>(scriptExecutionContext());
-    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::XRSpatialTracking, *document, LogPermissionsPolicyFailure::Yes)) {
+    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::XRSpatialTracking, *document, LogPermissionsPolicyFailure::Yes)) {
         promise.reject(Exception { ExceptionCode::SecurityError });
         return;
     }
@@ -279,7 +279,7 @@ bool WebXRSystem::isFeaturePermitted(PlatformXR::SessionFeature feature) const
     case PlatformXR::SessionFeature::HandTracking:
 #endif
         RefPtr document = downcast<Document>(scriptExecutionContext());
-        return document && isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::XRSpatialTracking, *document, LogPermissionsPolicyFailure::Yes);
+        return document && isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::XRSpatialTracking, *document, LogPermissionsPolicyFailure::Yes);
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -220,7 +220,7 @@ void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefP
 
         // The context object's node document, or an ancestor browsing context's document does not have
         // the fullscreen enabled flag set.
-        if (checkType == EnforceIFrameAllowFullscreenRequirement && !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Fullscreen, document)) {
+        if (checkType == EnforceIFrameAllowFullscreenRequirement && !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Fullscreen, document)) {
             ERROR_LOG(identifier, "task - ancestor document does not enable fullscreen; failing.");
             failedPreflights(WTFMove(element), WTFMove(promise));
             return;
@@ -475,7 +475,7 @@ bool FullscreenManager::isFullscreenEnabled() const
     // browsing context's documents have their fullscreen enabled flag set, or false otherwise.
 
     // Top-level browsing contexts are implied to have their allowFullscreen attribute set.
-    return isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Fullscreen, protectedDocument());
+    return isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Fullscreen, protectedDocument());
 }
 
 bool FullscreenManager::willEnterFullscreen(Element& element, HTMLMediaElementEnums::VideoFullscreenMode mode)

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -176,7 +176,7 @@ ReferrerPolicy HTMLIFrameElement::referrerPolicy() const
 const PermissionsPolicy& HTMLIFrameElement::permissionsPolicy() const
 {
     if (!m_permissionsPolicy)
-        m_permissionsPolicy = PermissionsPolicy::parse(document(), *this, attributeWithoutSynchronization(allowAttr));
+        m_permissionsPolicy = PermissionsPolicy::parse(document(), *this);
     return *m_permissionsPolicy;
 }
 

--- a/Source/WebCore/html/PermissionsPolicy.cpp
+++ b/Source/WebCore/html/PermissionsPolicy.cpp
@@ -39,62 +39,175 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-static ASCIILiteral policyTypeName(PermissionsPolicy::Type type)
+static ASCIILiteral toFeatureNameForLogging(PermissionsPolicy::Feature feature)
 {
-    switch (type) {
-    case PermissionsPolicy::Type::Camera:
+    switch (feature) {
+    case PermissionsPolicy::Feature::Camera:
         return "Camera"_s;
-    case PermissionsPolicy::Type::Microphone:
+    case PermissionsPolicy::Feature::Microphone:
         return "Microphone"_s;
-    case PermissionsPolicy::Type::SpeakerSelection:
+    case PermissionsPolicy::Feature::SpeakerSelection:
         return "SpeakerSelection"_s;
-    case PermissionsPolicy::Type::DisplayCapture:
+    case PermissionsPolicy::Feature::DisplayCapture:
         return "DisplayCapture"_s;
-    case PermissionsPolicy::Type::Gamepad:
+    case PermissionsPolicy::Feature::Gamepad:
         return "Gamepad"_s;
-    case PermissionsPolicy::Type::Geolocation:
+    case PermissionsPolicy::Feature::Geolocation:
         return "Geolocation"_s;
-    case PermissionsPolicy::Type::Payment:
+    case PermissionsPolicy::Feature::Payment:
         return "Payment"_s;
-    case PermissionsPolicy::Type::ScreenWakeLock:
+    case PermissionsPolicy::Feature::ScreenWakeLock:
         return "ScreenWakeLock"_s;
-    case PermissionsPolicy::Type::SyncXHR:
+    case PermissionsPolicy::Feature::SyncXHR:
         return "SyncXHR"_s;
-    case PermissionsPolicy::Type::Fullscreen:
+    case PermissionsPolicy::Feature::Fullscreen:
         return "Fullscreen"_s;
-    case PermissionsPolicy::Type::WebShare:
+    case PermissionsPolicy::Feature::WebShare:
         return "WebShare"_s;
 #if ENABLE(DEVICE_ORIENTATION)
-    case PermissionsPolicy::Type::Gyroscope:
+    case PermissionsPolicy::Feature::Gyroscope:
         return "Gyroscope"_s;
-    case PermissionsPolicy::Type::Accelerometer:
+    case PermissionsPolicy::Feature::Accelerometer:
         return "Accelerometer"_s;
-    case PermissionsPolicy::Type::Magnetometer:
+    case PermissionsPolicy::Feature::Magnetometer:
         return "Magnetometer"_s;
 #endif
 #if ENABLE(WEB_AUTHN)
-    case PermissionsPolicy::Type::PublickeyCredentialsGetRule:
+    case PermissionsPolicy::Feature::PublickeyCredentialsGetRule:
         return "PublickeyCredentialsGet"_s;
 #endif
 #if ENABLE(WEBXR)
-    case PermissionsPolicy::Type::XRSpatialTracking:
+    case PermissionsPolicy::Feature::XRSpatialTracking:
         return "XRSpatialTracking"_s;
 #endif
-    case PermissionsPolicy::Type::PrivateToken:
+    case PermissionsPolicy::Feature::PrivateToken:
         return "PrivateToken"_s;
+    case PermissionsPolicy::Feature::Invalid:
+        return "Invalid"_s;
     }
     ASSERT_NOT_REACHED();
     return ""_s;
 }
 
-bool isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type type, const Document& document, LogPermissionsPolicyFailure logFailure)
+// https://w3c.github.io/webappsec-permissions-policy/#serialized-policy-directive
+static std::pair<PermissionsPolicy::Feature, StringView> readFeatureIdentifier(StringView value)
+{
+    value = value.trim(isASCIIWhitespace<UChar>);
+
+    PermissionsPolicy::Feature feature = PermissionsPolicy::Feature::Invalid;
+    StringView remainingValue;
+
+    constexpr auto cameraToken { "camera"_s };
+    constexpr auto microphoneToken { "microphone"_s };
+    constexpr auto speakerSelectionToken { "speaker-selection"_s };
+    constexpr auto displayCaptureToken { "display-capture"_s };
+    constexpr auto gamepadToken { "gamepad"_s };
+    constexpr auto geolocationToken { "geolocation"_s };
+    constexpr auto paymentToken { "payment"_s };
+    constexpr auto screenWakeLockToken { "screen-wake-lock"_s };
+    constexpr auto syncXHRToken { "sync-xhr"_s };
+    constexpr auto fullscreenToken { "fullscreen"_s };
+    constexpr auto webShareToken { "web-share"_s };
+#if ENABLE(DEVICE_ORIENTATION)
+    constexpr auto gyroscopeToken { "gyroscope"_s };
+    constexpr auto accelerometerToken { "accelerometer"_s };
+    constexpr auto magnetometerToken { "magnetometer"_s };
+#endif
+#if ENABLE(WEB_AUTHN)
+    constexpr auto publickeyCredentialsGetRuleToken { "publickey-credentials-get"_s };
+#endif
+#if ENABLE(WEBXR)
+    constexpr auto xrSpatialTrackingToken { "xr-spatial-tracking"_s };
+#endif
+    constexpr auto privateTokenToken { "private-token"_s };
+
+    if (value.startsWith(cameraToken)) {
+        feature = PermissionsPolicy::Feature::Camera;
+        remainingValue = value.substring(cameraToken.length());
+    } else if (value.startsWith(microphoneToken)) {
+        feature = PermissionsPolicy::Feature::Microphone;
+        remainingValue = value.substring(microphoneToken.length());
+    } else if (value.startsWith(speakerSelectionToken)) {
+        feature = PermissionsPolicy::Feature::SpeakerSelection;
+        remainingValue = value.substring(speakerSelectionToken.length());
+    } else if (value.startsWith(displayCaptureToken)) {
+        feature = PermissionsPolicy::Feature::DisplayCapture;
+        remainingValue = value.substring(displayCaptureToken.length());
+    } else if (value.startsWith(gamepadToken)) {
+        feature = PermissionsPolicy::Feature::Gamepad;
+        remainingValue = value.substring(gamepadToken.length());
+    } else if (value.startsWith(geolocationToken)) {
+        feature = PermissionsPolicy::Feature::Geolocation;
+        remainingValue = value.substring(geolocationToken.length());
+    } else if (value.startsWith(paymentToken)) {
+        feature = PermissionsPolicy::Feature::Payment;
+        remainingValue = value.substring(paymentToken.length());
+    } else if (value.startsWith(screenWakeLockToken)) {
+        feature = PermissionsPolicy::Feature::ScreenWakeLock;
+        remainingValue = value.substring(screenWakeLockToken.length());
+    } else if (value.startsWith(syncXHRToken)) {
+        feature = PermissionsPolicy::Feature::SyncXHR;
+        remainingValue = value.substring(syncXHRToken.length());
+    } else if (value.startsWith(fullscreenToken)) {
+        feature = PermissionsPolicy::Feature::Fullscreen;
+        remainingValue = value.substring(fullscreenToken.length());
+    } else if (value.startsWith(webShareToken)) {
+        feature = PermissionsPolicy::Feature::WebShare;
+        remainingValue = value.substring(webShareToken.length());
+#if ENABLE(DEVICE_ORIENTATION)
+    } else if (value.startsWith(gyroscopeToken)) {
+        feature = PermissionsPolicy::Feature::Gyroscope;
+        remainingValue = value.substring(gyroscopeToken.length());
+    } else if (value.startsWith(accelerometerToken)) {
+        feature = PermissionsPolicy::Feature::Accelerometer;
+        remainingValue = value.substring(accelerometerToken.length());
+    } else if (value.startsWith(magnetometerToken)) {
+        feature = PermissionsPolicy::Feature::Magnetometer;
+        remainingValue = value.substring(magnetometerToken.length());
+#endif
+#if ENABLE(WEB_AUTHN)
+    } else if (value.startsWith(publickeyCredentialsGetRuleToken)) {
+        feature = PermissionsPolicy::Feature::PublickeyCredentialsGetRule;
+        remainingValue = value.substring(magnetometerToken.length());
+#endif
+#if ENABLE(WEBXR)
+    } else if (value.startsWith(xrSpatialTrackingToken)) {
+        feature = PermissionsPolicy::Feature::XRSpatialTracking;
+        remainingValue = value.substring(xrSpatialTrackingToken.length());
+#endif
+    } else if (value.startsWith(privateTokenToken)) {
+        feature = PermissionsPolicy::Feature::PrivateToken;
+        remainingValue = value.substring(privateTokenToken.length());
+    }
+
+    // FIXME: webkit.org/b/274159.
+    // Using colon as delimiter is no longer standard behavior. We should drop this,
+    // update tests and use splitOnAsciiWhiteSpace to read feature identifier.
+    if (remainingValue.startsWith(":"_s))
+        remainingValue = remainingValue.substring(1);
+
+    return { feature, remainingValue };
+}
+
+// Similar to https://infra.spec.whatwg.org/#split-on-ascii-whitespace but only extract one token at a time.
+static std::pair<StringView, StringView> splitOnAsciiWhiteSpace(StringView input)
+{
+    input = input.trim(isASCIIWhitespace<UChar>);
+    auto position = input.find(isASCIIWhitespace<UChar>);
+    if (position == notFound)
+        return { input, StringView { } };
+
+    return  { input.left(position), input.substring(position) };
+}
+
+bool isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature feature, const Document& document, LogPermissionsPolicyFailure logFailure)
 {
     Ref topDocument = document.topDocument();
     RefPtr ancestorDocument = &document;
     while (ancestorDocument.get() != topDocument.ptr()) {
         if (!ancestorDocument) {
             if (logFailure == LogPermissionsPolicyFailure::Yes && document.domWindow())
-                document.domWindow()->printErrorMessage(makeString("Permission policy '"_s, policyTypeName(type), "' check failed."_s));
+                document.domWindow()->printErrorMessage(makeString("Permission policy '"_s, toFeatureNameForLogging(feature), "' check failed."_s));
             return false;
         }
 
@@ -103,16 +216,16 @@ bool isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type ty
 
         bool isAllowedByPermissionsPolicy = false;
         if (iframe)
-            isAllowedByPermissionsPolicy = iframe->permissionsPolicy().allows(type, ancestorDocument->securityOrigin().data());
+            isAllowedByPermissionsPolicy = iframe->permissionsPolicy().allows(feature, ancestorDocument->securityOrigin().data());
         else if (ownerElement)
-            isAllowedByPermissionsPolicy = PermissionsPolicy::defaultPolicy(ownerElement->document()).allows(type, ancestorDocument->securityOrigin().data());
+            isAllowedByPermissionsPolicy = PermissionsPolicy::defaultPolicy(ownerElement->document()).allows(feature, ancestorDocument->securityOrigin().data());
 
         if (!isAllowedByPermissionsPolicy) {
             if (logFailure == LogPermissionsPolicyFailure::Yes && document.domWindow()) {
                 String allowValue;
                 if (iframe)
                     allowValue = iframe->attributeWithoutSynchronization(HTMLNames::allowAttr);
-                document.domWindow()->printErrorMessage(makeString("Permission policy '"_s, policyTypeName(type), "' check failed for element with origin '"_s, document.securityOrigin().toString(), "' and allow attribute '"_s, allowValue, "'."_s));
+                document.domWindow()->printErrorMessage(makeString("Permission policy '"_s, toFeatureNameForLogging(feature), "' check failed for element with origin '"_s, document.securityOrigin().toString(), "' and allow attribute '"_s, allowValue, "'."_s));
             }
             return false;
         }
@@ -123,315 +236,137 @@ bool isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type ty
     return true;
 }
 
-static bool isAllowedByPermissionsPolicy(const PermissionsPolicy::AllowRule& rule, const SecurityOriginData& origin)
+// This is simplified version of https://w3c.github.io/webappsec-permissions-policy/#matches.
+bool PermissionsPolicy::Allowlist::matches(const SecurityOriginData& origin) const
 {
-    switch (rule.type) {
-    case PermissionsPolicy::AllowRule::Type::None:
-        return false;
-    case PermissionsPolicy::AllowRule::Type::All:
+    return std::visit(WTF::makeVisitor([&origin](const HashSet<SecurityOriginData>& origins) -> bool {
+        return origins.contains(origin);
+    }, [&] (const auto&) {
         return true;
-    case PermissionsPolicy::AllowRule::Type::List:
-        return rule.allowedList.contains(origin);
-    }
-    ASSERT_NOT_REACHED();
-    return false;
+    }), m_origins);
 }
 
-static inline void processOriginItem(Document& document, const HTMLIFrameElement& iframe, PermissionsPolicy::AllowRule& rule, StringView item)
-{
-    if (rule.type == PermissionsPolicy::AllowRule::Type::None)
-        return;
-
-    item = item.trim(isASCIIWhitespace<UChar>);
-    if (item == "'src'"_s) {
-        auto srcURL = document.completeURL(iframe.getAttribute(srcAttr));
-        if (srcURL.isValid()) {
-            RefPtr<SecurityOrigin> allowedOrigin;
-            if (srcURL.protocolIsInHTTPFamily())
-                allowedOrigin = SecurityOrigin::create(srcURL);
-            else if (auto contentDocument = iframe.contentDocument())
-                allowedOrigin = &contentDocument->securityOrigin();
-            if (allowedOrigin)
-                rule.allowedList.add(allowedOrigin->data());
-        }
-        return;
-    }
-
-    if (item == "*"_s) {
-        rule.type = PermissionsPolicy::AllowRule::Type::All;
-        return;
-    }
-
-    if (item == "'self'"_s) {
-        rule.allowedList.add(document.securityOrigin().data());
-        return;
-    }
-    if (item == "'none'"_s) {
-        rule.type = PermissionsPolicy::AllowRule::Type::None;
-        return;
-    }
-    URL url { { }, item.toString() };
-    if (url.isValid())
-        rule.allowedList.add(SecurityOriginData::fromURL(url));
-}
-
-static inline void updateList(Document& document, const HTMLIFrameElement& iframe, PermissionsPolicy::AllowRule& rule, StringView value)
+PermissionsPolicy::Allowlist PermissionsPolicy::parseAllowlist(StringView value, const SecurityOriginData& containerOrigin, const SecurityOriginData& targetOrigin, bool useStarAsDefaultAllowlistValue)
 {
     if (value.isEmpty()) {
-        if (document.quirks().shouldStarBePermissionsPolicyDefaultValue()) {
-            rule.type = PermissionsPolicy::AllowRule::Type::All;
-            return;
-        }
+        if (useStarAsDefaultAllowlistValue)
+            return Allowlist { Allowlist::AllowAllOrigins };
 
-        // The allowlist for the features named in the attribute may be empty; in that case,
-        // the default value for the allowlist is 'src', which represents the origin of the
-        // URL in the iframe’s src attribute.
-        // https://w3c.github.io/webappsec-permissions-policy/#iframe-allow-attribute
-        processOriginItem(document, iframe, rule, "'src'"_s);
-        return;
+        return Allowlist { targetOrigin };
     }
 
+    HashSet<SecurityOriginData> allowedOrigins;
     while (!value.isEmpty()) {
-        auto position = value.find(isASCIIWhitespace<UChar>);
-        if (position == notFound) {
-            processOriginItem(document, iframe, rule, value);
-            return;
-        }
+        auto [token, remainingValue] = splitOnAsciiWhiteSpace(value);
+        if (!token.isEmpty()) {
+            if (token == "*"_s)
+                return PermissionsPolicy::Allowlist { Allowlist::AllowAllOrigins };
 
-        processOriginItem(document, iframe, rule, value.left(position));
-        value = value.substring(position + 1).trim(isASCIIWhitespace<UChar>);
+            if (equalIgnoringASCIICase(token, "'none'"_s))
+                return PermissionsPolicy::Allowlist { };
+
+            if (equalIgnoringASCIICase(token, "'self'"_s))
+                allowedOrigins.add(containerOrigin);
+            else if (equalIgnoringASCIICase(token, "'src'"_s))
+                allowedOrigins.add(targetOrigin);
+            else {
+                URL url { { }, token.toString() };
+                if (url.isValid()) {
+                    auto origin = SecurityOriginData::fromURL(url);
+                    if (!origin.isOpaque())
+                        allowedOrigins.add(origin);
+                }
+            }
+        }
+        value = remainingValue;
     }
+
+    return PermissionsPolicy::Allowlist { WTFMove(allowedOrigins) };
 }
 
-PermissionsPolicy PermissionsPolicy::parse(Document& document, const HTMLIFrameElement* iframe, StringView allowAttributeValue)
+// https://w3c.github.io/webappsec-permissions-policy/#algo-parse-policy-directive
+PermissionsPolicy::PolicyDirective PermissionsPolicy::parsePolicyDirective(StringView value, const SecurityOriginData& containerOrigin, const SecurityOriginData& targetOrigin, bool useStarAsDefaultAllowlistValue)
 {
-    PermissionsPolicy policy;
-    bool isCameraInitialized = false;
-    bool isMicrophoneInitialized = false;
-    bool isSpeakerSelectionInitialized = false;
-    bool isDisplayCaptureInitialized = false;
-    bool isGamepadInitialized = false;
-    bool isGeolocationInitialized = false;
-    bool isPaymentInitialized = false;
-    bool isScreenWakeLockInitialized = false;
-    bool isSyncXHRInitialized = false;
-    bool isFullscreenInitialized = false;
-    bool isWebShareInitialized = false;
-#if ENABLE(DEVICE_ORIENTATION)
-    bool isGyroscopeInitialized = false;
-    bool isAccelerometerInitialized = false;
-    bool isMagnetometerInitialized = false;
-#endif
-#if ENABLE(WEB_AUTHN)
-    bool isPublickeyCredentialsGetInitialized = false;
-#endif
-#if ENABLE(WEBXR)
-    bool isXRSpatialTrackingInitialized = false;
-#endif
-    bool isPrivateTokenInitialized = false;
-    if (iframe) {
-        for (auto allowItem : allowAttributeValue.split(';')) {
-            auto item = allowItem.trim(isASCIIWhitespace<UChar>);
-            if (item.startsWith("camera"_s)) {
-                isCameraInitialized = true;
-                updateList(document, *iframe, policy.m_cameraRule, item.substring(7));
-                continue;
-            }
-            if (item.startsWith("microphone"_s)) {
-                isMicrophoneInitialized = true;
-                updateList(document, *iframe, policy.m_microphoneRule, item.substring(11));
-                continue;
-            }
-            if (item.startsWith("speaker-selection"_s)) {
-                isSpeakerSelectionInitialized = true;
-                updateList(document, *iframe, policy.m_speakerSelectionRule, item.substring(18));
-                continue;
-            }
-            if (item.startsWith("display-capture"_s)) {
-                isDisplayCaptureInitialized = true;
-                updateList(document, *iframe, policy.m_displayCaptureRule, item.substring(16));
-                continue;
-            }
-            if (item.startsWith("gamepad"_s)) {
-                isGamepadInitialized = true;
-                updateList(document, *iframe, policy.m_gamepadRule, item.substring(8));
-                continue;
-            }
-            if (item.startsWith("geolocation"_s)) {
-                isGeolocationInitialized = true;
-                updateList(document, *iframe, policy.m_geolocationRule, item.substring(12));
-                continue;
-            }
-            if (item.startsWith("payment"_s)) {
-                isPaymentInitialized = true;
-                updateList(document, *iframe, policy.m_paymentRule, item.substring(8));
-                continue;
-            }
-            if (item.startsWith("screen-wake-lock"_s)) {
-                isScreenWakeLockInitialized = true;
-                updateList(document, *iframe, policy.m_screenWakeLockRule, item.substring(17));
-                continue;
-            }
-            if (item.startsWith("sync-xhr"_s)) {
-                isSyncXHRInitialized = true;
-                updateList(document, *iframe, policy.m_syncXHRRule, item.substring(9));
-                continue;
-            }
-            if (item.startsWith("fullscreen"_s)) {
-                isFullscreenInitialized = true;
-                updateList(document, *iframe, policy.m_fullscreenRule, item.substring(11));
-                continue;
-            }
-            if (item.startsWith("web-share"_s)) {
-                isWebShareInitialized = true;
-                updateList(document, *iframe, policy.m_webShareRule, item.substring(10));
-                continue;
-            }
-#if ENABLE(DEVICE_ORIENTATION)
-            if (item.startsWith("gyroscope"_s)) {
-                isGyroscopeInitialized = true;
-                updateList(document, *iframe, policy.m_gyroscopeRule, item.substring(10));
-                continue;
-            }
-            if (item.startsWith("accelerometer"_s)) {
-                isAccelerometerInitialized = true;
-                updateList(document, *iframe, policy.m_accelerometerRule, item.substring(14));
-                continue;
-            }
-            if (item.startsWith("magnetometer"_s)) {
-                isMagnetometerInitialized = true;
-                updateList(document, *iframe, policy.m_magnetometerRule, item.substring(13));
-                continue;
-            }
-#endif
-#if ENABLE(WEB_AUTHN)
-            if (item.startsWith("publickey-credentials-get"_s)) {
-                isPublickeyCredentialsGetInitialized = true;
-                updateList(document, *iframe, policy.m_publickeyCredentialsGetRule, item.substring(26));
-                continue;
-            }
-#endif
-#if ENABLE(WEBXR)
-            if (item.startsWith("xr-spatial-tracking"_s)) {
-                isXRSpatialTrackingInitialized = true;
-                updateList(document, *iframe, policy.m_xrSpatialTrackingRule, item.substring(19));
-                continue;
-            }
-#endif
-            constexpr auto privateTokenToken { "private-token"_s };
-            if (item.startsWith(privateTokenToken)) {
-                isPrivateTokenInitialized = true;
-                updateList(document, *iframe, policy.m_privateTokenRule, item.substring(privateTokenToken.length()));
-                continue;
-            }
+    PermissionsPolicy::PolicyDirective result;
+    for (auto item : value.split(';')) {
+        auto [feature, remainingItem] = readFeatureIdentifier(item);
+        if (feature == Feature::Invalid)
+            continue;
+
+        result.add(feature, parseAllowlist(remainingItem, containerOrigin, targetOrigin, useStarAsDefaultAllowlistValue));
+    }
+
+    return result;
+}
+
+// https://w3c.github.io/webappsec-permissions-policy/#declared-origin
+Ref<SecurityOrigin> PermissionsPolicy::declaredOrigin(const HTMLIFrameElement& iframe) const
+{
+    if (iframe.document().isSandboxed(SandboxOrigin) || (iframe.sandboxFlags() & SandboxOrigin))
+        return SecurityOrigin::createOpaque();
+
+    if (iframe.hasAttributeWithoutSynchronization(srcdocAttr))
+        return iframe.document().securityOrigin();
+
+    if (iframe.hasAttributeWithoutSynchronization(srcAttr)) {
+        auto url = iframe.document().completeURL(iframe.getAttribute(srcAttr));
+        if (url.isValid()) {
+            if (url.protocolIsInHTTPFamily())
+                return SecurityOrigin::create(url);
+            if (auto contentDocument = iframe.contentDocument())
+                return contentDocument->securityOrigin();
         }
     }
 
-    // By default, camera, microphone, speaker-selection, display-capture, fullscreen, xr-spatial-tracking, screen-wake-lock, and web-share policy is 'self'.
-    if (!isCameraInitialized)
-        policy.m_cameraRule.allowedList.add(document.securityOrigin().data());
-    if (!isMicrophoneInitialized)
-        policy.m_microphoneRule.allowedList.add(document.securityOrigin().data());
-    if (!isSpeakerSelectionInitialized)
-        policy.m_speakerSelectionRule.allowedList.add(document.securityOrigin().data());
-    if (!isDisplayCaptureInitialized)
-        policy.m_displayCaptureRule.allowedList.add(document.securityOrigin().data());
-    if (!isGamepadInitialized)
-        policy.m_gamepadRule.type = PermissionsPolicy::AllowRule::Type::All;
-    if (!isScreenWakeLockInitialized)
-        policy.m_screenWakeLockRule.allowedList.add(document.securityOrigin().data());
-    if (!isGeolocationInitialized)
-        policy.m_geolocationRule.allowedList.add(document.securityOrigin().data());
-    if (!isPaymentInitialized)
-        policy.m_paymentRule.allowedList.add(document.securityOrigin().data());
-    if (!isWebShareInitialized)
-        policy.m_webShareRule.allowedList.add(document.securityOrigin().data());
-#if ENABLE(DEVICE_ORIENTATION)
-    if (!isGyroscopeInitialized)
-        policy.m_gyroscopeRule.allowedList.add(document.securityOrigin().data());
-    if (!isAccelerometerInitialized)
-        policy.m_accelerometerRule.allowedList.add(document.securityOrigin().data());
-    if (!isMagnetometerInitialized)
-        policy.m_magnetometerRule.allowedList.add(document.securityOrigin().data());
-#endif
-#if ENABLE(WEB_AUTHN)
-    if (!isPublickeyCredentialsGetInitialized)
-        policy.m_publickeyCredentialsGetRule.allowedList.add(document.securityOrigin().data());
-#endif
-#if ENABLE(WEBXR)
-    if (!isXRSpatialTrackingInitialized)
-        policy.m_xrSpatialTrackingRule.allowedList.add(document.securityOrigin().data());
-#endif
-    if (!isPrivateTokenInitialized)
-        policy.m_privateTokenRule.allowedList.add(document.securityOrigin().data());
+    return iframe.document().securityOrigin();
+}
 
+PermissionsPolicy::PermissionsPolicy(Document& document, const HTMLIFrameElement* iframe)
+{
     // https://w3c.github.io/webappsec-permissions-policy/#algo-process-policy-attributes
-    // 9.5 Process Feature Policy Attributes
-    // 3.1 If element’s allowfullscreen attribute is specified, and container policy does
-    //     not contain an allowlist for fullscreen,
-    if (!isFullscreenInitialized) {
-        if (iframe && (iframe->hasAttribute(allowfullscreenAttr) || iframe->hasAttribute(webkitallowfullscreenAttr))) {
-            // 3.1.1 Construct a new declaration for fullscreen, whose allowlist is the special value *.
-            policy.m_fullscreenRule.type = PermissionsPolicy::AllowRule::Type::All;
-        } else {
-            // https://fullscreen.spec.whatwg.org/#permissions-policy-integration
-            // The default allowlist is 'self'.
-            policy.m_fullscreenRule.allowedList.add(document.securityOrigin().data());
-        }
+    if (iframe) {
+        auto allowAttributeValue = iframe->attributeWithoutSynchronization(allowAttr);
+        m_effectivePolicy = parsePolicyDirective(allowAttributeValue, iframe->document().securityOrigin().data(), declaredOrigin(*iframe)->data(), document.quirks().shouldStarBePermissionsPolicyDefaultValue());
+
+        if (iframe->hasAttribute(allowfullscreenAttr) || iframe->hasAttribute(webkitallowfullscreenAttr))
+            m_effectivePolicy.add(Feature::Fullscreen, Allowlist { Allowlist::AllowAllOrigins });
     }
 
-    if (!isSyncXHRInitialized)
-        policy.m_syncXHRRule.type = AllowRule::Type::All;
-
-    return policy;
-}
-
-bool PermissionsPolicy::allows(Type type, const SecurityOriginData& origin) const
-{
-    switch (type) {
-    case Type::Camera:
-        return isAllowedByPermissionsPolicy(m_cameraRule, origin);
-    case Type::Microphone:
-        return isAllowedByPermissionsPolicy(m_microphoneRule, origin);
-    case Type::SpeakerSelection:
-        return isAllowedByPermissionsPolicy(m_speakerSelectionRule, origin);
-    case Type::DisplayCapture:
-        return isAllowedByPermissionsPolicy(m_displayCaptureRule, origin);
-    case Type::Gamepad:
-        return isAllowedByPermissionsPolicy(m_gamepadRule, origin);
-    case Type::Geolocation:
-        return isAllowedByPermissionsPolicy(m_geolocationRule, origin);
-    case Type::Payment:
-        return isAllowedByPermissionsPolicy(m_paymentRule, origin);
-    case Type::ScreenWakeLock:
-        return isAllowedByPermissionsPolicy(m_screenWakeLockRule, origin);
-    case Type::SyncXHR:
-        return isAllowedByPermissionsPolicy(m_syncXHRRule, origin);
-    case Type::Fullscreen:
-        return isAllowedByPermissionsPolicy(m_fullscreenRule, origin);
-    case Type::WebShare:
-        return isAllowedByPermissionsPolicy(m_webShareRule, origin);
+    // Default allowlists: https://w3c.github.io/webappsec-permissions-policy/#default-allowlists
+    auto selfOrigin = document.securityOrigin().data();
+    auto allowlistWithSelfOrigin = Allowlist { selfOrigin };
+    auto allowlistWithAllOrigins = Allowlist { Allowlist::AllowAllOrigins };
+    m_effectivePolicy.add(Feature::Camera, allowlistWithSelfOrigin);
+    m_effectivePolicy.add(Feature::Microphone, allowlistWithSelfOrigin);
+    m_effectivePolicy.add(Feature::SpeakerSelection, allowlistWithSelfOrigin);
+    m_effectivePolicy.add(Feature::DisplayCapture, allowlistWithSelfOrigin);
+    m_effectivePolicy.add(Feature::Gamepad, allowlistWithAllOrigins);
+    m_effectivePolicy.add(Feature::Geolocation, allowlistWithSelfOrigin);
+    m_effectivePolicy.add(Feature::Payment, allowlistWithSelfOrigin);
+    m_effectivePolicy.add(Feature::ScreenWakeLock, allowlistWithSelfOrigin);
+    m_effectivePolicy.add(Feature::SyncXHR, allowlistWithAllOrigins);
+    m_effectivePolicy.add(Feature::Fullscreen, allowlistWithSelfOrigin);
+    m_effectivePolicy.add(Feature::WebShare, allowlistWithSelfOrigin);
 #if ENABLE(DEVICE_ORIENTATION)
-    case Type::Gyroscope:
-        return isAllowedByPermissionsPolicy(m_gyroscopeRule, origin);
-    case Type::Accelerometer:
-        return isAllowedByPermissionsPolicy(m_accelerometerRule, origin);
-    case Type::Magnetometer:
-        return isAllowedByPermissionsPolicy(m_magnetometerRule, origin);
+    m_effectivePolicy.add(Feature::Gyroscope, allowlistWithSelfOrigin);
+    m_effectivePolicy.add(Feature::Accelerometer, allowlistWithSelfOrigin);
+    m_effectivePolicy.add(Feature::Magnetometer, allowlistWithSelfOrigin);
 #endif
 #if ENABLE(WEB_AUTHN)
-    case Type::PublickeyCredentialsGetRule:
-        return isAllowedByPermissionsPolicy(m_publickeyCredentialsGetRule, origin);
+    m_effectivePolicy.add(Feature::PublickeyCredentialsGetRule, allowlistWithSelfOrigin);
 #endif
 #if ENABLE(WEBXR)
-    case Type::XRSpatialTracking:
-        return isAllowedByPermissionsPolicy(m_xrSpatialTrackingRule, origin);
+    m_effectivePolicy.add(Feature::XRSpatialTracking, allowlistWithSelfOrigin);
 #endif
-    case Type::PrivateToken:
-        return isAllowedByPermissionsPolicy(m_privateTokenRule, origin);
-    }
-    ASSERT_NOT_REACHED();
-    return false;
+    m_effectivePolicy.add(Feature::PrivateToken, allowlistWithSelfOrigin);
+
+    ASSERT(m_effectivePolicy.size() == static_cast<unsigned>(Feature::Invalid));
+}
+
+bool PermissionsPolicy::allows(Feature feature, const SecurityOriginData& origin) const
+{
+    auto iter = m_effectivePolicy.find(feature);
+    return iter != m_effectivePolicy.end() ? iter->value.matches(origin) : false;
 }
 
 }

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -2858,7 +2858,7 @@ void WebGLRenderingContextBase::makeXRCompatible(MakeXRCompatiblePromise&& promi
 
     // 1. If the requesting document’s origin is not allowed to use the "xr-spatial-tracking"
     // permissions policy, resolve promise and return it.
-    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::XRSpatialTracking, canvas->document(), LogPermissionsPolicyFailure::Yes)) {
+    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::XRSpatialTracking, canvas->document(), LogPermissionsPolicyFailure::Yes)) {
         promise.resolve();
         return;
     }

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3272,7 +3272,7 @@ void FrameLoader::updateRequestAndAddExtraFields(Frame& targetFrame, ResourceReq
         request.setHTTPHeaderField(HTTPHeaderName::Accept, CachedResourceRequest::acceptHeaderValueFromType(CachedResource::Type::MainResource));
 
     if (document && localFrame->settings().privateTokenUsageByThirdPartyEnabled() && !localFrame->loader().client().isRemoteWorkerFrameLoaderClient())
-        request.setIsPrivateTokenUsageByThirdPartyAllowed(isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::PrivateToken, *document, LogPermissionsPolicyFailure::No));
+        request.setIsPrivateTokenUsageByThirdPartyAllowed(isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::PrivateToken, *document, LogPermissionsPolicyFailure::No));
 
     // Only set fallback array if it's still empty (later attempts may be incorrect, see bug 117818).
     if (document && request.responseContentDispositionEncodingFallbackArray().isEmpty()) {

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2086,8 +2086,8 @@ bool LocalDOMWindow::isAllowedToUseDeviceMotion(String& message) const
         return false;
 
     Ref document = *this->document();
-    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Gyroscope, document, LogPermissionsPolicyFailure::No)
-        || !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Accelerometer, document, LogPermissionsPolicyFailure::No)) {
+    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Gyroscope, document, LogPermissionsPolicyFailure::No)
+        || !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Accelerometer, document, LogPermissionsPolicyFailure::No)) {
         message = "Third-party iframes are not allowed access to device motion unless explicitly allowed via Feature-Policy (gyroscope & accelerometer)"_s;
         return false;
     }
@@ -2101,9 +2101,9 @@ bool LocalDOMWindow::isAllowedToUseDeviceOrientation(String& message) const
         return false;
 
     Ref document = *this->document();
-    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Gyroscope, document, LogPermissionsPolicyFailure::No)
-        || !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Accelerometer, document, LogPermissionsPolicyFailure::No)
-        || !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Magnetometer, document, LogPermissionsPolicyFailure::No)) {
+    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Gyroscope, document, LogPermissionsPolicyFailure::No)
+        || !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Accelerometer, document, LogPermissionsPolicyFailure::No)
+        || !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::Magnetometer, document, LogPermissionsPolicyFailure::No)) {
         message = "Third-party iframes are not allowed access to device orientation unless explicitly allowed via Feature-Policy (gyroscope & accelerometer & magnetometer)"_s;
         return false;
     }

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -141,7 +141,7 @@ static std::optional<URL> shareableURLForShareData(ScriptExecutionContext& conte
 
 static bool validateWebSharePolicy(Document& document)
 {
-    return isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::WebShare, document, LogPermissionsPolicyFailure::Yes);
+    return isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::WebShare, document, LogPermissionsPolicyFailure::Yes);
 }
 
 bool Navigator::canShare(Document& document, const ShareData& data)

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -660,7 +660,7 @@ ExceptionOr<void> XMLHttpRequest::createRequest()
         // Either loader is null or some error was synchronously sent to us.
         ASSERT(m_loadingActivity || !m_sendFlag);
     } else {
-        if (scriptExecutionContext()->isDocument() && !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::SyncXHR, *document()))
+        if (scriptExecutionContext()->isDocument() && !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Feature::SyncXHR, *document()))
             return Exception { ExceptionCode::NetworkError };
 
         request.setDomainForCachePartition(scriptExecutionContext()->domainForCachePartition());


### PR DESCRIPTION
#### 061e4cd3970fe03212bc57c761cb3d5e4088421f
<pre>
Update PermissionsPolicy to match latest spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=273982">https://bugs.webkit.org/show_bug.cgi?id=273982</a>
<a href="https://rdar.apple.com/127848428">rdar://127848428</a>

Reviewed by Youenn Fablet.

This patch implements some algorithms and does some refactoring/renaming in PermissionPolicy based on latest version of
spec.

* Source/WebCore/Modules/applepay/PaymentSession.cpp:
(WebCore::PaymentSession::canCreateSession):
* Source/WebCore/Modules/audiosession/DOMAudioSession.cpp:
(WebCore::DOMAudioSession::setType):
(WebCore::DOMAudioSession::type const):
(WebCore::DOMAudioSession::state const):
(WebCore::DOMAudioSession::scheduleStateChangeEvent):
* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
* Source/WebCore/Modules/geolocation/Geolocation.cpp:
(WebCore::Geolocation::shouldBlockGeolocationRequests):
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::checkCameraAccess):
(WebCore::checkMicrophoneAccess):
(WebCore::checkSpeakerAccess):
(WebCore::MediaDevices::listenForDeviceChanges):
* Source/WebCore/Modules/mediastream/UserMediaController.cpp:
(WebCore::UserMediaController::logEnumerateDevicesDenial):
* Source/WebCore/Modules/mediastream/UserMediaRequest.cpp:
(WebCore::UserMediaRequest::start):
* Source/WebCore/Modules/permissions/Permissions.cpp:
(WebCore::isAllowedByPermissionsPolicy):
* Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp:
(WebCore::WakeLock::request):
* Source/WebCore/Modules/speech/SpeechRecognition.cpp:
(WebCore::SpeechRecognition::startRecognition):
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinator::discoverFromExternalSource):
* Source/WebCore/Modules/webxr/WebXRSystem.cpp:
(WebCore::WebXRSystem::isSessionSupported):
(WebCore::WebXRSystem::isFeaturePermitted const):
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::requestFullscreenForElement):
(WebCore::FullscreenManager::isFullscreenEnabled const):
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::HTMLIFrameElement::permissionsPolicy const):
* Source/WebCore/html/PermissionsPolicy.cpp:
(WebCore::toFeatureNameForLogging):
(WebCore::readFeatureIdentifier):
(WebCore::splitOnAsciiWhiteSpace):
(WebCore::isPermissionsPolicyAllowedByDocumentAndAllOwners):
(WebCore::PermissionsPolicy::Allowlist::matches const):
(WebCore::PermissionsPolicy::parseAllowlist):
(WebCore::PermissionsPolicy::parsePolicyDirective):
(WebCore::PermissionsPolicy::declaredOrigin const):
(WebCore::PermissionsPolicy::PermissionsPolicy):
(WebCore::PermissionsPolicy::allows const):
(WebCore::policyTypeName): Deleted.
(WebCore::isAllowedByPermissionsPolicy): Deleted.
(WebCore::processOriginItem): Deleted.
(WebCore::updateList): Deleted.
(WebCore::PermissionsPolicy::parse): Deleted.
* Source/WebCore/html/PermissionsPolicy.h:
(WebCore::PermissionsPolicy::defaultPolicy):
(WebCore::PermissionsPolicy::parse):
(WebCore::PermissionsPolicy::Allowlist::Allowlist):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::makeXRCompatible):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::updateRequestAndAddExtraFields):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::isAllowedToUseDeviceMotion const):
(WebCore::LocalDOMWindow::isAllowedToUseDeviceOrientation const):
* Source/WebCore/page/Navigator.cpp:
(WebCore::validateWebSharePolicy):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::createRequest):

Canonical link: <a href="https://commits.webkit.org/278786@main">https://commits.webkit.org/278786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bb49979c7e50bb336ff70c6bdacdcc4bd0f5137

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51537 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30847 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54804 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2230 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1910 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41958 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53636 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28485 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44448 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23084 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25791 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1729 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47750 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1794 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56396 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26656 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1668 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49356 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27896 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44517 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48546 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11281 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28789 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27631 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->