### PR TITLE
Remove more MSVC hacks

### DIFF
--- a/Source/JavaScriptCore/jit/JITMathIC.h
+++ b/Source/JavaScriptCore/jit/JITMathIC.h
@@ -133,11 +133,7 @@ public:
         };
 
         auto replaceCall = [&] () {
-#if COMPILER(MSVC) && !COMPILER(CLANG)
-            ftlThunkAwareRepatchCall(codeBlock, slowPathCallLocation().retagged<JSInternalPtrTag>(), callReplacement);
-#else
             ftlThunkAwareRepatchCall(codeBlock, slowPathCallLocation().template retagged<JSInternalPtrTag>(), callReplacement);
-#endif
         };
 
         bool shouldEmitProfiling = !JSC::JITCode::isOptimizingJIT(codeBlock->jitType());

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -109,16 +109,9 @@ ALWAYS_INLINE JSValue profiledAdd(JSGlobalObject* globalObject, JSValue op1, JSV
     return result;
 }
 
-#if COMPILER(MSVC)
-extern "C" void * _ReturnAddress(void);
-#pragma intrinsic(_ReturnAddress)
-
-#define OUR_RETURN_ADDRESS _ReturnAddress()
-#else
 // FIXME (see rdar://72897291): Work around a Clang bug where __builtin_return_address()
 // sometimes gives us a signed pointer, and sometimes does not.
 #define OUR_RETURN_ADDRESS removeCodePtrTag(__builtin_return_address(0))
-#endif
 
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationThrowStackOverflowError, void, (CodeBlock* codeBlock))

--- a/Source/JavaScriptCore/llint/LLIntData.h
+++ b/Source/JavaScriptCore/llint/LLIntData.h
@@ -213,11 +213,7 @@ ALWAYS_INLINE MacroAssemblerCodeRef<tag> getWide32CodeRef(OpcodeID opcodeID)
 template<PtrTag tag>
 ALWAYS_INLINE LLIntCode getCodeFunctionPtr(OpcodeID opcodeID)
 {
-#if COMPILER(MSVC)
-    return reinterpret_cast<LLIntCode>(getCodePtr<tag>(opcodeID).taggedPtr());
-#else
     return reinterpret_cast<LLIntCode>(getCodePtr<tag>(opcodeID).template taggedPtr());
-#endif
 }
 
 #if ENABLE(JIT)
@@ -225,21 +221,13 @@ ALWAYS_INLINE LLIntCode getCodeFunctionPtr(OpcodeID opcodeID)
 template<PtrTag tag>
 ALWAYS_INLINE LLIntCode getWide16CodeFunctionPtr(OpcodeID opcodeID)
 {
-#if COMPILER(MSVC)
-    return reinterpret_cast<LLIntCode>(getWide16CodePtr<tag>(opcodeID).taggedPtr());
-#else
     return reinterpret_cast<LLIntCode>(getWide16CodePtr<tag>(opcodeID).template taggedPtr());
-#endif
 }
 
 template<PtrTag tag>
 ALWAYS_INLINE LLIntCode getWide32CodeFunctionPtr(OpcodeID opcodeID)
 {
-#if COMPILER(MSVC)
-    return reinterpret_cast<LLIntCode>(getWide32CodePtr<tag>(opcodeID).taggedPtr());
-#else
     return reinterpret_cast<LLIntCode>(getWide32CodePtr<tag>(opcodeID).template taggedPtr());
-#endif
 }
 #else // not ENABLE(JIT)
 ALWAYS_INLINE void* getCodePtr(OpcodeID id)
@@ -358,11 +346,7 @@ ALWAYS_INLINE MacroAssemblerCodeRef<tag> getWide32CodeRef(WasmOpcodeID opcodeID)
 template<PtrTag tag>
 ALWAYS_INLINE LLIntCode getCodeFunctionPtr(WasmOpcodeID opcodeID)
 {
-#if COMPILER(MSVC)
-    return reinterpret_cast<LLIntCode>(getCodePtr<tag>(opcodeID).taggedPtr());
-#else
     return reinterpret_cast<LLIntCode>(getCodePtr<tag>(opcodeID).template taggedPtr());
-#endif
 }
 
 #if ENABLE(JIT)
