### PR TITLE
[webkitdirs] Delete isSVNVersion16OrNewer and runSvnUpdateAndResolveChangeLogs

### DIFF
--- a/Tools/Scripts/VCSUtils.pm
+++ b/Tools/Scripts/VCSUtils.pm
@@ -73,7 +73,6 @@ BEGIN {
         &isGitDirectory
         &isSVN
         &isSVNDirectory
-        &isSVNVersion16OrNewer
         &listOfChangedFilesBetweenRevisions
         &makeFilePathRelative
         &mergeChangeLogs
@@ -338,12 +337,6 @@ sub svnVersion()
         chomp($svnVersion = `svn --version --quiet`);
     }
     return $svnVersion;
-}
-
-sub isSVNVersion16OrNewer()
-{
-    my $version = svnVersion();
-    return "v$version" ge v1.6;
 }
 
 sub chdirReturningRelativePath($)

--- a/Tools/Scripts/prepare-ChangeLog
+++ b/Tools/Scripts/prepare-ChangeLog
@@ -2304,17 +2304,10 @@ sub generateFileList(\%$$$\%)
 
         if (isSVN()) {
             my $matches;
-            if (isSVNVersion16OrNewer()) {
-                $matches = /^([ ACDMR])([ CM]).{5} (.+?)[\r\n]*$/;
-                $status = $1;
-                $propertyStatus = $2;
-                $file = $3;
-            } else {
-                $matches = /^([ ACDMR])([ CM]).{4} (.+?)[\r\n]*$/;
-                $status = $1;
-                $propertyStatus = $2;
-                $file = $3;
-            }
+            $matches = /^([ ACDMR])([ CM]).{5} (.+?)[\r\n]*$/;
+            $status = $1;
+            $propertyStatus = $2;
+            $file = $3;
             if ($matches) {
                 $file = normalizePath($file);
                 $original = findOriginalFileFromSvn($file) if substr($_, 3, 1) eq "+";

--- a/Tools/Scripts/resolve-ChangeLogs
+++ b/Tools/Scripts/resolve-ChangeLogs
@@ -275,13 +275,8 @@ sub findUnmergedChangeLogs()
         if ($isSVN) {
             my $matches;
             my $file;
-            if (isSVNVersion16OrNewer()) {
-                $matches = /^([C]).{6} (.+?)[\r\n]*$/;
-                $file = $2;
-            } else {
-                $matches = /^([C]).{5} (.+?)[\r\n]*$/;
-                $file = $2;
-            }
+            $matches = /^([C]).{6} (.+?)[\r\n]*$/;
+            $file = $2;
             if ($matches) {
                 $file = findChangeLog(normalizePath($file));
                 push @results, $file if $file;

--- a/Tools/Scripts/update-webkit
+++ b/Tools/Scripts/update-webkit
@@ -60,14 +60,7 @@ __END__
     exit 1;
 }
 
-my @svnOptions = ();
-push @svnOptions, '-q' if $quiet;
-
-# Don't prompt when using svn-1.6 or newer.
-push @svnOptions, qw(--accept postpone) if isSVNVersion16OrNewer();
-
 print "Updating OpenSource\n" unless $quiet;
-runSvnUpdateAndResolveChangeLogs(@svnOptions) if isSVN();
 runGitUpdate() if isGit();
 
 exit 0;

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -172,7 +172,6 @@ BEGIN {
        &runMacWebKitApp
        &runMiniBrowser
        &runSafari
-       &runSvnUpdateAndResolveChangeLogs
        &runWebKitTestRunner
        &safariPath
        &sdkDirectory
@@ -3477,30 +3476,6 @@ sub formatBuildTime($)
         return sprintf("%dh:%02dm:%02ds", $buildHours, $buildMins, $buildSecs);
     }
     return sprintf("%02dm:%02ds", $buildMins, $buildSecs);
-}
-
-sub runSvnUpdateAndResolveChangeLogs(@)
-{
-    my @svnOptions = @_;
-    my $openCommand = "svn update " . join(" ", @svnOptions);
-    open my $update, "$openCommand |" or die "cannot execute command $openCommand";
-    my @conflictedChangeLogs;
-    while (my $line = <$update>) {
-        print $line;
-        $line =~ m/^C\s+(.+?)[\r\n]*$/;
-        if ($1) {
-          my $filename = normalizePath($1);
-          push @conflictedChangeLogs, $filename if basename($filename) eq "ChangeLog";
-        }
-    }
-    close $update or die;
-
-    if (@conflictedChangeLogs) {
-        print "Attempting to merge conflicted ChangeLogs.\n";
-        my $resolveChangeLogsPath = File::Spec->catfile(sourceDir(), "Tools", "Scripts", "resolve-ChangeLogs");
-        (system($resolveChangeLogsPath, "--no-warnings", @conflictedChangeLogs) == 0)
-            or die "Could not open resolve-ChangeLogs script: $!.\n";
-    }
 }
 
 sub runGitUpdate()


### PR DESCRIPTION
#### 70185c15ef27b9f2169a05723023d2a91a45f8ae
<pre>
[webkitdirs] Delete isSVNVersion16OrNewer and runSvnUpdateAndResolveChangeLogs
<a href="https://bugs.webkit.org/show_bug.cgi?id=274017">https://bugs.webkit.org/show_bug.cgi?id=274017</a>
<a href="https://rdar.apple.com/127899677">rdar://127899677</a>

Reviewed by Alexey Proskuryakov.

* Tools/Scripts/VCSUtils.pm:
(isSVNVersion16OrNewer): Deleted.
* Tools/Scripts/prepare-ChangeLog:
(generateFileList):
* Tools/Scripts/resolve-ChangeLogs:
(findUnmergedChangeLogs):
* Tools/Scripts/update-webkit:
* Tools/Scripts/webkitdirs.pm:
(runSvnUpdateAndResolveChangeLogs): Deleted.

Canonical link: <a href="https://commits.webkit.org/278632@main">https://commits.webkit.org/278632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d02aa31e983ec3886a359cb3ef042f62e5e13f58

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3512 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/54434 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/1867 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53480 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1541 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/54434 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53276 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/28109 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/44111 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/54434 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/1367 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/44516 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/1440 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56030 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/50679 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/26287 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1329 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49077 "Build is in progress. Recent messages:") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/27535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/44178 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/28416 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/59383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7437 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/27266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/59383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->