### PR TITLE
Add iterator to SpaceSplitString

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -5118,8 +5118,8 @@ bool AXObjectCache::addRelation(Element& origin, const QualifiedName& attribute)
     }
 
     SpaceSplitString ids(value, SpaceSplitString::ShouldFoldCase::No);
-    for (size_t i = 0; i < ids.size(); ++i) {
-        RefPtr target = origin.treeScope().getElementById(ids[i]);
+    for (auto& id : ids) {
+        RefPtr target = origin.treeScope().getElementById(id);
         if (!target || target == &origin)
             continue;
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -4069,15 +4069,11 @@ Vector<Ref<Element>> AccessibilityObject::elementsFromAttribute(const QualifiedN
         return { };
     }
 
-    Vector<Ref<Element>> elements;
     auto& treeScope = element->treeScope();
-    SpaceSplitString spaceSplitString(idsString, SpaceSplitString::ShouldFoldCase::No);
-    size_t length = spaceSplitString.size();
-    for (size_t i = 0; i < length; ++i) {
-        if (RefPtr element = treeScope.getElementById(spaceSplitString[i]))
-            elements.append(element.releaseNonNull());
-    }
-    return elements;
+    SpaceSplitString ids(idsString, SpaceSplitString::ShouldFoldCase::No);
+    return WTF::compactMap(ids, [&](auto& id) {
+        return treeScope.getElementById(id);
+    });
 }
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/css/SelectorFilter.cpp
+++ b/Source/WebCore/css/SelectorFilter.cpp
@@ -55,10 +55,9 @@ void SelectorFilter::collectElementIdentifierHashes(const Element& element, Vect
         identifierHashes.append(id.impl()->existingHash() * IdSalt);
 
     if (element.hasClass()) {
-        const SpaceSplitString& classNames = element.classNames();
-        size_t count = classNames.size();
-        for (size_t i = 0; i < count; ++i)
-            identifierHashes.append(classNames[i].impl()->existingHash() * ClassSalt);
+        identifierHashes.appendContainerWithMapping(element.classNames(), [](auto& className) {
+            return className.impl()->existingHash() * ClassSalt;
+        });
     }
     
     if (element.hasAttributesWithoutUpdate()) {

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2269,12 +2269,9 @@ std::optional<Vector<Ref<Element>>> Element::getElementsArrayAttribute(const Qua
         return std::nullopt;
 
     SpaceSplitString ids(getAttribute(attr), SpaceSplitString::ShouldFoldCase::No);
-    Vector<Ref<Element>> elements;
-    for (unsigned i = 0; i < ids.size(); ++i) {
-        if (RefPtr element = treeScope().getElementById(ids[i]))
-            elements.append(element.releaseNonNull());
-    }
-    return elements;
+    return WTF::compactMap(ids, [&](auto& id) {
+        return treeScope().getElementById(id);
+    });
 }
 
 void Element::setElementsArrayAttribute(const QualifiedName& attributeName, std::optional<Vector<Ref<Element>>>&& elements)

--- a/Source/WebCore/dom/SpaceSplitString.h
+++ b/Source/WebCore/dom/SpaceSplitString.h
@@ -31,6 +31,11 @@ class SpaceSplitStringData {
 public:
     static RefPtr<SpaceSplitStringData> create(const AtomString&);
 
+    auto begin() const { return tokenArrayStart(); }
+    auto end() const { return tokenArrayStart() + size(); }
+    auto begin() { return tokenArrayStart(); }
+    auto end() { return tokenArrayStart() + size(); }
+
     bool contains(const AtomString& string)
     {
         const AtomString* data = tokenArrayStart();
@@ -90,6 +95,7 @@ private:
     static void destroy(SpaceSplitStringData*);
 
     AtomString* tokenArrayStart() { return reinterpret_cast<AtomString*>(this + 1); }
+    const AtomString* tokenArrayStart() const { return reinterpret_cast<const AtomString*>(this + 1); }
 
     AtomString m_keyString;
     unsigned m_refCount;
@@ -117,6 +123,11 @@ public:
         ASSERT_WITH_SECURITY_IMPLICATION(m_data);
         return (*m_data)[i];
     }
+
+    auto begin() const { return m_data ? m_data->begin() : nullptr; }
+    auto end() const { return m_data ? m_data->end() : nullptr; }
+    auto begin() { return m_data ? m_data->begin() : nullptr; }
+    auto end() { return m_data ? m_data->end() : nullptr; }
 
     static bool spaceSplitStringContainsValue(StringView spaceSplitString, StringView value, ShouldFoldCase);
 

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -374,8 +374,8 @@ void HTMLAnchorElement::sendPings(const URL& destinationURL)
         return;
 
     SpaceSplitString pingURLs(pingValue, SpaceSplitString::ShouldFoldCase::No);
-    for (unsigned i = 0; i < pingURLs.size(); i++)
-        PingLoader::sendPing(*document().frame(), document().completeURL(pingURLs[i]), destinationURL);
+    for (auto& pingURL : pingURLs)
+        PingLoader::sendPing(*document().frame(), document().completeURL(pingURL), destinationURL);
 }
 
 #if USE(SYSTEM_PREVIEW)

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2509,12 +2509,12 @@ static bool findDropZone(Node& target, DataTransfer& dataTransfer)
         SpaceSplitString keywords(element->attributeWithoutSynchronization(webkitdropzoneAttr), SpaceSplitString::ShouldFoldCase::Yes);
         bool matched = false;
         std::optional<DragOperation> dragOperation;
-        for (unsigned i = 0, size = keywords.size(); i < size; ++i) {
-            if (auto operationFromKeyword = convertDropZoneOperationToDragOperation(keywords[i])) {
+        for (auto& keyword : keywords) {
+            if (auto operationFromKeyword = convertDropZoneOperationToDragOperation(keyword)) {
                 if (!dragOperation)
                     dragOperation = operationFromKeyword;
             } else
-                matched = matched || hasDropZoneType(dataTransfer, keywords[i].string());
+                matched = matched || hasDropZoneType(dataTransfer, keyword.string());
             if (matched && dragOperation)
                 break;
         }

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -209,8 +209,8 @@ void ElementRuleCollector::collectMatchingRules(const MatchRequest& matchRequest
     if (!id.isNull())
         collectMatchingRulesForList(matchRequest.ruleSet.idRules(id), matchRequest);
     if (element.hasClass()) {
-        for (size_t i = 0; i < element.classNames().size(); ++i)
-            collectMatchingRulesForList(matchRequest.ruleSet.classRules(element.classNames()[i]), matchRequest);
+        for (auto& className : element.classNames())
+            collectMatchingRulesForList(matchRequest.ruleSet.classRules(className), matchRequest);
     }
     if (element.hasAttributesWithoutUpdate() && matchRequest.ruleSet.hasAttributeRules()) {
         Vector<const RuleSet::RuleDataVector*, 4> ruleVectors;

--- a/Source/WebCore/style/PseudoClassChangeInvalidation.cpp
+++ b/Source/WebCore/style/PseudoClassChangeInvalidation.cpp
@@ -41,9 +41,9 @@ Vector<PseudoClassInvalidationKey, 4> makePseudoClassInvalidationKeys(CSSSelecto
         keys.append(makePseudoClassInvalidationKey(pseudoClass, InvalidationKeyType::Id, element.idForStyleResolution()));
 
     if (element.hasClass()) {
-        auto classCount = element.classNames().size();
-        for (size_t i = 0; i < classCount; ++i)
-            keys.append(makePseudoClassInvalidationKey(pseudoClass, InvalidationKeyType::Class, element.classNames()[i]));
+        keys.appendContainerWithMapping(element.classNames(), [&](auto& className) {
+            return makePseudoClassInvalidationKey(pseudoClass, InvalidationKeyType::Class, className);
+        });
     }
 
     keys.append(makePseudoClassInvalidationKey(pseudoClass, InvalidationKeyType::Tag, element.localNameLowercase()));

--- a/Source/WebCore/style/StyleSharingResolver.cpp
+++ b/Source/WebCore/style/StyleSharingResolver.cpp
@@ -348,8 +348,8 @@ bool SharingResolver::sharingCandidateHasIdenticalStyleAffectingAttributes(const
 
 bool SharingResolver::classNamesAffectedByRules(const SpaceSplitString& classNames) const
 {
-    for (unsigned i = 0; i < classNames.size(); ++i) {
-        if (m_ruleSets.features().classRules.contains(classNames[i]))
+    for (auto& className : classNames) {
+        if (m_ruleSets.features().classRules.contains(className))
             return true;
     }
     return false;


### PR DESCRIPTION
#### c1735d061bd8fa5c8ed66bfd91e8bc03e199bb2e
<pre>
Add iterator to SpaceSplitString
<a href="https://bugs.webkit.org/show_bug.cgi?id=273988">https://bugs.webkit.org/show_bug.cgi?id=273988</a>

Reviewed by Ryosuke Niwa.

Add iterator to SpaceSplitString. This results in nicer code and may be a bit
more efficient than using operator[] which does a bounds check. This also
allows us to use more efficient functions to construct or populate Vectors
(such as WTF:::map()).

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::addRelation):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::elementsFromAttribute const):
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/SelectorFilter.cpp:
(WebCore::SelectorFilter::collectElementIdentifierHashes):
* Source/WebCore/dom/CustomElementDefaultARIA.cpp:
(WebCore::CustomElementDefaultARIA::elementsForAttribute const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::getElementsArrayAttribute const):
* Source/WebCore/dom/SpaceSplitString.h:
(WebCore::SpaceSplitStringData::begin const):
(WebCore::SpaceSplitStringData::end const):
(WebCore::SpaceSplitStringData::begin):
(WebCore::SpaceSplitStringData::end):
(WebCore::SpaceSplitStringData::tokenArrayStart const):
(WebCore::SpaceSplitString::begin const):
(WebCore::SpaceSplitString::end const):
(WebCore::SpaceSplitString::begin):
(WebCore::SpaceSplitString::end):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::sendPings):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::findDropZone):
* Source/WebCore/style/ClassChangeInvalidation.cpp:
(WebCore::Style::collectClasses):
(WebCore::Style::computeClassChanges):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::collectMatchingRules):
* Source/WebCore/style/PseudoClassChangeInvalidation.cpp:
(WebCore::Style::makePseudoClassInvalidationKeys):
* Source/WebCore/style/StyleSharingResolver.cpp:
(WebCore::Style::SharingResolver::classNamesAffectedByRules const):

Canonical link: <a href="https://commits.webkit.org/278601@main">https://commits.webkit.org/278601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29fcde51f00f5804e8312c778915d9240cde5e16

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54345 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1777 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53390 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1452 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41601 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28021 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44025 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22721 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25346 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1279 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9528 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55940 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1248 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27446 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44093 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28326 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7418 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27177 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->