@@ -370,21 +354,13 @@ ALWAYS_INLINE LLIntCode getCodeFunctionPtr(WasmOpcodeID opcodeID)
 template<PtrTag tag>
 ALWAYS_INLINE LLIntCode getWide16CodeFunctionPtr(WasmOpcodeID opcodeID)
 {
-#if COMPILER(MSVC)
-    return reinterpret_cast<LLIntCode>(getWide16CodePtr<tag>(opcodeID).taggedPtr());
-#else
     return reinterpret_cast<LLIntCode>(getWide16CodePtr<tag>(opcodeID).template taggedPtr());
-#endif
 }
 
 template<PtrTag tag>
 ALWAYS_INLINE LLIntCode getWide32CodeFunctionPtr(WasmOpcodeID opcodeID)
 {
-#if COMPILER(MSVC)
-    return reinterpret_cast<LLIntCode>(getWide32CodePtr<tag>(opcodeID).taggedPtr());
-#else
     return reinterpret_cast<LLIntCode>(getWide32CodePtr<tag>(opcodeID).template taggedPtr());
-#endif
 }
 #else // not ENABLE(JIT)
 ALWAYS_INLINE void* getCodePtr(WasmOpcodeID id)

--- a/Source/JavaScriptCore/llint/LLIntThunks.cpp
+++ b/Source/JavaScriptCore/llint/LLIntThunks.cpp
@@ -228,11 +228,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> wasmFunctionEntryThunkSIMD()
 
 ALWAYS_INLINE void* untaggedPtr(void* ptr)
 {
-#if COMPILER(MSVC)
-        return CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).untaggedPtr();
-#else
-        return CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr();
-#endif
+    return CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr();
 }
 
 MacroAssemblerCodeRef<JITThunkPtrTag> inPlaceInterpreterEntryThunk()

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -2543,10 +2543,7 @@ bool GenericCacheEntry::decode(Decoder& decoder, std::pair<SourceCodeKey, Unlink
         RELEASE_ASSERT_NOT_REACHED();
     }
     RELEASE_ASSERT_NOT_REACHED();
-#if COMPILER(MSVC)
-    // Without this, MSVC will complain that this path does not return a value.
     return false;
-#endif
 }
 
 bool GenericCacheEntry::isStillValid(Decoder& decoder, const SourceCodeKey& key, CachedCodeBlockTag tag) const

--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -140,11 +140,7 @@ extern "C" {
 
    Signals are ignored by the crash reporter on OS X so we must do better.
 */
-#if COMPILER(GCC_COMPATIBLE) || COMPILER(MSVC)
 #define NO_RETURN_DUE_TO_CRASH NO_RETURN
-#else
-#define NO_RETURN_DUE_TO_CRASH
-#endif
 
 #ifdef __cplusplus
 enum class WTFLogChannelState : uint8_t { Off, On, OnWithAccumulation };
@@ -308,11 +304,7 @@ WTF_EXPORT_PRIVATE bool WTFIsDebuggerAttached(void);
 #define WTFBreakpointTrap() WTFCrash() // Not implemented.
 #endif
 
-#if COMPILER(MSVC)
-#define WTFBreakpointTrapUnderConstexprContext() ((void) 0)
-#else
 #define WTFBreakpointTrapUnderConstexprContext() __builtin_trap()
-#endif
 
 #ifndef CRASH
 

--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -175,11 +175,7 @@ protected:
 private:
     template<typename> friend class ThreadSafeWeakPtr;
     template<typename> friend class ThreadSafeWeakHashSet;
-#if COMPILER(MSVC)
-    ThreadSafeWeakPtrControlBlock& m_controlBlock { *new ThreadSafeWeakPtrControlBlock((T*)this) };
-#else
     ThreadSafeWeakPtrControlBlock& m_controlBlock { *new ThreadSafeWeakPtrControlBlock(static_cast<T*>(this)) };
-#endif
 };
 
 template<typename T>

