### PR TITLE
REGRESSION (268971@main): [ iOS ] TestWebKitAPI.iOSMouseSupport.MouseDidMoveOverElement is a consistent timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm
@@ -215,9 +215,8 @@ public:
         }
 
         for (UIGestureRecognizer *gestureRecognizer in contentView.gestureRecognizers) {
-            auto hoverGestureRecognizer = dynamic_objc_cast<UIHoverGestureRecognizer>(gestureRecognizer);
-            if ([hoverGestureRecognizer.allowedTouchTypes containsObject:@(UITouchTypeIndirectPointer)])
-                m_hoverGestureRecognizer = hoverGestureRecognizer;
+            if ([gestureRecognizer.name isEqualToString:@"WKMouseHover"])
+                m_hoverGestureRecognizer = dynamic_objc_cast<UIHoverGestureRecognizer>(gestureRecognizer);
             else if ([gestureRecognizer.name isEqualToString:@"WKMouseTouch"])
                 m_mouseTouchGestureRecognizer = gestureRecognizer;
         }


### PR DESCRIPTION
#### 7ee2bbe31b7ff81eb609d85ae5030cd12fcd4514
<pre>
REGRESSION (268971@main): [ iOS ] TestWebKitAPI.iOSMouseSupport.MouseDidMoveOverElement is a consistent timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=273839">https://bugs.webkit.org/show_bug.cgi?id=273839</a>
<a href="https://rdar.apple.com/127691561">rdar://127691561</a>

Reviewed by Megan Gardner and Richard Robinson.

The changes to `MouseEventTestHarness` in 268971@main made this API test time out, but only on iPad.
That&apos;s because UIKit adds its own `UIHoverGestureRecognizer` subclasses to `WKContentView` on iPad,
which causes the logic in the constructor of `MouseEventTestHarness` to initialize
`m_hoverGestureRecognizer` to the wrong gesture. Subsequently, attempts to simulate mouse movement
using this gesture recognizer fails to call into `WKMouseInteraction` delegate methods.

To fix this, simply adjust this logic to check the name of the gesture recognizer (`&quot;WKMouseHover&quot;`)
instead of relying on the class and `allowedTouchTypes`.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm:
(TestWebKitAPI::MouseEventTestHarness::MouseEventTestHarness):

Canonical link: <a href="https://commits.webkit.org/278651@main">https://commits.webkit.org/278651@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f27f25452c09e7ed0cb4af69e2a12ede5fc78698

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54463 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1896 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53509 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36805 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1570 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41699 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44139 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22817 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25457 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1395 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47438 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56059 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26316 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1354 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49097 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27564 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44206 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48239 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11202 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28445 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27295 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->