### PR TITLE
Web Manifest: parsing the id member should strip the hash

### DIFF
--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
@@ -448,6 +448,8 @@ URL ApplicationManifestParser::parseId(const JSON::Object& manifest, const URL& 
     if (!protocolHostAndPortAreEqual(idURL, startURL))
         return startURL;
 
+    idURL.removeFragmentIdentifier();
+
     return idURL;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp
@@ -380,9 +380,12 @@ TEST_F(ApplicationManifestParserTest, Id)
     testId("./foo"_s, m_startURL, "https://example.com/foo"_s);
     testId("foo/"_s, m_startURL, "https://example.com/foo/"_s);
     testId("../../foo/bar"_s, m_startURL, "https://example.com/foo/bar"_s);
-    testId("../../foo/bar?query=hi#hi"_s, m_startURL, "https://example.com/foo/bar?query=hi#hi"_s);
+    testId("../../foo/bar?query=hi#fragment"_s, m_startURL, "https://example.com/foo/bar?query=hi"_s);
+    testId("../../foo/bar?query=hi#"_s, m_startURL, "https://example.com/foo/bar?query=hi"_s);
 
     testId("https://example.com/foo"_s, m_startURL, "https://example.com/foo"_s);
+    testId("https://example.com/foo#"_s, m_startURL, "https://example.com/foo"_s);
+    testId("https://example.com/foo#fragment"_s, m_startURL, "https://example.com/foo"_s);
     testId("https://anothersite.com/foo"_s, m_startURL, m_startURL.string());
     testId("https://invalid.com:a"_s, m_startURL, m_startURL.string());
 }


### PR DESCRIPTION
#### 4a635aa2c910cd04b7a11db8ffe4d6ea2f34bc46
<pre>
Web Manifest: parsing the id member should strip the hash
<a href="https://rdar.apple.com/127864531">rdar://127864531</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=273991">https://bugs.webkit.org/show_bug.cgi?id=273991</a>

Reviewed by Sihui Liu.

Strips the hash from the id member when parsing the Web Manifest.
Part of <a href="https://github.com/w3c/manifest/pull/1122">https://github.com/w3c/manifest/pull/1122</a>

* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::ApplicationManifestParser::parseId):
* Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp:
(TEST_F):

Canonical link: <a href="https://commits.webkit.org/278724@main">https://commits.webkit.org/278724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b34778db9ddfc82814b71e0c4d9b4aeb79a1a977

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51213 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54470 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1903 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53516 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41706 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44146 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22824 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25473 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1402 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47444 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1476 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56066 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1365 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49108 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27571 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44213 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48255 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11247 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28452 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27302 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->