### PR TITLE
[git-webkit] Add screen-reader friendly review wizard (Part 2)

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/review_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/review_unittest.py
@@ -37,12 +37,23 @@ class TestReview(testing.PathTestCase):
     from webkitscmpy.test.pull_request_unittest import TestNetworkPullRequestBitBucket, TestNetworkPullRequestGitHub
 
     @classmethod
-    def editor_callback(cls, will_print=True):
-        def callback(path, will_print=will_print):
-            if will_print:
-                with open(path, 'r') as input_file:
-                    for line in input_file.readlines():
-                        sys.stdout.write(line)
+    def editor_callback(cls, will_print=True, replace=None, insert=None):
+        def callback(path, will_print=will_print, replace=replace, insert=insert):
+            replace = replace or dict()
+            insert = insert or dict()
+
+            with open(path, 'r') as input_file:
+                lines = input_file.readlines()
+            with open(path, 'w') as output_file:
+                for pos in range(len(lines)):
+                    if will_print:
+                        sys.stdout.write(lines[pos])
+                    if pos in replace:
+                        output_file.write(replace[pos])
+                    else:
+                        output_file.write(lines[pos])
+                    if pos in insert:
+                        output_file.write(insert[pos])
 
         return callback
 
@@ -157,6 +168,303 @@ class TestReview(testing.PathTestCase):
 
         self.assertEqual(captured.stderr.getvalue(), '')
         self.assertEqual(captured.root.log.getvalue().splitlines(), [])
