### PR TITLE
Check that slot + descriptor accesses are made under an Accessor attribute

### DIFF
--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -755,6 +755,8 @@ bool ordinarySetWithOwnDescriptor(JSGlobalObject* globalObject, JSObject* object
     if (!setter.isObject())
         return typeError(globalObject, scope, shouldThrow, ReadonlyPropertyWriteError);
 
+    RELEASE_ASSERT(ownDescriptor.attributes() & PropertyAttribute::Accessor);
+
     // 9.1.9.1-8 Perform ? Call(setter, Receiver, << V >>).
     JSObject* setterObject = asObject(setter);
     MarkedArgumentBuffer args;

--- a/Source/JavaScriptCore/runtime/PropertySlot.h
+++ b/Source/JavaScriptCore/runtime/PropertySlot.h
@@ -402,8 +402,10 @@ ALWAYS_INLINE JSValue PropertySlot::getValue(JSGlobalObject* globalObject, Prope
 {
     if (m_propertyType == TypeValue)
         return JSValue::decode(m_data.value);
-    if (m_propertyType == TypeGetter)
+    if (m_propertyType == TypeGetter) {
+        RELEASE_ASSERT(m_attributes & PropertyAttribute::Accessor);
         return functionGetter(globalObject);
+    }
     return customGetter(getVM(globalObject), propertyName);
 }
 
@@ -412,8 +414,10 @@ ALWAYS_INLINE JSValue PropertySlot::getValue(JSGlobalObject* globalObject, uint6
     VM& vm = getVM(globalObject);
     if (m_propertyType == TypeValue)
         return JSValue::decode(m_data.value);
-    if (m_propertyType == TypeGetter)
+    if (m_propertyType == TypeGetter) {
+        RELEASE_ASSERT(m_attributes & PropertyAttribute::Accessor);
         return functionGetter(globalObject);
+    }
     return customGetter(getVM(globalObject), Identifier::from(vm, propertyName));
 }
 


### PR DESCRIPTION
#### bce4562bde47db4de45ec667afe9ee503b14a2a0
<pre>
Check that slot + descriptor accesses are made under an Accessor attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=273576">https://bugs.webkit.org/show_bug.cgi?id=273576</a>
<a href="https://rdar.apple.com/127365044">rdar://127365044</a>

Reviewed by NOBODY (OOPS!).

This should always be the case, so adding asserts here helps document
the invariant and catch bugs elsewhere in the code. We can&apos;t add a
RELEASE_ASSERT right where we want to due to the performance impact,
but adding them here covers the most important code-path with no
measurable slowdown.

* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::ordinarySetWithOwnDescriptor):
* Source/JavaScriptCore/runtime/PropertySlot.h:
(JSC::PropertySlot::getValue const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bce4562bde47db4de45ec667afe9ee503b14a2a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54446 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1879 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41690 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44123 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22807 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25439 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1379 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/44528 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47417 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1452 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56042 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/50691 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26299 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1338 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49086 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27547 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44190 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48227 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28428 "Built successfully") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/62910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27278 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/62910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->