### PR TITLE
[UnifiedPDF] Generalize PDFPageCoverage

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
@@ -123,7 +123,7 @@ private:
     struct TileRenderInfo {
         WebCore::FloatRect tileRect;
         std::optional<WebCore::FloatRect> clipRect; // If set, represents the portion of the tile that needs repaint (in the same coordinate system as tileRect).
-        PDFPageCoverage pageCoverage;
+        PDFPageCoverageAndScales pageCoverage;
         PDFContentsVersionIdentifier contentsVersion;
 
         bool equivalentForPainting(const TileRenderInfo& other) const

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
@@ -29,7 +29,6 @@
 #if ENABLE(UNIFIED_PDF)
 
 #include "Logging.h"
-#include "PDFPageCoverage.h"
 #include "UnifiedPDFPlugin.h"
 #include <CoreGraphics/CoreGraphics.h>
 #include <PDFKit/PDFKit.h>
@@ -228,7 +227,7 @@ void AsyncPDFRenderer::coverageRectDidChange(const FloatRect& coverageRect)
     for (auto pageIndex : m_pagePreviews.keys())
         unwantedPageIndices.add(pageIndex);
 
-    for (auto& pageInfo : pageCoverage.pages) {
+    for (auto& pageInfo : pageCoverage) {
         auto it = unwantedPageIndices.find(pageInfo.pageIndex);
         if (it != unwantedPageIndices.end()) {
             unwantedPageIndices.remove(it);
@@ -321,7 +320,7 @@ auto AsyncPDFRenderer::renderInfoForTile(const TileForGrid& tileInfo, const Floa
         tilingScaleFactor = tiledBacking->tilingScaleFactor();
 
     auto paintingClipRect = convertTileRectToPaintingCoords(tileRect, tilingScaleFactor);
-    auto pageCoverage = plugin->pageCoverageForRect(paintingClipRect);
+    auto pageCoverage = plugin->pageCoverageAndScalesForRect(paintingClipRect);
 
     return TileRenderInfo { tileRect, clipRect, pageCoverage, m_contentsVersion };
 }
@@ -626,7 +625,7 @@ void AsyncPDFRenderer::pdfContentChangedInRect(float pageScaleFactor, const Floa
         return;
 
     auto pageCoverage = plugin->pageCoverageForRect(paintingRect);
-    if (pageCoverage.pages.isEmpty())
+    if (pageCoverage.isEmpty())
         return;
 
     RetainPtr pdfDocument = plugin->pdfDocument();
@@ -652,7 +651,7 @@ void AsyncPDFRenderer::pdfContentChangedInRect(float pageScaleFactor, const Floa
     }
 
     auto pagePreviewScale = plugin->scaleForPagePreviews();
-    for (auto& pageInfo : pageCoverage.pages)
+    for (auto& pageInfo : pageCoverage)
         generatePreviewImageForPage(pageInfo.pageIndex, pagePreviewScale);
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.h
@@ -42,17 +42,19 @@ struct PerPageInfo {
     bool operator==(const PerPageInfo&) const = default;
 };
 
-struct PDFPageCoverage {
-    Vector<PerPageInfo> pages;
+using PDFPageCoverage = Vector<PerPageInfo>;
+
+struct PDFPageCoverageAndScales {
+    PDFPageCoverage pages;
     float deviceScaleFactor { 1 };
     float pdfDocumentScale { 1 };
     float tilingScaleFactor { 1 };
 
-    bool operator==(const PDFPageCoverage&) const = default;
+    bool operator==(const PDFPageCoverageAndScales&) const = default;
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const PerPageInfo&);
-WTF::TextStream& operator<<(WTF::TextStream&, const PDFPageCoverage&);
+WTF::TextStream& operator<<(WTF::TextStream&, const PDFPageCoverageAndScales&);
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.mm
@@ -36,7 +36,7 @@ TextStream& operator<<(TextStream& ts, const PerPageInfo& pageInfo)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, const PDFPageCoverage& coverage)
+TextStream& operator<<(TextStream& ts, const PDFPageCoverageAndScales& coverage)
 {
     ts << "PDFPageCoverage " << coverage.pages << " pdfDocumentScale " << coverage.pdfDocumentScale << " " << " tiling scale " << coverage.tilingScaleFactor;
     return ts;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -28,6 +28,7 @@
 #if ENABLE(UNIFIED_PDF)
 
 #include "PDFDocumentLayout.h"
+#include "PDFPageCoverage.h"
 #include "PDFPluginBase.h"
 #include <WebCore/ElementIdentifier.h>
 #include <WebCore/GraphicsLayer.h>
@@ -63,7 +64,6 @@ class WebFrame;
 class WebMouseEvent;
 struct PDFContextMenu;
 struct PDFContextMenuItem;
-struct PDFPageCoverage;
 
 enum class WebEventType : uint8_t;
 enum class WebMouseEventButton : int8_t;
@@ -415,6 +415,7 @@ private:
 
     // Package up the data needed to paint a set of pages for the given clip, for use by UnifiedPDFPlugin::paintPDFContent and async rendering.
     PDFPageCoverage pageCoverageForRect(const WebCore::FloatRect& clipRect) const;
+    PDFPageCoverageAndScales pageCoverageAndScalesForRect(const WebCore::FloatRect& clipRect) const;
 
     enum class PaintingBehavior : bool { All, PageContentsOnly };
     enum class AllowsAsyncRendering : bool { No, Yes };


### PR DESCRIPTION
#### 6f439da8df038386e726c054b53aa2a3218fc171
<pre>
[UnifiedPDF] Generalize PDFPageCoverage
<a href="https://bugs.webkit.org/show_bug.cgi?id=274036">https://bugs.webkit.org/show_bug.cgi?id=274036</a>
<a href="https://rdar.apple.com/127937268">rdar://127937268</a>

Reviewed by Abrar Rahman Protyasha.

The concept of &quot;a set of page and page-relative rectangles&quot; will be used to
represent selection rects, among other things, so define `PDFPageCoverage` to
just be a `Vector&lt;PerPageInfo&gt;`, and use `PDFPageCoverageAndScales` for
the struct that&apos;s used for painting-related things, that has the additional
scales in it.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::coverageRectDidChange):
(WebKit::AsyncPDFRenderer::renderInfoForTile const):
(WebKit::AsyncPDFRenderer::pdfContentChangedInRect):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.mm:
(WebKit::operator&lt;&lt;):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::pageCoverageForRect const):
(WebKit::UnifiedPDFPlugin::pageCoverageAndScalesForRect const):
(WebKit::UnifiedPDFPlugin::paintPDFContent):
(WebKit::UnifiedPDFPlugin::paintPDFSelection):

Canonical link: <a href="https://commits.webkit.org/278702@main">https://commits.webkit.org/278702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e40431d38f5b0b06c991cc90278e90467cdb616b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54479 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1912 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41714 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53321 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28160 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44155 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22832 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25489 "Passed tests") | | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47455 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56075 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1372 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49114 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27580 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44222 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48261 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11232 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28463 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27311 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->