### PR TITLE
Fix PlayStation build following 278635@main

### DIFF
--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+RawTypes.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+RawTypes.h
@@ -93,7 +93,7 @@ struct SymbolRaw {
 NumberRaw replaceSymbol(SymbolRaw, const CSSCalcSymbolTable&);
 template<typename T> T replaceSymbol(T value, const CSSCalcSymbolTable&) { return value; }
 
-consteval double computeMinimumValue(CSSPropertyParserHelpers::IntegerValueRange range)
+constexpr double computeMinimumValue(CSSPropertyParserHelpers::IntegerValueRange range)
 {
     switch (range) {
     case CSSPropertyParserHelpers::IntegerValueRange::All:


### PR DESCRIPTION
#### e4580b83827141b83a6625ee5527c4a9552e2c94
<pre>
Fix PlayStation build following 278635@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=274031">https://bugs.webkit.org/show_bug.cgi?id=274031</a>

Unreviewed build fix.

278635@main introduced the first usage of `consteval` into the codebase;
apparently this works correctly in clang 9-10 and clang 15+, but not in clang 11-14.

Presumably we should introduce a macro in Compiler.h to allow us to use `consteval` where possible,
but for the moment, this patch just fixes the build by reverting `consteval` to `constexpr`.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+RawTypes.h:
(WebCore::computeMinimumValue):

Canonical link: <a href="https://commits.webkit.org/278650@main">https://commits.webkit.org/278650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da83b80b6d20cb5903250dbde9632eb120e05c68

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51219 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54476 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1909 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53522 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1583 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41711 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53318 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28154 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44152 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22829 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1408 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47449 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1483 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56072 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26329 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1369 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49111 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27577 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44219 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48257 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11201 "Found 1 new test failure: fast/dom/intersection-observer-document-leak.html (failure)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28459 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7448 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27308 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->