### PR TITLE
[CSS] @font-palette-values override-colors accepts only absolute color

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7431,7 +7431,3 @@ webkit.org/b/272417 imported/w3c/web-platform-tests/svg/path/property/priority.s
 
 # re-import css/css-align WPT failure
 webkit.org/b/271692 imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-break-overflow-020.html [ ImageOnlyFailure ]
-
-# re-import css/css-fonts/parsing crash. Skip until https://bugs.webkit.org/show_bug.cgi?id=273888 is fixed
-webkit.org/b/273888 imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-invalid.html [ Skip ]
-webkit.org/b/273888 imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-valid.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-invalid-expected.txt
@@ -21,7 +21,7 @@ PASS CSS Fonts Module Level 4: parsing @font-palette-values 18
 PASS CSS Fonts Module Level 4: parsing @font-palette-values 19
 PASS CSS Fonts Module Level 4: parsing @font-palette-values 20
 PASS CSS Fonts Module Level 4: parsing @font-palette-values 21
-FAIL CSS Fonts Module Level 4: parsing @font-palette-values 22 assert_equals: expected -1 but got 27
+PASS CSS Fonts Module Level 4: parsing @font-palette-values 22
 PASS CSS Fonts Module Level 4: parsing @font-palette-values 23
 PASS CSS Fonts Module Level 4: parsing @font-palette-values 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-valid-expected.txt
@@ -32,5 +32,5 @@ PASS CSS Fonts Module Level 4: parsing @font-palette-values 29
 PASS CSS Fonts Module Level 4: parsing @font-palette-values 30
 PASS CSS Fonts Module Level 4: parsing @font-palette-values 31
 PASS CSS Fonts Module Level 4: parsing @font-palette-values 32
-FAIL CSS Fonts Module Level 4: parsing @font-palette-values 33 assert_equals: expected "0 color-mix(in lch, red, blue)" but got "0 rgba(0, 0, 0, 0)"
+FAIL CSS Fonts Module Level 4: parsing @font-palette-values 33 assert_equals: expected "0 color-mix(in lch, red, blue)" but got ""
 

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -313,6 +313,21 @@ CSSPrimitiveValue::CSSPrimitiveValue(Color color)
     new (reinterpret_cast<Color*>(&m_value.colorAsInteger)) Color(WTFMove(color));
 }
 
+Color CSSPrimitiveValue::absoluteColor() const
+{
+    if (isColor())
+        return color();
+
+    // FIXME: there are some cases where we can resolve a dynamic color at parse time, we should support them.
+    if (isUnresolvedColor())
+        return { };
+
+    if (StyleColor::isAbsoluteColorKeyword(valueID()))
+        return StyleColor::colorFromAbsoluteKeyword(valueID());
+
+    return { };
+}
+
 CSSPrimitiveValue::CSSPrimitiveValue(StaticCSSValueTag, CSSValueID valueID)
     : CSSValue(PrimitiveClass)
 {

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -125,6 +125,10 @@ public:
     bool isColor() const { return primitiveUnitType() == CSSUnitType::CSS_RGBCOLOR; }
     const Color& color() const { ASSERT(isColor()); return *reinterpret_cast<const Color*>(&m_value.colorAsInteger); }
 
+    // Return an absolute color if possible, otherwise an invalid color.
+    // https://drafts.csswg.org/css-color-5/#absolute-color
+    Color absoluteColor() const;
+
     static Ref<CSSPrimitiveValue> createCustomIdent(String);
     bool isCustomIdent() const { return primitiveUnitType() == CSSUnitType::CustomIdent; }
 

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -927,7 +927,10 @@ RefPtr<StyleRuleFontPaletteValues> CSSParserImpl::consumeFontPaletteValuesRule(C
             if (!pair.key().isInteger())
                 continue;
             unsigned key = pair.key().value<unsigned>();
-            Color color = pair.color().isColor() ? pair.color().color() : StyleColor::colorFromKeyword(pair.color().valueID(), { });
+            auto color = pair.color().absoluteColor();
+            // Ignore non absolute color https://drafts.csswg.org/css-fonts/#override-color
+            if (!color.isValid())
+                continue;
             overrideColors.append(std::make_pair(key, color));
         }
     }


### PR DESCRIPTION
#### da248b2c463c58ae57e8fa70150cfaf77f681276
<pre>
[CSS] @font-palette-values override-colors accepts only absolute color
<a href="https://bugs.webkit.org/show_bug.cgi?id=273888">https://bugs.webkit.org/show_bug.cgi?id=273888</a>
<a href="https://rdar.apple.com/127714701">rdar://127714701</a>

Reviewed by Tim Nguyen.

&quot;The specified &lt;color&gt; must be an absolute color.&quot;

<a href="https://drafts.csswg.org/css-fonts/#override-color">https://drafts.csswg.org/css-fonts/#override-color</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-invalid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-valid-expected.txt:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::absoluteColor const):
* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeFontPaletteValuesRule):

Canonical link: <a href="https://commits.webkit.org/278645@main">https://commits.webkit.org/278645@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b400a63f6fd18d60f6f9ed89f09f1ac397c1da6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51202 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54459 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1892 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53505 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1566 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41696 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44135 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22814 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25451 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1391 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1464 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56055 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26312 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1350 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49095 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27560 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44202 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11197 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28441 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/27291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->