### PR TITLE
Unreviewed. Update OptionsWPE.cmake and NEWS for the 2.45.1 release

### DIFF
--- a/Source/WebKit/wpe/NEWS
+++ b/Source/WebKit/wpe/NEWS
@@ -1,4 +1,37 @@
 =================
+WPE WebKit 2.45.1
+=================
+
+What's new in WPE WebKit 2.45.1?
+
+  - Use Skia by default instead of Cairo for rendering. Cairo support may
+    still be built passing -DUSE_SKIA=OFF to CMake.
+  - Synchronize WebGL content using fences, where available.
+  - Disable the gst-libav AAC decoder.
+  - Support AXActiveElement and AXSelectedChildren for combo boxes,
+    lists and list boxes.
+  - Decrease input notifications for gamepad inputs.
+  - Make gamepads visible on axis movements, and not only on button presses.
+  - Improve DMA-BUF format negotiation and buffer allocation to facilitate
+    faster code paths in buffer handling.
+  - Make user scripts and style sheets visible in the Web Inspector.
+  - Make hole-punch media playback support video elements with rounded
+	corners.
+  - Enable by default building support for the MediaSession and WebCodecs APIs.
+  - Allow WebDriver connections to already running browsers.
+  - Support downloading files from the Web Inspector when using HTTP
+    remote connections.
+  - Replace build-time per-platform multimedia support option with quirks
+    applied at runtime. Automatic quirk detection is used by default, and
+    quirks may be overriden using the WEBKIT_GST_QUIRKS and
+    WEBKIT_GST_HOLE_PUNCH environment variables.
+  - Deprecate the WebKitWebView::insecure-content-detected signal.
+  - Fix mouse location in WebDriver when output device scaling is in effect.
+  - Fix touch input event propagation.
+  - Fix missing mouse cursor in the WPE Wayland platform support.
+  - Fix several crashes and rendering issues.
+
+=================
 WPE WebKit 2.43.1
 =================
 

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -1,7 +1,7 @@
 include(GNUInstallDirs)
 include(VersioningUtils)
 
-SET_PROJECT_VERSION(2 45 0)
+SET_PROJECT_VERSION(2 45 1)
 
 # This is required because we use the DEPFILE argument to add_custom_command().
 # Remove after upgrading cmake_minimum_required() to 3.20.


### PR DESCRIPTION
#### 27323d1e307080ec684b4fcab3cea2efc04b7126
<pre>
Unreviewed. Update OptionsWPE.cmake and NEWS for the 2.45.1 release

* Source/WebKit/wpe/NEWS: Add release notes for 2.45.1.
* Source/cmake/OptionsWPE.cmake: Bump version numbers.

Canonical link: <a href="https://commits.webkit.org/278634@main">https://commits.webkit.org/278634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/849805c76dd12c023836580f527f384a5ca243e8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51191 "Failed to checkout and rebase branch from PR 28416") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54448 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/1881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1555 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53290 "Failed to checkout and rebase branch from PR 28416") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/28124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/44124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/22806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/44530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/1453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/56044 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/50693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/26301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/56044 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/27549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/44191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/56044 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/28430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/62914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7439 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/27280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/62914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->