### PR TITLE
Fix some unified sources issues, mainly in PDF code

### DIFF
--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
@@ -35,8 +35,6 @@ OBJC_CLASS WKLinearMediaPlayerDelegate;
 
 namespace WebKit {
 
-using namespace WebCore;
-
 class PlaybackSessionInterfaceLMK final : public PlaybackSessionInterfaceIOS {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlaybackSessionInterfaceLMK);

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
@@ -38,8 +38,6 @@ class PlaybackSessionInterfaceIOS;
 
 namespace WebKit {
 
-using namespace WebCore;
-
 class VideoPresentationInterfaceLMK final : public VideoPresentationInterfaceIOS {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(VideoPresentationInterfaceLMK);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h
@@ -54,16 +54,16 @@ class PDFDataDetectorItem;
 class UnifiedPDFPlugin;
 class WebMouseEvent;
 
-class PDFDataDetectorOverlayController final : private PageOverlayClient, WebCore::DataDetectorHighlightClient {
+class PDFDataDetectorOverlayController final : private WebCore::PageOverlayClient, WebCore::DataDetectorHighlightClient {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(PDFDataDetectorOverlayController);
 public:
     explicit PDFDataDetectorOverlayController(UnifiedPDFPlugin&);
-    virtual ~PDFDataDetectorOverlayController() = default;
+    virtual ~PDFDataDetectorOverlayController();
     void teardown();
 
     bool handleMouseEvent(const WebMouseEvent&, PDFDocumentLayout::PageIndex);
-    RefPtr<PageOverlay> protectedOverlay() const { return m_overlay; }
+    RefPtr<WebCore::PageOverlay> protectedOverlay() const { return m_overlay; }
 
     enum class ShouldUpdatePlatformHighlightData : bool { No, Yes };
     enum class ActiveHighlightChanged : bool { No, Yes };
@@ -71,8 +71,8 @@ public:
 
 private:
     // PageOverlayClient
-    void willMoveToPage(WebCore::PageOverlay&, Page*) final;
-    void didMoveToPage(WebCore::PageOverlay&, Page*) final { }
+    void willMoveToPage(WebCore::PageOverlay&, WebCore::Page*) final;
+    void didMoveToPage(WebCore::PageOverlay&, WebCore::Page*) final { }
     void drawRect(WebCore::PageOverlay&, WebCore::GraphicsContext&, const WebCore::IntRect&) final { }
     bool mouseEvent(WebCore::PageOverlay&, const WebCore::PlatformMouseEvent&) final { return false; }
     void didScrollFrame(WebCore::PageOverlay&, WebCore::LocalFrame&) final { }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
@@ -62,6 +62,8 @@ PDFDataDetectorOverlayController::PDFDataDetectorOverlayController(UnifiedPDFPlu
 {
 }
 
+PDFDataDetectorOverlayController::~PDFDataDetectorOverlayController() = default;
+
 RefPtr<UnifiedPDFPlugin> PDFDataDetectorOverlayController::protectedPlugin() const
 {
     return m_plugin.get();


### PR DESCRIPTION
#### 8648d79fb455737c205759800594756fc79b93d1
<pre>
Fix some unified sources issues, mainly in PDF code
<a href="https://bugs.webkit.org/show_bug.cgi?id=273983">https://bugs.webkit.org/show_bug.cgi?id=273983</a>
<a href="https://rdar.apple.com/127848229">rdar://127848229</a>

Reviewed by Wenson Hsieh and Aditya Keerthi.

Fix some missing WebCore:: prefixes in PDFDataDetectorOverlayController.h and
remove some `using namespace WebCore` from headers.

* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm:

Canonical link: <a href="https://commits.webkit.org/278598@main">https://commits.webkit.org/278598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cc87e999d90957a7e4fc889e9bde35f102bccdf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30372 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54327 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1759 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1432 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53169 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/28004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44006 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22706 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9510 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1334 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55922 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26180 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/27428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44074 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11170 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28308 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/27159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->