--- a/Source/WTF/wtf/TypeTraits.h
+++ b/Source/WTF/wtf/TypeTraits.h
@@ -165,8 +165,6 @@ struct LooksLikeRCSerialDispatcher : decltype(detail::LooksLikeRCSerialDispatche
 class NativePromiseBase;
 class ConvertibleToNativePromise;
 
-// The use of C++20 concepts causes a crash with the current msvc (see webkit.org/b/261598)
-#if !COMPILER(MSVC)
 template <typename T>
 concept IsNativePromise = std::is_base_of<NativePromiseBase, T>::value;
 
@@ -180,20 +178,6 @@ concept RelatedNativePromise = requires(T, U)
     { IsConvertibleToNativePromise<U> };
     { std::is_same<typename T::PromiseType, typename U::PromiseType>::value };
 };
-#else
-template <typename T>
-constexpr bool IsNativePromise = std::is_base_of<NativePromiseBase, T>::value;
-
-template <typename T>
-constexpr bool IsConvertibleToNativePromise = std::is_base_of<ConvertibleToNativePromise, T>::value;
-
-// The test isn't as exhaustive as concept's version.
-// It will prevent having more user-friendly compilation error should mix&match of NativePromise is used.
-// This will do for now.
-template <typename T, typename U>
-constexpr bool RelatedNativePromise = IsConvertibleToNativePromise<T> && IsConvertibleToNativePromise<U>;
-#endif
-
 
 template <typename T>
 struct IsExpected : std::false_type { };

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
@@ -156,9 +156,7 @@ void ClipboardItemBindingsDataSource::collectDataForWriting(Clipboard& destinati
                 return;
 
             Ref itemTypeLoader { *weakItemTypeLoader };
-#if !(COMPILER(MSVC) && !COMPILER(CLANG))
             ASSERT_UNUSED(this, notFound != m_itemTypeLoaders.findIf([&] (auto& loader) { return loader.ptr() == itemTypeLoader.ptr(); }));
-#endif
 
             auto result = promise->result();
             if (!result) {

--- a/Source/WebCore/fileapi/AsyncFileStream.cpp
+++ b/Source/WebCore/fileapi/AsyncFileStream.cpp
@@ -52,20 +52,12 @@ struct AsyncFileStream::Internals {
 
     FileStream stream;
     FileStreamClient& client;
-#if !COMPILER(MSVC)
     std::atomic_bool destroyed { false };
-#else
-    std::atomic_bool destroyed;
-#endif
 };
 
 inline AsyncFileStream::Internals::Internals(FileStreamClient& client)
     : client(client)
 {
-#if COMPILER(MSVC)
-    // Work around a bug that prevents the default value above from compiling.
-    atomic_init(&destroyed, false);
-#endif
 }
 
 static void callOnFileThread(Function<void ()>&& function)

--- a/Source/WebCore/loader/SubresourceLoader.h
+++ b/Source/WebCore/loader/SubresourceLoader.h
@@ -121,9 +121,7 @@ private:
     };
 
     class RequestCountTracker {
-#if !COMPILER(MSVC)
         WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
-#endif
     public:
         RequestCountTracker(CachedResourceLoader&, const CachedResource&);
         RequestCountTracker(RequestCountTracker&&);

--- a/Source/WebCore/platform/PODInterval.h
+++ b/Source/WebCore/platform/PODInterval.h
@@ -76,17 +76,6 @@ protected:
     {
     }
 
-#if COMPILER(MSVC)
-    // Work around an MSVC bug.
-    PODIntervalBase(const T& low, const T& high, const UserData& data)
-        : m_low(low)
-        , m_high(high)
-        , m_data(data)
-        , m_maxHigh(high)
-    {
-    }
-#endif
-
 private:
     T m_low;
     T m_high;

--- a/Source/WebCore/platform/PlatformMouseEvent.h
+++ b/Source/WebCore/platform/PlatformMouseEvent.h
@@ -122,18 +122,4 @@ protected:
 #endif
 };
 
-#if COMPILER(MSVC)
-// These functions are necessary to work around the fact that MSVC will not find a most-specific
-// operator== to use after implicitly converting MouseButton to a short.
-inline bool operator==(short a, MouseButton b)
-{
-    return a == static_cast<short>(b);
-}
-
-inline bool operator!=(short a, MouseButton b)
-{
-    return a != static_cast<short>(b);
-}
-#endif
-
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
@@ -77,11 +77,7 @@ class TransformationMatrix {
 public:
 
 #if (PLATFORM(IOS_FAMILY) && CPU(ARM_THUMB2)) || defined(TRANSFORMATION_MATRIX_USE_X86_64_SSE2)
-#if COMPILER(MSVC)
-    __declspec(align(16)) typedef double Matrix4[4][4];
-#else
     typedef double Matrix4[4][4] __attribute__((aligned (16)));
-#endif
 #else
     typedef double Matrix4[4][4];
 #endif

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyList.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyList.h
@@ -111,11 +111,7 @@ public:
             m_animVal = nullptr;
     }
 
-    // Visual Studio doesn't seem to see these private constructors from subclasses.
-    // FIXME: See what it takes to remove this hack.
-#if !COMPILER(MSVC)
 protected:
-#endif
     template<typename... Arguments>
     SVGAnimatedPropertyList(SVGElement* contextElement, Arguments&&... arguments)
         : SVGAnimatedProperty(contextElement)

--- a/Source/WebCore/svg/properties/SVGProperty.h
+++ b/Source/WebCore/svg/properties/SVGProperty.h
@@ -89,11 +89,7 @@ public:
     // This is used when calling setAttribute().
     virtual String valueAsString() const { return emptyString(); }
 
-    // Visual Studio doesn't seem to see these private constructors from subclasses.
-    // FIXME: See what it takes to remove this hack.
-#if !COMPILER(MSVC)
 protected:
-#endif
     SVGProperty(SVGPropertyOwner* owner = nullptr, SVGPropertyAccess access = SVGPropertyAccess::ReadWrite)
         : m_owner(owner)
         , m_access(access)

--- a/Source/WebCore/svg/properties/SVGPropertyList.h
+++ b/Source/WebCore/svg/properties/SVGPropertyList.h
@@ -37,11 +37,7 @@ public:
     using BaseList::size;
     using BaseList::append;
 
-    // Visual Studio doesn't seem to see these private constructors from subclasses.
-    // FIXME: See what it takes to remove this hack.
-#if !COMPILER(MSVC)
 protected:
-#endif
     using SVGPropertyOwner::SVGPropertyOwner;
     using BaseList::m_items;
     using BaseList::m_access;

--- a/Source/WebCore/svg/properties/SVGValueProperty.h
+++ b/Source/WebCore/svg/properties/SVGValueProperty.h
@@ -46,11 +46,7 @@ public:
     // Used by the SVGAnimatedPropertyAnimator to pass m_value to SVGAnimationFunction.
     PropertyType& value() { return m_value; }
 
-    // Visual Studio doesn't seem to see these private constructors from subclasses.
-    // FIXME: See what it takes to remove this hack.
-#if !COMPILER(MSVC)
 protected:
-#endif
     // Create an initialized property, e.g creating an item to be appended in an SVGList.
     SVGValueProperty(const PropertyType& value)
         : m_value(value)

--- a/Source/WebCore/svg/properties/SVGValuePropertyList.h
+++ b/Source/WebCore/svg/properties/SVGValuePropertyList.h
@@ -66,11 +66,7 @@ public:
             remove(size() - 1);
     }
 
