### PR TITLE
REGRESSION (274876@main): [ iOS Debug ] accessibility/text-marker/text-marker-range-stale-node-crash.html is a consistent crash

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7298,5 +7298,3 @@ webkit.org/b/273848 [ Release ] imported/w3c/web-platform-tests/html/semantics/e
 webkit.org/b/273905 svg/filters/filter-on-root-tile-boundary.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/273984 http/tests/site-isolation/window-open-with-name-cross-site.html [ Timeout ]
-
-webkit.org/b/274020 [ Debug ] accessibility/text-marker/text-marker-range-stale-node-crash.html [ Skip ]

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2841,7 +2841,7 @@ CharacterOffset AXObjectCache::characterOffsetForTextMarkerData(TextMarkerData& 
     if (textMarkerData.ignored)
         return { };
 
-    RefPtrAllowingPartiallyDestroyed<Node> node = textMarkerData.node;
+    RefPtrAllowingPartiallyDestroyed<Node> node = textMarkerData.node.get();
     if (!node || !isNodeInUse(*node))
         return { };
 
@@ -3379,7 +3379,7 @@ CharacterOffset AXObjectCache::characterOffsetFromVisiblePosition(const VisibleP
 
 AccessibilityObject* AXObjectCache::accessibilityObjectForTextMarkerData(TextMarkerData& textMarkerData)
 {
-    RefPtr domNode = textMarkerData.node;
+    RefPtr domNode = textMarkerData.node.get();
     if (!isNodeInUse(*domNode))
         return nullptr;
 

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -153,14 +153,14 @@ AXTextMarker::operator CharacterOffset() const
     if (!cache)
         return { };
 
-    if (RefPtr node = m_data.node) {
+    if (RefPtr node = m_data.node.get()) {
         // Make sure that this node is still in cache->m_textMarkerNodes. Since this method can be called as a result of a dispatch from the AX thread, the Node may have gone away in a previous main loop cycle.
         if (!cache->isNodeInUse(*node))
             return { };
     } else
         setNodeIfNeeded();
 
-    CharacterOffset result((RefPtr { m_data.node }).get(), m_data.characterStart, m_data.characterOffset);
+    CharacterOffset result(RefPtr { m_data.node.get() }.get(), m_data.characterStart, m_data.characterOffset);
     // When we are at a line wrap and the VisiblePosition is upstream, it means the text marker is at the end of the previous line.
     // We use the previous CharacterOffset so that it will match the Range.
     if (m_data.affinity == Affinity::Upstream)

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -52,7 +52,7 @@ struct TextMarkerData {
     unsigned treeID;
     unsigned objectID;
 
-    Node* node; // FIXME: This should use a smart pointer.
+    WeakPtr<Node, WeakPtrImplWithEventTargetData> node;
     unsigned offset;
     Position::AnchorType anchorType;
     Affinity affinity;
@@ -261,7 +261,7 @@ private:
 inline Node* AXTextMarker::node() const
 {
     ASSERT(isMainThread());
-    return m_data.node;
+    return m_data.node.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -228,7 +228,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"[AXTextMarker %p] = node: %p offset: %d", self, _textMarkerData.node, _textMarkerData.offset];
+    return [NSString stringWithFormat:@"[AXTextMarker %p] = node: %p offset: %d", self, _textMarkerData.node.get(), _textMarkerData.offset];
 }
 
 - (TextMarkerData)textMarkerData


### PR DESCRIPTION
#### 1cb1fc89ec3694511688bddd083cc30f520f4ecf
<pre>
REGRESSION (274876@main): [ iOS Debug ] accessibility/text-marker/text-marker-range-stale-node-crash.html is a consistent crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=274020">https://bugs.webkit.org/show_bug.cgi?id=274020</a>
<a href="https://rdar.apple.com/127901543">rdar://127901543</a>

Reviewed by NOBODY (OOPS!).

Use a WeakPtr for TextMarkerData.node.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::characterOffsetForTextMarkerData):
(WebCore::AXObjectCache::accessibilityObjectForTextMarkerData):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::operator CharacterOffset const):
* Source/WebCore/accessibility/AXTextMarker.h:
(WebCore::AXTextMarker::node const):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityTextMarker description]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cb1fc89ec3694511688bddd083cc30f520f4ecf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54462 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1895 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53508 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36804 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1569 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41697 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53304 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44138 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22815 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25455 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1394 "1 failures") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47436 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1467 "Found 1 new test failure: accessibility/mac/text-marker-for-index.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56058 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26315 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1353 "Found 60 new test failures: accessibility/crash-adopt-node-from-new-document.html, accessibility/display-contents/list.html, accessibility/frame-disconnect-textmarker-cache-crash.html, accessibility/mac/accessibility-make-first-responder.html, accessibility/mac/aria-label-overrides-visible-text.html, accessibility/mac/attributed-string-for-text-marker-range-using-webarea.html, accessibility/mac/attributed-string-includes-insertion-deletion.html, accessibility/mac/attributed-string-with-listitem-multiple-lines.html, accessibility/mac/attributed-string/attributed-string-for-range-with-options.html, accessibility/mac/attributed-string/attributed-string-text-styling.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49100 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27563 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44205 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48243 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28444 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27294 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->