### PR TITLE
Support late resolution of symbols in CSS calc

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -878,7 +878,10 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/StyleSheetContents.h
     css/StyleSheetList.h
 
+    css/calc/CSSCalcSymbolsAllowed.h
     css/calc/CSSCalcValue.h
+
+    css/color/CSSColorDescriptors.h
 
     css/parser/CSSParser.h
     css/parser/CSSParserContext.h
@@ -886,6 +889,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/parser/CSSParserMode.h
     css/parser/CSSParserToken.h
     css/parser/CSSParserTokenRange.h
+    css/parser/CSSPropertyParserConsumer+Primitives.h
+    css/parser/CSSPropertyParserConsumer+RawTypes.h
+    css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.h
     css/parser/CSSSelectorParser.h
     css/parser/CSSSelectorParserContext.h
     css/parser/MutableCSSSelector.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -957,6 +957,8 @@ css/calc/CSSCalcInvertNode.cpp
 css/calc/CSSCalcNegateNode.cpp
 css/calc/CSSCalcOperationNode.cpp
 css/calc/CSSCalcPrimitiveValueNode.cpp
+css/calc/CSSCalcSymbolNode.cpp
+css/calc/CSSCalcSymbolsAllowed.cpp
 css/calc/CSSCalcSymbolTable.cpp
 css/calc/CSSCalcValue.cpp
 css/color/CSSResolvedColorMix.cpp
@@ -986,9 +988,11 @@ css/parser/CSSPropertyParserConsumer+Number.cpp
 css/parser/CSSPropertyParserConsumer+Percent.cpp
 css/parser/CSSPropertyParserConsumer+Primitives.cpp
 css/parser/CSSPropertyParserConsumer+RawResolver.cpp
+css/parser/CSSPropertyParserConsumer+RawTypes.cpp
 css/parser/CSSPropertyParserConsumer+Resolution.cpp
 css/parser/CSSPropertyParserConsumer+Symbol.cpp
 css/parser/CSSPropertyParserConsumer+Time.cpp
+css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.cpp
 css/parser/CSSPropertyParserHelpers.cpp
 css/parser/CSSPropertyParserWorkerSafe.cpp
 css/parser/CSSSelectorParser.cpp

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "CSSPrimitiveValue.h"
 
+#include "CSSCalcSymbolTable.h"
 #include "CSSCalcValue.h"
 #include "CSSHelper.h"
 #include "CSSMarkup.h"