+
+    def test_truncate_strs(self):
+        self.assertEqual(
+            program.Review.truncate_strs(dict(keya='value a ', keyb=' value b')),
+            dict(keya=['value a'], keyb=[' value b']),
+        )
+        self.assertEqual(
+            program.Review.truncate_strs(dict(key='value ')),
+            dict(key=['value']),
+        )
+        self.assertEqual(
+            program.Review.truncate_strs(dict(nested=dict(key='value '))),
+            dict(nested=dict(key=['value'])),
+        )
+
+    def test_user_delta_github(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestGitHub.webserver() as rmt:
+            pr = remote.GitHub('https://{}'.format(rmt.remote)).pull_requests.get(1)
+
+            self.assertEqual(
+                program.Review.user_delta(pr, pr.approvers, 'Eager Reviewer'),
+                (False, [], [], 0),
+            )
+            self.assertEqual(
+                program.Review.user_delta(pr, pr.approvers, ''),
+                (False, [], [pr.generator.repository.contributors.get('Eager Reviewer')], 0),
+            )
+            self.assertEqual(
+                program.Review.user_delta(pr, pr.approvers, 'Eager Reviewer, Suspicious Reviewer'),
+                (False, [pr.generator.repository.contributors.get('Suspicious Reviewer')], [], 0),
+            )
+            self.assertEqual(
+                program.Review.user_delta(pr, pr.approvers, 'Eager Reviewer, tcontributor'),
+                (True, [], [], 0),
+            )
+
+        self.assertEqual(captured.stdout.getvalue(), '')
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), [])
+
+    def test_user_delta_bitbucket(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestBitBucket.webserver() as rmt:
+            pr = remote.BitBucket('https://{}'.format(rmt.remote)).pull_requests.get(1)
+
+            self.assertEqual(
+                program.Review.user_delta(pr, pr.approvers, 'Eager Reviewer'),
+                (False, [], [], 0),
+            )
+            self.assertEqual(
+                program.Review.user_delta(pr, pr.approvers, ''),
+                (False, [], [pr.generator.repository.contributors.get('Eager Reviewer')], 0),
+            )
+            self.assertEqual(
+                program.Review.user_delta(pr, pr.approvers, 'Eager Reviewer, Suspicious Reviewer'),
+                (False, [pr.generator.repository.contributors.get('Suspicious Reviewer')], [], 0),
+            )
+            self.assertEqual(
+                program.Review.user_delta(pr, pr.approvers, 'Eager Reviewer, tcontributor'),
+                (True, [], [], 0),
+            )
+
+        self.assertEqual(captured.stdout.getvalue(), '')
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), [])
+
+    def test_edit_metadata(self):
+        with mocks.local.Git(self.path, editor=self.editor_callback(
+            replace={0: 'Title: Replacement title\n'},
+            will_print=False,
+        )):
+            self.assertEqual(
+                program.Review.invoke_wizard(
+                    editor=program.Review.editor(local.Git(self.path)),
+                    name='pr-1234',
+                    header={
+                        'Title': 'Example Change',
+                        'Status': 'Opened',
+                    },
+                    messages=['Example Change\nhttps://bugs.webkit.org/show_bug.cgi?id=1234\n\nReviewed by NOBODY (OOPS!).\n\n* Source/file.cpp:\n'],
+                    comments=['Person <person@webkit.org>: Top-level comment'],
+                    diff=[
+                        '--- a/ChangeLog\n',
+                        '+++ b/ChangeLog\n',
+                        '@@ -1,0 +1,0 @@\n',
+                        '+Example Change\n',
+                        '+https://bugs.webkit.org/show_bug.cgi?id=1234\n',
+                        '+\n',
+                        '+Reviewed by NOBODY (OOPS!).\n',
+                        '+* Source/file.cpp:\n',
+                    ],
+                ), dict(metadata=dict(Title='Replacement title')),
+            )
+
+    def test_comment_commit_message(self):
+        with mocks.local.Git(self.path, editor=self.editor_callback(
+            insert={6: "We need a reviewer!\n"},
+            will_print=False,
+        )):
+            self.assertEqual(
+                program.Review.invoke_wizard(
+                    editor=program.Review.editor(local.Git(self.path)),
+                    name='pr-1234',
+                    header={
+                        'Title': 'Example Change',
+                        'Status': 'Opened',
+                    },
+                    messages=['Example Change\nhttps://bugs.webkit.org/show_bug.cgi?id=1234\n\nReviewed by NOBODY (OOPS!).\n\n* Source/file.cpp:\n'],
+                    comments=['Person <person@webkit.org>: Top-level comment'],
+                    diff=[
+                        '--- a/ChangeLog\n',
+                        '+++ b/ChangeLog\n',
+                        '@@ -1,0 +1,0 @@\n',
+                        '+Example Change\n',
+                        '+https://bugs.webkit.org/show_bug.cgi?id=1234\n',
+                        '+\n',
+                        '+Reviewed by NOBODY (OOPS!).\n',
+                        '+* Source/file.cpp:\n',
+                    ],
+                ), dict(comments=['> Reviewed by NOBODY (OOPS!).\n\nWe need a reviewer!']),
+            )
+
+    def test_comment(self):
+        with mocks.local.Git(self.path, editor=self.editor_callback(
+            insert={9: 'Not sure about this change\n'},
+            will_print=False,
+        )):
+            self.assertEqual(
+                program.Review.invoke_wizard(
+                    editor=program.Review.editor(local.Git(self.path)),
+                    name='pr-1234',
+                    header={
+                        'Title': 'Example Change',
+                        'Status': 'Opened',
+                    },
+                    messages=['Example Change\nhttps://bugs.webkit.org/show_bug.cgi?id=1234\n\nReviewed by NOBODY (OOPS!).\n\n* Source/file.cpp:\n'],
+                    comments=['Person <person@webkit.org>: Top-level comment'],
+                    diff=[
+                        '--- a/ChangeLog\n',
+                        '+++ b/ChangeLog\n',
+                        '@@ -1,0 +1,0 @@\n',
+                        '+Example Change\n',
+                        '+https://bugs.webkit.org/show_bug.cgi?id=1234\n',
+                        '+\n',
+                        '+Reviewed by NOBODY (OOPS!).\n',
+                        '+* Source/file.cpp:\n',
+                    ],
+                ), dict(comments=['Not sure about this change']),
+            )
+
+    def test_comment_reply(self):
+        with mocks.local.Git(self.path, editor=self.editor_callback(
+            insert={10: 'Response to top-level comment\n'},
+            will_print=False,
+        )):
+            self.assertEqual(
+                program.Review.invoke_wizard(
+                    editor=program.Review.editor(local.Git(self.path)),
+                    name='pr-1234',
+                    header={
+                        'Title': 'Example Change',
+                        'Status': 'Opened',
+                    },
+                    messages=['Example Change\nhttps://bugs.webkit.org/show_bug.cgi?id=1234\n\nReviewed by NOBODY (OOPS!).\n\n* Source/file.cpp:\n'],
+                    comments=['Person <person@webkit.org>: Top-level comment'],
+                    diff=[
+                        '--- a/ChangeLog\n',
+                        '+++ b/ChangeLog\n',
+                        '@@ -1,0 +1,0 @@\n',
+                        '+Example Change\n',
+                        '+https://bugs.webkit.org/show_bug.cgi?id=1234\n',
+                        '+\n',
+                        '+Reviewed by NOBODY (OOPS!).\n',
+                        '+* Source/file.cpp:\n',
+                    ],
+                ), dict(comments=[('Person <person@webkit.org>: Top-level comment', '> Top-level comment\nResponse to top-level comment')]),
+            )
+
+    def test_comment_reply_only_one(self):
+        with mocks.local.Git(self.path, editor=self.editor_callback(
+            insert={12: 'Response to top-level comment\n'},
+            will_print=False,
+        )):
+            self.assertEqual(
+                program.Review.invoke_wizard(
+                    editor=program.Review.editor(local.Git(self.path)),
+                    name='pr-1234',
+                    header={
+                        'Title': 'Example Change',
+                        'Status': 'Opened',
+                    },
+                    messages=['Example Change\nhttps://bugs.webkit.org/show_bug.cgi?id=1234\n\nReviewed by NOBODY (OOPS!).\n\n* Source/file.cpp:\n'],
+                    comments=[
+                        'Person <person@webkit.org>: Top-level comment 1',
+                        'Person <person@webkit.org>: Top-level comment 2',
+                    ], diff=[
+                        '--- a/ChangeLog\n',
+                        '+++ b/ChangeLog\n',
+                        '@@ -1,0 +1,0 @@\n',
+                        '+Example Change\n',
+                        '+https://bugs.webkit.org/show_bug.cgi?id=1234\n',
+                        '+\n',
+                        '+Reviewed by NOBODY (OOPS!).\n',
+                        '+* Source/file.cpp:\n',
+                    ],
+                ), dict(comments=[('Person <person@webkit.org>: Top-level comment 2', '> Top-level comment 2\nResponse to top-level comment')]),
+            )
+
+    def test_comment_reply_both(self):
+        with mocks.local.Git(self.path, editor=self.editor_callback(
+            insert={
+                10: 'Response to top-level comment 1\n',
+                12: 'Response to top-level comment 2\n',
+            }, will_print=False,
+        )):
+            self.assertEqual(
+                program.Review.invoke_wizard(
+                    editor=program.Review.editor(local.Git(self.path)),
+                    name='pr-1234',
+                    header={
+                        'Title': 'Example Change',
+                        'Status': 'Opened',
+                    },
+                    messages=['Example Change\nhttps://bugs.webkit.org/show_bug.cgi?id=1234\n\nReviewed by NOBODY (OOPS!).\n\n* Source/file.cpp:\n'],
+                    comments=[
+                        'Person <person@webkit.org>: Top-level comment 1',
+                        'Person <person@webkit.org>: Top-level comment 2',
+                    ], diff=[
+                        '--- a/ChangeLog\n',
+                        '+++ b/ChangeLog\n',
+                        '@@ -1,0 +1,0 @@\n',
+                        '+Example Change\n',
+                        '+https://bugs.webkit.org/show_bug.cgi?id=1234\n',
+                        '+\n',
+                        '+Reviewed by NOBODY (OOPS!).\n',
+                        '+* Source/file.cpp:\n',
+                    ],
+                ), dict(comments=[
+                    ('Person <person@webkit.org>: Top-level comment 1', '> Top-level comment 1\nResponse to top-level comment 1'),
+                    ('Person <person@webkit.org>: Top-level comment 2', '> Top-level comment 2\nResponse to top-level comment 2'),
+                ]),
+            )
+
+    def test_diff_file_comment(self):
+        with mocks.local.Git(self.path, editor=self.editor_callback(
+            insert={12: 'ChangeLogs are deprecated\n'},
+            will_print=False,
+        )):
+            self.assertEqual(
+                program.Review.invoke_wizard(
+                    editor=program.Review.editor(local.Git(self.path)),
+                    name='pr-1234',
+                    header={
+                        'Title': 'Example Change',
+                        'Status': 'Opened',
+                    },
+                    messages=['Example Change\nhttps://bugs.webkit.org/show_bug.cgi?id=1234\n\nReviewed by NOBODY (OOPS!).\n\n* Source/file.cpp:\n'],
+                    comments=['Person <person@webkit.org>: Top-level comment'],
+                    diff=[
+                        '--- a/ChangeLog\n',
+                        '+++ b/ChangeLog\n',
+                        '@@ -1,0 +1,0 @@\n',
+                        '+Example Change\n',
+                        '+https://bugs.webkit.org/show_bug.cgi?id=1234\n',
+                        '+\n',
+                        '+Reviewed by NOBODY (OOPS!).\n',
+                        '+* Source/file.cpp:\n',
+                    ],
+                ), dict(diff=dict(diff_comments=dict(ChangeLog={0: ['ChangeLogs are deprecated']}))),
+            )
+
+    def test_diff_inline_comment(self):
+        with mocks.local.Git(self.path, editor=self.editor_callback(
+            insert={16: 'Is this the correct bug?\n'},
+            will_print=False,
+        )):
+            self.assertEqual(
+                program.Review.invoke_wizard(
+                    editor=program.Review.editor(local.Git(self.path)),
+                    name='pr-1234',
+                    header={
+                        'Title': 'Example Change',
+                        'Status': 'Opened',
+                    },
+                    messages=['Example Change\nhttps://bugs.webkit.org/show_bug.cgi?id=1234\n\nReviewed by NOBODY (OOPS!).\n\n* Source/file.cpp:\n'],
+                    comments=['Person <person@webkit.org>: Top-level comment'],
+                    diff=[
+                        '--- a/ChangeLog\n',
+                        '+++ b/ChangeLog\n',
+                        '@@ -1,0 +1,0 @@\n',
+                        '+Example Change\n',
+                        '+https://bugs.webkit.org/show_bug.cgi?id=1234\n',
+                        '+\n',
+                        '+Reviewed by NOBODY (OOPS!).\n',
+                        '+* Source/file.cpp:\n',
+                    ],
+                ), dict(diff=dict(diff_comments=dict(ChangeLog={2: ['Is this the correct bug?']}))),
+            )
 
     def test_bitbucket_read(self):
         with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestBitBucket.webserver() as rmt, mocks.local.Git(
@@ -337,3 +645,581 @@ class TestReview(testing.PathTestCase):
         )
         self.assertEqual(captured.stderr.getvalue(), '')
         self.assertEqual(captured.root.log.getvalue().splitlines(), [])