-    // Visual Studio doesn't seem to see these private constructors from subclasses.
-    // FIXME: See what it takes to remove this hack.
-#if !COMPILER(MSVC)
 protected:
-#endif
     using Base::append;
     using Base::remove;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4729,19 +4729,13 @@ bool WebPageProxy::isPageOpenedByDOMShowingInitialEmptyDocument() const
 
 // MSVC gives a redeclaration error if noreturn is used on the definition and not the declaration, while
 // Cocoa tests segfault if it is moved to the declaration site (even if we move the definition with it!).
-#if !COMPILER(MSVC)
-NO_RETURN_DUE_TO_ASSERT
-#endif
-void WebPageProxy::didFailToSuspendAfterProcessSwap()
+NO_RETURN_DUE_TO_ASSERT void WebPageProxy::didFailToSuspendAfterProcessSwap()
 {
     // Only the SuspendedPageProxy should be getting this call.
     ASSERT_NOT_REACHED();
 }
 
-#if !COMPILER(MSVC)
-NO_RETURN_DUE_TO_ASSERT
-#endif
-void WebPageProxy::didSuspendAfterProcessSwap()
+NO_RETURN_DUE_TO_ASSERT void WebPageProxy::didSuspendAfterProcessSwap()
 {
     // Only the SuspendedPageProxy should be getting this call.
     ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### b1897a24b1f14d6acd8a60244d8ee5e09f31f4ae
<pre>
Remove more MSVC hacks
<a href="https://bugs.webkit.org/show_bug.cgi?id=274018">https://bugs.webkit.org/show_bug.cgi?id=274018</a>
<a href="https://rdar.apple.com/127899955">rdar://127899955</a>

Reviewed by Mark Lam.

* Source/JavaScriptCore/jit/JITMathIC.h:
(JSC::JITMathIC::generateOutOfLine):
* Source/JavaScriptCore/jit/JITOperations.cpp:
* Source/JavaScriptCore/llint/LLIntData.h:
(JSC::LLInt::getCodeFunctionPtr):
(JSC::LLInt::getWide16CodeFunctionPtr):
(JSC::LLInt::getWide32CodeFunctionPtr):
* Source/JavaScriptCore/llint/LLIntThunks.cpp:
(JSC::LLInt::untaggedPtr):
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::GenericCacheEntry::decode const):
* Source/WTF/wtf/Assertions.h:
* Source/WTF/wtf/MathExtras.h:
(WTF::clz):
(WTF::ctz):
(wtf_pow): Deleted.
* Source/WTF/wtf/ThreadSafeWeakPtr.h:
* Source/WTF/wtf/TypeTraits.h:
(WTF::requires):
* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp:
(WebCore::ClipboardItemBindingsDataSource::collectDataForWriting):
* Source/WebCore/fileapi/AsyncFileStream.cpp:
(WebCore::AsyncFileStream::Internals::Internals):
* Source/WebCore/loader/SubresourceLoader.h:
* Source/WebCore/platform/PODInterval.h:
* Source/WebCore/platform/PlatformMouseEvent.h:
(WebCore::operator==): Deleted.
(WebCore::operator!=): Deleted.
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.h:
* Source/WebCore/svg/properties/SVGAnimatedPropertyList.h:
* Source/WebCore/svg/properties/SVGProperty.h:
* Source/WebCore/svg/properties/SVGPropertyList.h:
* Source/WebCore/svg/properties/SVGValueProperty.h:
* Source/WebCore/svg/properties/SVGValuePropertyList.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didFailToSuspendAfterProcessSwap):
(WebKit::WebPageProxy::didSuspendAfterProcessSwap):

Canonical link: <a href="https://commits.webkit.org/278643@main">https://commits.webkit.org/278643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e12e39baec868882a82952dd457d917ed219098

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51204 "Failed to checkout and rebase branch from PR 28410") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3539 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/54461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/1894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53507 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1568 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/54461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53303 "Failed to checkout and rebase branch from PR 28410") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/28134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/44137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/54461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/1393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/44543 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/1466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56057 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/50706 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/26314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/27562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/44204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/28443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/62944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7444 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/27293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/62944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->