### PR TITLE
REGRESSION (274876@main): [ iOS Debug ] accessibility/text-marker/text-marker-range-stale-node-crash.html is a consistent crash

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7298,5 +7298,3 @@ webkit.org/b/273848 [ Release ] imported/w3c/web-platform-tests/html/semantics/e
 webkit.org/b/273905 svg/filters/filter-on-root-tile-boundary.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/273984 http/tests/site-isolation/window-open-with-name-cross-site.html [ Timeout ]
-
-webkit.org/b/274020 [ Debug ] accessibility/text-marker/text-marker-range-stale-node-crash.html [ Skip ]

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -450,14 +450,14 @@ public:
     AXTextMarker nextTextMarker(const AXTextMarker&);
     TextMarkerData textMarkerDataForPreviousCharacterOffset(const CharacterOffset&);
     AXTextMarker previousTextMarker(const AXTextMarker&);
-    VisiblePosition visiblePositionForTextMarkerData(const TextMarkerData&);
-    CharacterOffset characterOffsetForTextMarkerData(TextMarkerData&);
+    template<typename TextMarkerDataType> VisiblePosition visiblePositionForTextMarkerData(const TextMarkerDataType&);
+    CharacterOffset characterOffsetForTextMarkerData(const SafeTextMarkerData&);
     // Use ignoreNextNodeStart/ignorePreviousNodeEnd to determine the behavior when we are at node boundary.
     CharacterOffset nextCharacterOffset(const CharacterOffset&, bool ignoreNextNodeStart = true);
     CharacterOffset previousCharacterOffset(const CharacterOffset&, bool ignorePreviousNodeEnd = true);
     TextMarkerData startOrEndTextMarkerDataForRange(const SimpleRange&, bool);
     CharacterOffset startOrEndCharacterOffsetForRange(const SimpleRange&, bool, bool enterTextControls = false);
-    AccessibilityObject* accessibilityObjectForTextMarkerData(TextMarkerData&);
+    AccessibilityObject* accessibilityObjectForTextMarkerData(const SafeTextMarkerData&);
     std::optional<SimpleRange> rangeForUnorderedCharacterOffsets(const CharacterOffset&, const CharacterOffset&);
     static SimpleRange rangeForNodeContents(Node&);
     static unsigned lengthForRange(const SimpleRange&);

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -847,22 +847,22 @@ static RetainPtr<AXTextMarkerRef> AXTextMarkerRangeEnd(AXTextMarkerRangeRef text
     return adoptCF(AXTextMarkerRangeCopyEndMarker(textMarkerRange));
 }
 
-static TextMarkerData getBytesFromAXTextMarker(AXTextMarkerRef textMarker)
+static SafeTextMarkerData getBytesFromAXTextMarker(AXTextMarkerRef textMarker)
 {
-    TextMarkerData data;
     if (!textMarker)
-        return data;
+        return { };
 
     ASSERT(CFGetTypeID(textMarker) == AXTextMarkerGetTypeID());
     if (CFGetTypeID(textMarker) != AXTextMarkerGetTypeID())
-        return data;
+        return { };
 
-    ASSERT(AXTextMarkerGetLength(textMarker) == sizeof(data));
-    if (AXTextMarkerGetLength(textMarker) != sizeof(data))
-        return data;
+    ASSERT(AXTextMarkerGetLength(textMarker) == sizeof(TextMarkerData));
+    if (AXTextMarkerGetLength(textMarker) != sizeof(TextMarkerData))
+        return { };
 
-    memcpy(&data, AXTextMarkerGetBytePtr(textMarker), sizeof(data));
-    return data;
+    TextMarkerData data;
+    memcpy(&data, AXTextMarkerGetBytePtr(textMarker), sizeof(TextMarkerData));
+    return data.toSafeTextMarkerData();
 }
 
 AccessibilityObject* accessibilityObjectForTextMarker(AXObjectCache* cache, AXTextMarkerRef textMarker)