+
+    def test_bitbucket_no_edit(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestBitBucket.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(will_print=False),
+        ):
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(1, result)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), 'No pull-request edits detected\n')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), [])
+
+    def test_github_no_edit(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestGitHub.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(will_print=False),
+        ):
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(1, result)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), 'No pull-request edits detected\n')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), [])
+
+    def test_bitbucket_approve(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestBitBucket.webserver(user='rreviewer') as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(will_print=False),
+        ), MockTerminal.input('Approve'):
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(0, result)
+
+            pr = remote.BitBucket('https://{}'.format(rmt.remote)).pull_requests.get(1)
+            self.assertEqual([p.name for p in pr.approvers], ['Eager Reviewer', 'rreviewer'])
+            self.assertEqual([p.name for p in pr.blockers], ['Suspicious Reviewer'])
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n'
+            'Would you like to approve this change? (Approve/Comment/Request changes): \n'
+            '1 change made\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), ['Posting review on pull-request...'])
+
+    def test_github_deny(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestGitHub.webserver(user='rreviewer') as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(will_print=False),
+        ), MockTerminal.input('Request changes'):
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(0, result)
+
+            pr = remote.GitHub('https://{}'.format(rmt.remote)).pull_requests.get(1)
+            self.assertEqual([p.name for p in pr.approvers], ['Eager Reviewer'])
+            self.assertEqual([p.name for p in pr.blockers], ['Suspicious Reviewer', 'Reluctant Reviewer'])
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n'
+            'Would you like to approve this change? (Approve/Comment/Request changes): \n'
+            '1 change made\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), ['Posting review on pull-request...'])
+
+    def test_bitbucket_edit_deny(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestBitBucket.webserver(user='rreviewer') as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(
+                replace={4: 'Blocked by: Suspicious Reviewer, me\n'},
+                will_print=False,
+            ),
+        ):
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(0, result)
+
+            pr = remote.BitBucket('https://{}'.format(rmt.remote)).pull_requests.get(1)
+            self.assertEqual([p.name for p in pr.approvers], ['Eager Reviewer'])
+            self.assertEqual([p.name for p in pr.blockers], ['Suspicious Reviewer', 'rreviewer'])
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n1 change made\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), ['Posting review on pull-request...'])
+
+    def test_github_edit_approve(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestGitHub.webserver(user='rreviewer') as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(
+                replace={3: 'Approved by: Eager Reviewer, rreviewer\n'},
+                will_print=False,
+            ),
+        ):
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(0, result)
+
+            pr = remote.GitHub('https://{}'.format(rmt.remote)).pull_requests.get(1)
+            self.assertEqual([p.name for p in pr.approvers], ['Eager Reviewer', 'Reluctant Reviewer'])
+            self.assertEqual([p.name for p in pr.blockers], ['Suspicious Reviewer'])
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n1 change made\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), ['Posting review on pull-request...'])
+
+    def test_bitbucket_edit_refresh(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestBitBucket.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(
+                replace={4: 'Blocked by:\n'},
+                will_print=False,
+            ),
+        ):
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(1, result)
+
+            pr = remote.BitBucket('https://{}'.format(rmt.remote)).pull_requests.get(1)
+            self.assertEqual([p.name for p in pr.approvers], ['Eager Reviewer'])
+            self.assertEqual([p.name for p in pr.blockers], ['Suspicious Reviewer'])
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n0 changes made\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), 'Failed to request Suspicious Reviewer as reviewer\n')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), [])
+
+    def test_github_edit_refresh(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestGitHub.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(
+                replace={3: 'Approved by:\n'},
+                will_print=False,
+            ),
+        ):
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(1, result)
+
+            pr = remote.GitHub('https://{}'.format(rmt.remote)).pull_requests.get(1)
+            self.assertEqual([p.name for p in pr.approvers], ['Eager Reviewer'])
+            self.assertEqual([p.name for p in pr.blockers], ['Suspicious Reviewer'])
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n0 changes made\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), 'Failed to request Eager Reviewer as reviewer\n')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), [])
+
+    def test_bitbucket_edit_comment(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestBitBucket.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(
+                insert={5: 'Not sure about this change\n'},
+                will_print=False,
+            ),
+        ):
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(0, result)
+
+            pr = remote.BitBucket('https://{}'.format(rmt.remote)).pull_requests.get(1)
+            self.assertEqual(['Not sure about this change'], [c.content for c in pr.comments])
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n1 change made\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), ['Making top-level comment on pull-request...'])
+
+    def test_github_edit_comment(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestGitHub.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(
+                insert={5: 'Not sure about this change\n'},
+                will_print=False,
+            ),
+        ):
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(0, result)
+
+            pr = remote.GitHub('https://{}'.format(rmt.remote)).pull_requests.get(1)
+            self.assertEqual(['Not sure about this change'], [c.content for c in pr.comments])
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n1 change made\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), ['Making top-level comment on pull-request...'])
+
+    def test_bitbucket_edit_comment_commit_message(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestBitBucket.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(
+                insert={9: 'We need a reviewer!\n'},
+                will_print=False,
+            ),
+        ):
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(0, result)
+
+            pr = remote.BitBucket('https://{}'.format(rmt.remote)).pull_requests.get(1)
+            self.assertEqual(['> Reviewed by NOBODY (OOPS!).\n\nWe need a reviewer!'], [c.content for c in pr.comments])
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n1 change made\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), ['Making top-level comment on pull-request...'])
+
+    def test_github_edit_comment_commit_message(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestGitHub.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(
+                insert={9: 'We need a reviewer!\n'},
+                will_print=False,
+            ),
+        ):
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(0, result)
+
+            pr = remote.GitHub('https://{}'.format(rmt.remote)).pull_requests.get(1)
+            self.assertEqual(['> Reviewed by NOBODY (OOPS!).\n\nWe need a reviewer!'], [c.content for c in pr.comments])
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n1 change made\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), ['Making top-level comment on pull-request...'])
+
+    def test_bitbucket_edit_comment_inline_diff(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestBitBucket.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(
+                insert={19: 'We need a reviewer!\n'},
+                will_print=False,
+            ),
+        ):
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(0, result)
+
+            pr = remote.BitBucket('https://{}'.format(rmt.remote)).pull_requests.get(1)
+            self.assertEqual([
+                '--- a/ChangeLog',
+                '+++ b/ChangeLog',
+                '@@ -1,0 +1,0 @@',
+                '+Example Change',
+                '+https://bugs.webkit.org/show_bug.cgi?id=1234',
+                '+',
+                '+Reviewed by NOBODY (OOPS!).',
+                '>>>>',
+                'Tim Committer <committer@webkit.org>: We need a reviewer!',
+                '<<<<',
+                '+* Source/file.cpp:',
+            ], list(pr.diff(comments=True)))
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n1 change made\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), ['Posting review on pull-request...'])
+
+    def test_github_edit_comment_inline_diff(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestGitHub.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(
+                insert={20: 'We need a reviewer!\n'},
+                will_print=False,
+            ),
+        ):
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(0, result)
+
+            pr = remote.GitHub('https://{}'.format(rmt.remote)).pull_requests.get(1)
+            self.assertEqual([
+                'diff --git a/ChangeLog b/ChangeLog',
+                '--- a/ChangeLog',
+                '+++ b/ChangeLog',
+                '@@ -1,0 +1,0 @@',
+                '+Example Change',
+                '+https://bugs.webkit.org/show_bug.cgi?id=1234',
+                '+',
+                '+Reviewed by NOBODY (OOPS!).',
+                '>>>>',
+                'tcontributor <?>: We need a reviewer!',
+                '<<<<',
+                '+* Source/file.cpp:',
+            ], list(pr.diff(comments=True)))
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n1 change made\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), ['Posting review on pull-request...'])
+
+    def test_bitbucket_edit_title(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestBitBucket.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(
+                replace={0: 'Title: New Title\n'},
+                will_print=False,
+            ),
+        ):
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(0, result)
+
+            pr = remote.BitBucket('https://{}'.format(rmt.remote)).pull_requests.get(1)
+            self.assertEqual(pr.title, 'New Title')
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n1 change made\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), ['Setting title of pull-request...'])
+
+    def test_github_edit_title(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestGitHub.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(
+                replace={0: 'Title: New Title\n'},
+                will_print=False,
+            ),
+        ):
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(0, result)
+
+            pr = remote.GitHub('https://{}'.format(rmt.remote)).pull_requests.get(1)
+            self.assertEqual(pr.title, 'New Title')
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n1 change made\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), ['Setting title of pull-request...'])
+
+    def test_bitbucket_edit_open(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestBitBucket.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(
+                replace={1: 'Status: Open\n'},
+                will_print=False,
+            ),
+        ):
+            remote.BitBucket('https://{}'.format(rmt.remote)).pull_requests.get(1).close()
+
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(0, result)
+
+            pr = remote.BitBucket('https://{}'.format(rmt.remote)).pull_requests.get(1)
+            self.assertTrue(pr.opened)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n1 change made\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), ['Opening pull-request...'])
+
+    def test_github_edit_close(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestGitHub.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(
+                replace={1: 'Status: Close\n'},
+                will_print=False,
+            ),
+        ):
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(0, result)
+
+            pr = remote.GitHub('https://{}'.format(rmt.remote)).pull_requests.get(1)
+            self.assertFalse(pr.opened)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n1 change made\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), ['Closing pull-request...'])
+
+    def test_bitbucket_edit_merged_close(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestBitBucket.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(
+                replace={1: 'Status: Close\n'},
+                will_print=False,
+            ),
+        ):
+            rmt.pull_requests[0]['state'] = 'MERGED'
+            rmt.pull_requests[0]['open'] = False
+            rmt.pull_requests[0]['closed'] = True
+
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(1, result)
+
+            pr = remote.BitBucket('https://{}'.format(rmt.remote)).pull_requests.get(1)
+            self.assertFalse(pr.opened)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n0 changes made\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), "Cannot change pull-request status to 'Close'\n")
+        self.assertEqual(captured.root.log.getvalue().splitlines(), [])
+
+    def test_github_edit_merged_open(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestGitHub.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(
+                replace={1: 'Status: Open\n'},
+                will_print=False,
+            ),
+        ):
+            rmt.pull_requests[0]['state'] = 'closed'
+            rmt.pull_requests[0]['merged'] = True
+
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(1, result)
+
+            pr = remote.GitHub('https://{}'.format(rmt.remote)).pull_requests.get(1)
+            self.assertFalse(pr.opened)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n0 changes made\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), "Cannot change pull-request status to 'Open'\n")
+        self.assertEqual(captured.root.log.getvalue().splitlines(), [])
+
+    def test_bitbucket_add_labels(self):
+        self.maxDiff = None
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestBitBucket.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(
+                insert={4: 'Labels: example\n'},
+                will_print=False,
+            ),
+        ):
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(1, result)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n0 changes made\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), "Cannot modify the 'Labels' key on this pull-request\n")
+        self.assertEqual(captured.root.log.getvalue().splitlines(), [])
+
+    def test_github_edit_labels(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestGitHub.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(
+                replace={5: 'Labels: bug and wontfix\n'},
+                will_print=False,
+            ),
+        ):
+            github.Tracker('https://{}'.format(rmt.remote)).issue(1).set_labels(['bug', 'good first issue'])
+
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(0, result)
+
+            self.assertEqual(['bug', 'wontfix'], github.Tracker('https://{}'.format(rmt.remote)).issue(1).labels)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n1 change made\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.root.log.getvalue().splitlines(), ['Setting labels on pull-request...'])
+
+    def test_github_edit_invalid_labels(self):
+        with OutputCapture(level=logging.INFO) as captured, self.TestNetworkPullRequestGitHub.webserver() as rmt, mocks.local.Git(
+            self.path, remote='https://{}'.format(rmt.remote),
+            editor=self.editor_callback(
+                replace={5: 'Labels: invalid-label\n'},
+                will_print=False,
+            ),
+        ):
+            github.Tracker('https://{}'.format(rmt.remote)).issue(1).set_labels(['bug', 'good first issue'])
+
+            result = program.main(
+                args=('review', '1', '-v'),
+                path=self.path,
+            )
+            self.assertEqual(1, result)
+
+            self.assertEqual(['bug', 'good first issue'], github.Tracker('https://{}'.format(rmt.remote)).issue(1).labels)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Waiting for user to modify textual pull-request...\n0 changes made\n',
+        )
+        self.assertEqual(captured.stderr.getvalue(), "'invalid-label' is not a label for 'https://github.example.com/WebKit/WebKit'\n")
+        self.assertEqual(captured.root.log.getvalue().splitlines(), ['Setting labels on pull-request...'])