@@ -1084,13 +1085,13 @@ double CSSPrimitiveValue::doubleValue(CSSUnitType unitType) const
 
 double CSSPrimitiveValue::doubleValue() const
 {
-    return isCalculated() ? m_value.calc->doubleValue() : m_value.number;
+    return isCalculated() ? m_value.calc->doubleValue({ }) : m_value.number;
 }
 
 double CSSPrimitiveValue::doubleValueDividingBy100IfPercentage() const
 {
     if (isCalculated())
-        return m_value.calc->primitiveType() == CSSUnitType::CSS_PERCENTAGE ? m_value.calc->doubleValue() / 100.0 : m_value.calc->doubleValue();
+        return m_value.calc->primitiveType() == CSSUnitType::CSS_PERCENTAGE ? m_value.calc->doubleValue({ }) / 100.0 : m_value.calc->doubleValue({ });
     if (isPercentage())
         return m_value.number / 100.0;
     return m_value.number;

--- a/Source/WebCore/css/calc/CSSCalcExpressionNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcExpressionNode.cpp
@@ -31,6 +31,8 @@
 
 namespace WebCore {
 
+CSSCalcExpressionNode::~CSSCalcExpressionNode() = default;
+
 TextStream& operator<<(TextStream& ts, const CSSCalcExpressionNode& node)
 {
     node.dump(ts);

--- a/Source/WebCore/css/calc/CSSCalcExpressionNode.h
+++ b/Source/WebCore/css/calc/CSSCalcExpressionNode.h
@@ -33,6 +33,7 @@
 
 namespace WebCore {
 
+class CSSCalcSymbolTable;
 class CSSToLengthConversionData;
 class CalcExpressionNode;
 
@@ -49,12 +50,15 @@ public:
         CssCalcOperation,
         CssCalcNegate,
         CssCalcInvert,
+        CssCalcSymbol,
     };
 
-    virtual ~CSSCalcExpressionNode() = default;
+    virtual ~CSSCalcExpressionNode();
+
+    virtual bool isResolvable() const = 0;
     virtual bool isZero() const = 0;
     virtual std::unique_ptr<CalcExpressionNode> createCalcExpression(const CSSToLengthConversionData&) const = 0;
-    virtual double doubleValue(CSSUnitType) const = 0;
+    virtual double doubleValue(CSSUnitType, const CSSCalcSymbolTable&) const = 0;
     virtual double computeLengthPx(const CSSToLengthConversionData&) const = 0;
     virtual bool equals(const CSSCalcExpressionNode& other) const { return m_category == other.m_category; }
     virtual Type type() const = 0;

--- a/Source/WebCore/css/calc/CSSCalcExpressionNodeParser.h
+++ b/Source/WebCore/css/calc/CSSCalcExpressionNodeParser.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CSSCalcSymbolsAllowed.h"
 #include "CSSValueKeywords.h"
 #include "CalcOperator.h"
 #include "CalculationCategory.h"
@@ -33,15 +34,14 @@
 namespace WebCore {
 
 class CSSCalcExpressionNode;
-class CSSCalcSymbolTable;
 class CSSParserToken;
 class CSSParserTokenRange;
 
 class CSSCalcExpressionNodeParser {
 public:
-    explicit CSSCalcExpressionNodeParser(CalculationCategory destinationCategory, const CSSCalcSymbolTable& symbolTable)
+    explicit CSSCalcExpressionNodeParser(CalculationCategory destinationCategory, CSSCalcSymbolsAllowed symbolsAllowed)
         : m_destinationCategory(destinationCategory)
-        , m_symbolTable(symbolTable)
+        , m_symbolsAllowed(WTFMove(symbolsAllowed))
     {
     }
 
@@ -57,7 +57,7 @@ private:
     bool parseCalcValue(CSSParserTokenRange&, CSSValueID, int depth, RefPtr<CSSCalcExpressionNode>&);
 
     CalculationCategory m_destinationCategory;
-    SingleThreadWeakRef<const CSSCalcSymbolTable> m_symbolTable;
+    CSSCalcSymbolsAllowed m_symbolsAllowed;
 };
 
 }

--- a/Source/WebCore/css/calc/CSSCalcInvertNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcInvertNode.cpp
@@ -31,15 +31,20 @@
 
 namespace WebCore {
 
+bool CSSCalcInvertNode::isResolvable() const
+{
+    return protectedChild()->isResolvable();
+}
+
 std::unique_ptr<CalcExpressionNode> CSSCalcInvertNode::createCalcExpression(const CSSToLengthConversionData& conversionData) const
 {
     auto childNode = protectedChild()->createCalcExpression(conversionData);
     return makeUnique<CalcExpressionInversion>(WTFMove(childNode));
 }
 
-double CSSCalcInvertNode::doubleValue(CSSUnitType unitType) const
+double CSSCalcInvertNode::doubleValue(CSSUnitType unitType, const CSSCalcSymbolTable& symbolTable) const
 {
-    auto childValue = protectedChild()->doubleValue(unitType);
+    auto childValue = protectedChild()->doubleValue(unitType, symbolTable);
     if (!childValue)
         return std::numeric_limits<double>::infinity();
     return 1.0 / childValue;

--- a/Source/WebCore/css/calc/CSSCalcInvertNode.h
+++ b/Source/WebCore/css/calc/CSSCalcInvertNode.h
@@ -51,8 +51,9 @@ private:
 
     std::unique_ptr<CalcExpressionNode> createCalcExpression(const CSSToLengthConversionData&) const final;
 
+    bool isResolvable() const final;
     bool isZero() const final { return m_child->isZero(); }
-    double doubleValue(CSSUnitType) const final;
+    double doubleValue(CSSUnitType, const CSSCalcSymbolTable&) const final;
     double computeLengthPx(const CSSToLengthConversionData&) const final;
     Type type() const final { return Type::CssCalcInvert; }
     CSSUnitType primitiveType() const final { return m_child->primitiveType(); }

--- a/Source/WebCore/css/calc/CSSCalcNegateNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcNegateNode.cpp
@@ -31,10 +31,20 @@
 
 namespace WebCore {
 
+bool CSSCalcNegateNode::isResolvable() const
+{
+    return protectedChild()->isResolvable();
+}
+
 std::unique_ptr<CalcExpressionNode> CSSCalcNegateNode::createCalcExpression(const CSSToLengthConversionData& conversionData) const
 {
     auto childNode = protectedChild()->createCalcExpression(conversionData);
     return makeUnique<CalcExpressionNegation>(WTFMove(childNode));
+}
+
+double CSSCalcNegateNode::doubleValue(CSSUnitType unitType, const CSSCalcSymbolTable& symbolTable) const
+{
+    return -m_child->doubleValue(unitType, symbolTable);
 }
 
 void CSSCalcNegateNode::dump(TextStream& ts) const

--- a/Source/WebCore/css/calc/CSSCalcNegateNode.h
+++ b/Source/WebCore/css/calc/CSSCalcNegateNode.h
@@ -51,8 +51,9 @@ private:
 
     std::unique_ptr<CalcExpressionNode> createCalcExpression(const CSSToLengthConversionData&) const final;
 
+    bool isResolvable() const final;
     bool isZero() const final { return m_child->isZero(); }
-    double doubleValue(CSSUnitType unitType) const final { return -m_child->doubleValue(unitType); }
+    double doubleValue(CSSUnitType, const CSSCalcSymbolTable&) const final;
     double computeLengthPx(const CSSToLengthConversionData& conversionData) const final { return -m_child->computeLengthPx(conversionData); }
     Type type() const final { return Type::CssCalcNegate; }
     CSSUnitType primitiveType() const final { return m_child->primitiveType(); }

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.h
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.h
@@ -114,17 +114,14 @@ private:
 
     Type type() const final { return CssCalcOperation; }
 
-    bool isZero() const final
-    {
-        return !doubleValue(primitiveType());
-    }
-
+    bool isResolvable() const final;
+    bool isZero() const final;
     bool equals(const CSSCalcExpressionNode&) const final;
 
     std::unique_ptr<CalcExpressionNode> createCalcExpression(const CSSToLengthConversionData&) const final;
 
     CSSUnitType primitiveType() const final;
-    double doubleValue(CSSUnitType) const final;
+    double doubleValue(CSSUnitType, const CSSCalcSymbolTable&) const final;
     double computeLengthPx(const CSSToLengthConversionData&) const final;
 
     void collectComputedStyleDependencies(ComputedStyleDependencies&) const final;

--- a/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp
@@ -103,13 +103,13 @@ void CSSCalcPrimitiveValueNode::add(const CSSCalcPrimitiveValueNode& node, UnitC
         break;
     case UnitConversion::Preserve:
         ASSERT(node.primitiveType() == valueType);
-        m_value = CSSPrimitiveValue::create(value->doubleValue() + node.doubleValue(valueType), valueType);
+        m_value = CSSPrimitiveValue::create(value->doubleValue() + node.doubleValue(valueType, { }), valueType);
         break;
     case UnitConversion::Canonicalize: {
         auto canonicalType = canonicalUnitTypeForUnitType(valueType);
         ASSERT(canonicalType != CSSUnitType::CSS_UNKNOWN);
         double leftValue = value->doubleValue(canonicalType);
-        double rightValue = node.doubleValue(canonicalType);
+        double rightValue = node.doubleValue(canonicalType, { });
         m_value = CSSPrimitiveValue::create(leftValue + rightValue, canonicalType);
         break;
     }
@@ -172,7 +172,7 @@ std::unique_ptr<CalcExpressionNode> CSSCalcPrimitiveValueNode::createCalcExpress
     return nullptr;
 }
 
-double CSSCalcPrimitiveValueNode::doubleValue(CSSUnitType unitType) const
+double CSSCalcPrimitiveValueNode::doubleValue(CSSUnitType unitType, const CSSCalcSymbolTable&) const
 {
     if (hasDoubleValue(unitType)) {
         Ref value = m_value;
@@ -213,6 +213,11 @@ double CSSCalcPrimitiveValueNode::computeLengthPx(const CSSToLengthConversionDat
 void CSSCalcPrimitiveValueNode::collectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const
 {
     protectedValue()->collectComputedStyleDependencies(dependencies);
+}
+
+bool CSSCalcPrimitiveValueNode::isResolvable() const
+{
+    return true;
 }
 
 bool CSSCalcPrimitiveValueNode::isZero() const

--- a/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.h
+++ b/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.h
@@ -65,9 +65,10 @@ public:
     const CSSPrimitiveValue& value() const { return m_value.get(); }
     Ref<CSSPrimitiveValue> protectedValue() const { return m_value; }
 
-    double doubleValue(CSSUnitType) const final;
+    double doubleValue(CSSUnitType, const CSSCalcSymbolTable&) const final;
 
 private:
+    bool isResolvable() const final;
     bool isZero() const final;
     bool equals(const CSSCalcExpressionNode& other) const final;
     Type type() const final { return CssCalcPrimitiveValue; }

--- a/Source/WebCore/css/calc/CSSCalcSymbolNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcSymbolNode.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSCalcSymbolNode.h"
+
+#include "CSSCalcSymbolTable.h"
+#include "CSSValueKeywords.h"
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+Ref<CSSCalcSymbolNode> CSSCalcSymbolNode::create(CSSValueID symbol, CSSUnitType unitType)
+{
+    return adoptRef(*new CSSCalcSymbolNode(symbol, unitType));
+}
+
+CSSCalcSymbolNode::CSSCalcSymbolNode(CSSValueID symbol, CSSUnitType unitType)
+    : CSSCalcExpressionNode(calcUnitCategory(unitType))
+    , m_symbol(symbol)
+    , m_unitType(unitType)
+{
+}
+
+bool CSSCalcSymbolNode::isResolvable() const
+{
+    return false;
+}
+
+bool CSSCalcSymbolNode::isZero() const
+{
+    return false;
+}
+
+std::unique_ptr<CalcExpressionNode> CSSCalcSymbolNode::createCalcExpression(const CSSToLengthConversionData&) const
+{
+    // CSSCalcSymbolNode does not support conversion to CalcExpression and there are currently
+    // no specifications that require it.
+    ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+double CSSCalcSymbolNode::doubleValue(CSSUnitType, const CSSCalcSymbolTable& symbolTable) const
+{
+    // The symbol table should only lack the value in the case of programmer error.
+    auto result = symbolTable.get(m_symbol);
+    ASSERT(result);
+    return result->value;
+}
+
+double CSSCalcSymbolNode::computeLengthPx(const CSSToLengthConversionData&) const
+{
+    // CSSCalcSymbolNode does not support length computation and there are currently
+    // no specifications that require it.
+    ASSERT_NOT_REACHED();
+    return 0;
+}
+
+bool CSSCalcSymbolNode::equals(const CSSCalcExpressionNode& other) const
+{
+    if (type() != other.type())
+        return false;
+
+    return m_symbol == static_cast<const CSSCalcSymbolNode&>(other).m_symbol
+        && m_unitType == static_cast<const CSSCalcSymbolNode&>(other).m_unitType;
+}
+
+CSSCalcExpressionNode::Type CSSCalcSymbolNode::type() const
+{
+    return Type::CssCalcSymbol;
+}
+
+CSSUnitType CSSCalcSymbolNode::primitiveType() const
+{
+    return m_unitType;
+}
+
+void CSSCalcSymbolNode::collectComputedStyleDependencies(ComputedStyleDependencies&) const
+{
+}
+
+void CSSCalcSymbolNode::dump(TextStream& ts) const
+{
+    ts << "symbol['" << nameLiteral(m_symbol) << "'] (category: " << category() << ", type: " << primitiveType() << ")";
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/calc/CSSCalcSymbolNode.h
+++ b/Source/WebCore/css/calc/CSSCalcSymbolNode.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSCalcExpressionNode.h"
+
+namespace WebCore {
+
+class CSSCalcSymbolNode final : public CSSCalcExpressionNode {
+public:
+    static Ref<CSSCalcSymbolNode> create(CSSValueID, CSSUnitType);
+
+private:
+    CSSCalcSymbolNode(CSSValueID, CSSUnitType);
+
+    // CSSCalcExpressionNode overrides
+    bool isResolvable() const final;
+    bool isZero() const final;
+    std::unique_ptr<CalcExpressionNode> createCalcExpression(const CSSToLengthConversionData&) const final;
+    double doubleValue(CSSUnitType, const CSSCalcSymbolTable&) const final;
+    double computeLengthPx(const CSSToLengthConversionData&) const final;
+    bool equals(const CSSCalcExpressionNode&) const final;
+    Type type() const final;
+    CSSUnitType primitiveType() const final;
+    void collectComputedStyleDependencies(ComputedStyleDependencies&) const final;
+    void dump(TextStream&) const final;
+
+    CSSValueID m_symbol;
+    CSSUnitType m_unitType;
+};
+
+}
+
+SPECIALIZE_TYPE_TRAITS_CSSCALCEXPRESSION_NODE(CSSCalcSymbolNode, type() == WebCore::CSSCalcExpressionNode::Type::CssCalcSymbol)

--- a/Source/WebCore/css/calc/CSSCalcSymbolTable.cpp
+++ b/Source/WebCore/css/calc/CSSCalcSymbolTable.cpp
@@ -50,4 +50,4 @@ bool CSSCalcSymbolTable::contains(CSSValueID valueID) const
     return m_table.contains(valueID);
 }
 
-}
+} // namespace WebCore

--- a/Source/WebCore/css/calc/CSSCalcSymbolTable.h
+++ b/Source/WebCore/css/calc/CSSCalcSymbolTable.h
@@ -28,22 +28,12 @@
 #include "CSSValueKeywords.h"
 #include <optional>
 #include <wtf/HashMap.h>
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class CSSCalcSymbolTable;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CSSCalcSymbolTable> : std::true_type { };
-}
 
 namespace WebCore {
 
 enum class CSSUnitType : uint8_t;
 
-class CSSCalcSymbolTable : public CanMakeSingleThreadWeakPtr<CSSCalcSymbolTable> {
+class CSSCalcSymbolTable {
 public:
     struct Value {
         CSSUnitType type;
@@ -60,4 +50,4 @@ private:
     HashMap<CSSValueID, std::pair<CSSUnitType, double>> m_table;
 };
 
-};
+}

--- a/Source/WebCore/css/calc/CSSCalcSymbolsAllowed.cpp
+++ b/Source/WebCore/css/calc/CSSCalcSymbolsAllowed.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSCalcSymbolsAllowed.h"
+
+#include "CSSUnits.h"
+
+namespace WebCore {
+
+CSSCalcSymbolsAllowed::CSSCalcSymbolsAllowed(std::initializer_list<std::tuple<CSSValueID, CSSUnitType>> initializer)
+{
+    for (auto& [identifier, type] : initializer)
+        m_table.add(identifier, type);
+}
+
+std::optional<CSSUnitType> CSSCalcSymbolsAllowed::get(CSSValueID valueID) const
+{
+    return m_table.getOptional(valueID);
+}
+
+bool CSSCalcSymbolsAllowed::contains(CSSValueID valueID) const
+{
+    return m_table.contains(valueID);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/calc/CSSCalcSymbolsAllowed.h
+++ b/Source/WebCore/css/calc/CSSCalcSymbolsAllowed.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSValueKeywords.h"
+#include <optional>
+#include <wtf/HashMap.h>
+
+namespace WebCore {
+
+enum class CSSUnitType : uint8_t;
+
+class CSSCalcSymbolsAllowed {
+public:
+    CSSCalcSymbolsAllowed() = default;
+    CSSCalcSymbolsAllowed(std::initializer_list<std::tuple<CSSValueID, CSSUnitType>>);
+
+    CSSCalcSymbolsAllowed& operator=(const CSSCalcSymbolsAllowed&) = default;
+    CSSCalcSymbolsAllowed(const CSSCalcSymbolsAllowed&) = default;
+    CSSCalcSymbolsAllowed& operator=(CSSCalcSymbolsAllowed&&) = default;
+    CSSCalcSymbolsAllowed(CSSCalcSymbolsAllowed&&) = default;
+
+    std::optional<CSSUnitType> get(CSSValueID) const;
+    bool contains(CSSValueID) const;
+
+private:
+    // FIXME: A HashMap here is not ideal, as these tables are always constant expressions
+    // and always quite small (currently always 4, but in the future will include one that
+    // is 5 elements, hard coding a size of 4 would be unfortunate. A more ideal solution
+    // would be to have this be a SortedArrayMap, but it currently has the restriction that
+    // that both the type and size of the storage is fixed. I can probably be updated to
+    // use the size only at construction and store store a std::span instead (or a variant
+    // version could be made).
+
+    HashMap<CSSValueID, CSSUnitType> m_table;
+};
+
+}

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -348,9 +348,9 @@ inline double CSSCalcValue::clampToPermittedRange(double value) const
     return m_shouldClampToNonNegative && value < 0 ? 0 : value;
 }
 
-double CSSCalcValue::doubleValue() const
+double CSSCalcValue::doubleValue(const CSSCalcSymbolTable& symbolTable) const
 {
-    return clampToPermittedRange(protectedExpressionNode()->doubleValue(primitiveType()));
+    return clampToPermittedRange(protectedExpressionNode()->doubleValue(primitiveType(), symbolTable));
 }
 
 double CSSCalcValue::computeLengthPx(const CSSToLengthConversionData& conversionData) const
@@ -409,9 +409,9 @@ Ref<CSSCalcExpressionNode> CSSCalcValue::protectedExpressionNode() const
     return m_expression;
 }
 
-RefPtr<CSSCalcValue> CSSCalcValue::create(CSSValueID function, const CSSParserTokenRange& tokens, CalculationCategory destinationCategory, ValueRange range, const CSSCalcSymbolTable& symbolTable, bool allowsNegativePercentage)
+RefPtr<CSSCalcValue> CSSCalcValue::create(CSSValueID function, const CSSParserTokenRange& tokens, CalculationCategory destinationCategory, ValueRange range, CSSCalcSymbolsAllowed symbolsAllowed, bool allowsNegativePercentage)
 {
-    CSSCalcExpressionNodeParser parser(destinationCategory, symbolTable);
+    CSSCalcExpressionNodeParser parser(destinationCategory, WTFMove(symbolsAllowed));
     auto expression = parser.parseCalc(tokens, function, allowsNegativePercentage);
     if (!expression)
         return nullptr;

--- a/Source/WebCore/css/calc/CSSCalcValue.h
+++ b/Source/WebCore/css/calc/CSSCalcValue.h
@@ -38,6 +38,7 @@ namespace WebCore {
 
 class CSSCalcExpressionNode;
 class CSSCalcSymbolTable;
+class CSSCalcSymbolsAllowed;
 class CSSParserTokenRange;
 class CSSToLengthConversionData;
 class CalculationValue;
@@ -51,14 +52,14 @@ enum class ValueRange : uint8_t;
 
 class CSSCalcValue final : public CSSValue {
 public:
-    static RefPtr<CSSCalcValue> create(CSSValueID function, const CSSParserTokenRange&, CalculationCategory destinationCategory, ValueRange, const CSSCalcSymbolTable&, bool allowsNegativePercentage = false);
+    static RefPtr<CSSCalcValue> create(CSSValueID function, const CSSParserTokenRange&, CalculationCategory destinationCategory, ValueRange, CSSCalcSymbolsAllowed, bool allowsNegativePercentage = false);
     static RefPtr<CSSCalcValue> create(CSSValueID function, const CSSParserTokenRange&, CalculationCategory destinationCategory, ValueRange);
     static RefPtr<CSSCalcValue> create(const CalculationValue&, const RenderStyle&);
     static Ref<CSSCalcValue> create(Ref<CSSCalcExpressionNode>&&, bool shouldClampToNonNegative = false);
     ~CSSCalcValue();
 
     CalculationCategory category() const;
-    double doubleValue() const;
+    double doubleValue(const CSSCalcSymbolTable&) const;
     double computeLengthPx(const CSSToLengthConversionData&) const;
     CSSUnitType primitiveType() const;
 

--- a/Source/WebCore/css/parser/CSSCalcParser.cpp
+++ b/Source/WebCore/css/parser/CSSCalcParser.cpp
@@ -32,13 +32,13 @@
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
 
-CalcParser::CalcParser(CSSParserTokenRange& range, CalculationCategory destinationCategory, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
+CalcParser::CalcParser(CSSParserTokenRange& range, CalculationCategory destinationCategory, CSSCalcSymbolsAllowed symbolsAllowed, CSSPropertyParserOptions options)
     : m_sourceRange(range)
     , m_range(range)
 {
     auto functionId = range.peek().functionId();
     if (CSSCalcValue::isCalcFunction(functionId))
-        m_value = CSSCalcValue::create(functionId, consumeFunction(m_range), destinationCategory, options.valueRange, symbolTable, options.negativePercentage == NegativePercentagePolicy::Allow);
+        m_value = CSSCalcValue::create(functionId, consumeFunction(m_range), destinationCategory, options.valueRange, WTFMove(symbolsAllowed), options.negativePercentage == NegativePercentagePolicy::Allow);
 }
 
 RefPtr<CSSPrimitiveValue> CalcParser::consumeValue()
@@ -72,7 +72,7 @@ bool canConsumeCalcValue(CalculationCategory category, CSSPropertyParserOptions 
     return false;
 }
 
-RefPtr<CSSCalcValue> consumeCalcRawWithKnownTokenTypeFunction(CSSParserTokenRange& range, CalculationCategory category, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
+RefPtr<CSSCalcValue> consumeCalcRawWithKnownTokenTypeFunction(CSSParserTokenRange& range, CalculationCategory category, CSSCalcSymbolsAllowed symbolsAllowed, CSSPropertyParserOptions options)
 {
     ASSERT(range.peek().type() == FunctionToken);
 
@@ -80,7 +80,7 @@ RefPtr<CSSCalcValue> consumeCalcRawWithKnownTokenTypeFunction(CSSParserTokenRang
     if (!CSSCalcValue::isCalcFunction(functionId))
         return nullptr;
 
-    RefPtr calcValue = CSSCalcValue::create(functionId, consumeFunction(range), category, options.valueRange, symbolTable);
+    RefPtr calcValue = CSSCalcValue::create(functionId, consumeFunction(range), category, options.valueRange, WTFMove(symbolsAllowed));
     if (calcValue && calcValue->category() == category)
         return calcValue;
 

--- a/Source/WebCore/css/parser/CSSCalcParser.h
+++ b/Source/WebCore/css/parser/CSSCalcParser.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "CSSCalcSymbolsAllowed.h"
 #include "CSSCalcValue.h"
 #include "CSSParserTokenRange.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
@@ -41,7 +42,7 @@ namespace CSSPropertyParserHelpers {
 
 class CalcParser {
 public:
-    explicit CalcParser(CSSParserTokenRange&, CalculationCategory, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
+    explicit CalcParser(CSSParserTokenRange&, CalculationCategory, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 
     const CSSCalcValue* value() const { return m_value.get(); }
 
@@ -55,7 +56,7 @@ private:
 };
 
 bool canConsumeCalcValue(CalculationCategory, CSSPropertyParserOptions);
-RefPtr<CSSCalcValue> consumeCalcRawWithKnownTokenTypeFunction(CSSParserTokenRange&, CalculationCategory, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
+RefPtr<CSSCalcValue> consumeCalcRawWithKnownTokenTypeFunction(CSSParserTokenRange&, CalculationCategory, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 
 }
 }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Angle.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Angle.cpp
@@ -44,17 +44,17 @@ std::optional<AngleRaw> validatedRange(AngleRaw value, CSSPropertyParserOptions 
     return value;
 }
 
-std::optional<UnevaluatedCalc<AngleRaw>> AngleKnownTokenTypeFunctionConsumer::consume(CSSParserTokenRange& range, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
+std::optional<UnevaluatedCalc<AngleRaw>> AngleKnownTokenTypeFunctionConsumer::consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed symbolsAllowed, CSSPropertyParserOptions options)
 {
     auto rangeCopy = range;
-    if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Angle, symbolTable, options)) {
+    if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Angle, WTFMove(symbolsAllowed), options)) {
         range = rangeCopy;
         return {{ value.releaseNonNull() }};
     }
     return std::nullopt;
 }
 
-std::optional<AngleRaw> AngleKnownTokenTypeDimensionConsumer::consume(CSSParserTokenRange& range, const CSSCalcSymbolTable&, CSSPropertyParserOptions options)
+std::optional<AngleRaw> AngleKnownTokenTypeDimensionConsumer::consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed, CSSPropertyParserOptions options)
 {
     ASSERT(range.peek().type() == DimensionToken);
 
@@ -79,7 +79,7 @@ std::optional<AngleRaw> AngleKnownTokenTypeDimensionConsumer::consume(CSSParserT
     return std::nullopt;
 }
 
-std::optional<AngleRaw> AngleKnownTokenTypeNumberConsumer::consume(CSSParserTokenRange& range, const CSSCalcSymbolTable&, CSSPropertyParserOptions options)
+std::optional<AngleRaw> AngleKnownTokenTypeNumberConsumer::consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed, CSSPropertyParserOptions options)
 {
     ASSERT(range.peek().type() == NumberToken);
 
@@ -104,7 +104,7 @@ std::optional<AngleRaw> consumeAngleRaw(CSSParserTokenRange& range, CSSParserMod
         .unitless = unitless,
         .unitlessZero = unitlessZero
     };
-    return RawResolver<AngleRaw>::consumeAndResolve(range, { }, options);
+    return RawResolver<AngleRaw>::consumeAndResolve(range, { }, { }, options);
 }
 
 RefPtr<CSSPrimitiveValue> consumeAngle(CSSParserTokenRange& range, CSSParserMode parserMode, UnitlessQuirk unitless, UnitlessZeroQuirk unitlessZero)
@@ -114,7 +114,7 @@ RefPtr<CSSPrimitiveValue> consumeAngle(CSSParserTokenRange& range, CSSParserMode
         .unitless = unitless,
         .unitlessZero = unitlessZero
     };
-    return CSSPrimitiveValueResolver<AngleRaw>::consumeAndResolve(range, { }, options);
+    return CSSPrimitiveValueResolver<AngleRaw>::consumeAndResolve(range, { }, { }, options);
 }
 
 RefPtr<CSSPrimitiveValue> consumeAngleOrPercent(CSSParserTokenRange& range, CSSParserMode parserMode)
@@ -123,7 +123,7 @@ RefPtr<CSSPrimitiveValue> consumeAngleOrPercent(CSSParserTokenRange& range, CSSP
         .parserMode = parserMode,
         .unitlessZero = UnitlessZeroQuirk::Allow
     };
-    return CSSPrimitiveValueResolver<AngleRaw, PercentRaw>::consumeAndResolve(range, { }, options);
+    return CSSPrimitiveValueResolver<AngleRaw, PercentRaw>::consumeAndResolve(range, { }, { }, options);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+AngleDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+AngleDefinitions.h
@@ -27,12 +27,13 @@
 #include "CSSParserToken.h"
 #include "CSSPropertyParserConsumer+MetaConsumerDefinitions.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
+#include "CSSPropertyParserConsumer+UnevaluatedCalc.h"
 #include <optional>
 #include <wtf/Brigand.h>
 
 namespace WebCore {
 
-class CSSCalcSymbolTable;
+class CSSCalcSymbolsAllowed;
 class CSSParserTokenRange;
 
 namespace CSSPropertyParserHelpers {
@@ -41,17 +42,17 @@ std::optional<AngleRaw> validatedRange(AngleRaw, CSSPropertyParserOptions);
 
 struct AngleKnownTokenTypeFunctionConsumer {
     static constexpr CSSParserTokenType tokenType = FunctionToken;
-    static std::optional<UnevaluatedCalc<AngleRaw>> consume(CSSParserTokenRange&, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
+    static std::optional<UnevaluatedCalc<AngleRaw>> consume(CSSParserTokenRange&, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 };
 
 struct AngleKnownTokenTypeDimensionConsumer {
     static constexpr CSSParserTokenType tokenType = DimensionToken;
-    static std::optional<AngleRaw> consume(CSSParserTokenRange&, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
+    static std::optional<AngleRaw> consume(CSSParserTokenRange&, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 };
 
 struct AngleKnownTokenTypeNumberConsumer {
     static constexpr CSSParserTokenType tokenType = NumberToken;
-    static std::optional<AngleRaw> consume(CSSParserTokenRange&, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
+    static std::optional<AngleRaw> consume(CSSParserTokenRange&, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 };
 
 template<> struct ConsumerDefinition<AngleRaw> {

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h
@@ -28,6 +28,7 @@
 #include "CSSPropertyParserConsumer+MetaConsumer.h"
 #include "CSSPropertyParserConsumer+MetaResolver.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
+#include "CSSPropertyParserConsumer+UnevaluatedCalc.h"
 #include <wtf/RefPtr.h>
 
 namespace WebCore {
@@ -59,14 +60,14 @@ struct CSSPrimitiveValueResolverBase {
     }
 
     template<typename IntType, IntegerValueRange integerRange>
-    static RefPtr<CSSPrimitiveValue> resolve(UnevaluatedCalc<IntegerRaw<IntType, integerRange>> calc, const CSSCalcSymbolTable&, CSSPropertyParserOptions)
+    static RefPtr<CSSPrimitiveValue> resolve(UnevaluatedCalc<IntegerRaw<IntType, integerRange>> calc, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions)
     {
         // FIXME: This should not be eagerly resolving the calc. Instead, callers
         // should resolve and round at style resolution.
 
         // https://drafts.csswg.org/css-values-4/#integers
         // Rounding to the nearest integer requires rounding in the direction of +∞ when the fractional portion is exactly 0.5.
-        auto value = clampTo<IntType>(std::floor(std::max(calc.calc->doubleValue(), computeMinimumValue(integerRange)) + 0.5));
+        auto value = clampTo<IntType>(std::floor(std::max(calc.calc->doubleValue(symbolTable), computeMinimumValue(integerRange)) + 0.5));
         return CSSPrimitiveValue::createInteger(value);
     }
 };

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Integer.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Integer.cpp
@@ -37,7 +37,7 @@ namespace CSSPropertyParserHelpers {
 template<typename IntType, IntegerValueRange integerRange>
 static std::optional<IntType> consumeIntegerTypeRaw(CSSParserTokenRange& range)
 {
-    if (auto result = RawResolver<IntegerRaw<IntType, integerRange>>::consumeAndResolve(range, { }, { }))
+    if (auto result = RawResolver<IntegerRaw<IntType, integerRange>>::consumeAndResolve(range, { }, { }, { }))
         return result->value;
     return std::nullopt;
 }
@@ -45,7 +45,7 @@ static std::optional<IntType> consumeIntegerTypeRaw(CSSParserTokenRange& range)
 template<typename IntType, IntegerValueRange integerRange>
 static RefPtr<CSSPrimitiveValue> consumeIntegerType(CSSParserTokenRange& range)
 {
-    return CSSPrimitiveValueResolver<IntegerRaw<IntType, integerRange>>::consumeAndResolve(range, { }, { });
+    return CSSPrimitiveValueResolver<IntegerRaw<IntType, integerRange>>::consumeAndResolve(range, { }, { }, { });
 }
 
 std::optional<int> consumeIntegerRaw(CSSParserTokenRange& range)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+IntegerDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+IntegerDefinitions.h
@@ -25,11 +25,14 @@
 #pragma once
 
 #include "CSSCalcParser.h"
+#include "CSSCalcSymbolsAllowed.h"
 #include "CSSCalcValue.h"
 #include "CSSParserToken.h"
 #include "CSSParserTokenRange.h"
 #include "CSSPropertyParserConsumer+MetaConsumerDefinitions.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
+#include "CSSPropertyParserConsumer+RawTypes.h"
+#include "CSSPropertyParserConsumer+UnevaluatedCalc.h"
 #include "CalculationCategory.h"
 #include "Length.h"
 #include <limits>
@@ -51,12 +54,12 @@ struct IntegerKnownTokenTypeFunctionConsumer {
     using RawType = IntegerRaw<IntType, integerRange>;
 
     static constexpr CSSParserTokenType tokenType = FunctionToken;
-    static std::optional<UnevaluatedCalc<RawType>> consume(CSSParserTokenRange& range, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
+    static std::optional<UnevaluatedCalc<RawType>> consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed symbolsAllowed, CSSPropertyParserOptions options)
     {
         ASSERT(range.peek().type() == FunctionToken);
 
         auto rangeCopy = range;
-        if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Number, symbolTable, options)) {
+        if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Number, WTFMove(symbolsAllowed), options)) {
             range = rangeCopy;
             return {{ value.releaseNonNull() }};
         }
@@ -69,7 +72,7 @@ struct IntegerKnownTokenTypeNumberConsumer {
     using RawType = IntegerRaw<IntType, integerRange>;
 
     static constexpr CSSParserTokenType tokenType = NumberToken;
-    static std::optional<RawType> consume(CSSParserTokenRange& range, const CSSCalcSymbolTable&, CSSPropertyParserOptions)
+    static std::optional<RawType> consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed, CSSPropertyParserOptions)
     {
         ASSERT(range.peek().type() == NumberToken);
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Length.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Length.cpp
@@ -28,6 +28,7 @@
 
 #include "CSSCalcParser.h"
 #include "CSSCalcSymbolTable.h"
+#include "CSSCalcSymbolsAllowed.h"
 #include "CSSCalcValue.h"
 #include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
 #include "CSSPropertyParserConsumer+MetaConsumer.h"
@@ -46,19 +47,19 @@ std::optional<LengthRaw> validatedRange(LengthRaw value, CSSPropertyParserOption
     return value;
 }
 
-std::optional<UnevaluatedCalc<LengthRaw>> LengthKnownTokenTypeFunctionConsumer::consume(CSSParserTokenRange& range, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
+std::optional<UnevaluatedCalc<LengthRaw>> LengthKnownTokenTypeFunctionConsumer::consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed symbolsAllowed, CSSPropertyParserOptions options)
 {
     ASSERT(range.peek().type() == FunctionToken);
 
     auto rangeCopy = range;
-    if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Length, symbolTable, options)) {
+    if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Length, WTFMove(symbolsAllowed), options)) {
         range = rangeCopy;
         return {{ value.releaseNonNull() }};
     }
     return std::nullopt;
 }
 
-std::optional<LengthRaw> LengthKnownTokenTypeDimensionConsumer::consume(CSSParserTokenRange& range, const CSSCalcSymbolTable&, CSSPropertyParserOptions options)
+std::optional<LengthRaw> LengthKnownTokenTypeDimensionConsumer::consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed, CSSPropertyParserOptions options)
 {
     ASSERT(range.peek().type() == DimensionToken);
 
@@ -131,7 +132,7 @@ std::optional<LengthRaw> LengthKnownTokenTypeDimensionConsumer::consume(CSSParse
     return std::nullopt;
 }
 
-std::optional<LengthRaw> LengthKnownTokenTypeNumberConsumer::consume(CSSParserTokenRange& range, const CSSCalcSymbolTable&, CSSPropertyParserOptions options)
+std::optional<LengthRaw> LengthKnownTokenTypeNumberConsumer::consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed, CSSPropertyParserOptions options)
 {
     ASSERT(range.peek().type() == NumberToken);
 
@@ -158,7 +159,7 @@ RefPtr<CSSPrimitiveValue> consumeLength(CSSParserTokenRange& range, CSSParserMod
         .unitless = unitless,
         .unitlessZero = UnitlessZeroQuirk::Allow
     };
-    return CSSPrimitiveValueResolver<LengthRaw>::consumeAndResolve(range, { }, options);
+    return CSSPrimitiveValueResolver<LengthRaw>::consumeAndResolve(range, { }, { }, options);
 }
 
 std::optional<LengthOrPercentRaw> consumeLengthOrPercentRaw(CSSParserTokenRange& range, CSSParserMode parserMode)
@@ -167,7 +168,7 @@ std::optional<LengthOrPercentRaw> consumeLengthOrPercentRaw(CSSParserTokenRange&
         .parserMode = parserMode,
         .valueRange = ValueRange::NonNegative
     };
-    return RawResolver<LengthRaw, PercentRaw>::consumeAndResolve(range, { }, options);
+    return RawResolver<LengthRaw, PercentRaw>::consumeAndResolve(range, { }, { }, options);
 }
 
 // FIXME: This doesn't work with the current scheme due to the NegativePercentagePolicy parameter

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Length.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Length.h
@@ -30,7 +30,6 @@
 
 namespace WebCore {
 
-class CSSCalcSymbolTable;
 class CSSParserTokenRange;
 class CSSPrimitiveValue;
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthDefinitions.h
@@ -27,16 +27,14 @@
 #include "CSSParserToken.h"
 #include "CSSPropertyParserConsumer+MetaConsumerDefinitions.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
+#include "CSSPropertyParserConsumer+UnevaluatedCalc.h"
 #include <optional>
 #include <wtf/Brigand.h>
 
 namespace WebCore {
 
-class CSSCalcSymbolTable;
+class CSSCalcSymbolsAllowed;
 class CSSParserTokenRange;
-
-enum CSSParserMode : uint8_t;
-enum class ValueRange : uint8_t;
 
 namespace CSSPropertyParserHelpers {
 
@@ -44,17 +42,17 @@ std::optional<LengthRaw> validatedRange(LengthRaw, CSSPropertyParserOptions);
 
 struct LengthKnownTokenTypeFunctionConsumer {
     static constexpr CSSParserTokenType tokenType = FunctionToken;
-    static std::optional<UnevaluatedCalc<LengthRaw>> consume(CSSParserTokenRange&, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
+    static std::optional<UnevaluatedCalc<LengthRaw>> consume(CSSParserTokenRange&, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 };
 
 struct LengthKnownTokenTypeDimensionConsumer {
     static constexpr CSSParserTokenType tokenType = DimensionToken;
-    static std::optional<LengthRaw> consume(CSSParserTokenRange&, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
+    static std::optional<LengthRaw> consume(CSSParserTokenRange&, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 };
 
 struct LengthKnownTokenTypeNumberConsumer {
     static constexpr CSSParserTokenType tokenType = NumberToken;
-    static std::optional<LengthRaw> consume(CSSParserTokenRange&, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
+    static std::optional<LengthRaw> consume(CSSParserTokenRange&, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 };
 
 template<> struct ConsumerDefinition<LengthRaw> {

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumer.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumer.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "CSSCalcSymbolsAllowed.h"
 #include "CSSCalcValue.h"
 #include "CSSParserToken.h"
 #include "CSSParserTokenRange.h"
@@ -37,7 +38,6 @@
 
 namespace WebCore {
 
-class CSSCalcSymbolTable;
 enum CSSParserMode : uint8_t;
 enum class ValueRange : uint8_t;
 
@@ -160,23 +160,23 @@ struct MetaConsumer {
     using ResultType = typename MetaConsumeResult<Ts...>::type;
 
     template<typename... Args>
-    static std::optional<ResultType> consume(CSSParserTokenRange& range, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options, Args&&... args)
+    static std::optional<ResultType> consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed symbolsAllowed, CSSPropertyParserOptions options, Args&&... args)
     {
         switch (range.peek().type()) {
         case FunctionToken:
-            return MetaConsumerUnroller<FunctionToken, ResultType, Ts...>::consume(range, symbolTable, options, std::forward<Args>(args)...);
+            return MetaConsumerUnroller<FunctionToken, ResultType, Ts...>::consume(range, WTFMove(symbolsAllowed), options, std::forward<Args>(args)...);
 
         case NumberToken:
-            return MetaConsumerUnroller<NumberToken, ResultType, Ts...>::consume(range, symbolTable, options, std::forward<Args>(args)...);
+            return MetaConsumerUnroller<NumberToken, ResultType, Ts...>::consume(range, WTFMove(symbolsAllowed), options, std::forward<Args>(args)...);
 
         case PercentageToken:
-            return MetaConsumerUnroller<PercentageToken, ResultType, Ts...>::consume(range, symbolTable, options, std::forward<Args>(args)...);
+            return MetaConsumerUnroller<PercentageToken, ResultType, Ts...>::consume(range, WTFMove(symbolsAllowed), options, std::forward<Args>(args)...);
 
         case DimensionToken:
-            return MetaConsumerUnroller<DimensionToken, ResultType, Ts...>::consume(range, symbolTable, options, std::forward<Args>(args)...);
+            return MetaConsumerUnroller<DimensionToken, ResultType, Ts...>::consume(range, WTFMove(symbolsAllowed), options, std::forward<Args>(args)...);
 
         case IdentToken:
-            return MetaConsumerUnroller<IdentToken, ResultType, Ts...>::consume(range, symbolTable, options, std::forward<Args>(args)...);
+            return MetaConsumerUnroller<IdentToken, ResultType, Ts...>::consume(range, WTFMove(symbolsAllowed), options, std::forward<Args>(args)...);
 
         default:
             return { };

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaResolver.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaResolver.h
@@ -52,9 +52,9 @@ struct MetaResolver : Base {
         });
     }
 
-    static ResultType consumeAndResolve(CSSParserTokenRange& range, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
+    static ResultType consumeAndResolve(CSSParserTokenRange& range, CSSCalcSymbolsAllowed symbolsAllowed, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
     {
-        auto result = MetaConsumer<Ts...>::consume(range, symbolTable, options);
+        auto result = MetaConsumer<Ts...>::consume(range, WTFMove(symbolsAllowed), options);
         if (!result)
             return { };
         return resolve(WTFMove(*result), symbolTable, options);

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+None.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+None.cpp
@@ -36,7 +36,7 @@ std::optional<NoneRaw> validatedNoneRaw(NoneRaw value, CSSPropertyParserOptions)
     return value;
 }
 
-std::optional<NoneRaw> NoneKnownTokenTypeIdentConsumer::consume(CSSParserTokenRange& range, const CSSCalcSymbolTable&, CSSPropertyParserOptions)
+std::optional<NoneRaw> NoneKnownTokenTypeIdentConsumer::consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed, CSSPropertyParserOptions)
 {
     ASSERT(range.peek().type() == IdentToken);
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+NoneDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+NoneDefinitions.h
@@ -32,7 +32,6 @@
 
 namespace WebCore {
 
-class CSSCalcSymbolTable;
 class CSSParserTokenRange;
 
 namespace CSSPropertyParserHelpers {
@@ -41,7 +40,7 @@ std::optional<NoneRaw> validatedNoneRaw(NoneRaw, CSSPropertyParserOptions);
 
 struct NoneKnownTokenTypeIdentConsumer {
     static constexpr CSSParserTokenType tokenType = IdentToken;
-    static std::optional<NoneRaw> consume(CSSParserTokenRange&, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
+    static std::optional<NoneRaw> consume(CSSParserTokenRange&, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 };
 
 template<> struct ConsumerDefinition<NoneRaw> {

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Number.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Number.cpp
@@ -28,6 +28,7 @@
 
 #include "CSSCalcParser.h"
 #include "CSSCalcSymbolTable.h"
+#include "CSSCalcSymbolsAllowed.h"
 #include "CSSCalcValue.h"
 #include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
 #include "CSSPropertyParserConsumer+MetaConsumer.h"
@@ -43,12 +44,12 @@ std::optional<NumberRaw> validatedRange(NumberRaw value, CSSPropertyParserOption
     return value;
 }
 
-std::optional<UnevaluatedCalc<NumberRaw>> NumberKnownTokenTypeFunctionConsumer::consume(CSSParserTokenRange& range, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
+std::optional<UnevaluatedCalc<NumberRaw>> NumberKnownTokenTypeFunctionConsumer::consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed symbolsAllowed, CSSPropertyParserOptions options)
 {
     ASSERT(range.peek().type() == FunctionToken);
 
     auto rangeCopy = range;
-    if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Number, symbolTable, options)) {
+    if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Number, WTFMove(symbolsAllowed), options)) {
         range = rangeCopy;
         return {{ value.releaseNonNull() }};
     }
@@ -56,7 +57,7 @@ std::optional<UnevaluatedCalc<NumberRaw>> NumberKnownTokenTypeFunctionConsumer::
     return std::nullopt;
 }
 
-std::optional<NumberRaw> NumberKnownTokenTypeNumberConsumer::consume(CSSParserTokenRange& range, const CSSCalcSymbolTable&, CSSPropertyParserOptions options)
+std::optional<NumberRaw> NumberKnownTokenTypeNumberConsumer::consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed, CSSPropertyParserOptions options)
 {
     ASSERT(range.peek().type() == NumberToken);
 
@@ -74,7 +75,7 @@ std::optional<NumberRaw> consumeNumberRaw(CSSParserTokenRange& range, ValueRange
     const auto options = CSSPropertyParserOptions {
         .valueRange = valueRange
     };
-    return RawResolver<NumberRaw>::consumeAndResolve(range, { }, options);
+    return RawResolver<NumberRaw>::consumeAndResolve(range, { }, { }, options);
 }
 
 RefPtr<CSSPrimitiveValue> consumeNumber(CSSParserTokenRange& range, ValueRange valueRange)
@@ -82,7 +83,7 @@ RefPtr<CSSPrimitiveValue> consumeNumber(CSSParserTokenRange& range, ValueRange v
     const auto options = CSSPropertyParserOptions {
         .valueRange = valueRange
     };
-    return CSSPrimitiveValueResolver<NumberRaw>::consumeAndResolve(range, { }, options);
+    return CSSPrimitiveValueResolver<NumberRaw>::consumeAndResolve(range, { }, { }, options);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+NumberDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+NumberDefinitions.h
@@ -27,12 +27,13 @@
 #include "CSSParserToken.h"
 #include "CSSPropertyParserConsumer+MetaConsumerDefinitions.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
+#include "CSSPropertyParserConsumer+UnevaluatedCalc.h"
 #include <optional>
 #include <wtf/Brigand.h>
 
 namespace WebCore {
 
-class CSSCalcSymbolTable;
+class CSSCalcSymbolsAllowed;
 class CSSParserTokenRange;
 
 namespace CSSPropertyParserHelpers {
@@ -41,12 +42,12 @@ std::optional<NumberRaw> validatedRange(NumberRaw, CSSPropertyParserOptions);
 
 struct NumberKnownTokenTypeFunctionConsumer {
     static constexpr CSSParserTokenType tokenType = FunctionToken;
-    static std::optional<UnevaluatedCalc<NumberRaw>> consume(CSSParserTokenRange&, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
+    static std::optional<UnevaluatedCalc<NumberRaw>> consume(CSSParserTokenRange&, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 };
 
 struct NumberKnownTokenTypeNumberConsumer {
     static constexpr CSSParserTokenType tokenType = NumberToken;
-    static std::optional<NumberRaw> consume(CSSParserTokenRange&, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
+    static std::optional<NumberRaw> consume(CSSParserTokenRange&, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 };
 
 template<> struct ConsumerDefinition<NumberRaw> {

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Percent.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Percent.cpp
@@ -28,6 +28,7 @@
 
 #include "CSSCalcParser.h"
 #include "CSSCalcSymbolTable.h"
+#include "CSSCalcSymbolsAllowed.h"
 #include "CSSCalcValue.h"
 #include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
 #include "CSSPropertyParserConsumer+MetaConsumer.h"
@@ -47,12 +48,12 @@ std::optional<PercentRaw> validatedRange(PercentRaw value, CSSPropertyParserOpti
     return value;
 }
 
-std::optional<UnevaluatedCalc<PercentRaw>> PercentKnownTokenTypeFunctionConsumer::consume(CSSParserTokenRange& range, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
+std::optional<UnevaluatedCalc<PercentRaw>> PercentKnownTokenTypeFunctionConsumer::consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed symbolsAllowed, CSSPropertyParserOptions options)
 {
     ASSERT(range.peek().type() == FunctionToken);
 
     auto rangeCopy = range;
-    if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Percent, symbolTable, options)) {
+    if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Percent, WTFMove(symbolsAllowed), options)) {
         range = rangeCopy;
         return {{ value.releaseNonNull() }};
     }
@@ -60,7 +61,7 @@ std::optional<UnevaluatedCalc<PercentRaw>> PercentKnownTokenTypeFunctionConsumer
     return std::nullopt;
 }
 
-std::optional<PercentRaw> PercentKnownTokenTypePercentConsumer::consume(CSSParserTokenRange& range, const CSSCalcSymbolTable&, CSSPropertyParserOptions options)
+std::optional<PercentRaw> PercentKnownTokenTypePercentConsumer::consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed, CSSPropertyParserOptions options)
 {
     ASSERT(range.peek().type() == PercentageToken);
 
@@ -78,7 +79,7 @@ std::optional<PercentRaw> consumePercentRaw(CSSParserTokenRange& range, ValueRan
     const auto options = CSSPropertyParserOptions {
         .valueRange = valueRange
     };
-    return RawResolver<PercentRaw>::consumeAndResolve(range, { }, options);
+    return RawResolver<PercentRaw>::consumeAndResolve(range, { }, { }, options);
 }
 
 RefPtr<CSSPrimitiveValue> consumePercent(CSSParserTokenRange& range, ValueRange valueRange)
@@ -86,7 +87,7 @@ RefPtr<CSSPrimitiveValue> consumePercent(CSSParserTokenRange& range, ValueRange 
     const auto options = CSSPropertyParserOptions {
         .valueRange = valueRange
     };
-    return CSSPrimitiveValueResolver<PercentRaw>::consumeAndResolve(range, { }, options);
+    return CSSPrimitiveValueResolver<PercentRaw>::consumeAndResolve(range, { }, { }, options);
 }
 
 RefPtr<CSSPrimitiveValue> consumePercentOrNumber(CSSParserTokenRange& range, ValueRange valueRange)
@@ -94,7 +95,7 @@ RefPtr<CSSPrimitiveValue> consumePercentOrNumber(CSSParserTokenRange& range, Val
     const auto options = CSSPropertyParserOptions {
         .valueRange = valueRange
     };
-    return CSSPrimitiveValueResolver<PercentRaw, NumberRaw>::consumeAndResolve(range, { }, options);
+    return CSSPrimitiveValueResolver<PercentRaw, NumberRaw>::consumeAndResolve(range, { }, { }, options);
 }
 
 RefPtr<CSSPrimitiveValue> consumePercentDividedBy100OrNumber(CSSParserTokenRange& range, ValueRange valueRange)
@@ -135,7 +136,7 @@ std::optional<PercentOrNumberRaw> consumePercentOrNumberRaw(CSSParserTokenRange&
     const auto options = CSSPropertyParserOptions {
         .valueRange = valueRange
     };
-    return RawResolver<PercentRaw, NumberRaw>::consumeAndResolve(range, { }, options);
+    return RawResolver<PercentRaw, NumberRaw>::consumeAndResolve(range, { }, { }, options);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+PercentDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+PercentDefinitions.h
@@ -27,12 +27,13 @@
 #include "CSSParserToken.h"
 #include "CSSPropertyParserConsumer+MetaConsumerDefinitions.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
+#include "CSSPropertyParserConsumer+UnevaluatedCalc.h"
 #include <optional>
 #include <wtf/Brigand.h>
 
 namespace WebCore {
 
-class CSSCalcSymbolTable;
+class CSSCalcSymbolsAllowed;
 class CSSParserTokenRange;
 
 namespace CSSPropertyParserHelpers {
@@ -41,12 +42,12 @@ std::optional<PercentRaw> validatedRange(PercentRaw, CSSPropertyParserOptions);
 
 struct PercentKnownTokenTypeFunctionConsumer {
     static constexpr CSSParserTokenType tokenType = FunctionToken;
-    static std::optional<UnevaluatedCalc<PercentRaw>> consume(CSSParserTokenRange&, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
+    static std::optional<UnevaluatedCalc<PercentRaw>> consume(CSSParserTokenRange&, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 };
 
 struct PercentKnownTokenTypePercentConsumer {
     static constexpr CSSParserTokenType tokenType = PercentageToken;
-    static std::optional<PercentRaw> consume(CSSParserTokenRange&, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
+    static std::optional<PercentRaw> consume(CSSParserTokenRange&, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 };
 
 template<> struct ConsumerDefinition<PercentRaw> {

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Primitives.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Primitives.cpp
@@ -25,7 +25,6 @@
 #include "config.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
 
-#include "CSSCalcValue.h"
 #include "CSSParserTokenRange.h"
 
 namespace WebCore {
@@ -42,11 +41,6 @@ bool shouldAcceptUnitlessValue(double value, CSSPropertyParserOptions options)
         return true;
 
     return options.parserMode == HTMLQuirksMode && options.unitless == UnitlessQuirk::Allow;
-}
-
-bool equal(const Ref<CSSCalcValue>& a, const Ref<CSSCalcValue>& b)
-{
-    return a->equals(b.get());
 }
 
 bool consumeCommaIncludingWhitespace(CSSParserTokenRange& range)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Primitives.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Primitives.h
@@ -32,21 +32,8 @@
 namespace WebCore {
 
 class CSSParserTokenRange;
-class CSSCalcValue;
 
 namespace CSSPropertyParserHelpers {
-
-bool equal(const Ref<CSSCalcValue>&, const Ref<CSSCalcValue>&);
-
-template<typename T> struct UnevaluatedCalc {
-    using RawType = T;
-    Ref<CSSCalcValue> calc;
-
-    inline bool operator==(const UnevaluatedCalc<T>& other)
-    {
-        return equal(calc, other.calc);
-    }
-};
 
 enum class NegativePercentagePolicy : bool { Forbid, Allow };
 enum class UnitlessQuirk : bool { Allow, Forbid };

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+RawResolver.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+RawResolver.cpp
@@ -35,6 +35,7 @@
 #include "CSSPropertyParserConsumer+PercentDefinitions.h"
 #include "CSSPropertyParserConsumer+ResolutionDefinitions.h"
 #include "CSSPropertyParserConsumer+TimeDefinitions.h"
+#include "CSSPropertyParserConsumer+UnevaluatedCalc.h"
 
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
@@ -76,42 +77,37 @@ std::optional<NoneRaw> RawResolverBase::resolve(NoneRaw value, const CSSCalcSymb
 
 std::optional<NumberRaw> RawResolverBase::resolve(SymbolRaw value, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions)
 {
-    if (auto variable = symbolTable.get(value.value))
-        return NumberRaw { variable->value };
-
-    // We should only get here if the symbol was previously looked up in the symbol table.
-    ASSERT_NOT_REACHED();
-    return std::nullopt;
+    return replaceSymbol(value, symbolTable);
 }
 
-std::optional<AngleRaw> RawResolverBase::resolve(UnevaluatedCalc<AngleRaw> value, const CSSCalcSymbolTable&, CSSPropertyParserOptions options)
+std::optional<AngleRaw> RawResolverBase::resolve(UnevaluatedCalc<AngleRaw> value, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
 {
-    return validatedRange(AngleRaw { value.calc->primitiveType(), value.calc->doubleValue() }, options);
+    return validatedRange(evaluateCalc(value, symbolTable), options);
 }
 
-std::optional<LengthRaw> RawResolverBase::resolve(UnevaluatedCalc<LengthRaw> value, const CSSCalcSymbolTable&, CSSPropertyParserOptions options)
+std::optional<LengthRaw> RawResolverBase::resolve(UnevaluatedCalc<LengthRaw> value, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
 {
-    return validatedRange(LengthRaw { value.calc->primitiveType(), value.calc->doubleValue() }, options);
+    return validatedRange(evaluateCalc(value, symbolTable), options);
 }
 
-std::optional<NumberRaw> RawResolverBase::resolve(UnevaluatedCalc<NumberRaw> value, const CSSCalcSymbolTable&, CSSPropertyParserOptions options)
+std::optional<NumberRaw> RawResolverBase::resolve(UnevaluatedCalc<NumberRaw> value, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
 {
-    return validatedRange(NumberRaw { value.calc->doubleValue() }, options);
+    return validatedRange(evaluateCalc(value, symbolTable), options);
 }
 
-std::optional<PercentRaw> RawResolverBase::resolve(UnevaluatedCalc<PercentRaw> value, const CSSCalcSymbolTable&, CSSPropertyParserOptions options)
+std::optional<PercentRaw> RawResolverBase::resolve(UnevaluatedCalc<PercentRaw> value, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
 {
-    return validatedRange(PercentRaw { value.calc->doubleValue() }, options);
+    return validatedRange(evaluateCalc(value, symbolTable), options);
 }
 
-std::optional<ResolutionRaw> RawResolverBase::resolve(UnevaluatedCalc<ResolutionRaw> value, const CSSCalcSymbolTable&, CSSPropertyParserOptions options)
+std::optional<ResolutionRaw> RawResolverBase::resolve(UnevaluatedCalc<ResolutionRaw> value, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
 {
-    return validatedRange(ResolutionRaw { value.calc->primitiveType(), value.calc->doubleValue() }, options);
+    return validatedRange(evaluateCalc(value, symbolTable), options);
 }
 
-std::optional<TimeRaw> RawResolverBase::resolve(UnevaluatedCalc<TimeRaw> value, const CSSCalcSymbolTable&, CSSPropertyParserOptions options)
+std::optional<TimeRaw> RawResolverBase::resolve(UnevaluatedCalc<TimeRaw> value, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
 {
-    return validatedRange(TimeRaw { value.calc->primitiveType(), value.calc->doubleValue() }, options);
+    return validatedRange(evaluateCalc(value, symbolTable), options);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+RawResolver.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+RawResolver.h
@@ -27,6 +27,7 @@
 #include "CSSPropertyParserConsumer+MetaConsumer.h"
 #include "CSSPropertyParserConsumer+MetaResolver.h"
 #include "CSSPropertyParserConsumer+RawTypes.h"
+#include "CSSPropertyParserConsumer+UnevaluatedCalc.h"
 #include <optional>
 
 namespace WebCore {
@@ -61,11 +62,11 @@ struct RawResolverBase {
     static std::optional<TimeRaw> resolve(UnevaluatedCalc<TimeRaw>, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
 
     template<typename IntType, IntegerValueRange integerRange>
-    static std::optional<IntegerRaw<IntType, integerRange>> resolve(UnevaluatedCalc<IntegerRaw<IntType, integerRange>> calc, const CSSCalcSymbolTable&, CSSPropertyParserOptions)
+    static std::optional<IntegerRaw<IntType, integerRange>> resolve(UnevaluatedCalc<IntegerRaw<IntType, integerRange>> calc, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions)
     {
         // https://drafts.csswg.org/css-values-4/#integers
         // Rounding to the nearest integer requires rounding in the direction of +∞ when the fractional portion is exactly 0.5.
-        return {{ clampTo<IntType>(std::floor(std::max(calc.calc->doubleValue(), computeMinimumValue(integerRange)) + 0.5)) }};
+        return {{ clampTo<IntType>(std::floor(std::max(calc.calc->doubleValue(symbolTable), computeMinimumValue(integerRange)) + 0.5)) }};
     }
 };
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+RawTypes.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+RawTypes.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSPropertyParserConsumer+RawTypes.h"
+
+#include "CSSCalcSymbolTable.h"
+
+namespace WebCore {
+
+NumberRaw replaceSymbol(SymbolRaw raw, const CSSCalcSymbolTable& symbolTable)
+{
+    auto result = symbolTable.get(raw.value);
+
+    // We should only get here if the symbol was previously looked up in the symbol table.
+    ASSERT(result);
+    return { result->value };
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Resolution.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Resolution.cpp
@@ -28,6 +28,7 @@
 
 #include "CSSCalcParser.h"
 #include "CSSCalcSymbolTable.h"
+#include "CSSCalcSymbolsAllowed.h"
 #include "CSSParserMode.h"
 #include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
 #include "CSSPropertyParserConsumer+MetaConsumer.h"
@@ -43,12 +44,12 @@ std::optional<ResolutionRaw> validatedRange(ResolutionRaw value, CSSPropertyPars
     return value;
 }
 
-std::optional<UnevaluatedCalc<ResolutionRaw>> ResolutionKnownTokenTypeFunctionConsumer::consume(CSSParserTokenRange& range, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
+std::optional<UnevaluatedCalc<ResolutionRaw>> ResolutionKnownTokenTypeFunctionConsumer::consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed symbolsAllowed, CSSPropertyParserOptions options)
 {
     ASSERT(range.peek().type() == FunctionToken);
 
     auto rangeCopy = range;
-    if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Resolution, symbolTable, options)) {
+    if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Resolution, WTFMove(symbolsAllowed), options)) {
         range = rangeCopy;
         return {{ value.releaseNonNull() }};
     }
@@ -56,7 +57,7 @@ std::optional<UnevaluatedCalc<ResolutionRaw>> ResolutionKnownTokenTypeFunctionCo
     return std::nullopt;
 }
 
-std::optional<ResolutionRaw> ResolutionKnownTokenTypeDimensionConsumer::consume(CSSParserTokenRange& range, const CSSCalcSymbolTable&, CSSPropertyParserOptions options)
+std::optional<ResolutionRaw> ResolutionKnownTokenTypeDimensionConsumer::consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed, CSSPropertyParserOptions options)
 {
     ASSERT(range.peek().type() == DimensionToken);
 
@@ -89,7 +90,7 @@ RefPtr<CSSPrimitiveValue> consumeResolution(CSSParserTokenRange& range)
     const auto options = CSSPropertyParserOptions {
         .valueRange = ValueRange::NonNegative
     };
-    return CSSPrimitiveValueResolver<ResolutionRaw>::consumeAndResolve(range, { }, options);
+    return CSSPrimitiveValueResolver<ResolutionRaw>::consumeAndResolve(range, { }, { }, options);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ResolutionDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ResolutionDefinitions.h
@@ -27,12 +27,13 @@
 #include "CSSParserToken.h"
 #include "CSSPropertyParserConsumer+MetaConsumerDefinitions.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
+#include "CSSPropertyParserConsumer+UnevaluatedCalc.h"
 #include <optional>
 #include <wtf/Brigand.h>
 
 namespace WebCore {
 
-class CSSCalcSymbolTable;
+class CSSCalcSymbolsAllowed;
 class CSSParserTokenRange;
 
 namespace CSSPropertyParserHelpers {
@@ -41,12 +42,12 @@ std::optional<ResolutionRaw> validatedRange(ResolutionRaw, CSSPropertyParserOpti
 
 struct ResolutionKnownTokenTypeFunctionConsumer {
     static constexpr CSSParserTokenType tokenType = FunctionToken;
-    static std::optional<UnevaluatedCalc<ResolutionRaw>> consume(CSSParserTokenRange&, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
+    static std::optional<UnevaluatedCalc<ResolutionRaw>> consume(CSSParserTokenRange&, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 };
 
 struct ResolutionKnownTokenTypeDimensionConsumer {
     static constexpr CSSParserTokenType tokenType = DimensionToken;
-    static std::optional<ResolutionRaw> consume(CSSParserTokenRange&, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
+    static std::optional<ResolutionRaw> consume(CSSParserTokenRange&, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 };
 
 template<> struct ConsumerDefinition<ResolutionRaw> {

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Symbol.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Symbol.cpp
@@ -25,7 +25,7 @@
 #include "config.h"
 #include "CSSPropertyParserConsumer+SymbolDefinitions.h"
 
-#include "CSSCalcSymbolTable.h"
+#include "CSSCalcSymbolsAllowed.h"
 #include "CSSParserTokenRange.h"
 
 namespace WebCore {
@@ -36,12 +36,12 @@ std::optional<SymbolRaw> validatedRange(SymbolRaw value, CSSPropertyParserOption
     return value;
 }
 
-std::optional<SymbolRaw> SymbolKnownTokenTypeIdentConsumer::consume(CSSParserTokenRange& range, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions)
+std::optional<SymbolRaw> SymbolKnownTokenTypeIdentConsumer::consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed symbolsAllowed, CSSPropertyParserOptions)
 {
     ASSERT(range.peek().type() == IdentToken);
 
     auto symbol = range.peek().id();
-    if (symbolTable.contains(symbol)) {
+    if (symbolsAllowed.contains(symbol)) {
         range.consumeIncludingWhitespace();
         return SymbolRaw { symbol };
     }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+SymbolDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+SymbolDefinitions.h
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-class CSSCalcSymbolTable;
+class CSSCalcSymbolsAllowed;
 class CSSParserTokenRange;
 
 namespace CSSPropertyParserHelpers {
@@ -41,7 +41,7 @@ std::optional<SymbolRaw> validatedRange(SymbolRaw, CSSPropertyParserOptions);
 
 struct SymbolKnownTokenTypeIdentConsumer {
     static constexpr CSSParserTokenType tokenType = IdentToken;
-    static std::optional<SymbolRaw> consume(CSSParserTokenRange&, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
+    static std::optional<SymbolRaw> consume(CSSParserTokenRange&, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 };
 
 template<> struct ConsumerDefinition<SymbolRaw> {

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Time.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Time.cpp
@@ -28,6 +28,7 @@
 
 #include "CSSCalcParser.h"
 #include "CSSCalcSymbolTable.h"
+#include "CSSCalcSymbolsAllowed.h"
 #include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
 #include "CSSPropertyParserConsumer+MetaConsumer.h"
 #include "Length.h"
@@ -42,12 +43,12 @@ std::optional<TimeRaw> validatedRange(TimeRaw value, CSSPropertyParserOptions op
     return value;
 }
 
-std::optional<UnevaluatedCalc<TimeRaw>> TimeKnownTokenTypeFunctionConsumer::consume(CSSParserTokenRange& range, const CSSCalcSymbolTable& symbolTable, CSSPropertyParserOptions options)
+std::optional<UnevaluatedCalc<TimeRaw>> TimeKnownTokenTypeFunctionConsumer::consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed symbolsAllowed, CSSPropertyParserOptions options)
 {
     ASSERT(range.peek().type() == FunctionToken);
 
     auto rangeCopy = range;
-    if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Time, symbolTable, options)) {
+    if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Time, WTFMove(symbolsAllowed), options)) {
         range = rangeCopy;
         return {{ value.releaseNonNull() }};
     }
@@ -55,7 +56,7 @@ std::optional<UnevaluatedCalc<TimeRaw>> TimeKnownTokenTypeFunctionConsumer::cons
     return std::nullopt;
 }
 
-std::optional<TimeRaw> TimeKnownTokenTypeDimensionConsumer::consume(CSSParserTokenRange& range, const CSSCalcSymbolTable&, CSSPropertyParserOptions options)
+std::optional<TimeRaw> TimeKnownTokenTypeDimensionConsumer::consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed, CSSPropertyParserOptions options)
 {
     ASSERT(range.peek().type() == DimensionToken);
 
@@ -78,7 +79,7 @@ std::optional<TimeRaw> TimeKnownTokenTypeDimensionConsumer::consume(CSSParserTok
     return std::nullopt;
 }
 
-std::optional<TimeRaw> TimeKnownTokenTypeNumberConsumer::consume(CSSParserTokenRange& range, const CSSCalcSymbolTable&, CSSPropertyParserOptions options)
+std::optional<TimeRaw> TimeKnownTokenTypeNumberConsumer::consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed, CSSPropertyParserOptions options)
 {
     ASSERT(range.peek().type() == NumberToken);
 
@@ -109,7 +110,7 @@ RefPtr<CSSPrimitiveValue> consumeTime(CSSParserTokenRange& range, CSSParserMode 
         .valueRange = valueRange,
         .unitless = unitless
     };
-    return CSSPrimitiveValueResolver<TimeRaw>::consumeAndResolve(range, { }, options);
+    return CSSPrimitiveValueResolver<TimeRaw>::consumeAndResolve(range, { }, { }, options);
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Time.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Time.h
@@ -30,7 +30,6 @@
 
 namespace WebCore {
 
-class CSSCalcSymbolTable;
 class CSSPrimitiveValue;
 
 namespace CSSPropertyParserHelpers {

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+TimeDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+TimeDefinitions.h
@@ -27,12 +27,13 @@
 #include "CSSParserToken.h"
 #include "CSSPropertyParserConsumer+MetaConsumerDefinitions.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
+#include "CSSPropertyParserConsumer+UnevaluatedCalc.h"
 #include <optional>
 #include <wtf/Brigand.h>
 
 namespace WebCore {
 
-class CSSCalcSymbolTable;
+class CSSCalcSymbolsAllowed;
 class CSSParserTokenRange;
 
 namespace CSSPropertyParserHelpers {
@@ -41,17 +42,17 @@ std::optional<TimeRaw> validatedRange(TimeRaw, CSSPropertyParserOptions);
 
 struct TimeKnownTokenTypeFunctionConsumer {
     static constexpr CSSParserTokenType tokenType = FunctionToken;
-    static std::optional<UnevaluatedCalc<TimeRaw>> consume(CSSParserTokenRange&, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
+    static std::optional<UnevaluatedCalc<TimeRaw>> consume(CSSParserTokenRange&, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 };
 
 struct TimeKnownTokenTypeDimensionConsumer {
     static constexpr CSSParserTokenType tokenType = DimensionToken;
-    static std::optional<TimeRaw> consume(CSSParserTokenRange&, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
+    static std::optional<TimeRaw> consume(CSSParserTokenRange&, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 };
 
 struct TimeKnownTokenTypeNumberConsumer {
     static constexpr CSSParserTokenType tokenType = NumberToken;
-    static std::optional<TimeRaw> consume(CSSParserTokenRange&, const CSSCalcSymbolTable&, CSSPropertyParserOptions);
+    static std::optional<TimeRaw> consume(CSSParserTokenRange&, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 };
 
 template<> struct ConsumerDefinition<TimeRaw> {

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSPropertyParserConsumer+UnevaluatedCalc.h"
+
+#include "CSSCalcSymbolTable.h"
+#include "CSSCalcValue.h"
+
+namespace WebCore {
+
+bool unevaluatedCalcEqual(const Ref<CSSCalcValue>& a, const Ref<CSSCalcValue>& b)
+{
+    return a->equals(b.get());
+}
+
+AngleRaw evaluateCalc(const UnevaluatedCalc<AngleRaw>& calc, const CSSCalcSymbolTable& symbolTable)
+{
+    return { calc.calc->primitiveType(), calc.calc->doubleValue(symbolTable) };
+}
+
+NumberRaw evaluateCalc(const UnevaluatedCalc<NumberRaw>& calc, const CSSCalcSymbolTable& symbolTable)
+{
+    return { calc.calc->doubleValue(symbolTable) };
+}
+
+PercentRaw evaluateCalc(const UnevaluatedCalc<PercentRaw>& calc, const CSSCalcSymbolTable& symbolTable)
+{
+    return { calc.calc->doubleValue(symbolTable) };
+}
+
+LengthRaw evaluateCalc(const UnevaluatedCalc<LengthRaw>& calc, const CSSCalcSymbolTable& symbolTable)
+{
+    return { calc.calc->primitiveType(), calc.calc->doubleValue(symbolTable) };
+}
+
+ResolutionRaw evaluateCalc(const UnevaluatedCalc<ResolutionRaw>& calc, const CSSCalcSymbolTable& symbolTable)
+{
+    return { calc.calc->primitiveType(), calc.calc->doubleValue(symbolTable) };
+}
+
+TimeRaw evaluateCalc(const UnevaluatedCalc<TimeRaw>& calc, const CSSCalcSymbolTable& symbolTable)
+{
+    return { calc.calc->primitiveType(), calc.calc->doubleValue(symbolTable) };
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPropertyParserConsumer+RawTypes.h"
+#include <optional>
+#include <variant>
+#include <wtf/Forward.h>
+#include <wtf/Ref.h>
+
+namespace WebCore {
+
+class CSSCalcSymbolTable;
+class CSSCalcValue;
+
+// Type-erased helpers to allow for shared code.
+bool unevaluatedCalcEqual(const Ref<CSSCalcValue>&, const Ref<CSSCalcValue>&);
+
+// `UnevaluatedCalc` annotates a `CSSCalcValue` with the raw value type that it
+// will be evaluated to, allowing the processing of calc in generic code.
+template<typename T> struct UnevaluatedCalc {
+    using RawType = T;
+    Ref<CSSCalcValue> calc;
+
+    bool operator==(const UnevaluatedCalc<T>& other) const
+    {
+        return unevaluatedCalcEqual(calc, other.calc);
+    }
+};
+
+AngleRaw evaluateCalc(const UnevaluatedCalc<AngleRaw>&, const CSSCalcSymbolTable&);
+NumberRaw evaluateCalc(const UnevaluatedCalc<NumberRaw>&, const CSSCalcSymbolTable&);
+PercentRaw evaluateCalc(const UnevaluatedCalc<PercentRaw>&, const CSSCalcSymbolTable&);
+LengthRaw evaluateCalc(const UnevaluatedCalc<LengthRaw>&, const CSSCalcSymbolTable&);
+ResolutionRaw evaluateCalc(const UnevaluatedCalc<ResolutionRaw>&, const CSSCalcSymbolTable&);
+TimeRaw evaluateCalc(const UnevaluatedCalc<TimeRaw>&, const CSSCalcSymbolTable&);
+
+template<typename Result, typename... Ts>
+auto evaluateCalc(const std::variant<Ts...>& component, const CSSCalcSymbolTable& symbolTable) -> Result
+{
+    return WTF::switchOn(component, [&](auto part) -> Result {
+        return evaluateCalc(part, symbolTable);
+    });
+}
+
+template<typename Result, typename... Ts>
+auto evaluateCalc(const std::optional<std::variant<Ts...>>& component, const CSSCalcSymbolTable& symbolTable) -> std::optional<Result>
+{
+    if (component)
+        return evaluateCalc<Result>(*component, symbolTable);
+    return std::nullopt;
+}
+
+template<typename T>
+auto evaluateCalc(const T& component, const CSSCalcSymbolTable&) -> T
+{
+    return component;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -48,6 +48,7 @@
 #include "CSSPropertyParserConsumer+Resolution.h"
 #include "CSSPropertyParserConsumer+ResolutionDefinitions.h"
 #include "CSSPropertyParserConsumer+Time.h"
+#include "CSSPropertyParserConsumer+UnevaluatedCalc.h"
 #include "CSSPropertyParsing.h"
 
 #include "CSSBackgroundRepeatValue.h"
@@ -90,7 +91,6 @@
 #include "CSSRayValue.h"
 #include "CSSRectValue.h"
 #include "CSSReflectValue.h"
-#include "CSSResolvedColorMix.h"
 #include "CSSScrollValue.h"
 #include "CSSSubgridValue.h"
 #include "CSSTimingFunctionValue.h"
@@ -134,7 +134,7 @@ struct ImageSetTypeFunctionRaw {
 struct ImageSetTypeFunctionRawKnownTokenTypeFunctionConsumer {
     static constexpr CSSParserTokenType tokenType = FunctionToken;
 
-    static std::optional<ImageSetTypeFunctionRaw> consume(CSSParserTokenRange& range, const CSSCalcSymbolTable&, CSSPropertyParserOptions)
+    static std::optional<ImageSetTypeFunctionRaw> consume(CSSParserTokenRange& range, CSSCalcSymbolsAllowed, CSSPropertyParserOptions)
     {
         ASSERT(range.peek().type() == FunctionToken);
         if (range.peek().functionId() != CSSValueType)
@@ -202,10 +202,10 @@ static std::optional<double> consumeFontWeightNumberRaw(CSSParserTokenRange& ran
     switch (token.type()) {
     case FunctionToken: {
         // "[For calc()], the used value resulting from an expression must be clamped to the range allowed in the target context."
-        auto unresolvedCalc = NumberKnownTokenTypeFunctionConsumer::consume(range, { }, { });
-        if (!unresolvedCalc)
+        auto unevaluatedCalc = NumberKnownTokenTypeFunctionConsumer::consume(range, { }, { });
+        if (!unevaluatedCalc)
             return std::nullopt;
-        auto result = RawResolver<NumberRaw>::resolve(*unresolvedCalc, { }, { });
+        auto result = RawResolver<NumberRaw>::resolve(*unevaluatedCalc, { }, { });
         if (!result)
             return std::nullopt;
 #if !ENABLE(VARIATION_FONTS)

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -108,8 +108,8 @@ struct FontStyleRaw {
     std::optional<AngleRaw> angle;
 };
 using FontWeightRaw = std::variant<CSSValueID, double>;
-using FontSizeRaw = std::variant<CSSValueID, CSSPropertyParserHelpers::LengthOrPercentRaw>;
-using LineHeightRaw = std::variant<CSSValueID, double, CSSPropertyParserHelpers::LengthOrPercentRaw>;
+using FontSizeRaw = std::variant<CSSValueID, LengthOrPercentRaw>;
+using LineHeightRaw = std::variant<CSSValueID, double, LengthOrPercentRaw>;
 using FontFamilyRaw = std::variant<CSSValueID, AtomString>;
 
 struct FontRaw {

--- a/Source/WebCore/style/StyleResolveForFontRaw.cpp
+++ b/Source/WebCore/style/StyleResolveForFontRaw.cpp
@@ -203,8 +203,8 @@ std::optional<FontCascade> resolveForFontRaw(const FontRaw& fontRaw, FontCascade
         default:
             return 0.f;
         }
-    }, [&] (const CSSPropertyParserHelpers::LengthOrPercentRaw& lengthOrPercent) {
-        return WTF::switchOn(lengthOrPercent, [&] (const CSSPropertyParserHelpers::LengthRaw& length) {
+    }, [&] (const LengthOrPercentRaw& lengthOrPercent) {
+        return WTF::switchOn(lengthOrPercent, [&] (const LengthRaw& length) {
             auto fontCascade = FontCascade(FontCascadeDescription(fontDescription));
             fontCascade.update(context.cssFontSelector());
             // FIXME: Passing null for the RenderView parameter means that vw and vh units will evaluate to
@@ -215,7 +215,7 @@ std::optional<FontCascade> resolveForFontRaw(const FontRaw& fontRaw, FontCascade
             // FIXME: How should root font units work in OffscreenCanvas?
             auto* document = dynamicDowncast<Document>(context);
             return static_cast<float>(CSSPrimitiveValue::computeUnzoomedNonCalcLengthDouble(length.type, length.value, CSSPropertyFontSize, &fontCascade, document ? document->renderView() : nullptr));
-        }, [&] (const CSSPropertyParserHelpers::PercentRaw& percentage) {
+        }, [&] (const PercentRaw& percentage) {
             return static_cast<float>((parentSize * percentage.value) / 100.0);
         });
     });


### PR DESCRIPTION
#### c7dc51fc9225e7ef06d5f956bb7a9837278d542c
<pre>
Support late resolution of symbols in CSS calc
<a href="https://bugs.webkit.org/show_bug.cgi?id=274001">https://bugs.webkit.org/show_bug.cgi?id=274001</a>

Reviewed by Darin Adler.

This change makes it so that symbols passed to `calc()`, such as done
for relative colors, are kept as symbols until evaluation of the `calc()`
is performed. This will allow us to delay resolving the symbols in
relative colors in cases like an origin color of `currentColor`, where
we don&apos;t have the values to resolve the symbol until much later.

To make this possible, a new `CSSCalcExpressionNode` type is added,
`CSSCalcSymbolNode`, which represents the unresolved symbol. Additionally,
instead of passing the `CSSCalcSymbolTable` to the parser, a new
`CSSCalcSymbolsAllowed` table is passed there, and `CSSCalcSymbolTable`
is passed to the evaluation function `doubleValue()`.

Only a few small changes were needed to processing `calc()` to support
these unresolved symbols, primarily in `CSSCalcOperationNode` where
a few places were making assumptions about how child nodes would be
combined by simplification if they had the same types, but with symbols
that is not possible in all cases anymore.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
    - Add new files.

* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::doubleValue const):
(WebCore::CSSPrimitiveValue::doubleValueDividingBy100IfPercentage const):
    - Pass empty symbol table to `doubleValue()`.

* Source/WebCore/css/calc/CSSCalcExpressionNode.cpp:
    - Move virtual destructor out of line to avoid vtable duplication.

* Source/WebCore/css/calc/CSSCalcExpressionNode.h:
    - Adds new `CssCalcSymbol` type
    - Adds new `isResolvable()` pure virtual function, which returns false
      if the node, or any of its children, is an unresolved symbol.
    - Adds `CSSCalcSymbolTable` parameter to `doubleValue()`.

* Source/WebCore/css/calc/CSSCalcExpressionNodeParser.cpp:
(WebCore::CSSCalcExpressionNodeParser::parseValue):
* Source/WebCore/css/calc/CSSCalcExpressionNodeParser.h:
(WebCore::CSSCalcExpressionNodeParser::CSSCalcExpressionNodeParser):
    - Utilize CSSCalcSymbolsAllowed to create symbol nodes for symbols
      at parse time.

* Source/WebCore/css/calc/CSSCalcInvertNode.cpp:
(WebCore::CSSCalcInvertNode::isResolvable const):
(WebCore::CSSCalcInvertNode::doubleValue const):
* Source/WebCore/css/calc/CSSCalcInvertNode.h:
    - Implement `isResolvable() and pass symbol table through to children
      in `doubleValue()`.

* Source/WebCore/css/calc/CSSCalcNegateNode.cpp:
(WebCore::CSSCalcNegateNode::isResolvable const):
(WebCore::CSSCalcNegateNode::doubleValue const):
* Source/WebCore/css/calc/CSSCalcNegateNode.h:
    - Implement `isResolvable() and pass symbol table through to children
      in `doubleValue()`.

* Source/WebCore/css/calc/CSSCalcOperationNode.h:
* Source/WebCore/css/calc/CSSCalcOperationNode.cpp:
(WebCore::CSSCalcOperationNode::combineChildren):
    - Adds check for `isResolvable()` before trying to early evaluate
      math functions, as you can&apos;t evaluate them if child is a symbol.
    - Passes empty symbol table through to resolvable children via
      `doubleValue()`.

(WebCore::CSSCalcOperationNode::isResolvable const):
    - Implement by checking children for `isResolvable()`.

(WebCore::CSSCalcOperationNode::isZero const):
    - Move definition to implementation file to avoid #including
      CSSCalcSymbolTable in the header.

(WebCore::CSSCalcOperationNode::primitiveType const):
    - Add support for computing the primitive type when there are
      multiple nodes of the same type that have not been combined,
      which can now happen with symbols.

(WebCore::CSSCalcOperationNode::doubleValue const):
    - Pass symbol table through to children.

(WebCore::CSSCalcOperationNode::buildCSSTextRecursive):
    - Pass empty symbol table to `doubleValue()`, which is fine because the
      child has been explicitly checked to be a `CSSCalcPrimitiveValueNode`.

* Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp:
(WebCore::CSSCalcPrimitiveValueNode::add):
(WebCore::CSSCalcPrimitiveValueNode::doubleValue const):
(WebCore::CSSCalcPrimitiveValueNode::isResolvable const):
* Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.h:
    - Implement `isResolvable() and pass symbol table through to children
      in `doubleValue()`.

* Source/WebCore/css/calc/CSSCalcSymbolNode.cpp: Added.
* Source/WebCore/css/calc/CSSCalcSymbolNode.h: Added.
    - New `calc` node. Only supported for numeric (`doubleValue()`) `calc()`,
      as there are currently no uses of symbols for anything else and adding
      additional support would require significantly more plumbing with
      `CalcExpressionNode` for no benefit.

* Source/WebCore/css/calc/CSSCalcSymbolTable.cpp:
* Source/WebCore/css/calc/CSSCalcSymbolTable.h:
    - Remove WeakPtr support. `CSSCalcSymbolTable` is not stored anywhere
      anymore, just passed through `doubleValue()`.

* Source/WebCore/css/calc/CSSCalcSymbolsAllowed.cpp: Copied from Source/WebCore/css/calc/CSSCalcSymbolTable.cpp.
(WebCore::CSSCalcSymbolsAllowed::CSSCalcSymbolsAllowed):
(WebCore::CSSCalcSymbolsAllowed::get const):
(WebCore::CSSCalcSymbolsAllowed::contains const):
* Source/WebCore/css/calc/CSSCalcSymbolsAllowed.h: Copied from Source/WebCore/css/calc/CSSCalcSymbolTable.h.
    - Added new table for allowed symbols which includes the symbol&apos;s
      name and type.

* Source/WebCore/css/calc/CSSCalcValue.cpp:
(WebCore::CSSCalcValue::doubleValue const):
(WebCore::CSSCalcValue::create):
* Source/WebCore/css/calc/CSSCalcValue.h:
    - Pass the `CSSCalcSymbolsAllowed` through the constructor, and
      `CSSCalcSymbolTable` through `doubleValue()`.

* Source/WebCore/css/parser/CSSCalcParser.cpp:
(WebCore::CSSPropertyParserHelpers::CalcParser::CalcParser):
(WebCore::CSSPropertyParserHelpers::consumeCalcRawWithKnownTokenTypeFunction):
* Source/WebCore/css/parser/CSSCalcParser.h:
    - Replace `CSSCalcSymbolTable` with `CSSCalcSymbolsAllowed` for parsing.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Angle.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+AngleDefinitions.h:
    - Replace `CSSCalcSymbolTable` with `CSSCalcSymbolsAllowed` for parsing,
      and pass empty values for both to combined `consumeAndResolve()`.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h:
    - Pass `CSSCalcSymbolTable` to `doubleValue()` for resolution.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp:
(WebCore::CSSPropertyParserHelpers::consumeAbsoluteComponent):
(WebCore::CSSPropertyParserHelpers::consumeRelativeComponent):
(WebCore::CSSPropertyParserHelpers::consumeRelativeComponents):
    - Pass both the `CSSCalcSymbolsAllowed` and `CSSCalcSymbolTable` to shared
      consume/resolve functions. This is temporary, and in a subsequent change
      resolution will be in a distinct place from consuming.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Integer.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+IntegerDefinitions.h:
    - Replace `CSSCalcSymbolTable` with `CSSCalcSymbolsAllowed` for parsing,
      and pass empty values for both to combined `consumeAndResolve()`.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Length.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Length.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthDefinitions.h:
    - Replace `CSSCalcSymbolTable` with `CSSCalcSymbolsAllowed` for parsing,
      and pass empty values for both to combined `consumeAndResolve()`.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumer.h:
(WebCore::CSSPropertyParserHelpers::MetaConsumer::consume):
    - Replace `CSSCalcSymbolTable` with `CSSCalcSymbolsAllowed` for parsing.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaResolver.h:
(WebCore::CSSPropertyParserHelpers::MetaResolver::consumeAndResolve):
    - Replace `CSSCalcSymbolTable` with `CSSCalcSymbolsAllowed` for parsing,
      and pass both to combined `consumeAndResolve()`.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+None.cpp:
(WebCore::CSSPropertyParserHelpers::NoneKnownTokenTypeIdentConsumer::consume):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+NoneDefinitions.h:
    - Replace `CSSCalcSymbolTable` with `CSSCalcSymbolsAllowed` for parsing.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Number.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+NumberDefinitions.h:
    - Replace `CSSCalcSymbolTable` with `CSSCalcSymbolsAllowed` for parsing,
      and pass empty values for both to combined `consumeAndResolve()`.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Percent.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+PercentDefinitions.h:
    - Replace `CSSCalcSymbolTable` with `CSSCalcSymbolsAllowed` for parsing,
      and pass empty values for both to combined `consumeAndResolve()`.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Primitives.cpp:
(WebCore::CSSPropertyParserHelpers::equal): Deleted.
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Primitives.h:
    - Moves UnevaluatedCalc out to its own files.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+RawResolver.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+RawResolver.h:
    - Pass `CSSCalcSymbolTable` to `doubleValue()` for resolution.
    - Utilize shared support for symbol replacing via `replaceSymbol()`.
    - Utilize shared support for calc evaluation via `evaluateCalc().

* Source/WebCore/css/parser/CSSPropertyParserConsumer+RawTypes.cpp: Added
(WebCore::replaceSymbol):
    - Added shared place for direct symbol (e.g. not in a `calc()`) replacement
      via a symbol table.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+RawTypes.h:
    - Moved raw types out of the CSSPropertyParserHelpers as it is now used
      beyond just the parser helpers and having that long prefix was unwieldily.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Resolution.cpp:
(WebCore::CSSPropertyParserHelpers::consumeResolution):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ResolutionDefinitions.h:
    - Replace `CSSCalcSymbolTable` with `CSSCalcSymbolsAllowed` for parsing,
      and pass empty values for both to combined `consumeAndResolve()`.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Symbol.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+SymbolDefinitions.h:
    - Replace `CSSCalcSymbolTable` with `CSSCalcSymbolsAllowed` for parsing,
      and pass empty values for both to combined `consumeAndResolve()`.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Time.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Time.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+TimeDefinitions.h:
    - Replace `CSSCalcSymbolTable` with `CSSCalcSymbolsAllowed` for parsing,
      and pass empty values for both to combined `consumeAndResolve()`.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.cpp: Copied from Source/WebCore/css/parser/CSSPropertyParserConsumer+Primitives.cpp.
(WebCore::CSSPropertyParserHelpers::unevaluatedCalcEqual):
(WebCore::CSSPropertyParserHelpers::unevaluatedCalcSerialization):
(WebCore::CSSPropertyParserHelpers::evaluateCalc):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.h: Added.
(WebCore::CSSPropertyParserHelpers::UnevaluatedCalc::operator== const):
(WebCore::CSSPropertyParserHelpers::serializationForCSS):
(WebCore::CSSPropertyParserHelpers::evaluateCalc):
    - Move UnevaluatedCalc to its own files and add support for evaluation that
      passes symbol table through and returns the correct raw type.

* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
    - Replace `CSSCalcSymbolTable` with `CSSCalcSymbolsAllowed` for parsing,
      and pass empty values for both to combined `consumeAndResolve()`.

* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
    - Removed CSSPropertyParserHelpers namespace prefixes from raw types.

* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp:
    - Added now needed missing #include.

* Source/WebCore/css/typedom/CSSNumericValue.cpp:
(WebCore::reifyMathExpression):
(WebCore::CSSNumericValue::reifyMathExpression):
    - Fill in support for the new calc node. Currently unsupported by the spec,
      so throughs an exception.

* Source/WebCore/style/StyleResolveForFontRaw.cpp:
    - Removed CSSPropertyParserHelpers namespace prefixes from raw types.

Canonical link: <a href="https://commits.webkit.org/278635@main">https://commits.webkit.org/278635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9330e2034910aab924088c93be9ddf52444d88e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51175 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30477 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54432 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1865 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53478 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1539 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41678 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44108 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22795 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25430 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1364 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56028 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1331 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49074 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27533 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44175 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48215 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11193 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28414 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27264 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->