### PR TITLE
REGRESSION: run-api-tests strips newlines in failure summary

### DIFF
--- a/Tools/Scripts/webkitpy/api_tests/runner.py
+++ b/Tools/Scripts/webkitpy/api_tests/runner.py
@@ -189,7 +189,7 @@ class _Worker(object):
             if line.lstrip().startswith('objc['):
                 continue
             result += line + '\n'
-        return result
+        return result.rstrip()
 
     def _run_single_test(self, binary_name, test):
         server_process = ServerProcess(
@@ -260,7 +260,7 @@ class _Worker(object):
                     line = self.EXCEEDED_LOG_LINE_MESSAGE.format(self.log_limit)
 
                 _log.error(line)
-                output_buffer += line
+                output_buffer += line + '\n'
 
                 if line_count > self.log_limit:
                     break


### PR DESCRIPTION
#### 11b43d3c00bef88afe9c312dcbab08bb295fd3cb
<pre>
REGRESSION: run-api-tests strips newlines in failure summary
<a href="https://bugs.webkit.org/show_bug.cgi?id=266044">https://bugs.webkit.org/show_bug.cgi?id=266044</a>
<a href="https://rdar.apple.com/119696758">rdar://119696758</a>

Reviewed by Sam Sneddon.

Our technique for grabbing the remaining stdout and stderr from
an API process accidentally strips newlines.

* Tools/Scripts/webkitpy/api_tests/runner.py:
(_Worker._filter_noisy_output): Strip trailing whitespace on output.
(_Worker._run_single_test): Re-add newlines when grabbing remaining stdout and stderr.

Canonical link: <a href="https://commits.webkit.org/278660@main">https://commits.webkit.org/278660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da6cdeedb48412eb01cfd2046ebd0420f3005bdb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3562 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54482 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1915 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53528 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1590 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41717 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53324 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28162 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44157 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22835 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/51074 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25487 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1414 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47457 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56078 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26335 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1374 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49119 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27583 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44224 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48266 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11207 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28466 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->