### PR TITLE
[Navigation] Make NavigationHistoryEntry getters check for fully active document

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entry-after-detach-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entry-after-detach-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL NavigationHistoryEntry properties after detach assert_equals: expected (object) null but got (string) "http://localhost:8800/common/blank.html"
+PASS NavigationHistoryEntry properties after detach
 

--- a/Source/WebCore/page/NavigationHistoryEntry.cpp
+++ b/Source/WebCore/page/NavigationHistoryEntry.cpp
@@ -68,10 +68,34 @@ enum EventTargetInterfaceType NavigationHistoryEntry::eventTargetInterface() con
     return EventTargetInterfaceType::NavigationHistoryEntry;
 }
 
+const String& NavigationHistoryEntry::url() const
+{
+    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
+    if (!document || !document->isFullyActive())
+        return nullString();
+    return m_url.string();
+}
+
+String NavigationHistoryEntry::key() const
+{
+    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
+    if (!document || !document->isFullyActive())
+        return nullString();
+    return m_key.toString();
+}
+
+String NavigationHistoryEntry::id() const
+{
+    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
+    if (!document || !document->isFullyActive())
+        return nullString();
+    return m_id.toString();
+}
+
 uint64_t NavigationHistoryEntry::index() const
 {
     RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
-    if (!document || !document->domWindow())
+    if (!document || !document->isFullyActive())
         return -1;
     return document->domWindow()->navigation().entries().findIf([this] (auto& entry) {
         return entry.ptr() == this;
@@ -81,10 +105,10 @@ uint64_t NavigationHistoryEntry::index() const
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationhistoryentry-samedocument
 bool NavigationHistoryEntry::sameDocument() const
 {
-    if (!m_documentSequenceNumber)
-        return false;
     RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
-    if (!document || !document->frame())
+    if (!document || !document->isFullyActive())
+        return false;
+    if (!m_documentSequenceNumber)
         return false;
     RefPtr currentItem = document->frame()->checkedHistory()->currentItem();
     if (!currentItem)
@@ -94,6 +118,10 @@ bool NavigationHistoryEntry::sameDocument() const
 
 JSC::JSValue NavigationHistoryEntry::getState(JSDOMGlobalObject& globalObject) const
 {
+    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
+    if (!document || !document->isFullyActive())
+        return JSC::jsUndefined();
+
     if (!m_associatedHistoryItem)
         return JSC::jsUndefined();
 

--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -49,9 +49,9 @@ public:
     static Ref<NavigationHistoryEntry> create(ScriptExecutionContext* context, Ref<HistoryItem>& historyItem) { return adoptRef(*new NavigationHistoryEntry(context, historyItem)); }
     static Ref<NavigationHistoryEntry> create(ScriptExecutionContext* context, const URL& url) { return adoptRef(*new NavigationHistoryEntry(context, url)); }
 
-    const String& url() const { return m_url.string(); };
-    String key() const { return m_key.toString(); };
-    String id() const { return m_id.toString(); };
+    const String& url() const;
+    String key() const;
+    String id() const;
     uint64_t index() const;
     bool sameDocument() const;
     JSC::JSValue getState(JSDOMGlobalObject&) const;


### PR DESCRIPTION
#### 9142a5f4e9ee7abc53ce1c77e2979f0065b46e1d
<pre>
[Navigation] Make NavigationHistoryEntry getters check for fully active document
<a href="https://bugs.webkit.org/show_bug.cgi?id=274000">https://bugs.webkit.org/show_bug.cgi?id=274000</a>

Reviewed by Alex Christensen.

Make NavigationHistoryEntry getters check for fully active document [see 1, 2 etc.].

[1] <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationhistoryentry-url">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationhistoryentry-url</a>
[2] <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-navigationhistoryentry-key">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-navigationhistoryentry-key</a>

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entry-after-detach-expected.txt:
* Source/WebCore/page/NavigationHistoryEntry.cpp:
(WebCore::NavigationHistoryEntry::url const):
(WebCore::NavigationHistoryEntry::key const):
(WebCore::NavigationHistoryEntry::id const):
(WebCore::NavigationHistoryEntry::index const):
(WebCore::NavigationHistoryEntry::sameDocument const):
(WebCore::NavigationHistoryEntry::getState const):
* Source/WebCore/page/NavigationHistoryEntry.h:

Canonical link: <a href="https://commits.webkit.org/278770@main">https://commits.webkit.org/278770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5f57a798923a21c087295d65b8687fee0679b93

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30421 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54376 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1809 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53422 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1483 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41634 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28082 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44059 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22750 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25407 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1314 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9559 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47387 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1387 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55972 "Build is being retried. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26229 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1281 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49232 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44126 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48403 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11270 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28358 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27208 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->