### PR TITLE
WorkerOrWorkletThread should crossThreadCopy the inspector identifier

### DIFF
--- a/Source/WebCore/workers/WorkerOrWorkletThread.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.cpp
@@ -63,7 +63,7 @@ static UniqueRef<WorkerRunLoop> constructRunLoop(WorkerThreadMode workerThreadMo
 }
 
 WorkerOrWorkletThread::WorkerOrWorkletThread(const String& inspectorIdentifier, WorkerThreadMode workerThreadMode)
-    : m_inspectorIdentifier(inspectorIdentifier)
+    : m_inspectorIdentifier(crossThreadCopy(inspectorIdentifier)) // inspectorIdentifier is accessed from the main thread.
     , m_runLoop(constructRunLoop(workerThreadMode))
 {
     workerOrWorkletThreads().add(*this);


### PR DESCRIPTION
#### dbe9f5f4143222854ac1ffd5b88ccffe4e440556
<pre>
WorkerOrWorkletThread should crossThreadCopy the inspector identifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=274019">https://bugs.webkit.org/show_bug.cgi?id=274019</a>

Reviewed by NOBODY (OOPS!).

Since m_inspectorIdentifier is accessed in the main thread in ResourceUsageThread::platformCollectCPUData,
we should be making a crossThreadCopy in the case the worker is created within another worker.

* Source/WebCore/workers/WorkerOrWorkletThread.cpp:
(WebCore::WorkerOrWorkletThread::WorkerOrWorkletThread):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbe9f5f4143222854ac1ffd5b88ccffe4e440556

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54437 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1870 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53483 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1544 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41681 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53279 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44115 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22798 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1371 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47433 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56033 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26290 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1333 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49079 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27538 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44182 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48219 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28419 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->