### PR TITLE
Need to change the method for determining the number of CPUs on Linux

### DIFF
--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -730,12 +730,8 @@ sub determineNumberOfCPUs
     if (defined($ENV{NUMBER_OF_PROCESSORS})) {
         $numberOfCPUs = $ENV{NUMBER_OF_PROCESSORS};
     } elsif (isLinux()) {
-        # First try the nproc utility, if it exists. If we get no
-        # results fall back to just interpretting /proc directly.
-        chomp($numberOfCPUs = `nproc --all 2> /dev/null`);
-        if ($numberOfCPUs eq "") {
-            $numberOfCPUs = (grep /processor/, `cat /proc/cpuinfo`);
-        }
+        # Don't use nproc because it returns unreliable results, https://webkit.org/b/273675
+        $numberOfCPUs = (grep /processor/, `cat /proc/cpuinfo`);
     } elsif (isAnyWindows()) {
         # Assumes cygwin
         $numberOfCPUs = `ls /proc/registry/HKEY_LOCAL_MACHINE/HARDWARE/DESCRIPTION/System/CentralProcessor | wc -w`;


### PR DESCRIPTION
#### 48c72c6743d4584a15fe455a414c95c661c65015
<pre>
Need to change the method for determining the number of CPUs on Linux
<a href="https://bugs.webkit.org/show_bug.cgi?id=273675">https://bugs.webkit.org/show_bug.cgi?id=273675</a>

Reviewed by NOBODY (OOPS!).

nproc is unreliable, so remove it and rely on the fallback that greps
/proc/cpuinfo instead. This looks a little bit fragile (e.g. it would
fail if my AMD Ryzen &quot;Processor&quot; were instead an AMD Ryzen &quot;processor&quot;)
but surely an improvement.

* Tools/Scripts/webkitdirs.pm:
(determineNumberOfCPUs):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48c72c6743d4584a15fe455a414c95c661c65015

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3446 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54370 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1802 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1477 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41626 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28050 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22745 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25380 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1308 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9553 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/44452 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47353 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1382 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55965 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/50615 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1273 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49026 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27471 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44122 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48160 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28351 "Built successfully") | | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/59309 "Failed to checkout and rebase branch from PR 28388") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27202 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/59309 "Failed to checkout and rebase branch from PR 28388") | 
<!--EWS-Status-Bubble-End-->