### PR TITLE
[UnifedPDF] Clean up annotation repaint code

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -492,10 +492,9 @@ private:
     void resetZoom();
 #endif
 
+    std::optional<PDFDocumentLayout::PageIndex> pageIndexForAnnotation(PDFAnnotation *) const;
     std::optional<PDFDocumentLayout::PageIndex> pageIndexWithHoveredAnnotation() const;
     void paintHoveredAnnotationOnPage(PDFDocumentLayout::PageIndex, WebCore::GraphicsContext&, const WebCore::FloatRect& clipRect);
-
-    WebCore::FloatRect documentRectForAnnotation(PDFAnnotation *) const;
 
     void followLinkAnnotation(PDFAnnotation *);
 
@@ -503,9 +502,12 @@ private:
     void updateTrackedAnnotation(PDFAnnotation *annotationUnderMouse);
     void finishTrackingAnnotation(PDFAnnotation *annotationUnderMouse, WebEventType, WebMouseEventButton, OptionSet<RepaintRequirement> = { });
 
+    void revealAnnotation(PDFAnnotation *);
+
     RefPtr<WebCore::GraphicsLayer> createGraphicsLayer(GraphicsLayerClient&, WebCore::GraphicsLayer::Type);
     RefPtr<WebCore::GraphicsLayer> createGraphicsLayer(const String& name, WebCore::GraphicsLayer::Type);
 
+    void setNeedsRepaintForAnnotation(PDFAnnotation *, OptionSet<RepaintRequirement>);
     void setNeedsRepaintInDocumentRect(OptionSet<RepaintRequirement>, const WebCore::FloatRect&);
     void setNeedsRepaintInDocumentRects(OptionSet<RepaintRequirement>, const Vector<WebCore::FloatRect>&);
 


### PR DESCRIPTION
#### b64c3ed8059502609a5dba0c79c6d84773362c4a
<pre>
[UnifedPDF] Clean up annotation repaint code
<a href="https://bugs.webkit.org/show_bug.cgi?id=274030">https://bugs.webkit.org/show_bug.cgi?id=274030</a>
<a href="https://rdar.apple.com/127915821">rdar://127915821</a>

Reviewed by Tim Horton.

Future changes will require that we target repaints at pages, not just at the entire
document.

To support this, tighten up annotation repaint code to target a page (until the final
conversion to document coordinates). Implement a `pageIndexForAnnotation()` helper,
and add `setNeedsRepaintForAnnotation()`.

Implementing `revealAnnotation()` eliminates the final call site of `documentRectForAnnotation()`,
which can be removed.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::setNeedsRepaintForAnnotation):
(WebKit::UnifiedPDFPlugin::paintHoveredAnnotationOnPage):
(WebKit::UnifiedPDFPlugin::pageIndexForAnnotation const):
(WebKit::UnifiedPDFPlugin::pageIndexWithHoveredAnnotation const):
(WebKit::UnifiedPDFPlugin::repaintAnnotationsForFormField):
(WebKit::UnifiedPDFPlugin::startTrackingAnnotation):
(WebKit::UnifiedPDFPlugin::updateTrackedAnnotation):
(WebKit::UnifiedPDFPlugin::finishTrackingAnnotation):
(WebKit::UnifiedPDFPlugin::setActiveAnnotation):
(WebKit::UnifiedPDFPlugin::revealAnnotation):
(WebKit::UnifiedPDFPlugin::annotationRectsForTesting const):
(WebKit::UnifiedPDFPlugin::documentRectForAnnotation const): Deleted.

Canonical link: <a href="https://commits.webkit.org/278658@main">https://commits.webkit.org/278658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5702371b9ede42542fd88fa22edbec996ef5e70

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51210 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54467 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1900 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36810 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1574 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41703 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28148 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44144 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22821 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25462 "Passed tests") | | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47440 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1475 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56063 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26320 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1364 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49103 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27568 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44211 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48246 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11204 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28449 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27299 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->