### PR TITLE
Replace unique frame names with frame identifiers in the history controller

### DIFF
--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -71,6 +71,7 @@ HistoryItem::HistoryItem(const HistoryItem& item)
     , m_originalURLString(item.m_originalURLString)
     , m_referrer(item.m_referrer)
     , m_target(item.m_target)
+    , m_frameID(item.m_frameID)
     , m_scrollPosition(item.m_scrollPosition)
     , m_pageScaleFactor(item.m_pageScaleFactor)
     , m_children(item.m_children.map([](auto& child) { return child->copy(); }))
@@ -102,6 +103,7 @@ void HistoryItem::reset()
     m_originalURLString = String();
     m_referrer = String();
     m_target = nullAtom();
+    m_frameID = std::nullopt;
 
     m_lastVisitWasFailure = false;
     m_isTargetItem = false;
@@ -287,7 +289,7 @@ void HistoryItem::setNavigationAPIStateObject(RefPtr<SerializedScriptValue>&& ob
 
 void HistoryItem::addChildItem(Ref<HistoryItem>&& child)
 {
-    ASSERT(!childItemWithTarget(child->target()));
+    ASSERT(!child->frameID() || !childItemWithFrameID(*child->frameID()));
     m_children.append(WTFMove(child));
 }
 
@@ -310,6 +312,15 @@ HistoryItem* HistoryItem::childItemWithTarget(const AtomString& target)
     unsigned size = m_children.size();
     for (unsigned i = 0; i < size; ++i) {
         if (m_children[i]->target() == target)
+            return m_children[i].ptr();
+    }
+    return nullptr;
+}
+
+HistoryItem* HistoryItem::childItemWithFrameID(FrameIdentifier frameID)
+{
+    for (unsigned i = 0; i < m_children.size(); ++i) {
+        if (m_children[i]->frameID() == frameID)
             return m_children[i].ptr();
     }
     return nullptr;

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -28,6 +28,7 @@
 
 #include "BackForwardItemIdentifier.h"
 #include "FloatRect.h"
+#include "FrameIdentifier.h"
 #include "FrameLoaderTypes.h"
 #include "IntPoint.h"
 #include "IntRect.h"
@@ -97,6 +98,7 @@ public:
     WEBCORE_EXPORT URL originalURL() const;
     WEBCORE_EXPORT const String& referrer() const;
     WEBCORE_EXPORT const AtomString& target() const;
+    std::optional<FrameIdentifier> frameID() const { return m_frameID; }
     WEBCORE_EXPORT bool isTargetItem() const;
     
     WEBCORE_EXPORT FormData* formData();
@@ -126,6 +128,7 @@ public:
     WEBCORE_EXPORT void setOriginalURLString(const String&);
     WEBCORE_EXPORT void setReferrer(const String&);
     WEBCORE_EXPORT void setTarget(const AtomString&);
+    void setFrameID(std::optional<FrameIdentifier> frameID) { m_frameID = frameID; }
     WEBCORE_EXPORT void setIsTargetItem(bool);
     
     WEBCORE_EXPORT void setStateObject(RefPtr<SerializedScriptValue>&&);
@@ -149,6 +152,7 @@ public:
     WEBCORE_EXPORT void addChildItem(Ref<HistoryItem>&&);
     void setChildItem(Ref<HistoryItem>&&);
     WEBCORE_EXPORT HistoryItem* childItemWithTarget(const AtomString&);
+    WEBCORE_EXPORT HistoryItem* childItemWithFrameID(FrameIdentifier);
     HistoryItem* childItemWithDocumentSequenceNumber(long long number);
     WEBCORE_EXPORT const Vector<Ref<HistoryItem>>& children() const;
     void clearChildren();
@@ -227,6 +231,7 @@ private:
     String m_originalURLString;
     String m_referrer;
     AtomString m_target;
+    std::optional<FrameIdentifier> m_frameID;
     
     IntPoint m_scrollPosition;
     float m_pageScaleFactor { 0 }; // 0 indicates "unset".

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -214,10 +214,10 @@ Frame* FrameTree::child(unsigned index) const
     return result;
 }
 
-Frame* FrameTree::childByUniqueName(const AtomString& name) const
+Frame* FrameTree::childByFrameID(FrameIdentifier frameID) const
 {
     for (auto* child = firstChild(); child; child = child->tree().nextSibling()) {
-        if (child->tree().uniqueName() == name)
+        if (child->frameID() == frameID)
             return child;
     }
     return nullptr;

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "FrameIdentifier.h"
 #include <wtf/Forward.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>
@@ -72,7 +73,7 @@ public:
 
     Frame* child(unsigned index) const;
     Frame* childBySpecifiedName(const AtomString& name) const;
-    Frame* childByUniqueName(const AtomString& name) const;
+    Frame* childByFrameID(FrameIdentifier) const;
     WEBCORE_EXPORT Frame* findByUniqueName(const AtomString&, Frame& activeFrame) const;
     WEBCORE_EXPORT Frame* findBySpecifiedName(const AtomString&, Frame& activeFrame) const;
     WEBCORE_EXPORT unsigned childCount() const;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1631,10 +1631,10 @@ ExceptionOr<Vector<AtomString>> Internals::formControlStateOfPreviousHistoryItem
     HistoryItem* mainItem = frame()->history().previousItem();
     if (!mainItem)
         return Exception { ExceptionCode::InvalidAccessError };
-    auto uniqueName = frame()->tree().uniqueName();
-    if (mainItem->target() != uniqueName && !mainItem->childItemWithTarget(uniqueName))
+    auto frameID = frame()->frameID();
+    if (mainItem->frameID() != frameID && !mainItem->childItemWithFrameID(frameID))
         return Exception { ExceptionCode::InvalidAccessError };
-    return Vector<AtomString> { mainItem->target() == uniqueName ? mainItem->documentState() : mainItem->childItemWithTarget(uniqueName)->documentState() };
+    return Vector<AtomString> { mainItem->frameID() == frameID ? mainItem->documentState() : mainItem->childItemWithFrameID(frameID)->documentState() };
 }
 
 ExceptionOr<void> Internals::setFormControlStateOfPreviousHistoryItem(const Vector<AtomString>& state)