@@ -871,11 +871,8 @@ AccessibilityObject* accessibilityObjectForTextMarker(AXObjectCache* cache, AXTe
     if (!cache || !textMarker)
         return nullptr;
 
-    auto textMarkerData = getBytesFromAXTextMarker(textMarker);
-    if (textMarkerData.ignored)
-        return nullptr;
-
-    return cache->accessibilityObjectForTextMarkerData(textMarkerData);
+    auto safeTextMarkerData = getBytesFromAXTextMarker(textMarker);
+    return cache->accessibilityObjectForTextMarkerData(safeTextMarkerData);
 }
 
 // TextMarker <-> VisiblePosition conversion.
@@ -899,8 +896,8 @@ VisiblePosition visiblePositionForTextMarker(AXObjectCache* cache, AXTextMarkerR
     if (!cache || !textMarker)
         return { };
 
-    auto textMarkerData = getBytesFromAXTextMarker(textMarker);
-    return cache->visiblePositionForTextMarkerData(textMarkerData);
+    auto safeTextMarkerData = getBytesFromAXTextMarker(textMarker);
+    return cache->visiblePositionForTextMarkerData(safeTextMarkerData);
 }
 
 // TextMarkerRange <-> VisiblePositionRange conversion.
@@ -947,8 +944,8 @@ CharacterOffset characterOffsetForTextMarker(AXObjectCache* cache, AXTextMarkerR
     if (!cache || !textMarker)
         return { };
 
-    auto textMarkerData = getBytesFromAXTextMarker(textMarker);
-    return cache->characterOffsetForTextMarkerData(textMarkerData);
+    auto safeTextMarkerData = getBytesFromAXTextMarker(textMarker);
+    return cache->characterOffsetForTextMarkerData(safeTextMarkerData);
 }
 
 // TextMarkerRange <-> SimpleRange conversion.


### PR DESCRIPTION
#### d7a54ec9f06058d19cfa177b6bb2b92e6794dc5b
<pre>
REGRESSION (274876@main): [ iOS Debug ] accessibility/text-marker/text-marker-range-stale-node-crash.html is a consistent crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=274020">https://bugs.webkit.org/show_bug.cgi?id=274020</a>
<a href="https://rdar.apple.com/127901543">rdar://127901543</a>

Reviewed by Darin Adler.

Introduce SafeTextMarkerData as an alternative to TextMarkerData, which uses
a WeakPtr for `node` instead of a raw pointer. TextMarkerData currently has
to keep using a raw pointer because memcpy() / memcmp() are used with this
type&apos;s bytes. However, we should use SafeTextMarkerData wherever possible
and this patch starts doing some adoption to address the crash.

* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::characterOffsetForTextMarkerData):
(WebCore::AXObjectCache::accessibilityObjectForTextMarkerData):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AXTextMarker.h:
(WebCore::SafeTextMarkerData::toTextMarkerData const):
(WebCore::TextMarkerData::toSafeTextMarkerData const):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityTextMarker initWithTextMarker:cache:]):
(-[WebAccessibilityTextMarker initWithData:cache:]):
(-[WebAccessibilityTextMarker dataRepresentation]):
(-[WebAccessibilityTextMarker visiblePosition]):
(-[WebAccessibilityTextMarker characterOffset]):
(-[WebAccessibilityTextMarker isIgnored]):
(-[WebAccessibilityTextMarker accessibilityObject]):
(-[WebAccessibilityTextMarker description]):
(-[WebAccessibilityTextMarker textMarkerData]):

Canonical link: <a href="https://commits.webkit.org/278655@main">https://commits.webkit.org/278655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64e165ab6d48eedcc5e7c7c39cbdb406c3a037dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54475 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1908 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53521 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36818 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1582 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41710 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22828 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25471 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1407 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47447 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56071 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26328 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1368 "Found 1 new test failure: http/tests/site-isolation/window-open-with-name-cross-site.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49109 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27576 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44218 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28458 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7449 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27307 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->