### PR TITLE
[WebGPU] https://philogb.github.io/page/indraspearls/ fails to compile shader

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTCompoundStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTCompoundStatement.h
@@ -35,15 +35,18 @@ public:
     using Ref = std::reference_wrapper<CompoundStatement>;
 
     NodeKind kind() const override;
+    Attribute::List& attributes() { return m_attributes; }
     Statement::List& statements() { return m_statements; }
     const Statement::List& statements() const { return m_statements; }
 
 private:
-    CompoundStatement(SourceSpan span, Statement::List&& statements)
+    CompoundStatement(SourceSpan span, Attribute::List&& attributes, Statement::List&& statements)
         : Statement(span)
+        , m_attributes(WTFMove(attributes))
         , m_statements(WTFMove(statements))
     { }
 
+    Attribute::List m_attributes;
     Statement::List m_statements;
 };
 

--- a/Source/WebGPU/WGSL/AttributeValidator.cpp
+++ b/Source/WebGPU/WGSL/AttributeValidator.cpp
@@ -51,6 +51,7 @@ public:
     void visit(AST::Variable&) override;
     void visit(AST::Structure&) override;
     void visit(AST::StructureMember&) override;
+    void visit(AST::CompoundStatement&) override;
 
 private:
     bool parseBuiltin(AST::Function*, std::optional<Builtin>&, AST::Attribute&);
@@ -383,6 +384,15 @@ void AttributeValidator::visit(AST::StructureMember& member)
     validateInvariant(member.span(), member.builtin(), member.invariant());
 
     AST::Visitor::visit(member);
+}
+
+void AttributeValidator::visit(AST::CompoundStatement& statement)
+{
+    for (auto& attribute : statement.attributes()) {
+        if (!is<AST::DiagnosticAttribute>(attribute))
+            error(attribute.span(), "invalid attribute for compound statement"_s);
+    }
+    AST::Visitor::visit(statement);
 }
 
 bool AttributeValidator::parseBuiltin(AST::Function* function, std::optional<Builtin>& builtin, AST::Attribute& attribute)

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -1857,6 +1857,7 @@ void RewriteGlobalVariables::initializeVariables(AST::Function& function, const 
 
     auto& body = m_shaderModule.astBuilder().construct<AST::CompoundStatement>(
         SourceSpan::empty(),
+        AST::Attribute::List { },
         WTFMove(initializations)
     );
 
@@ -2044,6 +2045,7 @@ void RewriteGlobalVariables::storeInitialValue(AST::Expression& target, AST::Sta
 
         auto& forBody = m_shaderModule.astBuilder().construct<AST::CompoundStatement>(
             SourceSpan::empty(),
+            AST::Attribute::List { },
             WTFMove(forBodyStatements)
         );
 

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -628,6 +628,14 @@ Result<AST::Attribute::Ref> Parser<Lexer>::parseAttribute()
     START_PARSE();
 
     CONSUME_TYPE(Attribute);
+
+    if (current().type == TokenType::KeywordDiagnostic) {
+        consume();
+        PARSE(diagnostic, Diagnostic);
+        RETURN_ARENA_NODE(DiagnosticAttribute, WTFMove(diagnostic));
+    }
+
+
     CONSUME_TYPE_NAMED(ident, Identifier);
 
     if (ident.ident == "group"_s) {
@@ -769,11 +777,6 @@ Result<AST::Attribute::Ref> Parser<Lexer>::parseAttribute()
 
     if (ident.ident == "const"_s)
         RETURN_ARENA_NODE(ConstAttribute);
-
-    if (ident.ident == "diagnostic"_s) {
-        PARSE(diagnostic, Diagnostic);
-        RETURN_ARENA_NODE(DiagnosticAttribute, WTFMove(diagnostic));
-    }
 
     // https://gpuweb.github.io/gpuweb/wgsl/#pipeline-stage-attributes
     if (ident.ident == "vertex"_s)
@@ -1209,6 +1212,8 @@ Result<AST::CompoundStatement::Ref> Parser<Lexer>::parseCompoundStatement()
 {
     START_PARSE();
 
+    PARSE(attributes, Attributes);
+
     CONSUME_TYPE(BraceLeft);
 
     AST::Statement::List statements;
@@ -1224,7 +1229,7 @@ Result<AST::CompoundStatement::Ref> Parser<Lexer>::parseCompoundStatement()
 
     CONSUME_TYPE(BraceRight);
 
-    RETURN_ARENA_NODE(CompoundStatement, WTFMove(statements));
+    RETURN_ARENA_NODE(CompoundStatement, WTFMove(attributes), WTFMove(statements));
 }
 
 template<typename Lexer>

--- a/Source/WebGPU/WGSL/tests/valid/for.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/for.wgsl
@@ -3,7 +3,9 @@
 @compute
 @workgroup_size(1, 1, 1)
 fn testForStatement() {
-    for (var i = -1; i <= 1; i++) {
+    for (var i = -1; i <= 1; i++)
+    @diagnostic(off,derivative_uniformity)
+    {
     }
 
     var i = 0;


### PR DESCRIPTION
#### 1d59f80ecec0eced8582a067dcb2d25b80e25f59
<pre>
[WebGPU] <a href="https://philogb.github.io/page/indraspearls/">https://philogb.github.io/page/indraspearls/</a> fails to compile shader
<a href="https://bugs.webkit.org/show_bug.cgi?id=273070">https://bugs.webkit.org/show_bug.cgi?id=273070</a>
<a href="https://rdar.apple.com/126865140">rdar://126865140</a>

Reviewed by Mike Wyrzykowski.

Add support for attributes before compound statements.

* Source/WebGPU/WGSL/AST/ASTCompoundStatement.h:
* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::AttributeValidator::visit):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::initializeVariables):
(WGSL::RewriteGlobalVariables::storeInitialValue):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseAttribute):
(WGSL::Parser&lt;Lexer&gt;::parseCompoundStatement):
* Source/WebGPU/WGSL/tests/valid/for.wgsl:

Canonical link: <a href="https://commits.webkit.org/278682@main">https://commits.webkit.org/278682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cccad10ce497d500e9ee62b574761cec3b532a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54409 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1842 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41663 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53251 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28087 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44086 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22780 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25412 "4 new passes 5 flakes") | | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47392 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56005 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26262 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1307 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49063 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27510 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44153 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48210 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11214 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28391 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27241 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->