@@ -1642,10 +1642,10 @@ ExceptionOr<void> Internals::setFormControlStateOfPreviousHistoryItem(const Vect
     HistoryItem* mainItem = frame()->history().previousItem();
     if (!mainItem)
         return Exception { ExceptionCode::InvalidAccessError };
-    auto uniqueName = frame()->tree().uniqueName();
-    if (mainItem->target() == uniqueName)
+    auto frameID = frame()->frameID();
+    if (mainItem->frameID() == frameID)
         mainItem->setDocumentState(state);
-    else if (HistoryItem* subItem = mainItem->childItemWithTarget(uniqueName))
+    else if (HistoryItem* subItem = mainItem->childItemWithFrameID(frameID))
         subItem->setDocumentState(state);
     else
         return Exception { ExceptionCode::InvalidAccessError };

--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -28,6 +28,7 @@
 #include "ViewSnapshotStore.h"
 #include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/FloatRect.h>
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/SerializedScriptValue.h>
@@ -80,6 +81,7 @@ public:
     String originalURLString;
     String referrer;
     AtomString target;
+    std::optional<WebCore::FrameIdentifier> frameID;
 
     std::optional<Vector<uint8_t>> stateObjectData;
 

--- a/Source/WebKit/Shared/SessionState.serialization.in
+++ b/Source/WebKit/Shared/SessionState.serialization.in
@@ -42,6 +42,7 @@ header: "SessionState.h"
     String originalURLString;
     String referrer;
     AtomString target;
+    std::optional<WebCore::FrameIdentifier> frameID;
 
     std::optional<Vector<uint8_t>> stateObjectData;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
@@ -72,6 +72,7 @@ static FrameState toFrameState(const HistoryItem& historyItem)
     frameState.originalURLString = historyItem.originalURLString();
     frameState.referrer = historyItem.referrer();
     frameState.target = historyItem.target();
+    frameState.frameID = historyItem.frameID();
 
     frameState.setDocumentState(historyItem.documentState());
     if (RefPtr<SerializedScriptValue> stateObject = historyItem.stateObject())
@@ -141,6 +142,7 @@ static void applyFrameState(WebCore::HistoryItemClient& client, HistoryItem& his
     historyItem.setOriginalURLString(frameState.originalURLString);
     historyItem.setReferrer(frameState.referrer);
     historyItem.setTarget(frameState.target);
+    historyItem.setFrameID(frameState.frameID);
 
     historyItem.setDocumentState(frameState.documentState());
 


### PR DESCRIPTION
#### 686240cb98d8182dc675f6a2aac9abd2704984ec
<pre>
Replace unique frame names with frame identifiers in the history controller
<a href="https://bugs.webkit.org/show_bug.cgi?id=273995">https://bugs.webkit.org/show_bug.cgi?id=273995</a>
<a href="https://rdar.apple.com/127870100">rdar://127870100</a>

Reviewed by Alex Christensen.

With site isolation, unique frame names should not be used to identify frames. This patch replaces most
of their usage in the history controller with frame identifiers. We cannot remove unique frame names from
`HistoryItem` because logic in `FrameLoader::loadURLIntoChildFrame` requires us to match current frames
with frames from a previous page. Unique frame names are also still used from session state and history
test output.

This also fixes a bug introduced by 277393@main, where shifting frames after a navigation could cause
the back/forward list to target an incorrect frame.

* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::HistoryItem):
(WebCore::HistoryItem::reset):
(WebCore::HistoryItem::addChildItem):
(WebCore::HistoryItem::childItemWithFrameID):
* Source/WebCore/history/HistoryItem.h:
(WebCore::HistoryItem::frameID const):
(WebCore::HistoryItem::setFrameID):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::initializeItem):
(WebCore::HistoryController::recursiveSetProvisionalItem):
(WebCore::HistoryController::recursiveGoToItem):
* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::childByFrameID const):
(WebCore::FrameTree::childByUniqueName const): Deleted.
* Source/WebCore/page/FrameTree.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::formControlStateOfPreviousHistoryItem):
(WebCore::Internals::setFormControlStateOfPreviousHistoryItem):
* Source/WebKit/Shared/SessionState.h:
* Source/WebKit/Shared/SessionState.serialization.in:
* Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp:
(WebKit::toFrameState):
(WebKit::applyFrameState):
* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm:
(TEST(WKBackForwardList, BackForwardListRemoveAndAddSubframes)):

Canonical link: <a href="https://commits.webkit.org/278629@main">https://commits.webkit.org/278629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72595704ae167b2187e23c9e783dfb492d45c07e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30467 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54422 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1855 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1529 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44100 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/22790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25420 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1356 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56018 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26275 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1318 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/27523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44167 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28404 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7434 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/27254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->