### PR TITLE
Inline DOMTokenList::associatedAttributeValueChanged

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2314,7 +2314,7 @@ void Element::classAttributeChanged(const AtomString& newClassString)
 
     if (hasRareData()) {
         if (auto* classList = elementRareData()->classList())
-            classList->associatedAttributeValueChanged(newClassString);
+            classList->associatedAttributeValueChanged();
     }
 }
 
@@ -2326,7 +2326,7 @@ void Element::partAttributeChanged(const AtomString& newValue)
 
     if (hasRareData()) {
         if (auto* partList = elementRareData()->partList())
-            partList->associatedAttributeValueChanged(newValue);
+            partList->associatedAttributeValueChanged();
     }
 
     if (needsStyleInvalidation() && isInShadowTree())

--- a/Source/WebCore/html/DOMTokenList.cpp
+++ b/Source/WebCore/html/DOMTokenList.cpp
@@ -254,15 +254,6 @@ void DOMTokenList::updateTokensFromAttributeValue(const AtomString& value)
     m_tokensNeedUpdating = false;
 }
 
-void DOMTokenList::associatedAttributeValueChanged(const AtomString&)
-{
-    // Do not reset the DOMTokenList value if the attribute value was changed by us.
-    if (m_inUpdateAssociatedAttributeFromTokens)
-        return;
-
-    m_tokensNeedUpdating = true;
-}
-
 // https://dom.spec.whatwg.org/#concept-dtl-update
 void DOMTokenList::updateAssociatedAttributeFromTokens()
 {

--- a/Source/WebCore/html/DOMTokenList.h
+++ b/Source/WebCore/html/DOMTokenList.h
@@ -30,13 +30,13 @@
 
 namespace WebCore {
 
-class DOMTokenList {
+class DOMTokenList final {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     using IsSupportedTokenFunction = Function<bool(Document&, StringView)>;
     DOMTokenList(Element&, const QualifiedName& attributeName, IsSupportedTokenFunction&& isSupportedToken = { });
 
-    void associatedAttributeValueChanged(const AtomString&);
+    inline void associatedAttributeValueChanged();
 
     void ref() { m_element.ref(); }
     void deref() { m_element.deref(); }
@@ -88,6 +88,14 @@ inline const AtomString& DOMTokenList::item(unsigned index) const
 {
     auto& tokens = this->tokens();
     return index < tokens.size() ? tokens[index] : nullAtom();
+}
+
+inline void DOMTokenList::associatedAttributeValueChanged()
+{
+    // Do not reset the DOMTokenList value if the attribute value was changed by us.
+    if (m_inUpdateAssociatedAttributeFromTokens)
+        return;
+    m_tokensNeedUpdating = true;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -259,7 +259,7 @@ void HTMLAnchorElement::attributeChanged(const QualifiedName& name, const AtomSt
         if (relValue.contains(opener))
             m_linkRelations.add(Relation::Opener);
         if (m_relList)
-            m_relList->associatedAttributeValueChanged(newValue);
+            m_relList->associatedAttributeValueChanged();
     }
 }
 

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -492,7 +492,7 @@ void HTMLFormElement::attributeChanged(const QualifiedName& name, const AtomStri
         break;
     case AttributeNames::relAttr:
         if (m_relList)
-            m_relList->associatedAttributeValueChanged(newValue);
+            m_relList->associatedAttributeValueChanged();
         break;
     default:
         HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -119,7 +119,7 @@ void HTMLIFrameElement::attributeChanged(const QualifiedName& name, const AtomSt
     switch (name.nodeName()) {
     case AttributeNames::sandboxAttr: {
         if (m_sandbox)
-            m_sandbox->associatedAttributeValueChanged(newValue);
+            m_sandbox->associatedAttributeValueChanged();
 
         String invalidTokens;
         setSandboxFlags(newValue.isNull() ? SandboxNone : SecurityContext::parseSandboxPolicy(newValue, invalidTokens));

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -170,7 +170,7 @@ void HTMLLinkElement::attributeChanged(const QualifiedName& name, const AtomStri
         auto didMutateRel = parsedRel != m_relAttribute;
         m_relAttribute = WTFMove(parsedRel);
         if (m_relList)
-            m_relList->associatedAttributeValueChanged(newValue);
+            m_relList->associatedAttributeValueChanged();
         if (didMutateRel)
             process();
         break;
@@ -191,7 +191,7 @@ void HTMLLinkElement::attributeChanged(const QualifiedName& name, const AtomStri
         break;
     case AttributeNames::sizesAttr:
         if (m_sizes)
-            m_sizes->associatedAttributeValueChanged(newValue);
+            m_sizes->associatedAttributeValueChanged();
         process();
         break;
     case AttributeNames::mediaAttr: {

--- a/Source/WebCore/html/HTMLOutputElement.cpp
+++ b/Source/WebCore/html/HTMLOutputElement.cpp
@@ -73,7 +73,7 @@ bool HTMLOutputElement::supportsFocus() const
 void HTMLOutputElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     if (name == HTMLNames::forAttr && m_forTokens)
-        m_forTokens->associatedAttributeValueChanged(newValue);
+        m_forTokens->associatedAttributeValueChanged();
     HTMLFormControlElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 

--- a/Source/WebCore/svg/SVGAElement.cpp
+++ b/Source/WebCore/svg/SVGAElement.cpp
@@ -85,7 +85,7 @@ void SVGAElement::attributeChanged(const QualifiedName& name, const AtomString& 
         return;
     } else if (name == SVGNames::relAttr) {
         if (m_relList)
-            m_relList->associatedAttributeValueChanged(newValue);
+            m_relList->associatedAttributeValueChanged();
     }
 
     SVGURIReference::parseAttribute(name, newValue);


### PR DESCRIPTION
#### 27f9caa6ed5c1a63c7bcce6973c2f8a21080b7fc
<pre>
Inline DOMTokenList::associatedAttributeValueChanged
<a href="https://bugs.webkit.org/show_bug.cgi?id=274041">https://bugs.webkit.org/show_bug.cgi?id=274041</a>

Reviewed by Chris Dumez.

Inlined this function and remove the unused argument.

Also made the class final since there is no subclass.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::classAttributeChanged):
(WebCore::Element::partAttributeChanged):
* Source/WebCore/html/DOMTokenList.cpp:
(WebCore::DOMTokenList::associatedAttributeValueChanged): Deleted.
* Source/WebCore/html/DOMTokenList.h:
(WebCore::DOMTokenList::associatedAttributeValueChanged):
(WebCore::DOMTokenList::DOMTokenList): Deleted.
(WebCore::DOMTokenList::ref): Deleted.
(WebCore::DOMTokenList::deref): Deleted.
(WebCore::DOMTokenList::isSupportedPropertyIndex const): Deleted.
(WebCore::DOMTokenList::element const): Deleted.
(WebCore::DOMTokenList::tokens const): Deleted.
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::attributeChanged):
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::attributeChanged):
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::HTMLIFrameElement::attributeChanged):
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::attributeChanged):
* Source/WebCore/html/HTMLOutputElement.cpp:
(WebCore::HTMLOutputElement::attributeChanged):
* Source/WebCore/svg/SVGAElement.cpp:
(WebCore::SVGAElement::attributeChanged):

Canonical link: <a href="https://commits.webkit.org/278728@main">https://commits.webkit.org/278728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f74a7c2796cebcd35e20704d2975be4f06075578

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54694 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2120 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1800 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53526 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28376 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44349 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23001 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/25684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1608 "Passed tests") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/47653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1686 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56286 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26546 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/1569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/49269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/27786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44409 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/48451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/28679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7488 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/27521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->