### PR TITLE
Web Manifest: scope url should strip both query and fragment components

### DIFF
--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
@@ -486,6 +486,8 @@ std::optional<URL> ApplicationManifestParser::parseScope(const JSON::Object& man
         return std::nullopt;
     }
 
+    scopeURL.removeQueryAndFragmentIdentifier();
+
     return scopeURL;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp
@@ -564,6 +564,18 @@ TEST_F(ApplicationManifestParserTest, Scope)
     m_startURL = URL { "https://example.com/documents/home"_s };
     m_manifestURL = URL { "https://example.com/resources/manifest.json"_s };
 
+    // Removes query
+    testScope("\"https://example.com/documents/home?query\""_s, "https://example.com/documents/home"_s, false);
+    testScope("\"https://example.com/documents/home?query=whatever\""_s, "https://example.com/documents/home"_s, false);
+
+    // Removes fragment
+    testScope("\"https://example.com/documents/home#\""_s, "https://example.com/documents/home"_s, false);
+    testScope("\"https://example.com/documents/home#fragment\""_s, "https://example.com/documents/home"_s, false);
+
+    // Removes query and fragment
+    testScope("\"https://example.com/documents/home?#\""_s, "https://example.com/documents/home"_s, false);
+    testScope("\"https://example.com/documents/home?query#fragment\""_s, "https://example.com/documents/home"_s, false);
+
     // It's fine if the document URL or manifest URL aren't within the application scope - only the start URL needs to be.
     testScope("\"https://example.com/other\""_s, "https://example.com/other/start-url"_s, "https://example.com/other"_s, false);
 }


### PR DESCRIPTION
#### a79153bc4ac32085c182850230d395a22926a997
<pre>
Web Manifest: scope url should strip both query and fragment components
<a href="https://bugs.webkit.org/show_bug.cgi?id=273989">https://bugs.webkit.org/show_bug.cgi?id=273989</a>
<a href="https://rdar.apple.com/127863839">rdar://127863839</a>

Reviewed by Brady Eidson.

Removes the query and fragment components from the scope URL.
Part of <a href="https://github.com/w3c/manifest/pull/1122">https://github.com/w3c/manifest/pull/1122</a>

* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::ApplicationManifestParser::parseScope):
* Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp:
(TEST_F):

Canonical link: <a href="https://commits.webkit.org/278795@main">https://commits.webkit.org/278795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bfd123be2f170f2092a9dd189ca2b9ef13d116c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54703 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2129 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53739 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1809 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41881 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44357 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23006 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1616 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47659 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1696 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56295 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26555 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1577 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49279 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27795 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44417 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48460 "2 api tests failed or timed out") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11288 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28688 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27530 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->