### PR DESCRIPTION
#### 74313d0521aae7fbcd8c8a287b92f924f34ce34c
<pre>
[git-webkit] Add screen-reader friendly review wizard (Part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=261242">https://bugs.webkit.org/show_bug.cgi?id=261242</a>
<a href="https://rdar.apple.com/115083100">rdar://115083100</a>

Reviewed by Andres Gonzalez and Elliott Williams.

Allow user to review and comment on a pull request by editing a local file.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/review.py:
(Review.truncate_strs): Turn a nested dictionary of strings into a nested dictionary
of lists of string based on where newline are in strings.
(Review.user_delta): Detect which users have been added or removed from a list of users.
(Review.invoke_wizard): Diff the original file with a user&apos;s local edits and return those
local edits to be converted into actions on a pull request.
(Review.main): Given the difference returned by invoke_wizard, programatically add comments,
change pull request metadata and approve (or reject) the pull request.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/review_unittest.py:
(TestReview.editor_callback):
(TestReview.editor_callback.callback):
(TestReview.test_truncate_strs):
(TestReview.test_user_delta_github):
(TestReview.test_user_delta_bitbucket):
(TestReview.test_edit_metadata):
(TestReview.test_comment_commit_message):
(TestReview.test_comment):
(TestReview.test_comment_reply):
(TestReview.test_comment_reply_only_one):
(TestReview.test_comment_reply_both):
(TestReview.test_diff_file_comment):
(TestReview.test_diff_inline_comment):
(TestReview.test_github_read_comments):
(TestReview.test_bitbucket_no_edit):
(TestReview.test_github_no_edit):
(TestReview.test_bitbucket_approve):
(TestReview.test_github_deny):
(TestReview.test_bitbucket_edit_deny):
(TestReview.test_github_edit_approve):
(TestReview.test_bitbucket_edit_refresh):
(TestReview.test_github_edit_refresh):
(TestReview.test_bitbucket_edit_comment):
(TestReview.test_github_edit_comment):
(TestReview.test_bitbucket_edit_comment_commit_message):
(TestReview.test_github_edit_comment_commit_message):
(TestReview.test_bitbucket_edit_comment_inline_diff):
(TestReview.test_github_edit_comment_inline_diff):
(TestReview.test_bitbucket_edit_title):
(TestReview.test_github_edit_title):
(TestReview.test_bitbucket_edit_open):
(TestReview.test_github_edit_close):
(TestReview.test_bitbucket_edit_merged_close):
(TestReview.test_github_edit_merged_open):
(TestReview.test_bitbucket_add_labels):
(TestReview.test_github_edit_labels):
(TestReview.test_github_edit_invalid_labels):

Canonical link: <a href="https://commits.webkit.org/279255@main">https://commits.webkit.org/279255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d8839c1a3c3b76e148d5d561889f2f149939a7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56198 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3642 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55224 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3367 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/2344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29962 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24049 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/52763 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2998 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1801 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57791 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28060 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3120 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/52926 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45895 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7775 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29034 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->